### PR TITLE
Gimbal range configs for GEM 46 and GEM 60

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -578,7 +578,7 @@
 	@node_attach = 0.0, 0.0, -0.76, 0.0, 0.0, 2.0
 	@title = GEM 60 SRM (Graphite Epoxy Motor)
 	&manufacturer = Thiokol ATK
-	@description = 60" SRB made by ATK with a case constructed of Graphite Epoxy instead of steel.
+	@description = 60" SRB used on the Delta IV, which can be equipped with 0, 2, or 4 boosters. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to save cost and weight.
 	@mass = 3.95215
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
@@ -612,13 +612,135 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = GEM-60
+		configuration = GEM-60-TVC
 		modded = false
+		origMass = 3.95215
+		CONFIG
+		{
+			name = GEM-60-TVC
+			maxThrust = 1235.947
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 274
+				key = 1 246
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99972 0.719
+				key = 0.98539 0.939
+				key = 0.97106 0.939
+				key = 0.95673 0.939
+				key = 0.94227 0.948
+				key = 0.92769 0.956
+				key = 0.91298 0.964
+				key = 0.89811 0.975
+				key = 0.88302 0.989
+				key = 0.86785 0.995
+				key = 0.85268 0.994
+				key = 0.83746 0.997
+				key = 0.82221 1
+				key = 0.80695 1
+				key = 0.7917 1
+				key = 0.77644 1
+				key = 0.76119 1
+				key = 0.74593 1
+				key = 0.73068 1
+				key = 0.71543 1
+				key = 0.70017 1
+				key = 0.68496 0.997
+				key = 0.66992 0.986
+				key = 0.65513 0.969
+				key = 0.6408 0.939
+				key = 0.62728 0.886
+				key = 0.61481 0.817
+				key = 0.60293 0.779
+				key = 0.59143 0.754
+				key = 0.58023 0.734
+				key = 0.56953 0.701
+				key = 0.55909 0.685
+				key = 0.5489 0.668
+				key = 0.539 0.649
+				key = 0.52932 0.635
+				key = 0.51985 0.621
+				key = 0.51063 0.604
+				key = 0.50162 0.591
+				key = 0.49282 0.577
+				key = 0.48419 0.566
+				key = 0.47573 0.555
+				key = 0.46731 0.552
+				key = 0.45877 0.56
+				key = 0.45014 0.566
+				key = 0.44143 0.571
+				key = 0.43263 0.577
+				key = 0.42371 0.585
+				key = 0.4147 0.59
+				key = 0.40561 0.596
+				key = 0.39644 0.601
+				key = 0.38718 0.607
+				key = 0.37779 0.615
+				key = 0.36832 0.621
+				key = 0.35877 0.626
+				key = 0.34913 0.632
+				key = 0.33936 0.64
+				key = 0.32951 0.646
+				key = 0.31958 0.651
+				key = 0.30952 0.659
+				key = 0.29938 0.665
+				key = 0.28915 0.67
+				key = 0.2788 0.679
+				key = 0.26836 0.684
+				key = 0.25779 0.693
+				key = 0.24714 0.698
+				key = 0.23641 0.704
+				key = 0.22564 0.706
+				key = 0.21482 0.709
+				key = 0.20392 0.715
+				key = 0.19297 0.717
+				key = 0.18199 0.72
+				key = 0.17092 0.726
+				key = 0.15981 0.728
+				key = 0.14865 0.731
+				key = 0.13746 0.734
+				key = 0.12618 0.739
+				key = 0.11494 0.737
+				key = 0.10371 0.737
+				key = 0.09255 0.731
+				key = 0.08148 0.726
+				key = 0.07054 0.717
+				key = 0.05964 0.714
+				key = 0.04883 0.709
+				key = 0.03814 0.701
+				key = 0.02754 0.695
+				key = 0.01913 0.551
+				key = 0.01527 0.253
+				key = 0.01302 0.148
+				key = 0.01157 0.095
+				key = 0.01054 0.067
+				key = 0.00969 0.056
+				key = 0.00904 0.042
+				key = 0.00856 0.031
+				key = 0.00816 0.026
+				key = 0.00785 0.02
+				key = 0.00763 0.015
+				key = 0.00753 0.006
+				key = 0.00743 0.006
+			}
+		}
 		CONFIG
 		{
 			name = GEM-60
 			maxThrust = 1235.947
 			heatProduction = 100
+			massMult = 0.844
+			gimbalRange = 0
 			PROPELLANT
 			{
 				name = SolidFuel
@@ -753,8 +875,8 @@
 	@node_attach = 0.0, 0.0, -0.585, 0.0, 0.0, 2.0
 	@title = GEM 46 SRM (Graphite Epoxy Motor)
 	%manufacturer = Thiokol ATK
-	@description = Slightly increased diameter Castor 4 with a case made from Graphite Epoxy rather than steel.
-	@mass = 2.275219
+	@description = 46" SRBs used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with thrust vector control (TVC) while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC.
+	@mass = 2.275
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
 	{
@@ -787,11 +909,114 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = GEM-46-Ground
+		origMass = 2.275
+		configuration = GEM-46-Ground-TVC
 		modded = false
 		CONFIG
 		{
+			name = GEM-46-Ground-TVC
+			maxThrust = 874.5204
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 279.8
+				key = 1 261
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99722 0.747
+				key = 0.98169 0.821
+				key = 0.96612 0.824
+				key = 0.9504 0.831
+				key = 0.93446 0.843
+				key = 0.91832 0.853
+				key = 0.90196 0.865
+				key = 0.88537 0.877
+				key = 0.86859 0.887
+				key = 0.85157 0.9
+				key = 0.83433 0.912
+				key = 0.81676 0.929
+				key = 0.79896 0.941
+				key = 0.78093 0.953
+				key = 0.76258 0.971
+				key = 0.74399 0.983
+				key = 0.72526 0.99
+				key = 0.70639 0.998
+				key = 0.68748 1
+				key = 0.66862 0.998
+				key = 0.6498 0.995
+				key = 0.63107 0.99
+				key = 0.61253 0.98
+				key = 0.59426 0.966
+				key = 0.57623 0.953
+				key = 0.55853 0.936
+				key = 0.54119 0.917
+				key = 0.52432 0.892
+				key = 0.508 0.863
+				key = 0.49229 0.831
+				key = 0.47708 0.804
+				key = 0.46234 0.779
+				key = 0.44792 0.762
+				key = 0.43411 0.73
+				key = 0.42062 0.713
+				key = 0.4075 0.694
+				key = 0.3948 0.672
+				key = 0.38247 0.652
+				key = 0.37051 0.632
+				key = 0.35888 0.615
+				key = 0.34748 0.603
+				key = 0.3363 0.591
+				key = 0.32523 0.586
+				key = 0.31415 0.586
+				key = 0.30311 0.583
+				key = 0.29208 0.583
+				key = 0.281 0.586
+				key = 0.26993 0.586
+				key = 0.25885 0.586
+				key = 0.24777 0.586
+				key = 0.23674 0.583
+				key = 0.22575 0.581
+				key = 0.21476 0.581
+				key = 0.20378 0.581
+				key = 0.19279 0.581
+				key = 0.18181 0.581
+				key = 0.17087 0.578
+				key = 0.15993 0.578
+				key = 0.14899 0.578
+				key = 0.13809 0.576
+				key = 0.1272 0.576
+				key = 0.11635 0.574
+				key = 0.1056 0.569
+				key = 0.09489 0.566
+				key = 0.08428 0.561
+				key = 0.07371 0.559
+				key = 0.06319 0.556
+				key = 0.05271 0.554
+				key = 0.04228 0.551
+				key = 0.03204 0.542
+				key = 0.02346 0.453
+				key = 0.01697 0.343
+				key = 0.01215 0.255
+				key = 0.00905 0.164
+				key = 0.0071 0.103
+				key = 0.00589 0.064
+				key = 0.0052 0.037
+				key = 0.00483 0.02
+				key = 0.00473 0.005
+			}
+		}
+		CONFIG
+		{
 			name = GEM-46-Ground
+			massMult = 0.879
+			gimbalRange = 0
 			maxThrust = 874.5204
 			heatProduction = 100
 			PROPELLANT
@@ -893,7 +1118,9 @@
 		{
 			name = GEM-46-Air
 			maxThrust = 916.3337
+			massMult = 0.969
 			heatProduction = 100
+			gimbalRange = 0
 			PROPELLANT
 			{
 				name = SolidFuel


### PR DESCRIPTION
Update to GEM 46 and GEM 60 with new gimbal range configs (thanks NK) for varying mass depending on TVC ability.

TVC-capable SRMs were appended with -TVC, open to alternatives. Couldn't think of a non-clumsy way to indicate TVC-less configs.

Data from (http://www.b14643.de/Spacerockets_2/Diverse/ATK-Thiokol/index.htm) and (https://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_(2012).pdf)