### PR TITLE
Adding stock fuel cells

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -628,3 +628,38 @@
 		@type = RealismOverhaulStackHollow
 	}
 }
+@PART[FuelCell]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+
+	!MODULE[ModuleResourceConverter]
+	{
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = Fuel Cell
+		conversionRate = 1.0
+		inputResources = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
+		outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
+	}
+}
+
+@PART[FuelCellArray]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+
+	!MODULE[ModuleResourceConverter]
+	{
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = Fuel Cell
+		conversionRate = 3.0
+		inputResources = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
+		outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
+	}
+}


### PR DESCRIPTION
Borrowed code from the FASA SM inbuilt fuel cell.

Array outputs 3 times the power as the basic fuel cell.