### PR TITLE
Increase LH2 in Service Module Tanks

### DIFF
--- a/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -517,8 +517,8 @@
 		TANK
 		{
 			name = LqdHydrogen
-			amount = 358.52
-			maxAmount = 358.52
+			amount = 580.0
+			maxAmount = 580.0
 		}
 		TANK
 		{


### PR DESCRIPTION
Current amount of LH2 in the Service Module only lasts 8 days, 16 hours; not enough to provide electricity for the duration of most missions to the moon. This update adds enough to last 14 days, putting it in line with the actual duration of missions, as well as the amount of food on the Service Module (which also lasts 14 days).