### PR TITLE
Added Realplume configs for KW and AIES

### DIFF
--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -1144,7 +1144,7 @@
 		}
 	}
 }
-@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] /Rocketdyne RS-25D/E (Four)
+@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] /RD-0120 using Rocketdyne RS-25D/E (Four) config
 {
 	!EFFECTS
 	{
@@ -1253,6 +1253,578 @@
 				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
 				volume = 0.65
 				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[KW3mengineTitanT1]:FOR[RealPlume]:NEEDS[SmokeScreen] //Vulcain 2 [5.0m] taken from RS-68 AEIS
+{
+	//Delete old effects
+     !fx_exhaustFlame_blue = DELETE
+    !fx_exhaustLight_blue = DELETE
+    !fx_smokeTrail_light = DELETE
+    !fx_exhaustSparks_flameout = DELETE
+    !sound_vent_medium = DELETE
+    !sound_rocket_hard = DELETE
+    !sound_vent_soft = DELETE
+    !sound_explosion_low = DELETE
+    EFFECTS
+    {
+        powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+			name = flamethrust
+			modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
+			transformName = thrustTransform
+			localPosition = 0,0,1.5
+			fixedScale = 1.2
+			speed = 0.0 1.75
+			speed = 1.0 1.75
+			fixedEmissions = false
+			grow
+			{
+			  density = 1.0 -0.999
+			  density = 0.12 0.0
+			  density = 0.0 0
+			}
+			size
+			{
+			  density = 1.0 0.4
+			  density = 0.12 1.0
+			  density = 0.0 1.0
+			}
+			logGrow
+			{
+			  density = 1.0 0.0
+			  density = 0.12 0.0
+			  density = 0.0 35.0
+			}
+			offset
+			{
+			  density = 1.0 -0.6
+			  density = 0.12 -0.2
+			  density = 0.0 .45
+			}
+			energy
+			{
+			  density = 1.0 0.33
+			  density = 0.0 1.0
+			}
+			emission
+			{
+			  density = 1.0 5.0
+			  density = 0.5 2.6
+			  density = 0.0 0.35
+			}
+		}
+            AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+			  volume = 0.0 0
+			  volume = 0.001 0.8
+			  volume = 1.0 1.5
+			  pitch = 0.0 1.0
+			  pitch = 1.0 1.0
+			  loop = true
+			}
+        }
+      
+        engage
+		{
+			AUDIO
+			{
+			  channel = Ship
+			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq10
+			  volume = 0.65
+			  pitch = 1.7
+			  loop = false
+			}
+		}
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        //engineID = rocketengine
+        runningEffectName = powersmoke
+        directThrottleEffectName = powerflame
+		!fxOffset = DELETE
+	
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesRF
+    }
+}
+@PART[KW3mengineWildcarXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 from squad
+{
+	!fx_exhaustFlames_yellow_tiny = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+				transformName = thrustTransform
+				localPosition = 0,0,1.0
+				fixedScale = 1.2
+				speed = 0.0 1.75
+				speed = 1.0 1.75
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.999
+					density = 0.12 0.0
+					density = 0.0 0
+				}
+				size
+				{
+					density = 1.0 0.6
+					density = 0.12 1.0
+					density = 0.0 1.0
+				}
+				logGrow
+				{
+					density = 1.0 0.0
+					density = 0.12 0.0
+					density = 0.0 15.0
+				}
+				offset
+				{
+					density = 1.0 -0.5
+					density = 0.12 0.1
+					density = 0.0 0.25
+				}
+				energy
+				{
+					density = 1.0 0.33
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 1.0
+					density = 0.5 0.6
+					density = 0.0 0.35
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[KW5mengineGriffonC]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne F-1 [5.5m] from Squad.cfg
+{
+	!EFFECTS
+	{
+	}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
+				transformName = thrustTransform
+				localPosition = 0,0,0.9
+				fixedScale = 0.45
+				emission = 0.0 0.0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15
+				energy = 1.0 15
+				size = 0.0 2
+				size = 1.0 2
+				fixedEmissions = false
+				sizeClamp = 250
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 10
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.0
+					density = 0.79 0.15
+					density = 0.0 45
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 3
+					density = 0.5 10
+					density = 0.05 25
+					density = 0.0 30
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0
+					density = 0.5 0.3
+					density = 0.0 0.15
+				}
+				energy
+				{
+					density = 1.0 0.9
+					density = 0.5 0.4
+					density = 0.05 0.1
+					density = 0.0 0.1
+				}
+				offset
+				{
+					density = 1.0 0.0
+					density = 0.7 1.75
+					density = 0.5 5
+					density = 0.3 17
+					density = 0.05 15
+					density = 0.0 15
+				}
+
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = 1.0 1.5
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		powersmoke
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = smokethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+				transformName = thrustTransform
+				localPosition = 0,0,0.9
+				fixedScale = 1.75
+				emission = 0.0 0.0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15
+				energy = 1.0 15
+				size = 0.0 2
+				size = 1.0 2
+				fixedEmissions = false
+				sizeClamp = 250
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 10
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.1
+					density = 0.79 0.1
+					density = 0.0 45
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 3
+					density = 0.5 10
+					density = 0.05 25
+					density = 0.0 30
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0
+					density = 0.5 0.3
+					density = 0.0 0.15
+				}
+				energy
+				{
+					density = 1.0 4
+					density = 0.5 4
+					density = 0.05 1
+					density = 0.0 0.0
+				}
+				offset
+				{
+					density = 1.0 0.0
+					density = 0.7 1.75
+					density = 0.5 5
+					density = 0.3 17
+					density = 0.05 15
+					density = 0.0 15
+				}
+
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq10
+				volume = 0.65
+				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//engineID = rocketengine
+		%runningEffectName = powersmoke
+		%powerEffectName = powerflame
+		!fxOffset = DELETE
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+}
+@PART[KW5mengineTitanV]:FOR[RealPlume]:NEEDS[SmokeScreen] // J2, uses J-2 FX for now.
+{
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+
+	!fx_exhaustFlame_blue  = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+				transformName = thrustTransform
+				localPosition = 0,0,0.3
+				fixedScale = 1.6
+				speed = 0.0 1.3
+				speed = 1.0 1.75
+				fixedEmissions = false
+				logGrow
+				{
+					density = 1.0 0.0
+					density = 0.08 0.0
+					density = 0.0 10.0
+				}
+				size
+				{
+					density = 1.0 0.6
+					density = 0.08 1.0
+					density = 0.0 1.0
+				}
+				grow
+				{
+					density = 1.0 -0.99
+					density = 0.08 0.0
+					density = 0.0 0.0
+				}
+				offset
+				{
+					density = 1.0 -0.2
+					density = 0.08 0.1
+					density = 0.0 0.3
+				}
+				energy
+				{
+					density = 1.0 0.33
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 0.8
+					density = 0.08 0.5
+					density = 0.0 0.25
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+				volume = 1.0
+				pitch = 1.0
 				loop = false
 			}
 		}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -444,7 +444,7 @@
 		%type = ModuleEnginesRF
     }
 }
-@PART[KW1mengineMaverick1D]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10
+@PART[KW1mengineMaverick1D]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 CONFIRMED WORKING
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -475,7 +475,7 @@
 			{
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
-				transformName = thrustTransform
+				transformName = FX2Transform
 				localPosition = 0,0,1.0
 				fixedScale = 1.2
 				speed = 0.0 1.75
@@ -563,7 +563,7 @@
 		}
 	}
 }
-@PART[KW1mengineVestaVR1]:FOR[RealPlume]:NEEDS[SmokeScreen] //AJ10-118K copied from FASAGeminiLFECentarTwin
+@PART[KW1mengineVestaVR1]:FOR[RealPlume]:NEEDS[SmokeScreen] //AJ10-118K copied from FASAGeminiLFECentarTwin CONFIRMED WORKING
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -593,8 +593,8 @@
 			{
 				name = Flame
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
-				transformName = OldFXTransform
-				localPosition = 0,0,0.3
+				transformName = NozzleTransform
+				localPosition = 0,0,0.0
 				fixedScale = 2.3
 				emission = 0.0 0.2
 				emission = 1.0 0.2
@@ -681,7 +681,7 @@
 		}
 	}
 }
-@PART[KW1mengineWildCarV]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 //COPIED FROM SQUAD engineLargeSkipper
+@PART[KW1mengineWildCarV]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 //COPIED FROM SQUAD engineLargeSkipper CONFIRMED WORKING
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -713,7 +713,7 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
 				transformName = thrustTransform
-				localPosition = 0,0,1.0
+				localPosition = 0,0,0.5
 				fixedScale = 1.2
 				speed = 0.0 1.75
 				speed = 1.0 1.75
@@ -800,7 +800,7 @@
 		}
 	}
 }
-@PART[KW2mengineMaverickV]:FOR[RealPlume]:NEEDS[SmokeScreen] //RS-27, used H1-RS27 config
+@PART[KW2mengineMaverickV]:FOR[RealPlume]:NEEDS[SmokeScreen] //RS-27, used H1-RS27 config CONFIRMED WORKING
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_exhaustLight_blue = DELETE
@@ -1027,7 +1027,7 @@
 		%type = ModuleEnginesRF
 	}
 }
-@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]   ALIGNMENT INCORRECT
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -1043,24 +1043,25 @@
 		@name = ModuleEnginesRF
 		//%runningEffectName = powersmoke
 		!runningEffectName = DELETE
-		%directThrottleEffectName = powerflame
+		%powerEffectName = powerflame
 	}
 	@MODULE[ModuleEngineConfigs]
-    {
+	{
 		%type = ModuleEnginesRF
-    }
+	}
+	!EFFECTS {}
 	EFFECTS
 	{
 		powerflame
 		{
 			MODEL_MULTI_PARTICLE_PERSIST
 			{
-				name = flamethrust
+				name = Flame
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
-				transformName = thrustTransform
-				localPosition = 0,0,1.3
+				transformName = OldFX2Transform
+				localPosition = 0,0,1.1
 				fixedScale = 5
-				emission = 0.0 0.20
+				emission = 0.0 0.0
 				emission = 1.0 0.20
 				speed = 0.0 2.79
 				speed = 1.0 2.79
@@ -1143,7 +1144,7 @@
 		}
 	}
 }
-@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] /RD-0120 using Rocketdyne RS-25D/E (Four) config
+@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] /RD-0120 using Rocketdyne RS-25D/E (Four) config CONFIRMED WORKING
 {
 	!EFFECTS
 	{
@@ -1167,8 +1168,8 @@
 			{
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/nasa4engine
-				transformName = thrustTransform
-				localPosition = 0,0,-0.3
+				transformName = FX2Transform
+				localPosition = 0,0,0.0
 				fixedScale = 1
 				sizeClamp = 250
 				initialDensity = 0.6
@@ -1279,7 +1280,7 @@
 		}
 	}
 }
-@PART[KW3mengineTitanT1]:FOR[RealPlume]:NEEDS[SmokeScreen] //Vulcain 2 [5.0m] taken from RS-68 AEIS
+@PART[KW3mengineTitanT1]:FOR[RealPlume]:NEEDS[SmokeScreen] //Vulcain 2 [5.0m] taken from RS-68 AEIS CONFIRMED WORKING
 {
 	//Delete old effects
      !fx_exhaustFlame_blue = DELETE
@@ -1298,7 +1299,7 @@
 			{
 			name = flamethrust
 			modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
-			transformName = thrustTransform
+			transformName = FX2Transform
 			localPosition = 0,0,1.5
 			fixedScale = 1.2
 			speed = 0.0 1.75
@@ -1401,7 +1402,7 @@
 		%type = ModuleEnginesRF
     }
 }
-@PART[KW3mengineWildcatXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 from squad
+@PART[KW3mengineWildcatXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 from squad CONFIRMED WORKING
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -1732,7 +1733,7 @@
 		%type = ModuleEnginesRF
 	}
 }
-@PART[KW5mengineTitanV]:FOR[RealPlume]:NEEDS[SmokeScreen] // J2, uses J-2 FX for now.
+@PART[KW5mengineTitanV]:FOR[RealPlume]:NEEDS[SmokeScreen] // J2, uses J-2 FX for now. CONFIRMED WORKING
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -1763,8 +1764,8 @@
 			{
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
-				transformName = thrustTransform
-				localPosition = 0,0,1.0
+				transformName = FX2Transform
+				localPosition = 0,0,0.5
 				fixedScale = 1.2
 				speed = 0.0 1.75
 				speed = 1.0 1.75

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -146,7 +146,7 @@
 				// ***************
 
 
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45Â°
 				angle = 45.0 1.0
 				angle = 50.0 1.0
 				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -369,7 +369,7 @@
 				// ***************
 
 
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45Â°
 				angle = 45.0 1.0
 				angle = 50.0 1.0
 				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -800,54 +800,54 @@
 		}
 	}
 }
-@PART[KW2mengineGriffonG8D]:FOR[RealPlume]:NEEDS[SmokeScreen] // RD-0105 / 0109 LiquidEngines3 Squad.cfg
+@PART[KW2mengineMaverickV]:FOR[RealPlume]:NEEDS[SmokeScreen] //RS-27, used H1-RS27 config
 {
-	//Kerolox vacuum
 	!fx_exhaustFlame_blue = DELETE
-	!fx_smokeTrail_light = DELETE
 	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
 	!fx_exhaustSparks_flameout = DELETE
 	!sound_vent_medium = DELETE
 	!sound_rocket_hard = DELETE
 	!sound_vent_soft = DELETE
 	!sound_explosion_low = DELETE
-	
-	!EFFECTS {}
 	EFFECTS
 	{
-		powerflame // name of effect to be added to the Engine Module
+		powerflame
 		{
 			MODEL_MULTI_PARTICLE_PERSIST
 			{
 				name = flamethrust
-				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamelarge
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
 				transformName = thrustTransform
-				localRotation = 0,0,0
-				localPosition = 0,0,0.24
-				offsetDirection = 0,0,1
-				fixedScale = 0.5
-				sizeClamp = 50
-				initialDensity = 0.6
-				physical = False
-				stickiness = 0.9
-				dragCoefficient = 0.1
-				singleEmitTimer = 0
-				randomInitalVelocityOffsetMaxRadius = 0
+				fixedScale = 0.3
+				emission = 0.0 3.5
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15 // Same for energy
+				energy = 1.0 15 // Same for energy
+				size = 0.0 2 // Rescale the particles to +0%
+				size = 1.0 2 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+
+				randomInitalVelocityOffsetMaxRadius = 0.2
 				logGrow
 				{
 					density = 1.0 10
-					density = 0.5 10
 					density = 0.0 10
 				}
 				logGrowScale
 				{
-					density = 1.0 -0.9
-					density = 0.79 3
-					density = 0.0 20
+					density = 1.0 0.0
+					density = 0.79 0.15
+					density = 0.0 45
 				}
 				linGrow
 				{
-					density = 1.0 -0.8
+					density = 1.0 0.0
 					density = 0.79 0.0
 					density = 0.005 0.0
 					density = 0.0 1
@@ -855,48 +855,128 @@
 				speed
 				{
 					density = 1.0 2
-					density = 0.79 3
-					density = 0.005 3
-					density = 0.0 3
+					density = 0.79 2
+					density = 0.005 15
+					density = 0.0 15
 				}
 				emission
 				{
 					density = 1.0 3.0
-					density = 0.79 1.0
+					density = 0.79 3.0
 					density = 0.5 0.3
 					density = 0.0 0.15
 				}
 				energy
 				{
-					density = 1.0 0.1
-					density = 0.5 0.8
-					density = 0.1 0.5
-					density = 0.0 0.4
+					density = 1.0 0.9
+					density = 0.005 1.5
+					density = 0.0 1.5
 				}
 				offset
 				{
 					density = 1.0 0.083
-					density = 0.79 0.5
-					density = 0.1 2
-					density = 0.0 3
+					density = 0.79 0.083
+					density = 0.5 2.583
+					density = 0.0 10.083
 				}
-				force
-				{
-					density = 1.0 0
-					density = 0.79 0
-					density = 0.5 0
-					density = 0.0 0
-				}
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flameflare
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+				transformName = thrustTransform
+				fixedScale = 0.3
+				emission = 0.0 2
+				emission = 1.0 2
+				speed = 0.0 1
+				speed = 1.0 1
+				offset = 0.0 -0.166
+				offset = 1.0 -0.166
+				energy = 0.0 0.2 // Same for energy
+				energy = 1.0 0.2 // Same for energy
+				size = 0.0 1.35 // Rescale the particles to +0%
+				size = 1.0 1.35 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+				grow = 0.0 0.2
+				grow = 1.0 0.2
+
+				randomInitalVelocityOffsetMaxRadius = 0.2
 			}
 			AUDIO
 			{
 				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
 				volume = 0.0 0.0
-				volume = 1.0 1.0
+				volume = 1.0 1.5
 				pitch = 0.0 1.0
 				pitch = 1.0 1.0
 				loop = true
+			}
+		}
+		powersmoke
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = smokethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+				transformName = thrustTransform
+				emission = 0.0 0.25  // Curve for emission like stock
+				emission = 1.0 0.25  // Curve for emission like stock
+				energy = 0.0 1.2 // Same for energy
+				energy = 1.0 1.2 // Same for energy
+				speed = 0.0 1.65  // And speed
+				speed = 1.0 1.65  // And speed
+				grow = 0.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
+				grow = 1.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
+				scale = 0.0 1.0 // Rescale the emitters to +0%
+				scale = 1.0 1.0 // Rescale the emitters to +0%
+				offset = 0.0 25  // Move the particle emitter away from its default position by x meters
+				offset = 1.0 25  // Move the particle emitter away from its default position by x meters
+				size = 0.0 1.85 // Rescale the particles to +0%
+				size = 1.0 1.85 // Rescale the particles to +0%
+
+				renderMode = "Billboard"  // Render mode : Billboard / SortedBillboard / HorizontalBillboard / VerticalBillboard / Stretch
+				collide = false // Collision active or not
+				collideRatio = 0 // how the particles react on collision. 1 is a mirror bounce, 0 is go parallel to the hit surface
+				fixedScale = 0.3 // Fixed rescale of the particle emitter (for when you rescale the model)
+
+				sizeClamp = 250 // Limits particle size. Default to 50
+
+				// ***************
+				// From here the value are not the default anymore.
+				// ***************
+
+
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45Â°
+				angle = 45.0 1.0
+				angle = 50.0 1.0
+				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
+				distance = 100.0 1.0
+				distance = 110.0 1.0
+
+				emission  // Modulate emission from mach and density curve. You can add other section for size, energy, speed, grow, offset and scale
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0 // don't display over .4 atmo
+					density = 0.5 0.15
+					density = 0.005 0.15
+					density = 0.004 0.0 // and stop under .001
+				}
+				offset
+				{
+					density = 1.0 1.0
+					density = 0.79 1.0
+					density = 0.1 75
+					density = 0.005 75
+					density = 0.004 25
+				}
+				size
+				{
+					density = 1.0 4
+					density = 0.79 4
+					density = 0.0 135
+				}
 			}
 		}
 		engage
@@ -936,17 +1016,21 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%powerEffectName = powerflame
+		//engineID = rocketengine
+		runningEffectName = powersmoke
+		directThrottleEffectName = powerflame
 		!fxOffset = DELETE
+
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
 		%type = ModuleEnginesRF
 	}
 }
-@PART[KW2mengineMaverickV]:FOR[RealPlume]:NEEDS[SmokeScreen] // LiquidEngine Squad.cfg Rocketdyne LR-105 Series [2m]
+@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RO-AJ10-137 RO.cfg
 {
-	!fx_exhaustFlame_blue = DELETE
+	!fx_exhaustFlames_yellow_tiny = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
 	!fx_exhaustLight_blue = DELETE
 	!fx_smokeTrail_light = DELETE
 	!fx_exhaustSparks_flameout = DELETE
@@ -954,216 +1038,6 @@
 	!sound_rocket_hard = DELETE
 	!sound_vent_soft = DELETE
 	!sound_explosion_low = DELETE
-
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%runningEffectName = powersmoke
-		%powerEffectName = powerflame
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-	}
-	!EFFECTS {}
-	EFFECTS
-	{
-		powerflame
-		{
-			MODEL_MULTI_PARTICLE_PERSIST
-			{
-				name = flamethrust
-				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
-				transformName = thrustTransform
-				fixedScale = 0.4
-				emission = 0.0 0
-				emission = 1.0 3.5
-				speed = 0.0 5
-				speed = 1.0 5
-				offset = 0.0 1.0
-				offset = 1.0 1.0
-				energy = 0.0 15 // Same for energy
-				energy = 1.0 15 // Same for energy
-				size = 0.0 2 // Rescale the particles to +0%
-				size = 1.0 2 // Rescale the particles to +0%
-				fixedEmissions = false
-				sizeClamp = 250
-
-				randomInitalVelocityOffsetMaxRadius = 0.2
-				logGrow
-				{
-					density = 1.0 10
-					density = 0.0 10
-				}
-				logGrowScale
-				{
-					density = 1.0 -0.5
-					density = 0.18 0.15
-					density = 0.0 25
-				}
-				speed
-				{
-					density = 1.0 1.5
-					density = 0.18 2.5
-					density = 0.005 22.5
-					density = 0.0 22.5
-				}
-				emission
-				{
-					density = 1.0 3.0
-					density = 0.18 2.0
-					density = 0.0 0.25
-				}
-				energy
-				{
-					density = 1.0 0.9
-					density = 0.005 1.5
-					density = 0.0 1.5
-				}
-				offset
-				{
-					density = 1.0 0.125
-					density = 0.18 0.125
-					density = 0.0 2.625
-				}
-			}
-			MODEL_MULTI_PARTICLE_PERSIST
-			{
-				name = flameflare
-				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
-				transformName = thrustTransform
-				fixedScale = 0.5
-				emission = 0.0 0
-				emission = 1.0 2
-				speed = 0.0 1
-				speed = 1.0 1
-				offset = 0.0 -0.166
-				offset = 1.0 -0.166
-				energy = 0.0 0.2 // Same for energy
-				energy = 1.0 0.2 // Same for energy
-				size = 0.0 1.35 // Rescale the particles to +0%
-				size = 1.0 1.35 // Rescale the particles to +0%
-				fixedEmissions = false
-				sizeClamp = 250
-				grow = 0.0 0.2
-				grow = 1.0 0.2
-
-				randomInitalVelocityOffsetMaxRadius = 0.2
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
-				volume = 0.0 0.0
-				volume = 1.0 1.5
-				pitch = 0.0 1.0
-				pitch = 1.0 1.0
-				loop = true
-			}
-		}
-		powersmoke
-		{
-			MODEL_MULTI_PARTICLE_PERSIST
-			{
-				name = smokethrust
-				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
-				transformName = thrustTransform
-				emission = 0.0 0.0  // Curve for emission like stock
-				emission = 1.0 0.25  // Curve for emission like stock
-				energy = 0.0 1.2 // Same for energy
-				energy = 1.0 1.2 // Same for energy
-				speed = 0.0 1.65  // And speed
-				speed = 1.0 1.65  // And speed
-				grow = 0.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
-				grow = 1.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
-				scale = 0.0 1.0 // Rescale the emitters to +0%
-				scale = 1.0 1.0 // Rescale the emitters to +0%
-				offset = 0.0 25  // Move the particle emitter away from its default position by x meters
-				offset = 1.0 25  // Move the particle emitter away from its default position by x meters
-				size = 0.0 1.85 // Rescale the particles to +0%
-				size = 1.0 1.85 // Rescale the particles to +0%
-
-				renderMode = "Billboard"  // Render mode : Billboard / SortedBillboard / HorizontalBillboard / VerticalBillboard / Stretch
-				collide = false // Collision active or not
-				collideRatio = 0 // how the particles react on collision. 1 is a mirror bounce, 0 is go parallel to the hit surface
-				fixedScale = 0.5 // Fixed rescale of the particle emitter (for when you rescale the model)
-
-				sizeClamp = 250 // Limits particle size. Default to 50
-
-				// ***************
-				// From here the value are not the default anymore.
-				// ***************
-
-
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
-				angle = 45.0 1.0
-				angle = 50.0 1.0
-				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
-				distance = 100.0 1.0
-				distance = 110.0 1.0
-
-				emission
-				{
-					density = 1.0 2.0
-					density = 0.18 2.0
-					density = 0.005 0.10
-					density = 0.004 0.0
-				}
-				offset
-				{
-					density = 1.0 1.0
-					density = 0.18 1.0
-					density = 0.1 75
-					density = 0.005 75
-					density = 0.004 25
-				}
-				size
-				{
-					density = 1.0 4
-					density = 0.18 4
-					density = 0.0 135
-				}
-
-			}
-		}
-		engage
-		{
-			AUDIO
-			{
-				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
-				volume = 1.0
-				pitch = 0.8
-				loop = false
-			}
-		}
-		disengage
-		{
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_vent_soft
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-		flameout
-		{
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-	}
-}
-@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]	//microEngine Squad.cfg Generic 1kN Thruster
-{
-	//small oms thruster MMH/NTO
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
@@ -1183,54 +1057,47 @@
 			MODEL_MULTI_PARTICLE_PERSIST
 			{
 				name = flamethrust
-				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamesmall
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
 				transformName = thrustTransform
-				localPosition = 0, 0, 0.42
-				fixedScale = 0.1
-				emission = 0 0
-				emission = 1 1.5
-				speed = 0 0.5
-				speed = 1 0.5
-				energy = 0 0.5
-				energy = 1 0.5
-				logGrowScale
+				localPosition = 0,0,1.3
+				fixedScale = 5
+				emission = 0.0 0.0
+				emission = 1.0 0.20
+				speed = 0.0 2.79
+				speed = 1.0 2.79
+				energy = 0.0 0.99 // Same for energy
+				energy = 1.0 0.99 // Same for energy
+				fixedEmissions = false
+				grow
 				{
-					density = 1 1
-					density = 0.0 1
+					density = 1.0 -0.99999
+					density = 0.008 0.0
+					density = 0.0 0.0
 				}
 				logGrow
 				{
-					density = 1 -1.5
-					density = 0.0 300
-				}
-				linGrow
-				{
-					density = 1 -1.5
-					density = 0.0 300
-				}
-				emission
-				{
-					density = 1.0 1.0
-					density = 0.0 1.0
-				}
-				size
-				{
-					density = 1.0 1
-					density = 0.0 0.2
+					density = 1.0 0
+					density = 0.008 0.3
+					density = 0.0 5.0
 				}
 				offset
 				{
-					density = 1.0 1
-					density = 0.0 2
+					density = 1.0 -0.1
+					density = 0.008 0.05
+					density = 0.0 0.10
+				}
+				size
+				{
+					density = 1.0 0.5
+					density = 0.008 1.0
+					density = 0.0 1.0
 				}
 				energy
 				{
-					density = 1 0.2
-					density = 0.0 0.2
+					density = 1.0 1.5
+					density = 0.0 1.7
 				}
-
 			}
-
 			AUDIO
 			{
 				channel = Ship
@@ -1247,8 +1114,8 @@
 			AUDIO
 			{
 				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
-				volume = 0.8
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
+				volume = 1.0
 				pitch = 1.0
 				loop = false
 			}
@@ -1277,17 +1144,11 @@
 		}
 	}
 }
-@PART[KW2mengineVestaVR9D]:FOR[RealPlume]:NEEDS[SmokeScreen]	//toroidalAerospike Squad.cfg //Rocketdyne J-2T-200/250K Aerospike
+@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] /Rocketdyne RS-25D/E (Four)
 {
-	!fx_exhaustFlame_blue = DELETE
-	!fx_exhaustLight_blue = DELETE
-	!fx_smokeTrail_light = DELETE
-	!fx_exhaustSparks_flameout = DELETE
-	!sound_vent_medium = DELETE
-	!sound_rocket_hard = DELETE
-	!sound_vent_soft = DELETE
-	!sound_explosion_low = DELETE
-	
+	!EFFECTS
+	{
+	}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
@@ -1299,7 +1160,6 @@
 		%type = ModuleEnginesRF
 	}
 	
-	!EFFECTS {}
 	EFFECTS
 	{
 		powerflame // name of effect to be added to the Engine Module
@@ -1310,7 +1170,7 @@
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/nasa4engine
 				transformName = thrustTransform
 				localPosition = 0,0,-0.3
-				fixedScale = 1.8
+				fixedScale = 1
 				sizeClamp = 250
 				initialDensity = 0.6
 				physical = False
@@ -1344,24 +1204,35 @@
 				}
 				emission
 				{
-					density = 1.0 1
-					density = 0.79 0.5
-					density = 0.5 0.3
-					density = 0.0 0.2
+					density = 1.0 0.5
+					density = 0.79 0.1
+					density = 0.5 0.05
+					density = 0.0 0.1
 				}
 				energy
 				{
-					density = 1.0 1.0
-					density = 0.005 0.7
+					density = 1.0 2
+					density = 0.7 3
+					density = 0.5 2
+					density = 0.005 1
 					density = 0.0 0.5
 				}
 				offset
 				{
 					density = 1.0 0.0
 					density = 0.79 0.2
-					density = 0.5 0.4
-					density = 0.0 0.6
+					density = 0.5 1
+					density = 0.1 3
+					density = 0.0 2.5
 				}
+				size
+				{
+					density = 1.0 3.2
+					density = 0.79 3.2
+					density = 0.5 3.2
+					density = 0.0 3.2
+				}
+
 			}
 			AUDIO
 			{
@@ -1382,125 +1253,6 @@
 				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
 				volume = 0.65
 				pitch = 1.7
-				loop = false
-			}
-		}
-		disengage
-		{
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_vent_soft
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-		flameout
-		{
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-	}
-}
-@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] //engineLargeSkipper Squad.cfg RL-10
-{
-	!fx_exhaustFlames_yellow_tiny = DELETE
-	!fx_exhaustFlames_white_tiny = DELETE
-	!fx_exhaustLight_blue = DELETE
-	!fx_smokeTrail_light = DELETE
-	!fx_exhaustSparks_flameout = DELETE
-	!sound_vent_medium = DELETE
-	!sound_rocket_hard = DELETE
-	!sound_vent_soft = DELETE
-	!sound_explosion_low = DELETE
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		//%runningEffectName = powersmoke
-		!runningEffectName = DELETE
-		%powerEffectName = powerflame
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-	}
-	!EFFECTS {}
-	EFFECTS
-	{
-		powerflame
-		{
-			MODEL_MULTI_PARTICLE_PERSIST
-			{
-				name = flamethrust
-				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
-				transformName = thrustTransform
-				localPosition = 0,0,1.0
-				fixedScale = 1.2
-				speed = 0.0 1.75
-				speed = 1.0 1.75
-				fixedEmissions = false
-				grow
-				{
-					density = 1.0 -0.999
-					density = 0.12 0.0
-					density = 0.0 0
-				}
-				size
-				{
-					density = 1.0 0.6
-					density = 0.12 1.0
-					density = 0.0 1.0
-				}
-				logGrow
-				{
-					density = 1.0 0.0
-					density = 0.12 0.0
-					density = 0.0 15.0
-				}
-				offset
-				{
-					density = 1.0 -0.5
-					density = 0.12 0.1
-					density = 0.0 0.25
-				}
-				energy
-				{
-					density = 1.0 0.33
-					density = 0.0 1.0
-				}
-				emission
-				{
-					density = 1.0 1.0
-					density = 0.5 0.6
-					density = 0.0 0.35
-				}
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
-				volume = 0.0 0.0
-				volume = 1.0 1.0
-				pitch = 0.0 0.2
-				pitch = 1.0 1.0
-				loop = true
-			}
-		}
-		engage
-		{
-			AUDIO
-			{
-				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
-				volume = 0.8
-				pitch = 1.0
 				loop = false
 			}
 		}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -1402,7 +1402,7 @@
 		%type = ModuleEnginesRF
     }
 }
-@PART[KW3mengineWildcarXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 from squad
+@PART[KW3mengineWildcatXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 from squad
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -1027,7 +1027,7 @@
 		%type = ModuleEnginesRF
 	}
 }
-@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RO-AJ10-137 RO.cfg
+@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -1043,13 +1043,12 @@
 		@name = ModuleEnginesRF
 		//%runningEffectName = powersmoke
 		!runningEffectName = DELETE
-		%powerEffectName = powerflame
+		%directThrottleEffectName = powerflame
 	}
 	@MODULE[ModuleEngineConfigs]
-	{
+    {
 		%type = ModuleEnginesRF
-	}
-	!EFFECTS {}
+    }
 	EFFECTS
 	{
 		powerflame
@@ -1061,7 +1060,7 @@
 				transformName = thrustTransform
 				localPosition = 0,0,1.3
 				fixedScale = 5
-				emission = 0.0 0.0
+				emission = 0.0 0.20
 				emission = 1.0 0.20
 				speed = 0.0 2.79
 				speed = 1.0 2.79

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -681,7 +681,7 @@
 		}
 	}
 }
-@PART[KW1mengineWildCatV]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 //COPIED FROM SQUAD engineLargeSkipper
+@PART[KW1mengineWildCarV]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-10 //COPIED FROM SQUAD engineLargeSkipper
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -1852,3 +1852,208 @@
 		}
 	}
 }
+@PART[KW2mengineGriffonG8D]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD107-108, taken from RD-170 novapunch.cfg 
+{
+	!EFFECTS
+	{
+	}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
+				transformName = FX3Transform
+				localPosition = 0,0,1.6 //changed
+				fixedScale = 0.27
+				emission = 0.0 0.0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15
+				energy = 1.0 15
+				size = 0.0 2
+				size = 1.0 2
+				fixedEmissions = false
+				sizeClamp = 250
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 1
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.0
+					density = 0.79 0.15
+					density = 0.0 45
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 2
+					density = 0.005 15
+					density = 0.0 15
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0
+					density = 0.5 0.1
+					density = 0.0 0.05
+				}
+				energy
+				{
+					density = 1.0 0.9
+					density = 0.5 0.7
+					density = 0.1 0.3
+					density = 0.0 0.2
+				}
+				offset
+				{
+					density = 1.0 -2.5
+					density = 0.79 -3.5
+					density = 0.5 -2.5
+					density = 0.0 15
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = 1.0 1.5
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		powersmoke
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = smokethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+				transformName = FX2Transform
+				localPosition = 0,0,20.0 //changed
+				fixedScale = 1
+				emission = 0.0 0.0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15
+				energy = 1.0 15
+				size = 0.0 2
+				size = 1.0 2
+				fixedEmissions = false
+				sizeClamp = 250
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 2
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.5
+					density = 0.79 0.15
+					density = 0.0 45
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 2
+					density = 0.005 15
+					density = 0.0 15
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0
+					density = 0.5 0.1
+					density = 0.0 0.05
+				}
+				energy
+				{
+					density = 1.0 1.8
+					density = 0.5 1.4
+					density = 0.1 0.6
+					density = 0.0 0.0
+				}
+				offset
+				{
+					density = 1.0 -2.5
+					density = 0.79 -3.5
+					density = 0.5 -2.5
+					density = 0.0 15
+				}
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq10
+				volume = 0.65
+				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//engineID = rocketengine
+		%runningEffectName = powersmoke
+		%powerEffectName = powerflame
+		!fxOffset = DELETE
+
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -800,3 +800,731 @@
 		}
 	}
 }
+@PART[KW2mengineGriffonG8D]:FOR[RealPlume]:NEEDS[SmokeScreen] // RD-0105 / 0109 LiquidEngines3 Squad.cfg
+{
+	//Kerolox vacuum
+	!fx_exhaustFlame_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame // name of effect to be added to the Engine Module
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamelarge
+				transformName = thrustTransform
+				localRotation = 0,0,0
+				localPosition = 0,0,0.24
+				offsetDirection = 0,0,1
+				fixedScale = 0.5
+				sizeClamp = 50
+				initialDensity = 0.6
+				physical = False
+				stickiness = 0.9
+				dragCoefficient = 0.1
+				singleEmitTimer = 0
+				randomInitalVelocityOffsetMaxRadius = 0
+				logGrow
+				{
+					density = 1.0 10
+					density = 0.5 10
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 -0.9
+					density = 0.79 3
+					density = 0.0 20
+				}
+				linGrow
+				{
+					density = 1.0 -0.8
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 3
+					density = 0.005 3
+					density = 0.0 3
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 1.0
+					density = 0.5 0.3
+					density = 0.0 0.15
+				}
+				energy
+				{
+					density = 1.0 0.1
+					density = 0.5 0.8
+					density = 0.1 0.5
+					density = 0.0 0.4
+				}
+				offset
+				{
+					density = 1.0 0.083
+					density = 0.79 0.5
+					density = 0.1 2
+					density = 0.0 3
+				}
+				force
+				{
+					density = 1.0 0
+					density = 0.79 0
+					density = 0.5 0
+					density = 0.0 0
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq10
+				volume = 0.65
+				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%powerEffectName = powerflame
+		!fxOffset = DELETE
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+}
+@PART[KW2mengineMaverickV]:FOR[RealPlume]:NEEDS[SmokeScreen] // LiquidEngine Squad.cfg Rocketdyne LR-105 Series [2m]
+{
+	!fx_exhaustFlame_blue = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%runningEffectName = powersmoke
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+				transformName = thrustTransform
+				fixedScale = 0.4
+				emission = 0.0 0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15 // Same for energy
+				energy = 1.0 15 // Same for energy
+				size = 0.0 2 // Rescale the particles to +0%
+				size = 1.0 2 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 10
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 -0.5
+					density = 0.18 0.15
+					density = 0.0 25
+				}
+				speed
+				{
+					density = 1.0 1.5
+					density = 0.18 2.5
+					density = 0.005 22.5
+					density = 0.0 22.5
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.18 2.0
+					density = 0.0 0.25
+				}
+				energy
+				{
+					density = 1.0 0.9
+					density = 0.005 1.5
+					density = 0.0 1.5
+				}
+				offset
+				{
+					density = 1.0 0.125
+					density = 0.18 0.125
+					density = 0.0 2.625
+				}
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flameflare
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+				transformName = thrustTransform
+				fixedScale = 0.5
+				emission = 0.0 0
+				emission = 1.0 2
+				speed = 0.0 1
+				speed = 1.0 1
+				offset = 0.0 -0.166
+				offset = 1.0 -0.166
+				energy = 0.0 0.2 // Same for energy
+				energy = 1.0 0.2 // Same for energy
+				size = 0.0 1.35 // Rescale the particles to +0%
+				size = 1.0 1.35 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+				grow = 0.0 0.2
+				grow = 1.0 0.2
+
+				randomInitalVelocityOffsetMaxRadius = 0.2
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = 1.0 1.5
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		powersmoke
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = smokethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+				transformName = thrustTransform
+				emission = 0.0 0.0  // Curve for emission like stock
+				emission = 1.0 0.25  // Curve for emission like stock
+				energy = 0.0 1.2 // Same for energy
+				energy = 1.0 1.2 // Same for energy
+				speed = 0.0 1.65  // And speed
+				speed = 1.0 1.65  // And speed
+				grow = 0.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
+				grow = 1.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
+				scale = 0.0 1.0 // Rescale the emitters to +0%
+				scale = 1.0 1.0 // Rescale the emitters to +0%
+				offset = 0.0 25  // Move the particle emitter away from its default position by x meters
+				offset = 1.0 25  // Move the particle emitter away from its default position by x meters
+				size = 0.0 1.85 // Rescale the particles to +0%
+				size = 1.0 1.85 // Rescale the particles to +0%
+
+				renderMode = "Billboard"  // Render mode : Billboard / SortedBillboard / HorizontalBillboard / VerticalBillboard / Stretch
+				collide = false // Collision active or not
+				collideRatio = 0 // how the particles react on collision. 1 is a mirror bounce, 0 is go parallel to the hit surface
+				fixedScale = 0.5 // Fixed rescale of the particle emitter (for when you rescale the model)
+
+				sizeClamp = 250 // Limits particle size. Default to 50
+
+				// ***************
+				// From here the value are not the default anymore.
+				// ***************
+
+
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 45.0 1.0
+				angle = 50.0 1.0
+				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
+				distance = 100.0 1.0
+				distance = 110.0 1.0
+
+				emission
+				{
+					density = 1.0 2.0
+					density = 0.18 2.0
+					density = 0.005 0.10
+					density = 0.004 0.0
+				}
+				offset
+				{
+					density = 1.0 1.0
+					density = 0.18 1.0
+					density = 0.1 75
+					density = 0.005 75
+					density = 0.004 25
+				}
+				size
+				{
+					density = 1.0 4
+					density = 0.18 4
+					density = 0.0 135
+				}
+
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+				volume = 1.0
+				pitch = 0.8
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[KW2mengineSPS]:FOR[RealPlume]:NEEDS[SmokeScreen]	//microEngine Squad.cfg Generic 1kN Thruster
+{
+	//small oms thruster MMH/NTO
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamesmall
+				transformName = thrustTransform
+				localPosition = 0, 0, 0.42
+				fixedScale = 0.1
+				emission = 0 0
+				emission = 1 1.5
+				speed = 0 0.5
+				speed = 1 0.5
+				energy = 0 0.5
+				energy = 1 0.5
+				logGrowScale
+				{
+					density = 1 1
+					density = 0.0 1
+				}
+				logGrow
+				{
+					density = 1 -1.5
+					density = 0.0 300
+				}
+				linGrow
+				{
+					density = 1 -1.5
+					density = 0.0 300
+				}
+				emission
+				{
+					density = 1.0 1.0
+					density = 0.0 1.0
+				}
+				size
+				{
+					density = 1.0 1
+					density = 0.0 0.2
+				}
+				offset
+				{
+					density = 1.0 1
+					density = 0.0 2
+				}
+				energy
+				{
+					density = 1 0.2
+					density = 0.0 0.2
+				}
+
+			}
+
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[KW2mengineVestaVR9D]:FOR[RealPlume]:NEEDS[SmokeScreen]	//toroidalAerospike Squad.cfg //Rocketdyne J-2T-200/250K Aerospike
+{
+	!fx_exhaustFlame_blue = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%powerEffectName = powerflame
+		!fxOffset = DELETE
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame // name of effect to be added to the Engine Module
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/nasa4engine
+				transformName = thrustTransform
+				localPosition = 0,0,-0.3
+				fixedScale = 1.8
+				sizeClamp = 250
+				initialDensity = 0.6
+				physical = False
+				singleEmitTimer = 0
+				randomInitalVelocityOffsetMaxRadius = 0
+				logGrow
+				{
+					density = 1.0 0
+					density = 0.5 10
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.0
+					density = 0.79 3
+					density = 0.0 20
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 3
+					density = 0.005 15
+					density = 0.0 15
+				}
+				emission
+				{
+					density = 1.0 1
+					density = 0.79 0.5
+					density = 0.5 0.3
+					density = 0.0 0.2
+				}
+				energy
+				{
+					density = 1.0 1.0
+					density = 0.005 0.7
+					density = 0.0 0.5
+				}
+				offset
+				{
+					density = 1.0 0.0
+					density = 0.79 0.2
+					density = 0.5 0.4
+					density = 0.0 0.6
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+				volume = 0.0 0.0
+				volume = 1.0 1.5
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+				volume = 0.65
+				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[engineLargeSkipper]:FOR[RealPlume]:NEEDS[SmokeScreen] //engineLargeSkipper Squad.cfg RL-10
+{
+	!fx_exhaustFlames_yellow_tiny = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+				transformName = thrustTransform
+				localPosition = 0,0,1.0
+				fixedScale = 1.2
+				speed = 0.0 1.75
+				speed = 1.0 1.75
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.999
+					density = 0.12 0.0
+					density = 0.0 0
+				}
+				size
+				{
+					density = 1.0 0.6
+					density = 0.12 1.0
+					density = 0.0 1.0
+				}
+				logGrow
+				{
+					density = 1.0 0.0
+					density = 0.12 0.0
+					density = 0.0 15.0
+				}
+				offset
+				{
+					density = 1.0 -0.5
+					density = 0.12 0.1
+					density = 0.0 0.25
+				}
+				energy
+				{
+					density = 1.0 0.33
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 1.0
+					density = 0.5 0.6
+					density = 0.0 0.35
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -1409,7 +1409,7 @@
 		}
 	}
 }
-@PART[engineLargeSkipper]:FOR[RealPlume]:NEEDS[SmokeScreen] //engineLargeSkipper Squad.cfg RL-10
+@PART[KW3mengineGriffonXX]:FOR[RealPlume]:NEEDS[SmokeScreen] //engineLargeSkipper Squad.cfg RL-10
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/KWRocketry.cfg
@@ -591,10 +591,10 @@
 		{
 			MODEL_MULTI_PARTICLE_PERSIST
 			{
-				name = flamethrust
+				name = Flame
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
-				transformName = thrustTransform
-				localPosition = 0,0,-0.75
+				transformName = OldFXTransform
+				localPosition = 0,0,0.3
 				fixedScale = 2.3
 				emission = 0.0 0.2
 				emission = 1.0 0.2
@@ -1520,7 +1520,7 @@
 		}
 	}
 }
-@PART[KW5mengineGriffonC]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne F-1 [5.5m] from Squad.cfg
+@PART[KW5mengineGriffonC]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne F-1 [5.5m] from Squad.cfg CONFIRMED WORKING
 {
 	!EFFECTS
 	{
@@ -1533,8 +1533,8 @@
 			{
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
-				transformName = thrustTransform
-				localPosition = 0,0,0.9
+				transformName = FX2Transform
+				localPosition = 0,0,0.0
 				fixedScale = 0.45
 				emission = 0.0 0.0
 				emission = 1.0 3.5
@@ -1615,10 +1615,10 @@
 		{
 			MODEL_MULTI_PARTICLE_PERSIST
 			{
-				name = smokethrust
+				name = fx_smokeTrail_veryLarge
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
-				transformName = thrustTransform
-				localPosition = 0,0,0.9
+				transformName = FX2Transform
+				localPosition = 0,0,0.5
 				fixedScale = 1.75
 				emission = 0.0 0.0
 				emission = 1.0 3.5
@@ -1734,19 +1734,8 @@
 }
 @PART[KW5mengineTitanV]:FOR[RealPlume]:NEEDS[SmokeScreen] // J2, uses J-2 FX for now.
 {
-
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-		%powerEffectName = powerflame
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-	}
-
-	!fx_exhaustFlame_blue  = DELETE
+	!fx_exhaustFlames_yellow_tiny = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
 	!fx_exhaustLight_blue = DELETE
 	!fx_smokeTrail_light = DELETE
 	!fx_exhaustSparks_flameout = DELETE
@@ -1754,6 +1743,17 @@
 	!sound_rocket_hard = DELETE
 	!sound_vent_soft = DELETE
 	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
 	!EFFECTS {}
 	EFFECTS
 	{
@@ -1764,34 +1764,34 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
 				transformName = thrustTransform
-				localPosition = 0,0,0.3
-				fixedScale = 1.6
-				speed = 0.0 1.3
+				localPosition = 0,0,1.0
+				fixedScale = 1.2
+				speed = 0.0 1.75
 				speed = 1.0 1.75
 				fixedEmissions = false
-				logGrow
+				grow
 				{
-					density = 1.0 0.0
-					density = 0.08 0.0
-					density = 0.0 10.0
+					density = 1.0 -0.999
+					density = 0.12 0.0
+					density = 0.0 0
 				}
 				size
 				{
 					density = 1.0 0.6
-					density = 0.08 1.0
+					density = 0.12 1.0
 					density = 0.0 1.0
 				}
-				grow
+				logGrow
 				{
-					density = 1.0 -0.99
-					density = 0.08 0.0
-					density = 0.0 0.0
+					density = 1.0 0.0
+					density = 0.12 0.0
+					density = 0.0 15.0
 				}
 				offset
 				{
-					density = 1.0 -0.2
-					density = 0.08 0.1
-					density = 0.0 0.3
+					density = 1.0 -0.5
+					density = 0.12 0.1
+					density = 0.0 0.25
 				}
 				energy
 				{
@@ -1800,15 +1800,15 @@
 				}
 				emission
 				{
-					density = 1.0 0.8
-					density = 0.08 0.5
-					density = 0.0 0.25
+					density = 1.0 1.0
+					density = 0.5 0.6
+					density = 0.0 0.35
 				}
 			}
 			AUDIO
 			{
 				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
 				volume = 0.0 0.0
 				volume = 1.0 1.0
 				pitch = 0.0 0.2
@@ -1821,8 +1821,8 @@
 			AUDIO
 			{
 				channel = Ship
-				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
-				volume = 1.0
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
 				pitch = 1.0
 				loop = false
 			}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/ProceduralParts.cfg
@@ -1,0 +1,210 @@
+@PART[proceduralSRBRealFuels]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Procedural Parts SRB, copied from Novapunch SRB.
+{
+	!fx_exhaustFlame_yellow = DELETE
+	!fx_exhaustSparks_yellow = DELETE
+	!fx_smokeTrail_medium = DELETE
+
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//engineID = rocketengine
+		%runningEffectName = powersmoke
+		%powerEffectName = powerflame
+		!fxOffset = DELETE
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame // name of effect to be added to the Engine Module
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamesrblarge
+				transformName = thrustTransform
+				localPosition = 0,0,0.0
+				fixedScale = 0.6
+				sizeClamp = 250
+				initialDensity = 0.6
+				physical = False
+				stickiness = 0.9
+				dragCoefficient = 0.1
+				singleEmitTimer = 0
+				randomInitalVelocityOffsetMaxRadius = 1
+				logGrow
+				{
+					density = 1.0 1
+					density = 0.7 5
+					density = 0.1 16
+					density = 0.0 20
+				}
+				logGrowScale
+				{
+					density = 1.0 0.0
+					density = 0.7 10
+					density = 0.0 20
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 1
+					density = 0.70 2
+					density = 0.1 3
+					density = 0.0 3
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 0.3
+					density = 0.1 0.05
+					density = 0.0 0.05
+				}
+				energy
+				{
+					density = 1.0 0.9
+					density = 0.005 0.9
+					density = 0.0 0.5
+				}
+				offset
+				{
+					density = 1.0 0.0
+					density = 0.7 0
+					density = 0.5 0.5
+					density = 0.0 6
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = 1.0 1.5
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		powersmoke //You can add as many effects to an engine as you like using this method.
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = smokethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster
+				transformName = thrustTransform
+				localRotation = 0,0,0
+				localPosition = 0,0,0
+				offsetDirection = 0,0,1
+				fixedScale = 1.2
+				sizeClamp = 250
+				initialDensity = 0.6
+				physical = False
+				stickiness = 0.9
+				dragCoefficient = 0.1
+				singleEmitTimer = 0
+				randomInitalVelocityOffsetMaxRadius = 0
+				logGrow
+				{
+					density = 1.0 1
+					density = 0.7 1
+					density = 0.0 1
+				}
+				logGrowScale
+				{
+					density = 1.0 0.0
+					density = 0.79 3
+					density = 0.0 4
+				}
+				linGrow
+				{
+					density = 1.0 0.5
+					density = 0.79 0.0
+					density = 0.005 0.5
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 3
+					density = 0.005 10
+					density = 0.0 15
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 1.0
+					density = 0.5 0.3
+					density = 0.0 0.15
+				}
+				energy
+				{
+					density = 1.0 0.9
+					density = 0.005 1.5
+					density = 0.0 1.5
+				}
+				offset
+				{
+					density = 1.0 0.083
+					density = 0.79 55
+					density = 0.1 75
+					density = 0.0 45
+				}
+				size
+				{
+					density = 1.0 1
+					density = 0.7 6
+					density = 0.1 25
+					density = 0.0 0
+				}
+
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq10
+				volume = 0.65
+				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/aies.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/aies.cfg
@@ -317,3 +317,800 @@
 		%type = ModuleEnginesRF
     }
 }
+@PART[liquidEngineconstelacion]:FOR[RealPlume]:NEEDS[SmokeScreen]	//J2X, uses J-2 FX from RO.cfg CONFIRMED WORKING 
+{
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+
+	!fx_exhaustFlame_blue  = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+				transformName = thrustTransform
+				localPosition = 0,0,0.3
+				fixedScale = 1.6
+				speed = 0.0 1.3
+				speed = 1.0 1.75
+				fixedEmissions = false
+				logGrow
+				{
+					density = 1.0 0.0
+					density = 0.08 0.0
+					density = 0.0 10.0
+				}
+				size
+				{
+					density = 1.0 0.6
+					density = 0.08 1.0
+					density = 0.0 1.0
+				}
+				grow
+				{
+					density = 1.0 -0.99
+					density = 0.08 0.0
+					density = 0.0 0.0
+				}
+				offset
+				{
+					density = 1.0 -0.2
+					density = 0.08 0.1
+					density = 0.0 0.3
+				}
+				energy
+				{
+					density = 1.0 0.33
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 0.8
+					density = 0.08 0.5
+					density = 0.0 0.25
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq5
+				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[engineexper05]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL-60, copied from RL-10 squad.cfg CONFIRMED WORKING
+{
+	!fx_exhaustFlames_yellow_tiny = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+				transformName = thrustTransform
+				localPosition = 0,0,1.0
+				fixedScale = 1.2
+				speed = 0.0 1.75
+				speed = 1.0 1.75
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.999
+					density = 0.12 0.0
+					density = 0.0 0
+				}
+				size
+				{
+					density = 1.0 0.6
+					density = 0.12 1.0
+					density = 0.0 1.0
+				}
+				logGrow
+				{
+					density = 1.0 0.0
+					density = 0.12 0.0
+					density = 0.0 15.0
+				}
+				offset
+				{
+					density = 1.0 -0.5
+					density = 0.12 0.1
+					density = 0.0 0.25
+				}
+				energy
+				{
+					density = 1.0 0.33
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 1.0
+					density = 0.5 0.6
+					density = 0.0 0.35
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[liquidEnginemogulmp1500]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-170, (2xF1B) from novapunch.cfg PARTIALLY WORKING. ALIGNMENT INCORRECT. 4 engines check.
+{
+	!EFFECTS
+	{
+	}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
+				transformName = thrustTransform
+				fixedScale = 0.27
+				emission = 0.0 0.0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15
+				energy = 1.0 15
+				size = 0.0 2
+				size = 1.0 2
+				fixedEmissions = false
+				sizeClamp = 250
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 1
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.0
+					density = 0.79 0.15
+					density = 0.0 45
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 2
+					density = 0.005 15
+					density = 0.0 15
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0
+					density = 0.5 0.1
+					density = 0.0 0.05
+				}
+				energy
+				{
+					density = 1.0 0.9
+					density = 0.5 0.7
+					density = 0.1 0.3
+					density = 0.0 0.2
+				}
+				offset
+				{
+					density = 1.0 -2.5
+					density = 0.79 -3.5
+					density = 0.5 -2.5
+					density = 0.0 15
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = 1.0 1.5
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		powersmoke
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = smokethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+				transformName = thrustTransform
+				localPosition = 0,0,1.5
+				fixedScale = 1
+				emission = 0.0 0.0
+				emission = 1.0 3.5
+				speed = 0.0 5
+				speed = 1.0 5
+				offset = 0.0 1.0
+				offset = 1.0 1.0
+				energy = 0.0 15
+				energy = 1.0 15
+				size = 0.0 2
+				size = 1.0 2
+				fixedEmissions = false
+				sizeClamp = 250
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				logGrow
+				{
+					density = 1.0 2
+					density = 0.0 10
+				}
+				logGrowScale
+				{
+					density = 1.0 0.5
+					density = 0.79 0.15
+					density = 0.0 45
+				}
+				linGrow
+				{
+					density = 1.0 0.0
+					density = 0.79 0.0
+					density = 0.005 0.0
+					density = 0.0 1
+				}
+				speed
+				{
+					density = 1.0 2
+					density = 0.79 2
+					density = 0.005 15
+					density = 0.0 15
+				}
+				emission
+				{
+					density = 1.0 3.0
+					density = 0.79 3.0
+					density = 0.5 0.1
+					density = 0.0 0.05
+				}
+				energy
+				{
+					density = 1.0 1.8
+					density = 0.5 1.4
+					density = 0.1 0.6
+					density = 0.0 0.0
+				}
+				offset
+				{
+					density = 1.0 -2.5
+					density = 0.79 -3.5
+					density = 0.5 -2.5
+					density = 0.0 15
+				}
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq10
+				volume = 0.65
+				pitch = 1.7
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//engineID = rocketengine
+		%runningEffectName = powersmoke
+		%powerEffectName = powerflame
+		!fxOffset = DELETE
+
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+}
+@PART[enginelmodc]:FOR[RealPlume]:NEEDS[SmokeScreen]	//TRW LM Ascent Engine, taken from squad.cfg CONFIRMED WORKING
+{
+	//Hypergolic engine
+	!EFFECTS
+	{
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
+				transformName = thrustTransform
+				localPosition = 0,0,0.0
+				fixedScale = 2.9
+				emission = 0.0 0
+				emission = 1.0 0.5
+				speed = 0.0 1.0
+				speed = 1.0 1.0
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.99999
+					density = 0.011 0.0
+					density = 0.0 0.0
+				}
+				speed
+				{
+					density = 1.0 1
+					density = 0.011 12
+					density = 0.0 15
+				}
+				logGrow
+				{
+					density = 1.0 0
+					density = 0.11 50
+					density = 0.0 75
+				}
+				offset
+				{
+					density = 1.0 -0.05
+					density = 0.011 0.05
+					density = 0.0 0.05
+				}
+				size
+				{
+					density = 1.0 0.5
+					density = 0.011 1.0
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 0.5
+					density = 0.11 1
+					density = 0.0 1
+				}
+				energy
+				{
+					power = 1.0 1.5
+					power = 0.0 0.4
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
+				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[galaxvr2]:FOR[RealPlume]:NEEDS[SmokeScreen] //Aestus, Aerojet AJ-10-190 Squad.cfg CONFIRMED WORKING. Changed localPosition to 0.3
+{
+	!fx_exhaustFlame_white_tiny = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_mini = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamesmall
+				transformName = thrustTransform
+				localPosition = 0,0,0.3
+				fixedScale = 2.9
+				emission = 0.0 0.0
+				emission = 1.0 0.5
+				speed = 0.0 1.0
+				speed = 1.0 1.0
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.99999
+					density = 0.011 0.0
+					density = 0.0 0.0
+				}
+				logGrow
+				{
+					density = 1.0 0
+					density = 0.11 55
+					density = 0.0 55
+				}
+				offset
+				{
+					density = 1.0 0
+					density = 0.11 0.03
+					density = 0.0 0.05
+				}
+				size
+				{
+					density = 1.0 0.5
+					density = 0.11 0.5
+					density = 0.0 1.0
+				}
+				energy
+				{
+					density = 1.0 1.5
+					density = 0.11 0.5
+					density = 0.0 0.5
+				}
+				speed
+				{
+					density = 1.0 1.5
+					density = 0.11 2.0
+					density = 0.0 2.0
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
+				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[liquidEngineorbit2]:FOR[RealPlume]:NEEDS[SmokeScreen] // LR91, taken from AJ10-137 (Apollo SPS) RO.cfg. localPosition to 0.8
+{
+	!fx_exhaustFlames_yellow_tiny = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
+				transformName = thrustTransform
+				localPosition = 0,0,0.8
+				fixedScale = 5
+				emission = 0.0 0.0
+				emission = 1.0 0.20
+				speed = 0.0 2.79
+				speed = 1.0 2.79
+				energy = 0.0 0.99 // Same for energy
+				energy = 1.0 0.99 // Same for energy
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.99999
+					density = 0.008 0.0
+					density = 0.0 0.0
+				}
+				logGrow
+				{
+					density = 1.0 0
+					density = 0.008 0.3
+					density = 0.0 5.0
+				}
+				offset
+				{
+					density = 1.0 -0.1
+					density = 0.008 0.05
+					density = 0.0 0.10
+				}
+				size
+				{
+					density = 1.0 0.5
+					density = 0.008 1.0
+					density = 0.0 1.0
+				}
+				energy
+				{
+					density = 1.0 1.5
+					density = 0.0 1.7
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
+				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/aies.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/aies.cfg
@@ -468,7 +468,7 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
 				transformName = thrustTransform
-				localPosition = 0,0,1.0
+				localPosition = 0,0,1.5 //changed
 				fixedScale = 1.2
 				speed = 0.0 1.75
 				speed = 1.0 1.75
@@ -555,7 +555,7 @@
 		}
 	}
 }
-@PART[liquidEnginemogulmp1500]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-170, (2xF1B) from novapunch.cfg PARTIALLY WORKING. ALIGNMENT INCORRECT. 4 engines check.
+@PART[liquidEnginemogulmp1500]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-170, (2xF1B) from novapunch.cfg CONFIRMED WORKING
 {
 	!EFFECTS
 	{
@@ -569,6 +569,7 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/flamef1fx
 				transformName = thrustTransform
+				localPosition = 0,0,1.6 //changed
 				fixedScale = 0.27
 				emission = 0.0 0.0
 				emission = 1.0 3.5
@@ -648,7 +649,7 @@
 				name = smokethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
 				transformName = thrustTransform
-				localPosition = 0,0,1.5
+				localPosition = 0,0,20.0 //changed
 				fixedScale = 1
 				emission = 0.0 0.0
 				emission = 1.0 3.5
@@ -785,7 +786,7 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
 				transformName = thrustTransform
-				localPosition = 0,0,0.0
+				localPosition = 0,0,1.5 //changed
 				fixedScale = 2.9
 				emission = 0.0 0
 				emission = 1.0 0.5
@@ -880,7 +881,7 @@
 		}
 	}
 }
-@PART[galaxvr2]:FOR[RealPlume]:NEEDS[SmokeScreen] //Aestus, Aerojet AJ-10-190 Squad.cfg CONFIRMED WORKING. Changed localPosition to 0.3
+@PART[galaxvr2]:FOR[RealPlume]:NEEDS[SmokeScreen] //Aestus, Aerojet AJ-10-190 Squad.cfg CONFIRMED WORKING
 {
 	!fx_exhaustFlame_white_tiny = DELETE
 	!sound_vent_medium = DELETE
@@ -907,7 +908,7 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamesmall
 				transformName = thrustTransform
-				localPosition = 0,0,0.3
+				localPosition = 0,0,0.7
 				fixedScale = 2.9
 				emission = 0.0 0.0
 				emission = 1.0 0.5
@@ -997,7 +998,7 @@
 		}
 	}
 }
-@PART[liquidEngineorbit2]:FOR[RealPlume]:NEEDS[SmokeScreen] // LR91, taken from AJ10-137 (Apollo SPS) RO.cfg. localPosition to 0.8
+@PART[liquidEngineorbit2]:FOR[RealPlume]:NEEDS[SmokeScreen] // LR91, taken from AJ10-137 (Apollo SPS) RO.cfg. CONFIRMED WORKING
 {
 	!fx_exhaustFlames_yellow_tiny = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -1029,7 +1030,7 @@
 				name = flamethrust
 				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
 				transformName = thrustTransform
-				localPosition = 0,0,0.8
+				localPosition = 0,0,1.1
 				fixedScale = 5
 				emission = 0.0 0.0
 				emission = 1.0 0.20
@@ -1086,6 +1087,780 @@
 				channel = Ship
 				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
 				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[liquidEngineprodulVR2]:FOR[RealPlume]:NEEDS[SmokeScreen] //LR-87-3, taken from FASA.cfg FASAGeminiLR87Twin CONFIRMED WORKING
+{
+	!fx_exhaustFlame_blue = DELETE
+	!fx_exhaustFlames_white_tiny = DELETE
+	!fx_exhaustLight_blue = DELETE
+	!fx_smokeTrail_light = DELETE
+	!fx_exhaustSparks_flameout = DELETE
+	!sound_vent_medium = DELETE
+	!sound_rocket_hard = DELETE
+	!sound_vent_soft = DELETE
+	!sound_explosion_low = DELETE
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%runningEffectName = powerflamehypergolic
+	}
+	@MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesRF
+    }
+	//@MODULE[ModuleEngineConfigs]
+	//{
+	//	@CONFIG[LR-87-3]
+	//	{
+	//		%runningEffectName = powerflamekerolox
+	//	}
+	//	@CONFIG[LR-87-5]
+	//	{
+	//		%runningEffectName = powerflamehypergolic
+	//	}
+	//	@CONFIG[LR-87-7]
+	//	{
+	//		%runningEffectName = powerflamehypergolic
+	//	}
+	//	@CONFIG[LR-87-9]
+	//	{
+	//		%runningEffectName = powerflamehypergolic
+	//	}
+	//	@CONFIG[LR-87-11]
+	//	{
+	//		%runningEffectName = powerflamehypergolic
+	//	}
+	//	@CONFIG[LR-87-11A]
+	//	{
+	//		%runningEffectName = powerflamehypergolic
+	//	}
+	//	@CONFIG[LR-87-LH2]
+	//	{
+	//		%runningEffectName = powerflamehydrolox
+	//	}
+	//}
+	EFFECTS
+	{
+		powerflamehypergolic
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrusthyper
+				modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicexhaust
+				transformName = thrustTransform
+				localPosition = 0,0,1.8
+				fixedScale = 1.2
+				emission = 0.0 1
+				emission = 1.0 1
+				speed = 0.0 1
+				speed = 1.0 1
+				energy = 0.0 1 // Same for energy
+				energy = 1.0 1 // Same for energy
+				offset = 0.0 0
+				offset = 1.0 0
+				size = 0.0 1.2
+				size = 0.0 1.2
+				fixedEmissions = false
+				logGrow
+				{
+					density = 1.0 10.0
+					density = 0.0 10.0
+				}
+				logGrowScale
+				{
+					density = 1.0 0
+					density = 0.9 0
+					density = 0 4
+				}
+				linGrow
+				{
+					density = 1.0 -0.5
+					density = 0.9 0.0
+					density = 0.0 0.0
+				}
+				offset
+				{
+					density = 1.0 -0.5
+					density = 0.0 -0.3
+				}
+				energy
+				{
+					density = 1.0 1.0
+					density = 0.9 1.5
+					density = 0.0 3
+				}
+				emission
+				{
+					density = 1.0 1.3
+					density = 0.9 1
+					density = 0.0 0.1
+				}
+				speed
+				{
+					density = 1.0 1.0
+					density = 0.9 1.0
+					density = 0 1.4
+				}
+			}
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flameflarehyper
+				modelName = RealismOverhaul/SmokeScreen_Ferram_FX/hypergolicflare
+				transformName = thrustTransform
+				localPosition = 0,0,1.0
+				emission = 0.0 1
+				emission = 1.0 1
+				speed = 0.0 1
+				speed = 1.0 1
+				offset = 0.0 -0.2
+				offset = 1.0 -0.2
+				energy = 0.0 1 // Same for energy
+				energy = 1.0 1 // Same for energy
+				size = 0.0 0.6 // Rescale the particles to +0%
+				size = 1.0 0.6 // Rescale the particles to +0%
+				fixedEmissions = false
+				sizeClamp = 250
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		//		powerflamehydrolox
+		//		{
+		//			MODEL_MULTI_PARTICLE_PERSIST
+		//			{
+		//				name = flamethrusthydro
+		//				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/noxflame
+		//				transformName = thrustTransform
+		//				localPosition = 0,0,-0.0
+		//				fixedScale = 1
+		//				speed = 0.0 0.75
+		//				speed = 1.0 0.75
+		//				fixedEmissions = false
+		//				grow
+		//				{
+		//				  density = 1.0 -0.999
+		//				  density = 0.64 0
+		//				  density = 0.0 0
+		//				}
+		//
+		//				logGrow
+		//				{
+		//				  density = 1.0 0.0
+		//				  density = 0.64 0.0
+		//				  density = 0.0 10.0
+		//				}
+		//				offset
+		//				{
+		//				  density = 1.0 0.4
+		//				  density = 0.64 0.45
+		//
+		//				  density = 0.0 0.5
+		//				}
+		//				energy
+		//				{
+		//				  density = 1.0 0.53
+		//				  density = 0.64 1.0
+		//				  density = 0.0 2.0
+		//				}
+		//				emission
+		//				{
+		//				  density = 1.0 1.0
+		//				  density = 0.64 0.6
+		//				  density = 0.0 0.25
+		//				}
+		//			}
+		//			MODEL_MULTI_PARTICLE_PERSIST
+		//			{
+		//				name = flameflarehydro
+		//				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2big
+		//				transformName = thrustTransform
+		//				fixedScale = 0.5
+		//				emission = 0.0 2
+		//				emission = 1.0 2
+		//				speed = 0.0 0.5
+		//				speed = 1.0 0.5
+		//				offset = 0.0 -1.8
+		//				offset = 1.0 -1.8
+		//				energy = 0.0 0.1 // Same for energy
+		//				energy = 1.0 0.1 // Same for energy
+		//				size = 0.0 2 // Rescale the particles to +0%
+		//				size = 1.0 2 // Rescale the particles to +0%
+		//				fixedEmissions = false
+		//				sizeClamp = 250
+		//				grow = 0.0 2
+		//				grow = 1.0 2
+		//				randomInitalVelocityOffsetMaxRadius = 0.2
+		//			}
+		//			AUDIO
+		//			{
+		//			  channel = Ship
+		//			  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop
+		//			  volume = 0.0 0.0
+		//			  volume = 1.0 1.0
+		//			  pitch = 0.0 0.2
+		//			  pitch = 1.0 2
+		//			  loop = true
+		//			}
+		//		}
+		//      	powerflamekerolox
+		//			{
+		//				MODEL_MULTI_PARTICLE_PERSIST
+		//				{
+		//					name = flamethrustkero
+		//					modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+		//					transformName = thrustTransform
+		//					fixedScale = 0.5
+		//					emission = 0.0 3.5
+		//					emission = 1.0 3.5
+		//					speed = 0.0 5
+		//					speed = 1.0 5
+		//					offset = 0.0 1.0
+		//					offset = 1.0 1.0
+		//					energy = 0.0 15 // Same for energy
+		//					energy = 1.0 15 // Same for energy
+		//					size = 0.0 2 // Rescale the particles to +0%
+		//					size = 1.0 2 // Rescale the particles to +0%
+		//					fixedEmissions = false
+		//					sizeClamp = 250
+		//
+		//					randomInitalVelocityOffsetMaxRadius = 0.2
+		//					logGrow
+		//					{
+		//					  density = 1.0 10
+		//					  density = 0.0 10
+		//					}
+		//					logGrowScale
+		//					{
+		//					  density = 1.0 0.0
+		//					  density = 0.74 0.15
+		//					  density = 0.0 45
+		//					}
+		//					linGrow
+		//					{
+		//					  density = 1.0 0.0
+		//					  density = 0.74 0.0
+		//					  density = 0.005 0.0
+		//					  density = 0.0 1
+		//					}
+		//					speed
+		//					{
+		//					  density = 1.0 2.5
+		//					  density = 0.74 2.5
+		//					  density = 0.005 22.5
+		//					  density = 0.0 22.5
+		//					}
+		//					emission
+		//					{
+		//					  density = 1.0 3.0
+		//					  density = 0.74 3.0
+		//					  density = 0.5 0.3
+		//					  density = 0.0 0.15
+		//					}
+		//					energy
+		//					{
+		//					  density = 1.0 0.9
+		//					  density = 0.005 1.5
+		//					  density = 0.0 1.5
+		//					}
+		//					offset
+		//					{
+		//					  density = 1.0 0.125
+		//					  density = 0.79 0.125
+		//					  density = 0.5 2.625
+		//					  density = 0.0 13.625
+		//					}
+		//				}
+		//				MODEL_MULTI_PARTICLE_PERSIST
+		//				{
+		//					name = flameflarekero
+		//					modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWbooster
+		//					transformName = thrustTransform
+		//					fixedScale = 0.5
+		//					emission = 0.0 2
+		//					emission = 1.0 2
+		//					speed = 0.0 1
+		//					speed = 1.0 1
+		//					offset = 0.0 -0.166
+		//					offset = 1.0 -0.166
+		//					energy = 0.0 0.2 // Same for energy
+		//					energy = 1.0 0.2 // Same for energy
+		//					size = 0.0 1.35 // Rescale the particles to +0%
+		//					size = 1.0 1.35 // Rescale the particles to +0%
+		//					fixedEmissions = false
+		//					sizeClamp = 250
+		//					grow = 0.0 0.2
+		//					grow = 1.0 0.2
+		//
+		//					randomInitalVelocityOffsetMaxRadius = 0.2
+		//				}
+		//				MODEL_MULTI_PARTICLE_PERSIST
+		//				{
+		//					name = smokethrustkero
+		//					modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/smokebooster2
+		//					transformName = thrustTransform
+		//					emission = 0.0 0.25  // Curve for emission like stock
+		//					emission = 1.0 0.25  // Curve for emission like stock
+		//					energy = 0.0 1.2 // Same for energy
+		//					energy = 1.0 1.2 // Same for energy
+		//					speed = 0.0 1.65  // And speed
+		//					speed = 1.0 1.65  // And speed
+		//					grow = 0.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
+		//					grow = 1.0 0.34 // Grow the particles at 0% per seconds ( 0.02 would be 2% )
+		//					scale = 0.0 1.0 // Rescale the emitters to +0%
+		//					scale = 1.0 1.0 // Rescale the emitters to +0%
+		//					offset = 0.0 25  // Move the particle emitter away from its default position by x meters
+		//					offset = 1.0 25  // Move the particle emitter away from its default position by x meters
+		//					size = 0.0 1.85 // Rescale the particles to +0%
+		//					size = 1.0 1.85 // Rescale the particles to +0%
+		//
+		//					renderMode = "Billboard"  // Render mode : Billboard / SortedBillboard / HorizontalBillboard / VerticalBillboard / Stretch
+		//					collide = false // Collision active or not
+		//					collideRatio = 0 // how the particles react on collision. 1 is a mirror bounce, 0 is go parallel to the hit surface
+		//					fixedScale = 0.5 // Fixed rescale of the particle emitter (for when you rescale the model)
+		//
+		//					sizeClamp = 250 // Limits particle size. Default to 50
+		//
+		//					// ***************
+		//					// From here the value are not the default anymore.
+		//					// ***************
+		//
+		//
+		//					angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+		//					angle = 45.0 1.0
+		//					angle = 50.0 1.0
+		//					distance = 0.0 1.0 // Display if the distance to camera is higher than 110
+		//					distance = 100.0 1.0
+		//					distance = 110.0 1.0
+		//
+		//					emission  // Modulate emission from mach and density curve. You can add other section for size, energy, speed, grow, offset and scale
+		//					{
+		//						density = 1.0 2.0
+		//						density = 0.79 2.0 // don't display over .4 atmo
+		//						density = 0.5 0.10
+		//						density = 0.005 0.10
+		//						density = 0.004 0.0 // and stop under .001
+		//					}
+		//					offset
+		//					{
+		//						density = 1.0 1.0
+		//						density = 0.79 1.0
+		//						density = 0.1 75
+		//						density = 0.005 75
+		//						density = 0.004 25
+		//					}
+		//					size
+		//					{
+		//						density = 1.0 4
+		//						density = 0.79 4
+		//						density = 0.0 135
+		//					}
+		//				}
+		//				AUDIO
+		//				{
+		//				  channel = Ship
+		//				  clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_altloop2
+		//				  volume = 0.0 0.0
+		//				  volume = 1.0 1.5
+		//				  pitch = 0.0 1.0
+		//				  pitch = 1.0 1.0
+		//				  loop = true
+		//				}
+		//			}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq4
+				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[microEngineex1sat]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Generic 0.5kn thruster, taken from microEngine squad.cfg CONFIRMED WORKING
+{
+	//small oms thruster MMH/NTO
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamesmall
+				transformName = thrustTransform
+				localPosition = 0, 0, 0.42
+				fixedScale = 0.1
+				emission = 0 0
+				emission = 1 1.5
+				speed = 0 0.5
+				speed = 1 0.5
+				energy = 0 0.5
+				energy = 1 0.5
+				logGrowScale
+				{
+					density = 1 1
+					density = 0.0 1
+				}
+				logGrow
+				{
+					density = 1 -1.5
+					density = 0.0 300
+				}
+				linGrow
+				{
+					density = 1 -1.5
+					density = 0.0 300
+				}
+				emission
+				{
+					density = 1.0 1.0
+					density = 0.0 1.0
+				}
+				size
+				{
+					density = 1.0 1
+					density = 0.0 0.2
+				}
+				offset
+				{
+					density = 1.0 1
+					density = 0.0 2
+				}
+				energy
+				{
+					density = 1 0.2
+					density = 0.0 0.2
+				}
+
+			}
+
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[microEngineSE1]:FOR[RealPlume]:NEEDS[SmokeScreen]	//LMAE Ascent Engine, taken from squad.cfg 
+{
+	//Hypergolic engine
+	!EFFECTS
+	{
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/ssmeflame2
+				transformName = thrustTransform
+				localPosition = 0,0,0.4//changed
+				fixedScale = 2.9
+				emission = 0.0 0
+				emission = 1.0 0.5
+				speed = 0.0 1.0
+				speed = 1.0 1.0
+				fixedEmissions = false
+				grow
+				{
+					density = 1.0 -0.99999
+					density = 0.011 0.0
+					density = 0.0 0.0
+				}
+				speed
+				{
+					density = 1.0 1
+					density = 0.011 12
+					density = 0.0 15
+				}
+				logGrow
+				{
+					density = 1.0 0
+					density = 0.11 50
+					density = 0.0 75
+				}
+				offset
+				{
+					density = 1.0 -0.05
+					density = 0.011 0.05
+					density = 0.0 0.05
+				}
+				size
+				{
+					density = 1.0 0.5
+					density = 0.011 1.0
+					density = 0.0 1.0
+				}
+				emission
+				{
+					density = 1.0 0.5
+					density = 0.11 1
+					density = 0.0 1
+				}
+				energy
+				{
+					power = 1.0 1.5
+					power = 0.0 0.4
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_sps
+				volume = 1.0
+				pitch = 1.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[dest5Engine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Generic 2kn thruster, taken from microEngine squad.cfg CONFIRMED WORKING
+{
+	//small oms thruster MMH/NTO
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		//%runningEffectName = powersmoke
+		!runningEffectName = DELETE
+		%powerEffectName = powerflame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		powerflame
+		{
+			MODEL_MULTI_PARTICLE_PERSIST
+			{
+				name = flamethrust
+				modelName = RealismOverhaul/SmokeScreen_MP_Nazari_FX/KWflamesmall
+				transformName = thrustTransform
+				localPosition = 0, 0, 0.2 //changed
+				fixedScale = 0.1
+				emission = 0 0
+				emission = 1 1.5
+				speed = 0 0.5
+				speed = 1 0.5
+				energy = 0 0.5
+				energy = 1 0.5
+				logGrowScale
+				{
+					density = 1 1
+					density = 0.0 1
+				}
+				logGrow
+				{
+					density = 1 -1.5
+					density = 0.0 300
+				}
+				linGrow
+				{
+					density = 1 -1.5
+					density = 0.0 300
+				}
+				emission
+				{
+					density = 1.0 1.0
+					density = 0.0 1.0
+				}
+				size
+				{
+					density = 1.0 1
+					density = 0.0 0.2
+				}
+				offset
+				{
+					density = 1.0 1
+					density = 0.0 2
+				}
+				energy
+				{
+					density = 1 0.2
+					density = 0.0 0.2
+				}
+
+			}
+
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_spsloop
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealismOverhaul/SmokeScreen_RE_Sounds/sound_liq7
+				volume = 0.8
 				pitch = 1.0
 				loop = false
 			}


### PR DESCRIPTION
Tested ingame 1.0.2

Working:
All AEIS working. Alignment is correct.
All KW working. 

Added Procedural Parts.

To do: Different size of realplume for different SRB.