### PR TITLE
added smaller RealChute case sizes

### DIFF
--- a/RealismOverhaul/RO_RecommendedMods/RO_RealChute.cfg
+++ b/RealismOverhaul/RO_RecommendedMods/RO_RealChute.cfg
@@ -6,6 +6,15 @@
         !SIZE,*
         {
         }
+        SIZE
+        {
+            size = 0.24, 0.24, 0.24
+			sizeID = 0.3m
+			caseMass = 0.00288
+			bottomNode = 0, -0.0055308, 0
+			bottomNodeSize = 0
+			cost = 0.24
+        }
 		SIZE
 		{
 			size = 0.4, 0.4, 0.4
@@ -371,6 +380,17 @@
 	{
         !SIZE,*
         {
+        }
+        SIZE
+        {
+            size = 0.24, 0.24, 0.24
+			sizeID = 0.3m
+			caseMass = 0.00288
+            topNode = 0, 0.037056, 0
+			topNodeSize = 0
+			bottomNode = 0, -0.031296, 0
+			bottomNodeSize = 0
+			cost = 0.24
         }
 		SIZE
 		{


### PR DESCRIPTION
0.3m cone and 0.3m stack chute cases, specifically for early RP-0 careers