### PR TITLE
Squad and KW H-1/RS-27

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -1054,7 +1054,7 @@
 	}
 	%title = H-1/RS-27 Series [2.5m]
 	%manufacturer = Rocketdyne
-	%description = First stage engine for the Delta II vehicle, burning Kerosene and LOX.
+	%description = The H-1 and RS-27 are first stage gas-generator engines burning LOX/kerosene. The H-1 was used on the Saturn I and Saturn IB launchers and was later modified into the RS-27 for use on the Delta rocket family. The H-1, H-1B, and RS-27 are optimized for use as first stage main engines. The RS-27A, used on the Delta III and most Delta II launchers, is optimized for performance at altitude since these rockets used solid boosters to augment thrust at liftoff.
 	@MODEL,0
 	{
 		%scale = 1.25, 1.25, 1.25
@@ -1068,20 +1068,20 @@
 	!node_stack_top2 = DELETE
 	%node_stack_bottom = 0.0, -1.597, 0.0, 0.0, 1.0, 0.0, 2
 	%attachRules = 1,0,1,0,0
-	%mass = 1.7205
+	%mass = 0.907
 	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
 	@MODULE[ModuleEngines*]
 	{
-		%maxThrust = 1037.2
-		%minThrust = 1037.2
+		%maxThrust = 910
+		%minThrust = 910
 		%heatProduction = 100
 		@atmosphereCurve
 		{
-			@key,0 = 0 306.0
-			@key,1 = 1 262.5
+			@key,0 = 0 289
+			@key,1 = 1 255
 		}
 		@PROPELLANT[LiquidFuel]
 		{
@@ -1110,7 +1110,9 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		configuration = H-1B
+		type = ModuleEngines
+		configuration = H-1
+		origMass = 0.907
 		modded = false
 		CONFIG
 		{
@@ -1134,14 +1136,15 @@
 				key = 0 289
 				key = 1 255
 			}
-			massMult = 0.643
+			massMult = 1
 		}
 		CONFIG
 		{
 			name = H-1B
-			minThrust = 1037.2
-			maxThrust = 1037.2
+			minThrust = 1030.2
+			maxThrust = 1030.2
 			heatProduction = 100
+			cost = 300
 			PROPELLANT
 			{
 				name = Kerosene
@@ -1155,10 +1158,11 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 306.0
-				key = 1 262.5
+				key = 0 296
+				key = 1 262
 			}
-			massMult = 1.0
+			techRequired = heavyRocketry
+			massMult = 1.71
 		}
 		CONFIG
 		{
@@ -1183,54 +1187,60 @@
 				key = 0 295
 				key = 1 264
 			}
-			massMult = 1.0395
+			massMult = 1.132
+			techRequired = heavierRocketry
 		}
 		CONFIG
 		{
 			name = RS-27A
 			maxThrust = 1054
 			minThrust = 1054
+			heatProduction = 100
+			cost = 150
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.383
+				ratio = 0.38264
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.617
+				ratio = 0.61736
 			}
 			atmosphereCurve
 			{
 				key = 0 302
 				key = 1 255
 			}
+			techRequired = veryHeavyRocketry
+			massMult = 1.265
 		}
 	}
 	MODULE
 	{
 		name = ModuleEngineIgnitor
 		ignitionsAvailable = 1
-		autoIgnitionTemperature = 700
-		ignitorType = Electric
-		useUllageSimulation = True
-		isPressureFed = False
-		IGNITOR_RESOURCE
-		{
-			name = Kerosene
-			amount = 0.383
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 0.617
-		}
+		autoIgnitionTemperature = 800
+		ignitorType = TEATEB
+		useUllageSimulation = true
+		isPressureFed = false
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
 			amount = 0.5
 		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 1
+		}
+	}
+	RESOURCE
+	{
+		name = TEATEB
+		amount = 1
+		maxAmount = 1
 	}
 }
 // ##########################################################################################	KW Rocketry Hypergolic Service Propulsion System

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -1054,7 +1054,7 @@
 	}
 	%title = H-1/RS-27 Series [2.5m]
 	%manufacturer = Rocketdyne
-	%description = The H-1 and RS-27 are first stage gas-generator engines burning LOX/kerosene. The H-1 was used on the Saturn I and Saturn IB launchers and was later modified into the RS-27 for use on the Delta rocket family. The H-1, H-1B, and RS-27 are optimized for use as first stage main engines. The RS-27A, used on the Delta III and most Delta II launchers, is optimized for performance at altitude since these rockets used solid boosters to augment thrust at liftoff.
+	%description = The H-1 and RS-27 are first stage gas-generator engines burning LOX/kerosene. The H-1 was used on the Saturn I and Saturn IB launchers and was later modified into the RS-27 for use on the Delta rocket family. The H-1 and RS-27 are optimized for use as first stage main engines. The RS-27A, used on the Delta III and most Delta II launchers, is optimized for performance at altitude since these rockets used solid boosters to augment thrust at liftoff.
 	@MODEL,0
 	{
 		%scale = 1.25, 1.25, 1.25
@@ -1068,15 +1068,15 @@
 	!node_stack_top2 = DELETE
 	%node_stack_bottom = 0.0, -1.597, 0.0, 0.0, 1.0, 0.0, 2
 	%attachRules = 1,0,1,0,0
-	%mass = 0.907
+	%mass = 0.635
 	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
 	@MODULE[ModuleEngines*]
 	{
-		%maxThrust = 910
-		%minThrust = 910
+		%maxThrust = 947
+		%minThrust = 947
 		%heatProduction = 100
 		@atmosphereCurve
 		{
@@ -1111,12 +1111,12 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = H-1
+		configuration = H-1-188klbf
 		origMass = 0.907
 		modded = false
 		CONFIG
 		{
-			name = H-1
+			name = H-1-188klbf
 			minThrust = 947
 			maxThrust = 947
 			heatProduction = 100
@@ -1136,11 +1136,11 @@
 				key = 0 289
 				key = 1 255
 			}
-			massMult = 1
+			massMult = 0.700
 		}
 		CONFIG
 		{
-			name = H-1B
+			name = H-1-205klbf
 			minThrust = 1030.2
 			maxThrust = 1030.2
 			heatProduction = 100
@@ -1159,10 +1159,10 @@
 			atmosphereCurve
 			{
 				key = 0 296
-				key = 1 262
+				key = 1 265
 			}
 			techRequired = heavyRocketry
-			massMult = 1.3
+			massMult = 1
 		}
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -1111,12 +1111,12 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = H-1-188klbf
+		configuration =  H-1-SaturnI
 		origMass = 0.907
 		modded = false
 		CONFIG
 		{
-			name = H-1-188klbf
+			name =  H-1-SaturnI
 			minThrust = 947
 			maxThrust = 947
 			heatProduction = 100
@@ -1140,7 +1140,7 @@
 		}
 		CONFIG
 		{
-			name = H-1-205klbf
+			name =  H-1-SaturnIB
 			minThrust = 1030.2
 			maxThrust = 1030.2
 			heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -1162,7 +1162,7 @@
 				key = 1 262
 			}
 			techRequired = heavyRocketry
-			massMult = 1.71
+			massMult = 1.3
 		}
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -661,19 +661,19 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -1.332244, 0.0, 0.0, 1.0, 0.0, 2
 	@title = H-1/RS-27 Series Booster [1.0m]
-	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role; the RS-27A has a higher area ratio since it is not ignited until SRB burnout on the Delta II.
+	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is agumented by solid boosters.
 	@attachRules = 1,0,1,0,0
-	@mass = 0.988
+	@mass = 0.907
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
 	{
-		%maxThrust = 1037.2
-		%minThrust = 1037.2
+		%maxThrust = 947
+		%minThrust = 947
 		%heatProduction = 100
 		@atmosphereCurve
 		{
-			@key,0 = 0 306.0
-			@key,1 = 1 262.5
+			@key,0 = 0 289
+			@key,1 = 1 255
 		}
 		@PROPELLANT[LiquidFuel]
 		{
@@ -707,8 +707,8 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = H-1B
-		origMass = 0.988
+		configuration = H-1
+		origMass = 0.907
 		modded = false
 		CONFIG
 		{
@@ -732,13 +732,13 @@
 				key = 0 289
 				key = 1 255
 			}
-			massMult = 0.643
+			massMult = 1
 		}
 		CONFIG
 		{
 			name = H-1B
-			minThrust = 1037.2
-			maxThrust = 1037.2
+			minThrust = 1030.2
+			maxThrust = 1030.2
 			heatProduction = 100
 			cost = 300
 			PROPELLANT
@@ -754,11 +754,11 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 306.0
-				key = 1 262.5
+				key = 0 296
+				key = 1 262
 			}
 			techRequired = heavyRocketry
-			massMult = 1.0
+			massMult = 1.71
 		}
 		CONFIG
 		{
@@ -783,7 +783,7 @@
 				key = 0 295
 				key = 1 264
 			}
-			massMult = 1.0395
+			massMult = 1.132
 			techRequired = heavierRocketry
 		}
 		CONFIG
@@ -810,7 +810,7 @@
 				key = 1 255
 			}
 			techRequired = veryHeavyRocketry
-			massMult = 1.10425
+			massMult = 1.265
 		}
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -663,7 +663,7 @@
 	@title = H-1/RS-27 Series Booster [1.0m]
 	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is agumented by solid boosters.
 	@attachRules = 1,0,1,0,0
-	@mass = 0.907
+	@mass = 0.635
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
 	{
@@ -707,12 +707,12 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = H-1
+		configuration = H-1-188klbf
 		origMass = 0.907
 		modded = false
 		CONFIG
 		{
-			name = H-1
+			name = H-1-188klbf
 			minThrust = 947
 			maxThrust = 947
 			heatProduction = 100
@@ -732,11 +732,11 @@
 				key = 0 289
 				key = 1 255
 			}
-			massMult = 1
+			massMult = 0.700
 		}
 		CONFIG
 		{
-			name = H-1B
+			name = H-1-205klbf
 			minThrust = 1030.2
 			maxThrust = 1030.2
 			heatProduction = 100
@@ -755,10 +755,10 @@
 			atmosphereCurve
 			{
 				key = 0 296
-				key = 1 262
+				key = 1 265
 			}
 			techRequired = heavyRocketry
-			massMult = 1.3
+			massMult = 1
 		}
 		CONFIG
 		{
@@ -839,7 +839,6 @@
 		maxAmount = 1
 	}
 }
-
 // Mainsail Clone, now LR-79/89
 +PART[liquidEngine1-2]:AFTER[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -758,7 +758,7 @@
 				key = 1 262
 			}
 			techRequired = heavyRocketry
-			massMult = 1.71
+			massMult = 1.3
 		}
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -707,12 +707,12 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = H-1-188klbf
+		configuration =  H-1-SaturnI
 		origMass = 0.907
 		modded = false
 		CONFIG
 		{
-			name = H-1-188klbf
+			name =  H-1-SaturnI
 			minThrust = 947
 			maxThrust = 947
 			heatProduction = 100
@@ -736,7 +736,7 @@
 		}
 		CONFIG
 		{
-			name = H-1-205klbf
+			name =  H-1-SaturnIB
 			minThrust = 1030.2
 			maxThrust = 1030.2
 			heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -661,7 +661,7 @@
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -1.332244, 0.0, 0.0, 1.0, 0.0, 2
 	@title = H-1/RS-27 Series Booster [1.0m]
-	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is agumented by solid boosters.
+	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1 and RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is agumented by solid boosters.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.635
 	@maxTemp = 1700


### PR DESCRIPTION
Used the same engine and ignitor configs on both so weight, thrust, and Isp are consistent. Updated weight of H-1: according to NASA sources the engine weighed around 2000 lbs, Astronautix was the only place that listed it as ~400 kg. And couldn't find any information about H-1B, it seems to only exist on Astronautix. Saturn IB used regular H-1 engines at about 910 kN.