### PR TITLE
rescale Agena-D flight pack fairings

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Fairings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Fairings.cfg
@@ -150,6 +150,11 @@
 @PART[FASAFairingWall05m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.219, 1.219, 1.219
+	}
+	@scale = 1.219
 	MODULE
 	{
 		name = TweakScale


### PR DESCRIPTION
Version 5.3 removed all FASA-Fairings but those for the Agena-Module (named FASAFairingWall05m) for procedural ones. The 05 ones seem to be used as a fairing on the FASA Agena-D flight pack. Since all Agena parts are rescaled by factor 1.219 through module manager by RO, this rescale should also be applied to those fairings, otherwise they are too small.