### PR TITLE
Punctuation fix: "it's landing" -> "its landing".

### DIFF
--- a/RealismOverhaul/RO_FASA_LEM.cfg
+++ b/RealismOverhaul/RO_FASA_LEM.cfg
@@ -243,7 +243,7 @@
 	@node_stack_top = 0.0, 0.6, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.7, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Apollo Lunar Module Ascent Engine
-	@description = An engine that is built to get the Ascent Module back to the Command/Service Module from it's lunar landing.
+	@description = An engine that is built to get the Ascent Module back to the Command/Service Module from its lunar landing.
 	@mass = 0.0816
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]


### PR DESCRIPTION
Interesting fact, "it's" was a perfectly fine possessive as recently as 1803.

https://en.wiktionary.org/wiki/it's#Determiner
