### PR TITLE
Adds J2-X Engine Config for RLA's J-2 (Albatross)

### DIFF
--- a/RealismOverhaul/RO_RLA_Engine.cfg
+++ b/RealismOverhaul/RO_RLA_Engine.cfg
@@ -1072,7 +1072,7 @@
 			}
 			ModuleEngineIgnitor
 			{
-				ignitionsAvailable = 8
+				ignitionsAvailable = 3
 				autoIgnitionTemperature = 800
 				ignitorType = Electric
 				useUllageSimulation = true
@@ -1119,7 +1119,7 @@
 			}
 			ModuleEngineIgnitor
 			{
-				ignitionsAvailable = 8
+				ignitionsAvailable = 3
 				autoIgnitionTemperature = 800
 				ignitorType = Electric
 				useUllageSimulation = true
@@ -1166,7 +1166,7 @@
 			}
 			ModuleEngineIgnitor
 			{
-				ignitionsAvailable = 8
+				ignitionsAvailable = 3
 				autoIgnitionTemperature = 800
 				ignitorType = Electric
 				useUllageSimulation = true


### PR DESCRIPTION
Information obtained from http://www.nasa.gov/pdf/214593main_Bouley%28Lamm%292-26-08.pdf
-max thrust
-min thrust (secondary mode PC)
-Isp

Information obtained from http://www.nasa.gov/pdf/528269main_J-2X_Facts2011.pdf
-confirmation that "secondary mode PC" was the minimum thrust (82% nominal). Look under the capabilities section.

Information obtained from http://www.rocket.com/j-2x-engine
-fuel/oxidizer ratio

This is my first time researching something like this, so please be polite if I screwed something up...
