### PR TITLE
Increase RS-68 gimbal range

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -1482,7 +1482,7 @@
 	}
 	@MODULE[ModuleGimbal]
 	{
-		@gimbalRange = 6
+		@gimbalRange = 6 //guess based on http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf, which is re: RS-68B for Ares 5
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
@@ -527,7 +527,7 @@
 	}
 	@MODULE[ModuleGimbal]
 	{
-		%gimbalRange = 4
+		%gimbalRange = 6 //guess based on http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf, which is re: RS-68B for Ares 5
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}


### PR DESCRIPTION
Unable to find actual gimbal range, but guessed 6 degrees based on http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf . Delta IV Medium+ variants difficult to control without increased range.