### PR TITLE
RN launchers fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon_Adapters.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon_Adapters.cfg
@@ -11,6 +11,9 @@
 	!MODULE[ModuleFairingDecoupler]
 	{
 	}
+	!MODULE[AeroHider]
+	{
+	}
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 4
@@ -61,6 +64,9 @@
 	@title = Falcon 1e Fairing
 	@manufacturer = SpaceX
 	!MODULE[ModuleFairingDecoupler]
+	{
+	}
+	!MODULE[AeroHider]
 	{
 	}
 	@MODULE[ModuleEngines*]


### PR DESCRIPTION
Removed module from fairing not needed if has FAR