### PR TITLE
Update RO_FASA_Gemini_Pod.cfg

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -336,19 +336,20 @@
 	{
 		@resourceAmount = .05
 	}
-	@MODULE[ModuleHeatShield]
+	MODULE
 	{
-		@reflective = 0.08
-		@loss
+		name = ModuleHeatShield
+		reflective = 0.08
+		loss
 		{
-			@key,0 = 650 0 0 0
-			@key,1 = 2000 568 0 0
-			@key,2 = 6000 710 0 0
+			key,0 = 650 0 0 0
+			key,1 = 2000 568 0 0
+			key,2 = 6000 710 0 0
 		}
-		@dissipation
+		dissipation
 		{
-			@key,0 = 300 0 0 0
-			@key,1 = 800 140 0 0
+			key,0 = 300 0 0 0
+			key,1 = 800 140 0 0
 		}
 		area = 4.209747371
 		emissiveConst = 0.00036
@@ -356,10 +357,11 @@
 		lossConst = 0.06
 		pyrolysisLoss = 13000
 	}
-	@RESOURCE[AblativeShielding]
+	RESOURCE
 	{
-		@amount = 144
-		@maxAmount = 144
+		name = AblativeShielding
+		amount = 144
+		maxAmount = 144
 	}
 	MODULE
 	{
@@ -467,19 +469,20 @@
 	{
 		@resourceAmount = .05
 	}
-	@MODULE[ModuleHeatShield]
+	MODULE
 	{
-		@reflective = 0.08
-		@loss
+		name = ModuleHeatShield
+		reflective = 0.08
+		loss
 		{
-			@key,0 = 650 0 0 0
-			@key,1 = 2000 568 0 0
-			@key,2 = 6000 710 0 0
+			key,0 = 650 0 0 0
+			key,1 = 2000 568 0 0
+			key,2 = 6000 710 0 0
 		}
-		@dissipation
+		dissipation
 		{
-			@key,0 = 300 0 0 0
-			@key,1 = 800 140 0 0
+			key,0 = 300 0 0 0
+			key,1 = 800 140 0 0
 		}
 		area = 4.209747371
 		emissiveConst = 0.00036
@@ -487,10 +490,11 @@
 		lossConst = 0.06
 		pyrolysisLoss = 13000
 	}
-	@RESOURCE[AblativeShielding]
+	RESOURCE
 	{
-		@amount = 144
-		@maxAmount = 144
+		name = AblativeShielding
+		amount = 144
+		maxAmount = 144
 	}
 	MODULE
 	{


### PR DESCRIPTION
The original FASA (as of 5.20, and the past few revisions) Gemini Pod doesn't have active heat shield code, so this config will actively add and set it.

Tested and confirmed working.