### PR TITLE
Add NK-15 and NK-15V configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -5,7 +5,7 @@
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.589812, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = NK-33 [2.0 m]
+	%title = NK-15/33 [2.0 m]
 	%manufacturer = SNTK Kuznetsov
 	%description = Originally built in the late 1960s/early 1970s for the Soviet N1F rocket. Though the N1F was scrapped, the engines survived. Aerojet aquired several NK-33 engines in the 1990s and refurbished them as AJ26-62 engines for Orbital Science's Antares launch vehicle. Modifications made by Aerojet included increasing rated thrust and equipping the engines to support gimballing.
 	%attachRules = 1,0,1,0,0
@@ -19,12 +19,12 @@
 		@PROPELLANT[Kerosene]
 		{
 			%name = Kerosene
-			%ratio = 0.332
+			%ratio = 0.347
 		}
 		@PROPELLANT[LqdOxygen]
 		{
 			%name = LqdOxygen
-			%ratio = 0.668
+			%ratio = 0.653
 		}
 		@atmosphereCurve
 		{
@@ -67,6 +67,57 @@
 		origMass = 1.222
 		CONFIG
 		{
+			name = NK-15
+			maxThrust = 1574.5
+			minThrust = 841
+			heatProduction = 100
+			massMult = 1.020458
+			ignitions = 1
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.35574
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.64426
+			}
+			atmosphereCurve
+			{
+				key = 0 318
+				key = 1 284
+			}
+		}
+		CONFIG
+		{
+			name = NK-15-Original-NoGimbal
+			maxThrust = 1574.5
+			minThrust = 841
+			heatProduction = 100
+			massMult = 1.020458
+			gimbalRange = 0
+			ignitions = 1
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.35574
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.64426
+			}
+			atmosphereCurve
+			{
+				key = 0 318
+				key = 1 284
+			}
+		}
+		CONFIG
+		{
 			name = NK-33
 			maxThrust = 1766
 			minThrust = 841
@@ -75,13 +126,13 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.332
+				ratio = 0.347
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.668
+				ratio = 0.653
 			}
 			atmosphereCurve
 			{
@@ -100,13 +151,13 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.332
+				ratio = 0.347
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.668
+				ratio = 0.653
 			}
 			atmosphereCurve
 			{
@@ -124,13 +175,13 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.332
+				ratio = 0.347
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.668
+				ratio = 0.653
 			}
 			atmosphereCurve
 			{
@@ -153,7 +204,7 @@
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.711397, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	%title = NK-43 [2.0 m]
+	%title = NK-15V/43 [2.0 m]
 	%manufacturer = SNTK Kuznetsov 
 	%description = Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
 	%attachRules = 1,0,1,0,0
@@ -176,8 +227,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 346
-			@key,1 = 1 246
+			@key,0 = 0 325
+			@key,1 = 1 200
 		}
 		ullage = True
 		ignitions = 3
@@ -212,6 +263,54 @@
 		name = ModuleEngineConfigs
 		configuration = NK-43
 		modded = false
+		CONFIG
+		{
+			name = NK-15V
+			maxThrust = 1680
+			minThrust = 877.5
+			heatProduction = 100
+			massMult = 0.963467
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.35574
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.64426
+			}atmosphereCurve
+			{
+				key = 0 325
+				key = 1 200
+			}
+		}
+		CONFIG
+		{
+			name = NK-15V-Original-NoGimbal
+			maxThrust = 1680
+			minThrust = 877.5
+			heatProduction = 100
+			massMult = 0.963467
+			gimbalRange = 0
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.35574
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.64426
+			}
+			atmosphereCurve
+			{
+				key = 0 325
+				key = 1 200
+			}
+		}
 		CONFIG
 		{
 			name = NK-43

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -123,6 +123,7 @@
 			minThrust = 841
 			heatProduction = 100
 			massMult = 1
+			ignitions = 2
 			PROPELLANT
 			{
 				name = Kerosene
@@ -148,6 +149,7 @@
 			heatProduction = 100
 			massMult = 1
 			gimbalRange = 0
+			ignitions = 2
 			PROPELLANT
 			{
 				name = Kerosene
@@ -172,6 +174,7 @@
 			minThrust = 941.92		
 			heatProduction = 100
 			massMult = 1.0106
+			ignitions = 2
 			PROPELLANT
 			{
 				name = Kerosene
@@ -270,6 +273,7 @@
 			minThrust = 877.5
 			heatProduction = 100
 			massMult = 0.963467
+			ignitions = 1
 			PROPELLANT
 			{
 				name = Kerosene
@@ -294,6 +298,7 @@
 			heatProduction = 100
 			massMult = 0.963467
 			gimbalRange = 0
+			ignitions = 1
 			PROPELLANT
 			{
 				name = Kerosene
@@ -317,6 +322,7 @@
 			minThrust = 877.5
 			maxThrust = 1755
 			heatProduction = 100
+			ignitions = 3
 			PROPELLANT
 			{
 				name = Kerosene


### PR DESCRIPTION
also noticed and corrected the NK-33 mixture ratio that disagreed with the majority of sources, going with 2.62 as mixture ratio for NK-33

sources include:
	http://www.lpre.de/sntk/NK-33/index.htm
	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm

