### PR TITLE
Add upper node attach sizes, SI formatting

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -12,7 +12,7 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -2.92000075, 0.0, 0.0, -1.0, 0.0, 1
-	@title = Merlin Family Rocket Engine [1.75m]
+	@title = Merlin Family Rocket Engine [1.75 m]
 	%manufacturer = SpaceX
 	@description = The whole family of Merlin rocket engines, made by SpaceX.
 	@attachRules = 1,0,1,0,0

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -210,7 +210,7 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -1.6, 0.0, 0.0, -1.0, 0.0, 1
-	@title = Aestus II [1.5m]
+	@title = Aestus II [1.5 m]
 	%manufacturer = EADS Astrium
 	@description = Smaller MMH/NTO upper stage rocket engine that can also be used for orbital manuevers.
 	@attachRules = 1,0,1,0,0
@@ -300,7 +300,7 @@
 	@node_stack_bottom = 0.0, -2.9578846, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 2.961952, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.40132, 0.0, 0.0, 1.0
-	@title = Castor I Solid Motor
+	@title = Castor I Solid Motor [0.8 m]
 	%manufacturer = Thiokol
 	@description = The motor used in the Sergeant tactical missile, the Castor (later Castor I) has been used in many applications: a set of four were used in Little Joe, the Mercury test vehicle; they were used as strap-on boosters for Thor-Delta and Thor-Agena; they were used as the second stage in the all-solid Scout launch vehicle; and they were used in many other minor applications. Burn time 27s. Other models have reported burn times of 37s, so set thrust limiter to 73 to simulate those.
 	@attachRules = 1,1,1,1,0
@@ -388,7 +388,7 @@
 	@node_stack_bottom = 0.0, -2.289366, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 1.876235, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 0
-	@title = Castor 30B [92"]
+	@title = Castor 30B [2.34 m]
 	%manufacturer = Thiokol (ATK)
 	@description = A shortened Castor 120 became the Castor 30 used as an upper stage.
 	@attachRules = 1,1,1,1,0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -1,7 +1,7 @@
 @PART[liquidEngineconstelacion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	@title = J-2X [3.5m]
+	@title = J-2X [3.5 m]
 	%manufacturer = Rocketdyne
 	@description = Restartable, cryogenic-fed engine that powered the second and third stages of the Saturn-V vehicle.
 	MODEL
@@ -175,7 +175,7 @@
 @PART[engineexper05]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = RL60 [1.5m]
+	%title = RL60 [1.5 m]
 	%manufacturer = Pratt & Whitney
 	@description = Next generation cryogenic upper stage engine designed to replace the RL10, providing higher performance while maintaining the same installation envelope.  Also available in a lower 180kN thrust Vinci-180 model.
 	MODEL
@@ -294,7 +294,7 @@
 @PART[liquidEnginemogulmp1500]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = RD-170 [4.0m]
+	%title = RD-170 [4.0 m]
 	%manufacturer = NPO Energomash
 	%description = Most powerful Kerosene-burning engine, powered the first stage boosters of the Energiya vehicle.
 	!mesh = DELETE
@@ -407,7 +407,7 @@
 @PART[enginelmodc]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = LM Descent Engine [1.5m]
+	%title = LM Descent Engine [1.5 m]
 	%manufacturer = TRW
 	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability.
 	MODEL
@@ -571,7 +571,7 @@
 @PART[galaxvr2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = Aestus [1.5m]
+	%title = Aestus [1.5 m]
 	%manufacturer = EADS Astrium
 	%description = Upper stage engine of the Ariane 5ES vehicle that launches the ATV to ISS. Burns hypergolic propellants.
 	MODEL
@@ -670,7 +670,7 @@
 @PART[liquidEngineorbit2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = LR91 [3.0m]
+	%title = LR91 [3.0 m]
 	%manufacturer = Aeroject
 	%description = Second stage engine for the Titan III vehicle, burns hypergolic propellants.
 	MODEL
@@ -863,7 +863,7 @@
 @PART[liquidEngineprodulVR2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = LR87 [3.0m]
+	%title = LR87 [3.0 m]
 	%manufacturer = Aerojet
 	%description = Used in the first stage of the Titan rocket family, the LR87 is composed of two engines with separate turbomachinery integrated into one unit. The version used on Titan I burned kerosene and liquid oxygen, while Titan II through Titan IV burned storable propellants. A modified version burning liquid hydrogen was developed for the upper stages of Saturn V and Saturn IB, but the J-2 was selected instead.
 	MODEL
@@ -1093,7 +1093,7 @@
 @PART[microEngineex1sat]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = Generic 0.5kN Thruster [0.3m]
+	%title = Generic 0.5kN Thruster [0.3 m]
 	%description = Thruster for orbital maneuvers, similar to ones used in the Galileo probe.
 	%node_stack_top = 0.0, 0.035, 0.0, 0.0, 1.0, 0.0, 0
 	%node_attach = 0.0, 0.035, 0.0, 0.0, 1.0, 0.0, 0
@@ -1150,7 +1150,7 @@
 @PART[microEngineSE1]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = LM Ascent Engine (LMAE) [1.0m]
+	%title = LM Ascent Engine (LMAE) [1.0 m]
 	%manufacturer = Bell
 	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander.
 	MODEL
@@ -1241,7 +1241,7 @@
 @PART[VR1vulcan]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = RS-68 [3.5m]
+	%title = RS-68 [3.5 m]
 	%manufacturer = Rocketdyne
 	%description = Powerful cryogenic engine used in the core and boosters of the Delta-IV vehicle.
 	MODEL
@@ -1375,7 +1375,7 @@
 	%rescaleFactor = 1
 	%node_stack_top = 0.0, 0.6925, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_bottom = 0.0, -1.7075, 0.0, 0.0, -1.0, 0.0, 1
-	@title = Kestrel
+	@title = Kestrel [1.4 m]
 	@manufacturer = SpaceX
 	@description = Pressure-fed kerosene/LOX engine that was used in the second stage of the Falcon 1 launcher.
 	%mass = 0.052

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -5,7 +5,7 @@
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.589812, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = NK-33
+	%title = NK-33 [2.0 m]
 	%manufacturer = SNTK Kuznetsov
 	%description = Originally built in the late 1960s/early 1970s for the Soviet N1F rocket. Though the N1F was scrapped, the engines survived. Aerojet aquired several NK-33 engines in the 1990s and refurbished them as AJ26-62 engines for Orbital Science's Antares launch vehicle. Modifications made by Aerojet included increasing rated thrust and equipping the engines to support gimballing.
 	%attachRules = 1,0,1,0,0
@@ -153,7 +153,7 @@
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.711397, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = NK-43
+	%title = NK-43 [2.0 m]
 	%manufacturer = SNTK Kuznetsov 
 	%description = Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
 	%attachRules = 1,0,1,0,0
@@ -250,7 +250,7 @@
 	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = RD-0120
+	%title = RD-0120 [2.6 m]
 	%manufacturer = KB Khimavtomatika
 	%description = Originally designed to power the core stage of the Energia rocket, with similar performance and lower cost of the RS-25 (SSME) the RD-0120 is a powerful cryogenic rocket engine.
 	%attachRules = 1,0,1,0,0
@@ -337,7 +337,7 @@
 	%node_stack_top = 0.0, 0.790815, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.785566, 0, 0.0, -1.0, 0.0, 2
 	%category = Propulsion
-	%title = RD-0110/0124
+	%title = RD-0110/0124 [1.7 m]
 	%manufacturer = KB Khimavtomatika
 	%description = An upper stage Kerosene/LOx engine designed for new versions of the Soyuz-2 launchers. To also be used with the Angara family of launchers.
 	%attachRules = 1,0,1,0,0
@@ -459,7 +459,7 @@
 	%node_stack_top = 0.0, 0.7816036, 0, 0.0, 1.0, 0.0, 1
 	%node_stack_bottom = 0.0, -1.882533, 0, 0.0, -1.0, 0.0, 1
 	!node_attach = DELETE
-	%title = RD-0146
+	%title = RD-0146 [1.3 m]
 	%manufacturer = KB Khimavtomatika
 	%description = A designed based upon the RL10 series of rocket engines, with a more Russian flavour.
 	%attachRules = 1,0,1,0,0
@@ -546,7 +546,7 @@
 	%node_stack_top = 0.0, 1.826991, 0, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -2.177579, 0, 0.0, -1.0, 0.0, 4
 	!node_attach = DELETE
-	%title = RD-171M
+	%title = RD-171M [4.1 m]
 	%manufacturer = NPO Energomash
 	%description = The RD-170 is the most powerful liquid rocket engine ever flown. Originally developed for the Energia launcher's boosters, the engine consists of four combustion chambers fed by a single turbopump. A modified version, the RD-171M, is used on the first stage of the Zenit launch vehicle.
 	%attachRules = 1,0,1,0,0
@@ -643,7 +643,7 @@
 	%node_stack_top = 0.0, 2.11619, 0, 0.0, 1.0, 0.0, 3
 	%node_stack_bottom = 0.0, -1.642843, 0, 0.0, -1.0, 0.0, 3
 	!node_attach = DELETE
-	%title = RD-180
+	%title = RD-180 [3.5 m]
 	%manufacturer = NPO Energomash
 	%description = The RD-180 is a two-chamber derivative of the four-chamber RD-170/171 and powers the first stage of the Atlas V.
 	%attachRules = 1,0,1,0,0
@@ -741,7 +741,7 @@
 	%node_stack_top = 0.0, 2.124936, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.840061, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = RD-191
+	%title = RD-191 [1.7 m]
 	%manufacturer = NPO Energomash
 	%description = A further continuation of the RD-170/171 series, the RD-191 features a single combustion chamber and nozzle. Powers the Angara family of launchers.
 	%attachRules = 1,0,1,0,0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
@@ -20,7 +20,7 @@
 	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = RD-270
+	%title = RD-270 [3.55 m]
 	%manufacturer = NPO Energomash / V.P. Glushko
 	%description = Largest single-chamber engine ever built in the Soviet Union.  Fueled by an N2O4/UDMH mixture combined under some of the highest pressures ever encountered in an ignition chamber.  Never flown but extensively tested.
 	%attachRules = 1,0,1,0,0
@@ -123,7 +123,7 @@
 	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = RD-270M
+	%title = RD-270M [3.55 m]
 	%manufacturer = NPO Energomash / V.P. Glushko
 	%description = Modification of the RD-270 to use highly toxic pentaborane as fuel.  Although the M variant boasts higher thrust and isp, the fuel mixture is much, much more toxic than even UDMH.
 	%attachRules = 1,0,1,0,0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -481,7 +481,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RL10 Series Vacuum Engine [2.0 m]
+	%title = RL10 Series Vacuum Engine [1.5 m]
 	%manufacturer = Pratt & Whitney
 	%description = Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators.
 	@MODEL,0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -5,7 +5,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RL10 Series Vacuum Engine [2.0m]
+	%title = RL10 Series Vacuum Engine [2.0 m]
 	%manufacturer = Pratt & Whitney
 	%description = Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators.
 	@MODEL,0
@@ -370,7 +370,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = AJ10-118K [2.0m]
+	%title = AJ10-118K [2.0 m]
 	%manufacturer = Aerojet
 	%description = Upper stage, pressure-fed engine of the Delta II vehicle, burns hypergolic propellants and is optimized for vacuum operation.
 	@MODEL,0
@@ -481,7 +481,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RL10 Series Vacuum Engine [1.5m]
+	%title = RL10 Series Vacuum Engine [2.0 m]
 	%manufacturer = Pratt & Whitney
 	%description = Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators.
 	@MODEL,0
@@ -846,7 +846,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RD-107/108 Series [2m]
+	%title = RD-107/108 Series [2.0 m]
 	%manufacturer = NPO Energomash
 	%description = The engine series built for the R-7, Vostok, Soyuz, and it's derivative Molynia launch vehicles.
 	@MODEL,0
@@ -1038,7 +1038,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = H-1/RS-27 Series [2.5m]
+	%title = H-1/RS-27 Series [2.5 m]
 	%manufacturer = Rocketdyne
 	%description = The H-1 and RS-27 are first stage gas-generator engines burning LOX/kerosene. The H-1 was used on the Saturn I and Saturn IB launchers and was later modified into the RS-27 for use on the Delta rocket family. The H-1 and RS-27 are optimized for use as first stage main engines. The RS-27A, used on the Delta III and most Delta II launchers, is optimized for performance at altitude since these rockets used solid boosters to augment thrust at liftoff.
 	@MODEL,0
@@ -1231,7 +1231,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = AJ10-137 [4.0m]
+	%title = AJ10-137 [4.0 m]
 	%manufacturer = Aerojet
 	%description = Engine used in the Apollo Service Module, burns hypergolic propellants and is optimized for vacuum operation.
 	@MODEL,0
@@ -1332,7 +1332,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = LE-7A [5m]
+	%title = LE-7A [5.0 m]
 	%manufacturer = Mitsubishi
 	%description = Dual LE-7A engines are used on the core stage of the H-2B launcher. These staged combustion engines burn hydrogen/LOX and are throttleable to 72% of maximum thrust.
 	@MODEL,0
@@ -1443,7 +1443,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RD-0120 [7.5m]
+	%title = RD-0120 [7.5 m]
 	%manufacturer = KB Khimavtomatiki
 	%description = Cluster of four very large engines each roughly equivalent to the Space Shuttle Main Engine (RS-25). This has four (4) of them as found on the Energia launcher core.
 	@MODEL,0
@@ -1553,7 +1553,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = Vulcain 2 [5.0m]
+	%title = Vulcain 2 [5.0 m]
 	%manufacturer = EADS Astrium
 	%description = First stage of the Ariane 5 vehicle, burns cryogenic propellants.
 	@MODEL,0
@@ -1686,7 +1686,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = HM-7 Series [5.0m]
+	%title = HM-7 Series [5.0 m]
 	%manufacturer = EADS Astrium
 	%description = Upper stage of the Ariane 5ECA vehicle that launches satellites into GTO. Uses cryogenic propellants.
 	@MODEL,0
@@ -1827,7 +1827,7 @@
 	@node_stack_bottom2 = 3.871079, 4.783, -3.871079, 0.00, 1.0, 0.0, 1
 	@node_stack_bottom3 = -3.871079, 4.783, 3.871079, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom4 = 3.871079, 4.783, 3.871079, 0.0, 1.0, 0.0, 1
-	@title = F-1 Series [10.0m]
+	@title = F-1 Series [10.0 m]
 	%manufacturer = Rocketdyne
 	@description = Five of the most powerful engines in the world strapped together in a Saturn V type arrangement.
 	@mass = 42
@@ -1972,7 +1972,7 @@
 	@node_stack_top = 0.0, 7.363, 0.0, 0.0, 1.0, 0.0, 10
 	!node_stack_top2 = DELETE
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 10
-	@title = J-2 [10.0m]
+	@title = J-2 [10.0 m]
 	%manufacturer = Rocketdyne
 	@description = Cluster of five (5) Rocketdyne J-2 engines as found on the Saturn V.
 	@mass = 13.41075

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -429,7 +429,7 @@
 		@scale = 4, 3, 4
 	}
 	@node_attach = 0.0, 0.0, -0.76, 0.0, 0.0, 0.0
-	@title = GEM 60
+	@title = GEM 60 [1.37 m]
 	%manufacturer = Thiokol ATK
 	@description = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time: 90 seconds
 	@mass = 3.95215
@@ -1481,7 +1481,7 @@
 	@node_stack_bottom = 0.0, -6.786727, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 6.193274, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.585, 0.0, 0.0, 2.0
-	@title = GEM 46
+	@title = GEM 46 [1.05 m]
 	%manufacturer = Thiokol ATK
 	@description =  The 46-inch (1.2-meter) diameter GEM 46 was used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with thrust vector control (TVC) while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC. Burn time: 75 seconds.
 	@mass = 2.275
@@ -1844,7 +1844,7 @@
 	@node_stack_bottom = 0.0, -14.945000001245, 0.0, 0.0, -1.0, 0.0, 3
 	@node_stack_top = 0.0, 14.945000001245, 0.0, 0.0, 1.0, 0.0, 3
 	@node_attach = 0.0, 0.0, -1.6002, 0.0, 0.0, 0.0, 2
-	@title = Solid Rocket Motor Upgrade (SRMU)
+	@title = Solid Rocket Motor Upgrade (SRMU) [3.2 m]
 	%manufacturer = ATK
 	@description = The SRMU was developed for the upgraded Titan IVB, with the goal of achieving a 25% increase in capacity over the Titan IVA with the UA1207 SRM. It achieved this through the use of a more energetic propellant and a 3-segment composite case that carried more fuel and weighed less than the UA1207's 7-segment steel case. Burn time 150 seconds.
 	@mass = 36.56453
@@ -2078,7 +2078,7 @@
 	@node_stack_bottom = 0.0, -14.9447452, 0.0, 0.0, -1.0, 0.0, 3
 	@node_stack_top = 0.0, 14.9447452, 0.0, 0.0, 1.0, 0.0, 3
 	@node_attach = 0.0, 0.0, -1.555, 0.0, 0.0, 0.0, 2
-	@title = UA1207
+	@title = UA1207 [3.0 m]
 	%manufacturer = United Technologies
 	@description = The UA1207 was used on the Titan IVA, which was developed to launch payloads that had been designed to fly on the Shuttle from Vandenberg. It was a 7-segment modification of the 5-segment UA1205 used on the Titan 3. Burn time 130 seconds.
 	@mass = 50.730

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NovaPunch/RO_NovaPunch_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NovaPunch/RO_NovaPunch_Engines.cfg
@@ -16,7 +16,7 @@
     	@node_attach = 0.0, 0.6613605, 0.0, 0.0, 1.0, 0.0, 2
     	@node_stack_bottom = 0.0, -2.176805, 0.0, 0.0, -1.0, 0.0, 2
 
-	@title = Viking/Vikas Series Booster
+	@title = Viking/Vikas Series Booster [0.7 m]
 	@manufacturer = SNECMA / ISRO
 	@description = Hypergolic gas generator engine used on the first stage and on the liquid boosters of Ariane 1, 2, 3, and 4.  Viking was eventually used as the starting point for the Vikas engines developed by India for use on the boosters of its GSLV MkI and MkII.  Earliest versions used UDMH + NTO, but later versions switched over to UH25 + NTO.  Highly reliable engine, though somewhat low chamber pressure and hypergolic propellants make for low efficiency compared to contemporaries.
 	@attachRules = 1,1,1,0,0
@@ -234,7 +234,7 @@
 	@node_attach = 0.0, 0.8525898, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -2.806218, 0.0, 0.0, -1.0, 0.0, 2
 
-	@title = Viking/Vikas Series Vacuum Engine
+	@title = Viking/Vikas Series Vacuum Engine [1.2 m]
 	@manufacturer = SNECMA / ISRO
 	@description = Hypergolic gas generator engine used on the second stage of Ariane 1, 2, 3, and 4.  Viking was eventually used as the starting point for the Vikas engines developed by India for use on the second stage of its PSLV, GSLV MkI and MkII, as well as for the core stage of the LVM3.  Earliest versions used UDMH + NTO, but later versions switched over to UH25 + NTO.  Highly reliable engine, though somewhat low chamber pressure and hypergolic propellants make for low efficiency compared to contemporaries.
 	@mass = 1.02

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Engine.cfg
@@ -16,7 +16,7 @@
 	@node_stack_bottom = 0.0, -0.3119931, 0.0, 0.0, -1.0, 0.0, 0
 	%node_attach = 0.0, 0.3069868, 0.0, 0.0, 1.0, 0.0, 0
 	@attachRules = 1,1,1,0,0
-	@title = Alta XR-150 ResistoJet [0.125m]
+	@title = Alta XR-150 ResistoJet [0.125 m]
 	%manufacturer = Alta
 	@description = Small, lightweight, low force propulsion unit
 	@mass = 0.000220
@@ -116,7 +116,7 @@
 	@node_stack_top = 0.0, 0.1497139, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -0.2392179, 0.0, 0.0, -1.0, 0.0, 0
 	%node_attach = 0.0, 0.1497139, 0.0, 0.0, 1.0, 0.0, 0
-	@title = XIPS 25cm ION Thruster [0.4m]
+	@title = XIPS 25cm ION Thruster [0.4 m]
 	%manufacturer = L-3 Electron Technologies
 	@description = Smaller cousin to the NSTAR or 30cm thruster good for station keeping or raising orbit.
 	@attachRules = 1,1,1,0,0
@@ -193,7 +193,7 @@
 	@node_stack_top = 0.0, 0.2873363, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -0.6544343, 0.0, 0.0, -1.0, 0.0, 0
 	%node_attach = 0.0, -0.0294343, 0.0, 0.0, 1.0, 0.0, 0
-	@title = R-4D-11 [0.625m]
+	@title = R-4D-11 [0.625 m]
 	%manufacturer = Aerojet (GenCorp)
 	@description = Nice R-4D-11 490N thrusters as found as the main propulsion of the ESA ATV, and used as various other control thrusters on numerous vehicles.
 	@attachRules = 1,1,1,0,0
@@ -297,7 +297,7 @@
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = RS-2200 [2.5m]
+	@title = RS-2200 [2.5 m]
 	%manufacturer = Rocketdyne
 	@description = Linear aerospike production engine following the XRS-2200 and X-33.
 	@MODULE[ModuleEngines*]
@@ -399,7 +399,7 @@
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = RD-253/275 [2.0m]
+	@title = RD-253/275 [2.0 m]
 	%manufacturer = NPO Energomash
 	@description = A high thrust engine designed for use with storable propellants. In use with the Proton series of rockets.
 	@MODULE[ModuleEngines*]
@@ -529,7 +529,7 @@
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = RD-0210/0213 [2.0m]
+	@title = RD-0210/0213 [2.0 m]
 	%manufacturer = KB Khimavtomatika
 	@description = A series of engines found on the second and third stages of the Proton series launcher. While the four installed second stage engines gimbal, the single third stage does not.
 	@MODULE[ModuleEngines*]
@@ -625,7 +625,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.1364338, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.3957303, 0.0, 0.0, -1.0, 0.0, 2
-	@title = Bell 80XX
+	@title = Bell 80XX [1.5 m]
 	@description = Primary Propulsion System for the Gemini Agena Target Vehicle. Use this for regular Agena-D missions too.
 	@mass = 0.132
 	@MODULE[ModuleEngines*]
@@ -788,7 +788,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.2092719, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.466487, 0.0, 0.0, -1.0, 0.0, 1
-	@title = RS-88 [1.5m]
+	@title = RS-88 [1.5 m]
 	%manufacturer = Rocketdyne
 	@description = Smaller Ethanol75/LOX fueled engine, slated for use with the Boeing CST-100.
 	@mass = 0.250
@@ -881,7 +881,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.5201485, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.5784716, 0.0, 0.0, -1.0, 0.0, 2
-	@title = J-2T-200/250K Aerospike [2.5m]
+	@title = J-2T-200/250K Aerospike [2.5 m]
 	%manufacturer = Rocketdyne
 	@description = Using proven technology from the J-2 and introducing an aerospike nozzle to the developing J-2S machinery.
 	@attachRules = 1,0,1,0,0
@@ -999,7 +999,7 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.5193721, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -1.83345, 0.0, 0.0, -1.0, 0.0, 3
-	@title = RL60 [1.5m]
+	@title = RL60 [1.5 m]
 	%manufacturer = Pratt & Whitney
 	@description = Next generation cryogenic upper stage engine designed to replace the RL10, providing higher performance while maintaining the same installation envelope.  Also available in a lower 180kN thrust Vinci-180 model.
 	@attachRules = 1,0,1,0,0
@@ -1127,7 +1127,7 @@
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = TR-201 [1.75m]
+	@title = TR-201 [1.75 m]
 	%manufacturer = TRW
 	@description = A derivative of the Lunar Module Descent Engine, the TR-201 powered the Delta-P upper stage. 77 launches, 0 failures.
 	@MODULE[ModuleEngines*]
@@ -1326,7 +1326,7 @@
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = S5.92/98M [2.25m]
+	@title = S5.92/98M [2.25 m]
 	%manufacturer = KB KhIMMASH
 	@description = The S5.92/98M are used in the Briz-M and Fregat upper stages using storable propellant.
 	@MODULE[ModuleEngines*]
@@ -1565,7 +1565,7 @@
 	@node_stack_bottom = 0.0, -3.0, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.136376, 0.0, 0.0, 1.0, 0
-	@title = Castor IVAXL
+	@title = Castor IVAXL [1.0 m]
 	%manufacturer = Thiokol (ATK)
 	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads. Slightly larger than it's siblings produces a bit more thrust.
 	@mass = 1.871069
@@ -1697,7 +1697,7 @@
 	@node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.136376, 0.0, 0.0, 1.0, 0
-	@title = Castor IVA
+	@title = Castor IVA [1.0 m]
 	%manufacturer = Thiokol (ATK)
 	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads.
 	@mass = 1.565347
@@ -1821,7 +1821,7 @@
 	@node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 7
 	@node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 7
 	@node_attach = 0.0, 0.0, -0.36, 0.0, 0.0, 1.0, 0
-	@title = AJ-260 HL
+	@title = AJ-260 HL [6.55 m]
 	%manufacturer = Aerojet
 	@description = The largest solid rocket motor ever designed, intended for uprated Saturn and Nova applications.  Half-length version, burn time 114s or 140s.
 	@mass = 85.321
@@ -1926,7 +1926,7 @@
 	@node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 7
 	@node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 7
 	@node_attach = 0.0, 0.0, -0.216, 0.0, 0.0, 1.0, 0
-	@title = AJ-260 FL
+	@title = AJ-260 FL [6.55 m]
 	%manufacturer = Aerojet
 	@description = The largest solid rocket motor ever designed, intended for uprated Saturn and Nova applications.  Full-length version, burn time 140s.
 	@mass = 156.126
@@ -2003,7 +2003,7 @@
 	@node_stack_bottom = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 0.4895, 0.0, 0.0, 1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.4826, 0.0, 0.0, 1.0, 0
-	@title = Orion 38
+	@title = Orion 38 [0.95 m]
 	%manufacturer = ATK
 	@description = A small booster developed as a low-cost, high performance third stage for the Pegasus XL, Taurus, Taurus XL, and Taurus Lite Launch Vehicles.
 	@mass = 0.09344
@@ -2162,7 +2162,7 @@
 	@node_stack_bottom = 0.0, -1.635, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 0.982, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.63754, 0.0, 0.0, 1.0, 1
-	@title = Orion 50
+	@title = Orion 50 [1.25 m]
 	%manufacturer = ATK
 	@description = A small booster developed as a low-cost, high performance second stage for the Pegasus Launch Vehicle.
 	@mass = 0.3039

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -20,7 +20,7 @@
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.9985625, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-	%title = RL10 Series Vacuum Engine [1.5m]
+	%title = RL10 Series Vacuum Engine [1.5 m]
 	%manufacturer = Pratt & Whitney
 	%description = Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators.
 	%attachRules = 1,1,1,1,0
@@ -434,7 +434,7 @@
 	@node_stack_top = 0.0, 0.2135562, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.1872844, 0.0, 0.0, -1.0, 0.0, 1
 	@category = Propulsion
-	@title = NSTAR Ion Engine
+	@title = NSTAR Ion Engine [0.6 m]
 	@manufacturer = L-3 Electron Industries
 	@description = Small lighter weight efficient engine, takes a bit of power though, and doesn't provide much force.
 	@mass = 0.0495
@@ -528,7 +528,7 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 1.3707759, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.3820657, 0.0, 0.0, -1.0, 0.0, 2
-	@title = LR105 Series Sustainer [1.5m]
+	@title = LR105 Series Sustainer [1.5 m]
 	@manufacturer = Rocketdyne
 	@description = Kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s) are lit on the ground, but after a bit over 2 minutes' flight the boosters are dropped and the Atlas core continues to orbit under the power of the sustainer engine (and the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for increased performance. As a sustainer engine, the LR105 has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine.
 	@attachRules = 1,0,1,0,0
@@ -728,7 +728,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.7350625, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.332244, 0.0, 0.0, -1.0, 0.0, 2
-	@title = LR79/H-1/RS-27 Series Booster [1.0m]
+	@title = LR79/H-1/RS-27 Series Booster [1.0 m]
 	@description = Long-lasting US Kerolox gas-generator booster engine. The same components and broadly the same performance as the LR89, the LR79 (also known as S-3D in Jupiter / Juno II) powered Jupiter, Thor, and Thor-Delta (Delta) rockets. An upgrade to it was named H-1 and that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The LR79/H-1/RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters and the core burns rather longer.
 	@attachRules = 1,0,1,0,0
 	@mass = 0.907
@@ -1053,7 +1053,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.7196156, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.3042473, 0.0, 0.0, -1.0, 0.0, 2
-	@title = LR89 Series Booster [1m]
+	@title = LR89 Series Booster [1.0 m]
 	@manufacturer = Rocketdyne
 	@description = Kerolox gas-generator engine that served as booster for Atlas. Late model LR89s were upgraded with RS-27 components for higher efficiency. Very similar to LR79 (this was the pure-booster variant).
 	@attachRules = 1,0,1,0,0
@@ -1248,7 +1248,7 @@
 	@node_stack_top = 0.0, 1.172374125, 0.0, 0.0, 1.0, 0.0, 1
 	%node_attach = 0.0, 1.172374125, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.93329925, 0.0, 0.0, -1.0, 0.0, 1
-	@title = S1.5400/RD-58 Vacuum Engine Series [2m]
+	@title = S1.5400/RD-58 Vacuum Engine Series [2.0 m]
 	@manufacturer = RKK Energiya
 	@description = World's first closed-cycle kerolox vacuum engine. The S1.5400 served as an R-7 upper stage and the RD-58 (an upgrade) as upper stage / OMS for many Soviet and Russian launchers and spacecraft (Proton, N1, Zenit, Buran...). The S1.5400 was designed for the Blok L stage which was the final stage for the Molniya configuration of the R-7, used to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (this was needed to perform apogee kick to place Molniya satellites in their final orbits). It was given the industry designation 11D33. An upgraded version, termed 11D33M, had slightly improved performance. The RD-58 is a derivative of the 11D33M engine with higher performance (industry designation 11D58); it has been used on many Russian launchers and is still in use today on Proton and Zenit. In comparison to hydrolox upper stages, kerolox ones do not suffer boiloff as badly and need far less volume (kerosene being far denser than liquid hydrogen), but have much lower specific impulse.
 	@attachRules = 1,1,1,0,0
@@ -1468,7 +1468,7 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 0.8723286, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.88252272, 0.0, 0.0, -1.0, 0.0, 2
-	%title = LM Descent Engine [1.5m]
+	%title = LM Descent Engine [1.5 m]
 	%manufacturer = TRW
 	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability.
 	%attachRules = 1,0,1,0,0
@@ -1631,7 +1631,7 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 0.432996, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.756502, 0.0, 0.0, -1.0, 0.0, 2
-	%title = RD-0105/0109 (Blok E) [2m]
+	%title = RD-0105/0109 (Blok E) [2.0 m]
 	%manufacturer = KB Khimavtomatiki (Kosberg)
 	%description = Kerolox gas generator vacuum engine which served in R-7 upper stages (Luna, Vostok). The RD-0105 was designed for Luna launches; it was the first upper stage for the R-7 series and was reused for uncrewed Vostok tests. An enhanced version, the RD-0109, was used for crewed Vostok launches.
 	%attachRules = 1,0,1,0,0
@@ -1758,7 +1758,7 @@
 	}
 	!mesh = DELETE
 	!MODEL {}
-	%title = LM Ascent Engine [1.4m]
+	%title = LM Ascent Engine [1.4 m]
 	%manufacturer = Bell
 	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander.
 	MODEL
@@ -1905,9 +1905,9 @@
 	%node_attach = 0.0, 0.016, 0.01, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -2.93, 0.0, 0.0, -1.0, 0.0, 3
 	%attachRules = 1,1,1,0,0
-	@title = AJ10-137 (Service Propulsion System)
+	@title = AJ10-137 (SPS) [3.9 m]
 	%manufacturer = Aerojet
-	@description = The Aerojet AJ10-137 rocket engine used on the Apollo Service Module as the Service Propulsion System.
+	@description = The Aerojet AJ10-137 rocket engine used on the Apollo Service Module as the Service Propulsion System (SPS).
 	@mass = 0.650
 	@maxTemp = 1973.15
 	!MODULE[ModuleEngineConfigs] {}
@@ -2023,7 +2023,7 @@
 	%node_stack_top = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
 	%node_attach = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -0.08432, 0.0, 0.0, -1.0, 0.0, 0
-	%title = Aerobee Sustainer [0.3m]
+	%title = Aerobee Sustainer [0.3 m]
 	%manufacturer = Aerojet
 	%description = Small sustainer for WAC Corporal, Aerobee sounding rockets. Pressure-fed. Used after a small solid booster.
 	%attachRules = 1,1,1,0,0
@@ -2228,7 +2228,7 @@
 	%node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 	%node_attach = 0.0, 0.0, 0.1, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -0.11091152, 0.0, 0.0, -1.0, 0.0, 0
-	%title = Aerobee Sustainer [0.3M]
+	%title = Aerobee Sustainer [0.3 m]
 }
 @PART[nuclearEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
@@ -2364,7 +2364,7 @@
 	}
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@title = AJ10-190
+	@title = AJ10-190 [Radial]
 	@manufacturer = Aerojet
 	@description = Aerojet AJ10-190 as found on the Space Shuttle Orbital Manoeuvring System (OMS)
 	@mass = 0.118
@@ -2436,7 +2436,7 @@
 	{
 	}
 	
-	@title = LR101 Vernier
+	@title = LR101 Vernier [Radial]
 	%manufacturer = Rocketdyne
 	@description = Pump or pressure-fed kerolox vernier engine. Used for attitude control and final velocity adjustment in conjunction with S-3D (LR79) on Thor and Jupiter, and in the MA-x system (2x LR89 + LR105 + 2x LR101) on Atlas, and MB-x system (LR79 or RS-27 + 2xLR101) on Thor-Able / Thor-Agena / Thor-Delta / Delta.
 	%attachRules = 0,1,0,0,0
@@ -2617,7 +2617,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RD-855
+	%title = RD-855 [Radial]
 	%manufacturer = KB Yuzhnoye
 	%description = Vernier thruster used on the first stage of the Tsyklon rocket.
 	%attachRules = 1,1,1,0,0
@@ -2767,7 +2767,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = RD-856
+	%title = RD-856 [Radial]
 	%manufacturer = KB Yuzhnoye
 	%description = Vernier thruster used on the second stage of the Tsyklon rocket.
 	%attachRules = 1,1,1,0,0
@@ -2862,7 +2862,7 @@
 	@node_stack_bottom = 0.0, -3.294453, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 2.699947, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
-	@title = Castor 30XL SRM [92"]
+	@title = Castor 30XL Vacuum Motor [2.34 m]
 	@manufacturer = Thiokol (ATK)
 	@description = The Castor 30XL is an enlarged Castor 30. Designed for the second stage of the Antares launcher.
 	@attachRules = 1,1,1,1,0
@@ -3079,7 +3079,7 @@
 	@node_stack_bottom = 0.0, -4.494219107637, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 4.522782865317, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1811, 0.0, 0.0, 1.0
-	@title = Castor 120 SRM [92"]
+	@title = Castor 120 Booster SRM [2.34 m]
 	@manufacturer = Thiokol (ATK)
 	@description = The Castor 120 is a medium solid booster used on the Minotaur and Athena launch vehicles. Its design was based on the TU-903, which serves as the first stage of the Peacekeeper ICBM. Burn time 79 s.
 	@attachRules = 1,1,1,1,0
@@ -3241,7 +3241,7 @@
 	@node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 2
 	@mass = 1.4
 	@maxTemp = 1973.15
-	@title = J-2T-200/250K Aerospike [2.5m]
+	@title = J-2T-200/250K Aerospike [2.5 m]
 	@manufacturer = Rocketdyne
 	@description = Using proven technology from the J-2 and introducing an aerospike nozzle to the developing J-2S machinery.
 	@attachRules = 1,0,1,0,0
@@ -3417,7 +3417,7 @@
 	@node_stack_bottom = 0.0, -1.002142, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 1.00352, 0.0, 0.0, 1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.2193544, 0.0, 0.0, 1.0, 0
-	@title = Altair Solid Kick Motor
+	@title = Altair Solid Kick Motor [0.45 m]
 	@manufacturer = Allegany Ballistics Laboratory
 	@description = A small solid kick motor. Developed for Vanguard's third stage but, with the second stage, reused as Able/Delta. Used to circularize at apogee or perform final payload kick.
 	@mass = 0.03
@@ -3500,7 +3500,7 @@
 	@node_stack_bottom = 0.0, -1.5, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 1.03125, 0.0, 0.0, 1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.4, 0.0, 0.0, 1.0, 0
-	@title = Altair II Solid Kick Motor
+	@title = Altair II Solid Kick Motor [0.65 m]
 	@manufacturer = Allegany Ballistics Laboratory
 	@description = A small solid kick motor. Developed from the Altair, this successor was used on Scout and Delta. Used to circularize at apogee or perform final payload kick. Maximum thrust 26.4kN, burn time 28 seconds.
 	@mass = 0.037
@@ -3631,7 +3631,7 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 0.9, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.513004, 0.0, 0.0, -1.0, 0.0, 2
-	%title = KVD-1/CE-7.5 Vacuum Engine
+	%title = KVD-1/CE-7.5 Vacuum Engine [2.5 m]
 	%manufacturer = KB Khimavtomatiki (Kosberg) / ISRO
 	%description = Staged combustion hydrolox upper stage engine intended for use on the N-1M and considered for use on Proton and Angara, eventually licensed to India for its GSLV MkI and MkII.  Later versions were developed by India for domestic use on the as the CE-7.5.  The main engine bell is fixed in place, and two verniers are used to provide combined pitch-yaw-roll control; this leads to lower control authority than on stages where the main engine can gimbal.  This engine runs with a somewhat higher than average O/F ratio, resulting in a denser than average hydrolox stage.
 	%attachRules = 1,1,1,1,0
@@ -3892,7 +3892,7 @@
 	@node_stack_bottom = 0.0, -1.0838, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 0.7451125, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.625, 0.0, 0.0, 1.0, 1
-	@title = Star 48B Kick Motor (Short Nozzle)
+	@title = Star 48B (PAM-B) Solid Kick Motor [1.3 m]
 	@manufacturer = Thiokol
 	@description = Also known as the Payload Assistance Module (PAM) B, this kick motor was used for Delta and STS launches to add extra impulse to the payload. This is the short-nozzle version. Maximum thrust 76.11kN, burn time 85 seconds.
 	@mass = 0.12 // averaged initial and burnout dry mass

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -71,9 +71,9 @@
 	@node_stack_top = 0.0, 23.671403085430272, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -23.691976914812928, 0.0, 0.0, -1.0, 0.0, 3
 	@node_attach = 0.0, 0.0, -1.8838672, 0.0, 0.0, 1.0	
-	@title = 5-Segment RSRM
-	%manufacturer = ATK L.S.G
-	@description = ATK Launch Systems Group. An increased length Space Shuttle SRB by adding a full segment, originally developed for the Ares I as the first stage and as strap-on boosters for the Ares V.  Now that Ares has been cancelled ATK is continuing development for the Space Launch System. Nose Cone 6.50662m tall.
+	@title = RSRMV [3.6 m]
+	%manufacturer = Oribital ATK
+	@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
 	@mass = 85.4187
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
@@ -315,9 +315,9 @@
 	@node_attach = 2.7432, 0.0, 0.0, 1.0, 0.0, 0.0
 	@mass = 33.565836
 	@maxTemp = 1973.15
-	@title = Pyrios Booster
+	@title = Pyrios Booster [5.5 m]
 	%manufacturer = Dynetics
-	@description = An eighteen (18') foot diameter liquid fuel booster employing two (2) F-1B series engines built for cost efficiency. Dynetics teaming with Pratt & Whitney Rocketdyne.
+	@description = An 18-foot diameter liquid fuel booster employing two F-1B engines built for cost efficiency. Dynetics teaming with Pratt & Whitney Rocketdyne.
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -438,7 +438,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 2.144171975, 0.0, 0.0, 1.0, 0.0, 5
 	@node_stack_bottom = 0.0, -3.655633993, 0.0, 0.0, -1.0, 0.0, 5
-	@title = F-1 [5.5m]
+	@title = F-1 [5.5 m]
 	@manufacturer = Rocketdyne
 	@description = The massive Rocketdyne F-1 engine. One of the largest, most powerful rocket engines ever built.
 	@mass = 8.391459
@@ -584,9 +584,9 @@
 	%node_stack_bottom = 0.0, -5.9685, 0.0, 0.0, -1.0, 0.0, 8
 	@mass = 19.062	// 12.708
 	@maxTemp = 1973.15
-	@title = RS-25D/E (Four) [8.4m]
+	@title = RS-25D/E (Four) [8.4 m]
 	@manufacturer = Rocketdyne
-	@description = Engine core for the Space Launch System (SLS). Features four (4) Rocketdyne RS-25D/E engines.
+	@description = Engine core for the Space Launch System (SLS). Features four Rocketdyne RS-25D/E engines.
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 5601.2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
@@ -34,7 +34,7 @@
 	@cost = 800
 	@TechRequired = start
 	@entryCost = 0
-	@title = M55 (Minuteman) Solid Rocket Motor
+	@title = M55 (Minuteman) Solid Rocket Motor [1.7 m]
 	@manufacturer = Thiokol
 	@description = First stage of the Minuteman ICBM, used in various proposed NASA launch vehicles as a solid booster.
 	@mass = 2.292

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StarShineIndustries/RO_StarShine_MerlinPack.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StarShineIndustries/RO_StarShine_MerlinPack.cfg
@@ -10,7 +10,7 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_bottom = 0.0, -.75, 0.0, 0.0, -1.0, 0.0, 1
-	%title = Merlin 1D Booster Engine
+	%title = Merlin 1D Booster [1.05 m]
 	%manufacturer = SpaceX
 	%description = Gas generator engine used on the first stage of the Falcon 9.
 	%mass = 0.517
@@ -137,7 +137,7 @@
 	%rescaleFactor = 1.5
 	%node_stack_top = 0.0, 1.05, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.75, 0.0, 0.0, -1.0, 0.0, 2
-	%title = Merlin 1D Vacuum Engine
+	%title = Merlin 1D Vacuum Engine [1.5 m]
 	%manufacturer = SpaceX
 	%description = Gas generator vacuum engine used on the second stage of the Falcon 9.
 	%mass = 0.760


### PR DESCRIPTION
Added size of upper node of engines where missing and added spaces between the number and unit symbol per SI usage guides.