### PR TITLE
N1 update, tweak

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_N1.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_N1.cfg
@@ -206,32 +206,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 325
+			@key,0 = 0 347
 			@key,1 = 1 200
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.005
-		}
-		IGNITOR_RESOURCE
-		{
-			name = Kerosene
-			amount = 1.42
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 3.58
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 5
 		}
 	}
 	@MODULE[ModuleGimbal]
@@ -271,11 +247,40 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 325
+				key = 0 347
 				key = 1 200
 			}
 		}
 	}	
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 800
+		ignitorType = TEATEB
+		useUllageSimulation = true
+		isPressureFed = false
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 1.42
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 3.58
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 5
+		}
+	}
 	RESOURCE
 	{
 		name = TEATEB
@@ -337,32 +342,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 340
+			@key,0 = 0 353
 			@key,1 = 1 200
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.005
-		}
-		IGNITOR_RESOURCE
-		{
-			name = Kerosene
-			amount = 1.42
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 3.58
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 5
 		}
 	}
 	@MODULE[ModuleGimbal]
@@ -402,11 +383,40 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 340
+				key = 0 353
 				key = 1 200
 			}
 		}
 	}	
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 800
+		ignitorType = TEATEB
+		useUllageSimulation = true
+		isPressureFed = false
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 1.42
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 3.58
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 5
+		}
+	}
 	RESOURCE
 	{
 		name = TEATEB
@@ -454,20 +464,33 @@
 	
 	!RESOURCE[MonoPropellant]
 	{ }
-	
 	!RESOURCE[ElectricCharge]
+	{ }
+	!RESOURCE[Oxygen]
+	{ }
+	!RESOURCE[CO2]
+	{ }
+	!RESOURCE[LiquidFuel]
+	{ }
+	!RESOURCE[Oxidizer]
 	{ }
 	
 	@MODULE[ModuleRCS]
 	{
 		@name = ModuleRCSFX
-		@thrusterPower = 0.275
+		@thrusterPower = 0.442
 		!resourceName = DELETE
 		%resourceFlowMode = STACK_PRIORITY_SEARCH
 		PROPELLANT
 		{
-			ratio = 1.0
-			name = Hydrazine
+			name = UDMH
+			ratio = 0.413
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.587
 		}
 		@atmosphereCurve
 		{
@@ -475,132 +498,7 @@
 			@key,1 = 1 82.08
 		}
 	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleRCSFX
-		thrustRating = thrusterPower
-		techLevel = 2
-		origTechLevel = 2
-		engineType = L
-		origMass = 0.01
-		configuration = UDMH+NTO
-		modded = false
-		CONFIG
-		{
-			name = UDMH+NTO
-			thrusterPower = 0.442
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.413
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.587
-			}
-			IspSL = 0.95
-			IspV = 0.943
-		}
-		CONFIG
-		{
-			name = HTP
-			thrusterPower = 0.255
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = HTP
-			}
-			IspSL = 0.177
-			IspV = 0.465
-		}
-		CONFIG
-		{
-			name = Hydrazine
-			thrusterPower = 0.275
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Hydrazine
-			}
-			IspSL = 0.274
-			IspV = 0.72
-		}
-		CONFIG
-		{
-			name = NitrousOxide
-			thrusterPower = 0.118
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = NitrousOxide
-			}
-			IspSL = 0.2
-			IspV = 0.525
-		}
-		CONFIG
-		{
-			name = Helium
-			thrusterPower = 0.006
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Helium
-			}
-			IspSL = 0.203
-			IspV = 0.453
-		}
-		CONFIG
-		{
-			name = Nitrogen
-			thrusterPower = 0.019
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Nitrogen
-			}
-			IspSL = 0.1001462
-			IspV = 0.195
-		}
-		CONFIG
-		{
-			name = MMH+NTO
-			thrusterPower = 0.445
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.437
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.563
-			}
-			IspSL = 0.953
-			IspV = 0.952
-		}
-		CONFIG
-		{
-			name = Aerozine50+NTO
-			thrusterPower = 0.455
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			IspSL = 0.963
-			IspV = 0.955
-		}
-	}
+	
 	EFFECTSdisabled
 	{
 		running
@@ -642,66 +540,36 @@
 	@MODULE[ModuleEngines*]
 	{
 		%minThrust = 0
-		%maxThrust = 16.3
+		%maxThrust = 4.17
 		%heatProduction = 100
-		@PROPELLANT[UDMH]
+		@PROPELLANT[LiquidFuel]
 		{
 			%name = UDMH
 			%ratio = 0.349
 		}
-		@PROPELLANT[NTO]
+		@PROPELLANT[Oxidizer]
 		{
 			%name = NTO
 			%ratio = 0.651
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 282
+			@key,0 = 0 296
 			@key,1 = 1 150
 		}
-		%ullage = True
-		%pressureFed = True
-		%ignitions = -1
-		!IGNITOR_RESOURCE,* {}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = -1
+		autoIgnitionTemperature = 700
+		ignitorType = Hypergolic
+		useUllageSimulation = True
+		isPressureFed = True
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
 			amount = 0.5
-		}
-	}	
-	!MODULE[ModuleEngineConfigs]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = 7K-LOK PAO
-		origMass = 2.5
-		modded = false
-		CONFIG
-		{
-			name = 7K-LOK PAO
-			minThrust = 0
-			maxThrust = 16.3
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.357
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.643
-			}
-			atmosphereCurve
-			{
-				key = 0 282
-				key = 1 150
-			}
-			MassMult = 1.0
 		}
 	}
 	MODULE
@@ -714,8 +582,38 @@
 	{
 		name = ElectricCharge
 		amount = Full
-		maxAmount = 90000
+		maxAmount = 1000
 	}
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 50
+			maxAmount = 50
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 42.139
+			maxAmount = 42.139
+		}
+		TANK
+		{
+			name = Water
+			amount = 0.0
+			maxAmount = 0.5
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 1
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 0
+			maxAmount = 28
+		}
 	TANK
 	{
 		name = UDMH
@@ -729,6 +627,12 @@
 		maxAmount = 926.7
 	}
 	}
+	
+	!MODULE[LifeSupportRegeneratorModule]
+	{}
+	!MODULE[ModuleGenerator]
+	{}
+	
 	MODULE
 	{
 		name = TacGenericConverter
@@ -736,6 +640,14 @@
 		conversionRate = 1.0
 		inputResources = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
 		outputResources = Water, 0.0001041667, true, ElectricCharge, 1.5, true
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = LOX-O2
+		conversionRate = 2.0
+		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
+		outputResources = Oxygen, 0.006883126, false
 	}
 }
 
@@ -763,12 +675,41 @@
 	!RESOURCE[Oxidizer]
 	{
 	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 14312.2
+		volume = 14512.2 // 14312.2
 		type = Default
 		basemass = -1
+		
+		TANK
+		{
+			name = UDMH
+			amount = Full
+			maxAmount = 166.8
+		}
+		TANK
+		{
+			name = NTO
+			amount = Full
+			maxAmount = 92.7
+		}
+		TANK
+		{
+			name = Kerosene
+			amount = Full
+			maxAmount = 5057.3
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = Full
+			maxAmount = 9195.4
+		}
 	}
 	@MODULE[ModuleEngines*]
 	{
@@ -788,32 +729,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 346
+			@key,0 = 0 353 // 346
 			@key,1 = 1 200
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 5
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.005
-		}
-		IGNITOR_RESOURCE
-		{
-			name = Kerosene
-			amount = 1.42
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 3.58
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 5
 		}
 	}
 	@MODULE[ModuleGimbal]
@@ -853,16 +770,67 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 346
+				key = 0 353 // 346
 				key = 1 200
 			}
 		}
 	}	
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 5
+		autoIgnitionTemperature = 800
+		ignitorType = TEATEB
+		useUllageSimulation = true
+		isPressureFed = false
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 1.42
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 3.58
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 5
+		}
+	}
 	RESOURCE
 	{
 		name = TEATEB
 		amount = 25
 		maxAmount = 25
+	}
+	
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCSFX
+		@thrusterPower = 0.275
+		!resourceName = DELETE
+		PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.498
+			}
+		PROPELLANT
+			{
+				name = NTO
+				ratio = 0.502
+			}
+		@atmosphereCurve
+		{
+			@key,0 = 0 312
+			@key,1 = 1 285
+		}
 	}
 }
 
@@ -935,32 +903,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 345
+			@key,0 = 0 353
 			@key,1 = 1 200
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.005
-		}
-		IGNITOR_RESOURCE
-		{
-			name = Kerosene
-			amount = 1.42
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 3.58
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 5
 		}
 	}
 	@MODULE[ModuleGimbal]
@@ -1000,11 +944,40 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 345
+				key = 0 353
 				key = 1 200
 			}
 		}
 	}	
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 800
+		ignitorType = TEATEB
+		useUllageSimulation = true
+		isPressureFed = false
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 1.42
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 3.58
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 5
+		}
+	}
 	RESOURCE
 	{
 		name = TEATEB
@@ -1040,18 +1013,28 @@
 	@rescaleFactor = 1.25
 	@node_stack_top = 0.0, 0.6395855, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.3130512, 0.0, 0.0, -1.0, 0.0, 2
-	@mass = 0.4
+	@mass = 0.5
 	@title = Soyuz7K-LOK BO SU
+	
+	!RESOURCE[MonoPropellant] {}
+	
 	@MODULE[ModuleRCS]
 	{
+		// filler values for fuel mix, could also be HTP, need an information source to confirm
 		@name = ModuleRCSFX
 		@thrusterPower = 0.275
 		!resourceName = DELETE
 		%resourceFlowMode = STACK_PRIORITY_SEARCH
 		PROPELLANT
 		{
-			ratio = 1.0
-			name = Hydrazine
+			name = UDMH
+			ratio = 0.413
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.587
 		}
 		@atmosphereCurve
 		{
@@ -1059,132 +1042,25 @@
 			@key,1 = 1 82.08
 		}
 	}
+	
 	MODULE
 	{
-		name = ModuleEngineConfigs
-		type = ModuleRCSFX
-		thrustRating = thrusterPower
-		techLevel = 2
-		origTechLevel = 2
-		engineType = L
-		origMass = 0.01
-		configuration = UDMH+NTO
-		modded = false
-		CONFIG
-		{
-			name = UDMH+NTO
-			thrusterPower = 0.442
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.413
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.587
-			}
-			IspSL = 0.95
-			IspV = 0.943
-		}
-		CONFIG
-		{
-			name = HTP
-			thrusterPower = 0.255
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = HTP
-			}
-			IspSL = 0.177
-			IspV = 0.465
-		}
-		CONFIG
-		{
-			name = Hydrazine
-			thrusterPower = 0.275
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Hydrazine
-			}
-			IspSL = 0.274
-			IspV = 0.72
-		}
-		CONFIG
-		{
-			name = NitrousOxide
-			thrusterPower = 0.118
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = NitrousOxide
-			}
-			IspSL = 0.2
-			IspV = 0.525
-		}
-		CONFIG
-		{
-			name = Helium
-			thrusterPower = 0.006
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Helium
-			}
-			IspSL = 0.203
-			IspV = 0.453
-		}
-		CONFIG
-		{
-			name = Nitrogen
-			thrusterPower = 0.019
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Nitrogen
-			}
-			IspSL = 0.1001462
-			IspV = 0.195
-		}
-		CONFIG
-		{
-			name = MMH+NTO
-			thrusterPower = 0.445
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.437
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.563
-			}
-			IspSL = 0.953
-			IspV = 0.952
-		}
-		CONFIG
-		{
-			name = Aerozine50+NTO
-			thrusterPower = 0.455
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			IspSL = 0.963
-			IspV = 0.955
-		}
+		name = ModuleFuelTanks
+		basemass = -1
+		volume = 257
+		type = ServiceModule
+	TANK
+	{
+		name = UDMH
+		amount = 106
 	}
+	TANK
+	{
+		name = NTO
+		amount = 151
+	}
+	}
+
 	EFFECTSdisabled
 	{
 		running
@@ -1248,8 +1124,8 @@
 	{ }
 	!RESOURCE[CO2]
 	{ }
-	!RESOURCE[O2 Candle]
-	{ }
+	//!RESOURCE[O2?Candle]
+	//{ }
 	MODULE
 	{
 	name = ModuleFuelTanks
@@ -1260,37 +1136,37 @@
 	{
 		name = ElectricCharge
 		amount = Full
-		maxAmount = 210000
+		maxAmount = 500
 	}
 	TANK
 	{
 		name = Food
 		amount = Full
-		maxAmount = 810.191093199999
+		maxAmount = 10
 	}
 	TANK
 	{
 		name = Water
 		amount = Full
-		maxAmount = 459.1082812
+		maxAmount = 5
 	}
 	TANK
 	{
 		name = Waste
 		amount = 0
-		maxAmount = 810.191093199999
+		maxAmount = 2
 	}
 	TANK
 	{
 		name = WasteWater
 		amount = 0
-		maxAmount = 459.1082812
+		maxAmount = 10
 	}
 	TANK
 	{
 		name = CarbonDioxide
 		amount = 0
-		maxAmount = 170140.12936
+		maxAmount = 1000
 	}
 	}
 }
@@ -1298,34 +1174,92 @@
 @PART[LOK_DescentModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		position = -0.4,0.99259,0
+		scale = 0.5,0.5,0.5
+		rotation = 0,0,90
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		position = 0,0.99259,0.4
+		scale = 0.5,0.5,0.5
+		rotation = 0,90,90
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		position = 0.4,0.99259,0
+		scale = 0.5,0.5,0.5
+		rotation = 0,180,90
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		position = 0,0.99259,-0.4
+		scale = 0.5,0.5,0.5
+		rotation = 0,270,90
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		position = 0,0,0.82
+		scale = 0.5,0.5,0.5
+		rotation = 0,0,90
+	}
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		position = 0,0,0.82
+		scale = 0.5,0.5,0.5
+		rotation = 0,0,270
+	}
+	MODEL
+	{
+		model = SovietPack/Parts/N1L3/LOK_pod/model
+		scale = 1.0, 1.0, 1.0
+		position = 0.0, 0.0, 0.0
+		rotation = 0,0,0
+	}
 	@scale = 1
 	@rescaleFactor = 1.25
 	@node_stack_top = 0.0, 1.419485, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_para = 0.0, 1, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.09476185, 0.0, 0.0, -1.0, 0.0, 2
-	@mass = 2.504 // 1.1221
+	@mass = 2.404 // 1.1221
 	@title = Soyuz7K-LOK SA
+	
+	MODULE
+	{
+		name = CoMShifter
+		DescentModeCoM = 0, 0, -0.192
+	}
 
 	!MODULE[ModuleReactionWheel]
-	{ }
-	!MODULE[ModuleRCS]
 	{ }
 	
 	MODULE
 	{
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
+		thrusterPower = 0.442
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.13
 		PROPELLANT
 		{
-			name = HTP
-			ratio = 1.0
+			name = UDMH
+			ratio = 0.413
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.587
 		}
 		atmosphereCurve
 		{
-			key = 0 144.1
-			key = 1 49.4
+			key = 0 254
+			key = 1 82.08
 		}
 	}
 	
@@ -1343,8 +1277,9 @@
 	{ }
 	!RESOURCE[CO2]
 	{ }
-	!RESOURCE[O2 Candle]
+	!RESOURCE[O2?Candle]
 	{ }
+	
 	MODULE
 	{
 	name = ModuleFuelTanks
@@ -1355,39 +1290,65 @@
 	{
 		name = ElectricCharge
 		amount = Full
-		maxAmount = 210000
+		maxAmount = 13000
 	}
 	TANK
 	{
 		name = Food
 		amount = Full
-		maxAmount = 810.191093199999
+		maxAmount = 41
 	}
 	TANK
 	{
 		name = Water
-		amount = Full
-		maxAmount = 459.1082812
+		amount = 5
+		maxAmount = 27
 	}
 	TANK
 	{
 		name = Waste
 		amount = 0
-		maxAmount = 810.191093199999
+		maxAmount = 40
 	}
 	TANK
 	{
 		name = WasteWater
 		amount = 0
-		maxAmount = 459.1082812
+		maxAmount = 35
 	}
 	TANK
 	{
 		name = CarbonDioxide
 		amount = 0
-		maxAmount = 170140.12936
+		maxAmount = 520
 	}
+		TANK
+		{
+			name = UDMH
+			amount = 116.826
+			maxAmount = 116.826
+		}
+		TANK
+		{
+			name = NTO
+			amount = 129.373
+			maxAmount = 129.373
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1200
+			maxAmount = 1200
+		}
+		TANK
+		{
+			name = PotassiumSuperoxide
+			amount = 75
+			maxAmount = 75
+		}
+		
 	}
+	
 	!MODULE[ModuleAblator] {}
 	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
@@ -1422,6 +1383,16 @@
 		amount = 200
 		maxAmount = 200
 	}
+	
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 2.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, PotassiumSuperoxide, 0.00001735323
+		outputResources = Oxygen, 0.008392225, true, Waste, 0.0000481257, false
+	}
+
 }
 
 @PART[LOK_Parachute]:FOR[RealismOverhaul]
@@ -1617,6 +1588,7 @@
 	!RESOURCE[CO2] {}
 	!RESOURCE[MonoPropellant] {}
 	!RESOURCE[ElectricCharge] {}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -1632,8 +1604,8 @@
 		TANK
 		{
 			name = Oxygen
-			amount = 1890
-			maxAmount = 1890
+			amount = 1500
+			maxAmount = 1500
 		}
 		TANK
 		{
@@ -1667,12 +1639,6 @@
 		}
 		TANK
 		{
-			name = LithiumHydroxide
-			amount = 2.25
-			maxAmount = 2.25
-		}
-		TANK
-		{
 			name = UDMH
 			amount = 867.849
 			maxAmount = 867.849
@@ -1684,14 +1650,7 @@
 			maxAmount = 961.056
 		}
 	}
-	MODULE
-	{
-		name = TacGenericConverter
-		converterName = CO2 Scrubber
-		conversionRate = 1.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
-	}
+	
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -1716,25 +1675,6 @@
 			@key,0 = 0 315
 			@key,1 = 1 300
 		}
-		%ullage = True
-		%pressureFed = True
-		%ignitions = -1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-		IGNITOR_RESOURCE
-		{
-			name = UDMH
-			amount = 0.498
-		}
-		IGNITOR_RESOURCE
-		{
-			name = NTO
-			amount = 0.502
-		}
 	}
 	!MODULE[ModuleGimbal]
 	{
@@ -1742,7 +1682,6 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		origMass = 0.1
 		configuration = RD-858 
 		modded = false
 		CONFIG
@@ -1766,6 +1705,30 @@
 				key = 0 315
 				key = 1 285
 			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = -1
+		autoIgnitionTemperature = 700
+		ignitorType = Electric
+		useUllageSimulation = true
+		isPressureFed = true
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+		IGNITOR_RESOURCE
+		{
+			name = UDMH
+			amount = 0.498
+		}
+		IGNITOR_RESOURCE
+		{
+			name = NTO
+			amount = 0.502
 		}
 	}
 


### PR DESCRIPTION
Needs e_14159 patch to be redone, sorry e_14159.

Few outstanding issues remaining. Re-entry pod now has all necessary LS
and re-entry mode. LS added to all, needs rebalancing.

Engines made more efficient, the craft can now fly the historically
planned mission.