### PR TITLE
Plume settings for BobCat parts

### DIFF
--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat
@@ -1,5 +1,5 @@
 // BobCat Proton ##############################################################
-@PART[Proton_Core_Oxidizer_Tank]:FOR[RealPlume] // Proton stage 1
+@PART[Proton_Core_Oxidizer_Tank]:FOR[RealPlume] // Proton stage 1 ===========================================================
 {
   !fx_exhaustFlame_yellow = DELETE
   !fx_smokeTrail_medium = DELETE
@@ -226,7 +226,7 @@ EFFECTS
   }
 }
 
-@PART[Proton_Second_Stage]:FOR[RealPlume] // Proton stage 2
+@PART[Proton_Second_Stage]:FOR[RealPlume] // Proton stage 2 ================================================================
 {
 !fx_exhaustFlame_yellow = DELETE
 !fx_smokeTrail_medium = DELETE
@@ -436,7 +436,7 @@ EFFECTS
     }
 }
 
-@PART[Proton_Third_Stage]:FOR[RealPlume] // Proton stage 3
+@PART[Proton_Third_Stage]:FOR[RealPlume] // Proton stage 3 ================================================================
 {
 !fx_exhaustFlame_blue = DELETE
 !fx_exhaustLight_blue = DELETE
@@ -647,8 +647,804 @@ EFFECTS
     }
 }
 
-// BobCat Soviet Engines ##############################################################
-@PART[RD0146]:FOR[RealPlume] //RD-0146
+// BobCat Soviet Engines ####################################################################################################
+
+@PART[NK43]:FOR[RealPlume] //NK-43 ================================================================
+{
+!fx_exhaustFlame_blue = DELETE
+!fx_exhaustFlame_yellow = DELETE
+!fx_exhaustLight_blue = DELETE
+!fx_smokeTrail_light = DELETE
+!fx_smokeTrail_light = DELETE
+!fx_exhaustSparks_flameout = DELETE
+    !sound_vent_medium = DELETE
+    !sound_rocket_hard = DELETE
+    !sound_vent_soft = DELETE
+    !sound_explosion_low = DELETE
+    @MODULE[ModuleEngines]
+    {
+        @name = ModuleEnginesFX
+        //engineID = rocketengine
+		%runningEffectName = powersmoke
+		%directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesFX
+    }
+	EFFECTS
+	{
+        	powerflame
+			{
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = flamethrust
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+transformName = thrustTransform
+localRotation = 0,0,0
+localPosition = 0,0,0.7
+offsetDirection = 0,0,1
+fixedScale = 0.6
+size = 0.1 .5
+size = 1.0 1
+sizeClamp = 50
+initialDensity = 0.6
+physical = False
+stickiness = 0.9
+dragCoefficient = 0.1
+singleEmitTimer = 0
+randomInitalVelocityOffsetMaxRadius = 0
+logGrow
+{
+  density = 1.0 10
+  density = 0.5 10
+  density = 0.0 10
+}
+logGrowScale
+{
+  density = 1.0 0.0
+  density = 0.79 3
+  density = 0.1 20
+  density = 0.0 30
+}
+linGrow
+{
+  density = 1.0 0.0
+  density = 0.79 0.0
+  density = 0.005 0.0
+  density = 0.0 1
+}
+speed
+{
+  density = 1.0 2
+  density = 0.79 3
+  density = 0.005 15
+  density = 0.0 15
+}
+emission
+{
+  density = 1.0 4.0
+  density = 0.79 1.0
+  density = 0.5 0.3
+  density = 0.0 0.15
+}
+energy
+{
+  density = 1.0 0.65
+  density = 0.1 0.75
+  density = 0.0 0.5
+}
+offset
+{
+  density = 1.0 0.0
+  density = 0.79 0.5
+  density = 0.5 0.5
+  density = 0.0 10
+}
+force
+{
+  density = 1.0 0
+  density = 0.79 0
+  density = 0.5 0
+  density = 0.0 0
+}
+				}
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = flameflare
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+transformName = thrustTransform
+fixedScale = 0.5
+emission = 0.0 1
+emission = 1.0 1
+energy = 0.0 0.2
+energy = 1.0 .3
+size = 0.0 1.35
+size = 1.0 2
+fixedEmissions = false
+sizeClamp = 250
+grow = 0.0 0.2
+grow = 1.0 0.2
+logGrow
+{
+density = 0.1 1
+density = 0 50
+}
+offset
+{
+density = 0.1 4
+density = 0 6
+}
+speed
+{
+density = 1.0 1
+density = 0.9 2
+density = 0.1 3
+density = 0 5
+}
+randomInitalVelocityOffsetMaxRadius = 0.2
+				}
+				AUDIO
+				{
+				  channel = Ship
+				  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				  volume = 0.0 0.0
+				  volume = 1.0 1.5
+				  pitch = 0.0 1.0
+				  pitch = 1.0 1.0
+				  loop = true
+				}
+			}
+			powersmoke
+			{
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = smokethrust
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokejet
+transformName = thrustTransform
+emission = 0.0 0.25
+emission = 1.0 0.25
+energy = 0.0 .6
+energy = 1.0 1.2
+grow = 0.0 0.34
+grow = 1.0 0.34
+scale = 0.0 1.0
+scale = 1.0 1.0
+offset = 0.0 25
+offset = 1.0 25
+size = 0.0 1.85
+size = 1.0 1.85
+renderMode = "Billboard"
+collide = false
+collideRatio = 0
+fixedScale = 0.5
+sizeClamp = 250
+angle = 0.0 1.0
+angle = 45.0 1.0
+angle = 50.0 1.0
+distance = 0.0 1.0
+distance = 100.0 1.0
+distance = 110.0 1.0
+speed
+  density = 1.0 .5
+  density = 0.79 .5
+  density = 0.5 0.5
+  density = 0.005 1
+  density = 0.0 4
+emission
+{
+  density = 1.0 0
+  density = 0.79 0
+  density = 0.5 0.3
+  density = 0.005 0.2
+  density = 0.004 0.1
+}
+offset
+{
+  density = 1.0 1.0
+  density = 0.79 1.0
+  density = 0.1 2
+  density = 0.005 3
+  density = 0.0 5
+}
+size
+{
+  density = 1.0 2
+  density = 0.79 4
+  density = 0.0 20
+}
+				}
+			}
+        	engage
+        	{
+            		AUDIO
+					{
+					  channel = Ship
+					  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+					  volume = 1.0
+					  pitch = 0.8
+					  loop = false
+					}
+        	}
+        	disengage
+        	{
+            		AUDIO
+            		{
+                		channel = Ship
+                		clip = sound_vent_soft
+                		volume = 1.0
+                		pitch = 2.0
+                		loop = false
+            		}
+        	}
+        	flameout
+        	{
+            		AUDIO
+            		{
+                		channel = Ship
+                		clip = sound_explosion_low
+                		volume = 1.0
+                		pitch = 2.0
+                		loop = false
+            		}
+        	}
+	}
+}
+
+@PART[RD171]:FOR[RealPlume] //RD-171 ================================================================
+{
+!fx_exhaustFlame_blue = DELETE
+!fx_exhaustFlame_yellow = DELETE
+!fx_exhaustFlame_yellow = DELETE
+!fx_exhaustLight_blue = DELETE
+!fx_smokeTrail_medium = DELETE
+!fx_smokeTrail_medium = DELETE
+!fx_exhaustSparks_flameout = DELETE
+    !sound_vent_medium = DELETE
+    !sound_rocket_hard = DELETE
+    !sound_vent_soft = DELETE
+    !sound_explosion_low = DELETE
+    @MODULE[ModuleEngines]
+    {
+        @name = ModuleEnginesFX
+        //engineID = rocketengine
+		%runningEffectName = powersmoke
+		%directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesFX
+    }
+	EFFECTS
+	{
+        	powerflame
+			{
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = flamethrust
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+transformName = thrustTransform
+localRotation = 0,0,0
+localPosition = 0,0,0.7
+offsetDirection = 0,0,1
+fixedScale = 0.6
+size = 0.1 .5
+size = 1.0 1
+sizeClamp = 50
+initialDensity = 0.6
+physical = False
+stickiness = 0.9
+dragCoefficient = 0.1
+singleEmitTimer = 0
+randomInitalVelocityOffsetMaxRadius = 0
+logGrow
+{
+  density = 1.0 10
+  density = 0.5 10
+  density = 0.0 10
+}
+logGrowScale
+{
+  density = 1.0 1.5
+  density = 0.79 3
+  density = 0.1 20
+  density = 0.0 30
+}
+linGrow
+{
+  density = 1.0 0.0
+  density = 0.79 0.0
+  density = 0.005 0.0
+  density = 0.0 1
+}
+speed
+{
+  density = 1.0 2
+  density = 0.79 3
+  density = 0.005 15
+  density = 0.0 15
+}
+emission
+{
+  density = 1.0 4.0
+  density = 0.79 1.0
+  density = 0.5 0.3
+  density = 0.0 0.15
+}
+energy
+{
+  density = 1.0 0.65
+  density = 0.1 0.75
+  density = 0.0 0.5
+}
+offset
+{
+  density = 1.0 1.5
+  density = 0.9 1.5
+  density = 0.5 2
+  density = 0.0 2
+}
+force
+{
+  density = 1.0 0
+  density = 0.79 0
+  density = 0.5 0
+  density = 0.0 0
+}
+				}
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = flameflare
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+transformName = thrustTransform
+fixedScale = 0.5
+emission = 0.0 2
+emission = 1.0 2
+speed = 0.0 1
+speed = 1.0 3
+offset = 0.0 3
+offset = 1.0 0
+energy = 0.0 0.2
+energy = 1.0 .2
+size = 0.0 1.35
+size = 1.0 2
+fixedEmissions = false
+sizeClamp = 250
+grow = 0.0 0.2
+grow = 1.0 0.2
+randomInitalVelocityOffsetMaxRadius = 0.2
+				}
+				AUDIO
+				{
+				  channel = Ship
+				  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				  volume = 0.0 0.0
+				  volume = 1.0 1.5
+				  pitch = 0.0 1.0
+				  pitch = 1.0 1.0
+				  loop = true
+				}
+			}
+			powersmoke
+			{
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = smokethrust
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+transformName = thrustTransform
+emission = 0.0 0.05
+emission = 1.0 0.25
+energy = 0.0 0.1
+energy = 1.0 1.2
+grow = 0.0 0.34
+grow = 1.0 0.34
+scale = 0.0 1.0
+scale = 1.0 1.0
+offset = 0.0 25
+offset = 1.0 25
+size = 0.0 1.85
+size = 1.0 1.85
+renderMode = "Billboard"
+collide = false
+collideRatio = 0
+fixedScale = 0.5
+sizeClamp = 250
+angle = 0.0 1.0
+angle = 45.0 1.0
+angle = 50.0 1.0
+distance = 0.0 1.0
+distance = 100.0 1.0
+distance = 110.0 1.0
+energy
+{
+  density = 1.0 0.1
+  density = 0.79 0.1
+  density = 0.5 0.1
+  density = 0.005 .05
+  density = 0.0 0.05
+}
+speed
+{
+  density = 1.0 3
+  density = 0.79 4
+  density = 0.5 4
+  density = 0.005 3
+  density = 0.0 3
+}
+emission
+{
+  density = 1.0 .1
+  density = 0.79 .2
+  density = 0.5 0.3
+  density = 0.1 0
+  density = 0.000 0
+}
+offset
+{
+  density = 1.0 18
+  density = 0.79 20
+  density = 0.5 60
+  density = 0.1 40
+  density = 0.005 40
+  density = 0.0 50
+}
+size
+{
+  density = 1.0 10
+  density = 0.79 10
+  density = 0.5 15
+  density = 0.1 10
+  density = 0.0 20
+}
+				}
+			}
+        	engage
+        	{
+            		AUDIO
+					{
+					  channel = Ship
+					  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+					  volume = 1.0
+					  pitch = 0.8
+					  loop = false
+					}
+        	}
+        	disengage
+        	{
+            		AUDIO
+            		{
+                		channel = Ship
+                		clip = sound_vent_soft
+                		volume = 1.0
+                		pitch = 2.0
+                		loop = false
+            		}
+        	}
+        	flameout
+        	{
+            		AUDIO
+            		{
+                		channel = Ship
+                		clip = sound_explosion_low
+                		volume = 1.0
+                		pitch = 2.0
+                		loop = false
+            		}
+        	}
+	}
+}
+
+@PART[RD0124]:FOR[RealPlume] //RD-0124 ================================================================
+{
+!fx_exhaustFlame_blue = DELETE
+!fx_exhaustFlame_yellow = DELETE
+!fx_exhaustLight_blue = DELETE
+!fx_smokeTrail_light = DELETE
+!fx_smokeTrail_light = DELETE
+!fx_exhaustSparks_flameout = DELETE
+    !sound_vent_medium = DELETE
+    !sound_rocket_hard = DELETE
+    !sound_vent_soft = DELETE
+    !sound_explosion_low = DELETE
+    @MODULE[ModuleEngines]
+    {
+        @name = ModuleEnginesFX
+        //engineID = rocketengine
+		%runningEffectName = powersmoke
+		%directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesFX
+    }
+	EFFECTS
+	{
+        	powerflame
+			{
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = flameflare
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
+transformName = thrustTransform
+fixedScale = 0.5
+emission = 0.0 2
+emission = 1.0 2
+speed = 0.0 1
+speed = 1.0 1
+offset = 0.0 1.4
+offset = 1.0 1.4
+energy = 0.0 0.2
+energy = 1.0 .2
+size = 0.0 1
+size = 1.0 1
+fixedEmissions = false
+sizeClamp = 250
+grow = 0.0 0.2
+grow = 1.0 0.2
+logGrow
+{
+  density = 1.0 10
+  density = 0.5 10
+  density = 0.0 10
+}
+logGrowScale
+{
+  density = 1.0 0.0
+  density = 0.79 3
+  density = 0.1 20
+  density = 0.0 30
+}
+linGrow
+{
+  density = 1.0 0.0
+  density = 0.79 0.0
+  density = 0.005 0.0
+  density = 0.0 1
+}
+speed
+{
+  density = 1.0 2
+  density = 0.79 3
+  density = 0.005 15
+  density = 0.0 5
+}
+emission
+{
+  density = 1.0 4.0
+  density = 0.79 1.0
+  density = 0.5 0.3
+  density = 0.0 .2
+}
+energy
+{
+  density = 1.0 0.65
+  density = 0.1 0.75
+  density = 0.0 .4
+}
+offset
+{
+  density = 1.0 0.0
+  density = 0.79 0.5
+  density = 0.5 0.5
+  density = 0.0 1
+}
+force
+{
+  density = 1.0 0
+  density = 0.79 0
+  density = 0.5 0
+  density = 0.0 0
+}
+
+randomInitalVelocityOffsetMaxRadius = 0.2
+				}
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = flamecore
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+transformName = thrustTransform
+fixedScale = 0.5
+emission = 0.0 2
+emission = 1.0 2
+speed = 0.0 1
+speed = 1.0 1
+offset = 0.0 1.4
+offset = 1.0 3
+energy = 0.0 0.2
+energy = 1.0 .2
+size = 0.0 1
+size = 1.0 1
+fixedEmissions = false
+sizeClamp = 250
+grow = 0.0 0.2
+grow = 1.0 0.2
+logGrow
+{
+  density = 1.0 10
+  density = 0.5 10
+  density = 0.0 1
+}
+logGrowScale
+{
+  density = 1.0 0.0
+  density = 0.79 3
+  density = 0.1 20
+  density = 0.0 30
+}
+linGrow
+{
+  density = 1.0 0.0
+  density = 0.79 0.0
+  density = 0.005 0.0
+  density = 0.0 1
+}
+speed
+{
+  density = 1.0 2
+  density = 0.79 3
+  density = 0.005 15
+  density = 0.0 5
+}
+emission
+{
+  density = 1.0 4.0
+  density = 0.79 1.0
+  density = 0.5 0.3
+  density = 0.0 .2
+}
+energy
+{
+  density = 1.0 0.65
+  density = 0.1 0.75
+  density = 0.0 .4
+}
+offset
+{
+  density = 1.0 0.0
+  density = 0.79 0.5
+  density = 0.5 0.5
+  density = 0.0 0
+}
+force
+{
+  density = 1.0 0
+  density = 0.79 0
+  density = 0.5 0
+  density = 0.0 0
+}
+
+randomInitalVelocityOffsetMaxRadius = 0.2
+				}
+
+				AUDIO
+				{
+				  channel = Ship
+				  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+				  volume = 0.0 0.0
+				volume = 0.01 1.5
+				  volume = 1.0 1.5
+				  pitch = 0.0 1.0
+				  pitch = 1.0 1.0
+				  loop = true
+				}
+			}
+			powersmoke
+			{
+				MODEL_MULTI_PARTICLE_PERSIST
+				{
+name = smokethrust
+modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/methanolflame
+transformName = thrustTransform
+emission = 0.0 0.25
+emission = 1.0 0.25
+energy = 0.0 1.2
+energy = 1.0 1.2
+speed = 0.0 1.65
+speed = 1.0 1.65
+grow = 0.0 0.34
+grow = 1.0 0.34
+scale = 0.0 1.0
+scale = 1.0 1.0
+offset = 0.0 25
+offset = 1.0 25
+size = 0.0 1.85
+size = 1.0 1.85
+renderMode = "Billboard"
+collide = false
+collideRatio = 0
+fixedScale = 0.5
+sizeClamp = 250
+angle = 0.0 1.0
+angle = 45.0 1.0
+angle = 50.0 1.0
+distance = 0.0 1.0
+distance = 100.0 1.0
+distance = 110.0 1.0
+logGrow
+{
+  density = 1.0 0
+  density = 0.5 0
+  density = 0.0 0
+}
+logGrowScale
+{
+  density = 1.0 0.0
+  density = 0.79 3
+  density = 0.1 5
+  density = 0.0 10
+}
+linGrow
+{
+  density = 1.0 0.0
+  density = 0.79 0.0
+  density = 0.005 0.0
+  density = 0.0 1
+}
+
+emission
+{
+  density = 1.0 .8
+  density = 0.79 .5
+  density = 0.5 0.5
+  density = 0.005 0.01
+  density = 0.004 .1
+}
+offset
+{
+  density = 1.0 1.0
+  density = 0.79 1.0
+  density = 0.1 30
+  density = 0.005 10
+  density = 0.004 12
+}
+size
+{
+  density = 1.0 2
+  density = 0.79 4
+  density = 0.0 20
+}
+				}
+			}
+        	engage
+        	{
+            		AUDIO
+					{
+					  channel = Ship
+					  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+					  volume = 1.0
+					  pitch = 0.8
+					  loop = false
+					}
+        	}
+        	disengage
+        	{
+            		AUDIO
+            		{
+                		channel = Ship
+                		clip = sound_vent_soft
+                		volume = 1.0
+                		pitch = 2.0
+                		loop = false
+            		}
+        	}
+        	flameout
+        	{
+            		AUDIO
+            		{
+                		channel = Ship
+                		clip = sound_explosion_low
+                		volume = 1.0
+                		pitch = 2.0
+                		loop = false
+            		}
+        	}
+	}
+}
+
+@PART[RD0146]:FOR[RealPlume] //RD-0146 ================================================================
 {
 !fx_exhaustFlame_blue = DELETE
 !fx_exhaustLight_blue = DELETE

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat
@@ -1,0 +1,814 @@
+// BobCat Proton ##############################################################
+@PART[Proton_Core_Oxidizer_Tank]:FOR[RealPlume] // Proton stage 1
+{
+  !fx_exhaustFlame_yellow = DELETE
+  !fx_smokeTrail_medium = DELETE
+  !fx_exhaustSparks_flameout = DELETE
+  !sound_vent_medium = engage
+  !sound_rocket_hard = running
+  !sound_vent_soft = disengage
+  !sound_explosion_low = flameout
+
+EFFECTS
+  {
+    powerflame
+    {
+      MODEL_MULTI_PARTICLE_PERSIST
+        {
+            name = flamethrust
+            modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicexhaust
+            transformName = thrustTransform
+            localPosition = 0,0,0.65
+            fixedScale = 1.4
+            emission = 0.0 1
+            emission = 1.0 1
+            speed = 0.0 1
+            speed = 1.0 1
+            energy = 0.0 1
+            energy = 1.0 1
+            offset = 0.0 0
+            offset = 1.0 0
+            size = 0.0 1.3
+            size = 1.0 1.3
+            fixedEmissions = false
+            logGrow
+            {
+              density = 1.0 10.0
+              density = 0.0 10.0
+            }
+            logGrowScale
+            {
+              density = 1.0 0
+              density = 0.9 0
+              density = 0.5 0
+              density = 0.9 1
+              density = 0.1 2
+              density = 0 5
+            }
+            linGrow
+            {
+              density = 1.0 -0.5
+              density = 0.9 0
+              density = 0.0 70
+            }
+            offset
+            {
+              density = 1.0 -0.2
+              density = .1 -.5
+              density = 0.0 0
+            }
+            energy
+            {
+              density = 1.0 1.0
+              density = 0.9 1.5
+              density = 0.1 1
+              density = 0.0 1
+            }
+            emission
+            {
+              density = 1.0 3
+              density = 0.9 .1
+              density = 0.0 0.08
+            }
+            speed
+            {
+              density = 1.0 3
+              density = 0.9 2.5
+              density = 0 6
+            }
+            size
+            {
+              density = 1.0 1
+              density = 0.9 1
+              density = 0.1 1
+              density = 0 1.3
+            }
+          }
+          MODEL_MULTI_PARTICLE_PERSIST
+          {
+            name = flamecore
+            modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicexhaust
+            transformName = thrustTransform
+            localPosition = 0,0,0.65
+            fixedScale = 1.3
+            emission = 0.0 1
+            emission = 1.0 1
+            speed = 0.0 1
+            speed = 1.0 1
+            energy = 0.0 1
+            energy = 1.0 1
+            offset = 0.0 0
+            offset = 1.0 0
+            size = 0.0 1.3
+            size = 1.0 1.3
+            fixedEmissions = false
+            logGrow
+            {
+              density = 1.0 10.0
+              density = 0.0 10
+            }
+            logGrowScale
+            {
+              density = 1.0 0
+              density = 0.9 0
+              density = 0 0
+            }
+            linGrow
+            {
+              density = 1.0 -0.5
+              density = 0.9 0.0
+              density = 0.0 0
+            }
+            offset
+            {
+              density = 1.0 -0.2
+              density = 0.0 0
+            }
+            energy
+            {
+              density = 1.0 3
+              density = 0.9 1
+              density = 0.3 .6
+              density = 0.01 .4
+              density = 0.0 .2
+            }
+            emission
+            {
+              density = 1.0 1.9
+              density = 0.9 1.8
+              density = 0.3 1.5
+              density = 0.01 0.4
+              density = 0.0 0.4
+            }
+            speed
+            {
+              density = 1.0 1.3
+              density = 0.9 1.3
+              density = 0.5 1.5
+              density = 0.1 0.5
+              density = 0 0.5
+            }
+          }
+          MODEL_MULTI_PARTICLE_PERSIST
+          {
+            name = flameglow
+            modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicflare
+            transformName = thrustTransform
+            emission = 0.0 1
+            emission = 1.0 1
+            speed = 0.0 1
+            speed = 1.0 1
+            offset = 0.0 1.2
+            offset = 1.0 1.2
+            energy = 0.0 1 // Same for energy
+            energy = 1.0 1 // Same for energy
+            size = 0.0 1 // Rescale the particles to +0%
+            size = 1.0 1 // Rescale the particles to +0%
+            fixedEmissions = false
+            sizeClamp = 250
+          }
+          AUDIO
+          {
+            channel = Ship
+            clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+            volume = 0.0 0.0
+            volume = 1.0 1.0
+            pitch = 0.0 1.6
+            pitch = 1.0 1.6
+            loop = true
+          }
+        }
+      engage
+      {
+        AUDIO
+        {
+          channel = Ship
+          clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq4
+          volume = 1.0
+          pitch = 1.4
+          loop = false
+        }
+      }
+      disengage
+      {
+        AUDIO
+        {
+          channel = Ship
+          clip = sound_vent_soft
+          volume = 1.0
+          pitch = 2.0
+          loop = false
+        }
+      }
+      flameout
+      {
+        AUDIO
+        {
+          channel = Ship
+          clip = sound_explosion_low
+          volume = 1.0
+          pitch = 2.0
+          loop = false
+        }
+      }
+    }
+  @MODULE[ModuleEngines]
+  {
+    @name = ModuleEnginesFX
+    //engineID = rocketengine
+    runningEffectName = powersmoke
+    directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+    }
+  @MODULE[ModuleEngineConfigs]
+ {
+		%type = ModuleEnginesFX
+  }
+}
+
+@PART[Proton_Second_Stage]:FOR[RealPlume] // Proton stage 2
+{
+!fx_exhaustFlame_yellow = DELETE
+!fx_smokeTrail_medium = DELETE
+!fx_exhaustSparks_flameout = DELETE
+!sound_vent_medium = engage
+!sound_rocket_hard = running
+!sound_vent_soft = disengage
+!sound_explosion_low = flameout
+
+EFFECTS
+  {
+  powerflame
+		{
+		MODEL_MULTI_PARTICLE_PERSIST
+			{
+        name = flamethrust
+        modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicexhaust
+        transformName = thrustTransform
+        localPosition = 0,0,0.65
+        fixedScale = 1.6
+        emission = 0.0 1
+        emission = 1.0 1
+        speed = 0.0 1
+        speed = 1.0 1
+        energy = 0.0 1
+        energy = 1.0 1
+        offset = 0.0 0
+        offset = 1.0 0
+        size = 0.0 1.3
+        size = 1.0 1.3
+        fixedEmissions = false
+        logGrow
+      {
+          density = 1.0 10.0
+          density = 0.0 4.0
+      }
+      logGrowScale
+      {
+        density = 1.0 0
+        density = 0.9 0
+        density = 0 18
+      }
+      linGrow
+      {
+        density = 1.0 -0.5
+        density = 0.9 0.0
+      density = 0.0 0.0
+      }
+      offset
+      {
+        density = 1.0 -0.2
+        density = 0.0 2
+      }
+      energy
+      {
+        density = 1.0 .1
+        density = 0.9 .5
+        density = 0.0 1.0
+      }
+      emission
+      {
+        density = 1.0 1.3
+        density = 0.9 1
+        density = 0.0 0.1
+      }
+      speed
+      {
+        density = 1.0 1.0
+        density = 0.9 1.0
+        density = 0 3
+      }
+	  	}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flameflare
+				modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicflare
+				transformName = thrustTransform
+				emission = 0.0 1
+				emission = 1.0 1
+				speed = 0.0 1
+				speed = 1.0 1
+				offset = 0.0 1.2
+				offset = 1.0 1.2
+				energy = 0.0 1 // Same for energy
+				energy = 1.0 1 // Same for energy
+				size = 0.0 1 // Rescale the particles to +0%
+				size = 1.0 1 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+        name = flamecore
+        modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/NPnukeoffset
+        transformName = thrustTransform
+        localPosition = 0,0,0.65
+        fixedScale = 1.3
+        emission = 0.0 1
+        emission = 1.0 1
+        speed = 0.0 1
+        speed = 1.0 1
+        energy = 0.0 1
+        energy = 1.0 1
+        offset = 0.0 0
+        offset = 1.0 0
+        size = 0.0 1.3
+        size = 1.0 1.3
+        fixedEmissions = false
+        logGrow
+        {
+          density = 1.0 10.0
+          density = 0.0 3
+        }
+        logGrowScale
+        {
+          density = 1.0 0
+         density = 0.9 0
+          density = 0 8
+        }
+        linGrow
+        {
+          density = 1.0 -0.5
+          density = 0.9 1
+          density = 0.0 1
+        }
+        offset
+        {
+          density = 1.0 .5
+          density = 0.0 .2
+        }
+        energy
+        {
+          density = 1.0 0
+          density = 0.9 .1
+          density = 0.0 .5
+        }
+        emission
+        {
+          density = 1.0 1.3
+          density = 0.9 1
+          density = 0.0 .5
+        }
+        speed
+        {
+          density = 1.0 1.0
+          density = 0.9 1.0
+          density = 0 3
+        }
+      }
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+			  volume = 0.0 0.0
+			  volume = 1.0 1.0
+			  pitch = 0.0 1.6
+			  pitch = 1.0 1.6
+			  loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq4
+			  volume = 1.0
+			  pitch = 1.4
+			  loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+@MODULE[ModuleEngines]
+    {
+        @name = ModuleEnginesFX
+        //engineID = rocketengine
+        runningEffectName = powersmoke
+        directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+	
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesFX
+    }
+}
+
+@PART[Proton_Third_Stage]:FOR[RealPlume] // Proton stage 3
+{
+!fx_exhaustFlame_blue = DELETE
+!fx_exhaustLight_blue = DELETE
+!fx_smokeTrail_light = DELETE
+!fx_exhaustSparks_flameout = DELETE
+!sound_vent_medium = engage
+!sound_rocket_hard = running
+!sound_vent_soft = disengage
+!sound_explosion_low = flameout
+
+EFFECTS
+  {
+	powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+        name = flamethrust
+        modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicexhaust
+        transformName = thrustTransform
+        localPosition = 0,0,0.65
+        fixedScale = 1.6
+        emission = 0.0 1
+        emission = 1.0 1
+        speed = 0.0 1
+        speed = 1.0 1
+        energy = 0.0 1
+        energy = 1.0 1
+        offset = 0.0 0
+        offset = 1.0 0
+        size = 0.0 1.3
+        size = 1.0 1.3
+        fixedEmissions = false
+        logGrow
+        {
+          density = 1.0 10.0
+          density = 0.0 4.0
+        }
+        logGrowScale
+        {
+          density = 1.0 0
+          density = 0.9 0
+          density = 0 18
+        }
+        linGrow
+        {
+          density = 1.0 -0.5
+          density = 0.9 0.0
+          density = 0.0 0.0
+        }
+        offset
+        {
+          density = 1.0 -0.2
+          density = 0.0 1
+        }
+        energy
+        {
+          density = 1.0 .1
+          density = 0.9 .5
+          density = 0.0 1.0
+        }
+        emission
+        {
+          density = 1.0 1.3
+          density = 0.9 1
+          density = 0.0 0.1
+        }
+        speed
+        {
+          density = 1.0 1.0
+          density = 0.9 1.0
+          density = 0 3
+        }
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flameflare
+				modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicflare
+				transformName = thrustTransform
+				emission = 0.0 1
+				emission = 1.0 1
+				speed = 0.0 1
+				speed = 1.0 1
+				offset = 0.0 1.2
+				offset = 1.0 1.2
+				energy = 0.0 1 // Same for energy
+				energy = 1.0 1 // Same for energy
+				size = 0.0 1 // Rescale the particles to +0%
+				size = 1.0 1 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+        name = flamecore
+        modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/NPnukeoffset
+        transformName = thrustTransform
+        localPosition = 0,0,0.65
+        fixedScale = 1.3
+        emission = 0.0 1
+        emission = 1.0 1
+        speed = 0.0 1
+        speed = 1.0 1
+        energy = 0.0 1
+        energy = 1.0 1
+        offset = 0.0 0
+        offset = 1.0 0
+        size = 0.0 1.3
+        size = 1.0 1.3
+        fixedEmissions = false
+        logGrow
+        {
+          density = 1.0 10.0
+          density = 0.0 3
+        }
+        logGrowScale
+        {
+          density = 1.0 0
+          density = 0.9 0
+          density = 0 8
+        }
+        linGrow
+        {
+          density = 1.0 -0.5
+          density = 0.9 1
+          density = 0.0 1
+        }
+        offset
+        {
+          density = 1.0 .5
+          density = 0.0 .2
+        }
+        energy
+        {
+          density = 1.0 0
+          density = 0.9 .1
+          density = 0.0 .5
+        }
+        emission
+        {
+          density = 1.0 1.3
+          density = 0.9 1
+          density = 0.0 .5
+        }
+        speed
+        {
+          density = 1.0 1.0
+          density = 0.9 1.0
+          density = 0 3
+        }
+      }
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+			  volume = 0.0 0.0
+			  volume = 1.0 1.0
+			  pitch = 0.0 1.6
+			  pitch = 1.0 1.6
+			  loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq4
+			  volume = 1.0
+			  pitch = 1.4
+			  loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+@MODULE[ModuleEngines]
+    {
+        @name = ModuleEnginesFX
+        //engineID = rocketengine
+        runningEffectName = powersmoke
+        directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+	
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesFX
+    }
+}
+
+// BobCat Soviet Engines ##############################################################
+@PART[RD0146]:FOR[RealPlume] //RD-0146
+{
+!fx_exhaustFlame_blue = DELETE
+!fx_exhaustLight_blue = DELETE
+!fx_smokeTrail_light = DELETE
+!fx_exhaustSparks_flameout = DELETE
+!sound_vent_medium = DELETE
+!sound_rocket_hard = DELETE
+!sound_vent_soft = DELETE
+!sound_explosion_low = DELETE
+EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+        name = flamethrust
+        modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+        transformName = thrustTransform
+        localPosition = 0,0,1.0
+        fixedScale = 1.2
+        speed = 0.0 1.75
+        speed = 1.0 1.75
+        fixedEmissions = false
+        grow
+        {
+          density = 1.0 -0.999
+          density = 0.12 0.0
+          density = 0.0 0
+        }
+        size
+        {
+          density = 1.0 0.6
+          density = 0.12 1.0
+          density = 0.0 4
+        }
+        logGrow
+        {
+          density = 1.0 0.0
+          density = 0.12 0.0
+          density = 0.0 7
+        }
+        offset
+        {
+          density = 1.0 -0.5
+          density = 0.12 0.1
+          density = 0.0 2.5
+        }
+        energy
+        {
+          density = 1.0 0.33
+          density = 0.0 1.0
+        }
+        emission
+        {
+          density = 1.0 1.0
+          density = 0.5 0.6
+          density = 0.0 0.35
+        }
+      }
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+        name = flamecore
+        modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/NPflamesmall
+        transformName = thrustTransform
+        localPosition = 0,0,1.0
+        fixedScale = 1.2
+        speed = 0.0 1.75
+        speed = 1.0 1.75
+        fixedEmissions = false
+        grow
+        {
+          density = 1.0 -0.999
+          density = 0.12 0.0
+          density = 0.0 1
+        }
+        size
+        {
+          density = 1.0 0.6
+          density = 0.12 0.7
+          density = 0.0 0.8
+        }
+        logGrow
+        {
+          density = 1.0 0.0
+          density = 0.12 0.0
+          density = 0.0 15.0
+        }
+        offset
+        {
+          density = 1.0 -0.5
+          density = 0.12 0.1
+          density = 0.0 -.4
+        }
+        energy
+        {
+          density = 1.0 0.33
+          density = 0.0 1
+        }
+        emission
+        {
+          density = 1.0 1.0
+          density = 0.5 0.6
+          density = 0.0 0.3
+        }
+      }
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+			  volume = 0.0 0.0
+			  volume = 1.0 1.0
+			  pitch = 0.0 0.2
+			  pitch = 1.0 1.0
+			  loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+			  volume = 0.8
+			  pitch = 1.0
+			  loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+  @MODULE[ModuleEngines]
+  {
+    @name = ModuleEnginesFX
+    //engineID = rocketengine
+		%runningEffectName = powerflame
+		%directThrottleEffectName = powersmoke
+		!fxOffset = DELETE
+	}
+  @MODULE[ModuleEngineConfigs]
+  {
+		%type = ModuleEnginesFX
+  }
+}


### PR DESCRIPTION
Added plume configs for BobCat Proton and RD-0146 engines.

Test launch: https://youtu.be/jyntJCPGxfo

![screenshot101](https://cloud.githubusercontent.com/assets/11747970/7151786/d219b3ee-e2e4-11e4-8426-d559cbcc14dc.png)
![screenshot115](https://cloud.githubusercontent.com/assets/11747970/7151788/d3f9a23c-e2e4-11e4-91e6-f9c983165587.png)
![screenshot118](https://cloud.githubusercontent.com/assets/11747970/7151789/d625973c-e2e4-11e4-8a7e-2c578da107a6.png)
![screenshot119](https://cloud.githubusercontent.com/assets/11747970/7151790/d8b859e4-e2e4-11e4-8d2f-5257af3c22bd.png)
![screenshot123](https://cloud.githubusercontent.com/assets/11747970/7151792/dbab92ce-e2e4-11e4-8864-52f8fe269c66.png)
![screenshot124](https://cloud.githubusercontent.com/assets/11747970/7151794/ddf4dd42-e2e4-11e4-9d4d-7d881f31ca38.png)
