### PR TITLE
adding sxt-rd107/108

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -1436,3 +1436,224 @@
 		}
 	}
 }
+
++PART[SXTKD170]:FOR[RealismOverhaul]
+{
+	@name = R7_Core_Engine
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	@MODEL
+	{
+		@scale = 1.0, 1.0, 1.0
+	}
+	@scale = 1.0
+	%rescaleFactor = 0.5398
+	@mass = 1.23
+	@maxTemp = 1973.15
+	@title = R7 Core Engine [2.0m]
+	@attachRules = 1,0,1,0,0
+	
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	
+	@MODULE[ModuleGimbal]
+	{
+		gimbalRange = 1.5
+	}
+	
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 778.3
+		@maxThrust = 778.3
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.368
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.632
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 308
+			@key,1 = 1 241
+		}
+		
+		%ullage = True
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.500
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RD-108 8D75PS
+		modded = false
+		
+		CONFIG
+		{
+			name = RD-108 8D75PS
+			maxThrust = 778.3
+			minThrust = 778.3
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.368
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.632
+			}
+			atmosphereCurve
+			{
+				key = 0 308
+				key = 1 241
+			}
+		}
+		CONFIG
+		{
+			name = RD-108-8D727
+			maxThrust = 831.4
+			minThrust = 831.4
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.368
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.632
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 253
+			}
+			techRequired = advRocketry
+			entryCost = 750
+		}
+	}
+}
+
++PART[R7_Core_Engine]:FOR[RealismOverhaul]
+{
+	@name = R7_Booster_Engine
+	
+	%RSSROConfig = True
+
+	%rescaleFactor = 0.73
+	@mass = 1.145
+	@maxTemp = 1973.15
+	@title = R7 Booster Engine [2.7m]
+	@attachRules = 1,0,1,0,0
+
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 902.3
+		@maxThrust = 902.3
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.3603
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.6397
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 306
+			@key,1 = 1 250
+		}
+		
+		%ullage = True
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.500
+		}
+	}
+	
+	!MODULE[ModuleEngineConfigs] {}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RD-107 8D74PS
+		modded = false
+		CONFIG
+		{
+			name = RD-107 8D74PS
+			maxThrust = 902.3
+			minThrust = 902.3
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3603
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6397
+			}
+			atmosphereCurve
+			{
+				key = 0 306
+				key = 1 250
+			}
+		}
+		CONFIG
+		{
+			name = RD-107-8D728
+			maxThrust = 930.7
+			minThrust = 930.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3603
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6397
+			}
+			atmosphereCurve
+			{
+				key = 0 314
+				key = 1 257
+			}
+			techRequired = advRocketry
+			entryCost = 750
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/KSP-RO/RP-0/pull/217

Clone the existing RD-170 model, rescale. Intended for use with RP-0 to allow the construction of R-7 rockets.

One upgraded config placed, price and tech-tree spot estimated. This may require refinement in the future.

Engines gimbal so that the craft is controllable without verniers, as MechJeb control of actual verniers is a bit poor.


There will also be an RP-0 PR for initial placement in the techtree for RP-0.