### PR TITLE
fix for MM 2.5.9, tweak for changine RC sizes

### DIFF
--- a/RealismOverhaul/RO_RecommendedMods/RO_RealChute.cfg
+++ b/RealismOverhaul/RO_RecommendedMods/RO_RealChute.cfg
@@ -1,16 +1,11 @@
 @PART[RC_cone]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[ProceduralChute]
+	@MODULE[ProceduralChute]
 	{
-	}
-	MODULE
-	{
-		name = ProceduralChute
-		textureLibrary = RealChute
-		type = Cone
-		currentCase = Main
-		currentCanopies = Main chute
+        !SIZE,*
+        {
+        }
 		SIZE
 		{
 			size = 0.4, 0.4, 0.4
@@ -187,17 +182,11 @@
 @PART[RC_cone_double]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[ProceduralChute]
+	@MODULE[ProceduralChute]
 	{
-	}
-	MODULE
-	{
-		name = ProceduralChute
-		textureLibrary = RealChute
-		type = Cone
-		currentCase = Combo
-		currentCanopies = Main chute, Drogue chute
-		currentTypes = Main, Drogue
+        !SIZE,*
+        {
+        }
 		SIZE
 		{
 			size = 0.4, 0.4, 0.4
@@ -378,16 +367,11 @@
 @PART[RC_stack]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[ProceduralChute]
+	@MODULE[ProceduralChute]
 	{
-	}
-	MODULE
-	{
-		name = ProceduralChute
-		textureLibrary = RealChute
-		type = Stack
-		currentCase = Main
-		currentCanopies = Main chute, Main chute
+        !SIZE,*
+        {
+        }
 		SIZE
 		{
 			size = 0.4, 0.4, 0.4

--- a/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[!MODULE[ModuleEngines*]&!MODULE[ModuleHeatShield]]:BEFORE[RealismOverhaul]
+@PART[*]:HAS[!MODULE[ModuleEngines*],!MODULE[ModuleHeatShield]]:BEFORE[RealismOverhaul]
 {
 	%maxTemp = 800
 	%crashTolerance = 12


### PR DESCRIPTION
- fix for MM 2.5.9 (& to ,)
- apply RealChute sizes dynamically: Instead of deleting MODULE[ProceduralChute] we could just delete the sizes. Then the config doesn't break that quick if RealChute changes something in the Module in later versions