### PR TITLE
RN_Skylab Update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -1,179 +1,3 @@
-@PART[skylab_unbroken]:FOR[RealismOverhaul]
-{
-
-%RSSROConfig = True
-
-@MODEL
-	{
-		@scale = 1.00, 1.00, 1.00
-	}
-	@scale = 1.00
-	@rescaleFactor = 1
-
-@mass = 70
-@CrewCapacity = 3
-
-@node_stack_bottom = 0.0, -9.88688, 0.0, 0.0, -1.0, 0.0, 2
-
-node_stack_test = 0.0, -12.88688, 0.0, 0.0, 1.0, 0.0, 2
-
-node_stack_test2 = 0.0, -15.84688, 0.0, 0.0, 1.0, 0.0, 2
-
-@CrewCapacity = 3
-
-@MODULE[ModuleCommand]
-{
-	@minimumCrew = 0
-
-	RESOURCE
-	{
-		name = ElectricCharge
-		rate = 5
-	}
-}
-
-!MODULE[ModuleReactionWheel]
-{
-}
-
-!RESOURCE[ElectricCharge]
-{
-}
-
-!RESOURCE[MonoPropellant]
-{
-}
-
-!MODULE[LifeSupportModule]
-{
-}
-
-MODULE
-{
-	// 100 days of life support
-		name = ModuleFuelTanks
-		type = ServiceModule
-		volume = 85500.0
-		basemass = -1
-		TANK
-		{
-			name = ElectricCharge
-			amount = 30000
-			maxAmount = 30000
-		}
-		TANK
-		{
-			name = MMH
-			amount = 93.8
-			maxAmount = 93.8
-		}
-		TANK
-		{
-			name = NTO
-			amount = 112.2
-			maxAmount = 112.2
-		}
-		TANK
-		{
-			name = Oxygen
-			amount = 1890
-			maxAmount = 1890
-		}
-		TANK
-		{
-			name = Water
-			amount = 510
-			maxAmount = 510
-		}
-		TANK
-		{
-			name = Food
-			amount = 900
-			maxAmount = 900
-		}
-		TANK
-		{
-			name = LithiumHydroxide
-			amount = 211
-			maxAmount = 211
-		}
-		TANK
-		{
-			name = CarbonDioxide
-			amount = 0
-			maxAmount = 1040
-		}
-		TANK
-		{
-			name = Waste
-			amount = 0
-			maxAmount = 405
-		}
-		TANK
-		{
-			name = WasteWater
-			amount = 0
-			maxAmount = 735
-		}
-		TANK
-		{
-			name = LqdOxygen
-			amount = 275
-			maxAmount = 275
-		}
-}
-
-@MODULE[ModuleRCS]
-{
-	@name = ModuleRCSFX
-	%thrusterTransformName = RCSthruster
-	%resourceFlowMode = STACK_PRIORITY_SEARCH
-	%thrusterPower = 0.500
-	!resourceName = DELETE
-	PROPELLANT
-		{
-			name = MMH
-			ratio = 0.456
-		}
-		PROPELLANT
-		{
-			name = NTO
-			ratio = 0.544
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 260
-			@key,1 = 1 100
-		}
-}
-
-MODULE
-	{
-		name = TacGenericConverter
-		converterName = CO2 Scrubber
-		conversionRate = 3.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0062500000, ElectricCharge, 0.010, 				LithiumHydroxide, 0.0000085683
-		outputResources = Waste, 0.0000191062, false
-	}
-
-MODULE
-	{
-		name = TacGenericConverter
-		converterName = LOX-O2
-		conversionRate = 3.0
-		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
-		outputResources = Oxygen, 0.00729166666666666666666666666667, false
-	}
-
-
-@MODULE[ModuleDeployableSolarPanel]
-{
-	@chargeRate = 4.6
-}
-
-}
-
-
 @PART[skylab]:FOR[RealismOverhaul]
 {
 
@@ -186,7 +10,7 @@ MODULE
 	@scale = 1.00
 	@rescaleFactor = 1
 
-@mass = 71
+@mass = 68
 
 @node_stack_bottom = 0.0, -9.88688, 0.0, 0.0, -1.0, 0.0, 2
 
@@ -194,7 +18,7 @@ node_stack_test = 0.0, -12.88688, 0.0, 0.0, 1.0, 0.0, 2
 
 node_stack_test2 = 0.0, -15.84688, 0.0, 0.0, 1.0, 0.0, 2
 
-@CrewCapacity = 3
+@CrewCapacity = 6
 
 @MODULE[ModuleCommand]
 {
@@ -338,11 +162,6 @@ MODULE
 		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
 		outputResources = Oxygen, 0.00729166666666666666666666666667, false
 	}
-
-@MODULE[ModuleDeployableSolarPanel]
-{
-	@chargeRate = 4.6
-}
 
 }
 
@@ -373,6 +192,17 @@ MODULE
 	@rescaleFactor = 1
 
 	@mass = 1.5
+}
+
+@PART[rn_skylab_telescope]:FOR[RealismOverhaul]
+{
+%RSSROConfig = True
+
+@MODULE[ModuleDeployableSolarPanel]
+{
+	@chargeRate = 4.6
+}
+
 }
 
 


### PR DESCRIPTION
Remove now defunct skylab_unbroken
Subtract 3 from the mass of skylab as the telescope is now a separate part which weighs 3 tonnes
Skylab should "technically" be able to hold 6 people, the IVA supports this many, and there are 2 docking ports even though 1 was unused
Added definition for telescope solar panel