### PR TITLE
Add configs for StarShine Athena 2c launcher

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_StarShine_Athena2c
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_StarShine_Athena2c
@@ -1,0 +1,544 @@
+@PART[castor120]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 12.084
+	@mass = 4.07
+	%node_attach = 0.0, 0.0, -0.0985, 0.0, 0.0, 1.0
+	%attachRules = 1,1,1,1,0
+	@title = Castor 120
+	@manufacturer = Orbital ATK
+	@description = The Castor 120 is a large monolithic composite-case solid motor used on Athena and Minotaur-C launchers. Burn time: 79 seconds.
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0
+		@maxThrust = 1957
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 280
+			@key,1 = 1 253
+		}
+	}
+	!MODULE[ModuleDecouple]
+	{
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 27499.4
+		type = Solid
+		basemass = -1
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 4.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Castor-120
+		modded = false
+		CONFIG
+		{
+			name = Castor-120
+			maxThrust = 1957.2
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key,0 = 0 280
+				key,1 = 1 253
+			}
+			curveResource = SolidFuel
+thrustCurve
+			{
+				key = 0.98796 0.827
+				key = 0.97561 0.848
+				key = 0.96289 0.873
+				key = 0.94975 0.903
+				key = 0.93654 0.907
+				key = 0.92334 0.907
+				key = 0.91013 0.907
+				key = 0.89693 0.907
+				key = 0.88372 0.907
+				key = 0.87046 0.911
+				key = 0.85713 0.915
+				key = 0.8438 0.915
+				key = 0.83047 0.915
+				key = 0.81715 0.915
+				key = 0.80382 0.915
+				key = 0.79049 0.915
+				key = 0.77716 0.915
+				key = 0.76377 0.919
+				key = 0.75026 0.928
+				key = 0.73675 0.928
+				key = 0.72318 0.932
+				key = 0.70961 0.932
+				key = 0.69604 0.932
+				key = 0.68234 0.94
+				key = 0.66865 0.94
+				key = 0.65495 0.94
+				key = 0.6412 0.945
+				key = 0.62732 0.953
+				key = 0.61344 0.953
+				key = 0.59957 0.953
+				key = 0.58569 0.953
+				key = 0.57181 0.953
+				key = 0.55793 0.953
+				key = 0.54406 0.953
+				key = 0.5303 0.945
+				key = 0.51661 0.94
+				key = 0.50291 0.94
+				key = 0.48922 0.94
+				key = 0.47552 0.94
+				key = 0.46183 0.94
+				key = 0.4482 0.936
+				key = 0.43469 0.928
+				key = 0.42117 0.928
+				key = 0.40779 0.919
+				key = 0.3944 0.919
+				key = 0.38107 0.915
+				key = 0.36787 0.907
+				key = 0.35466 0.907
+				key = 0.34164 0.894
+				key = 0.32886 0.877
+				key = 0.31639 0.856
+				key = 0.30416 0.84
+				key = 0.29212 0.827
+				key = 0.28014 0.823
+				key = 0.26822 0.819
+				key = 0.25623 0.823
+				key = 0.24425 0.823
+				key = 0.23208 0.835
+				key = 0.21986 0.84
+				key = 0.20757 0.844
+				key = 0.19528 0.844
+				key = 0.18299 0.844
+				key = 0.17071 0.844
+				key = 0.15842 0.844
+				key = 0.14613 0.844
+				key = 0.1339 0.84
+				key = 0.12174 0.835
+				key = 0.10963 0.831
+				key = 0.09771 0.819
+				key = 0.08603 0.802
+				key = 0.07472 0.777
+				key = 0.06384 0.747
+				key = 0.05333 0.722
+				key = 0.04312 0.701
+				key = 0.03309 0.689
+				key = 0.02319 0.68
+				key = 0.01347 0.668
+				key = 0.00387 0.659
+			}
+		}
+	}
+}
+
+@PART[castor30]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 12.084
+	@title = Castor 30B
+	@mass = 1.083179
+	@manufacturer = Orbital ATK
+	@description = The Castor 30B is a large vacuum-optimized solid motor used on the Athena and Antares launchers. Burn time: 130 seconds.
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0
+		@maxThrust = 396.3
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 300.6
+			@key,1 = 1 215
+		}
+	}
+	!MODULE[ModuleDecouple]
+	{
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7240.2
+		type = Solid
+		basemass = -1
+	}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Castor30B
+		modded = false
+		CONFIG
+		{
+			name = Castor30B
+			maxThrust = 396.2921
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = SolidFuel
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key,0 = 0 300.6
+				key,1 = 1 215
+			}
+			curveResource = SolidFuel
+			thrustCurve
+			{
+				key = 0.99998 0.250
+				key = 0.99493 0.483
+				key = 0.98966 0.505
+				key = 0.9842 0.524
+				key = 0.97861 0.535
+				key = 0.97282 0.554
+				key = 0.96679 0.578
+				key = 0.96056 0.597
+				key = 0.95403 0.625
+				key = 0.9473 0.644
+				key = 0.9403 0.67
+				key = 0.93308 0.692
+				key = 0.92559 0.718
+				key = 0.91787 0.739
+				key = 0.91006 0.749
+				key = 0.90219 0.753
+				key = 0.89421 0.765
+				key = 0.88619 0.768
+				key = 0.87813 0.772
+				key = 0.87005 0.775
+				key = 0.86193 0.777
+				key = 0.85377 0.782
+				key = 0.84556 0.787
+				key = 0.83725 0.796
+				key = 0.82887 0.803
+				key = 0.82036 0.815
+				key = 0.81178 0.822
+				key = 0.8031 0.832
+				key = 0.79432 0.841
+				key = 0.78541 0.853
+				key = 0.77644 0.86
+				key = 0.76734 0.872
+				key = 0.75813 0.881
+				key = 0.74884 0.891
+				key = 0.73946 0.898
+				key = 0.73001 0.905
+				key = 0.72047 0.915
+				key = 0.71082 0.924
+				key = 0.70113 0.929
+				key = 0.69136 0.936
+				key = 0.68151 0.943
+				key = 0.67157 0.953
+				key = 0.6616 0.955
+				key = 0.65159 0.96
+				key = 0.64152 0.964
+				key = 0.63138 0.972
+				key = 0.62121 0.974
+				key = 0.61097 0.981
+				key = 0.60071 0.983
+				key = 0.59042 0.986
+				key = 0.58011 0.988
+				key = 0.56977 0.99
+				key = 0.5594 0.993
+				key = 0.54899 0.998
+				key = 0.53855 1
+				key = 0.52812 1
+				key = 0.51768 1
+				key = 0.50724 1
+				key = 0.4968 1
+				key = 0.48636 1
+				key = 0.47593 1
+				key = 0.46551 0.998
+				key = 0.45512 0.995
+				key = 0.44474 0.995
+				key = 0.43437 0.993
+				key = 0.42403 0.991
+				key = 0.41374 0.986
+				key = 0.40348 0.983
+				key = 0.39326 0.979
+				key = 0.38312 0.972
+				key = 0.37303 0.967
+				key = 0.36298 0.962
+				key = 0.35301 0.955
+				key = 0.34312 0.948
+				key = 0.33327 0.943
+				key = 0.3235 0.936
+				key = 0.31381 0.929
+				key = 0.30418 0.922
+				key = 0.29468 0.91
+				key = 0.28528 0.901
+				key = 0.27598 0.891
+				key = 0.26683 0.877
+				key = 0.25773 0.872
+				key = 0.24877 0.858
+				key = 0.23994 0.846
+				key = 0.23123 0.834
+				key = 0.22262 0.825
+				key = 0.21413 0.813
+				key = 0.2058 0.799
+				key = 0.19758 0.787
+				key = 0.18952 0.773
+				key = 0.1816 0.759
+				key = 0.17381 0.747
+				key = 0.16619 0.73
+				key = 0.15869 0.718
+				key = 0.15136 0.702
+				key = 0.14419 0.687
+				key = 0.13716 0.673
+				key = 0.13031 0.657
+				key = 0.12358 0.645
+				key = 0.11702 0.628
+				key = 0.11058 0.616
+				key = 0.10435 0.597
+				key = 0.09828 0.581
+				key = 0.09232 0.571
+				key = 0.08653 0.555
+				key = 0.08089 0.541
+				key = 0.07542 0.524
+				key = 0.07007 0.512
+				key = 0.06485 0.5
+				key = 0.05977 0.486
+				key = 0.05485 0.472
+				key = 0.05009 0.455
+				key = 0.04551 0.439
+				key = 0.04108 0.425
+				key = 0.0368 0.41
+				key = 0.03264 0.399
+				key = 0.02865 0.382
+				key = 0.02479 0.37
+				key = 0.0211 0.354
+				key = 0.01756 0.339
+				key = 0.01416 0.325
+				key = 0.01097 0.306
+				key = 0.00787 0.297
+				key = 0.00497 0.278
+				key = 0.00249 0.237
+				key = 0.00137 0.107
+				key = 0.00069 0.07
+				key = 0.00000 0.05
+			}
+		}
+	}
+}
+
++PART[castor30]:AFTER[RealismOverhaul]
+{
+	@name = ro2castor30xl
+	!mesh = DELETE
+	MODEL
+	{
+		model = StarShine Industries/Athena/Parts/Castor30/Castor30
+		scale = 12.220, 12.5, 12.220
+		rotation = 0, 0, 0
+		position = 0, 0, 0
+	}
+	MODEL
+	{
+		model = StarShine Industries/Athena/Parts/Castor30/Castor30
+		scale = 12.120, 12.5, 12.120
+		rotation = 0, 0, 0
+		position = 0, 1.5, 0
+	}
+	%scale = 12.5
+	@rescaleFactor = 1
+	%node_stack_bottom = 0.0, -0.1725, 0.0, 0.0, 1.0, 0.0, 3
+	%node_stack_top = 0.0, 0.2025, 0.0, 0.0, 1.0, 0.0, 3
+	@title = Castor 30XL
+	@mass = 2.105
+	@manufacturer = Orbital ATK
+	@description = The Castor 30XL is a larger version of the Castor 30B. It was developed for use as the second stage of the Antares launcher. Burn time: 134 seconds.
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0
+		@maxThrust = 555
+		@atmosphereCurve
+		{
+			@key,0 = 0 303
+			@key,1 = 1 215
+		}
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 13031
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Castor30XL
+		@CONFIG[Castor30B]
+		{
+			@name = Castor30XL
+			@maxThrust = 555
+			@atmosphereCurve
+			{
+				@key,0 = 0 303
+				@key,1 = 1 215
+			}
+		}
+	}
+}
+
+
+@PART[AthenaFairings]:FOR[RealismOverhaul]//Only resized; fairing is buggy
+{
+	@rescaleFactor = 12.084
+	@mass = 1.3
+}
+
+@PART[OAM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@module = Part
+	@rescaleFactor = 12.084
+	@title = Orbit Adjust Module (OAM)
+	@mass = 0.36
+MODULE
+{
+	name = ModuleCommand
+	minimumCrew = 0
+	
+	RESOURCE
+	{
+		name = ElectricCharge
+		rate = 0.02777778
+	}
+}
+	MODULE
+	{
+		name = ModuleSAS
+		SASServiceLevel = 2
+	}
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 1500000
+		%EnergyCost = 0.08
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+
+	@manufacturer = Primex
+	@description = Pressure-fed monopropellant upper stage for the Athena launcher.
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0.833
+		@maxThrust = 0.883
+		@heatProduction = 100
+		%useEngineResponseTime = False
+		!engineAccelerationSpeed = DELETE
+		@atmosphereCurve
+		{
+			@key,0 = 0 222
+			@key,1 = 1 100
+		}
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = Hydrazine
+		}
+	}
+	%stagingIcon = LIQUID_ENGINE
+	!MODULE[ModuleDecouple]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 372
+		type = ServiceModule
+		basemass = -1
+		TANK
+		{
+			name = ElectricCharge
+			amount = 18000
+			maxAmount = 18000
+		}
+		TANK
+		{
+			name = Hydrazine
+			amount = 354
+			maxAmount = 354
+		}
+
+	}
+	//MODULE
+	//{
+	//	name = ModuleGimbal
+	//	gimbalTransformName = thrustTransform
+	//	gimbalRange = 5.0
+	//	%useGimbalResponseSpeed = true
+	//	%gimbalResponseSpeed = 16
+	//}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.1
+		@YawTorque = 0.1
+		@RollTorque = 0.1
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = OAM
+		modded = false
+		CONFIG
+		{
+			name = OAM
+			minThrust = 0.883
+			maxThrust = 0.883
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Hydrazine
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key,0 = 0 222
+				key,1 = 1 100
+			}
+		}
+	}
+	!MODULE[ModuleRCS]
+	{
+	}
+}
+


### PR DESCRIPTION
Added configs for realistic size, mass, thrust for StarShine Athena 2c. My understanding is it's ok to use rescaleFactor for parts not using MODEL nodes, if not I'll change. Was unable to get fairing to work properly, decoupling imparts tons of torque.

https://youtu.be/awG8sNfPbhA