### PR TITLE
RN rp fix

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_r7_proton_fairings.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_r7_proton_fairings.cfg
@@ -1,4 +1,4 @@
-@PART[r7_blok_i_fairing|r7_blok_i_fairing_s|r7_soyuz_fairing|r7_blok_i_fairing_m|r7_vostok_fairing_l|r7_vostok_fairing_r|r7_voskhod_fairing_l|r7_voskhod_fairing_r|rn_almaz_fairing|rn_salyut1_fairing|rn_salyut7_fairing|rn_salyut467_fairing|rn_tks_fairing|rn_zond_fairing|rn_voskhod_airlock]:BEFORE[zRealPlume]
+@PART[r7_blok_i_fairing|r7_blok_i_fairing_s|r7_soyuz_fairing|r7_blok_i_fairing_m|r7_vostok_fairing_l|r7_vostok_fairing_r|r7_voskhod_fairing_l|r7_voskhod_fairing_r|rn_almaz_fairing|rn_salyut1_fairing|rn_salyut7_fairing|rn_salyut467_fairing|rn_tks_fairing|rn_zond_fairing|rn_voskhod_airlock|r7_blok_bvgd_sput|r7_blok_bvgd|r7_blok_bvgd_s|r7_blok_bvgd_m]:BEFORE[zRealPlume]
 {
     %FIXMYPLUME = FALSE
     !PLUME,* {}


### PR DESCRIPTION
remove realplume from invisible booster sep motors, should not be
visible as IRL it didn't have them anyway(needed for ksp to aide
decouple)