### PR TITLE
Fix AJ10-190 Position and Rotation

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -2293,8 +2293,8 @@
 	@MODEL
 	{
 		%scale = 11.0, 11.0, 11.0
-		%position = 0.0, -0.2, 1.4
-		%rotation = 38, 180, 0
+		%position = 0, 0, 0
+		%rotation = 38, 0, 0
 	}
 	@scale = 1.0
 	%rescaleFactor = 1.0


### PR DESCRIPTION
Before, the engine was flipped 180 degrees away from the surface it was supposed to be attached to, and offset in a weird way.