### PR TITLE
Fix AIES antennae RemoteTech configs.

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Antenna.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Antenna.cfg
@@ -1,4 +1,11 @@
-@PART[Antennacomtec1]:FOR[RealismOverhaul] // CommTech - 1 // TECH LEVEL 3 // AIES
+// Alas, AIES_Aerospace runs its pass right at the end (as it doesn't
+// have a .dll), and RemoteTech applies its changes :AFTER[AIES_Aerospace].
+// Even if we did the same, we'd still not get our changes in after RT.
+// So for now, we're doing everything in :FINAL.
+//
+// See #194 as a possible solution.
+
+@PART[Antennacomtec1]:FINAL // CommTech - 1 // TECH LEVEL 3 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.045
@@ -32,7 +39,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Antennacomtec2]:FOR[RealismOverhaul] // CommTech - 2 // TECH LEVEL 4 // AIES
+@PART[Antennacomtec2]:FINAL // CommTech - 2 // TECH LEVEL 4 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.055
@@ -65,7 +72,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Antennaesc]:FOR[RealismOverhaul] // CommTech ESC-EXP // TECH LEVEL 3 // AIES
+@PART[Antennaesc]:FINAL // CommTech ESC-EXP // TECH LEVEL 3 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.022
@@ -96,7 +103,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Antennaexpatvr2]:FOR[RealismOverhaul] // EXP-VR-2T // TECH LEVEL 2 // AIES
+@PART[Antennaexpatvr2]:FINAL // EXP-VR-2T // TECH LEVEL 2 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.025
@@ -127,7 +134,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[AntennaDF2]:FOR[RealismOverhaul] // CommTech DF-RD // TECH LEVEL 3 // AIES
+@PART[AntennaDF2]:FINAL // CommTech DF-RD // TECH LEVEL 3 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.012
@@ -159,7 +166,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishcl1]:FOR[RealismOverhaul] // CommTech CL-1 Dish // TECH LEVEL 2 // AIES
+@PART[Dishcl1]:FINAL // CommTech CL-1 Dish // TECH LEVEL 2 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.035
@@ -193,7 +200,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishmccomu]:FOR[RealismOverhaul] // CommTech CM-60 Dish // TECH LEVEL 6 // AIES
+@PART[Dishmccomu]:FINAL // CommTech CM-60 Dish // TECH LEVEL 6 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.065
@@ -226,7 +233,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishomega2g]:FOR[RealismOverhaul] // CommTech Omega-2G // TECH LEVEL 5 // AIES
+@PART[Dishomega2g]:FINAL // CommTech Omega-2G // TECH LEVEL 5 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.075
@@ -259,7 +266,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishpcf]:FOR[RealismOverhaul] // CommTech PCF-5 Dish // TECH LEVEL 4 // AIES
+@PART[Dishpcf]:FINAL // CommTech PCF-5 Dish // TECH LEVEL 4 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.065
@@ -292,7 +299,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[dishcomlar1]:FOR[RealismOverhaul] // Comlar 1 // TECH LEVEL 5 // AIES
+@PART[dishcomlar1]:FINAL // Comlar 1 // TECH LEVEL 5 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.105

--- a/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Antenna.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Antenna.cfg
@@ -17,6 +17,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -51,6 +54,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -83,6 +89,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -114,6 +123,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -146,6 +158,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -178,6 +193,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -212,6 +230,9 @@
 	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -245,6 +266,9 @@
 	{
 		allowManualControl = false
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -277,6 +301,9 @@
 	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna
@@ -311,6 +338,9 @@
 	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
+        !MODULE[ModuleRTAntenna]
+        {
+        }
 	MODULE
 	{
 		name = ModuleRTAntenna


### PR DESCRIPTION
This PR makes two changes:

- It runs the config passes in `:FINAL`, so they actually apply, rather than being overwritten by RemoteTech's `:AFTER[AIES_Aerospace]` run. (See #194)
- It *removes* the old ModuleRTAntenna before adding its own. Without this, Antennae end up with *two* copies of the module.

Relates to KSP-RO/RP-0#135 and KSP-RO/RP-0#136.

Tested in sandbox mode.