### PR TITLE
LR-89 Ignition fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1079,12 +1079,43 @@
 			@name = LqdOxygen
 			@ratio = 0.618
 		}
-		ullage = True
-		ignitions = 1
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
 			amount = 0.5
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 3.82
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 6.18
+		}
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 3.82
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 6.18
 		}
 	}
 	@MODULE[ModuleGimbal]


### PR DESCRIPTION
Some smart person(s) pointed out earlier in the week that this engine was failing to light on the pad. This appears to fix that.