### PR TITLE
Update RO_PorkWorks_HabitatPack.cfg

### DIFF
--- a/RealismOverhaul/REWORK/RO_PorkWorks_HabitatPack.cfg
+++ b/RealismOverhaul/REWORK/RO_PorkWorks_HabitatPack.cfg
@@ -1,6 +1,6 @@
 @PART[centrifuge1]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = True
 	!mesh = DELETE
 	MODEL
 	{
@@ -10,88 +10,209 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 2.91725, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.667, 0.0, 0.0, 1.0, 0.0, 2
-	@CrewCapacity = 6
-	@mass = 20
-	@title = Nautilus-X Centrifuge
-	@description = A loosely based example of the Nautilus-X Centrifuge for artificial gravity.
+	@CrewCapacity = 4
+	@mass = 6
+	@cost = 16000
+	@title = ISS Centrifuge Demo
+	@description = A downsized version of the centrifuge from the Nautilus-X design study, proposed to be installed at the ISS to demonstrate the feasibility of the concept. Only large enough to serve as sleeping quarters for 4 people under partial gravity. Not enough space to stand up, too small a radius to provide full gravity. Relatively high spin rate quite possibly makes the whole experience very nauseating. Could nonetheless still be a substantial health benefit for the crew on a long mission.
 	@crashTolerance = 12
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 800
 	@MODULE[deployableHabRestrictor]
 	{
-		@crewCapacityDeployed = 6
+		@crewCapacityDeployed = 4
 	}
 	MODULE
 	{
 		name = LifeSupportModule
 	}
-	MODULE
+MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1500
+		volume = 300
 		basemass = -1
 		type = ServiceModule
 		TANK
 		{
+			name = ElectricCharge
+			amount = 19000
+			maxAmount = 19000
+		}
+		TANK
+		{
 			name = Oxygen
-			amount = 113400
-			maxAmount = 113400
+			amount = 2520
+			maxAmount = 2520
 		}
 		TANK
 		{
 			name = Food
-			amount = 540
-			maxAmount = 540
+			amount = 12
+			maxAmount = 12
 		}
 		TANK
 		{
 			name = Water
-			amount = 306
-			maxAmount = 306
+			amount = 6.8
+			maxAmount = 6.8
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 97200
+			maxAmount = 1200
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 270
+			maxAmount = 6
 		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 486
+			maxAmount = 10.8
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 3
+			maxAmount = 9
+		}
+	}
+MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+	}
+}
+
++PART[centrifuge1]:FIRST
+{
+@name = centrifugeXL
+}
+
+@PART[centrifugeXL]:FOR[RealismOverhaul]
+{
+%RSSROConfig = true
+!mesh = DELETE
+	MODEL
+	{
+		model = HabitatPack/Parts/centrifuge1/model
+		scale = 3, 3, 3
+	}
+@rescaleFactor = 1
+@node_stack_top = 0.0, 5.25, 0.0, 0.0, 1.0, 0.0, 4
+@node_stack_bottom = 0.0, -3, 0.0, 0.0, 1.0, 0.0, 4
+
+@CrewCapacity = 6
+
+@cost = 80000
+@title = Nautilus-X Centrifuge
+@manufacturer = Porky's Snacks & Inflatable Living Spaces
+description = The full-sized version of the centrifuge from the Nautilus-X proposal. With a habitable volume close to that of the entire ISS put together, it's large enough to provide comfortable habitation to six astronauts. Although the diameter remains too small to allow for full Earth-like gravity under tolerable rotation rates, Martian gravity levels are easily achievable.
+
+@mass = 30.0
+@crashTolerance = 12
+@breakingForce = 250
+@breakingTorque = 250
+@maxTemp = 800
+
+@MODULE[deployableHabRestrictor]
+{
+	@crewCapacityDeployed = 6
+}
+MODULE
+{
+	name = LifeSupportModule
+}
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 1500
+	basemass = -1
+	type = ServiceModule
+	TANK
+	{
+		name = Oxygen
+		amount = 56700
+		maxAmount = 56700
+	}
+	TANK
+	{
+		name = Food
+		amount = 270
+		maxAmount = 270
+	}
+	TANK
+		{
+			name = Water
+			amount = 153
+			maxAmount = 153
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 4860
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 135
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 243
 		}
 		TANK
 		{
 			name = ElectricCharge
-			amount = 10800
-			maxAmount = 10800
+			amount = 28500
+			maxAmount = 28500
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 13.5
+			maxAmount = 13.5
 		}
 	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+	}
 }
+
 @PART[inflato1]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = True
 	!mesh = DELETE
 	MODEL
 	{
 		model = HabitatPack/Parts/inflato1/model
-		scale = 1.52, 2.283, 1.52
+		scale = 1.52, 1.886, 1.52
 	}
 	@rescaleFactor = 1.0
-	@node_stack_top = 0.0, 7.9905, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -5.7075, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_top = 0.0, 6.601, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -4.715, 0.0, 0.0, 1.0, 0.0, 3
 	@CrewCapacity = 6
 	@title = Bigelow BA330 Inflatable Habitat
-	@description = A loosely based example of the upcoming Bigelow BA330 inflatable habitat. Room for 6, and 30 days of supplies.
+	@description = The upcoming Bigelow BA330 inflatable habitat. As the name suggests, it has 330 cubic meters of pressurized volume. Room for 6, and 30 days of supplies. Add a few tonnes of water for radiation shielding purposes to simulate the Deep Space configuration (otherwise it's only suitable for low Earth orbit).
 	@mass = 20
+	@cost = 17000
 	@crashTolerance = 12
 	@breakingForce = 250
 	@breakingTorque = 250
@@ -107,7 +228,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 2500
+		volume = 4500
 		basemass = -1
 		type = ServiceModule
 		TANK
@@ -132,7 +253,7 @@
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 97200
+			maxAmount = 9720
 		}
 		TANK
 		{
@@ -149,14 +270,128 @@
 		TANK
 		{
 			name = ElectricCharge
-			amount = 10800
-			maxAmount = 10800
+			amount = 28500
+			maxAmount = 28500
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 27
+			maxAmount = 27
 		}
 	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+	}
 }
+
++PART[inflato1]:FIRST
+{
+	@name = inflatoXL
+}
+
+@PART[inflatoXL]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = HabitatPack/Parts/inflato1/model
+		scale = 2.74, 3.56, 2.74
+	}
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 12.46, 0.0, 0.0, 1.0, 0.0, 5
+	@node_stack_bottom = 0.0, -8.9, 0.0, 0.0, 1.0, 0.0, 5
+	@CrewCapacity = 18
+	@title = Bigelow BA2100 "Olympus" Inflatable Habitat
+	@description = The largest of the habitats designed by Bigelow Aerospace. As the name suggests, it has a whooping 2100 cubic meters of pressurized volume, more than twice that of the entire International Space Station combined. Can comfortably house 18 astronauts. Add at least a dozen tonnes of water for radiation shielding purposes to simulate the Deep Space configuration, otherwise it should be kept in low Earth orbit.
+	@mass = 100
+	@cost = 70000
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 800
+	@MODULE[deployableHabRestrictor]
+	{
+		@crewCapacityDeployed = 18
+	}
+	MODULE
+	{
+		name = LifeSupportModule
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Oxygen
+			amount = 340200
+			maxAmount = 340200
+		}
+		TANK
+		{
+			name = Food
+			amount = 1620
+			maxAmount = 1620
+		}
+		TANK
+		{
+			name = Water
+			amount = 918
+			maxAmount = 918
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 27000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 810
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1458
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 85500
+			maxAmount = 85500
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 81
+			maxAmount = 81
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 18.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+	}
+}
+
 @PART[inflato2]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = True
 	!mesh = DELETE
 	MODEL
 	{
@@ -170,6 +405,7 @@
 	@title = Bigelow Sundancer Inflatable Habitat
 	@description = A loosely based example of the proposed (now cancelled) Bigelow Sundancer inflatable habitat. Room for 3, and 30 days of supplies.
 	@mass = 8.6184
+	@cost = 10000
 	@crashTolerance = 12
 	@breakingForce = 250
 	@breakingTorque = 250
@@ -210,7 +446,7 @@
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 48600
+			maxAmount = 4860
 		}
 		TANK
 		{
@@ -227,14 +463,29 @@
 		TANK
 		{
 			name = ElectricCharge
-			amount = 10800
-			maxAmount = 10800
+			amount = 16400
+			maxAmount = 16400
+		}
+	TANK
+		{
+			name = LithiumHydroxide
+			amount = 14
+			maxAmount = 14
 		}
 	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 3.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+	}
 }
+
 @PART[inflatoFlat]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = true
 	!mesh = DELETE
 	MODEL
 	{
@@ -244,6 +495,7 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 1.614583, 0.0, 0.0, 1.0, 0.0, 4
 	@node_stack_bottom = 0.0, -1.614583, 0.0, 0.0, 1.0, 0.0, 4
+	@CrewCapacity = 4
 	@MODULE[ModuleDockingNode],0
 	{
 		@nodeType = NASADock
@@ -257,8 +509,9 @@
 		@nodeType = NASADock
 	}
 	@title = Inflatable Docking Hub
-	@description = A big balloon with 4 docking ports to help increase the size of an inflatable station.
-	@mass = 20
+	@description = A big balloon with 4 docking ports to help increase the size of an inflatable station. At about 160 cubic meters of pressurized volume it's large enough to replace two conventional station segments.
+	@mass = 16
+	@cost = 12000
 	@crashTolerance = 12
 	@breakingForce = 250
 	@breakingTorque = 250
@@ -270,7 +523,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1500
+		volume = 2000
 		basemass = -1
 		type = ServiceModule
 		TANK
@@ -295,7 +548,7 @@
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 64800
+			maxAmount = 6480
 		}
 		TANK
 		{
@@ -312,25 +565,41 @@
 		TANK
 		{
 			name = ElectricCharge
-			amount = 10800
-			maxAmount = 10800
+			amount = 22000
+			maxAmount = 22000
+		}
+	TANK
+		{
+			name = LithiumHydroxide
+			amount = 14
+			maxAmount = 14
 		}
 	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+	}
 }
+
 @PART[orbitalorb]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = True
 	!mesh = DELETE
 	MODEL
 	{
 		model = HabitatPack/Parts/orbitalorb/model000
-		scale = 0.944, 1.263, 0.944
+		scale = 0.944, 1.05, 0.944
 	}
 	@scale = 1.0
 	@rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.49034, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.49034, 0.0, 0.0, 1.0, 0.0, 2
-	@description = A lightweight crew module for transporting people and supplies to any station.
+	@node_stack_top = 0.0, 1.239, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.239, 0.0, 0.0, 1.0, 0.0, 2
+	@name = Orbital Module
+	@description = A generic orbital module loosely based on that of the Soviet Soyuz spacecraft. Designed to provide additional habitation space in orbit. As it is not supposed to survive reentry, remember to put a decoupler between this module and your reentry capsule.
 	@mass = 1.37
 	@crashTolerance = 12
 	@breakingForce = 250
@@ -378,7 +647,7 @@
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 7560
+			maxAmount = 756
 		}
 		TANK
 		{
@@ -398,11 +667,26 @@
 			amount = 10800
 			maxAmount = 10800
 		}
+	TANK
+		{
+			name = LithiumHydroxide
+			amount = 3
+			maxAmount = 7
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 2.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
 	}
 }
+
 @PART[BaseMount]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = True
 	!mesh = DELETE
 	MODEL
 	{
@@ -417,3 +701,10 @@
 	@breakingTorque = 250
 	@maxTemp = 800
 }
+
+///////Changed the length of BA330, Sundancer and Orbital Module to better match their real-life dimensions. Kept the other two dimensions the same to keep them matched with docking ports.
+//////Estimated prices for everything except the Orbital Module and the Base Mount, and converted them to 1965 dollars.
+/////Wrote new, more detailed descriptions for most parts.
+////Added CO2 scrubbers and Lithium Hydroxide tanks, and reduced CO2 storage capacity to keep the parts in-line with changes made to stock squad parts' configs.
+////Added two new parts, BA-2100 and full-size Nautilus-X centrifuge.
+///Adjusted masses and storage volumes to be more realistic.


### PR DESCRIPTION
Changed the length of BA330, Sundancer and Orbital Module to better match their real-life dimensions. Kept the other two dimensions the same to keep them matched with docking ports.
Estimated prices for everything except the Orbital Module and the Base Mount, and converted them to 1965 dollars.
Wrote new, more detailed descriptions for most parts.
Added CO2 scrubbers and Lithium Hydroxide tanks, and reduced CO2 storage capacity to keep the parts in-line with changes made to stock squad parts' configs.
Added two new parts, BA-2100 and full-size Nautilus-X centrifuge.
Adjusted masses and storage volumes to be more realistic.
