### PR TITLE
KSP-AVC support

### DIFF
--- a/RealismOverhaul/RO.version
+++ b/RealismOverhaul/RO.version
@@ -1,0 +1,21 @@
+{
+     "NAME":"RealismOverhaul",
+	 "URL":"https://raw.githubusercontent.com/NathanKell/RealismOverhaul/master/RealismOverhaul/RO.version"
+	 "DOWNLOAD":"https://github.com/NathanKell/RealismOverhaul/releases"
+     "GITHUB":{
+         "USERNAME":"NathanKell",
+         "REPOSITORY":"RealismOverhaul",
+         "ALLOW_PRE_RELEASE":false
+     },
+     "VERSION":{
+         "MAJOR":6,
+         "MINOR":0,
+         "PATCH":12,
+         "BUILD":0
+     },
+     "KSP_VERSION":{
+         "MAJOR":0,
+         "MINOR":24,
+         "PATCH":2
+     }
+ } 


### PR DESCRIPTION
Adds a .version file to work with KSP-AVC.

Since RO is released through github, I also added a GITHUB field for AVC that will check against the latest stable release.
