### PR TITLE
Rename AJ-73F to AJ-60A

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -1046,10 +1046,10 @@
 	%rescaleFactor = 1.0
 	@scale = 1.0
 	@node_attach = 0.0, 0.0, -0.768800, 0.0, 0.0, 0.0
-	@title = AJ-73F
-	%manufacturer = Aerojet
-	@description = Up to 5 of these are installed onto the Atlas V launch vehicle for a boost in thrust.
-	@mass = 4.15
+	@title = AJ-60A
+	%manufacturer = Aerojet Rocketdyne
+	@description = The AJ-60A was developed for the Atlas V, which can be configured with up to five boosters.
+	@mass = 4.0
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
 	{
@@ -1060,7 +1060,7 @@
 		!engineAccelerationSpeed = DELETE
 		@atmosphereCurve
 		{
-			@key,0 = 0 279
+			@key,0 = 0 275
 			@key,1 = 1 250
 		}
 	}
@@ -1081,11 +1081,11 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = AJ-37F
+		configuration = AJ-60A
 		modded = false
 		CONFIG
 		{
-			name = AJ-37F
+			name = AJ-60A
 			maxThrust = 1270
 			heatProduction = 100
 			PROPELLANT
@@ -1096,7 +1096,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 279
+				key = 0 275
 				key = 1 250
 			}
 			//curveResource = HTPB


### PR DESCRIPTION
All kinds of names out there for the Atlas V boosters, but AR seems to have settled on AJ-60A

http://www.rocket.com/atlas-v-solid-rocket-motor
https://twitter.com/aerojetrdyne/status/576432871826575360

Isp and inert mass from:
http://enu.kz/repository/2009/AIAA-2009-5519.pdf