### PR TITLE
Partial ESA support

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_ATV.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_ATV.cfg
@@ -1,0 +1,359 @@
+@PART[ATV1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/ATV/ATV1/model
+		scale = 1.55, 1.55, 1.55
+	}
+	@scale = 1.55
+	%maxTemp = 800
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@mass =	4.351
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.4
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleCrossFeed
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 12500
+		basemass = -1
+		TANK
+		{
+			name = Water
+			amount = 285
+			maxAmount = 885
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 76600
+			maxAmount = 76600
+		}
+		TANK
+		{
+			name = Food
+			amount = 2750
+			maxAmount = 4000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 6430
+		}
+		TANK
+		{
+			name = UDMH
+			amount = 387
+			maxAmount = 387
+		}
+		TANK
+		{
+			name = NTO
+			amount = 382
+			maxAmount = 382
+		}
+	}
+	MODULE:NEEDS[KAS]
+	{
+	    name = KASModuleContainer
+	    maxSize = 1024
+	    maxOpenDistance = 2
+	    sndStorePath = KAS/Sounds/hookBayStore
+	    sndOpenPath = KAS/Sounds/containerOpen
+	    sndClosePath = KAS/Sounds/containerClose
+	    bipWrongSndPath = KAS/Sounds/bipwrong
+	}
+	MODULE:NEEDS[RemoteTech]
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	%MODULE[ModuleRTAntennaPassive]:NEEDS[RemoteTech]	
+	{
+		%TechRequired = unmannedTech
+		%OmniRange = 1000000
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.05
+		}
+	}
+}
+
+@PART[ATV2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/ATV/ATV2/model
+		scale = 1.55, 1.55, 1.55
+	}
+	@scale = 1.55
+	%maxTemp = 1200
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@mass = 5.0
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!MODULE[ModuleGimbal]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 6150
+		basemass = -1
+		TANK
+		{
+			name = MMH
+			amount = 1745
+			maxAmount = 3052.5
+		}
+		TANK
+		{
+			name = MON3
+			amount = 1750.5
+			maxAmount = 3062
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 40320
+			maxAmount = 40320
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 1.96
+		@maxThrust = 1.96
+		@heatProduction = 100
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = MMH
+			@ratio = 0.4992
+			@DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5008
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 315.5
+			@key,1 = 1 150
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Aerojet R4D-11
+		modded = false
+		CONFIG
+		{
+			name = Aerojet R4D-11
+			minThrust = 1.96
+			maxThrust = 1.96
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4992
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.5008
+			}
+			atmosphereCurve
+			{
+				key = 0 315.5
+				key = 1 150
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = -1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = True
+		IGNITOR_RESOURCE
+		{
+			name = MMH
+			amount = 0.4992
+		}
+		IGNITOR_RESOURCE
+		{
+			name = MON3
+			amount = 0.5008
+		}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.046
+		}
+	}
+}
+
+@PART[ATVpanel]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/ATV/ATVpanel/model
+		scale = 1.55, 1.55, 1.55
+	}
+	@scale = 1.55
+	%maxTemp = 800
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@mass = 0.007
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 1.2
+	}
+}
+
+@PART[ATV_RCS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/ATV/ATV_RCS/model
+		scale = 1.55, 1.55, 1.55
+	}
+	@scale = 1.55
+	%maxTemp = 800
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@mass = 0.013
+	@title = ATV RCS front
+	@description = A pair of EADS Astrium 216N thrusters. Place four units on the front plate of the ATV, facing away from the docking port.
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCSFX
+		@thrusterPower = 0.432
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			ratio = 0.4992
+			name = MMH
+		}
+		PROPELLANT
+		{
+			ratio = 0.5008
+			name = MON3
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 270
+			@key,1 = 1 100
+		}
+	}
+}
+
++PART[RCSBlock]:FOR[RealismOverhaul]
+{
+	@name = ATV_RCS_back
+	%RSSROConfig = True
+	!mesh = DELETE
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Utility/rcsBlockRV-105/model
+		scale = 1.0, 1.0, 1.0
+		rotation = 90, 0, 0
+	}
+	@mass = 0.028
+	@title = ATV RCS aft
+	@description = Intended to represent the ATVs aft RCS thrusters. Place four near the aft end of ATVs sides.
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCSFX
+		@thrusterPower = 0.216
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			ratio = 0.4992
+			name = MMH
+		}
+		PROPELLANT
+		{
+			ratio = 0.5008
+			name = MON3
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 270
+			@key,1 = 1 100
+		}
+	}
+}
+
+@PART[Mir?Docking?Port?Probe]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = BobCatind/Parts/MIR_soviet_dockport_papa/model
+		scale = 1.55, 1.55, 1.55
+		rotation = 0, 90, 0
+	}
+	@scale = 1.55
+	@mass = 0.235
+	%maxTemp = 800
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleDockingNode]
+	{
+		@nodeType = SSVP
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}

--- a/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_Ariane4.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_Ariane4.cfg
@@ -1,0 +1,841 @@
+@PART[Ariane4Stage1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/Stage1/model
+		scale = 1.27, 1.343, 1.27
+	}
+	@node_stack_top = 0.0, 7.43, 0.0, 0, 1, 0, 2
+	@mass = 17.25
+	@maxTemp = 1700
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 205700
+		basemass = -1
+		TANK
+		{
+			name = UH25
+			amount = 104016
+			maxAmount = 104016
+		}
+		TANK
+		{
+			name = NTO
+			amount = 101689
+			maxAmount = 101689
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 3042
+		@maxThrust = 3042
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = UH25
+			@ratio = 0.506
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.494
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 278
+			@key,1 = 1 248
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Viking 5C
+		modded = false
+		CONFIG
+		{
+			name = Viking 5C
+			minThrust = 3042
+			maxThrust = 3042
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.506
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.494
+			}
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 248
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = False
+			IGNITOR_RESOURCE
+		{
+			name = UH25
+			amount = 0.506
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.494
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[Ariane4Stage2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/Stage2/model
+		scale = 1.27, 1.274, 1.27
+	}
+	@node_stack_top = 0.0, 3.153, 0.0, 0, 1, 0, 2
+	@node_stack_bottom = 0.0, -5.164, 0.0, 0, 1, 0, 2
+	@mass = 3.24
+	@maxTemp = 1700
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 31200
+		basemass = -1
+		TANK
+		{
+			name = UH25
+			amount = 15797
+			maxAmount = 15797
+		}
+		TANK
+		{
+			name = NTO
+			amount = 15444
+			maxAmount = 15444
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 807.8
+		@maxThrust = 807.8
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = UH25
+			@ratio = 0.506
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.494
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 292.7
+			@key,1 = 1 200
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Viking 4B+
+		modded = false
+		CONFIG
+		{
+			name = Viking 4B+
+			minThrust = 807.8
+			maxThrust = 807.8
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.506
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.494
+			}
+			atmosphereCurve
+			{
+				key = 0 292.7
+				key = 1 200
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = False
+			IGNITOR_RESOURCE
+		{
+			name = UH25
+			amount = 0.506
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.494
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[Ariane4Stage3]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/Stage3/model
+		scale = 1.27, 1.284, 1.27
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.2, 0.2, 0.2
+		position = 0.0, 0.5, 1.05
+		rotation = 90, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.2, 0.2, 0.2
+		position = 0.0, 0.5, -1.05
+		rotation = 270, 0, 0
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/rcsBlockRV-105/model
+		scale = 0.25, 0.25, 0.25
+		position = 0.0, 0.5, 1.05
+		rotation = 0, 90, 0
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/rcsBlockRV-105/model
+		scale = 0.25, 0.25, 0.25
+		position = 0.0, 0.5, -1.05
+		rotation = 0, 270, 0
+	}
+	@node_stack_fairing1 = 0.0, 10.282, 0.0, 0, 1, 0, 2
+	@node_stack_fairing2 = 0.0, 10.282, 0.0, 0, 1, 0, 2
+	@node_stack_sylda = 0.0, 4.99, 0.0, 0, 1, 0, 2
+	@node_stack_top = 0.0, 2.3, 0.0, 0, 1, 0, 2
+	@node_stack_bottom = 0.0, -6.63, 0.0, 0, 1, 0, 2
+	@title = Ariane 4 H10 III (3rd stage)
+	@description = The cryogenic third stage of the variety used in the majority of Ariane 4 launches. Powered by a HM7B++ engine, and equiped with small attitude control thrusters fueled with gaseous hydrogen (boil-off from the main tank).
+	@mass = 2.15
+	@maxTemp = 1700
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Cryogenic
+		volume = 37200
+		basemass = -1
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 28539
+			maxAmount = 28539
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 8625
+			maxAmount = 8625
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 64.8
+		@maxThrust = 64.8
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.767
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.233
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 445.6
+			@key,1 = 1 310
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = HM7B++
+		modded = false
+		CONFIG
+		{
+			name = HM7B++
+			minThrust = 64.8
+			maxThrust = 64.8
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.767
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.233
+			}
+			atmosphereCurve
+			{
+				key = 0 445.6
+				key = 1 310
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Electric
+		useUllageSimulation = True
+		isPressureFed = False
+			IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 3
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	@MODULE[ModuleCommand]
+	{
+		RESOURCE[ElectricCharge]
+		{
+			rate = 0.06
+		}
+	}
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 1080
+		@maxAmount = 1080
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	MODULE:NEEDS[RemoteTech]
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	%MODULE[ModuleRTAntennaPassive]:NEEDS[RemoteTech]	
+	{
+		%TechRequired = unmannedTech
+		%OmniRange = 300000
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.025
+		}
+	}
+	MODULE
+	{
+		name = ModuleRCSFX
+		thrusterTransformName = RCSthruster
+		resourceFlowMode = STACK_PRIORITY_SEARCH
+		thrusterPower = 0.05
+		PROPELLANT
+		{
+			name = LqdHydrogen
+			ratio = 1
+		}
+		atmosphereCurve
+		{
+			key = 0 250
+			key = 1 50
+		}
+	}
+}
+
+@PART[Ariane4Decoupler1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/Decoupler1/model
+		scale = 1.27, 1.343, 1.27
+	}
+	@node_stack_bottom = 0.0, -0.645, 0.0, 0, 1, 0, 2
+	@node_stack_top = 0.0, 0.645, 0.0, 0, 1, 0, 2
+	@mass = 0.425
+	@MODULE[ModuleEngines]
+	{
+		@heatProduction = 100
+		@exhaustDamage = True
+		@atmosphereCurve
+		{
+			@key,0 = 0 200
+			@key,1 = 1 100
+		}
+	}
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 5
+	}
+}
+
+@PART[Ariane4Decoupler2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/Decoupler2/model
+		scale = 1.27, 1.274, 1.27
+	}
+	@node_stack_bottom = 0.0, -0.489, 0.0, 0, 1, 0, 2
+	@node_stack_top = 0.0, 0.489, 0.0, 0, 1, 0, 2
+	@mass = 0.255
+	@MODULE[ModuleEngines]
+	{
+		@heatProduction = 100
+		@exhaustDamage = True
+		@atmosphereCurve
+		{
+			@key,0 = 0 200
+			@key,1 = 1 100
+		}
+	}
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 5
+	}
+}
+
+@PART[Ariane4Sylda]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/SYLDA/model
+		scale = 1.27, 0.84, 1.27
+	}
+	@mass = 0.458
+	@node_stack_top = 0.0, 3.016, 0.0, 0, 1, 0, 2
+	@node_stack_bottom = 0.0, 2.688, 0.0, 0, 1, 0, 2
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 5
+	}
+}
+
+@PART[Ariane4Fairing]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/Fairing/model
+		scale = 1.27, 1.0, 1.27
+	}
+	@mass = 0.504
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 10
+	}
+}
+
+@PART[Ariane4LiquidBooster]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/LiquidBooster/model
+		scale = 1.24, 1.283, 1.24
+	}
+	@node_stack_top = 0.0, 4.774, 0.0, 0, 1, 0, 2
+	@node_attach = 0.0, 0.0, -0.873, 0, 0, 1
+	@mass = 3.83
+	@maxTemp = 1700
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 34800
+		basemass = -1
+		TANK
+		{
+			name = UH25
+			amount = 17611
+			maxAmount = 17611
+		}
+		TANK
+		{
+			name = NTO
+			amount = 17221
+			maxAmount = 17221
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 749
+		@maxThrust = 749
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = UH25
+			@ratio = 0.506
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.494
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 274
+			@key,1 = 1 245.2
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Viking 6
+		modded = false
+		CONFIG
+		{
+			name = Viking 6
+			minThrust = 749
+			maxThrust = 749
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.506
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.494
+			}
+			atmosphereCurve
+			{
+				key = 0 274
+				key = 1 245.2
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = False
+			IGNITOR_RESOURCE
+		{
+			name = UH25
+			amount = 0.506
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.494
+		}
+	}
+}
+
+@PART[Ariane4NoseCone]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/NoseCone/model
+		scale = 1.24, 1.283, 1.24
+	}
+	@mass = 0.435
+	@maxTemp = 1200
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines]
+	{
+		@heatProduction = 100
+		@exhaustDamage = True
+		@atmosphereCurve
+		{
+			@key,0 = 0 200
+			@key,1 = 1 100
+		}
+	}
+}
+
+@PART[Ariane4Srb]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/SolidBooster/model
+		scale = 1.34, 1.21, 1.34
+	}
+	@node_stack_top = 0.0, 3.872, 0.0, 0, 1, 0, 1
+	@node_attach = 0.0, 0.0, -0.423, 0, 0, 1
+	@mass = 2.86
+	@maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 650
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 263
+			@key,1 = 1 237.2
+		}
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5337.1
+		type = Solid
+		basemass = -1
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = SEP P9.5
+		modded = false
+		CONFIG
+		{
+			name = SEP P9.5
+			maxThrust = 650
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 263
+				key = 1 237.2
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.98796 0.827
+				key = 0.97561 0.848
+				key = 0.96289 0.873
+				key = 0.94975 0.903
+				key = 0.93654 0.907
+				key = 0.92334 0.907
+				key = 0.91013 0.907
+				key = 0.89693 0.907
+				key = 0.88372 0.907
+				key = 0.87046 0.911
+				key = 0.85713 0.915
+				key = 0.8438 0.915
+				key = 0.83047 0.915
+				key = 0.81715 0.915
+				key = 0.80382 0.915
+				key = 0.79049 0.915
+				key = 0.77716 0.915
+				key = 0.76377 0.919
+				key = 0.75026 0.928
+				key = 0.73675 0.928
+				key = 0.72318 0.932
+				key = 0.70961 0.932
+				key = 0.69604 0.932
+				key = 0.68234 0.94
+				key = 0.66865 0.94
+				key = 0.65495 0.94
+				key = 0.6412 0.945
+				key = 0.62732 0.953
+				key = 0.61344 0.953
+				key = 0.59957 0.953
+				key = 0.58569 0.953
+				key = 0.57181 0.953
+				key = 0.55793 0.953
+				key = 0.54406 0.953
+				key = 0.5303 0.945
+				key = 0.51661 0.94
+				key = 0.50291 0.94
+				key = 0.48922 0.94
+				key = 0.47552 0.94
+				key = 0.46183 0.94
+				key = 0.4482 0.936
+				key = 0.43469 0.928
+				key = 0.42117 0.928
+				key = 0.40779 0.919
+				key = 0.3944 0.919
+				key = 0.38107 0.915
+				key = 0.36787 0.907
+				key = 0.35466 0.907
+				key = 0.34164 0.894
+				key = 0.32886 0.877
+				key = 0.31639 0.856
+				key = 0.30416 0.84
+				key = 0.29212 0.827
+				key = 0.28014 0.823
+				key = 0.26822 0.819
+				key = 0.25623 0.823
+				key = 0.24425 0.823
+				key = 0.23208 0.835
+				key = 0.21986 0.84
+				key = 0.20757 0.844
+				key = 0.19528 0.844
+				key = 0.18299 0.844
+				key = 0.17071 0.844
+				key = 0.15842 0.844
+				key = 0.14613 0.844
+				key = 0.1339 0.84
+				key = 0.12174 0.835
+				key = 0.10963 0.831
+				key = 0.09771 0.819
+				key = 0.08603 0.802
+				key = 0.07472 0.777
+				key = 0.06384 0.747
+				key = 0.05333 0.722
+				key = 0.04312 0.701
+				key = 0.03309 0.689
+				key = 0.02319 0.68
+				key = 0.01347 0.668
+				key = 0.00387 0.659
+			}
+		}
+	}
+}
+
+@PART[Ariane4NoseCone2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/NoseCone2/model
+		scale = 1.34, 1.21, 1.34
+	}
+	@mass = 0.075
+	@maxTemp = 1200
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines]
+	{
+		@heatProduction = 100
+		@exhaustDamage = True
+		@atmosphereCurve
+		{
+			@key,0 = 0 200
+			@key,1 = 1 100
+		}
+	}
+}
+
+@PART[Ariane4RadialDecoupler]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 4/RadialDecoupler/model
+		scale = 1.27, 1.27, 1.27
+	}
+	@mass = 0.1
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 10
+	}
+}

--- a/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_Ariane5.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_Ariane5.cfg
@@ -1,0 +1,613 @@
+@PART[Ariane5_tank]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 9.05
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Cryogenic
+		volume = 474000
+		basemass = -1
+		TANK
+		{
+			name = LqdOxygen
+			amount = 130266
+			maxAmount = 130266
+		}
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 343910
+			maxAmount = 343910
+		}
+	}
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 10
+	}
+}
+
+@PART[Ariane5_engine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	%mass = 3.15
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines*]
+	{
+		%maxThrust = 1359
+		%minThrust = 1359
+		%heatProduction = 100
+		@atmosphereCurve
+		{
+			@key,0 = 0 429
+			@key,1 = 1 310
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.725
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.275
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6.0
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!MODULE[ModuleJettison]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		origMass = 3.15
+		configuration = LqdHydrogen+LqdOxygen
+		modded = false
+		CONFIG
+		{
+			name = LqdHydrogen+LqdOxygen
+			maxThrust = 1359
+			minThrust = 1359
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.725
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.275
+			}
+			atmosphereCurve
+			{
+				key = 0 429
+				key = 1 310
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Electric
+		useUllageSimulation = True
+		isPressureFed = false
+		IGNITOR_RESOURCE
+		{
+			name = LqdHydrogen
+			amount = 0.725
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.275
+		}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+	}
+}
+
+@PART[Ariane5_EPS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Ariane 5/EPS/model
+		scale = 1.0, 1.0, 1.0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.2, 0.2, 0.2
+		position = 0.0, -0.4, -2.71
+		rotation = 270, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.2, 0.2, 0.2
+		position = 0.0, -0.4, 2.71
+		rotation = 90, 0, 0
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/rcsBlockRV-105/model
+		scale = 0.25, 0.25, 0.25
+		position = 0.0, -0.4, -2.7
+		rotation = 0, 270, 0
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/rcsBlockRV-105/model
+		scale = 0.25, 0.25, 0.25
+		position = 0.0, -0.4, 2.7
+		rotation = 0, 90, 0
+	}
+	@rescaleFactor = 1
+	@mass = 2.7
+	@maxTemp = 1700
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleCommand]
+	{
+		RESOURCE
+		{
+		name = ElectricCharge
+		rate = 0.04
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	MODULE:NEEDS[RemoteTech]
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	%MODULE[ModuleRTAntennaPassive]:NEEDS[RemoteTech]	
+	{
+		%TechRequired = unmannedTech
+		%OmniRange = 300000
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.025
+		}
+	}
+	MODULE
+	{
+		name = ModuleRCSFX
+		thrusterTransformName = RCSthruster
+		resourceFlowMode = STACK_PRIORITY_SEARCH
+		thrusterPower = 0.4
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 1
+		}
+		atmosphereCurve
+		{
+			key = 0 224
+			key = 1 100
+		}
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 8500
+		basemass = -1
+		TANK
+		{
+			name = MMH
+			amount = 3864.3
+			maxAmount = 3864.3
+		}
+		TANK
+		{
+			name = NTO
+			amount = 4381.7
+			maxAmount = 4381.7
+		}
+		TANK
+		{
+			name = Hydrazine
+			amount = 106
+			maxAmount = 212
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 864
+			maxAmount = 864
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 29.6
+		@maxThrust = 29.6
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = MMH
+			@ratio = 0.469
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.531
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 324
+			@key,1 = 1 113
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Aestus+
+		modded = false
+		CONFIG
+		{
+			name = Aestus+
+			minThrust = 29.6
+			maxThrust = 29.6
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.469
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.531
+			}
+			atmosphereCurve
+			{
+				key = 0 324
+				key = 1 113
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 20
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = True
+			IGNITOR_RESOURCE
+		{
+			name = MMH
+			amount = 0.506
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.494
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 9.5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleJettison]
+	{
+	}
+}
+
+@PART[Ariane5_EAP]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 35
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@title = EADS Astrium EAP MPS-241A
+	@description = Ariane 5's solid booster
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0
+		@maxThrust = 7080
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 278
+			@key,1 = 1 253
+		}
+	}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalRange = 7.3
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 135182.6
+		type = Solid
+		basemass = -1
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = SolidFuel
+		modded = false
+		CONFIG
+		{
+			name = SolidFuel
+			maxThrust = 7080
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 253
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99013 0.944
+				key = 0.98028 0.941
+				key = 0.97034 0.95
+				key = 0.9603 0.96
+				key = 0.95018 0.968
+				key = 0.93997 0.976
+				key = 0.92961 0.99
+				key = 0.91917 0.998
+				key = 0.90871 1
+				key = 0.89825 1
+				key = 0.88779 1
+				key = 0.87736 0.997
+				key = 0.86697 0.994
+				key = 0.85661 0.99
+				key = 0.84632 0.984
+				key = 0.8361 0.978
+				key = 0.82595 0.97
+				key = 0.8159 0.962
+				key = 0.80592 0.954
+				key = 0.7961 0.939
+				key = 0.78641 0.927
+				key = 0.77678 0.92
+				key = 0.76731 0.906
+				key = 0.75808 0.882
+				key = 0.7493 0.84
+				key = 0.74079 0.813
+				key = 0.7326 0.783
+				key = 0.72462 0.764
+				key = 0.71678 0.749
+				key = 0.70906 0.738
+				key = 0.70144 0.729
+				key = 0.69389 0.722
+				key = 0.68638 0.717
+				key = 0.67895 0.711
+				key = 0.67156 0.706
+				key = 0.66421 0.703
+				key = 0.6569 0.698
+				key = 0.64964 0.695
+				key = 0.6424 0.692
+				key = 0.63518 0.69
+				key = 0.62798 0.689
+				key = 0.62076 0.69
+				key = 0.61347 0.697
+				key = 0.60614 0.701
+				key = 0.59877 0.705
+				key = 0.59132 0.713
+				key = 0.58381 0.717
+				key = 0.57623 0.725
+				key = 0.56857 0.732
+				key = 0.56089 0.735
+				key = 0.55313 0.741
+				key = 0.54531 0.748
+				key = 0.53743 0.754
+				key = 0.52949 0.759
+				key = 0.52148 0.765
+				key = 0.51343 0.77
+				key = 0.50529 0.778
+				key = 0.4971 0.783
+				key = 0.48887 0.788
+				key = 0.4806 0.791
+				key = 0.47234 0.789
+				key = 0.46425 0.773
+				key = 0.4562 0.77
+				key = 0.44815 0.77
+				key = 0.44009 0.77
+				key = 0.432 0.773
+				key = 0.42388 0.776
+				key = 0.41573 0.78
+				key = 0.40756 0.781
+				key = 0.39935 0.784
+				key = 0.39112 0.788
+				key = 0.38284 0.791
+				key = 0.37454 0.794
+				key = 0.36618 0.799
+				key = 0.3578 0.802
+				key = 0.34937 0.805
+				key = 0.34092 0.808
+				key = 0.33243 0.812
+				key = 0.32391 0.815
+				key = 0.31535 0.818
+				key = 0.30678 0.82
+				key = 0.29816 0.824
+				key = 0.28952 0.826
+				key = 0.28087 0.828
+				key = 0.27219 0.829
+				key = 0.26349 0.832
+				key = 0.25477 0.834
+				key = 0.24601 0.837
+				key = 0.23724 0.839
+				key = 0.22845 0.84
+				key = 0.21964 0.842
+				key = 0.21082 0.844
+				key = 0.20198 0.845
+				key = 0.19313 0.847
+				key = 0.18426 0.848
+				key = 0.17537 0.85
+				key = 0.16648 0.85
+				key = 0.15757 0.851
+				key = 0.14866 0.851
+				key = 0.13976 0.851
+				key = 0.13085 0.851
+				key = 0.12193 0.853
+				key = 0.11301 0.853
+				key = 0.10409 0.853
+				key = 0.0953 0.84
+				key = 0.08688 0.805
+				key = 0.07882 0.77
+				key = 0.07122 0.727
+				key = 0.06402 0.689
+				key = 0.05746 0.626
+				key = 0.05105 0.614
+				key = 0.04496 0.582
+				key = 0.0393 0.542
+				key = 0.034 0.507
+				key = 0.02924 0.455
+				key = 0.02482 0.422
+				key = 0.02078 0.387
+				key = 0.0173 0.333
+				key = 0.01452 0.265
+				key = 0.01206 0.235
+				key = 0.0099 0.206
+				key = 0.00811 0.171
+				key = 0.00661 0.144
+				key = 0.0053 0.125
+				key = 0.00409 0.115
+				key = 0.003 0.104
+				key = 0.00196 0.099
+				key = 0.00097 0.095
+				key = 0 0.093
+			}
+		}
+	}
+}
+
+@PART[Ariane5_NoseCone]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 0.7
+	@maxTemp = 1200
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines]
+	{
+		@heatProduction = 100
+		@exhaustDamage = True
+		@atmosphereCurve
+		{
+			@key,0 = 0 200
+			@key,1 = 1 100
+		}
+	}
+}
+
+@PART[Ariane5_FairingSmall]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 1.015
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 200
+	}
+}
+
+@PART[Ariane5_FairingBig]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 1.3
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 200
+	}
+}
+
+@PART[Ariane5_RadialDecoupler]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 0.26
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 40
+	}
+}
+
+@PART[DecouplerSylda]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 0.1
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 2
+	}
+}
+
+@PART[Sylda]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1
+	@mass = 0.538
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 5
+	}
+}

--- a/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_Diamant_Europa.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/ESA_Diamant_Europa.cfg
@@ -1,0 +1,976 @@
+@PART[Diamant_Stage1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Diamant/Stage1/model
+		scale = 1.255, 1.313, 1.255
+	}
+	@node_stack_top = 0.0, 3.403, 0.0, 0, 1, 0, 2
+	@title = Diamant A 1st stage "Emeraude"
+	@description = First stage of the Diamant A rocket, powered by an LRBA Vexin engine.
+	@mass = 1.95
+	@maxTemp = 1700
+	@stagingIcon = LIQUID_ENGINE
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 9900
+		basemass = -1
+		TANK
+		{
+			name = Turpentine
+			amount = 3395.4
+			maxAmount = 3395.4
+		}
+		TANK
+		{
+			name = IWFNA
+			amount = 6407.5
+			maxAmount = 6407.5
+		}
+		TANK
+		{
+			name = Furfuryl
+			amount = 100.4
+			maxAmount = 100.4
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 301.6
+		@maxThrust = 301.6
+		@heatProduction = 100
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@allowShutdown = True
+		@PROPELLANT[SolidFuel]
+		{
+			@name = Turpentine
+			@ratio = 0.3464
+			@DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = IWFNA
+			ratio = 0.6536
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 233
+			@key,1 = 1 205
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = LRBA Vexin
+		modded = false
+		CONFIG
+		{
+			name = LRBA Vexin
+			minThrust = 301.6
+			maxThrust = 301.6
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Turpentine
+				ratio = 0.3464
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.6536
+			}
+			atmosphereCurve
+			{
+				key = 0 233
+				key = 1 205
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = True
+		IGNITOR_RESOURCE
+		{
+			name = Furfuryl
+			amount = 100.4
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[Diamant_Stage2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Diamant/Stage2/model
+		scale = 1.255, 1.210, 1.255
+	}
+	@node_stack_top = 0.0, 2.217, 0.0, 0, 1, 0, 2
+	@node_stack_bottom = 0.0, -2.174, 0.0, 0, 1, 0, 2
+	@title = Diamant A/B 2nd stage "Topaze"
+	@description = The second stage of the Diamant rocket, and simultaneously the first stage of the Topaze sounding rocket. For complete realism add some small solid rockets at the top of this stage to spin stabilize the rocket before firing the third stage.
+	@mass = 0.655
+	@maxTemp = 1700
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 120.1
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 255
+			@key,1 = 1 225
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 4
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1278.1
+		type = Solid
+		basemass = -1
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = SEP P2.2
+		modded = false
+		CONFIG
+		{
+			name = SEP P2.2
+			maxThrust = 120.1
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 255
+				key = 1 225
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.98796 0.827
+				key = 0.97561 0.848
+				key = 0.96289 0.873
+				key = 0.94975 0.903
+				key = 0.93654 0.907
+				key = 0.92334 0.907
+				key = 0.91013 0.907
+				key = 0.89693 0.907
+				key = 0.88372 0.907
+				key = 0.87046 0.911
+				key = 0.85713 0.915
+				key = 0.8438 0.915
+				key = 0.83047 0.915
+				key = 0.81715 0.915
+				key = 0.80382 0.915
+				key = 0.79049 0.915
+				key = 0.77716 0.915
+				key = 0.76377 0.919
+				key = 0.75026 0.928
+				key = 0.73675 0.928
+				key = 0.72318 0.932
+				key = 0.70961 0.932
+				key = 0.69604 0.932
+				key = 0.68234 0.94
+				key = 0.66865 0.94
+				key = 0.65495 0.94
+				key = 0.6412 0.945
+				key = 0.62732 0.953
+				key = 0.61344 0.953
+				key = 0.59957 0.953
+				key = 0.58569 0.953
+				key = 0.57181 0.953
+				key = 0.55793 0.953
+				key = 0.54406 0.953
+				key = 0.5303 0.945
+				key = 0.51661 0.94
+				key = 0.50291 0.94
+				key = 0.48922 0.94
+				key = 0.47552 0.94
+				key = 0.46183 0.94
+				key = 0.4482 0.936
+				key = 0.43469 0.928
+				key = 0.42117 0.928
+				key = 0.40779 0.919
+				key = 0.3944 0.919
+				key = 0.38107 0.915
+				key = 0.36787 0.907
+				key = 0.35466 0.907
+				key = 0.34164 0.894
+				key = 0.32886 0.877
+				key = 0.31639 0.856
+				key = 0.30416 0.84
+				key = 0.29212 0.827
+				key = 0.28014 0.823
+				key = 0.26822 0.819
+				key = 0.25623 0.823
+				key = 0.24425 0.823
+				key = 0.23208 0.835
+				key = 0.21986 0.84
+				key = 0.20757 0.844
+				key = 0.19528 0.844
+				key = 0.18299 0.844
+				key = 0.17071 0.844
+				key = 0.15842 0.844
+				key = 0.14613 0.844
+				key = 0.1339 0.84
+				key = 0.12174 0.835
+				key = 0.10963 0.831
+				key = 0.09771 0.819
+				key = 0.08603 0.802
+				key = 0.07472 0.777
+				key = 0.06384 0.747
+				key = 0.05333 0.722
+				key = 0.04312 0.701
+				key = 0.03309 0.689
+				key = 0.02319 0.68
+				key = 0.01347 0.668
+				key = 0.00387 0.659
+			}
+		}
+	}
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 1
+	}	
+}
+
+@PART[Diamant_Stage3]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Diamant/Stage3/model
+		scale = 1.255, 1.088, 1.255
+	}
+	@mass = 0.095
+	@maxTemp = 1700
+	@node_stack_top = 0.0, 2.312, 0.0, 0, 1, 0, 2
+	@node_stack_top2 = 0.0, 2.312, 0.0, 0, 1, 0, 2
+	@node_stack_payload = 0.0, 0.4765, 0.0, 0, 1, 0, 1
+	@node_stack_bottom = 0.0, -0.9716, 0.0, 0, 1, 0, 2
+	!RESOURCE[SolidFuel]
+	{
+	}
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 38.2
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 273
+			@key,1 = 1 160
+		}
+	}
+	!MODULE[ModuleGimbal]
+	{
+	}
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 1
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 360.1
+		type = Solid
+		basemass = -1
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = SEP P0.6
+		modded = false
+		CONFIG
+		{
+			name = SEP P0.6
+			maxThrust = 38.2
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 273
+				key = 1 160
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.98796 0.827
+				key = 0.97561 0.848
+				key = 0.96289 0.873
+				key = 0.94975 0.903
+				key = 0.93654 0.907
+				key = 0.92334 0.907
+				key = 0.91013 0.907
+				key = 0.89693 0.907
+				key = 0.88372 0.907
+				key = 0.87046 0.911
+				key = 0.85713 0.915
+				key = 0.8438 0.915
+				key = 0.83047 0.915
+				key = 0.81715 0.915
+				key = 0.80382 0.915
+				key = 0.79049 0.915
+				key = 0.77716 0.915
+				key = 0.76377 0.919
+				key = 0.75026 0.928
+				key = 0.73675 0.928
+				key = 0.72318 0.932
+				key = 0.70961 0.932
+				key = 0.69604 0.932
+				key = 0.68234 0.94
+				key = 0.66865 0.94
+				key = 0.65495 0.94
+				key = 0.6412 0.945
+				key = 0.62732 0.953
+				key = 0.61344 0.953
+				key = 0.59957 0.953
+				key = 0.58569 0.953
+				key = 0.57181 0.953
+				key = 0.55793 0.953
+				key = 0.54406 0.953
+				key = 0.5303 0.945
+				key = 0.51661 0.94
+				key = 0.50291 0.94
+				key = 0.48922 0.94
+				key = 0.47552 0.94
+				key = 0.46183 0.94
+				key = 0.4482 0.936
+				key = 0.43469 0.928
+				key = 0.42117 0.928
+				key = 0.40779 0.919
+				key = 0.3944 0.919
+				key = 0.38107 0.915
+				key = 0.36787 0.907
+				key = 0.35466 0.907
+				key = 0.34164 0.894
+				key = 0.32886 0.877
+				key = 0.31639 0.856
+				key = 0.30416 0.84
+				key = 0.29212 0.827
+				key = 0.28014 0.823
+				key = 0.26822 0.819
+				key = 0.25623 0.823
+				key = 0.24425 0.823
+				key = 0.23208 0.835
+				key = 0.21986 0.84
+				key = 0.20757 0.844
+				key = 0.19528 0.844
+				key = 0.18299 0.844
+				key = 0.17071 0.844
+				key = 0.15842 0.844
+				key = 0.14613 0.844
+				key = 0.1339 0.84
+				key = 0.12174 0.835
+				key = 0.10963 0.831
+				key = 0.09771 0.819
+				key = 0.08603 0.802
+				key = 0.07472 0.777
+				key = 0.06384 0.747
+				key = 0.05333 0.722
+				key = 0.04312 0.701
+				key = 0.03309 0.689
+				key = 0.02319 0.68
+				key = 0.01347 0.668
+				key = 0.00387 0.659
+			}
+		}
+	}
+}
+
+@PART[DiamantFairing]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Diamant/Fairing/model
+		scale = 1.255, 1.352, 1.255
+	}
+	@node_stack_top = 0.0, 0.911, 0.0, 0, 1, 0, 2
+	@mass = 0.025
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 1
+	}
+}
+
+@PART[DecouplerDiamant]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Diamant/Decoupler/model
+		scale = 0.314, 0.314, 0.314
+	}
+	@rescaleFactor = 1
+	@node_stack_top = 0.0, 0.102, 0.0, 0, 1, 0, 1
+	@node_stack_bottom = 0.0, -0.096, 0.0, 0, 1, 0, 1
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 1
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	!MODULE[ModuleSAS]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+}
+
+@PART[DiamantAsterix]:FOR[RealismOverhaul]
+{
+	@module = Part
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Diamant/Asterix/model
+		scale = 1.1, 1.1, 1.1
+	}
+	%title = A-1 "Asterix"
+	@subcategory = 0
+	@description = The first French satellite in orbit.
+	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 0
+	@mass = 0.042
+	!stagingIcon = DELETE
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	@MODULE[ModuleCommand]
+	{
+		RESOURCE
+		{
+		name = ElectricCharge
+		rate = 0.001
+		}
+	}
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 1000
+		@maxAmount = 1000
+	}
+}
+
+@PART[DiamantAsterix]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+        MODULE
+        {
+		name = ModuleRTAntenna
+		IsRTActive = true
+           Mode0OmniRange = 0
+           Mode1OmniRange = 1000000
+           EnergyCost = 0.0015
+           TRANSMITTER
+           {
+                PacketInterval = 0.4
+                PacketSize = 0.29
+                PacketResourceCost = 0.0075
+           }
+        }
+	MODULE
+	{
+		name = ModuleSPU
+	}
+	%MODULE[ModuleRTAntennaPassive]	
+	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.01
+		}
+	}
+}
+
+@PART[EuropaStage1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Europa 1/Stage1/model
+		scale = 1.25, 1.28, 1.25
+	}
+	@node_stack_top = 0.0, 7.78, 0.0, 0, 1, 0, 2
+	@description = The first stage of the Europa launcher, derived from the cancelled British "Blue Streak" missile. Powered by two Rolls-Royce RZ.2 engines.
+	@mass = 6.697
+	@maxTemp = 1800
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Balloon
+		volume = 81060
+		basemass = -1
+		TANK
+		{
+			name = Kerosene
+			amount = 31406
+			maxAmount = 31406
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 49655
+			maxAmount = 49655
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 1672
+		@maxThrust = 1672
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.3874
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			ratio = 0.6126
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 282
+			@key,1 = 1 248
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Rolls-Royce RZ.2
+		modded = false
+		CONFIG
+		{
+			name = Rolls-Royce RZ.2
+			minThrust = 1672
+			maxThrust = 1672
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3874
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6126
+			}
+			atmosphereCurve
+			{
+				key = 0 282
+				key = 1 248
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Electric
+		useUllageSimulation = true
+		isPressureFed = false
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 0.384
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.616
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 1
+		}
+	}
+	RESOURCE
+	{
+		name = TEATEB
+		amount = 1
+		maxAmount = 1
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 7
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[EuropaStage2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Europa 1/Stage2/model
+		scale = 1.25, 1.1, 1.25
+	}
+	@node_stack_top = 0.0, 2.605, 0.0, 0, 1, 0, 2
+	@node_stack_bottom = 0.0, -1.619, 0.0, 0, 1, 0, 2
+	@description = The second stage of the Europa launcher, derived from the French Diamant rocket. Powered by four LRBA Vexin A engines.
+	@mass = 1.899
+	@maxTemp = 1800
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+		MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 8710
+		basemass = -1
+		TANK
+		{
+			name = UDMH
+			amount = 4298.3
+			maxAmount = 4298.3
+		}
+		TANK
+		{
+			name = NTO
+			amount = 4413.8
+			maxAmount = 4413.8
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 274.6
+		@maxThrust = 274.6
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = UDMH
+			@ratio = 0.493
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.507
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 277
+			@key,1 = 1 240
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = LRBA Vexin A
+		modded = false
+		CONFIG
+		{
+			name = LRBA Vexin A
+			minThrust = 274.6
+			maxThrust = 274.6
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.493
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.507
+			}
+			atmosphereCurve
+			{
+				key = 0 277
+				key = 1 240
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = True
+			IGNITOR_RESOURCE
+		{
+			name = UDMH
+			amount = 0.493
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.507
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[EuropaStage3]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Europa 1/Stage3/model
+		scale = 1.25, 1.12, 1.25
+	}
+	@node_stack_top = 0.0, 4.881, 0.0, 0, 1, 0, 2
+	@node_stack_top2 = 0.0, 4.881, 0.0, 0, 1, 0, 2
+	@node_stack_payload = 0.0, 1.567, 0.0, 0, 1, 0, 1
+	@node_stack_bottom = 0.0, -1.3, 0.0, 0, 1, 0, 2
+	@description = The third stage of the Europa launcher, developed by West Germany. Powered by the Astris engine.
+	@mass = 0.61
+	@maxTemp = 1800
+	!RESOURCE[LiquidFuel]
+	{
+	}
+	!RESOURCE[Oxidizer]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!MODULE[ModuleCommand]
+	{
+	}
+	!CrewCapacity = DELETE
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 2320
+		basemass = -1
+		TANK
+		{
+			name = Aerozine50
+			amount = 1100
+			maxAmount = 1100
+		}
+		TANK
+		{
+			name = NTO
+			amount = 1220
+			maxAmount = 1220
+		}
+	}
+	@MODULE[ModuleEngines]
+	{
+		@minThrust = 23.33
+		@maxThrust = 23.33
+		@heatProduction = 100
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@allowShutdown = True
+		@PROPELLANT[LiqidFuel]
+		{
+			@name = Aerozine50
+			@ratio = 0.474
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.526
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 300
+			@key,1 = 1 260
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Astris
+		modded = false
+		CONFIG
+		{
+			name = Astris
+			minThrust = 23.33
+			maxThrust = 23.33
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.474
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.526
+			}
+			atmosphereCurve
+			{
+				key = 0 300
+				key = 1 260
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 3
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = True
+		IGNITOR_RESOURCE
+		{
+			name = Aerozine50
+			amount = 0.474
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.526
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[EuropaDecoupler1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Europa 1/Decoupler1/model
+		scale = 1.25, 1.25, 1.25
+	}
+	@node_stack_bottom = 0.0, -0.15, 0.0, 0, 1, 0, 2
+	@node_stack_top = 0.0, 0.15, 0.0, 0, 1, 0, 2
+	@mass = 0.3
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 1
+	}
+}
+
+@PART[EuropaDecoupler2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Europa 1/Decoupler2/model
+		scale = 1.25, 1.25, 1.25
+	}
+	@node_stack_bottom = 0.0, -0.1, 0.0, 0, 1, 0, 2
+	@node_stack_top = 0.0, 0.1, 0.0, 0, 1, 0, 2
+	@mass = 0.2
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 1
+	}
+}
+
+@PART[EuropaFairing]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = Lionhead_Aerospace_Inc/Europa 1/Fairing/model
+		scale = 1.25, 1.34, 1.25
+	}
+	@mass = 0.154
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 10
+	}
+}
+

--- a/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_RealFuels_Turpentine.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_RealFuels_Turpentine.cfg
@@ -1,0 +1,23 @@
+RESOURCE_DEFINITION
+{
+  name = Turpentine
+  density = 0.00087
+  unitCost = 0.0003
+  flowMode = STACK_PRIORITY_SEARCH
+  transfer = PUMP
+  isTweakable = True
+}
+
+@TANK_DEFINITION[ServiceModule] 
+{ 
+	TANK 
+	{ 
+		name = Turpentine
+		mass = 0.000078
+    		utilization = 1
+    		fillable = True
+    		amount = 0.0
+    		maxAmount = 0.0
+    		note = (pressurized) 
+	}
+}


### PR DESCRIPTION
as we discussed, for now it's Ariane 4, Ariane 5, Diamant, and Europa 1. A minor bug in one of the other configs slowed me down, so ATV should be ready tomorrow.