### PR TITLE
Modification of LR87 LH2 config to match Isp stated by Aeronautix

### DIFF
--- a/RealismOverhaul/Parts/LR87LH2.cfg
+++ b/RealismOverhaul/Parts/LR87LH2.cfg
@@ -57,8 +57,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 414
-			@key,1 = 1 160
+			@key,0 = 0 403
+			@key,1 = 1 350
 		}
 	}
 	@MODULE[ModuleGimbal]


### PR DESCRIPTION
Hello Felger,

Please disregard this pull request if you've got a more reliable source for the LR87 LH2 Isp, or deliberately changed it for gameplay reasons. This came out of Aeronautix, whose information on the LR87 LH2 does not seem reliable.

-Starman4308