### PR TITLE
Create RO_Mir.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_Mir.cfg
@@ -1,0 +1,700 @@
+@PART[Mir_Kristall]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.4
+	@mass = 16
+	@title = Mir Kristall
+	@manufacturer = Russia
+	@description = Kristall, the fourth module, consisted of two main sections. The first was largely used for materials processing (via various processing furnaces), astronomical observations, and a biotechnology experiment utilising the Aniur electrophoresis unit. The second section was a docking compartment which featured two APAS-89 docking ports initially intended for use with the Buran programme and eventually used during the Shuttle-Mir programme. The docking compartment also contained the Priroda 5 camera used for Earth resources experiments. Kristall also carried six gyrodines for attitude control to augment those already on the station, and two collapsible solar arrays.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 2
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+    {
+	}
+	%MODULE[ModuleRTAntennaPassive] 
+	{
+		%OmniRange = 500000
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	!RESOURCE
+	{	
+	}
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 8.76
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = N2O4
+			@ratio = 0.5
+		}
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 0.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 350
+			@key,1 = 1 120
+		}
+  	}
+	MODULE
+         	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5
+       	}
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 140000
+			maxAmount = 140000
+		}
+		TANK
+		{
+			name = Food
+			amount = 675
+			maxAmount = 675
+		}
+		TANK
+		{
+			name = Water
+			amount = 375
+			maxAmount = 375
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 30000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 330
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 250
+		}
+		TANK
+		{
+			name = N2O4
+			amount = 2500
+			maxAmount = 2500
+          		}
+            	TANK
+          	  	{
+            		name = Hydrazine
+            		amount = 2500
+            		maxAmount = 2500
+            	}
+	}
+	!MODULE[LifeSupportRegenerateModule]
+	{
+    } 
+}
+@PART[Mir_Kvant_2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.4
+	@mass = 16
+	@title = Mir Kvant-2
+	@manufacturer = Russia
+	@description = The first TKS based module, Kvant-2, was divided into three compartments: an EVA airlock, an instrument/cargo compartment (which could function as a backup airlock), and an instrument/experiment compartment. The module also carried a Soviet version of the Manned Maneuvering Unit for the Orlan space suit, referred to as Ikar, a system for regenerating water from urine, a shower, the Rodnik water storage system and six gyrodynes to augment those already located in Kvant-1. Scientific equipment included a high-resolution camera, spectrometers, X-ray sensors, the Volna 2 fluid flow experiment, and the Inkubator-2 unit, which was used for hatching and raising quail.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 2
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+    {
+	}
+	%MODULE[ModuleRTAntennaPassive] 
+	{
+		%OmniRange = 500000
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	!RESOURCE
+	{	
+	}
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 8.76
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = N2O4
+			@ratio = 0.5
+		}
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 0.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 350
+			@key,1 = 1 120
+		}
+  	}
+	MODULE
+         	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5
+       	}
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 140000
+			maxAmount = 140000
+		}
+		TANK
+		{
+			name = Food
+			amount = 675
+			maxAmount = 675
+		}
+		TANK
+		{
+			name = Water
+			amount = 375
+			maxAmount = 375
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 30000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 330
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 250
+		}
+		TANK
+		{
+			name = N2O4
+			amount = 2500
+			maxAmount = 2500
+          		}
+            	TANK
+          	  	{
+            		name = Hydrazine
+            		amount = 2500
+            		maxAmount = 2500
+            	}
+	}
+	!MODULE[LifeSupportRegenerateModule]
+	{
+    } 
+}
+@PART[Mir_Priroda]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.4
+	@mass = 16
+	@title = Mir Priroda
+	@manufacturer = Russia
+	@description = The seventh and final Mir module, Priroda's primary purpose was to conduct Earth resource experiments through remote sensing and to develop and verify remote sensing methods. The module's experiments were provided by twelve different nations, and covered microwave, visible, near infrared, and infrared spectral regions using both passive and active sounding methods. The module possessed both pressurised and unpressurised segments, and featured a large, externally mounted synthetic aperture radar dish.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 2
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+    {
+	}
+	%MODULE[ModuleRTAntennaPassive] 
+	{
+		%OmniRange = 500000
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	!RESOURCE
+	{	
+	}
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 8.76
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = N2O4
+			@ratio = 0.5
+		}
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 0.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 350
+			@key,1 = 1 120
+		}
+  	}
+	MODULE
+         	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5
+       	}
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 140000
+			maxAmount = 140000
+		}
+		TANK
+		{
+			name = Food
+			amount = 675
+			maxAmount = 675
+		}
+		TANK
+		{
+			name = Water
+			amount = 375
+			maxAmount = 375
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 30000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 330
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 250
+		}
+		TANK
+		{
+			name = N2O4
+			amount = 2500
+			maxAmount = 2500
+          		}
+            	TANK
+          	  	{
+            		name = Hydrazine
+            		amount = 2500
+            		maxAmount = 2500
+            	}
+	}
+	!MODULE[LifeSupportRegenerateModule]
+	{
+    } 
+}
+@PART[Mir_Spektr]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.4
+	@mass = 16
+	@title = Mir Spektr
+	@manufacturer = Russia
+	@description = Spektr was the first of the three modules launched during the Shuttle-Mir programme; it served as the living quarters for American astronauts and housed NASA-sponsored experiments. The module was designed for remote observation of Earth's environment and contained atmospheric and surface research equipment. Additionally, it featured four solar arrays which generated approximately half of the station's electrical power. The module also featured a science airlock to expose experiments to the vacuum of space selectively. Spektr was rendered unusable following the collision with Progress M-34 in 1997 which damaged the module, exposing it directly to the vacuum of space.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 2
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+    {
+	}
+	%MODULE[ModuleRTAntennaPassive] 
+	{
+		%OmniRange = 500000
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	!RESOURCE
+	{	
+	}
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 8.76
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = N2O4
+			@ratio = 0.5
+		}
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 0.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 350
+			@key,1 = 1 120
+		}
+  	}
+	MODULE
+         	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5
+       	}
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 140000
+			maxAmount = 140000
+		}
+		TANK
+		{
+			name = Food
+			amount = 675
+			maxAmount = 675
+		}
+		TANK
+		{
+			name = Water
+			amount = 375
+			maxAmount = 375
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 30000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 330
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 250
+		}
+		TANK
+		{
+			name = N2O4
+			amount = 2500
+			maxAmount = 2500
+          		}
+            	TANK
+          	  	{
+            		name = Hydrazine
+            		amount = 2500
+            		maxAmount = 2500
+            	}
+	}
+	!MODULE[LifeSupportRegenerateModule]
+	{
+    } 
+}
+@PART[TKS_tug]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.4
+	@mass = 7.78
+	@title = Functional Service Module (FSM)
+	@manufacturer = Russia
+	@description = The FSM was derived from the TKS spacecraft, which would later form the basis for the Functional Cargo Block of the Kvant-2, Kristall, Spektr, and Priroda modules.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 2
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+    {
+	}
+	%MODULE[ModuleRTAntennaPassive] 
+	{
+		%OmniRange = 500000
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	!RESOURCE
+	{	
+	}
+	@MODULE[ModuleEngines]
+	{
+		@maxThrust = 8.76
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = N2O4
+			@ratio = 0.5
+		}
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 0.5
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 350
+			@key,1 = 1 120
+		}
+  	}
+	MODULE
+         	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5
+       	}
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = N2O4
+			amount = 2500
+			maxAmount = 2500
+          		}
+            	TANK
+          	  	{
+            		name = Hydrazine
+            		amount = 2500
+            		maxAmount = 2500
+            	}
+	}
+}
+@PART[Kvant_1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.4325
+	@mass = 9.18
+	@title = Kvant-1
+	@manufacturer = Russia
+	@description = The first expansion module to be launched, Kvant-1 consisted of two pressurised working compartments and one unpressurised experiment compartment. Scientific equipment included an X-ray telescope, an ultraviolet telescope, a wide-angle camera, high-energy X-ray experiments, an X-ray/gamma ray detector, and the Svetlana electrophoresis unit. The module also carried six gyrodynes for attitude control, in addition to life support systems including an Elektron oxygen generator and a Vozdukh carbon dioxide scrubber.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 50000
+			maxAmount = 50000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 70000
+			maxAmount = 70000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 15000
+		}
+	}
+}
+@PART[Mir_Core_TopSolarPanel]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.85
+	@mass = 0.1
+	@title = Mir Core Radiators
+	@manufacturer = Russia
+	@description = Radiators to provide refrigeration to Mir, and a bit of electricity. 
+	@maxTemp = 1073.15
+	@MODULE[ModuleDeployableSolarPanel]
+            {
+            	@chargeRate = 1
+            }
+}
+@PART[Kvant_1_Solar_Panel]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.85
+	@mass = 0.1
+	@title = Kvant-1 Solar Panels
+	@manufacturer = Russia
+	@description = Solar panels to provide power for Kvant-1 and Kristall. 
+	@maxTemp = 1073.15
+	@MODULE[ModuleDeployableSolarPanel]
+            {
+            	@chargeRate = 1.65
+            }
+}
+@PART[mirdockingmodule]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.32
+	@mass = 4.975
+	@title = Mir Docking Module 
+	@manufacturer = Russia 
+	@description = The docking module was designed to help simplify Space Shuttle dockings to Mir. Before the first shuttle docking mission (STS-71), the Kristall module had to be tediously moved to ensure sufficient clearance between Atlantis and Mir's solar arrays. With the addition of the docking module, enough clearance was provided without the need to relocate Kristall. It had two identical APAS-89 docking ports, one attached to the distal port of Kristall with the other available for shuttle docking.
+	@maxTemp = 1073.15
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+}


### PR DESCRIPTION
RO config for Bobcat's Mir

Does not conflict with ISS, so DOS-7 will still be Zvezda (which needs a fix for the rescale bug btw)