### PR TITLE
Fix TACLS scubbers and purifiers

### DIFF
--- a/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -91,7 +91,7 @@
 	{
 		@conversionRate = 3.0	// # of people - Figures based on per/person
 		@inputResources = IntakeAir, 0.035, ElectricCharge, 0.010
-		@outputResources = Oxygen, 0.0073, true
+		@outputResources = Oxygen, 0.0073, false
 	}
 }
 @PART[TacCarbonExtractor]:FOR[RealismOverhaul]
@@ -111,7 +111,7 @@
 		@converterName = CO2 Scrubber
 		@conversionRate = 3.0	// # of people - Figures based on per/person
 		@inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumPeroxide, 0.0000051872
-		@outputResources = Oxygen, 0.0029240301, true, Waste, 0.0000191062, false
+		@outputResources = Oxygen, 0.0029240301, true, Waste, 0.0000191062, true
 	}
 	!RESOURCE[CarbonDioxide]
 	{
@@ -126,14 +126,14 @@
 +PART[TacCarbonExtractor]:FINAL
 {
 	@name = RO_TACLithiumHydroxide
-	@title = TACLS CO2 Scrubber (LithiumHydroxide)
-	@description = A simple CO2 scrubber using lithium hydroxide. Absorbs CO2, and releases water and lithium carbonate (waste). Requires small electric charge to run air pump. Figure 0.75L of LithiumHydroxide/person/day. Rated for 3 people. Resources for 14days.
+	@title = TACLS CO2 Scrubber (Lithium Hydroxide)
+	@description = A simple CO2 scrubber using lithium hydroxide. Absorbs CO2, and releases water (which needs purification before use) and lithium carbonate (waste). Requires small electric charge to run air pump. Figure 0.75L of LithiumHydroxide/person/day. Rated for 3 people. Resources for 14days.
 	@MODULE[TacGenericConverter]
 	{
 		@converterName = CO2 Scrubber
 		@conversionRate = 3.0	// # of people - Figures based on per/person
 		@inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		@outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
+		@outputResources = WasteWater, 0.0032924498, true, Waste, 0.0000191062, true
 	}
 	@RESOURCE[LithiumPeroxide]
 	{
@@ -145,14 +145,14 @@
 +PART[TacCarbonExtractor]:FINAL
 {
 	@name = RO_TACPotassiumSuperoxide
-	@title = TACLS CO2 Scrubber (PotassiumSuperoxide)
-	@description = A simple CO2 scrubber using potassium superoxide. Absorbs CO2, and releases water and carbon (waste). Requires small electric charge to run air pump. Figure 0.75L of PotassiumSuperoxide/person/day. Rated for 3 people. Resources for 14days.
+	@title = TACLS CO2 Scrubber (Potassium Superoxide)
+	@description = A simple CO2 scrubber using potassium superoxide. Absorbs CO2, and releases water (which needs purification before use) and carbon (waste). Requires small electric charge to run air pump. Figure 0.75L of PotassiumSuperoxide/person/day. Rated for 3 people. Resources for 14days.
 	@MODULE[TacGenericConverter]
 	{
 		@converterName = CO2 Scrubber
 		@conversionRate = 3.0	// # of people - Figures based on per/person
-		@inputResources = CarbonDioxide, 0.0062500000, Water, 0.0000023525, ElectricCharge, 0.010, PotassiumSuperoxide, 0.0000086769
-		@outputResources = Oxygen, 0.0043860452, true, Waste, 0.0000258874, false
+		@inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, PotassiumSuperoxide, 0.0000086769
+		@outputResources = Oxygen, 0.0043860452, true, Waste, 0.0000258874, true, WasteWater, 0.0000023525, true
 	}
 	@RESOURCE[LithiumPeroxide]
 	{
@@ -178,7 +178,7 @@
 		@converterName = Bosch Reactor
 		@conversionRate = 3.0	// # of people - Figures based on per/person
 		@inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 2.5, Hydrogen, 0.0117123855
-		@outputResources = Water, 0.0000094098, true, Waste, 0.0000031058, false
+		@outputResources = WasteWater, 0.0000094098, true, Waste, 0.0000031058, true
 	}
 	!RESOURCE[CarbonDioxide]
 	{
@@ -243,7 +243,7 @@
 	{
 		@conversionRate = 1.0	// # of people - Figures based on per/person
 		@inputResources = WasteWater, 0.0000403538, ElectricCharge, 0.1
-		@outputResources = Water, 0.0000383361, true, Waste, 0.0000020177, false
+		@outputResources = Water, 0.0000383361, false, Waste, 0.0000020177, true
 	}
 	!RESOURCE[WasteWater]
 	{
@@ -264,7 +264,7 @@
 	{
 		@conversionRate = 2.0	// # of people - Figures based on per/person
 		@inputResources = WasteWater, 0.0000403538, ElectricCharge, 0.3
-		@outputResources = Water, 0.0000383361, true, Waste, 0.0000020177, false
+		@outputResources = Water, 0.0000383361, false, Waste, 0.0000020177, true
 	}
 	!RESOURCE[WasteWater]
 	{
@@ -284,6 +284,6 @@
 	{
 		@conversionRate = 2.0	// # of people - Figures based on per/person
 		@inputResources = Water, 0.0000053129, ElectricCharge, 0.5
-		@outputResources = Hydrogen, 0.0066129570, true, Oxygen, 0.0033018868, true
+		@outputResources = Hydrogen, 0.0066129570, true, Oxygen, 0.0033018868, false
 	}
 }


### PR DESCRIPTION
Note that 'true' in output resources means it's okay for that resource
to be thrown away. Reference:

https://github.com/taraniselsu/TacLifeSupport/blob/master/Source/TacGenericConverter.cs#L61-L64

This is backed up by the converters that come with TACLS itself.

This commit fixes the following:

- The air filter will no longer run in a fully oxygenated environment.
- Water splitters will no longer run in a fully oxygenated environment.
- Water purifiers will no longer vent water, but insist on keeping waste.
- CO2 scrubbers no longer fascinated with keeping waste, either.
- CO2 scrubbers produce WasteWater when appropriate, not Water. (Closes #177)
- Potassium superoxide scrubber now produces water, rather than requiring it.
- CO2 scrubbers will continue to run as long as CO2 is available. No
  more kerbonauts dying from CO2 exposure because the wastewater tank
  was full, or the cabin was fully oxygenated.