### PR TITLE
Fixed 2 missing commas

### DIFF
--- a/RealismOverhaul/RO.version
+++ b/RealismOverhaul/RO.version
@@ -1,7 +1,7 @@
 {
      "NAME":"RealismOverhaul",
-	 "URL":"https://raw.githubusercontent.com/NathanKell/RealismOverhaul/master/RealismOverhaul/RO.version"
-	 "DOWNLOAD":"https://github.com/NathanKell/RealismOverhaul/releases"
+	 "URL":"https://raw.githubusercontent.com/NathanKell/RealismOverhaul/master/RealismOverhaul/RO.version",
+	 "DOWNLOAD":"https://github.com/NathanKell/RealismOverhaul/releases",
      "GITHUB":{
          "USERNAME":"NathanKell",
          "REPOSITORY":"RealismOverhaul",


### PR DESCRIPTION
In the original PR I had missed 2 commas.
This made the file not compliant with the JSON standard: adding the two commas makes it parsable by standard JSON parsers other than AVC.
