### PR TITLE
Corrected Bobcat Soviet Engine Plumes

### DIFF
--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/NK33.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/NK33.cfg
@@ -1,0 +1,25 @@
+@PART[NK33]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-33
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/NK43.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/NK43.cfg
@@ -1,0 +1,25 @@
+@PART[NK43]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-43
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,3
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD0120.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD0120.cfg
@@ -1,0 +1,25 @@
+@PART[RD0120]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0120
+{
+    PLUME
+    {
+        name = Hydrolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2.6
+        fixedScale = 2
+        energy = 0.2
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD0124.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD0124.cfg
@@ -1,0 +1,25 @@
+@PART[RD0124]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0124
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.9
+        fixedScale = 0.6
+        energy = 0.5
+        speed = 2
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD0146.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD0146.cfg
@@ -1,0 +1,25 @@
+@PART[RD0146]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0146
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.1
+        fixedScale = 1
+        energy = 0.2
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD171.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD171.cfg
@@ -1,0 +1,25 @@
+@PART[RD171]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-171
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD180.cfg
+++ b/GameData/RealismOverhaul/SmokeScreen_EffectCfgs/BobCat/RD180.cfg
@@ -1,0 +1,25 @@
+@PART[RD180]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-180
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}


### PR DESCRIPTION
Corrected positions for plumes, and tweaked other parameters to make the plumes look like they belong to their engine. All Bobcat Soviet engines covered. It might not be 100% accurate, but it is definitely better than it was before and I wanted to get this out there.

I uploaded some sample screenshots here:
http://imgur.com/a/BFxSy