### PR TITLE
enlarge science storageRange for mk1landerCan und mk2landerCan

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -526,6 +526,11 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
+	@MODULE[ModuleScienceContainer]
+	{
+	@storageRange = 2.08
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -808,6 +813,10 @@
 	}
 	!MODULE[ModuleReactionWheel]
 	{
+	}
+	@MODULE[ModuleScienceContainer]
+	{
+	@storageRange = 3.2
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -528,7 +528,7 @@
 	}
 	@MODULE[ModuleScienceContainer]
 	{
-	@storageRange = 2.08
+		@storageRange = 2.08
 	}
 
 	MODULE
@@ -816,7 +816,7 @@
 	}
 	@MODULE[ModuleScienceContainer]
 	{
-	@storageRange = 3.2
+		@storageRange = 3.2
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -816,7 +816,7 @@
 	}
 	@MODULE[ModuleScienceContainer]
 	{
-		@storageRange = 3.2
+		@storageRange = 2.8 // found by trial and error
 	}
 	MODULE
 	{


### PR DESCRIPTION
Otherwise it was only possible from the top of the can to store data in it or retrieve data. 
The external access to making crew reports might still be screwed, but that should be done internally anyway. 
