### PR TITLE
Rename parts post-RLA update. Reassign some engines

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Engine.cfg
@@ -1,4 +1,4 @@
-@PART[RLA_arcjet]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RLA EE-A-05 Arcjet Thruster
+@PART[RLA_small_arcjet]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RLA EE-A-05 Arcjet Thruster
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -7,7 +7,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/ec_arcjet/model
+		model = RLA_Stockalike/Parts/Engine/ec_small_arcjet/model
 		scale = 0.2, 0.36, 0.2
 	}
 	@scale = 0.36
@@ -16,25 +16,20 @@
 	@node_stack_bottom = 0.0, -0.3119931, 0.0, 0.0, -1.0, 0.0, 0
 	%node_attach = 0.0, 0.3069868, 0.0, 0.0, 1.0, 0.0, 0
 	@attachRules = 1,1,1,0,0
-	@title = Alta XR-150 ResistoJet [0.125 m]
-	%manufacturer = Alta
-	@description = Small, lightweight, low force propulsion unit
-	@mass = 0.000220
+	@title = MR-510 Arcjet [0.125 m]
+	%manufacturer = Aerojet
+	@description = Small, lightweight, low force propulsion unit. Efficient but very power hungry.
+	@mass = 0.00158
 	@crashTolerance = 12
 	@maxTemp = 1973.15
-	!MODULE[MultiModeEngine]
+	@MODULE[ModuleEngines*] //http://soliton.ae.gatech.edu/people/jseitzma/classes/ae6450/electrothermal_thrusters.pdf
 	{
-	}
-	!MODULE[ModuleEnginesFX],0
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 0.000100
-		@maxThrust = 0.000100
+		@minThrust = 0.000235
+		@maxThrust = 0.000235
 		@heatProduction = 0
 		@PROPELLANT[XenonGas]
 		{
+			@name = Hydrazine
 			@ratio = 1.0
 		}
 		!PROPELLANT[ElectricCharge]
@@ -42,7 +37,7 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 58
+			@key,0 = 0 585
 			key = 1 1
 		}
 	}
@@ -51,40 +46,58 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		configuration = XR50Xenon
+		configuration = MR-510-Hydrazine
 		CONFIG
 		{
-			name = XR50Xenon
-			minThrust = 0.000100
-			maxThrust = 0.000250
+			name = MR-510-Hydrazine
+			minThrust = 0.000235
+			maxThrust = 0.000235
 			heatProduction = 0
 			PROPELLANT
 			{
-				name = XenonGas
+				name = Hydrazine
 				ratio = 1.0
 				DrawGauge = True
 			}
 			atmosphereCurve
 			{
-				key = 0 58
+				key = 0 585
 				key = 1 1
 			}
 		}
 		CONFIG
 		{
-			name = XR50Argon
-			minThrust = 0.000100
-			maxThrust = 0.000100
+			name = MR-510-Ammonia
+			minThrust = 0.000235
+			maxThrust = 0.000235
 			heatProduction = 0
 			PROPELLANT
 			{
-				name = ArgonGas
+				name = LqdAmmonia
 				ratio = 1.0
 				DrawGauge = True
 			}
 			atmosphereCurve
 			{
-				key = 0 90
+				key = 0 800
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			name = MR-510-Hydrogen
+			minThrust = 0.000235
+			maxThrust = 0.000235
+			heatProduction = 0
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 2000
 				key = 1 1
 			}
 		}
@@ -95,11 +108,11 @@
 		RESOURCE
 		{
 			name = ElectricCharge
-			rate = -0.095
+			rate = -2.15
 		}
 	}
 }
-@PART[RLA_ion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RLA EE-I-05 Ion Thruster
+@PART[RLA_small_ion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RLA EE-I-05 Ion Thruster
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -108,7 +121,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/ec_ion/model
+		model = RLA_Stockalike/Parts/Engine/ec_small_ion/model
 		scale = 0.625, 0.625, 0.625
 	}
 	@scale = 0.625
@@ -176,7 +189,7 @@
 		}
 	}
 }
-@PART[RLA_resistojet]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RLA EE-R-05 Resistojet Thruster
+@PART[RLA_small_resistojet]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RLA EE-R-05 Resistojet Thruster
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -185,99 +198,130 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/ec_resistojet/model
-		scale = 1.0, 1.0, 1.0
+		model = RLA_Stockalike/Parts/Engine/ec_small_resistojet/model
+		scale = 1.9, 1.9, 1.9
 	}
-	@scale = 1.0
+	@scale = 1.9
 	@rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.2873363, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_top = 0.0, -0.0294343, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -0.6544343, 0.0, 0.0, -1.0, 0.0, 0
 	%node_attach = 0.0, -0.0294343, 0.0, 0.0, 1.0, 0.0, 0
-	@title = R-4D-11 [0.625 m]
-	%manufacturer = Aerojet (GenCorp)
-	@description = Nice R-4D-11 490N thrusters as found as the main propulsion of the ESA ATV, and used as various other control thrusters on numerous vehicles.
-	@attachRules = 1,1,1,0,0
-	@mass = 0.00363
+	@mass = 0.075
 	@crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
 	@maxTemp = 1973.15
-	!MODULE[MultiModeEngine]
-	{
-	}
-	!MODULE[ModuleEnginesFX],0
-	{
-	}
+	@title = S5.92/98M [2.25 m]
+	%manufacturer = KB KhIMMASH
+	@description = The S5.92/98M are used in the Briz-M and Fregat upper stages using storable propellant.
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 0.490
-		@maxThrust = 0.490
+		@minThrust = 19.6
+		@maxThrust = 19.6
 		@heatProduction = 100
-		@PROPELLANT[ElectricCharge]
+		@PROPELLANT[MonoPropellant]
 		{
-			@name = MMH
-			@ratio = 0.50
+			@name = UDMH
+			@ratio = 0.478
+			!resourceFlowMode = DELETE
 		}
-		@PROPELLANT[XenonGas]
+		PROPELLANT
 		{
-			@name = NTO
-			@ratio = 0.50
+			name = NTO
+			ratio = 0.522
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 312
-			key = 1 150
+			@key,0 = 0 327
+			@key,1 = 1 150
 		}
 		%ullage = True
-		%pressureFed = True
-		%ignitions = -1
+		%pressureFed = False
+		%ignitions = 20
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
-			name = MMH
-			amount = 0.50
+			name = UDMH
+			amount = 0.478
 		}
 		IGNITOR_RESOURCE
 		{
 			name = NTO
-			amount = 0.50
+			amount = 0.522
 		}
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
-			amount = 0.046
+			amount = 1.0
 		}
+	}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 5.0
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
 	}
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = R-4D-11
+		configuration = S5.92
+		origMass = 0.075
 		modded = false
 		CONFIG
 		{
-			name = R-4D-11
-			minThrust = 0.490
-			maxThrust = 0.490
+			name = S5.92
+			minThrust = 19.6
+			maxThrust = 19.6
 			heatProduction = 100
 			PROPELLANT
 			{
-				name = MMH
-				ratio = 0.50
+				name = UDMH
+				ratio = 0.478
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.50
+				ratio = 0.522
 			}
 			atmosphereCurve
 			{
-				key = 0 312
+				key = 0 327
 				key = 1 150
 			}
+			massMult = 1.0
+		}
+		CONFIG
+		{
+			name = S5.98M
+			minThrust = 19.62
+			maxThrust = 19.62
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.478
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.522
+			}
+			atmosphereCurve
+			{
+				key = 0 326
+				key = 1 150
+			}
+			massMult = 1.267
 		}
 	}
 }
-@PART[RLA_lfo_m_linearspike]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Rockomax "Cutter" Linear Aerospike Rocket
+
+@PART[RLA_lfo_medium_linearspike]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Rockomax "Cutter" Linear Aerospike Rocket
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -286,24 +330,24 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/lfo_m_linearspike/model
+		model = RLA_Stockalike/Parts/Engine/lfo_medium_linearspike/model
 		scale = 2.0, 2.0, 2.0
 	}
 	@scale = 2.0
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.3462526, 0.0, 0.0, 1.0, 0.0, 2
-	@mass = 1.5
+	@mass = 3.5 // TWR approx 35, aerospike engines are heavy! http://www.flightglobal.com/pdfarchive/view/1998/1998%20-%203141.html
 	@crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = RS-2200 [2.5 m]
+	@title = XRS-2200 [2.5 m]
 	%manufacturer = Rocketdyne
-	@description = Linear aerospike production engine following the XRS-2200 and X-33.
-	@MODULE[ModuleEngines*]
+	@description = A linear aerospike engine developed for NASA's X-33 sub-scale SSTO technology demonstrator. Like the toroidal J-2T engines, the XRS-2200 used machinery derived from the J-2S.
+	@MODULE[ModuleEngines*] // http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20020017580.pdf
 	{
-		@minThrust = 440.2
-		@maxThrust = 2201
+		@minThrust = 593
+		@maxThrust = 1185
 		@heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
@@ -317,8 +361,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 455
-			@key,1 = 1 347
+			@key,0 = 0 439
+			@key,1 = 1 336.5
 		}
 		%ullage = True
 		%pressureFed = False
@@ -340,24 +384,27 @@
 			amount = 1.0
 		}
 	}
-	@MODULE[ModuleGimbal]
+	@MODULE[ModuleGimbal] // Would have used differential throttle for control
 	{
 		%gimbalTransformName = thrustTransform
 		%gimbalRange = 5.0
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}
+	!MODULE[ModuleAlternator]
+	{
+	}
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = RS-2200
+		configuration = XRS-2200
 		modded = false
 		CONFIG
 		{
-			name = RS-2200
-			minThrust = 440.2
-			maxThrust = 2201
+			name = XRS-2200
+			minThrust = 593
+			maxThrust = 1185
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -372,13 +419,13 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 455
-				key = 1 347
+				key = 0 439
+				key = 1 336.5
 			}
 		}
 	}
 }
-@PART[RLA_s_highengine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Rockomax "Spinnaker" Liquid Engine
+@PART[RLA_small_highthrust]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Rockomax "Spinnaker" Liquid Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -387,7 +434,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/lfo_s_highengine/model
+		model = RLA_Stockalike/Parts/Engine/lfo_small_highthrust/small_highthrust
 		scale = 3.75, 3.333, 3.75
 	}
 	@scale = 3.333
@@ -508,7 +555,7 @@
 		}
 	}
 }
-@PART[RLA_s_lowengine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // LV-T5 Liquid Fuel Engine
+@PART[RLA_tiny_vac]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // LV-0 "Aphid" Liquid Fuel Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -517,263 +564,140 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/lfo_s_lowengine/model
-		scale = 3.92, 5.825, 3.92
+		model = RLA_Stockalike/Parts/Engine/lfo_tiny_vac/tiny_vac
+		scale = 2.88, 2.88, 2.88
 	}
-	@scale = 5.825
+	nodeScaleX = 2.88
+	nodeScaleY = 2.88
+	nodeScaleZ = 2.88
+	@scale = 1
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.11, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -0.2277572, 0.0, 0.0, -1.0, 0.0, 2
-	@mass = 0.566
+	@title = R-4D-11 [0.46 m]
+	%manufacturer = Aerojet (GenCorp)
+	@description = 490N thrusters as found as the main propulsion of the ESA ATV, and used as various other control thrusters on numerous vehicles.
+	@attachRules = 1,1,1,0,0
+	@mass = 0.00363
 	@crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = RD-0210/0213 [2.0 m]
-	%manufacturer = KB Khimavtomatika
-	@description = A series of engines found on the second and third stages of the Proton series launcher. While the four installed second stage engines gimbal, the single third stage does not.
+	!MODULE[MultiModeEngine]
+	{
+	}
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 582.1
-		@maxThrust = 582.1
+		@minThrust = 0.490
+		@maxThrust = 0.490
 		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
+		@PROPELLANT[ElectricCharge]
 		{
-			@name = UDMH
-			@ratio = 0.413
+			@name = MMH
+			@ratio = 0.50
 		}
-		@PROPELLANT[Oxidizer]
+		@PROPELLANT[MonoPropellant]
 		{
 			@name = NTO
-			@ratio = 0.587
+			@ratio = 0.50
+			!resourceFlowMode = DELETE
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 327
-			@key,1 = 1 225
+			@key,0 = 0 312
+			key = 1 150
 		}
 		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
+		%pressureFed = True
+		%ignitions = -1
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
-			name = UDMH
-			amount = 0.413
+			name = MMH
+			amount = 0.50
 		}
 		IGNITOR_RESOURCE
 		{
 			name = NTO
-			amount = 0.587
+			amount = 0.50
 		}
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
-			amount = 1.0
+			amount = 0.046
 		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 5.0
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
 	}
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = RD-0210
+		configuration = R-4D-11
 		modded = false
 		CONFIG
 		{
-			name = RD-0210
-			minThrust = 582.1
-			maxThrust = 582.1
+			name = R-4D-11
+			minThrust = 0.490
+			maxThrust = 0.490
 			heatProduction = 100
 			PROPELLANT
 			{
-				name = UDMH
-				ratio = 0.413
+				name = MMH
+				ratio = 0.50
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.587
+				ratio = 0.50
 			}
 			atmosphereCurve
 			{
-				key = 0 327
-				key = 1 225
+				key = 0 312
+				key = 1 150
 			}
 		}
 	}
+
+	stack_top0 = #$node_stack_top[0]$
+	stack_top1 = #$node_stack_top[1]$
+	stack_top2 = #$node_stack_top[2]$
+	@stack_top0 *= #$nodeScaleX$
+	@stack_top1 *= #$nodeScaleY$
+	@stack_top2 *= #$nodeScaleZ$
+	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,0
+	@node_stack_top = #$stack_top_new$
+	!stack_top0 = DEL
+	!stack_top1 = DEL
+	!stack_top2 = DEL
+	!stack_top_new = DEL
+	
+	stack_bottom0 = #$node_stack_bottom[0]$
+	stack_bottom1 = #$node_stack_bottom[1]$
+	stack_bottom2 = #$node_stack_bottom[2]$
+	@stack_bottom0 *= #$nodeScaleX$
+	@stack_bottom1 *= #$nodeScaleY$
+	@stack_bottom2 *= #$nodeScaleZ$
+	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,0
+	@node_stack_bottom = #$stack_bottom_new$
+	!stack_bottom0 = DEL
+	!stack_bottom1 = DEL
+	!stack_bottom2 = DEL
+	!stack_bottom_new = DEL
+	
+	attach0 = #$node_attach[0]$
+	attach1 = #$node_attach[1]$
+	attach2 = #$node_attach[2]$
+	@attach0 *= #$nodeScaleX$
+	@attach1 *= #$nodeScaleY$
+	@attach2 *= #$nodeScaleZ$
+	attach_new = #$attach0$,$attach1$,$attach2$,$node_attach[3]$,$node_attach[4]$,$node_attach[5]$,0
+	@node_attach = #$attach_new$
+	!attach0 = DEL
+	!attach1 = DEL
+	!attach2 = DEL
+	!attach_new = DEL
+	!nodeScaleX = DEL
+	!nodeScaleY = DEL
+	!nodeScaleZ = DEL
+
 }
-@PART[RLA_s_midengine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // TtH-2B "Kingfisher" Liquid Engine
-{
-	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	!mesh = DELETE
-	MODEL
-	{
-		model = RLA_Stockalike/Parts/Engine/lfo_s_midengine/model
-		scale = 3.0, 3.0, 3.0
-	}
-	@scale = 3.0
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.1364338, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -0.3957303, 0.0, 0.0, -1.0, 0.0, 2
-	@title = Bell 80XX [1.5 m]
-	@description = Primary Propulsion System for the Gemini Agena Target Vehicle. Use this for regular Agena-D missions too.
-	@mass = 0.132
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 71.2
-		@maxThrust = 71.2
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = UDMH
-			@ratio = 0.433
-			@DrawGauge = False
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = IRFNA-III
-			@ratio = 0.567
-			DrawGauge = True
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 291
-			@key,1 = 1 100
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 16
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.050
-		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		%gimbalRange = 5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleEngineConfigs]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = Bell-8247
-		modded = false
-		CONFIG
-		{
-			name = Bell-8048
-			maxThrust = 68.9
-			minThrust = 68.9
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.433
-			}
-			PROPELLANT
-			{
-				name = IRFNA-III
-				ratio = 0.567
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 276
-				key = 1 100
-			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-		}
-		CONFIG
-		{
-			name = Bell-8081
-			maxThrust = 71.2
-			minThrust = 71.2
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.433
-			}
-			PROPELLANT
-			{
-				name = IRFNA-III
-				ratio = 0.567
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 285
-				key = 1 100
-			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.2
-			}
-		}
-		CONFIG
-		{
-			name = Bell-8247
-			maxThrust = 71.2
-			minThrust = 71.2
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.433
-			}
-			PROPELLANT
-			{
-				name = IRFNA-III
-				ratio = 0.567
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 291
-				key = 1 100
-			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 16
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.050
-			}
-		}
-	}
-}
-@PART[RLA_s_nerva]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // LV-Nc Atomic Rocket Motor
+@PART[RLA_small_ntr]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // LV-Nc Atomic Rocket Motor
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -781,7 +705,7 @@
 	}
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/lfo_s_nerva/model
+		model = RLA_Stockalike/Parts/Engine/lf_small_ntr/smallntr
 		scale = 3.048, 1.443, 3.048
 	}
 	@scale = 1.443
@@ -865,7 +789,7 @@
 		}
 	}
 }
-@PART[RLA_mp_l_spike]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // TtKH-6B "Cormorant" Monopropellant Engine
+@PART[RLA_mp_large_spike]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // TtKH-6B "Cormorant" Monopropellant Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -874,7 +798,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/mp_l_spike/model
+		model = RLA_Stockalike/Parts/Engine/mp_large_spike/model
 		scale = 1.0, 1.0, 1.0
 	}
 	@scale = 1.0
@@ -983,7 +907,7 @@
 		}
 	}
 }
-@PART[RLA_mp_l_vac]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // TtK-6A "Albatross" Monopropellant Engine
+@PART[RLA_mp_large_vac]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // TtK-6A "Albatross" Monopropellant Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -992,7 +916,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/mp_l_vac/model
+		model = RLA_Stockalike/Parts/Engine/mp_large_vac/model
 		scale = 0.7, 1, 0.7
 	}
 	@scale = 1
@@ -1106,7 +1030,8 @@
 		}
 	}
 }
-@PART[RLA_mp_m_vac]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-45 Monopropellent Engine
+@PART[RLA_mp_medium_vac
+]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-45 Monopropellent Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1115,7 +1040,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/mp_m_vac/model
+		model = RLA_Stockalike/Parts/Engine/mp_medium_vac/model
 		scale = 1.4, 1.0, 1.4
 	}
 	@scale = 1.0
@@ -1208,7 +1133,7 @@
 		}
 	}
 }
-@PART[RLA_mp_rad]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-5R Monopropellent Engine
+@PART[RLA_mp_small_radial]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-5R Monopropellent Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1306,7 +1231,7 @@
 		}
 	}
 }
-@PART[RLA_mp_small]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-5 Monopropellent Engine
+//@PART[RLA_mp_small_stack]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-5 Monopropellent Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1314,19 +1239,17 @@
 	}
 	@MODEL
 	{
-		scale = 4.2, 4.681, 4.2
+		scale = 2.94, 3.277, 2.94
 	}
-	@scale = 4.681
+	@scale = 3.277
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.1463242, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -0.2298474, 0.0, 0.0, -1.0, 0.0, 2
 	@attachRules = 1,0,1,1,0
 	@mass = 0.075
 	@crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
 	@maxTemp = 1973.15
-	@title = S5.92/98M [2.25 m]
+	@title = S5.92/98M [0.625 m]
 	%manufacturer = KB KhIMMASH
 	@description = The S5.92/98M are used in the Briz-M and Fregat upper stages using storable propellant.
 	@MODULE[ModuleEngines*]
@@ -1433,7 +1356,7 @@
 		}
 	}
 }
-@PART[RLA_mp_t]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-1 Monopropellent Engine
+@PART[RLA_mp_tiny_stack]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-1 Monopropellent Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1446,9 +1369,9 @@
 	}
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.08650, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_bottom = 0.0, -0.117, 0.0, 0.0, -1.0, 0.0, 0
-	@node_attach = 0.0, 0.08650, 0.0, 0.0, 1.0, 0.0, 0
+	//@node_stack_top = 0.0, 0.08650, 0.0, 0.0, 1.0, 0.0, 0
+	//@node_stack_bottom = 0.0, -0.117, 0.0, 0.0, -1.0, 0.0, 0
+	//@node_attach = 0.0, 0.08650, 0.0, 0.0, 1.0, 0.0, 0
 	@attachRules = 1,1,1,0,0
 	@mass = 0.014
 	@crashTolerance = 12
@@ -1492,20 +1415,20 @@
 	useRcsCostMult = 0.25
 	useRcsMass = True
 }
-@PART[RLA_mp_tr]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-45 Monopropellent Engine
+@PART[RLA_mp_tiny_radial]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // MPR-45 Monopropellent Engine
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
 	{
 	}
-	!mesh = DELETE
-	@MODEL
-	{
-		@scale = 1.0, 1.0, 1.0
-	}
+	//!mesh = DELETE
+	//@MODEL
+	//{
+	//	@scale = 1.0, 1.0, 1.0
+	//}
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@node_attach = 0.0, 0.0, -0.12, 0.0, 0.0, 0.0, 0
+	//@node_attach = 0.0, 0.0, -0.12, 0.0, 0.0, 0.0, 0
 	@attachRules = 0,1,0,0,0
 	@mass = 0.014
 	@crashTolerance = 12
@@ -1550,7 +1473,7 @@
 	useRcsCostMult = 0.25
 	useRcsMass = True
 }
-@PART[RLA_solid_s_long]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Boostertron II Solid Rocket Booster
+@PART[RLA_solid_small_long]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Boostertron II Solid Rocket Booster
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1682,7 +1605,7 @@
 		}
 	}
 }
-@PART[RLA_solid_s_short]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Boostertron I Solid Rocket Booster
+@PART[RLA_solid_small_short]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // Boostertron I Solid Rocket Booster
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1810,7 +1733,7 @@
 		}
 	}
 }
-+PART[RLA_solid_s_short]:AFTER[RealismOverhaul]
++PART[RLA_solid_small_short]:AFTER[RealismOverhaul]
 {
 	@name = RO_RLA_AJ260_HL
 	@MODEL
@@ -1903,7 +1826,7 @@
 		gimbalResponseSpeed = 13
 	}
 }
-+PART[RLA_solid_s_short]:AFTER[RealismOverhaul]
++PART[RLA_solid_small_short]:AFTER[RealismOverhaul]
 {
 	@name = RO_RLA_AJ260_FL
 	@MODEL
@@ -1986,7 +1909,7 @@
 	}
 }
 
-@PART[RLA_solid_s_upper]:FOR[RealismOverhaul]
+//@PART[RLA_solid_s_upper]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -2145,7 +2068,7 @@
 		}	
 	}
 }
-@PART[RLA_solid_m_upper]:FOR[RealismOverhaul]
+@PART[RLA_solid_medium_upper]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -2154,7 +2077,7 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = RLA_Stockalike/Parts/Engine/solid_m_upper/model
+		model = RLA_Stockalike/Parts/Engine/solid_medium_upper/model
 		scale = 1.020064, 1.31064, 1.020064
 	}
 	@rescaleFactor = 1.0


### PR DESCRIPTION
RLA has been updated. Almost all parts were renamed and some were removed. Fixed part names for engines that are still in pack and reassigned some engines to different real counterparts.