### PR TITLE
Added Cygnus/e mass values.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Cygnus.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Cygnus.cfg
@@ -8,6 +8,7 @@
 	%scale = 1.0
 	@rescaleFactor = 1.0
 	@maxTemp = 1973.15
+	@mass = 1.45
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -254,6 +255,7 @@
 	%scale = 1.0
 	@rescaleFactor = 1.0
 	@maxTemp = 1973.15
+	@mass = 1.73
 	!MODULE[ModuleReactionWheel]
 	{
 	}


### PR DESCRIPTION
Mass was previously 4kg dry weight for both Cygnus spacecraft. Added real values.