### PR TITLE
Changed stats of dish antennas.

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
@@ -53,20 +53,20 @@
 		}
 	}
 }
-@PART[RTShortDish2]:AFTER[RemoteTech]
+@PART[RTShortDish2]:AFTER[RemoteTech]  //KR-7, 1.4m
 {
 	%RSSROConfig = True
 	@mass = 0.025
-	@description = A small fixed parabolic dish. Suitable for communications within the inner planets.
+	@description = A small fixed parabolic dish. Narrow focus and better electronis make this perform similar to the KR-14 at less bulk, weight and power. Suitable for communications within the inner planets. 
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, -0.225, 0.0, 0.0, -1.0, 0.0, 1
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 200000000000
-		@EnergyCost = 0.18
+		@Mode1DishRange = 250000000000
+		@EnergyCost = 0.09
 		@MaxQ = 6000
-		@DishAngle = 1.4
+		@DishAngle = 10
 		@TRANSMITTER
 		{
 			@PacketInterval = 0.3
@@ -75,20 +75,20 @@
 		}
 	}
 }
-@PART[RTLongDish2]:AFTER[RemoteTech]
+@PART[RTLongDish2]:AFTER[RemoteTech] //KR-14, 2.8m
 {
 	%RSSROConfig = True
-	@mass = 0.050
-	@description = A small fixed parabolic dish. Suitable for communications within the inner planets.
+	@mass = 0.075
+	@description = A fixed parabolic dish. Performance allows for communications within the inner planets. The cone is wide enough to cover Earth from GEO.
 	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 1000000000000
+		@Mode1DishRange = 200000000000
 		@EnergyCost = 0.2
 		@MaxQ = 6000
-		@DishAngle = 1
+		@DishAngle = 10
 		@TRANSMITTER
 		{
 			@PacketInterval = 0.3
@@ -97,7 +97,7 @@
 		}
 	}
 }
-@PART[RTShortDish1]:AFTER[RemoteTech]
+@PART[RTShortDish1]:AFTER[RemoteTech] // ?? what part is this?
 {
 	%RSSROConfig = False
 	@mass = 0.110
@@ -141,29 +141,29 @@
 		}
 	}
 }
-@PART[RTGigaDish1]:AFTER[RemoteTech]
+@PART[RTGigaDish1]:AFTER[RemoteTech] //Gx128, 1.4/6.4m
 {
 	%RSSROConfig = True
-	@mass = 0.070
-	@description = A massive interplanetary dish. Useful as a high-speed orbital relay, or an interplanetary probe. Be careful, however, of its high power usage.
+	@mass = 0.030
+	@description = A large folding dish, suitable for deep-space missions. Very low power requirements.
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 8000000000000
-		@EnergyCost = 0.65
+		@Mode1DishRange = 40000000000000 //40Tm
+		@EnergyCost = 0.1
 		@MaxQ = 6000
-		@DishAngle = 0.2
+		@DishAngle = 0.3
 		@TRANSMITTER
 		{
 			@PacketInterval = 1.0
 			@PacketSize = 1.34
-			@PacketResourceCost = 3.25
+			@PacketResourceCost = 1
 		}
 	}
 }
-+PART[RTGigaDish1]:AFTER[RemoteTech] // was final, but it will run after the above patch so who cares.
++PART[RTGigaDish1]:AFTER[RemoteTech] // Gx256, 2.2/10.5m; was final, but it will run after the above patch so who cares.
 {
 	@name = RO_gx256
 	!mesh = DELETE
@@ -181,7 +181,7 @@
 	@mass = 0.100
 	@MODULE[ModuleRTAntenna]
 	{
-		@Mode1DishRange = 25000000000000
+		@Mode1DishRange = 40000000000000 //40Tm
 		@EnergyCost = 0.85
 		@DishAngle = 0.5
 		@TRANSMITTER
@@ -192,24 +192,25 @@
 		}
 	}
 }
-@PART[RTGigaDish2]:AFTER[RemoteTech]
+@PART[RTGigaDish2]:AFTER[RemoteTech] //CommTech1, 3.4m static
 {
 	%RSSROConfig = True
-	@mass = 0.075
+	@mass = 0.05
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+	@description = A massive dish, allowing for deep-space missions well beyond Pluto.
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 4000000000000
-		@EnergyCost = 0.2
+		@Mode1DishRange = 40000000000000 //40Tm
+		@EnergyCost = 0.3
 		@MaxQ = 6000
-		@DishAngle = 0.6
+		@DishAngle = 0.4
 		@TRANSMITTER
 		{
 			@PacketInterval = 2
 			@PacketSize = 1.0
-			@PacketResourceCost = 1.0
+			@PacketResourceCost = 1.5
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -1,48 +1,50 @@
-@PART[commDish]:FOR[RealismOverhaul]
+@PART[commDish]:FOR[RealismOverhaul] //Comm-88, folding dish 
 {
 	%RSSROConfig = True
-	@mass = 0.035
+	@mass = 0.015
+	@description = Improved circuitry allows this small folding dish to be suitable for deep-space missions.
 }
 @PART[commDish]:AFTER[RemoteTech]
 {
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 1500000000000
-		@EnergyCost = 0.35
+		@Mode1DishRange = 40000000000000 //40Tm
+		@EnergyCost = 0.25
 		@MaxQ = 6000
 		@DishAngle = 0.4
 		@TRANSMITTER
 		{
 			@PacketInterval = 1.5
-			@PacketSize = 1.15
+			@PacketSize = 0.84
 			@PacketResourceCost = 1.75
 		}
 	}
 }
-@PART[mediumDishAntenna]:FOR[RealismOverhaul]
+@PART[mediumDishAntenna]:FOR[RealismOverhaul]  //DTS-M1, radial, high-end inner planets
 {
 	%RSSROConfig = True
-	@mass = 0.015
+	@mass = 0.008
 }
-@PART[mediumDishAntenna]:AFTER[RemoteTech]
+@PART[mediumDishAntenna]:AFTER[RemoteTech] 
 {
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 400000000
-		@EnergyCost = 0.02
+		@Mode1DishRange = 250000000000 //250Gm
+		@EnergyCost = 0.12
 		@MaxQ = 6000
-		@DishAngle = 40
+		@DishAngle = 12
 		@TRANSMITTER
 		{
 			@PacketInterval = 0.3
 			@PacketSize = 0.56
-			@PacketResourceCost = 0.1
+			@PacketResourceCost = 0.15
 		}
 	}
+	%description = The DTS-M1 is a fully deployable communications and data transmission system. It has been designed to have a minimal form factor when stowed, at the price of a lower data rate and higher power requirements.
 }
-@PART[longAntenna]:FOR[RealismOverhaul]
+@PART[longAntenna]:FOR[RealismOverhaul] //Comm-16
 {
 	%RSSROConfig = True
 	@mass = 0.003
@@ -61,6 +63,7 @@
 			@PacketResourceCost = 0.0075
 		}
 	}
+	%description = A powerful omni antenna, adequate for early lunar probes. If you wonder how a 4Mm antenna can reach the Moon, check the Realism Overhaul FAQ.
 }
 @PART[radialDecoupler1-2]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
All dishes have a range of either 250Gm (inner planets) or 40Tm (well past Pluto), but vary by weight and power demand.

Antenna descriptions now indicate their useful range in the game.