### PR TITLE
Bump the maxTemp on the procedural thrust plate to 1800

### DIFF
--- a/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -29,7 +29,7 @@
 @PART[KzThrustPlate]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@maxTemp = 1200
+	@maxTemp = 1800
 	@MODULE[KzThrustPlateResizer]
 	{
 		%size = 1.0


### PR DESCRIPTION
I'm not sure if the temperature value for this part is based on realism or playability, but it was still exploding for me with 6 x RS-25D's.  1800 seems to fix that problem.