### PR TITLE
Rover wheel energy consumption 

### DIFF
--- a/RealismOverhaul/RO_Squad_Wheel.cfg
+++ b/RealismOverhaul/RO_Squad_Wheel.cfg
@@ -13,7 +13,7 @@
 	%RSSROConfig = true
 	@MODULE[ModuleWheel]
 	{
-		@resourceConsumptionRate = 0.0009
+		@resourceConsumptionRate = 0.001
 	}
 }
 // ##########################################################################################	RoveMax Model XL3


### PR DESCRIPTION
The small rover wheel had a power of 0.0002, which apparently is less than the minimum possible - the rover only moved on 3x physics warp. Increased the power consumption. It may be possible to increase it less than I have increased it.
