### PR TITLE
Adding configs for RD-270 and RD-270M

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
@@ -1,0 +1,229 @@
++PART[RD0120]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	@name = RD270
+
+    %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_exhaustLight_blue = 0.0, -2.728, 0.0, 0.0, 0.0, 1.364, running
+    %fx_exhaustLight_blue = 0.0, -2.728, 0.0, 0.0, 0.0, 1.364, running
+    %fx_smokeTrail_light = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_smokeTrail_light = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_smokeTrail_light = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_exhaustSparks_flameout = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, flameout
+    %sound_vent_medium = engage
+    %sound_rocket_hard = running
+    %sound_vent_soft = disengage
+    %sound_explosion_low = flameout
+
+	%RSSROConfig = True
+	%rescaleFactor = 1.364
+	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, 1.0, 0.0, 2
+	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+	!node_attach = DELETE
+	%title = RD-270
+	%manufacturer = NPO Energomash / V.P. Glushko
+	%description = Largest single-chamber engine ever built in the Soviet Union.  Fueled by an N2O4/UDMH mixture combined under some of the highest pressures ever encountered in an ignition chamber.  Never flown but extensively tested.
+	%attachRules = 1,0,1,0,0
+	%mass = 4.47
+	%maxTemp = 1850
+	@MODULE[ModuleEngines*]
+	{
+        @name = ModuleEnginesFX
+		%maxThrust = 6272
+		%minThrust = 6272
+		%heatProduction = 205
+		@atmosphereCurve
+		{
+			@key,0 = 0 322
+			@key,1 = 1 301
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = UDMH
+			@ratio = 0.468
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.532
+		}
+	}
+	!MODULE[ModuleEngineConfigs] { }
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 4.47
+		techLevel = 4
+		origTechLevel = 4
+		maxTechLevel = 4
+		engineType = L
+		configuration = RD-270
+		modded = false
+		CONFIG
+		{
+            name = RD-270
+            minThrust = 6272
+            maxThrust = 6272
+            heatProduction = 205
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.468
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.532
+            }
+            atmosphereCurve
+            {
+                key = 0 322
+                key = 1 301
+            }
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 8
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleAlternator] { }
+	!RESOURCE[ElectricCharge] { }
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 500
+		ignitorType = Electric
+		useUllageSimulation = True
+		isPressureFed = False
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+	}
+	@MODULE[ModuleJettison],*
+	{
+		@bottomNodeName = shroud
+	}
+}
+
++PART[RD0120]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	@name = RD270M
+
+    %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_exhaustLight_blue = 0.0, -2.728, 0.0, 0.0, 0.0, 1.364, running
+    %fx_exhaustLight_blue = 0.0, -2.728, 0.0, 0.0, 0.0, 1.364, running
+    %fx_smokeTrail_light = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_smokeTrail_light = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_smokeTrail_light = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
+    %fx_exhaustSparks_flameout = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, flameout
+    %sound_vent_medium = engage
+    %sound_rocket_hard = running
+    %sound_vent_soft = disengage
+    %sound_explosion_low = flameout
+
+	%RSSROConfig = True
+	%rescaleFactor = 1.364
+	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, 1.0, 0.0, 2
+	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+	!node_attach = DELETE
+	%title = RD-270M
+	%manufacturer = NPO Energomash / V.P. Glushko
+	%description = Modification of the RD-270 to use highly toxic pentaborane as fuel.  Although the M variant boasts higher thrust and isp, the fuel mixture is much, much more toxic than even UDMH.
+	%attachRules = 1,0,1,0,0
+	%mass = 4.47
+	%maxTemp = 1850
+	@MODULE[ModuleEngines*]
+	{
+        @name = ModuleEnginesFX
+		%maxThrust = 7159
+		%minThrust = 7159
+		%heatProduction = 205
+		@atmosphereCurve
+		{
+			@key,0 = 0 365
+			@key,1 = 1 340
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Pentaborane
+			@ratio = 0.468
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.532
+		}
+	}
+	!MODULE[ModuleEngineConfigs] { }
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 4.47
+		techLevel = 4
+		origTechLevel = 4
+		maxTechLevel = 4
+		engineType = L
+		configuration = RD-270M
+		modded = false
+		CONFIG
+		{
+            name = RD-270M
+            minThrust = 7159
+            maxThrust = 7159
+            heatProduction = 225
+            PROPELLANT
+            {
+                name = Pentaborane
+                ratio = 0.468
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.532
+            }
+            atmosphereCurve
+            {
+                key = 0 365
+                key = 1 340
+            }
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 8
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleAlternator] { }
+	!RESOURCE[ElectricCharge] { }
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 500
+		ignitorType = Electric
+		useUllageSimulation = True
+		isPressureFed = False
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+	}
+	@MODULE[ModuleJettison],*
+	{
+		@bottomNodeName = shroud
+	}
+}

--- a/RealismOverhaul/SmokeScreen_EffectCfgs/BobCatSovietEnginesExtras.cfg
+++ b/RealismOverhaul/SmokeScreen_EffectCfgs/BobCatSovietEnginesExtras.cfg
@@ -1,0 +1,359 @@
+@PART[RD270]:FOR[RealPlume] // UDMH/NTO
+{
+    !fx_exhaustFlame_blue = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_exhaustFlame_blue = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_exhaustLight_blue = 0.0, -2, 0.0, 0.0, 0.0, 1.0, running
+    !fx_exhaustLight_blue = 0.0, -2, 0.0, 0.0, 0.0, 1.0, running
+    !fx_smokeTrail_light = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_smokeTrail_light = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_smokeTrail_light = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_exhaustSparks_flameout = 0.0, -2, 0.0, 0.0, 1.0, 0.0, flameout
+    !sound_vent_medium = engage
+    !sound_rocket_hard = running
+    !sound_vent_soft = disengage
+    !sound_explosion_low = flameout
+
+	@MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+		%runningEffectName = extraflame
+		%directThrottleEffectName = powerflame
+    	!fxOffset = 0, 0, 1.9
+    }
+	EFFECTS
+    {
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+                name = flamethrust
+                modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/courierflame
+                transformName = thrustTransform
+                localPosition = 0,0,4.1
+                fixedScale = 2.9
+                fixedEmissions = false
+                sizeClamp = 250
+                randomInitalVelocityOffsetMaxRadius = 0.2
+                logGrow
+                {
+                    density = 1.0 10
+                    density = 0.0 6
+                }
+                logGrowScale
+                {
+                    density = 1.0 0.0
+                    density = 0.46 0.45
+                    density = 0.0 15
+                }
+                linGrow
+                {
+                    density = 1.0 -0.2
+                    density = 0.46 0.14
+                    density = 0.0 1
+                }
+                speed
+                {
+                    density = 1.0 15
+                    density = 0.46 30
+                    density = 0.0 45
+                }
+                emission
+                {
+                    density = 1.0 2.0
+                    density = 0.46 0.9
+                    density = 0.0 0.15
+                }
+                energy
+                {
+                    density = 1.0 0.35
+                    density = 0.005 0.5
+                    density = 0.0 0.85
+                }
+                offset
+                {
+                    density = 1.0 0.55
+                    density = 0.46 0.75
+                    density = 0.0 1.25
+                }
+			}
+			AUDIO
+			{
+                channel = Ship
+                clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+                volume = 0.0 0.0
+                volume = 1.0 1.5
+                pitch = 0.0 1.0
+                pitch = 1.0 1.0
+                loop = true
+			}
+		}
+		extraflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+                name = extraflamethrust
+                modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamenuke
+                transformName = thrustTransform
+                localPosition = 0,0,2.1
+                fixedScale = 6.0
+                fixedEmissions = false
+                sizeClamp = 250
+                randomInitalVelocityOffsetMaxRadius = 0.2
+                logGrow
+                {
+                    density = 1.0 10
+                    density = 0.0 6
+                }
+                logGrowScale
+                {
+                    density = 1.0 0.0
+                    density = 0.46 0.45
+                    density = 0.0 15
+                }
+                linGrow
+                {
+                    density = 1.0 0.2
+                    density = 0.46 0.14
+                    density = 0.0 1
+                }
+                speed
+                {
+                    density = 1.0 5
+                    density = 0.46 12
+                    density = 0.0 45
+                }
+                emission
+                {
+                    density = 1.0 1.0
+                    density = 0.46 0.75
+                    density = 0.0 0.15
+                }
+                energy
+                {
+                    density = 1.0 2.0
+                    density = 0.005 0.9
+                    density = 0.0 1.5
+                }
+                offset
+                {
+                    density = 1.0 0.25
+                    density = 0.46 0.25
+                    density = 0.0 0.25
+                }
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+                channel = Ship
+                clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq8
+                volume = 3.5
+                pitch = 1.0
+                loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+    }
+}
+
+@PART[RD270M]:FOR[RealPlume] // Pentaborane/NTO
+{
+    !fx_exhaustFlame_blue = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_exhaustFlame_blue = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_exhaustLight_blue = 0.0, -2, 0.0, 0.0, 0.0, 1.0, running
+    !fx_exhaustLight_blue = 0.0, -2, 0.0, 0.0, 0.0, 1.0, running
+    !fx_smokeTrail_light = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_smokeTrail_light = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_smokeTrail_light = 0.0, -2, 0.0, 0.0, 1.0, 0.0, running
+    !fx_exhaustSparks_flameout = 0.0, -2, 0.0, 0.0, 1.0, 0.0, flameout
+    !sound_vent_medium = engage
+    !sound_rocket_hard = running
+    !sound_vent_soft = disengage
+    !sound_explosion_low = flameout
+
+	@MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesFX
+		%runningEffectName = extraflame
+		%directThrottleEffectName = powerflame
+    	!fxOffset = 0, 0, 1.9
+    }
+	EFFECTS
+    {
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+                name = flamethrust
+                modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/courierflame
+                transformName = thrustTransform
+                localPosition = 0,0,4.1
+                fixedScale = 2.9
+                fixedEmissions = false
+                sizeClamp = 250
+                randomInitalVelocityOffsetMaxRadius = 0.2
+                logGrow
+                {
+                    density = 1.0 10
+                    density = 0.0 6
+                }
+                logGrowScale
+                {
+                    density = 1.0 0.0
+                    density = 0.46 0.45
+                    density = 0.0 15
+                }
+                linGrow
+                {
+                    density = 1.0 -0.2
+                    density = 0.46 0.14
+                    density = 0.0 1
+                }
+                speed
+                {
+                    density = 1.0 15
+                    density = 0.46 30
+                    density = 0.0 45
+                }
+                emission
+                {
+                    density = 1.0 2.0
+                    density = 0.46 0.9
+                    density = 0.0 0.15
+                }
+                energy
+                {
+                    density = 1.0 0.35
+                    density = 0.005 0.5
+                    density = 0.0 0.85
+                }
+                offset
+                {
+                    density = 1.0 0.55
+                    density = 0.46 0.75
+                    density = 0.0 1.25
+                }
+			}
+			AUDIO
+			{
+                channel = Ship
+                clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+                volume = 0.0 0.0
+                volume = 1.0 1.5
+                pitch = 0.0 1.0
+                pitch = 1.0 1.0
+                loop = true
+			}
+		}
+		extraflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+                name = extraflamethrust
+                modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/fusionflame2
+                transformName = thrustTransform
+                localPosition = 0,0,2.1
+                fixedScale = 6.0
+                fixedEmissions = false
+                sizeClamp = 250
+                randomInitalVelocityOffsetMaxRadius = 0.2
+                logGrow
+                {
+                    density = 1.0 10
+                    density = 0.0 6
+                }
+                logGrowScale
+                {
+                    density = 1.0 0.0
+                    density = 0.46 0.45
+                    density = 0.0 15
+                }
+                linGrow
+                {
+                    density = 1.0 0.2
+                    density = 0.46 0.14
+                    density = 0.0 1
+                }
+                speed
+                {
+                    density = 1.0 5
+                    density = 0.46 12
+                    density = 0.0 45
+                }
+                emission
+                {
+                    density = 1.0 1.0
+                    density = 0.46 0.75
+                    density = 0.0 0.15
+                }
+                energy
+                {
+                    density = 1.0 2.0
+                    density = 0.005 0.9
+                    density = 0.0 1.5
+                }
+                offset
+                {
+                    density = 1.0 0.25
+                    density = 0.46 0.25
+                    density = 0.0 0.25
+                }
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+                channel = Ship
+                clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq8
+                volume = 3.5
+                pitch = 1.0
+                loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+    }
+}


### PR DESCRIPTION
This includes config files for the RD-270 and RD-270M.  The configs generate two engines so that the pentaborane variant can use a green backflame in its SmokeScrren effects.  I have added these configs as additional files because they copy engines that already exist.