### PR TITLE
Set propellant to Kerosene for RSSRO configured jet engines

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -1,6 +1,13 @@
 @PART[aje_f404]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@MODULE[ModuleEngines*]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name=Kerosene
+		}
+	}
 }
 @PART[CircularAirIntakesmall]:FOR[RealismOverhaul]
 {
@@ -15,6 +22,13 @@
 @PART[aje_j85]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@MODULE[ModuleEngines*]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name=Kerosene
+		}
+	}
 }
 @PART[aje_solarPanels]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -454,6 +454,13 @@
 	!MODULE[TweakScale]
 	{
 	}
+	@MODULE[ModuleEngines*]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name=Kerosene
+		}
+	}
 }
 
 // LR-105
@@ -3148,6 +3155,13 @@
 	%RSSROConfig = True
 	!MODULE[TweakScale]
 	{
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name=Kerosene
+		}
 	}
 }
 @PART[vernierEngine]:FOR[RealismOverhaul]


### PR DESCRIPTION
There is probably a cleaner way to do this but I don't know MM well enough. This fixes the issue I referred to here:
http://www.reddit.com/r/RealSolarSystem/comments/32ao6r/jet_engines_trying_to_consume_liquidfuel_instead/

That I believe is a side-effect of:
https://github.com/NathanKell/AJE-1/commit/230b96aac78f78609c3bd225f5d494166f5204fb

As an aside, if there is a more general way to handle this. I'd love to see it.