### PR TITLE
Create RO_Engines.cfg to categorize engines

### DIFF
--- a/GameData/RealismOverhaul/RO_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_Engines.cfg
@@ -1,4 +1,11 @@
+// some FASA fuel tanks are labelled as Propulsion, this should catch them and move them to the proper category
+@PART[FASA*LFT]:HAS[#category[Propulsion]]:FIRST
+{
+	%category = FuelTank
+}
+// and this should move engines previously categorized as Propulson to the new Engine category for VAB sorting
 @PART[*]:HAS[#category[Propulsion]]
 {
 	%category = Engine
 }
+// some issue still exist, such as some stock fuel tanks that were labelled as Propulsion that need to be caught and moved as well

--- a/GameData/RealismOverhaul/RO_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_Engines.cfg
@@ -1,0 +1,4 @@
+@PART[*]:HAS[#category[Propulsion]]
+{
+	%category = Engine
+}

--- a/GameData/RealismOverhaul/RO_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_Engines.cfg
@@ -1,11 +1,7 @@
-// some FASA fuel tanks are labelled as Propulsion, this should catch them and move them to the proper category
-@PART[FASA*LFT]:HAS[#category[Propulsion]]:FIRST
-{
-	%category = FuelTank
-}
-// and this should move engines previously categorized as Propulson to the new Engine category for VAB sorting
-@PART[*]:HAS[#category[Propulsion]]
+// final added to catch engines where gimbal is added by RO
+// this method does not catch the LEM ascent engine specifically
+// ModuleCommand added to not catch MechJeb
+@PART[*]:HAS[@MODULE[ModuleGimbal],!MODULE[ModuleCommand]]:FINAL
 {
 	%category = Engine
 }
-// some issue still exist, such as some stock fuel tanks that were labelled as Propulsion that need to be caught and moved as well

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Explorer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Explorer.cfg
@@ -70,6 +70,7 @@
 	@node_stack_top = 0.0, 0.535, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -0.3206, 0.0, 0.0, -1.0, 0.0, 0
 	!node_attach = DELETE
+	%category = Engine
 	@title = Baby Sergeant Rocket Motor
 	%manufacturer = Thiokol
 	@description = Attaches under the Explorer probe.
@@ -166,6 +167,7 @@
 	@node_stack_top = 0.0, 0.601, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -0.244, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_connect1 = 0.0, 0.601, 0.0 , 0.0, 1.0, 0.0, 0
+	%category = Engine
 	@title = 3x Baby Sergeant Rocket Motor Cluster
 	%manufacturer = Thiokol
 	@description = A cluster of 3 Thiokol Baby Sergeant Rocket Motors. Attaches to the 3x decoupler.
@@ -253,6 +255,7 @@
 		scale = 1.494, 1.186, 1.494
 	}
 	@scale = 1.186
+	%category = Engine
 	@title = Baby Sergeant 11x Rocket Motor Cluster
 	%manufacturer = Thiokol
 	@description = A cluster of 11 Thiokol Baby Sergeant Rocket Motors. Attaches to the Baby Sergeant 11x decoupler.


### PR DESCRIPTION
1.0 Appears to place engines into the wrong category.

This MM code places them back into the Engines category. If you would prefer, take this code and put it wherever in RO you think it should be.