### PR TITLE
Partial config for BoxSat parts, mostly based on Thales Alenia-built satellites

### DIFF
--- a/GameData/RealismOverhaul/REWORK/RO_BoxSat.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_BoxSat.cfg
@@ -1,0 +1,208 @@
+//Proteus satellite bus
+@PART[62cm_BoxSat_Frame]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%rescaleFactor = 1.6
+	@mass = 0.06
+	@category = Structural
+	@title = Proteus Satellite bus
+	@manufacturer = Thales Alenia Space
+	@description = 1 meter bus for small sats. To replicate the real-life bus, mount the following BoxSat modules: 1 command, 1 battery, 1 LFO tank, 1 reaction wheel.
+	@cost = 250
+}
+
+//bus hatch
+@PART[62cm_BoxSat_Hatch]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%rescaleFactor = 1.6
+	@mass = 0.006
+	@title = Proteus bus hatch
+	@manufacturer = Thales Alenia Space
+	@description = Hatch for the Proteus bus
+	@cost = 50
+}
+
+//Deployable panel
+@PART[62cm_BoxSat_Folding1x3_SolarPanel]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.028
+	@title = Proteus bus solar array
+	%rescaleFactor = 1.6
+	@manufacturer = Thales Alenia Space
+	@description = 4.8m^2 of area.
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 0.550
+	}
+}
+
+//Cosmiac deployable tape antenna
+@PART[Antenna_Tape1]:FOR[RealismOverhaul]
+{	
+	%RSSROConfig = True
+	%rescaleFactor = 0.2857
+	%scale = 0.1
+	@mass = 0.0001
+	%title = Cosmiac Deployable Antenna System
+	%description = Contains four deployable monopole tape antennas. Useful for cubesats.
+	
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
+	{
+	}
+	!MODULE[TweakScale]
+	{
+	}
+	@MODULE[ModuleAnimateGeneric]
+	{
+	isOneShot = true
+	}
+	MODULE
+	{
+		name = ModuleRTAntenna
+		Mode0OmniRange = 1000000
+		Mode1OmniRange = 1000000
+		MaxQ = 3000
+		EnergyCost = 0.002
+		DeployFxModules = 0
+		TRANSMITTER
+		{
+			PacketInterval = 0.5
+			PacketSize = 0.1
+			PacketResourceCost = 0.005
+		}
+	}
+}
+
+//Gyroscope unit
+@PART[62cm_BoxSat_ReactionWheel_Module]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%rescaleFactor = 1.6
+	@mass = 0.05
+	@title = Proteus reaction wheel unit
+	@manufacturer = Thales Alenia Space
+	@description = Contains reaction wheels and magnetorquers for the Proteus satellite bus.
+	@cost = 400
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.005
+		@YawTorque = 0.005
+		@RollTorque = 0.005
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.090
+		}
+	}
+}
+
+//Probe core
+@PART[62cm_BoxSat_ProbeCore_Module]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%rescaleFactor = 1.6
+	@mass = 0.03
+	@manufacturer = Thales Alenia Space
+	@title = Proteus bus control module
+	@description = Stick one of these into the Proteus bus to control your satellite.
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.08
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+}
+
+//battery module
+@PART[62cm_BoxSat_Battery_Module]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%rescaleFactor = 1.6
+	@mass = 0.05
+	@title = Proteus bus battery module
+	@manufacturer = Thales Alenia Space
+	@description = Stick one of these into the Proteus bus to provide power storage to your satellite.
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 10000
+		@maxAmount = 10000
+	}
+}
+
+//Propellant tank
+@PART[62cm_BoxSat_LFO_Tank_Module]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%rescaleFactor = 1.6
+	%mass = 0.02
+	@category = FuelTank
+	@title = Proteus bus propellant tank
+	@manufacturer = Thales Alenia Space
+	@description = propellant module for the Proteus bus. Contains hydrazine pressurised with nitrogen.
+	@cost = 500
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 28
+		type = ServiceModule
+	}
+}
+
+//Artemis antenna
+@PART[Antenna_HingedDish1]:FOR[RealismOverhaul]
+{	
+	%RSSROConfig = True
+	%rescaleFactor = 4
+	%scale = 1
+	@mass = 0.124
+	%title = Artemis S/Ka band relay
+	%description = A 2.85m relay antenna as used on the Artemis satellite.
+	
+	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
+	{
+	}
+	!MODULE[TweakScale]
+	{
+	}
+	MODULE
+	{
+		name = ModuleRTAntenna
+		Mode0OmniRange = 10000000
+		Mode1OmniRange = 10000000
+		MaxQ = 3000
+		EnergyCost = 0.800
+		DeployFxModules = 0
+		TRANSMITTER
+		{
+			PacketInterval = 0.3
+			PacketSize = 2
+			PacketResourceCost = 20 
+		}
+	}
+}


### PR DESCRIPTION
The RCS thrusters, fixed panels, monopropellant tank and science modules do not have configs yet.

I tried to replicate the real equivalents as close as possible. Unfortunately not much data is available for antennae on the Artemis satellite, so it *could* be overpowered.