### PR TITLE
RS-27A

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -661,7 +661,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -1.332244, 0.0, 0.0, 1.0, 0.0, 2
 	@title = H-1/RS-27 Series Booster [1.0m]
-	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role; the RS-27A has a higher area ratio since it is not ignited until SRB burnout on the Delta II.
+	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is agumented by solid boosters.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.988
 	@maxTemp = 1700


### PR DESCRIPTION
RS-27A is ignited at liftoff on Delta II but GEMs provide majority of thrust until out of lower atmosphere (GEMs on Delta II have no thrust vectoring so RS-27A and vernier engines required for vehicle control)