### PR TITLE
Small fixes to XLR11 and XLR99

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -207,8 +207,8 @@ PART
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 338
-			@key,1 = 1 284
+			@key,0 = 0 225
+			@key,1 = 1 208
 		}
 	}
 	!MODULE[ModuleGimbal]
@@ -242,8 +242,8 @@ PART
 			}
 			atmosphereCurve
 			{
-				key = 0 338
-				key = 1 284
+				key = 0 225
+				key = 1 208
 			}
 		}
 	}
@@ -254,7 +254,7 @@ PART
 		autoIgnitionTemperature = 500
 		ignitorType = Electric
 		useUllageSimulation = true
-		isPressureFed = false
+		isPressureFed = true
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
@@ -337,7 +337,7 @@ PART
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		ignitionsAvailable = 3
+		ignitionsAvailable = 6
 		autoIgnitionTemperature = 500
 		ignitorType = Electric
 		useUllageSimulation = true


### PR DESCRIPTION
I'm still not convinced on the proper Isp for XLR99.  I've seen many different values, some indicating 236, 230, even lower at SL, and that in turn doesn't give me much faith in the Vac ISP especially since almost every source  of the 239-276 values seems to be derived from Nautix.