### PR TITLE
Cygnus/Cygnus_E mass value correction

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Cygnus.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Cygnus.cfg
@@ -8,6 +8,7 @@
 	%scale = 1.0
 	@rescaleFactor = 1.0
 	@maxTemp = 1973.15
+	@mass = 1.45
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -179,7 +180,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = BT-4
-		origMass = 0.004
+		origMass = 1.45
 		modded = false
 		CONFIG
 		{
@@ -254,6 +255,7 @@
 	%scale = 1.0
 	@rescaleFactor = 1.0
 	@maxTemp = 1973.15
+	@mass = 1.73
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -424,7 +426,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = BT-4
-		origMass = 0.004
+		origMass = 1.73
 		modded = false
 		CONFIG
 		{


### PR DESCRIPTION
Prior mass values were 4kg! The weight of one BT-4 Engine. This was a copy from the moduleengineconfigs. This has been corrected to the true mass of these spacecraft.