### PR TITLE
Vernor RCS config

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -3192,6 +3192,7 @@
 	{
 	}
 	@mass = 0.01
+	%useRcsConfig = RCSBlock
 	@MODULE[ModuleRCS]
 	{
 		@name = ModuleRCSFX
@@ -3202,145 +3203,35 @@
 			ratio = 1.0
 			name = Hydrazine
 		}
+		!PROPELLANT[LiquidFuel]
+		{
+		}
+		!PROPELLANT[Oxidizer]
+		{
+		}
 		@atmosphereCurve
 		{
 			@key,0 = 0 254
 			@key,1 = 1 82.08
 		}
 	}
-	MODULE
+}
+
+@PART[vernierEngine]:AFTER[RO-RCS]
+{
+	@MODULE[ModuleEngineConfigs]
 	{
-		name = ModuleEngineConfigs
-		type = ModuleRCS
-		thrustRating = thrusterPower
-		techLevel = 2
-		origTechLevel = 2
-		engineType = L
-		origMass = 0.01
-		configuration = Hydrazine
-		modded = false
-		CONFIG
+		@CONFIG[MMH+NTO]
 		{
-			name = HTP
-			thrusterPower = 0.255
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = HTP
-			}
-			IspSL = 0.177
-			IspV = 0.465
+			@IspSL = 0.953
 		}
-		CONFIG
+		@CONFIG[UDMH+NTO]
 		{
-			name = Hydrazine
-			thrusterPower = 0.275
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Hydrazine
-			}
-			IspSL = 0.274
-			IspV = 0.72
-			cost = 3
+			@IspSL = 0.95
 		}
-		CONFIG
+		@CONFIG[Aerozine50+NTO]
 		{
-			name = NitrousOxide
-			thrusterPower = 0.118
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = NitrousOxide
-			}
-			IspSL = 0.2
-			IspV = 0.525
-			cost = -1
-		}
-		CONFIG
-		{
-			name = Helium
-			thrusterPower = 0.006
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Helium
-			}
-			IspSL = 0.203
-			IspV = 0.453
-		}
-		CONFIG
-		{
-			name = Nitrogen
-			thrusterPower = 0.019
-			PROPELLANT
-			{
-				ratio = 1.0
-				name = Nitrogen
-			}
-			IspSL = 0.1001462
-			IspV = 0.195
-			cost = -5
-		}
-		CONFIG
-		{
-			name = MMH+NTO
-			thrusterPower = 0.445
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.437
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.563
-			}
-			IspSL = 0.953
-			IspV = 0.952
-			cost = 10
-			techRequired = flightControl
-		}
-		CONFIG
-		{
-			name = UDMH+NTO
-			thrusterPower = 0.442
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.413
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.587
-			}
-			IspSL = 0.95
-			IspV = 0.943
-			cost = 8
-			techRequired = flightControl
-		}
-		CONFIG
-		{
-			name = Aerozine50+NTO
-			thrusterPower = 0.455
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			IspSL = 0.963
-			IspV = 0.955
-			cost = 10
-			techRequired = flightControl
+			@IspSL = 0.963
 		}
 	}
 }


### PR DESCRIPTION
The engine GUI for the Vernor (vernierEngine) was non-functional, replaced with useRcsConfig = RCSBlock, then modify config after RO-RCS to adjust IspSL