### PR TITLE
Correcting Plume Position for RD-191

### DIFF
--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD191.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD191.cfg
@@ -1,0 +1,25 @@
+@PART[RD191]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-191
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}


### PR DESCRIPTION
I'm still a bit confused about the realplume prefab system. Is this the proper way to correct an engine plume if the auto-assigned plume is a bit off?