### PR TITLE
Gimbal and thrust curve for Castor 30XL

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -2688,16 +2688,16 @@
 	@node_stack_bottom = 0.0, -3.294453, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_top = 0.0, 2.699947, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
-	@title = 30XL SRM [92"]
+	@title = Castor 30XL SRM [92"]
 	@manufacturer = Thiokol (ATK)
-	@description = Enlarged Castor 30 to create the Castor 30XL for upper stages. DOES NOT HAVE A THRUST CURVE AT THIS TIME.
+	@description = The Castor 30XL is an enlarged Castor 30. Designed for the second stage of the Antares launcher.
 	@attachRules = 1,1,1,1,0
 	@mass = 2.3
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 0
-		@maxThrust = 396.2921
+		@maxThrust = 715
 		@heatProduction = 100
 		@atmosphereCurve
 		{
@@ -2715,6 +2715,14 @@
 		type = Solid
 		basemass = -1
 	}
+		MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 3.5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -2724,7 +2732,7 @@
 		CONFIG
 		{
 			name = 30XL
-			maxThrust = 396.2921
+			maxThrust = 715
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -2737,10 +2745,139 @@
 				key = 0 303
 				key = 1 100
 			}
-			//curveResource = SolidFuel
-			//thrustCurve
-			//{
-			//}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99998 0.250
+				key = 0.99493 0.483
+				key = 0.98966 0.505
+				key = 0.9842 0.524
+				key = 0.97861 0.535
+				key = 0.97282 0.554
+				key = 0.96679 0.578
+				key = 0.96056 0.597
+				key = 0.95403 0.625
+				key = 0.9473 0.644
+				key = 0.9403 0.67
+				key = 0.93308 0.692
+				key = 0.92559 0.718
+				key = 0.91787 0.739
+				key = 0.91006 0.749
+				key = 0.90219 0.753
+				key = 0.89421 0.765
+				key = 0.88619 0.768
+				key = 0.87813 0.772
+				key = 0.87005 0.775
+				key = 0.86193 0.777
+				key = 0.85377 0.782
+				key = 0.84556 0.787
+				key = 0.83725 0.796
+				key = 0.82887 0.803
+				key = 0.82036 0.815
+				key = 0.81178 0.822
+				key = 0.8031 0.832
+				key = 0.79432 0.841
+				key = 0.78541 0.853
+				key = 0.77644 0.86
+				key = 0.76734 0.872
+				key = 0.75813 0.881
+				key = 0.74884 0.891
+				key = 0.73946 0.898
+				key = 0.73001 0.905
+				key = 0.72047 0.915
+				key = 0.71082 0.924
+				key = 0.70113 0.929
+				key = 0.69136 0.936
+				key = 0.68151 0.943
+				key = 0.67157 0.953
+				key = 0.6616 0.955
+				key = 0.65159 0.96
+				key = 0.64152 0.964
+				key = 0.63138 0.972
+				key = 0.62121 0.974
+				key = 0.61097 0.981
+				key = 0.60071 0.983
+				key = 0.59042 0.986
+				key = 0.58011 0.988
+				key = 0.56977 0.99
+				key = 0.5594 0.993
+				key = 0.54899 0.998
+				key = 0.53855 1
+				key = 0.52812 1
+				key = 0.51768 1
+				key = 0.50724 1
+				key = 0.4968 1
+				key = 0.48636 1
+				key = 0.47593 1
+				key = 0.46551 0.998
+				key = 0.45512 0.995
+				key = 0.44474 0.995
+				key = 0.43437 0.993
+				key = 0.42403 0.991
+				key = 0.41374 0.986
+				key = 0.40348 0.983
+				key = 0.39326 0.979
+				key = 0.38312 0.972
+				key = 0.37303 0.967
+				key = 0.36298 0.962
+				key = 0.35301 0.955
+				key = 0.34312 0.948
+				key = 0.33327 0.943
+				key = 0.3235 0.936
+				key = 0.31381 0.929
+				key = 0.30418 0.922
+				key = 0.29468 0.91
+				key = 0.28528 0.901
+				key = 0.27598 0.891
+				key = 0.26683 0.877
+				key = 0.25773 0.872
+				key = 0.24877 0.858
+				key = 0.23994 0.846
+				key = 0.23123 0.834
+				key = 0.22262 0.825
+				key = 0.21413 0.813
+				key = 0.2058 0.799
+				key = 0.19758 0.787
+				key = 0.18952 0.773
+				key = 0.1816 0.759
+				key = 0.17381 0.747
+				key = 0.16619 0.73
+				key = 0.15869 0.718
+				key = 0.15136 0.702
+				key = 0.14419 0.687
+				key = 0.13716 0.673
+				key = 0.13031 0.657
+				key = 0.12358 0.645
+				key = 0.11702 0.628
+				key = 0.11058 0.616
+				key = 0.10435 0.597
+				key = 0.09828 0.581
+				key = 0.09232 0.571
+				key = 0.08653 0.555
+				key = 0.08089 0.541
+				key = 0.07542 0.524
+				key = 0.07007 0.512
+				key = 0.06485 0.5
+				key = 0.05977 0.486
+				key = 0.05485 0.472
+				key = 0.05009 0.455
+				key = 0.04551 0.439
+				key = 0.04108 0.425
+				key = 0.0368 0.41
+				key = 0.03264 0.399
+				key = 0.02865 0.382
+				key = 0.02479 0.37
+				key = 0.0211 0.354
+				key = 0.01756 0.339
+				key = 0.01416 0.325
+				key = 0.01097 0.306
+				key = 0.00787 0.297
+				key = 0.00497 0.278
+				key = 0.00249 0.237
+				key = 0.00137 0.107
+				key = 0.00119 0.017
+				key = 0.00119 0.001
+			}
 		}
 	}
 }


### PR DESCRIPTION
No official thrust curve yet, but an identical one to the Castor 30 seems reasonable and at any rate more realistic than flat thrust. Engine has TVC, like Castor 30.