### PR TITLE
Expanded descriptions, a few engine tweaks

### DIFF
--- a/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -145,7 +145,7 @@
 		CONFIG
 		{
 			name = Merlin1D
-			minThrust = 519.68574
+			minThrust = 445
 			maxThrust = 742.4082
 			heatProduction = 100
 			PROPELLANT
@@ -169,7 +169,7 @@
 		CONFIG
 		{
 			name = Merlin1DVac
-			minThrust = 563.58967
+			minThrust = 403
 			maxThrust = 805.1281
 			heatProduction = 100
 			PROPELLANT
@@ -185,7 +185,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 347
+				key = 0 345
 				key = 1 200
 			}
 			MassMult = 1.0

--- a/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -19,7 +19,7 @@
 	@node_stack_bottom = 0.0, -2.92000075, 0.0, 0.0, 1.0, 0.0, 1
 	@title = SpaceX Merlin [1.75m]
 	%manufacturer = SpaceX
-	@description = The Merlin is a multi-role kerlox engine. Gas generator, good Isp. Ground lit and vacuum optimized versions. Merlin 1D is throttleable. Used on first stage of Falcon 1 and both stages of Falcon 9 launchers.
+	@description = The Merlin is a multi-role engine burning semi-cryogenic propellant. Gas generator, medium thrust, good Isp. Ground lit and vacuum optimized versions. Merlin 1D is throttleable. Used on first stage of Falcon 1 and both stages of Falcon 9 launchers.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.760
 	@maxTemp = 1700
@@ -326,7 +326,7 @@
 	@node_attach = 0.0, 0.0, -0.40132, 0.0, 0.0, 1.0
 	@title = Castor 1 Solid Motor
 	%manufacturer = Thiokol
-	@description = The Castor 1 is a solid fuel multi-purpose engine. Burn time 27s. Used as a set of four in Little Joe (Mercury test vehicle), as strap-on boosters for Thor-Delta and Thor-Agena, as the second stage in the all-solid Scout launch vehicle, and many other minor applications.
+	@description = The Castor 1 is a solid fuel multi-purpose engine. Burn time 27s. Sergeant tactical missile. Used as a set of four in Little Joe (Mercury test vehicle), as strap-on boosters for Thor-Delta and Thor-Agena, as the second stage in the all-solid Scout launch vehicle, and many other minor applications.
 	@attachRules = 1,1,1,1,0
 	@mass = 0.535
 	@maxTemp = 1700

--- a/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -19,7 +19,7 @@
 	@node_stack_bottom = 0.0, -2.92000075, 0.0, 0.0, 1.0, 0.0, 1
 	@title = SpaceX Merlin [1.75m]
 	%manufacturer = SpaceX
-	@description = The Merlin is a multi-role engine burning semi-cryogenic propellant. Gas generator, medium thrust, good Isp. Ground lit and vacuum optimized versions. Merlin 1D is throttleable. Used on first stage of Falcon 1 and both stages of Falcon 9 launchers.
+	@description = The Merlin is a multi-role engine burning semi-cryogenic propellant. Gas generator. Ground lit and vacuum optimized versions. Merlin 1D is throttleable. Used on first stage of Falcon 1 and both stages of Falcon 9 launchers.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.760
 	@maxTemp = 1700
@@ -227,7 +227,7 @@
 	@node_stack_bottom = 0.0, -1.6, 0.0, 0.0, 1.0, 0.0, 1
 	@title = EADS Astrium Aestus II/PWR RS 72 [1.5m]
 	%manufacturer = EADS Astrium/PWR
-	@description = The Aestus II/RS 72 is a restartable hypergolic upper stage engine. Gas generator cycle, good ISP. Collaboration between Airbus and Prat and Whitney Rocketdyne. Based on Ariane 5 Aestus engine, pressure fed system replaced with turbopump.
+	@description = The Aestus II/RS 72 is a restartable hypergolic upper stage engine. Gas generator. Collaboration between Airbus and Prat and Whitney Rocketdyne. Based on Ariane 5 Aestus engine, pressure fed system replaced with turbopump.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.138
 	@maxTemp = 1700
@@ -301,7 +301,7 @@
 		autoIgnitionTemperature = 700
 		ignitorType = Hypergolic
 		useUllageSimulation = True
-		isPressureFed = True
+		isPressureFed = False
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge

--- a/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -17,9 +17,9 @@
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_shroud = 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -2.92000075, 0.0, 0.0, 1.0, 0.0, 1
-	@title = SpaceX Merlin Family Rocket Engine [1.75m]
+	@title = SpaceX Merlin [1.75m]
 	%manufacturer = SpaceX
-	@description = The whole family of Merlin rocket engines, made by SpaceX.
+	@description = The Merlin is a multi-role kerlox engine. Gas generator, good Isp. Ground lit and vacuum optimized versions. Merlin 1D is throttleable. Used on first stage of Falcon 1 and both stages of Falcon 9 launchers.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.760
 	@maxTemp = 1700
@@ -225,9 +225,9 @@
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_shroud = 0.0, -0.8, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -1.6, 0.0, 0.0, 1.0, 0.0, 1
-	@title = EADS Astrium Aestus II [1.5m]
-	%manufacturer = EADS Astrium
-	@description = Smaller MMH/NTO upper stage rocket engine that can also be used for orbital manuevers.
+	@title = EADS Astrium Aestus II/PWR RS 72 [1.5m]
+	%manufacturer = EADS Astrium/PWR
+	@description = The Aestus II/RS 72 is a restartable hypergolic upper stage engine. Gas generator cycle, good ISP. Collaboration between Airbus and Prat and Whitney Rocketdyne. Based on Ariane 5 Aestus engine, pressure fed system replaced with turbopump.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.138
 	@maxTemp = 1700
@@ -326,7 +326,7 @@
 	@node_attach = 0.0, 0.0, -0.40132, 0.0, 0.0, 1.0
 	@title = Castor 1 Solid Motor
 	%manufacturer = Thiokol
-	@description = The motor used in the Sergeant tactical missile, the Castor 1 has been used in many applications: a set of four were used in Little Joe, the Mercury test vehicle; they were used as strap-on boosters for Thor-Delta and Thor-Agena; they were used as the second stage in the all-solid Scout launch vehicle; and they were used in many other minor applications. Burn time 27s.
+	@description = The Castor 1 is a solid fuel multi-purpose engine. Burn time 27s. Used as a set of four in Little Joe (Mercury test vehicle), as strap-on boosters for Thor-Delta and Thor-Agena, as the second stage in the all-solid Scout launch vehicle, and many other minor applications.
 	@attachRules = 1,1,1,1,0
 	@mass = 0.535
 	@maxTemp = 1700
@@ -475,7 +475,7 @@
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 0
 	@title = Thiokol Castor 30B [92"]
 	%manufacturer = Thiokol (ATK)
-	@description = A shortened Castor 120 became the Castor 30 used as an upper stage.
+	@description = The Castor 30B is a solid fuel upper stage engine. Burn time 127 seconds. Based on the design for the Castor 120, shortened and vacuum-optimized. Used as second stage on the Antares launcher.
 	@attachRules = 1,1,1,1,0
 	@mass = 1.083179
 	@maxTemp = 1700

--- a/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -2,7 +2,7 @@
 {
 	%RSSROConfig = True
 	@title = KB Khimavtomatika RD-0210/0213 [2.0m]
-	@description = A series of engines found on the second and third stages of the Proton series launcher. While the four installed second stage engines gimbal, the single third stage does not.
+	@description = The RD-0210/0213 is a second and third stage engine burning hypergolic propellant. Staged combustion, high thrust, good Isp. Used on second and third stages of Proton launchers. Four engines on second stage gimbal, single engine on third stage does not.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESconstelacion/model
@@ -202,7 +202,7 @@
 {
 	%RSSROConfig = True
 	%title = Common Extensible Cryogenic Engine [3.5m]
-	%description = Test bed derivative of the venerable RL-10. Deep throttle capability. Methane version too!
+	%description = The Common Extensible Cryogenic Engine (CECE) is a throttleable upper stage engine burning cryogenic or semi-cryogenic propellant. Expander cycle, low to medium thrust, very good Isp. Based on RL-10, was demonstrator engine testing deep throttle and methane fuel.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESengine exper/model
@@ -225,7 +225,7 @@
 		%heatProduction = 100
 		@atmosphereCurve
 		{
-			@key,0 = 0 445
+			@key,0 = 0 449
 			@key,1 = 1 100
 		}
 		@PROPELLANT[LiquidFuel]
@@ -278,14 +278,14 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 445
+				key = 0 449
 				key = 1 100
 			}
 		}
 		CONFIG
 		{
 			name = HighPower
-			minThrust = 111.2
+			minThrust = 102.2
 			maxThrust = 111.2
 			heatProduction = 100
 			PROPELLANT
@@ -308,7 +308,7 @@
 		CONFIG
 		{
 			name = Methane
-			minThrust = 22.2
+			minThrust = 13.5
 			maxThrust = 66.7
 			heatProduction = 100
 			PROPELLANT
@@ -323,7 +323,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 350
+				key = 0 365
 				key = 1 100
 			}
 			massMult = 1.0
@@ -348,7 +348,7 @@
 {
 	%RSSROConfig = True
 	%title = NPO Energomash RD-170 [4.0m]
-	%description = Most powerful Kerosene-burning engine, powered the first stage boosters of the Energiya vehicle.
+	%description = The RD-170 is a throttleable first stage engine burning semi-cryogenic propellant. Oxidizer rich staged combustion, very high thrust, very good Isp. Most powerful liquid rocket engine ever flown, single turbopump drives four combustion chambers. Used on the boosters for Energia and first stage of Zenit launcher.
 	!mesh = DELETE
 	MODEL
 	{
@@ -465,7 +465,7 @@
 {
 	%RSSROConfig = True
 	%title = TRW LM Descent Engine [1.75m]
-	%description = Pressure-fed engine used for the descent module of the Apollo lunar lander.
+	%description = The LMDE is a deep-throttling vacuum engine burning hypergolic propellant. Pressure-fed, moderate Isp. Used for the descent module of the Apollo lunar lander.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESenginelMODC/model
@@ -597,7 +597,7 @@
 {
 	%RSSROConfig = True
 	%title = EADS Astrium Aestus [1.5m]
-	%description = Upper stage engine of the Ariane 5ES vehicle that launches the ATV to ISS. Burns hypergolic propellants.
+	%description = The Aestus is an upper stage engine burning hypergolic propellant. Pressure-fed, good Isp. Restartable for precise orbital injection. Used on upper stage of Ariane 5ES launcher.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESenginegalaxvr2/model
@@ -700,7 +700,7 @@
 {
 	%RSSROConfig = True
 	%title = Aerojet LR-91 [3.0m]
-	%description = Second stage engine for the Titan III vehicle, burns hypergolic propellants.
+	%description = The LR-91 is a second stage engine burning hypergolic propellant. Gas generator cycle, high thrust, medium Isp. Used on second stage of Titan launchers.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESengineorbit2/model
@@ -897,7 +897,7 @@
 {
 	%RSSROConfig = True
 	%title = Aerojet LR-87 [3.0m]
-	%description = Used in the first stage of the Titan III vehicle, one of the few hypergolic propellant first stage engines in operation.
+	%description = The LR-87 is a first stage engine burning semi-cryogenic, hypergolic or cryogenic propellant. Gas generator, high thrust, low to moderate Isp. Actually two engines with separate turbomachinery. Original version burned kerosene/LOX, later versions burned Aerozene/NTO. Tested using LH2/LOX. Used on first stage of Titan launchers.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESengine produlvr2/model
@@ -1108,8 +1108,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 451
-				key = 1 351
+				key = 0 403
+				key = 1 350
 			}
 		}
 	}	
@@ -1234,7 +1234,7 @@
 {
 	%RSSROConfig = True
 	%title = TRW LM Ascent Engine [1.0m]
-	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander.
+	%description = The LM Ascent Engine is a vacuum engine burning hypergolic propellant. Gas generator cycle, moderate Isp. Used for the ascent module of the Apollo lunar lander.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESmicroEngineSE/model
@@ -1329,7 +1329,7 @@
 {
 	%RSSROConfig = True
 	%title = Rocketdyne RS-68A [3.5m]
-	%description = Powerful cryogenic engine used in the core and boosters of the Delta-IV vehicle.
+	%description = The RS-68A is a first stage engine burning cryogenic propellant. Gas generator, high thrust, low Isp. Most powerful cryogenic engine in the world. Used on the first stage of the Delta IV launcher.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESVR1vulcan/model

--- a/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -2,7 +2,7 @@
 {
 	%RSSROConfig = True
 	@title = KB Khimavtomatika RD-0210/0213 [2.0m]
-	@description = The RD-0210/0213 is a second and third stage engine burning hypergolic propellant. Staged combustion, high thrust, good Isp. Used on second and third stages of Proton launchers. Four engines on second stage gimbal, single engine on third stage does not.
+	@description = The RD-0210/0213 is a second and third stage engine burning hypergolic propellant. Oxidizer-rich staged combustion. Used on second and third stages of Proton launchers. Four engines on second stage gimbal, single engine on third stage does not.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESconstelacion/model
@@ -202,7 +202,7 @@
 {
 	%RSSROConfig = True
 	%title = Common Extensible Cryogenic Engine [3.5m]
-	%description = The Common Extensible Cryogenic Engine (CECE) is a throttleable upper stage engine burning cryogenic or semi-cryogenic propellant. Expander cycle, low to medium thrust, very good Isp. Based on RL-10, was demonstrator engine testing deep throttle and methane fuel.
+	%description = The Common Extensible Cryogenic Engine (CECE) is a throttleable upper stage engine burning cryogenic or semi-cryogenic propellant. Expander cycle. Based on RL-10, was demonstrator engine testing deep throttle and methane fuel.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESengine exper/model
@@ -348,7 +348,7 @@
 {
 	%RSSROConfig = True
 	%title = NPO Energomash RD-170 [4.0m]
-	%description = The RD-170 is a throttleable first stage engine burning semi-cryogenic propellant. Oxidizer rich staged combustion, very high thrust, very good Isp. Most powerful liquid rocket engine ever flown, single turbopump drives four combustion chambers. Used on the boosters for Energia and first stage of Zenit launcher.
+	%description = The RD-170 is a throttleable first stage engine burning semi-cryogenic propellant. Oxidizer rich staged combustion. Most powerful liquid rocket engine ever flown, single turbopump drives four combustion chambers. Used on the boosters for Energia and first stage of Zenit launcher.
 	!mesh = DELETE
 	MODEL
 	{
@@ -465,7 +465,7 @@
 {
 	%RSSROConfig = True
 	%title = TRW LM Descent Engine [1.75m]
-	%description = The LMDE is a deep-throttling vacuum engine burning hypergolic propellant. Pressure-fed, moderate Isp. Used for the descent module of the Apollo lunar lander.
+	%description = The LMDE is a deep-throttling vacuum engine burning hypergolic propellant. Pressure-fed. Used for the descent module of the Apollo lunar lander.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESenginelMODC/model
@@ -597,7 +597,7 @@
 {
 	%RSSROConfig = True
 	%title = EADS Astrium Aestus [1.5m]
-	%description = The Aestus is an upper stage engine burning hypergolic propellant. Pressure-fed, good Isp. Restartable for precise orbital injection. Used on upper stage of Ariane 5ES launcher.
+	%description = The Aestus is an upper stage engine burning hypergolic propellant. Pressure-fed. Restartable for precise orbital injection. Used on upper stage of Ariane 5ES launcher.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESenginegalaxvr2/model
@@ -700,7 +700,7 @@
 {
 	%RSSROConfig = True
 	%title = Aerojet LR-91 [3.0m]
-	%description = The LR-91 is a second stage engine burning hypergolic propellant. Gas generator cycle, high thrust, medium Isp. Used on second stage of Titan launchers.
+	%description = The LR-91 is a second stage engine burning hypergolic propellant. Gas generator. Used on second stage of Titan launchers.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESengineorbit2/model
@@ -897,7 +897,7 @@
 {
 	%RSSROConfig = True
 	%title = Aerojet LR-87 [3.0m]
-	%description = The LR-87 is a first stage engine burning semi-cryogenic, hypergolic or cryogenic propellant. Gas generator, high thrust, low to moderate Isp. Actually two engines with separate turbomachinery. Original version burned kerosene/LOX, later versions burned Aerozene/NTO. Tested using LH2/LOX. Used on first stage of Titan launchers.
+	%description = The LR-87 is a first stage engine burning semi-cryogenic, hypergolic or cryogenic propellant. Gas generator. Actually two engines with separate turbomachinery. Original version burned kerosene/LOX, later versions burned Aerozene/NTO. Tested using LH2/LOX. Used on first stage of Titan launchers.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESengine produlvr2/model
@@ -1234,7 +1234,7 @@
 {
 	%RSSROConfig = True
 	%title = TRW LM Ascent Engine [1.0m]
-	%description = The LM Ascent Engine is a vacuum engine burning hypergolic propellant. Gas generator cycle, moderate Isp. Used for the ascent module of the Apollo lunar lander.
+	%description = The LM Ascent Engine is a vacuum engine burning hypergolic propellant. Gas generator cycle. Used for the ascent module of the Apollo lunar lander.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESmicroEngineSE/model
@@ -1329,7 +1329,7 @@
 {
 	%RSSROConfig = True
 	%title = Rocketdyne RS-68A [3.5m]
-	%description = The RS-68A is a first stage engine burning cryogenic propellant. Gas generator, high thrust, low Isp. Most powerful cryogenic engine in the world. Used on the first stage of the Delta IV launcher.
+	%description = The RS-68A is a first stage engine burning cryogenic propellant. Gas generator. Most powerful cryogenic engine in the world. Used on the first stage of the Delta IV launcher.
 	MODEL
 	{
 		model = AIES_Aerospace/Engine/AIESVR1vulcan/model

--- a/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -7,7 +7,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = SNTK Kuznetsov NK-33
-	%description = The NK-33 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Very high T/W. Originally built as upgraded NK-15 which was used on N1 rocket. Intended for the N1F rocket, eventually used on Antares 100 series and Soyuz 2-1v.
+	%description = The NK-33 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion. Very high T/W. Originally built as upgraded NK-15 which was used on N1 rocket. Intended for the N1F rocket, eventually used on Antares 100 series and Soyuz 2-1v.
 	%attachRules = 1,0,1,0,0
 	%mass = 1.222
 	%maxTemp = 1700
@@ -115,7 +115,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = SNTK Kuznetsov NK-43
-	%description = The NK-43 is an upper stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
+	%description = The NK-43 is an upper stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion. Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
 	%attachRules = 1,0,1,0,0
 	%mass = 1.396
 	%maxTemp = 1700
@@ -223,7 +223,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = KB Khimavtomatika RD-0120
-	%description = The RD-0120 is a first stage/sustainer engine burning cryogenic propellant. Fuel-rich staged combustion, high thrust, high Isp. Like RS-25 (SSME), lit on ground and burned to slightly suborbital disposal trajectory. Used on core stage of Energia launcher.
+	%description = The RD-0120 is a first stage/sustainer engine burning cryogenic propellant. Fuel-rich staged combustion. Like RS-25 (SSME), lit on ground and burned to slightly suborbital disposal trajectory. Used on core stage of Energia launcher.
 	%attachRules = 1,0,1,0,0
 	%mass = 3.45
 	%maxTemp = 1700
@@ -321,7 +321,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	%category = Propulsion
 	%title = KB Khimavtomatika RD-0110/0124
-	%description = The RD-0110/0124 is a second stage engine burning semi-cryogenic propellant. RD-0110: gas generator, medium thrust, moderate Isp; RD-0124: oxidizer-rich staged combustion, medium thrust, high Isp. Used on second stage of Soyuz and Angara launchers.
+	%description = The RD-0110/0124 is a second stage engine burning semi-cryogenic propellant. RD-0110: gas generator; RD-0124: oxidizer-rich staged combustion. Used on second stage of Soyuz and Angara launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 0.451
 	%maxTemp = 1700
@@ -454,7 +454,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = KB Khimavtomatiki RD-0146
-	%description = The RD-0146 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. Designed in cooperation with Rocketdyne, based on RL-10. Intended to be used on upper stages of Angara launchers.
+	%description = The RD-0146 is an upper stage engine burning cryogenic propellant. Expander cycle. Designed in cooperation with Rocketdyne, based on RL-10. Intended to be used on upper stages of Angara launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 0.242
 	%maxTemp = 1700
@@ -552,7 +552,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = NPO Energomash RD-171M
-	%description = The RD-171M is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, very high thrust, high Isp. Most powerful liquid rocket engine ever flown, single turbopump feeds four chambers. Used as first stage of Zenit launcher.
+	%description = The RD-171M is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion. Most powerful liquid rocket engine ever flown, single turbopump feeds four chambers. Used as first stage of Zenit launcher.
 	%attachRules = 1,0,1,0,0
 	%mass = 9.5
 	%maxTemp = 1700
@@ -660,7 +660,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = NPO Energomash RD-180
-	%description = The RD-180 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Based on RD-170/171, single turbopump feeds two combustion chambers. Used on the first stage of Atlas III and Atlas V.
+	%description = The RD-180 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion. Based on RD-170/171, single turbopump feeds two combustion chambers. Used on the first stage of Atlas III and Atlas V.
 	%attachRules = 1,0,1,0,0
 	%mass = 5.48
 	%maxTemp = 1700
@@ -769,7 +769,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = NPO Energomash RD-191
-	%description = The RD-191 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Based on RD-170/171, single turbopump and single combustion chamber. Used on first stage of Angara launchers.
+	%description = The RD-191 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion. Based on RD-170/171, single turbopump and single combustion chamber. Used on first stage of Angara launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 3.23
 	%maxTemp = 1700

--- a/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -7,7 +7,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = SNTK Kuznetsov NK-33
-	%description = Originally built for the N1F rocket, while the rockets were scrapped, the engines survived and are now being refurbished to power new designs, and manufacturing of new engines is starting.
+	%description = The NK-33 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Very high T/W. Originally built as upgraded NK-15 which was used on N1 rocket. Intended for the N1F rocket, eventually used on Antares 100 series and Soyuz 2-1v.
 	%attachRules = 1,0,1,0,0
 	%mass = 1.222
 	%maxTemp = 1700
@@ -115,7 +115,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = SNTK Kuznetsov NK-43
-	%description = Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
+	%description = The NK-43 is an upper stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
 	%attachRules = 1,0,1,0,0
 	%mass = 1.396
 	%maxTemp = 1700
@@ -223,7 +223,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = KB Khimavtomatika RD-0120
-	%description = Originally designed to power the core stage of the Energia rocket, with similar performance and lower cost of the RS-25 (SSME) the RD-0120 is a powerful cryogenic rocket engine.
+	%description = The RD-0120 is a first stage/sustainer engine burning cryogenic propellant. Fuel-rich staged combustion, high thrust, high Isp. Like RS-25 (SSME), lit on ground and burned to slightly suborbital disposal trajectory. Used on core stage of Energia launcher.
 	%attachRules = 1,0,1,0,0
 	%mass = 3.45
 	%maxTemp = 1700
@@ -321,7 +321,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	%category = Propulsion
 	%title = KB Khimavtomatika RD-0110/0124
-	%description = An upper stage Kerosene/LOx engine designed for new versions of the Soyuz-2 launchers. To also be used with the Angara family of launchers.
+	%description = The RD-0110/0124 is a second stage engine burning semi-cryogenic propellant. RD-0110: gas generator, medium thrust, moderate Isp; RD-0124: oxidizer-rich staged combustion, medium thrust, high Isp. Used on second stage of Soyuz and Angara launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 0.451
 	%maxTemp = 1700
@@ -343,7 +343,7 @@
 		@atmosphereCurve
 		{
 			@key,0 = 0 359
-			@key,1 = 1 331
+			@key,1 = 1 150
 		}
 	}
 	!MODULE[ModuleEngineConfigs]
@@ -386,7 +386,7 @@
 			atmosphereCurve
 			{
 				key = 0 330
-				key = 1 99
+				key = 1 150
 			}
 			massMult = 1.0
 		}
@@ -410,7 +410,7 @@
 			atmosphereCurve
 			{
 				key = 0 359
-				key = 1 331
+				key = 1 150
 			}
 			massMult = 1.064302
 		}
@@ -454,7 +454,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = KB Khimavtomatiki RD-0146
-	%description = A designed based upon the RL-10 series of rocket engines, with a more Russian flavour.
+	%description = The RD-0146 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. Designed in cooperation with Rocketdyne, based on RL-10. Intended to be used on upper stages of Angara launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 0.242
 	%maxTemp = 1700
@@ -552,7 +552,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = NPO Energomash RD-171M
-	%description = The worlds most powerful rocket engine ever built, however it uses one pump to feed 4 chambers. Originally designed for the Energia launcher, powering each of the 4 boosters, it is now used by the Zenit launcher.
+	%description = The RD-171M is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, very high thrust, high Isp. Most powerful liquid rocket engine ever flown, single turbopump feeds four chambers. Used as first stage of Zenit launcher.
 	%attachRules = 1,0,1,0,0
 	%mass = 9.5
 	%maxTemp = 1700
@@ -660,7 +660,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = NPO Energomash RD-180
-	%description = A follow up to the RD-170/171 series the RD-180 reduces the number of chambers by half. Power the first stage of the Atlas V.
+	%description = The RD-180 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Based on RD-170/171, single turbopump feeds two combustion chambers. Used on the first stage of Atlas III and Atlas V.
 	%attachRules = 1,0,1,0,0
 	%mass = 5.48
 	%maxTemp = 1700
@@ -769,7 +769,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
 	%title = NPO Energomash RD-191
-	%description = A further continuation of the RD-170/171 series, the RD-191 features a single combustion chamber and nozzle. Powers the Angara family of launchers.
+	%description = The RD-191 is a first stage engine burning semi-cryogenic propellant. Oxidizer-rich staged combustion, high thrust, high Isp. Based on RD-170/171, single turbopump and single combustion chamber. Used on first stage of Angara launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 3.23
 	%maxTemp = 1700

--- a/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -5,9 +5,9 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = Pratt & Whitney RL-10 (Two) [2.0m]
+	%title = Pratt & Whitney RL10 (Two) [2.0m]
 	%manufacturer = Pratt & Whitney
-	%description = A pair of cryogenic, expander-cycle vacuum engines used in countless applications.
+	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. Early versions of the Centaur upper stage used two RL10 engines, Atlas V Centaur typically uses single RL10 but dual RL10 version is available.
 	@MODEL,0
 	{
 		%scale = 2.0, 2.0, 2.0
@@ -164,9 +164,9 @@
 		}
 		CONFIG
 		{
-			name = RL-10B-2
-			minThrust = 222.411
-			maxThrust = 222.411
+			name = RL-10C-1
+			minThrust = 212.411
+			maxThrust = 212.411
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -181,10 +181,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 462
+				key = 0 448.5
 				key = 1 235
 			}
-			massMult = 1.659
+			massMult = 1.39
 		}
 	}
 	MODULE
@@ -221,7 +221,7 @@
 	}
 	%title = Aerojet AJ10-118K [2.0m]
 	%manufacturer = Aerojet
-	%description = Upper stage, pressure-fed engine of the Delta II vehicle, burns hypergolic propellants and is optimized for vacuum operation.
+	%description = The AJ10-118K is an upper stage engine burning hypergolic propellant. Pressure-fed, low thrust, moderate Isp. Used on second stage of Delta II launcher.
 	@MODEL,0
 	{
 		%scale = 2.0, 2.0, 2.0
@@ -235,7 +235,7 @@
 	!node_stack_top2 = DELETE
 	%node_stack_bottom = 0.0, -1.476, 0.0, 0.0, 1.0, 0.0, 2
 	%attachRules = 1,0,1,0,0
-	%mass = 0.15
+	%mass = 0.098
 	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
@@ -335,9 +335,9 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = Pratt & Whitney RL-10 [1.5m]
+	%title = Pratt & Whitney RL10 [1.5m]
 	%manufacturer = Pratt & Whitney
-	%description = A single cryogenic, expander-cycle vacuum engine that is used in countless applications.
+	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. World's first LH2/LOX engine and first expander cycle engine. Used on Centaur upper stage for Atlas and Titan launchers, second stage engine (in cluster of six) for Saturn IB, and second stage of Delta III and Delta IV.
 	@MODEL,0
 	{
 		%scale = 1.5075, 1.5075, 1.5075
@@ -395,10 +395,10 @@
 		name = ModuleEngineConfigs
 		origMass = 0.167
 		modded = false
-		configuration = RL-10A-3
+		configuration = RL10A-3
 		CONFIG
 		{
-			name = RL-10A-3
+			name = RL10A-3
 			minThrust = 65.6
 			maxThrust = 65.6
 			heatProduction = 100
@@ -422,7 +422,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-3A
+			name = RL10A-3A
 			minThrust = 73.4
 			maxThrust = 73.4
 			heatProduction = 100
@@ -446,7 +446,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-4
+			name = RL10A-4
 			minThrust = 92.5
 			maxThrust = 92.5
 			heatProduction = 100
@@ -470,7 +470,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-4-1/2
+			name = RL10A-4-1/2
 			minThrust = 99.1
 			maxThrust = 99.1
 			heatProduction = 100
@@ -494,7 +494,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10B-2
+			name = RL10B-2
 			minThrust = 111.2055
 			maxThrust = 111.2055
 			heatProduction = 100
@@ -515,6 +515,30 @@
 				key = 1 235
 			}
 			massMult = 1.659
+		}
+				CONFIG
+		{
+			name = RL10C-1
+			minThrust = 106.3
+			maxThrust = 106.3
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.734
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.266
+			}
+			atmosphereCurve
+			{
+				key = 0 448.5
+				key = 1 235
+			}
+			massMult = 1.14
 		}
 	}
 	MODULE
@@ -969,7 +993,7 @@
 	}
 	%title = Mitsubishi LE-7A (Two) [5m]
 	%manufacturer = Mitsubishi
-	%description = A pair of Mitsubishi LE-7A rocket engines as found on the HII-B first stage.
+	%description = The LE-7A is a throttleable first stage/sustainer engine burning cryogenic propellant. Fuel-rich staged combustion, medium thrust, moderate Isp. Dual LE-7A engines are used on the first stage of the H-IIB launcher.
 	@MODEL,0
 	{
 		%scale = 2.5, 2.5, 2.5
@@ -991,7 +1015,7 @@
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 2196
-		%minThrust = 2196
+		%minThrust = 1581
 		%heatProduction = 100
 		@atmosphereCurve
 		{
@@ -1032,7 +1056,7 @@
 		{
 			name = LE-7A
 			maxThrust = 2196
-			minThrust = 2196
+			minThrust = 1581
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -1200,7 +1224,7 @@
 	}
 	%title = EADS Astrium Vulcain 2 [5.0m]
 	%manufacturer = EADS Astrium
-	%description = First stage of the Ariane 5 vehicle, burns cryogenic propellants.
+	%description = The Vulcain 2 is a first stage/sustainer engine burning cryogenic propellant. Gas generator, medium thrust, medium Isp. Upgrade of the original Vulcain engine with 30% more thrust, higher vacuum Isp, and denser propellant mix. Used on the core stage of Ariane 5 launcher.
 	@MODEL,0
 	{
 		%scale = 1.65336, 1.65336, 1.65336
@@ -1214,7 +1238,7 @@
 	!node_stack_top2 = DELETE
 	%node_stack_bottom = 0.0, -1.1122, 0.0, 0.0, 1.0, 0.0, 5
 	%attachRules = 1,0,1,0,0
-	%mass = 3.15
+	%mass = 1.8
 	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
@@ -1256,7 +1280,7 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		origMass = 3.15
+		origMass = 1.8
 		configuration = LqdHydrogen+LqdOxygen
 		modded = false
 		CONFIG

--- a/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -68,7 +68,7 @@
 		configuration = RL10A-3
 		CONFIG
 		{
-			name = RL-10A-3
+			name = RL10A-3
 			minThrust = 131.2
 			maxThrust = 131.2
 			heatProduction = 100

--- a/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -65,7 +65,7 @@
 		name = ModuleEngineConfigs
 		origMass = 0.334
 		modded = false
-		configuration = RL-10A-3
+		configuration = RL10A-3
 		CONFIG
 		{
 			name = RL-10A-3
@@ -92,7 +92,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-3A
+			name = RL10A-3A
 			minThrust = 146.8
 			maxThrust = 146.8
 			heatProduction = 100
@@ -116,7 +116,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-4
+			name = RL10A-4
 			minThrust = 185
 			maxThrust = 185
 			heatProduction = 100
@@ -140,7 +140,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-4-1/2
+			name = RL10A-4-1/2
 			minThrust = 198.2
 			maxThrust = 198.2
 			heatProduction = 100
@@ -164,7 +164,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10C-1
+			name = RL10C-1
 			minThrust = 212.411
 			maxThrust = 212.411
 			heatProduction = 100

--- a/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -7,7 +7,7 @@
 	}
 	%title = Pratt & Whitney RL10 (Two) [2.0m]
 	%manufacturer = Pratt & Whitney
-	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. Early versions of the Centaur upper stage used two RL10 engines, Atlas V Centaur typically uses single RL10 but dual RL10 version is available.
+	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle. Early versions of the Centaur upper stage used two RL10 engines, Atlas V Centaur typically uses single RL10 but dual RL10 version is available.
 	@MODEL,0
 	{
 		%scale = 2.0, 2.0, 2.0
@@ -221,7 +221,7 @@
 	}
 	%title = Aerojet AJ10-118K [2.0m]
 	%manufacturer = Aerojet
-	%description = The AJ10-118K is an upper stage engine burning hypergolic propellant. Pressure-fed, low thrust, moderate Isp. Used on second stage of Delta II launcher.
+	%description = The AJ10-118K is an upper stage engine burning hypergolic propellant. Pressure-fed. Used on second stage of Delta II launcher.
 	@MODEL,0
 	{
 		%scale = 2.0, 2.0, 2.0
@@ -337,7 +337,7 @@
 	}
 	%title = Pratt & Whitney RL10 [1.5m]
 	%manufacturer = Pratt & Whitney
-	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. World's first LH2/LOX engine and first expander cycle engine. Used on Centaur upper stage for Atlas and Titan launchers, second stage engine (in cluster of six) for Saturn IB, and second stage of Delta III and Delta IV.
+	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle. World's first LH2/LOX engine and first expander cycle engine. Used on Centaur upper stage for Atlas and Titan launchers, second stage engine (in cluster of six) for Saturn IB, and second stage of Delta III and Delta IV.
 	@MODEL,0
 	{
 		%scale = 1.5075, 1.5075, 1.5075
@@ -993,7 +993,7 @@
 	}
 	%title = Mitsubishi LE-7A (Two) [5m]
 	%manufacturer = Mitsubishi
-	%description = The LE-7A is a throttleable first stage/sustainer engine burning cryogenic propellant. Fuel-rich staged combustion, medium thrust, moderate Isp. Dual LE-7A engines are used on the first stage of the H-IIB launcher.
+	%description = The LE-7A is a throttleable first stage/sustainer engine burning cryogenic propellant. Fuel-rich staged combustion. Dual LE-7A engines are used on the first stage of the H-IIB launcher.
 	@MODEL,0
 	{
 		%scale = 2.5, 2.5, 2.5
@@ -1224,7 +1224,7 @@
 	}
 	%title = EADS Astrium Vulcain 2 [5.0m]
 	%manufacturer = EADS Astrium
-	%description = The Vulcain 2 is a first stage/sustainer engine burning cryogenic propellant. Gas generator, medium thrust, medium Isp. Upgrade of the original Vulcain engine with 30% more thrust, higher vacuum Isp, and denser propellant mix. Used on the core stage of Ariane 5 launcher.
+	%description = The Vulcain 2 is a first stage/sustainer engine burning cryogenic propellant. Gas generator. Upgrade of the original Vulcain engine with 30% more thrust, higher vacuum Isp, and denser propellant mix. Used on the core stage of Ariane 5 launcher.
 	@MODEL,0
 	{
 		%scale = 1.65336, 1.65336, 1.65336

--- a/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -18,7 +18,7 @@
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	%title = Pratt & Whitney RL10 Series [2.5m]
 	%manufacturer = Pratt & Whitney
-	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. World's first LH2/LOX engine, as well as first expander cycle engine. Used on Centaur upper stage for Atlas and Titan launch vehicles, as second stage engine (in cluster of six) for Saturn IB, and as second stage engine on Delta III and Delta IV.
+	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle. World's first LH2/LOX engine, as well as first expander cycle engine. Used on Centaur upper stage for Atlas and Titan launch vehicles, as second stage engine (in cluster of six) for Saturn IB, and as second stage engine on Delta III and Delta IV.
 	%attachRules = 1,1,1,1,0
 	%mass = 0.167
 	%maxTemp = 1700
@@ -2026,7 +2026,7 @@
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
 	@title = Thiokol Castor 30XL [92"]
 	@manufacturer = Thiokol (ATK)
-	@description = Enlarged Castor 30 to create the Castor 30XL for upper stages. DOES NOT HAVE A THRUST CURVE AT THIS TIME.
+	@description = The Castor 30XL is a solid fuel upper stage engine. Larger version of Castor 30 engine. Used as second stage on Antares launcher. DOES NOT HAVE A THRUST CURVE AT THIS TIME.
 	@attachRules = 1,1,1,1,0
 	@mass = 2.3
 	@maxTemp = 1700

--- a/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -2101,7 +2101,7 @@
 	@manufacturer = Thiokol (ATK)
 	@description = Medium sized booster for helping lift heavier payloads.
 	@attachRules = 1,1,1,1,0
-	@mass = 9.079
+	@mass = 4.09
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
 	{
@@ -2153,7 +2153,7 @@
 			atmosphereCurve
 			{
 				key = 0 280
-				key = 1 253
+				key = 1 229
 			}
 			curveResource = SolidFuel
 			thrustCurve

--- a/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -16,9 +16,9 @@
 	%node_stack_shroud = 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -2.375, 0.0, 0.0, 1.0, 0.0, 2
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-	%title = Pratt & Whitney RL-10 Series [2.5m]
+	%title = Pratt & Whitney RL10 Series [2.5m]
 	%manufacturer = Pratt & Whitney
-	%description = Cryogenic, expander-cycle vacuum engine used in countless applications.
+	%description = The RL10 is an upper stage engine burning cryogenic propellant. Expander cycle, low thrust, very high Isp. World's first LH2/LOX engine, as well as first expander cycle engine. Used on Centaur upper stage for Atlas and Titan launch vehicles, as second stage engine (in cluster of six) for Saturn IB, and as second stage engine on Delta III and Delta IV.
 	%attachRules = 1,1,1,1,0
 	%mass = 0.167
 	%maxTemp = 1700
@@ -65,10 +65,10 @@
 		type = ModuleEngines
 		origMass = 0.167
 		modded = false
-		configuration = RL-10A-3
+		configuration = RL10A-3
 		CONFIG
 		{
-			name = RL-10A-3
+			name = RL10A-3
 			minThrust = 65.6
 			maxThrust = 65.6
 			heatProduction = 100
@@ -92,7 +92,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-3A
+			name = RL10A-3A
 			minThrust = 73.4
 			maxThrust = 73.4
 			heatProduction = 100
@@ -116,7 +116,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-4
+			name = RL10A-4
 			minThrust = 92.5
 			maxThrust = 92.5
 			heatProduction = 100
@@ -140,7 +140,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10A-4-1/2
+			name = RL10A-4-1/2
 			minThrust = 99.1
 			maxThrust = 99.1
 			heatProduction = 100
@@ -164,7 +164,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10B-2
+			name = RL10B-2
 			minThrust = 111.2055
 			maxThrust = 111.2055
 			heatProduction = 100
@@ -188,7 +188,7 @@
 		}
 		CONFIG
 		{
-			name = RL-10C-1
+			name = RL10C-1
 			minThrust = 106.3125
 			maxThrust = 106.3125
 			heatProduction = 100

--- a/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -2033,11 +2033,11 @@
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 0
-		@maxThrust = 396.2921
+		@maxThrust = 501
 		@heatProduction = 100
 		@atmosphereCurve
 		{
-			@key,0 = 0 303
+			@key,0 = 0 301
 			@key,1 = 0 100
 		}
 	}
@@ -2060,7 +2060,7 @@
 		CONFIG
 		{
 			name = SolidFuel
-			maxThrust = 396.2921
+			maxThrust = 501
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -2070,7 +2070,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 303
+				key = 0 301
 				key = 1 100
 			}
 			//curveResource = SolidFuel


### PR DESCRIPTION
Expanded/standardized descriptions for several engines: [engine name], [use - first stage, second/third stage, sustainer, upper stage, vacuum], [fuel - hypergolic, semi-cryogenic, cryogenic]. [cycle - ORSC, FRSC, GG, expander, pressure-fed]. [other information]. [vehicles and stages used].

Expanded throttle range on Merlin 1D per https://twitter.com/elonmusk/status/462104679116050432 (arguable whether throttle is TO 40% or BY 40%, went with more conservative BY).

Updated Castor 120 with dry mass and Isp from Astronautix, Castor 30XL thrust estimate per spacelaunchreport.com.

Increased CECE methane Isp (release only specified "> 350 sec", since staged combustion Raptor will hit 363 for ground lit and 380 for vacuum optimized, at least 365 seems reasonable for vacuum optimized expander cycle.)

Changed RL-10 to RL10 (documentation doesn't use the "-"), removed dual RL10B-2 since extensible nozzle wouldn't fit in same footprint, added dual RL10C-1.

Updated mass of AJ10 and Vulcain 2 from Astronautix.

Added throttle to dual LE-7A.

Changed Aestus II to non-pressure fed (uses gas generator turbopump).