### PR TITLE
+part AIES SpaceX Kestrel

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -1704,7 +1704,7 @@
 	%node_stack_bottom = 0.0, -0.125, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Kestrel
 	@manufacturer = SpaceX
-	@description = Pressure-fed engine used in the Falcon 1 launcher.
+	@description = Pressure-fed kerosene/LOX engine that was used in the second stage of the Falcon 1 launcher.
 	%mass = 0.052
 	@MODULE[ModuleEngines*]
 	{
@@ -1759,7 +1759,7 @@
 			minThrust = 30.7
 			maxThrust = 30.7
 			heatProduction = 100
-			massMult = 0.85
+			massMult = 1
 			PROPELLANT
 			{
 				name = Kerosene

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -1690,3 +1690,127 @@
 		}
 	}
 }
+// M-SE Clone, now Kestrel
++PART[microEngineSE1]:AFTER[RealismOverhaul]
+{
+	@name = RO-Kestrel
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1.0
+	%rescaleFactor = 10.75
+	%node_stack_top = 0.0, 0.055, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_bottom = 0.0, -0.125, 0.0, 0.0, 1.0, 0.0, 1
+	@title = Kestrel
+	@manufacturer = SpaceX
+	@description = Pressure-fed engine used in the Falcon 1 launcher.
+	%mass = 0.052
+	@MODULE[ModuleEngines*]
+	{
+		%maxThrust = 30.5
+		%minThrust = 30.5
+		%heatProduction = 100
+		@atmosphereCurve
+		{
+			@key,0 = 0 317
+			@key,1 = 1 100
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.372
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.628
+		}
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		origMass = 0.052
+		@configuration = Kestrel
+		@CONFIG[LMAE]
+		{
+			@name = Kestrel
+			@minThrust = 30.5
+			@maxThrust = 30.5
+			massMult = 1
+			@PROPELLANT[Aerozine50]
+			{
+				@name = Kerosene
+				@ratio = 0.372
+			}
+			@PROPELLANT[NTO]
+			{
+				@name = LqdOxygen
+				@ratio = 0.628
+			}
+			@atmosphereCurve
+			{
+				@key,0 = 0 317
+				@key,1 = 1 100
+			}
+		}
+		CONFIG
+		{
+			name = Kestrel-2
+			minThrust = 30.7
+			maxThrust = 30.7
+			heatProduction = 100
+			massMult = 0.85
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.372
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.628
+			}
+			atmosphereCurve
+			{
+				key = 0 320
+				key = 1 100
+			}
+		}
+	}
+	MODULE
+	{
+	name = ModuleGimbal
+	gimbalTransformName = thrustTransform
+	gimbalRange = 4
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleEngineIgnitor]
+	{
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 20
+		autoIgnitionTemperature = 800
+		ignitorType = Electric
+		useUllageSimulation = true
+		isPressureFed = true
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 0.372
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.628
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -1698,10 +1698,10 @@
 	{
 		@scale = 13.5, 13.5, 13.5
 	}
-	@scale = 9
+	@scale = 1
 	%rescaleFactor = 1
-	%node_stack_top = 0.0, 0.090, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_bottom = 0.0, -0.190, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_top = 0.0, 0.6925, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_bottom = 0.0, -1.7075, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Kestrel
 	@manufacturer = SpaceX
 	@description = Pressure-fed kerosene/LOX engine that was used in the second stage of the Falcon 1 launcher.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -1696,12 +1696,12 @@
 	@name = RO-Kestrel
 	@MODEL
 	{
-		@scale = 1, 1, 1
+		@scale = 13.5, 13.5, 13.5
 	}
-	@scale = 1.0
-	%rescaleFactor = 10.75
-	%node_stack_top = 0.0, 0.055, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_bottom = 0.0, -0.125, 0.0, 0.0, 1.0, 0.0, 1
+	@scale = 9
+	%rescaleFactor = 1
+	%node_stack_top = 0.0, 0.090, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_bottom = 0.0, -0.190, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Kestrel
 	@manufacturer = SpaceX
 	@description = Pressure-fed kerosene/LOX engine that was used in the second stage of the Falcon 1 launcher.

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/aies.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/aies.cfg
@@ -119,3 +119,199 @@
 		%type = ModuleEnginesFX
     }
 }
+@PART[RO-Kestrel]:FOR[RealPlume]
+{
+	!fx_exhaustFlame_white_tiny = DELETE
+	!sound_vent_medium = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamecore
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KerbXflame
+				transformName = thrustTransform
+				localPosition = 0,0,0.0
+				fixedScale = 5
+				emission = 0.0 1
+				emission = 1.0 1
+				speed = 0.0 1.0
+				speed = 1.0 1.0
+				fixedEmissions = false
+				grow
+				{
+  					density = 1.0 -0.99999
+					density = 0.011 0.0
+					density = 0.0 -.5
+				}
+				speed
+				{
+					density = 1.0 1
+					density = 0.011 1
+  					density = 0.0 2
+				}
+				logGrow
+				{
+  					density = 1.0 0
+  					density = 0.11 2
+  					density = 0.0 2
+				}
+				logGrowScale
+				{
+  					density = 1.0 0.0
+  					density = 0.79 3
+  					density = 0.1 2
+  					density = 0.0 2
+				}
+				linGrow
+				{
+ 					density = 1.0 0.0
+  					density = 0.79 0.0
+  					density = 0.005 0.0
+  					density = 0.0 10
+				}
+				offset
+				{
+  					density = 1.0 -0.1
+  					density = 0.011 0.05
+  					density = 0.0 0.05
+				}
+				size
+				{
+  					density = 1.0 0.5
+  					density = 0.011 1.0
+  					density = 0.0 .5
+				}
+				emission
+				{
+  					density = 1.0 0.5
+  					density = 0.11 1
+  					density = 0.0 .3
+				}
+				energy
+				{
+  					density = 1.0 .5
+  					density  = 0.0 .5
+				}
+				energy
+				{
+  					power = 1.0 1
+  					power = 0.0 1
+				}
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+				transformName = thrustTransform
+				localPosition = 0,0,1.0
+				fixedScale = 1.2
+				speed = 0.0 1
+				speed = 1.0 1
+				fixedEmissions = false
+				grow
+				{
+  					density = 1.0 -0.999
+  					density = 0.12 0.0
+  					density = 0.0 20
+				}
+				size
+				{
+  					density = 1.0 0.6
+  					density = 0.12 1.0
+  					density = 0.0 5
+				}
+				speed
+				{
+  					density = 1.0 0.6
+  					density = 0.12 1.0
+  					density = 0.0 4
+				}
+				logGrow
+				{
+  					density = 1.0 0.0
+  					density = 0.12 0.0
+  					density = 0.0 5
+				}
+				offset
+				{
+  					density = 1.0 -0.5
+  					density = 0.12 0.1
+  					density = 0.0 -.5
+				}
+				energy
+				{
+  					density = 1.0 0.33
+  				density = 0.0 .5
+				}
+				emission
+				{
+  					density = 1.0 1.0
+  					density = 0.5 0.6
+  					density = 0.0 .8
+				}
+			}
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+			  volume = 0.0 0.0
+			  volume = 1.0 1.0
+			  pitch = 0.0 0.2
+			  pitch = 1.0 1.0
+			  loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
+			  volume = 1.0
+			  pitch = 1.0
+			  loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+    @MODULE[ModuleEngines]
+    {
+        @name = ModuleEnginesFX
+        //engineID = rocketengine
+        %runningEffectName = powersmoke
+        %directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+	
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesFX
+    }
+}


### PR DESCRIPTION
Duplicate LMAE to create SpaceX Kestrel. Don't think there are any pressure-fed kerosene/LOX engines in RO yet. Model looks very similar to Kestrel, and should be scaled approximately the same. Demo image is using same 1.7 m diameter as Falcon 1.
![ro kestrel](https://cloud.githubusercontent.com/assets/11747970/6993889/89c09dd4-dab9-11e4-92d8-6463d452e9ca.png)
![kestrel](https://cloud.githubusercontent.com/assets/11747970/6993890/8c68f09a-dab9-11e4-89b7-fdb146e67f47.jpg)
![kestrel diagram](https://cloud.githubusercontent.com/assets/11747970/6993891/905d7c20-dab9-11e4-851e-40e3b9bedd19.png)


