### PR TITLE
FASA Bug fix 2

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -292,12 +292,13 @@
 		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000191062, false
 	}
-	MODULE
+	@MODULE[ModuleRCS]
 	{
-		name = ModuleRCSFX
-		thrusterTransformName = RCSthruster
-		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.4136846
+		@name = ModuleRCSFX
+		@thrusterTransformName = RCSthruster
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.4136846
+		!resourceName = DELETE
 		PROPELLANT
 		{
 			name = MMH
@@ -308,10 +309,10 @@
 			name = NTO
 			ratio = 0.544
 		}
-		atmosphereCurve
+		@atmosphereCurve
 		{
-			key = 0 260
-			key = 1 100
+			@key, 0 = 0 260
+			@key, 1 = 1 100
 		}
 	}
 }

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -379,6 +379,7 @@
 		name = ModuleFuelTanks
 		type = ServiceModule
 		volume = 350
+		basemass = -1
 		TANK
 		{
 			name = ElectricCharge
@@ -518,6 +519,7 @@
 		name = ModuleFuelTanks
 		type = ServiceModule
 		volume = 350
+		basemass = -1
 		TANK
 		{
 			name = ElectricCharge
@@ -587,6 +589,7 @@
 	@scale = 1.575
 	@node_stack_top = 0.0, 0.27, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.27, 0.0, 0.0, 1.0, 0.0, 2
+	%fuelCrossFeed = False
 	@title = Gemini Adapter Retrograde Section
 	@description = The Gemini Adapter Retrograde Section. Contains the retrograde engines to de-orbit Gemini. Also houses RCS for translation up/down/left/right/aft. Modelled with the 2 backwards firing thrusters as well. RCS O/F Ratio 1.3:1.
 	@mass = 0.491

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -55,7 +55,7 @@
 	%node_stack_fairing2 = 0.0, 2.527, -3.302, 0.0, 1.0, 0.0, 1
 	%node_stack_fairing3 = 3.302, 2.527, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_fairing4 = -3.302, 2.527, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_connect1 = 0.0, -0.17, 0.0, 0.0, 1.0, 0.0, 3
+	%node_stack_connect1 = 0.0, -0.10, 0.0, 0.0, 1.0, 0.0, 3
 	@category = Structural
 	@stackSymmetry = 3
 	@title = Spacecraft Lunar Module Adapter - Base


### PR DESCRIPTION
Remove some more of the existing FASA/RO issues.

Gemini capsule now retains base mass + fuel mass.

Gemini main engine no longer draws fuel from the re-entry RCS pack.

Final fine tune of the attachment node for the LEM in the LMA. LEM now
fits below the CSM engine and without clipping the S-IVb tank below.