### PR TITLE
AIES antenna fix

### DIFF
--- a/RealismOverhaul/RO_AIES_Antenna.cfg
+++ b/RealismOverhaul/RO_AIES_Antenna.cfg
@@ -3,7 +3,7 @@
 	%RSSROConfig = True
 	@mass = 0.045
 	@description = A small folding antenna that must be deployed before use. Most useful within Kerbin's SOI.
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -37,7 +37,7 @@
 	%RSSROConfig = True
 	@mass = 0.055
 	@description = The next generation of the CommTech 1. Slightly larger, but capable of reaching to the inner planets.
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -69,7 +69,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.022
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -100,7 +100,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.025
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -132,7 +132,7 @@
 	%RSSROConfig = True
 	@mass = 0.012
 	@description = A very small onmi antenna. It is always on, lightweight, and requires little power, however, it has a very short range. Best used during ascent, or for a lander to communicate with a orbiting relay.
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -164,7 +164,7 @@
 	%RSSROConfig = True
 	@mass = 0.035
 	@description = A small dish perfect for communications as far away as the Mun.
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -202,7 +202,7 @@
 	{
 		allowManualControl = false
 	}
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	MODULE
@@ -231,7 +231,7 @@
 	%RSSROConfig = True
 	@mass = 0.075
 	@description = Excellent as an orbital relay, or for communicating anywhere within the inner planets.
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	@MODULE[ModuleAnimateGeneric]
@@ -267,7 +267,7 @@
 	{
 		allowManualControl = false
 	}
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	MODULE
@@ -301,7 +301,7 @@
 	{
 		allowManualControl = false
 	}
-	!MODULE[ModuleDataTransmitter]
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
 	MODULE


### PR DESCRIPTION
AIES Antenna fix, don't delete data transmitter unless remotetech is
installed.

Didn't see any other locations where we're removing the stock transmitter without checking for remotetech.
