### PR TITLE
Adding 1.04 Heatshields for Gemini & Apollo

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -1,5 +1,7 @@
 @PART[FASAApollo_LES]:FOR[RealismOverhaul]
 {
+	%category = Engine
+
 	%RSSROConfig = True
 	@MODEL
 	{
@@ -103,15 +105,14 @@
 	@title = Apollo Command Module Forward Heat Shield
 	@description = This heat shield protects the earth landing (recovery) system components and everything else in the forward compartment.
 	@mass = 0.0766
+	%skinMaxTemp = 3200
+	%maxTemp = 2000
+	@emissiveConst = 0.50
 	@MODULE[ModuleDecouple]
 	{
 		@ejectionForce = 25
 		@explosiveNodeID = bottom
 	}
-}
-@PART[FASAApollo_CM_Top]:AFTER[RealismOverhaul]:NEEDS[DeadlyReentry]
-{
-	@maxTemp = 3000 // is in aero flow during re-entry
 }
 @PART[FASAApollo_CM_parachutes]:FOR[RealismOverhaul]:AFTER[RealChute]
 {
@@ -170,6 +171,13 @@
 	}
 	MODEL
 	{
+		model=FASA/Apollo/ApolloCSM/FASAApollo_Heatshield
+		scale = 1.0, 1.0, 1.0
+		position = 0, -1.271, 0
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
 		model = FASA/Apollo/ApolloCSM/Apollo_CM_RCS
 		scale = 1.0, 1.0, 1.0
 		position = 0, 0.67, -0.85
@@ -196,8 +204,9 @@
 		position = -1.82, -0.89, 0
 		rotation = 0, 90, 0
 	}
+
 	@node_stack_top = 0.0, 1.010881, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.810862, 0.0, 0.0, -1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -1.271, 0.0, 0.0, -1.0, 0.0, 4
 	!node_stack_rcs1 = 1.84092, -0.928395, 0.004761, 0.0, 1.0, 0.0, 0
 	!node_stack_rcs2 = -1.84092, -0.928395, 0.004761, 0.0, 1.0, 0.0, 0
 	!node_stack_rcs3 = 0.0, 0.660192, 0.910938, 0.0, 1.0, 0.0, 0
@@ -205,9 +214,11 @@
 	%node_stack_connect = 0.0, 0.810881, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Apollo Command Module
 	@description = Apollo Command Module. Contains three astronauts.
-	@mass = 4.5195
-	@maxTemp = 2273.15
+	@mass = 4.6715 // 4.5195
+	%skinMaxTemp = 3200
+	@maxTemp = 500 
 	@CoMOffset = 0.0, -0.5, 0.0
+	
 	@MODULE[ModuleCommand]
 	{
 		@minimumCrew = 1
@@ -329,6 +340,30 @@
 			@key, 1 = 1 100
 		}
 	}
+	
+	%skinMaxTemp = 3500 // 3200
+	%maxTemp = 2273.15
+	@emissiveConst = 0.85 // pretty much black, but not perfect emitter
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 0.6
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		lossExp = -12000 // more negative values yield small increases in skin temp
+		lossConst = 0.0035 // lower values yield more ablative loss
+		pyrolysisLossFactor = 600 // 6000
+		ablationTempThresh = 400
+		reentryConductivity = 0.01
+		charMax = 0
+		charMin = 0
+	}
+	RESOURCE
+	{
+		name = Ablator
+		amount = 848
+		maxAmount = 848
+	}
 }
 @PART[FASAApollo_CM_RCS]:FOR[RealismOverhaul]
 {
@@ -371,20 +406,23 @@
 		@scale = 1.0, 1.0, 1.0
 		%position = 0.0, -0.1, 0.0
 	}
+	category = Aero
 	@node_stack_top = 0.0,0.36,0.0, 0.0, 1.0, 0.0, 4
 	@node_stack_bottom = 0.0, -0.1, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Apollo Command Module Heat Shield
 	@description = This part is the ablative heat shield for the Apollo Command Module.
 	@mass = 0.152
-	@maxTemp = 2273.15
 	// Thermo
 	!MODULE[ModuleAblator] {}
 	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}
+	%skinMaxTemp = 3200
+	%maxTemp = 2273.15
 	@emissiveConst = 0.85 // pretty much black, but not perfect emitter
 	%thermalMassModifier = 1.0
+	%skinMassPerArea = 0.6
 	MODULE
 	{
 		name = ModuleAblator
@@ -394,19 +432,8 @@
 		pyrolysisLossFactor = 6000
 		ablationTempThresh = 400
 		reentryConductivity = 0.01
-		//reentryConductivity = 0.12
-		//@reentryConductivity = #$../heatConductivity$ // if it exists, use it
 		charMax = 0
 		charMin = 0
-	}
-	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
-	{
-		@name = ModuleHeatShield
-		@pyrolysisLossFactor = 55000 // experimenting
-		// we want the skin thermal mass of the shield, not the whole pod.
-		skinThicknessFactor = // 0.85 // should be higher for this part, is heatshield
-		skinHeatConductivity = 0.00045 // slightly less than Mercury, experimenting
-		skinMaxTemp = 3200 // higher than Mercury, experimenting
 	}
 	RESOURCE
 	{
@@ -414,10 +441,6 @@
 		amount = 848
 		maxAmount = 848
 	}
-}
-@PART[FASAApollo_CM_HeatShield]:AFTER[RealismOverhaul]:NEEDS[DeadlyReentry]
-{
-	@maxTemp = 2000
 }
 @PART[FASAApollo_CM_Decoupler]:FOR[RealismOverhaul]
 {
@@ -596,6 +619,7 @@
 			key = 1 100
 		}
 	}
+	
 }
 @PART[FASAApollo_SM_RCS]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -312,7 +312,6 @@
 	@title = Gemini Cabin
 	@description = The Gemini cabin.  Contains two astronauts.
 	@mass = 1.3811
-	@maxTemp = 2273.15
 	@MODULE[ModuleCommand]
 	{
 		RESOURCE
@@ -411,31 +410,22 @@
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}
-	@maxTemp = 2000
+	%skinMaxTemp = 3200
+	%maxTemp = 600
 	@emissiveConst = 0.85 // pretty much black, but not perfect emitter
 	%thermalMassModifier = 1.0
+	%skinMassPerArea = 0.6
 	MODULE
 	{
 		name = ModuleAblator
 		ablativeResource = Ablator
-		lossExp = -6000
-		lossConst = 0.007
-		pyrolysisLossFactor = 6000
+		lossExp = -4000 // -6000, no ablation occured, over 2400K ; same at -20000
+		lossConst = 0.007 // lower values yield more ablative loss
+		pyrolysisLossFactor = 3000 // lastval6000 // at 60k temp low, no ablation // at 1k temp 2400, little ablation
 		ablationTempThresh = 400
 		reentryConductivity = 0.01
-		//reentryConductivity = 0.12
-		//@reentryConductivity = #$../heatConductivity$ // if it exists, use it
 		charMax = 0
 		charMin = 0
-	}
-	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
-	{
-		@name = ModuleHeatShield
-		@pyrolysisLossFactor = 60000 // higher than Mercury
-		// we want the skin thermal mass of the shield, not the whole pod.
-		skinThicknessFactor = 0.012
-		skinHeatConductivity = 0.00045 // slightly less than Mercury
-		skinMaxTemp = 3200 // higher than Mercury, allow translunar re-entry speeds
 	}
 	RESOURCE
 	{
@@ -443,10 +433,6 @@
 		amount = 144 //changed from Mercury model to match previous amount in Gemini model
 		maxAmount = 144
 	}
-}
-@PART[FASAGeminiPod2]:AFTER[RealismOverhaul]:NEEDS[DeadlyReentry]
-{
-	@maxTemp = 900
 }
 @PART[FASAGeminiPod2White]:FOR[RealismOverhaul]
 {
@@ -586,6 +572,36 @@
 		conversionRate = 2.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+	
+	// Thermo
+	!MODULE[ModuleAblator] {}
+	!MODULE[ModuleHeatShield] {}
+	!MODULE[ModuleAeroReentry] {}
+	!RESOURCE[AblativeShielding] {}
+	!RESOURCE[Ablator] {}
+	%skinMaxTemp = 2500
+	%maxTemp = 600
+	@emissiveConst = 0.85 // pretty much black, but not perfect emitter
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 0.6
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		lossExp = -10000
+		lossConst = 0.007
+		pyrolysisLossFactor = 6000 // 6000
+		ablationTempThresh = 400
+		reentryConductivity = 0.01
+		charMax = 0
+		charMin = 0
+	}
+	RESOURCE
+	{
+		name = Ablator
+		amount = 144 //changed from Mercury model to match previous amount in Gemini model
+		maxAmount = 144
 	}
 }
 @PART[FASAGeminiUtilitySasRcs]:FOR[RealismOverhaul]


### PR DESCRIPTION
A bit crude, but quite functional.

Both can survive lunar velocity re-entry.

Welded the heathshield onto the Apollo capsule as otherwise the capsule
kept exploding while in angled re-entry mode.

A bit different from each other. Apollo hits the desired high
temperature regime but doesn't burn off much Ablative. Gemini doesn't
reach as high a temp but loses much more ablative.