### PR TITLE
Additional SRM correction, UA-1207

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_SRBs.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_SRBs.cfg
@@ -689,6 +689,7 @@
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
+		@configuration = UA-1207
 		@CONFIG[UA-1206]
 		{
 			@name = UA-1207


### PR DESCRIPTION
I missed a line in my changes last night, this one will make the UA-1207 configuration the default, such that the thrust curve applies to the part by default.