### PR TITLE
Update RO_FASA_LEM.cfg

### DIFF
--- a/RealismOverhaul/RO_FASA_LEM.cfg
+++ b/RealismOverhaul/RO_FASA_LEM.cfg
@@ -544,7 +544,7 @@
 	@node_stack_top = 0.0, 0.182, 0.4, 0.0, 1.0, 0.0, 0
 	@title = Apollo Lunar Module Leg - Ladder
 	@description = The landing leg with ladder.
-	@mass = 0.1
+	@mass = 0.005
 }
 @PART[FASALM_OutputPlace]:FOR[RealismOverhaul]
 {
@@ -556,7 +556,7 @@
 	}
 	@title = Apollo Lunar Module Mobility Enhancer
 	@description = A walkway to get from the door to the ladder.
-	@mass = 0.05
+	@mass = 0.005
 }
 @PART[FASALM_StairCase]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
At the moment the LEM has an offset center of mass created by the landing leg with ladder part, which weirdly seems to have much more mass than stated in the configs. This makes it impossible to fly as is.
To counter this I have reduced the mass of the part and the LEM shelf to 0.005, there landing on the Moon is much easier :)