### PR TITLE
Balance SAS torque costs.

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -180,9 +180,9 @@
 	}
 	@MODULE[ModuleReactionWheel]
 	{
-		@PitchTorque = 0.5
-		@YawTorque = 0.5
-		@RollTorque = 0.5
+		@PitchTorque = 0.1
+		@YawTorque = 0.1
+		@RollTorque = 0.1
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.100


### PR DESCRIPTION
This brings the `sasModule` in line with its counterparts in terms
of torque per EC cost.

Closes #175.