### PR TITLE
RN remove molniya rcs fuel

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Molniya_Luna9_Luna10.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Molniya_Luna9_Luna10.cfg
@@ -107,32 +107,20 @@
 		amount = 15000
 		maxAmount = 15000
 	}
-	TANK
-	{
-		name = Nitrogen
-		amount = 13000
-		maxAmount = 13000
 	}
-
-	}
-
-	MODULE
+	
+	@MODULE[ModuleReactionWheel]
 	{
-		name = ModuleRCSFX
-		thrusterTransformName = RCSthruster
-		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.26
-		PROPELLANT
+		@PitchTorque = 0.02
+		@YawTorque = 0.02
+		@RollTorque = 0.02
+	
+		@RESOURCE[ElectricCharge]
 		{
-			name = Nitrogen
-			ratio = 1.0
-		}
-		atmosphereCurve
-		{
-			key = 0 65
-			key = 1 5
+			@rate = 0.1
 		}
 	}
+
 }
 
 


### PR DESCRIPTION
fix molniya, it has no rcs thrust transforms it uses RW, so the rcs fuel
and module are useless