### PR TITLE
Update RO_BobCat_SovietEngines.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -6,15 +6,16 @@
 	%node_stack_bottom = 0.0, -1.589812, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = SNTK Kuznetsov NK-33
-	%description = Originally built for the N1F rocket, while the rockets were scrapped, the engines survived and are now being refurbished to power new designs, and manufacturing of new engines is starting.
+	%title = NK-33
+	%manufacturer = SNTK Kuznetsov
+	%description = Originally built in the late 1960s/early 1970s for the Soviet N1F rocket. Though the N1F was scrapped, the engines survived. Aerojet aquired several NK-33 engines in the 1990s and refurbished them as AJ26-62 engines for Orbital Science's Antares launch vehicle.
 	%attachRules = 1,0,1,0,0
 	%mass = 1.222
 	%maxTemp = 1700
 	@MODULE[ModuleEngines*]
 	{
-		%minThrust = 941.92
-		%maxThrust = 1682
+		%minThrust = 841
+		%maxThrust = 1766
 		%heatProduction = 100
 		@PROPELLANT[Kerosene]
 		{
@@ -52,12 +53,38 @@
 		name = ModuleEngineConfigs
 		configuration = NK-33
 		modded = false
+		origMass = 1.222
 		CONFIG
 		{
 			name = NK-33
-			minThrust = 941.92
-			maxThrust = 1682
+			maxThrust = 1766
+			minThrust = 841
 			heatProduction = 100
+			massMult = 1
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.332
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.668
+			}
+			atmosphereCurve
+			{
+				key = 0 331
+				key = 1 297
+			}
+		}
+		CONFIG
+		{
+			name = AJ26-62
+			maxThrust = 1815
+			minThrust = 941.92		
+			heatProduction = 100
+			massMult = 1.0106
 			PROPELLANT
 			{
 				name = Kerosene
@@ -114,7 +141,8 @@
 	%node_stack_bottom = 0.0, -2.711397, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = SNTK Kuznetsov NK-43
+	%title = NK-43
+	%manufacturer = SNTK Kuznetsov 
 	%description = Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
 	%attachRules = 1,0,1,0,0
 	%mass = 1.396
@@ -222,7 +250,8 @@
 	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = KB Khimavtomatika RD-0120
+	%title = RD-0120
+	%manufacturer = KB Khimavtomatika
 	%description = Originally designed to power the core stage of the Energia rocket, with similar performance and lower cost of the RS-25 (SSME) the RD-0120 is a powerful cryogenic rocket engine.
 	%attachRules = 1,0,1,0,0
 	%mass = 3.45
@@ -320,7 +349,8 @@
 	%node_stack_bottom = 0.0, -0.785566, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	%category = Propulsion
-	%title = KB Khimavtomatika RD-0110/0124
+	%title = RD-0110/0124
+	%manufacturer = KB Khimavtomatika
 	%description = An upper stage Kerosene/LOx engine designed for new versions of the Soyuz-2 launchers. To also be used with the Angara family of launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 0.451
@@ -453,7 +483,8 @@
 	%node_stack_bottom = 0.0, -1.882533, 0, 0.0, 1.0, 0.0, 1
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = KB Khimavtomatiki RD-0146
+	%title = RD-0146
+	%manufacturer = KB Khimavtomatika
 	%description = A designed based upon the RL-10 series of rocket engines, with a more Russian flavour.
 	%attachRules = 1,0,1,0,0
 	%mass = 0.242
@@ -551,8 +582,9 @@
 	%node_stack_bottom = 0.0, -2.177579, 0, 0.0, 1.0, 0.0, 4
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = NPO Energomash RD-171M
-	%description = The worlds most powerful rocket engine ever built, however it uses one pump to feed 4 chambers. Originally designed for the Energia launcher, powering each of the 4 boosters, it is now used by the Zenit launcher.
+	%title = RD-171M
+	%manufacturer = NPO Energomash
+	%description = The RD-170 is the most powerful liquid rocket engine ever flown. Originally developed for the Energia launcher's boosters, the engine consists of four combustion chambers fed by a single turbopump. A modified version, the RD-171M, is used on the first stage of the Zenit launch vehicle.
 	%attachRules = 1,0,1,0,0
 	%mass = 9.5
 	%maxTemp = 1700
@@ -659,8 +691,9 @@
 	%node_stack_bottom = 0.0, -1.642843, 0, 0.0, 1.0, 0.0, 3
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = NPO Energomash RD-180
-	%description = A follow up to the RD-170/171 series the RD-180 reduces the number of chambers by half. Power the first stage of the Atlas V.
+	%title = RD-180
+	%manufacturer = NPO Energomash
+	%description = The RD-180 is a two-chamber derivative of the four-chamber RD-170/171 and powers the first stage of the Atlas V.
 	%attachRules = 1,0,1,0,0
 	%mass = 5.48
 	%maxTemp = 1700
@@ -733,7 +766,7 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		ignitionsAvailable = 2
+		ignitionsAvailable = 1
 		autoIgnitionTemperature = 700
 		ignitorType = TEATEB
 		useUllageSimulation = True
@@ -768,7 +801,8 @@
 	%node_stack_bottom = 0.0, -1.840061, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	!node_attach = DELETE
-	%title = NPO Energomash RD-191
+	%title = RD-191
+	%manufacturer = NPO Energomash
 	%description = A further continuation of the RD-170/171 series, the RD-191 features a single combustion chamber and nozzle. Powers the Angara family of launchers.
 	%attachRules = 1,0,1,0,0
 	%mass = 3.23


### PR DESCRIPTION
Added AJ26 config for NK-33 and adjusted thrust: the original can throttle from 50%-105% rated (source http://www.lpre.de/sntk/NK-33/index.htm) while the AJ26 can throttle 56%-108% (source http://www.spacelaunchreport.com/taurus2.html & engine mass source http://www.spaceflight101.com/antares-launch-vehicle-information.html)

Broke out manufacturer from title into %manufacturer under the impression this is the preferred format, if not apologies.