### PR TITLE
Replace KW RSRMV with SRMU, switch model with UA1207

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -1862,11 +1862,9 @@
 	!RESOURCE[SolidFuel]
 	{
 	}
-	MODULE
+	@MODULE[ModuleGimbal]
 	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 3.5
+		@gimbalRange = 3.5
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -1828,8 +1828,8 @@
 		}
 	}
 }
-// ##########################################################################################	Globe X-10L "Thor II" SRB
-@PART[KWsrbGlobeX10L]:FOR[RealismOverhaul]
+// ##########################################################################################	Globe X-10S "Thor II" SRB
+@PART[KWsrbGlobeX10S]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1837,26 +1837,26 @@
 	}
 	@MODEL
 	{
-		@scale = 1.6002, 1.524974, 1.6002
+		@scale = 1.6002, 1.978160159, 1.6002
 	}
 	@rescaleFactor = 1.0
 	@scale = 1.0
-	@node_stack_bottom = 0.0, -14.9447452, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_top = 0.0, 14.9447452, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -14.945000001245, 0.0, 0.0, -1.0, 0.0, 3
+	@node_stack_top = 0.0, 14.945000001245, 0.0, 0.0, 1.0, 0.0, 3
 	@node_attach = 0.0, 0.0, -1.6002, 0.0, 0.0, 0.0, 2
-	@title = L.S.G. 5-Segment RSRM
+	@title = Solid Rocket Motor Upgrade (SRMU)
 	%manufacturer = ATK
-	@description = ATK Launch Systems Group. An increased length Space Shuttle SRB by adding a full segment, originally developed for the Ares I as the first stage and as strap-on boosters for the Ares V.  Now that Ares has been cancelled ATK is continuing development for the Space Launch System. Nose Cone 6.50662m tall.
-	@mass = 85.4187
+	@description = The SRMU was developed for the upgraded Titan IVB, with the goal of achieving a 25% increase in capacity over the Titan IVA with the UA1207 SRM. It achieved this through the use of a more energetic propellant and a 3-segment composite case that carried more fuel and weighed less than the UA1207's 7-segment steel case. Burn time 150 seconds.
+	@mass = 36.56453
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
 	{
-		@maxThrust = 17885.99
+		@maxThrust = 8245
 		@heatProduction = 100
 		@atmosphereCurve
 		{
-			@key,0 = 0 268
-			@key,1 = 1 242
+			@key,0 = 0 281
+			@key,1 = 1 251
 		}
 	}
 	!RESOURCE[SolidFuel]
@@ -1873,181 +1873,199 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 365486.64
+		volume = 178013
 		basemass = -1
-		type = PBAN
+		type = HTPB
 	}
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = RSRM5Seg
+		configuration = SRMU
 		modded = false
 		CONFIG
 		{
-			name = RSRM5Seg
-			maxThrust = 17885.99
+			name = SRMU
+			maxThrust = 8245
 			heatProduction = 100
 			PROPELLANT
 			{
-				name = PBAN
+				name = HTPB
 				ratio = 1
 				DrawGauge = True
 			}
 			atmosphereCurve
 			{
-				key = 0 268
-				key = 1 242
+				key = 0 281
+				key = 1 251
 			}
-			curveResource = PBAN
+			curveResource = HTPB
 			thrustCurve
 			{
-				key = 0.99986 0.950
-				key = 0.9887 0.961
-				key = 0.97757 0.961
-				key = 0.96646 0.961
-				key = 0.95535 0.963
-				key = 0.94419 0.97
-				key = 0.93296 0.978
-				key = 0.92167 0.985
-				key = 0.91034 0.991
-				key = 0.89901 0.994
-				key = 0.88768 0.996
-				key = 0.87632 1
-				key = 0.86499 1
-				key = 0.85368 1
-				key = 0.8424 1
-				key = 0.83114 1
-				key = 0.81993 0.998
-				key = 0.8088 0.993
-				key = 0.79778 0.985
-				key = 0.78689 0.976
-				key = 0.77616 0.963
-				key = 0.76566 0.945
-				key = 0.75529 0.935
-				key = 0.74509 0.922
-				key = 0.73504 0.911
-				key = 0.72512 0.9
-				key = 0.71535 0.889
-				key = 0.70576 0.874
-				key = 0.69632 0.863
-				key = 0.68703 0.85
-				key = 0.67789 0.839
-				key = 0.66888 0.828
-				key = 0.65998 0.819
-				key = 0.65127 0.804
-				key = 0.64267 0.795
-				key = 0.63414 0.791
-				key = 0.62576 0.778
-				key = 0.61749 0.769
-				key = 0.60936 0.758
-				key = 0.60131 0.752
-				key = 0.59336 0.745
-				key = 0.58546 0.741
-				key = 0.5777 0.73
-				key = 0.57002 0.724
-				key = 0.56247 0.713
-				key = 0.55505 0.702
-				key = 0.54772 0.695
-				key = 0.54047 0.689
-				key = 0.53328 0.684
-				key = 0.52613 0.682
-				key = 0.51902 0.68
-				key = 0.51187 0.684
-				key = 0.5047 0.689
-				key = 0.49749 0.693
-				key = 0.49025 0.697
-				key = 0.48299 0.702
-				key = 0.47569 0.706
-				key = 0.46834 0.712
-				key = 0.46091 0.721
-				key = 0.45344 0.728
-				key = 0.44595 0.73
-				key = 0.43839 0.738
-				key = 0.43078 0.745
-				key = 0.4231 0.753
-				key = 0.41539 0.758
-				key = 0.40765 0.762
-				key = 0.39986 0.769
-				key = 0.39202 0.775
-				key = 0.38412 0.782
-				key = 0.3762 0.786
-				key = 0.36825 0.79
-				key = 0.36024 0.797
-				key = 0.35218 0.801
-				key = 0.34408 0.805
-				key = 0.33592 0.812
-				key = 0.32768 0.818
-				key = 0.31941 0.823
-				key = 0.31109 0.827
-				key = 0.30277 0.827
-				key = 0.29443 0.829
-				key = 0.28609 0.829
-				key = 0.27775 0.829
-				key = 0.26944 0.827
-				key = 0.26116 0.823
-				key = 0.25298 0.814
-				key = 0.24486 0.807
-				key = 0.23682 0.799
-				key = 0.22886 0.792
-				key = 0.22098 0.783
-				key = 0.21316 0.777
-				key = 0.20544 0.768
-				key = 0.19782 0.757
-				key = 0.19032 0.746
-				key = 0.1829 0.738
-				key = 0.17559 0.727
-				key = 0.16839 0.716
-				key = 0.16132 0.703
-				key = 0.15433 0.694
-				key = 0.14746 0.683
-				key = 0.14066 0.677
-				key = 0.13389 0.672
-				key = 0.12715 0.67
-				key = 0.12046 0.666
-				key = 0.11382 0.659
-				key = 0.10726 0.653
-				key = 0.10078 0.644
-				key = 0.09437 0.638
-				key = 0.08805 0.629
-				key = 0.08179 0.622
-				key = 0.07559 0.616
-				key = 0.06949 0.607
-				key = 0.06347 0.598
-				key = 0.05754 0.59
-				key = 0.05176 0.574
-				key = 0.04608 0.566
-				key = 0.04052 0.553
-				key = 0.03507 0.542
-				key = 0.02977 0.527
-				key = 0.0247 0.505
-				key = 0.0199 0.477
-				key = 0.01557 0.431
-				key = 0.01218 0.337
-				key = 0.00959 0.257
-				key = 0.00762 0.196
-				key = 0.00593 0.168
-				key = 0.00465 0.127
-				key = 0.00371 0.094
-				key = 0.00294 0.077
-				key = 0.00236 0.057
-				key = 0.00187 0.048
-				key = 0.00147 0.04
-				key = 0.00114 0.033
-				key = 0.00087 0.027
-				key = 0.00065 0.022
-				key = 0.00047 0.018
-				key = 0.00033 0.014
-				key = 0.00022 0.011
-				key = 0.00013 0.009
-				key = 0.00006 0.007
-				key = 0.00001 0.005
+				key = 0.99171 0.88
+				key = 0.9831 0.914
+				key = 0.97439 0.924
+				key = 0.96565 0.928
+				key = 0.95687 0.932
+				key = 0.94803 0.938
+				key = 0.93916 0.942
+				key = 0.93022 0.948
+				key = 0.92125 0.952
+				key = 0.91225 0.956
+				key = 0.90318 0.962
+				key = 0.89406 0.968
+				key = 0.88488 0.974
+				key = 0.87566 0.978
+				key = 0.86639 0.984
+				key = 0.85706 0.99
+				key = 0.84767 0.996
+				key = 0.83825 1
+				key = 0.82882 1
+				key = 0.8194 1
+				key = 0.80997 1
+				key = 0.80057 0.998
+				key = 0.79118 0.996
+				key = 0.78181 0.994
+				key = 0.77244 0.994
+				key = 0.7631 0.992
+				key = 0.75375 0.992
+				key = 0.74442 0.99
+				key = 0.7351 0.988
+				key = 0.72581 0.986
+				key = 0.71652 0.986
+				key = 0.70724 0.984
+				key = 0.69799 0.982
+				key = 0.68875 0.98
+				key = 0.67953 0.978
+				key = 0.67032 0.978
+				key = 0.66112 0.976
+				key = 0.65194 0.974
+				key = 0.64277 0.972
+				key = 0.63363 0.97
+				key = 0.62451 0.968
+				key = 0.61542 0.964
+				key = 0.60637 0.96
+				key = 0.59742 0.95
+				key = 0.58868 0.928
+				key = 0.58017 0.902
+				key = 0.57181 0.888
+				key = 0.56355 0.876
+				key = 0.55535 0.87
+				key = 0.54718 0.868
+				key = 0.53907 0.86
+				key = 0.53106 0.85
+				key = 0.52313 0.842
+				key = 0.51531 0.83
+				key = 0.50751 0.828
+				key = 0.49978 0.82
+				key = 0.49215 0.81
+				key = 0.48458 0.804
+				key = 0.47704 0.8
+				key = 0.46956 0.794
+				key = 0.46212 0.79
+				key = 0.45475 0.782
+				key = 0.44744 0.776
+				key = 0.44021 0.768
+				key = 0.43301 0.764
+				key = 0.42585 0.76
+				key = 0.41869 0.76
+				key = 0.41153 0.76
+				key = 0.40439 0.758
+				key = 0.39725 0.758
+				key = 0.39009 0.76
+				key = 0.38293 0.76
+				key = 0.37577 0.76
+				key = 0.36861 0.76
+				key = 0.36145 0.76
+				key = 0.35429 0.76
+				key = 0.34713 0.76
+				key = 0.33999 0.758
+				key = 0.33285 0.758
+				key = 0.32573 0.756
+				key = 0.3186 0.756
+				key = 0.3115 0.754
+				key = 0.3044 0.754
+				key = 0.29729 0.754
+				key = 0.29021 0.752
+				key = 0.28314 0.75
+				key = 0.2761 0.748
+				key = 0.26905 0.748
+				key = 0.26202 0.746
+				key = 0.25499 0.746
+				key = 0.24798 0.744
+				key = 0.24099 0.742
+				key = 0.23402 0.74
+				key = 0.22707 0.738
+				key = 0.22013 0.736
+				key = 0.21322 0.734
+				key = 0.20632 0.732
+				key = 0.19944 0.73
+				key = 0.1926 0.726
+				key = 0.18578 0.724
+				key = 0.17898 0.722
+				key = 0.1722 0.72
+				key = 0.16543 0.718
+				key = 0.15869 0.716
+				key = 0.15196 0.714
+				key = 0.14527 0.71
+				key = 0.13862 0.706
+				key = 0.13202 0.7
+				key = 0.12549 0.694
+				key = 0.11899 0.69
+				key = 0.11249 0.69
+				key = 0.106 0.688
+				key = 0.09956 0.684
+				key = 0.09315 0.68
+				key = 0.08688 0.666
+				key = 0.0808 0.646
+				key = 0.07482 0.634
+				key = 0.06897 0.622
+				key = 0.06324 0.608
+				key = 0.05768 0.589
+				key = 0.05226 0.575
+				key = 0.04699 0.559
+				key = 0.04183 0.547
+				key = 0.03705 0.507
+				key = 0.03263 0.469
+				key = 0.0287 0.417
+				key = 0.02497 0.395
+				key = 0.02152 0.367
+				key = 0.01826 0.345
+				key = 0.01526 0.319
+				key = 0.01271 0.271
+				key = 0.01061 0.223
+				key = 0.00886 0.186
+				key = 0.00731 0.164
+				key = 0.00602 0.136
+				key = 0.00502 0.106
+				key = 0.00417 0.09
+				key = 0.00349 0.072
+				key = 0.00289 0.064
+				key = 0.00243 0.048
+				key = 0.00208 0.038
+				key = 0.00179 0.03
+				key = 0.00155 0.026
+				key = 0.00132 0.024
+				key = 0.00113 0.02
+				key = 0.00096 0.018
+				key = 0.00081 0.016
+				key = 0.00068 0.014
+				key = 0.00057 0.012
+				key = 0.00047 0.01
+				key = 0.00038 0.01
+				key = 0.0003 0.008
+				key = 0.00022 0.008
+				key = 0.00017 0.006
+				key = 0.00011 0.006
+				key = 0.00005 0.006
+				key = 0.00002 0.004
+				key = 0 0.002
 			}
 		}
 	}
 }
-// ##########################################################################################	Globe X-10S "Thor II" SRB
-@PART[KWsrbGlobeX10S]:FOR[RealismOverhaul]
+// ##########################################################################################	Globe X-10L "Thor II" SRB
+@PART[KWsrbGlobeX10L]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -2055,16 +2073,16 @@
 	}
 	@MODEL
 	{
-		@scale = 1.555, 1.978160159, 1.555
+		@scale = 1.555, 1.524974, 1.555
 	}
 	@rescaleFactor = 1.0
 	@scale = 1.0
-	@node_stack_bottom = 0.0, -14.945000001245, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_top = 0.0, 14.945000001245, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -14.9447452, 0.0, 0.0, -1.0, 0.0, 3
+	@node_stack_top = 0.0, 14.9447452, 0.0, 0.0, 1.0, 0.0, 3
 	@node_attach = 0.0, 0.0, -1.555, 0.0, 0.0, 0.0, 2
-	@title = UA-1207 SRM
+	@title = UA1207
 	%manufacturer = United Technologies
-	@description = Seven segment solid boosters in the series by United Technologies for use with the Titan IV. Afternoon Delight. Burn time: 130 seconds.
+	@description = The UA1207 was used on the Titan IVA, which was developed to launch payloads that had been designed to fly on the Shuttle from Vandenberg. It was a 7-segment modification of the 5-segment UA1205 used on the Titan 3. Burn time 130 seconds.
 	@mass = 50.730
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
@@ -2076,8 +2094,8 @@
 		!engineAccelerationSpeed = DELETE
 		@atmosphereCurve
 		{
-			@key,0 = 0 265
-			@key,1 = 1 240
+			@key,0 = 0 272
+			@key,1 = 1 245
 		}
 	}
 	@MODULE[ModuleGimbal]
@@ -2598,225 +2616,6 @@
 			{
 				key = 0 250
 				key = 1 250
-			}
-		}
-	}
-}
-
-// ##########################################################################################	Globe X-10L "Thor II" SRB
-+PART[KWsrbGlobeX10L]:AFTER[RealismOverhaul]
-{
-	@name = RO_SRMU
-	@MODEL
-	{
-		@scale = 1.6002, 1.524974, 1.6002
-	}
-	@rescaleFactor = 1.0
-	@scale = 1.0
-	@node_stack_bottom = 0.0, -14.9447452, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_top = 0.0, 14.9447452, 0.0, 0.0, 1.0, 0.0, 3
-	@node_attach = 0.0, 0.0, -1.6002, 0.0, 0.0, 0.0, 2
-	@title = SRMU
-	%manufacturer = Thoikol (ATK)
-	@description = The 3-segment, composite-case SRMU (Solid Rocket Motor Upgrade) was used on the Titan IVB, replacing the 7-segment, steel-case UA1207 used on the Titan IVA. Burn time: 150 seconds. 
-	@mass = 36.56453
-	@crashTolerance = 12
-	@breakingForce = 250
-	@breakingTorque = 250
-	@maxTemp = 2073.15
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 0
-		@maxThrust = 8244.42362
-		@heatProduction = 100
-		%useEngineResponseTime = False
-		!engineAccelerationSpeed = DELETE
-		@atmosphereCurve
-		{
-			@key,0 = 0 281
-			@key,1 = 1 251
-		}
-	}
-	!RESOURCE[SolidFuel]
-	{
-	}
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 178013.76
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG[SolidFuel]
-		{
-			@maxThrust = 8244.42362
-			@atmosphereCurve
-			{
-				@key,0 = 0 281
-				@key,1 = 1 251
-			}
-			!thrustCurve
-			{
-			}
-			thrustCurve
-			{
-				key = 0.99171 0.88
-				key = 0.9831 0.914
-				key = 0.97439 0.924
-				key = 0.96565 0.928
-				key = 0.95687 0.932
-				key = 0.94803 0.938
-				key = 0.93916 0.942
-				key = 0.93022 0.948
-				key = 0.92125 0.952
-				key = 0.91225 0.956
-				key = 0.90318 0.962
-				key = 0.89406 0.968
-				key = 0.88488 0.974
-				key = 0.87566 0.978
-				key = 0.86639 0.984
-				key = 0.85706 0.99
-				key = 0.84767 0.996
-				key = 0.83825 1
-				key = 0.82882 1
-				key = 0.8194 1
-				key = 0.80997 1
-				key = 0.80057 0.998
-				key = 0.79118 0.996
-				key = 0.78181 0.994
-				key = 0.77244 0.994
-				key = 0.7631 0.992
-				key = 0.75375 0.992
-				key = 0.74442 0.99
-				key = 0.7351 0.988
-				key = 0.72581 0.986
-				key = 0.71652 0.986
-				key = 0.70724 0.984
-				key = 0.69799 0.982
-				key = 0.68875 0.98
-				key = 0.67953 0.978
-				key = 0.67032 0.978
-				key = 0.66112 0.976
-				key = 0.65194 0.974
-				key = 0.64277 0.972
-				key = 0.63363 0.97
-				key = 0.62451 0.968
-				key = 0.61542 0.964
-				key = 0.60637 0.96
-				key = 0.59742 0.95
-				key = 0.58868 0.928
-				key = 0.58017 0.902
-				key = 0.57181 0.888
-				key = 0.56355 0.876
-				key = 0.55535 0.87
-				key = 0.54718 0.868
-				key = 0.53907 0.86
-				key = 0.53106 0.85
-				key = 0.52313 0.842
-				key = 0.51531 0.83
-				key = 0.50751 0.828
-				key = 0.49978 0.82
-				key = 0.49215 0.81
-				key = 0.48458 0.804
-				key = 0.47704 0.8
-				key = 0.46956 0.794
-				key = 0.46212 0.79
-				key = 0.45475 0.782
-				key = 0.44744 0.776
-				key = 0.44021 0.768
-				key = 0.43301 0.764
-				key = 0.42585 0.76
-				key = 0.41869 0.76
-				key = 0.41153 0.76
-				key = 0.40439 0.758
-				key = 0.39725 0.758
-				key = 0.39009 0.76
-				key = 0.38293 0.76
-				key = 0.37577 0.76
-				key = 0.36861 0.76
-				key = 0.36145 0.76
-				key = 0.35429 0.76
-				key = 0.34713 0.76
-				key = 0.33999 0.758
-				key = 0.33285 0.758
-				key = 0.32573 0.756
-				key = 0.3186 0.756
-				key = 0.3115 0.754
-				key = 0.3044 0.754
-				key = 0.29729 0.754
-				key = 0.29021 0.752
-				key = 0.28314 0.75
-				key = 0.2761 0.748
-				key = 0.26905 0.748
-				key = 0.26202 0.746
-				key = 0.25499 0.746
-				key = 0.24798 0.744
-				key = 0.24099 0.742
-				key = 0.23402 0.74
-				key = 0.22707 0.738
-				key = 0.22013 0.736
-				key = 0.21322 0.734
-				key = 0.20632 0.732
-				key = 0.19944 0.73
-				key = 0.1926 0.726
-				key = 0.18578 0.724
-				key = 0.17898 0.722
-				key = 0.1722 0.72
-				key = 0.16543 0.718
-				key = 0.15869 0.716
-				key = 0.15196 0.714
-				key = 0.14527 0.71
-				key = 0.13862 0.706
-				key = 0.13202 0.7
-				key = 0.12549 0.694
-				key = 0.11899 0.69
-				key = 0.11249 0.69
-				key = 0.106 0.688
-				key = 0.09956 0.684
-				key = 0.09315 0.68
-				key = 0.08688 0.666
-				key = 0.0808 0.646
-				key = 0.07482 0.634
-				key = 0.06897 0.622
-				key = 0.06324 0.608
-				key = 0.05768 0.589
-				key = 0.05226 0.575
-				key = 0.04699 0.559
-				key = 0.04183 0.547
-				key = 0.03705 0.507
-				key = 0.03263 0.469
-				key = 0.0287 0.417
-				key = 0.02497 0.395
-				key = 0.02152 0.367
-				key = 0.01826 0.345
-				key = 0.01526 0.319
-				key = 0.01271 0.271
-				key = 0.01061 0.223
-				key = 0.00886 0.186
-				key = 0.00731 0.164
-				key = 0.00602 0.136
-				key = 0.00502 0.106
-				key = 0.00417 0.09
-				key = 0.00349 0.072
-				key = 0.00289 0.064
-				key = 0.00243 0.048
-				key = 0.00208 0.038
-				key = 0.00179 0.03
-				key = 0.00155 0.026
-				key = 0.00132 0.024
-				key = 0.00113 0.02
-				key = 0.00096 0.018
-				key = 0.00081 0.016
-				key = 0.00068 0.014
-				key = 0.00057 0.012
-				key = 0.00047 0.01
-				key = 0.00038 0.01
-				key = 0.0003 0.008
-				key = 0.00022 0.008
-				key = 0.00017 0.006
-				key = 0.00011 0.006
-				key = 0.00005 0.006
-				key = 0.00002 0.004
-				key = 0 0.002
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -299,7 +299,7 @@
 	@node_stack_bottom = 0.0, -8.240668, 0.0, 0.0, -2.0, 0.0, 2
 	@node_stack_top = 0.0, 14.0348321, 0.0, 0.0, 2.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.524, 0.0, 0.0, 2.0
-	@title = UA-1205 SRM
+	@title = UA1205 SRM
 	%manufacturer = United Technologies
 	@description = Strap-on booster for Titan IIIC, IIID, IIIE, proposed for Saturn IB derivatives. Burn time 115s.
 	@mass = 38.4
@@ -334,11 +334,11 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = UA-1205
+		configuration = UA1205
 		modded = false
 		CONFIG
 		{
-			name = UA-1205
+			name = UA1205
 			maxThrust = 5849.5
 			heatProduction = 100
 			PROPELLANT


### PR DESCRIPTION
At some point the KW SRMU was replaced with the RSRMV, though the model size was never changed. Since the RSRMV is part of the Squad pack, switching the KW version back to SRMU makes sense. Also switched models for the SRMU and UA1207 so the 7-segment UA1207 gets the model with more segments and the 3-segment SRMU gets the model with fewer.