### PR TITLE
RemoteTech_Settings: Set HideGroundStationsBehindBody = True

### DIFF
--- a/GameData/RealismOverhaul/RemoteTech_Settings.cfg
+++ b/GameData/RealismOverhaul/RemoteTech_Settings.cfg
@@ -9,6 +9,7 @@ RemoteTechSettings
 	RangeModelType = Root
 	MultipleAntennaMultiplier = 1
 	ThrottleTimeWarp = True
+	HideGroundStationsBehindBody = True
 	DishConnectionColor = 0.9960784,0.7019608,0.03137255,1
 	OmniConnectionColor = 0.5529412,0.5176471,0.4078431,1
 	ActiveConnectionColor = 0.6588235,1,0.01568628,1


### PR DESCRIPTION
This setting means that ground stations on the other side of the Earth
aren't visible *through* the Earth.

Tested on RemoteTech v1.6.7, RSS v10.2.0, KSP 1.0.4