### PR TITLE
Adding a J-2X Config for the FASA J-2 Engine

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -916,6 +916,53 @@
 				key = 1 200
 			}
 		}
+		CONFIG
+		{
+			name = J-2X
+			minThrust = 1072.377
+			maxThrust = 1307.777
+			heatProduction = 100
+			massMult = 1.56609240032
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.745
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.255
+			}
+			atmosphereCurve
+			{
+				key = 0 448
+				key = 1 200
+			}
+			ModuleEngineIgnitor
+			{
+				ignitionsAvailable = 8
+				autoIgnitionTemperature = 800
+				ignitorType = Electric
+				useUllageSimulation = true
+				isPressureFed = false
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.500
+				}
+				IGNITOR_RESOURCE
+				{
+					name = LqdHydrogen
+					amount = 0.745
+				}
+				IGNITOR_RESOURCE
+				{
+					name = LqdOxygen
+					amount = 0.255
+				}
+			}
+		}
 	}
 	MODULE
 	{


### PR DESCRIPTION
I already added a J-2X config for AIES's J-2, so I though I would extend it to FASA's J-2.

I just need to know if the ModuleEngineIgnitor declaration in the J-2X config overrides the one in the ModuleEngineConfigs' declaration. Or if there will be nasty clashes....