### PR TITLE
RN FASA gemini pod ec fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -317,7 +317,7 @@
 		RESOURCE
 		{
 			name = ElectricCharge
-			rate = 2.09
+			rate = 0.25
 		}
 	}
 	!RESOURCE[ElectricCharge]


### PR DESCRIPTION
-fixed insanely high power usage on black pod to match white pod, there is no reason it should be different than the white pod or as high as it is.