### PR TITLE
Fasa bugs 3

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -693,9 +693,9 @@
 	}
 	MODULE
 	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 4.5
+		%name = ModuleGimbal
+		%gimbalTransformName = thrustTransform
+		%gimbalRange = 4.5
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -198,12 +198,12 @@
 }
 +PART[FASAMercuryAtlasLFTLong]:AFTER[RealismOverhaul]
 {
-	@name = FASAAtlasFMod
+	@name = FASAAtlasSLV3C
 	@MODEL,0
 	{
 		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
-		%scale = 1.219, 0.819, 1.219
-		%position = 0.0, 7.1597, 0.0
+		%scale = 1.219, 2.00, 1.219
+		%position = 0.0, 8.2, 0.0
 	}
 	@MODEL,1
 	{
@@ -211,24 +211,24 @@
 		%scale = 1.219, 1.219, 1.219
 		%position = 0.0, 0.0, 0.0
 	}
-	@node_stack_top = 0.0, 8.2244, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_top = 0.0, 10.7848, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, 1.0, 0.0, 3
 	CoMOffset = 0, 2.0, 0
-	@title = Atlas F-Mod Fuel Tank
-	@description = The fuel tank for the Atlas F-Mod launcher.  Extended fuel tank for larger payloads.
-	@mass = 1.506
+	@title = Atlas SLV-3C Fuel Tank
+	@description = The fuel tank for the Atlas SLV-3C. Historically used with the Centaur D1 to send 1.75T to GTO.  
+	@mass = 4.296
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 99866.6
+		@volume = 110323
 		@TANK[Kerosene]
 		{
-			@amount = 31351.0
-			@maxAmount = 31351.0
+			@amount = 35345
+			@maxAmount = 35345
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 68515.6
-			@maxAmount = 68515.6
+			@amount = 74978
+			@maxAmount = 74978
 		}
 	}
 }

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -234,7 +234,7 @@
 }
 +PART[FASAMercuryAtlasLFTLong]:AFTER[RealismOverhaul]
 {
-	@name = FASAAtlasH
+	@name = FASAAtlasLV3C
 	@MODEL,0
 	{
 		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
@@ -250,21 +250,21 @@
 	@node_stack_top = 0.0, 9.5452, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, 1.0, 0.0, 3
 	CoMOffset = 0, 2.0, 0
-	@title = Atlas H Fuel Tank
-	@description = The fuel tank for the Atlas H launcher.  Extended fuel tank for larger payloads.
+	@title = Atlas LV-3C Fuel Tank
+	@description = The fuel tank for the Atlas LV-3C. Historically used to loft the Centaur D1 into orbit, but has many uses.
 	@mass = 3.726
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 108390.3
+		@volume = 104860
 		@TANK[Kerosene]
 		{
-			@amount = 34621.0
-			@maxAmount = 45621.0
+			@amount = 32918.6
+			@maxAmount = 32918.6
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 73769.3
-			@maxAmount = 73769.3
+			@amount = 71941.4
+			@maxAmount = 71941.4
 		}
 	}
 }

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ClampTower.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ClampTower.cfg
@@ -147,6 +147,7 @@
 	{
 		scale = 1.824, 1.824, 1.824
 	}
+	@scale = 1.824
 	@maxTemp = 5000
 	!MODULE[RefuelingPump]
 	{

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -372,7 +372,7 @@
 	MODULE
 	{
 		name = CoMShifter
-		DescentModeCoM = 0.0, 0.0, 0.05
+		DescentModeCoM = 0.0, 0.0, -0.192
 	}
 	MODULE
 	{

--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
@@ -477,11 +477,10 @@
 	!MODULE[ModuleAlternator]
 	{
 	}
-	MODULE
+	@MODULE[ModuleGimbal]
 	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 6.0
+		%gimbalTransformName = thrustTransform
+		%gimbalRange = 6.0
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}


### PR DESCRIPTION
A number of FASA bug fixes and changes. Includes shifting the Gemini descent CoM to the same side as on the Apollo, adding SLV-3C and LV-3C Atlas tanks, fixed gimballing for the SM and LEM descent engine.