### PR TITLE
Remove Reaction Wheel on Soyuz upper

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_R-7 Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_R-7 Tanks.cfg
@@ -456,24 +456,6 @@
 		amount = 1.0
 		maxAmount = 1.0
 	}
-	MODULE
-	{
-		name = ModuleSAS
-	}
-	// Testing this to cover up poor stability after BECO.
-	MODULE
-	{
-	name = ModuleReactionWheel
-	PitchTorque = 0.3
-	YawTorque = 0.3
-	RollTorque = 0.3
-	RESOURCE
-	{
-		name = ElectricCharge
-		rate = 0.01
-	}
-
-	}
 }
 @PART[r7_blok_i]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {


### PR DESCRIPTION
Remove Reaction Wheel on Soyuz upper, actual stage does not have a reaction wheel.