### PR TITLE
Add GEM 63 and GEM 63XL

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -420,6 +420,298 @@
 		}
 	}
 }
+// ##########################################################################################	GEM63
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
+{
+	@name = RO_KWsrbGlobeI_GEM63
+	@MODEL,0
+	{
+		@scale = 4.2, 4, 4.2
+	}
+	@node_attach = 0.0, 0.0, -0.8, 0.0, 0.0, 0.0
+	@title = GEM 63
+	%manufacturer = Orbital ATK
+	@description = The GEM 63 is intended to be a drop-in replacement for the Atlas V's AJ-60A boosters.
+	@mass = 4 //same as AJ-60A
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 1750
+		@atmosphereCurve
+		{
+			@key,0 = 0 275
+			@key,1 = 1 250
+		}
+	}
+	!MODULE[ModuleGimbal]
+	{
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 24039.5 //same as AJ-60A
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = GEM-63
+		@CONFIG[Castor-4A]
+		{
+			@name = GEM-63
+			@maxThrust = 1658
+			%heatProduction = 100
+			@atmosphereCurve //same as AJ-60A
+			{
+				@key,0 = 0 275
+				@key,1 = 1 250
+			}
+			!thrustCurve
+			{
+			}
+			thrustCurve //same as GEM 60
+			{
+				key = 0.99972 0.719
+				key = 0.98539 0.939
+				key = 0.97106 0.939
+				key = 0.95673 0.939
+				key = 0.94227 0.948
+				key = 0.92769 0.956
+				key = 0.91298 0.964
+				key = 0.89811 0.975
+				key = 0.88302 0.989
+				key = 0.86785 0.995
+				key = 0.85268 0.994
+				key = 0.83746 0.997
+				key = 0.82221 1
+				key = 0.80695 1
+				key = 0.7917 1
+				key = 0.77644 1
+				key = 0.76119 1
+				key = 0.74593 1
+				key = 0.73068 1
+				key = 0.71543 1
+				key = 0.70017 1
+				key = 0.68496 0.997
+				key = 0.66992 0.986
+				key = 0.65513 0.969
+				key = 0.6408 0.939
+				key = 0.62728 0.886
+				key = 0.61481 0.817
+				key = 0.60293 0.779
+				key = 0.59143 0.754
+				key = 0.58023 0.734
+				key = 0.56953 0.701
+				key = 0.55909 0.685
+				key = 0.5489 0.668
+				key = 0.539 0.649
+				key = 0.52932 0.635
+				key = 0.51985 0.621
+				key = 0.51063 0.604
+				key = 0.50162 0.591
+				key = 0.49282 0.577
+				key = 0.48419 0.566
+				key = 0.47573 0.555
+				key = 0.46731 0.552
+				key = 0.45877 0.56
+				key = 0.45014 0.566
+				key = 0.44143 0.571
+				key = 0.43263 0.577
+				key = 0.42371 0.585
+				key = 0.4147 0.59
+				key = 0.40561 0.596
+				key = 0.39644 0.601
+				key = 0.38718 0.607
+				key = 0.37779 0.615
+				key = 0.36832 0.621
+				key = 0.35877 0.626
+				key = 0.34913 0.632
+				key = 0.33936 0.64
+				key = 0.32951 0.646
+				key = 0.31958 0.651
+				key = 0.30952 0.659
+				key = 0.29938 0.665
+				key = 0.28915 0.67
+				key = 0.2788 0.679
+				key = 0.26836 0.684
+				key = 0.25779 0.693
+				key = 0.24714 0.698
+				key = 0.23641 0.704
+				key = 0.22564 0.706
+				key = 0.21482 0.709
+				key = 0.20392 0.715
+				key = 0.19297 0.717
+				key = 0.18199 0.72
+				key = 0.17092 0.726
+				key = 0.15981 0.728
+				key = 0.14865 0.731
+				key = 0.13746 0.734
+				key = 0.12618 0.739
+				key = 0.11494 0.737
+				key = 0.10371 0.737
+				key = 0.09255 0.731
+				key = 0.08148 0.726
+				key = 0.07054 0.717
+				key = 0.05964 0.714
+				key = 0.04883 0.709
+				key = 0.03814 0.701
+				key = 0.02754 0.695
+				key = 0.01913 0.551
+				key = 0.01204 0.404
+				key = 0.00877 0.32
+				key = 0.00682 0.20
+				key = 0.00483 0.15
+				key = 0.0028 0.11
+				key = 0.0018 0.08
+				key = 0.0005 0.03
+				key = 0.0000 0.005
+			}
+		}
+	}
+}
+// ##########################################################################################	GEM63XL
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
+{
+	@name = RO_KWsrbGlobeI_GEM63XL
+	@MODEL,0
+	{
+		@scale = 4.2, 4.3, 4.2 //1.5 m stretch
+	}
+	@node_attach = 0.0, 0.0, -0.8, 0.0, 0.0, 0.0
+	@title = GEM 63XL
+	%manufacturer = Orbital ATK
+	@description = The GEM 63XL is approximately 1.5 m longer than the standard GEM 63 and is planned to be used on the Vulcan launch vehicle.
+	@mass = 4.3 //107.5% AJ-60A
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 1785
+		@atmosphereCurve
+		{
+			@key,0 = 0 275
+			@key,1 = 1 250
+		}
+	}
+	!MODULE[ModuleGimbal]
+	{
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 25842.5 //107.5% AJ-60A
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = GEM-63XL
+		@CONFIG[Castor-4A]
+		{
+			@name = GEM-63XL
+			@maxThrust = 1885
+			%heatProduction = 100
+			@atmosphereCurve
+			{
+				@key,0 = 0 275
+				@key,1 = 1 250
+			}
+			!thrustCurve
+			{
+			}
+			thrustCurve
+			{
+				key = 0.99972 0.719
+				key = 0.98539 0.939
+				key = 0.97106 0.939
+				key = 0.95673 0.939
+				key = 0.94227 0.948
+				key = 0.92769 0.956
+				key = 0.91298 0.964
+				key = 0.89811 0.975
+				key = 0.88302 0.989
+				key = 0.86785 0.995
+				key = 0.85268 0.994
+				key = 0.83746 0.997
+				key = 0.82221 1
+				key = 0.80695 1
+				key = 0.7917 1
+				key = 0.77644 1
+				key = 0.76119 1
+				key = 0.74593 1
+				key = 0.73068 1
+				key = 0.71543 1
+				key = 0.70017 1
+				key = 0.68496 0.997
+				key = 0.66992 0.986
+				key = 0.65513 0.969
+				key = 0.6408 0.939
+				key = 0.62728 0.886
+				key = 0.61481 0.817
+				key = 0.60293 0.779
+				key = 0.59143 0.754
+				key = 0.58023 0.734
+				key = 0.56953 0.701
+				key = 0.55909 0.685
+				key = 0.5489 0.668
+				key = 0.539 0.649
+				key = 0.52932 0.635
+				key = 0.51985 0.621
+				key = 0.51063 0.604
+				key = 0.50162 0.591
+				key = 0.49282 0.577
+				key = 0.48419 0.566
+				key = 0.47573 0.555
+				key = 0.46731 0.552
+				key = 0.45877 0.56
+				key = 0.45014 0.566
+				key = 0.44143 0.571
+				key = 0.43263 0.577
+				key = 0.42371 0.585
+				key = 0.4147 0.59
+				key = 0.40561 0.596
+				key = 0.39644 0.601
+				key = 0.38718 0.607
+				key = 0.37779 0.615
+				key = 0.36832 0.621
+				key = 0.35877 0.626
+				key = 0.34913 0.632
+				key = 0.33936 0.64
+				key = 0.32951 0.646
+				key = 0.31958 0.651
+				key = 0.30952 0.659
+				key = 0.29938 0.665
+				key = 0.28915 0.67
+				key = 0.2788 0.679
+				key = 0.26836 0.684
+				key = 0.25779 0.693
+				key = 0.24714 0.698
+				key = 0.23641 0.704
+				key = 0.22564 0.706
+				key = 0.21482 0.709
+				key = 0.20392 0.715
+				key = 0.19297 0.717
+				key = 0.18199 0.72
+				key = 0.17092 0.726
+				key = 0.15981 0.728
+				key = 0.14865 0.731
+				key = 0.13746 0.734
+				key = 0.12618 0.739
+				key = 0.11494 0.737
+				key = 0.10371 0.737
+				key = 0.09255 0.731
+				key = 0.08148 0.726
+				key = 0.07054 0.717
+				key = 0.05964 0.714
+				key = 0.04883 0.709
+				key = 0.03814 0.701
+				key = 0.02754 0.695
+				key = 0.01913 0.551
+				key = 0.01204 0.404
+				key = 0.00877 0.32
+				key = 0.00682 0.20
+				key = 0.00483 0.15
+				key = 0.0028 0.11
+				key = 0.0018 0.08
+				key = 0.0005 0.03
+				key = 0.0000 0.005
+			}
+		}
+	}
+}
 // ##########################################################################################	GEM60
 +PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeI.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeI.cfg
@@ -98,3 +98,42 @@
         speed = 1
     }
 }
+@PART[RO_KWsrbGlobeI_GEM63]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+        %powerEffectName = Solid-Lower
+	}
+    PLUME
+    {
+        name = Solid-Lower
+        transformName = NozzleTransform
+        localRotation = 0,0,0
+        flarePosition = 0,0,-0.3
+        plumePosition = 0,0,-0.1
+        fixedScale = 0.8
+        energy = 1
+        speed = 1
+    }
+}@PART[RO_KWsrbGlobeI_GEM63XL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+        %powerEffectName = Solid-Lower
+	}
+    PLUME
+    {
+        name = Solid-Lower
+        transformName = NozzleTransform
+        localRotation = 0,0,0
+        flarePosition = 0,0,-0.3
+        plumePosition = 0,0,-0.1
+        fixedScale = 0.8
+        energy = 1
+        speed = 1
+    }
+}


### PR DESCRIPTION
Educated guesses for stats. Drop in replacement for AJ-60A. http://www.spaceflightinsider.com/organizations/ula/ula-selects-orbital-atks-gem-6363-xl-srbs-for-atlas-v-and-vulcan-boosters/