### PR TITLE
Fixed AJ-10 @PROPELLANT[] nodes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -990,12 +990,12 @@
 		%minThrust = 33.4
 		%maxThrust = 33.4
 		%heatProduction = 100
-		@PROPELLANT[Aerozine50]
+		@PROPELLANT[LiquidFuel]
 		{
 			@name = UDMH
 			@ratio = 0.406
 		}
-		@PROPELLANT[NTO]
+		@PROPELLANT[Oxidizer]
 		{
 			@name = IWFNA
 			@ratio = 0.594


### PR DESCRIPTION
Originally was Aerozine50/NTO, changed to LF/O, since engine was configured
originally for LF/O