### PR TITLE
Add motors; thrust curve; burn time; remove FINAL

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -14,7 +14,7 @@
 	@node_attach = 0.0, 0.0, -0.50927, 0.0, 0.0, 0.0
 	@title = Castor 4A
 	%manufacturer = Thiokol ATK
-	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads.
+	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads. Burn time: 53 seconds.
 	@mass = 1.565347
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
@@ -126,7 +126,7 @@
 	}
 }
 // ##########################################################################################	***NEW*** Castor 4AXL
-+PART[KWsrbGlobeI]:FINAL
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
 {
 	@name = RO_KWsrbGlobeI
 	@MODEL,0
@@ -135,7 +135,7 @@
 	}
 	@title = Castor 4 AXL
 	%manufacturer = Thiokol (ATK)
-	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads. Slightly larger than it's siblings produces a bit more thrust.
+	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads. Slightly larger than it's siblings produces a bit more thrust. Burn time: 57 seconds.
 	@mass = 1.871069
 	@MODULE[ModuleEngines*]
 	{
@@ -229,16 +229,16 @@
 	}
 }
 // ##########################################################################################	GEM40
-+PART[KWsrbGlobeI]:FINAL
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
 {
 	@name = RO_KWsrbGlobeI_GEM
 	@MODEL,0
 	{
 		@scale = 2.62697, 2.268297, 2.62697
 	}
-	@title = GEM 40 SRM (Graphite Epoxy Motor)
+	@title = GEM 40
 	%manufacturer = Thiokol ATK
-	@description = Graphite-Epoxy Motor (GEM) 40". An upgraded Castor IV with a new case. Available in ground and air start version.
+	@description = The Graphite-Epoxy Motor (GEM) replaced the Castor 4's steel case with a lighter composite case. The 40-inch (1-meter) diameter GEM 40 was used on the Delta II 7000-series in sets of three, four, or nine. When nine boosters were used, six were ignited at liftoff and the remaining three were ignited after burnout and jettison of the first six. Burn time: 58 seconds.
 	@mass = 1.196123
 	@MODULE[ModuleEngines*]
 	{
@@ -328,8 +328,10 @@
 				key = 0.03664 0.699
 				key = 0.02329 0.655
 				key = 0.01124 0.592
-				key = 0.0009 0.507
-				key = 0.0005 0.25
+				key = 0.00861 0.55
+				key = 0.00661 0.52
+				key = 0.0040 0.481
+				key = 0.0015 0.25
 			}
 			massMult = 1.0
 		}
@@ -408,10 +410,624 @@
 				key = 0.06507 0.724
 				key = 0.05052 0.714
 				key = 0.03625 0.7
-				key = 0.02273 0.663
-				key = 0.01061 0.594
-				key = 0.0008 0.481
-				key = 0.0005 0.25
+				key = 0.02329 0.655
+				key = 0.01124 0.592
+				key = 0.00861 0.55
+				key = 0.00661 0.52
+				key = 0.0040 0.481
+				key = 0.0015 0.25
+			}
+		}
+	}
+}
+// ##########################################################################################	GEM60
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
+{
+	@name = RO_KWsrbGlobeI_GEM60
+	@MODEL,0
+	{
+		@scale = 4, 3, 4
+	}
+	@node_attach = 0.0, 0.0, -0.76, 0.0, 0.0, 0.0
+	@title = GEM 60
+	%manufacturer = Thiokol ATK
+	@description = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time: 90 seconds
+	@mass = 3.95215
+	@maxTemp = 1700
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 1235.947
+		@atmosphereCurve
+		{
+			@key,0 = 0 274
+			@key,1 = 1 246
+		}
+	}
+	!MODULE[ModuleGimbal]
+	{
+	}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = NozzleTransform
+		gimbalRange = 4
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 16684.0
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = GEM-60-TVC
+		%origMass = 3.95215
+		@CONFIG[Castor-4A]
+		{
+			@name = GEM-60-TVC
+			@maxThrust = 1235.947
+			%heatProduction = 100
+			@atmosphereCurve
+			{
+				@key,0 = 0 274
+				@key,1 = 1 246
+			}
+			!thrustCurve
+			{
+			}
+			thrustCurve
+			{
+				key = 0.99972 0.719
+				key = 0.98539 0.939
+				key = 0.97106 0.939
+				key = 0.95673 0.939
+				key = 0.94227 0.948
+				key = 0.92769 0.956
+				key = 0.91298 0.964
+				key = 0.89811 0.975
+				key = 0.88302 0.989
+				key = 0.86785 0.995
+				key = 0.85268 0.994
+				key = 0.83746 0.997
+				key = 0.82221 1
+				key = 0.80695 1
+				key = 0.7917 1
+				key = 0.77644 1
+				key = 0.76119 1
+				key = 0.74593 1
+				key = 0.73068 1
+				key = 0.71543 1
+				key = 0.70017 1
+				key = 0.68496 0.997
+				key = 0.66992 0.986
+				key = 0.65513 0.969
+				key = 0.6408 0.939
+				key = 0.62728 0.886
+				key = 0.61481 0.817
+				key = 0.60293 0.779
+				key = 0.59143 0.754
+				key = 0.58023 0.734
+				key = 0.56953 0.701
+				key = 0.55909 0.685
+				key = 0.5489 0.668
+				key = 0.539 0.649
+				key = 0.52932 0.635
+				key = 0.51985 0.621
+				key = 0.51063 0.604
+				key = 0.50162 0.591
+				key = 0.49282 0.577
+				key = 0.48419 0.566
+				key = 0.47573 0.555
+				key = 0.46731 0.552
+				key = 0.45877 0.56
+				key = 0.45014 0.566
+				key = 0.44143 0.571
+				key = 0.43263 0.577
+				key = 0.42371 0.585
+				key = 0.4147 0.59
+				key = 0.40561 0.596
+				key = 0.39644 0.601
+				key = 0.38718 0.607
+				key = 0.37779 0.615
+				key = 0.36832 0.621
+				key = 0.35877 0.626
+				key = 0.34913 0.632
+				key = 0.33936 0.64
+				key = 0.32951 0.646
+				key = 0.31958 0.651
+				key = 0.30952 0.659
+				key = 0.29938 0.665
+				key = 0.28915 0.67
+				key = 0.2788 0.679
+				key = 0.26836 0.684
+				key = 0.25779 0.693
+				key = 0.24714 0.698
+				key = 0.23641 0.704
+				key = 0.22564 0.706
+				key = 0.21482 0.709
+				key = 0.20392 0.715
+				key = 0.19297 0.717
+				key = 0.18199 0.72
+				key = 0.17092 0.726
+				key = 0.15981 0.728
+				key = 0.14865 0.731
+				key = 0.13746 0.734
+				key = 0.12618 0.739
+				key = 0.11494 0.737
+				key = 0.10371 0.737
+				key = 0.09255 0.731
+				key = 0.08148 0.726
+				key = 0.07054 0.717
+				key = 0.05964 0.714
+				key = 0.04883 0.709
+				key = 0.03814 0.701
+				key = 0.02754 0.695
+				key = 0.01913 0.551
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
+			}
+		}
+		CONFIG
+		{
+			name = GEM-60
+			maxThrust = 1235.947
+			gimbalRange = 0
+			heatProduction = 100
+			massMult = 0.844
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 274
+				key = 1 246
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99972 0.719
+				key = 0.98539 0.939
+				key = 0.97106 0.939
+				key = 0.95673 0.939
+				key = 0.94227 0.948
+				key = 0.92769 0.956
+				key = 0.91298 0.964
+				key = 0.89811 0.975
+				key = 0.88302 0.989
+				key = 0.86785 0.995
+				key = 0.85268 0.994
+				key = 0.83746 0.997
+				key = 0.82221 1
+				key = 0.80695 1
+				key = 0.7917 1
+				key = 0.77644 1
+				key = 0.76119 1
+				key = 0.74593 1
+				key = 0.73068 1
+				key = 0.71543 1
+				key = 0.70017 1
+				key = 0.68496 0.997
+				key = 0.66992 0.986
+				key = 0.65513 0.969
+				key = 0.6408 0.939
+				key = 0.62728 0.886
+				key = 0.61481 0.817
+				key = 0.60293 0.779
+				key = 0.59143 0.754
+				key = 0.58023 0.734
+				key = 0.56953 0.701
+				key = 0.55909 0.685
+				key = 0.5489 0.668
+				key = 0.539 0.649
+				key = 0.52932 0.635
+				key = 0.51985 0.621
+				key = 0.51063 0.604
+				key = 0.50162 0.591
+				key = 0.49282 0.577
+				key = 0.48419 0.566
+				key = 0.47573 0.555
+				key = 0.46731 0.552
+				key = 0.45877 0.56
+				key = 0.45014 0.566
+				key = 0.44143 0.571
+				key = 0.43263 0.577
+				key = 0.42371 0.585
+				key = 0.4147 0.59
+				key = 0.40561 0.596
+				key = 0.39644 0.601
+				key = 0.38718 0.607
+				key = 0.37779 0.615
+				key = 0.36832 0.621
+				key = 0.35877 0.626
+				key = 0.34913 0.632
+				key = 0.33936 0.64
+				key = 0.32951 0.646
+				key = 0.31958 0.651
+				key = 0.30952 0.659
+				key = 0.29938 0.665
+				key = 0.28915 0.67
+				key = 0.2788 0.679
+				key = 0.26836 0.684
+				key = 0.25779 0.693
+				key = 0.24714 0.698
+				key = 0.23641 0.704
+				key = 0.22564 0.706
+				key = 0.21482 0.709
+				key = 0.20392 0.715
+				key = 0.19297 0.717
+				key = 0.18199 0.72
+				key = 0.17092 0.726
+				key = 0.15981 0.728
+				key = 0.14865 0.731
+				key = 0.13746 0.734
+				key = 0.12618 0.739
+				key = 0.11494 0.737
+				key = 0.10371 0.737
+				key = 0.09255 0.731
+				key = 0.08148 0.726
+				key = 0.07054 0.717
+				key = 0.05964 0.714
+				key = 0.04883 0.709
+				key = 0.03814 0.701
+				key = 0.02754 0.695
+				key = 0.01913 0.551
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
+			}
+		}
+	}
+}
+// ##########################################################################################	GEM46
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
+{
+	@name = RO_KWsrbGlobeI_GEM46
+	@MODEL,0
+	{
+		@scale = 3.02, 2.81, 3.02
+	}
+	@node_attach = 0.0, 0.0, -0.585, 0.0, 0.0, 0.0
+	@title = GEM 46
+	%manufacturer = Thiokol ATK
+	@description =  The 46-inch (1.2-meter) diameter GEM 46 was used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with thrust vector control (TVC) while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC. Burn time: 58 seconds.
+	@mass = 2.275
+	@maxTemp = 1700
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 1235.947
+		@atmosphereCurve
+		{
+			@key,0 = 0 274
+			@key,1 = 1 246
+		}
+	}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = NozzleTransform
+		gimbalRange = 6
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 9474.5
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = GEM-46-Ground-TVC
+		%origMass = 2.275
+		@CONFIG[Castor-4A]
+		{
+			@name = GEM-46-Ground-TVC
+			@maxThrust = 874.5204
+			%heatProduction = 100
+			gimbalRange = 4
+			@atmosphereCurve
+			{
+				@key,0 = 0 279.8
+				@key,1 = 1 251
+			}
+			!thrustCurve
+			{
+			}
+			thrustCurve
+			{
+				key = 0.99722 0.747
+				key = 0.98169 0.821
+				key = 0.96612 0.824
+				key = 0.9504 0.831
+				key = 0.93446 0.843
+				key = 0.91832 0.853
+				key = 0.90196 0.865
+				key = 0.88537 0.877
+				key = 0.86859 0.887
+				key = 0.85157 0.9
+				key = 0.83433 0.912
+				key = 0.81676 0.929
+				key = 0.79896 0.941
+				key = 0.78093 0.953
+				key = 0.76258 0.971
+				key = 0.74399 0.983
+				key = 0.72526 0.99
+				key = 0.70639 0.998
+				key = 0.68748 1
+				key = 0.66862 0.998
+				key = 0.6498 0.995
+				key = 0.63107 0.99
+				key = 0.61253 0.98
+				key = 0.59426 0.966
+				key = 0.57623 0.953
+				key = 0.55853 0.936
+				key = 0.54119 0.917
+				key = 0.52432 0.892
+				key = 0.508 0.863
+				key = 0.49229 0.831
+				key = 0.47708 0.804
+				key = 0.46234 0.779
+				key = 0.44792 0.762
+				key = 0.43411 0.73
+				key = 0.42062 0.713
+				key = 0.4075 0.694
+				key = 0.3948 0.672
+				key = 0.38247 0.652
+				key = 0.37051 0.632
+				key = 0.35888 0.615
+				key = 0.34748 0.603
+				key = 0.3363 0.591
+				key = 0.32523 0.586
+				key = 0.31415 0.586
+				key = 0.30311 0.583
+				key = 0.29208 0.583
+				key = 0.281 0.586
+				key = 0.26993 0.586
+				key = 0.25885 0.586
+				key = 0.24777 0.586
+				key = 0.23674 0.583
+				key = 0.22575 0.581
+				key = 0.21476 0.581
+				key = 0.20378 0.581
+				key = 0.19279 0.581
+				key = 0.18181 0.581
+				key = 0.17087 0.578
+				key = 0.15993 0.578
+				key = 0.14899 0.578
+				key = 0.13809 0.576
+				key = 0.1272 0.576
+				key = 0.11635 0.574
+				key = 0.1056 0.569
+				key = 0.09489 0.566
+				key = 0.08428 0.561
+				key = 0.07371 0.559
+				key = 0.06319 0.556
+				key = 0.05271 0.554
+				key = 0.04228 0.551
+				key = 0.03204 0.542
+				key = 0.02346 0.453
+				key = 0.01697 0.343
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
+			}
+		}
+		CONFIG
+		{
+			name = GEM-46-Ground
+			massMult = 0.879
+			gimbalRange = 0
+			maxThrust = 874.5204
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 279.8
+				key = 1 251
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99722 0.747
+				key = 0.98169 0.821
+				key = 0.96612 0.824
+				key = 0.9504 0.831
+				key = 0.93446 0.843
+				key = 0.91832 0.853
+				key = 0.90196 0.865
+				key = 0.88537 0.877
+				key = 0.86859 0.887
+				key = 0.85157 0.9
+				key = 0.83433 0.912
+				key = 0.81676 0.929
+				key = 0.79896 0.941
+				key = 0.78093 0.953
+				key = 0.76258 0.971
+				key = 0.74399 0.983
+				key = 0.72526 0.99
+				key = 0.70639 0.998
+				key = 0.68748 1
+				key = 0.66862 0.998
+				key = 0.6498 0.995
+				key = 0.63107 0.99
+				key = 0.61253 0.98
+				key = 0.59426 0.966
+				key = 0.57623 0.953
+				key = 0.55853 0.936
+				key = 0.54119 0.917
+				key = 0.52432 0.892
+				key = 0.508 0.863
+				key = 0.49229 0.831
+				key = 0.47708 0.804
+				key = 0.46234 0.779
+				key = 0.44792 0.762
+				key = 0.43411 0.73
+				key = 0.42062 0.713
+				key = 0.4075 0.694
+				key = 0.3948 0.672
+				key = 0.38247 0.652
+				key = 0.37051 0.632
+				key = 0.35888 0.615
+				key = 0.34748 0.603
+				key = 0.3363 0.591
+				key = 0.32523 0.586
+				key = 0.31415 0.586
+				key = 0.30311 0.583
+				key = 0.29208 0.583
+				key = 0.281 0.586
+				key = 0.26993 0.586
+				key = 0.25885 0.586
+				key = 0.24777 0.586
+				key = 0.23674 0.583
+				key = 0.22575 0.581
+				key = 0.21476 0.581
+				key = 0.20378 0.581
+				key = 0.19279 0.581
+				key = 0.18181 0.581
+				key = 0.17087 0.578
+				key = 0.15993 0.578
+				key = 0.14899 0.578
+				key = 0.13809 0.576
+				key = 0.1272 0.576
+				key = 0.11635 0.574
+				key = 0.1056 0.569
+				key = 0.09489 0.566
+				key = 0.08428 0.561
+				key = 0.07371 0.559
+				key = 0.06319 0.556
+				key = 0.05271 0.554
+				key = 0.04228 0.551
+				key = 0.03204 0.542
+				key = 0.02346 0.453
+				key = 0.01697 0.343
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
+			}
+		}
+		CONFIG
+		{
+			name = GEM-46-Air
+			maxThrust = 916.3337
+			massMult = 0.969
+			heatProduction = 100
+			gimbalRange = 0
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 290.7
+				key = 1 225
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99692 0.762
+				key = 0.98133 0.82
+				key = 0.96571 0.822
+				key = 0.95 0.826
+				key = 0.93407 0.838
+				key = 0.91797 0.847
+				key = 0.90162 0.86
+				key = 0.88501 0.874
+				key = 0.86822 0.883
+				key = 0.85114 0.899
+				key = 0.8338 0.912
+				key = 0.8162 0.926
+				key = 0.7983 0.941
+				key = 0.78011 0.957
+				key = 0.76161 0.973
+				key = 0.7429 0.984
+				key = 0.72401 0.993
+				key = 0.70504 0.998
+				key = 0.68603 1
+				key = 0.66702 1
+				key = 0.64805 0.998
+				key = 0.62916 0.993
+				key = 0.61036 0.989
+				key = 0.59186 0.973
+				key = 0.57362 0.96
+				key = 0.55568 0.944
+				key = 0.53803 0.928
+				key = 0.52103 0.894
+				key = 0.50458 0.865
+				key = 0.48874 0.834
+				key = 0.47349 0.802
+				key = 0.45863 0.782
+				key = 0.44423 0.757
+				key = 0.43027 0.735
+				key = 0.41673 0.712
+				key = 0.40354 0.694
+				key = 0.39081 0.669
+				key = 0.37834 0.656
+				key = 0.3663 0.633
+				key = 0.35452 0.62
+				key = 0.34308 0.602
+				key = 0.33181 0.593
+				key = 0.32058 0.591
+				key = 0.30936 0.591
+				key = 0.29813 0.591
+				key = 0.2869 0.591
+				key = 0.27567 0.591
+				key = 0.26444 0.591
+				key = 0.25321 0.591
+				key = 0.24198 0.591
+				key = 0.2308 0.588
+				key = 0.21961 0.588
+				key = 0.20847 0.586
+				key = 0.19732 0.586
+				key = 0.18618 0.586
+				key = 0.17507 0.584
+				key = 0.16397 0.584
+				key = 0.15287 0.584
+				key = 0.14181 0.582
+				key = 0.13075 0.582
+				key = 0.11973 0.58
+				key = 0.10875 0.577
+				key = 0.09786 0.573
+				key = 0.08702 0.571
+				key = 0.07625 0.566
+				key = 0.06553 0.564
+				key = 0.05486 0.562
+				key = 0.04422 0.559
+				key = 0.03363 0.557
+				key = 0.02415 0.499
+				key = 0.01707 0.373
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
 			}
 		}
 	}
@@ -576,9 +1192,9 @@
 	@node_stack_bottom = 0.0, -6.816574, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_top = 0.0, 6.34343, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.76, 0.0, 0.0, 2.0
-	@title = GEM 60 SRM (Graphite Epoxy Motor)
+	@title = GEM 60
 	&manufacturer = Thiokol ATK
-	@description = 60" SRB used on the Delta IV, which can be equipped with 0, 2, or 4 boosters. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to save cost and weight.
+	@description = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time: 90 seconds.
 	@mass = 3.95215
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
@@ -720,18 +1336,14 @@
 				key = 0.03814 0.701
 				key = 0.02754 0.695
 				key = 0.01913 0.551
-				key = 0.01527 0.253
-				key = 0.01302 0.148
-				key = 0.01157 0.095
-				key = 0.01054 0.067
-				key = 0.00969 0.056
-				key = 0.00904 0.042
-				key = 0.00856 0.031
-				key = 0.00816 0.026
-				key = 0.00785 0.02
-				key = 0.00763 0.015
-				key = 0.00753 0.006
-				key = 0.00743 0.006
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
 			}
 		}
 		CONFIG
@@ -841,18 +1453,14 @@
 				key = 0.03814 0.701
 				key = 0.02754 0.695
 				key = 0.01913 0.551
-				key = 0.01527 0.253
-				key = 0.01302 0.148
-				key = 0.01157 0.095
-				key = 0.01054 0.067
-				key = 0.00969 0.056
-				key = 0.00904 0.042
-				key = 0.00856 0.031
-				key = 0.00816 0.026
-				key = 0.00785 0.02
-				key = 0.00763 0.015
-				key = 0.00753 0.006
-				key = 0.00743 0.006
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
 			}
 		}
 	}
@@ -873,9 +1481,9 @@
 	@node_stack_bottom = 0.0, -6.786727, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_top = 0.0, 6.193274, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.585, 0.0, 0.0, 2.0
-	@title = GEM 46 SRM (Graphite Epoxy Motor)
+	@title = GEM 46
 	%manufacturer = Thiokol ATK
-	@description = 46" SRBs used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with thrust vector control (TVC) while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC.
+	@description =  The 46-inch (1.2-meter) diameter GEM 46 was used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with thrust vector control (TVC) while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC. Burn time: 75 seconds.
 	@mass = 2.275
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
@@ -1003,13 +1611,14 @@
 				key = 0.03204 0.542
 				key = 0.02346 0.453
 				key = 0.01697 0.343
-				key = 0.01215 0.255
-				key = 0.00905 0.164
-				key = 0.0071 0.103
-				key = 0.00589 0.064
-				key = 0.0052 0.037
-				key = 0.00483 0.02
-				key = 0.00473 0.005
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
 			}
 		}
 		CONFIG
@@ -1105,13 +1714,14 @@
 				key = 0.03204 0.542
 				key = 0.02346 0.453
 				key = 0.01697 0.343
-				key = 0.01215 0.255
-				key = 0.00905 0.164
-				key = 0.0071 0.103
-				key = 0.00589 0.064
-				key = 0.0052 0.037
-				key = 0.00483 0.02
-				key = 0.00473 0.005
+				key = 0.01204 0.264
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
 			}
 		}
 		CONFIG
@@ -1205,14 +1815,15 @@
 				key = 0.04422 0.559
 				key = 0.03363 0.557
 				key = 0.02415 0.499
-				key = 0.01707 0.373
+				key = 0.01697 0.343
 				key = 0.01204 0.264
-				key = 0.00877 0.172
-				key = 0.00682 0.102
-				key = 0.00565 0.062
-				key = 0.00503 0.033
-				key = 0.00475 0.015
-				key = 0.00473 0.001
+				key = 0.00877 0.22
+				key = 0.00682 0.20
+				key = 0.00483 0.18
+				key = 0.0028 0.16
+				key = 0.0018 0.13
+				key = 0.0005 0.09
+				key = 0.0000 0.08
 			}
 		}
 	}
@@ -1452,7 +2063,7 @@
 	@node_attach = 0.0, 0.0, -1.555, 0.0, 0.0, 0.0, 2
 	@title = UA-1207 SRM
 	%manufacturer = United Technologies
-	@description = Seven segment solid boosters in the series by United Technologies for use with the Titan IV. Afternoon Delight.
+	@description = Seven segment solid boosters in the series by United Technologies for use with the Titan IV. Afternoon Delight. Burn time: 130 seconds.
 	@mass = 50.730
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
@@ -1642,7 +2253,7 @@
 				key = 0.00117 0.026
 				key = 0.00095 0.022
 				key = 0.00082 0.013
-				key = 0.00077 0.005
+				key = 0.00000 0.005
 			}
 		}
 	}
@@ -1663,7 +2274,7 @@
 	@node_attach = 0.0, 0.0, -1.525, 0.0, 0.0, 0.0
 	@title = P241A EAP
 	%manufacturer = EADS Astrium
-	@description = Solid booster as found on the Ariane 5. Sky rockets in flight.
+	@description = Solid booster as found on the Ariane 5. Sky rockets in flight. Burn time: 124 seconds.
 	@mass = 35.975
 	@maxTemp = 1700
 	@MODULE[ModuleEngines*]
@@ -1989,6 +2600,226 @@
 		}
 	}
 }
+
+// ##########################################################################################	Globe X-10L "Thor II" SRB
++PART[KWsrbGlobeX10L]:AFTER[RealismOverhaul]
+{
+	@name = RO_SRMU
+	@MODEL
+	{
+		@scale = 1.6002, 1.524974, 1.6002
+	}
+	@rescaleFactor = 1.0
+	@scale = 1.0
+	@node_stack_bottom = 0.0, -14.9447452, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_top = 0.0, 14.9447452, 0.0, 0.0, 1.0, 0.0, 3
+	@node_attach = 0.0, 0.0, -1.6002, 0.0, 0.0, 0.0, 2
+	@title = SRMU
+	%manufacturer = Thoikol (ATK)
+	@description = The 3-segment, composite-case SRMU (Solid Rocket Motor Upgrade) was used on the Titan IVB, replacing the 7-segment, steel-case UA1207 used on the Titan IVA. Burn time: 150 seconds. 
+	@mass = 36.56453
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1800
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0
+		@maxThrust = 8244.42362
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 281
+			@key,1 = 1 251
+		}
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 177213.7
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG[SolidFuel]
+		{
+			@maxThrust = 8244.42362
+			@atmosphereCurve
+			{
+				@key,0 = 0 281
+				@key,1 = 1 251
+			}
+			!thrustCurve
+			{
+			}
+			thrustCurve
+			{
+				key = 0.99171 0.88
+				key = 0.9831 0.914
+				key = 0.97439 0.924
+				key = 0.96565 0.928
+				key = 0.95687 0.932
+				key = 0.94803 0.938
+				key = 0.93916 0.942
+				key = 0.93022 0.948
+				key = 0.92125 0.952
+				key = 0.91225 0.956
+				key = 0.90318 0.962
+				key = 0.89406 0.968
+				key = 0.88488 0.974
+				key = 0.87566 0.978
+				key = 0.86639 0.984
+				key = 0.85706 0.99
+				key = 0.84767 0.996
+				key = 0.83825 1
+				key = 0.82882 1
+				key = 0.8194 1
+				key = 0.80997 1
+				key = 0.80057 0.998
+				key = 0.79118 0.996
+				key = 0.78181 0.994
+				key = 0.77244 0.994
+				key = 0.7631 0.992
+				key = 0.75375 0.992
+				key = 0.74442 0.99
+				key = 0.7351 0.988
+				key = 0.72581 0.986
+				key = 0.71652 0.986
+				key = 0.70724 0.984
+				key = 0.69799 0.982
+				key = 0.68875 0.98
+				key = 0.67953 0.978
+				key = 0.67032 0.978
+				key = 0.66112 0.976
+				key = 0.65194 0.974
+				key = 0.64277 0.972
+				key = 0.63363 0.97
+				key = 0.62451 0.968
+				key = 0.61542 0.964
+				key = 0.60637 0.96
+				key = 0.59742 0.95
+				key = 0.58868 0.928
+				key = 0.58017 0.902
+				key = 0.57181 0.888
+				key = 0.56355 0.876
+				key = 0.55535 0.87
+				key = 0.54718 0.868
+				key = 0.53907 0.86
+				key = 0.53106 0.85
+				key = 0.52313 0.842
+				key = 0.51531 0.83
+				key = 0.50751 0.828
+				key = 0.49978 0.82
+				key = 0.49215 0.81
+				key = 0.48458 0.804
+				key = 0.47704 0.8
+				key = 0.46956 0.794
+				key = 0.46212 0.79
+				key = 0.45475 0.782
+				key = 0.44744 0.776
+				key = 0.44021 0.768
+				key = 0.43301 0.764
+				key = 0.42585 0.76
+				key = 0.41869 0.76
+				key = 0.41153 0.76
+				key = 0.40439 0.758
+				key = 0.39725 0.758
+				key = 0.39009 0.76
+				key = 0.38293 0.76
+				key = 0.37577 0.76
+				key = 0.36861 0.76
+				key = 0.36145 0.76
+				key = 0.35429 0.76
+				key = 0.34713 0.76
+				key = 0.33999 0.758
+				key = 0.33285 0.758
+				key = 0.32573 0.756
+				key = 0.3186 0.756
+				key = 0.3115 0.754
+				key = 0.3044 0.754
+				key = 0.29729 0.754
+				key = 0.29021 0.752
+				key = 0.28314 0.75
+				key = 0.2761 0.748
+				key = 0.26905 0.748
+				key = 0.26202 0.746
+				key = 0.25499 0.746
+				key = 0.24798 0.744
+				key = 0.24099 0.742
+				key = 0.23402 0.74
+				key = 0.22707 0.738
+				key = 0.22013 0.736
+				key = 0.21322 0.734
+				key = 0.20632 0.732
+				key = 0.19944 0.73
+				key = 0.1926 0.726
+				key = 0.18578 0.724
+				key = 0.17898 0.722
+				key = 0.1722 0.72
+				key = 0.16543 0.718
+				key = 0.15869 0.716
+				key = 0.15196 0.714
+				key = 0.14527 0.71
+				key = 0.13862 0.706
+				key = 0.13202 0.7
+				key = 0.12549 0.694
+				key = 0.11899 0.69
+				key = 0.11249 0.69
+				key = 0.106 0.688
+				key = 0.09956 0.684
+				key = 0.09315 0.68
+				key = 0.08688 0.666
+				key = 0.0808 0.646
+				key = 0.07482 0.634
+				key = 0.06897 0.622
+				key = 0.06324 0.608
+				key = 0.05768 0.589
+				key = 0.05226 0.575
+				key = 0.04699 0.559
+				key = 0.04183 0.547
+				key = 0.03705 0.507
+				key = 0.03263 0.469
+				key = 0.0287 0.417
+				key = 0.02497 0.395
+				key = 0.02152 0.367
+				key = 0.01826 0.345
+				key = 0.01526 0.319
+				key = 0.01271 0.271
+				key = 0.01061 0.223
+				key = 0.00886 0.186
+				key = 0.00731 0.164
+				key = 0.00602 0.136
+				key = 0.00502 0.106
+				key = 0.00417 0.09
+				key = 0.00349 0.072
+				key = 0.00289 0.064
+				key = 0.00243 0.048
+				key = 0.00208 0.038
+				key = 0.00179 0.03
+				key = 0.00155 0.026
+				key = 0.00132 0.024
+				key = 0.00113 0.02
+				key = 0.00096 0.018
+				key = 0.00081 0.016
+				key = 0.00068 0.014
+				key = 0.00057 0.012
+				key = 0.00047 0.01
+				key = 0.00038 0.01
+				key = 0.0003 0.008
+				key = 0.00022 0.008
+				key = 0.00017 0.006
+				key = 0.00011 0.006
+				key = 0.00005 0.006
+				key = 0.00002 0.004
+				key = 0 0.002
+			}
+		}
+	}
+}
+
 // ##########################################################################################	ATK Advanced SRB // change to + and remove RO_ from name when more data arrives.
 @PART[RO_KWsrbGlobeX5]:FINAL
 {


### PR DESCRIPTION
Added GEM 46 and GEM 60 using same model as GEM 40 and Castor 4 for family continuity, add back SRMU config, Adjust thrust curves for GEMs to reduce Unity-spiking, Added burn time to descriptions.