### PR TITLE
Adding Surveyor Vernier to RO_Squad_Engines.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1848,6 +1848,100 @@
 		}
 	}
 }
++PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	@name = RO-SurveyorVernier
+}
+@PART[RO-SurveyorVernier]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+	@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
+	}
+	@title = Surveyor Vernier (TD-339)
+	%manufacturer = Thiokol
+	@description = The Vernier System as used on the Suveyor Probes. Uses storable hypergolic propellants, has Infinite Restarts and is not subject to Ullage and Throttleable. Historically 3 of them were used on the Surveyor Probes to the moon
+	@mass = 0.009
+	@maxTemp = 1973.15
+	!MODULE[ModuleEngineConfigs] {}
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 97.86
+		@maxThrust = 97.86
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+			@ratio = 0.502
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.498
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 314
+			@key,1 = 1 150
+		}
+		%ullage = False
+		%pressureFed = True
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.01
+		}
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 8
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = TD-339
+		CONFIG
+		{
+			name = TD-339
+			minThrust = 0.133446648
+			maxThrust = 0.462615048
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.516
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = MON10
+				ratio = 0.484
+			}
+			atmosphereCurve
+			{
+				key = 0 287
+				key = 1 100
+			}
+		}
+	}
+	!useRcsConfig = DEL
+	!useRcsCostMult = DEL
+	!useRcsMass = DEL
+}
 @PART[microEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
The file change adds a clone of the micro engine as the Surveyor Vernier system.