### PR TITLE
Added Procedural Crew Tubes

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -51,6 +51,7 @@
 		}
 	}
 }
+
 @PART[proceduralTankRealFuels]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -65,6 +66,7 @@
 		typeAvailable = LifeSupport
 	}
 }
+
 @PART[proceduralTankKethane]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -137,4 +139,80 @@
 			}
 		}
 	}
+}
+
+
+
+
+// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internalls traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivelent and more expensive to reflect the aditional shielding etc in the part. They also have a minimum diameter of 2m. CLS support is removed form the regular stuctural parts.
+
+@PART[proceduralStructural]:NEEDS[ProceduralParts]:FINAL
+{
+	!MODULE[ModuleConnectedLivingSpace],* {}
+}
+
++PART[proceduralStructural]:NEEDS[ProceduralParts]:FINAL
+{
+	@name = proceduralCrewTube
+	@title = Procedural Crew Tube
+	%description = Air tight pressure hull protected by a thick layer of kevlar and carbon nano fibre blankets to provide protection against micro-metorites as well as thermal insulation and limited raditation shielding. These parts provide safe and structurally intact internal spaces to allow crew to move between crewed parts. 
+	@cost *= 5
+	@entryCost *= 3.5
+	%TechRequired = spaceExploration
+
+
+	@MODULE[ProceduralPart]
+	{
+		!TECHLIMIT,* {}
+		
+		TECHLIMIT {
+			name = spaceExploration
+			diameterMax = 2
+			lengthMax = 4
+			volumeMax = Infinity
+		}
+
+
+		TECHLIMIT {
+			name = advExploration
+			diameterMax = 3
+			lengthMax = 8
+			volumeMax = Infinity
+		}
+
+
+		TECHLIMIT {
+			name = composites
+			diameterMax = 4.5
+			lengthMax = 20
+			volumeMax = Infinity
+		}
+
+		TECHLIMIT {
+			name = metaMaterials
+			diameterMax = Infinity
+			lengthMax = Infinity
+			volumeMax = Infinity
+		}
+
+		%diameterMin = 2
+		%lengthMin = 0.5
+	}
+
+	@MODULE[TankContentSwitcher]
+	{
+		@TANK_TYPE_OPTION[Structural] 
+		{
+			@dryDensity *= 2.5
+		}
+	}
+
+	!MODULE[ModuleConnectedLivingSpace],* {}
+	
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+        surfaceAttachmentsPassable = true
+	}	
 }

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -158,6 +158,7 @@
 	@cost *= 5
 	@entryCost *= 3.5
 	%TechRequired = spaceExploration
+	%RSSROConfig = True
 
 
 	@MODULE[ProceduralPart]


### PR DESCRIPTION
This pull request adds the concept of "procedural crew tubes" for Realism Overhaul. crew tubes are structural parts that allow crew to pass through them from a CLS point of view. They are more massive and costly than regular structural parts, and have a minimum size. They add an extra realism consideration to station and base building.
I am not terribly experienced with module manager, but have tested this in both career and sandbox modes and it seems to do what I intended. It is humbly offered to the community, I hope it is seen as an  improvement.