### PR TITLE
PF transparency, CMES updates

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -72,3 +72,16 @@
 {
 	%RSSROConfig = True
 }
+
+//	==================================================
+//	See - through procedural fairings.
+//	==================================================
+
+	@PART[KzProcFairingFuselage*|KzProcFairingSide*]:FOR[RealismOverhaul]
+	{
+		MODULE
+		{
+			name 		  = ModuleSeeThroughObject
+			transformName = model
+		}
+	}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -72,16 +72,3 @@
 {
 	%RSSROConfig = True
 }
-
-//	==================================================
-//	See - through procedural fairings.
-//	==================================================
-
-	@PART[KzProcFairingFuselage*|KzProcFairingSide*]:FOR[RealismOverhaul]
-	{
-		MODULE
-		{
-			name 		  = ModuleSeeThroughObject
-			transformName = model
-		}
-	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -170,22 +170,177 @@
 	@node_stack_bottom = 0.0, -0.266667, 0.0, 0.0, -1.0, 0.0, 3
 	@node_stack_top = 0.0, 1.4826667, 0.0, 0.0, 1.0, 0.0, 3
 }
-@PART[MonkeyPodOrionTypeS]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	//	Update this once we get fancy new model!
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Hab/Monkey_Pod_Orion_S/model
-		scale = 4.26667, 4.26667, 4.26667
-	}
-	@rescaleFactor = 1.0s
 
-	@node_stack_bottom = 0.0, -3.89, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_top = 0.0, 3.89, 0.0, 0.0, 1.0, 0.0, 3
+//	==================================================
+//	SP-600 deep space habitation module (TransHab II).
+
+//	Dimensions: 8.300 x 11.700 m
+//	Gross Mass: 27372.000 Kg
+//	==================================================
+
+	@PART[MonkeyPodOrionTypeS22]:FOR[RealismOverhaul]
+	{
+		%RSSROConfig = true
+
+		MODEL
+		{
+			model	 = CMES/Hab/Monkey_Pod_Orion_S/model
+			scale	 = 4.000, 3.950, 4.000
+			position = 0.000, 0.000, 0.000
+			rotation = 0.000, 0.000, 0.000
+		}
+
+		!mesh		   = NULL
+		%scale		   = 1.000
+		%rescaleFactor = 1.000
+
+		%node_stack_bottom = 0.000, -3.550, 0.000, 0.000, -1.000, 0.000, 3
+		%node_stack_top    = 0.000,  3.550, 0.000, 0.000,  1.000, 0.000, 3
+		%attachRules	   = 1,0,1,1,0
+
+		%TechRequired = spaceExploration
+		%entryCost	  = 20400
+		%cost		  = 8000
+		%category	  = Utility
+		%subcategory  = 0
+		%title		  = SP-600 Habitation Module
+		%manufacturer = Bigelow Aerospace
+		%description  = The evolution of the inflatable SP-300 TransHab concept. SP-600 "TransHab II" is a hard shell, long term habitation module, designed for either deep space or planetary surface applications. Can support up to 6 crew for 18 months.
+
+		%mass		  	  = 27.372
+		%dragModelType 	  = default
+		%maximum_drag  	  = 0.25
+		%minimum_drag  	  = 0.25
+		%angularDrag   	  = 0.5
+		%crashTolerance	  = 12
+		%breakingForce 	  = 250
+		%breakingTorque	  = 250
+		%maxTemp		  = 1073.15
+		%fuelCrossFeed 	  = true
+		%CrewCapacity     = 6
+		%vesselType		  = Ship
+		%bulkheadProfiles = size3
+
+		!INTERNAL[xinflato1internal]{}
+
+		@MODULE[ModuleCommand]
+		{
+			RESOURCE
+			{
+				name = ElectricCharge
+				rate = 0.864
+			}
+		}
+
+		!MODULE[MechJebCore]{}
 	
-}
+		!MODULE[ModuleSAS]{}
+
+		@MODULE[ModuleScienceContainer]
+		{
+			%storageRange = 4.5
+		}
+
+		!MODULE[ModuleScienceLab]{}
+
+		!MODULE[ModuleDataTransmitter]{}
+
+		MODULE
+		{
+			name	 = ModuleFuelTanks
+			volume	 = 19400
+			basemass = -1
+			type	 = ServiceModule
+
+			TANK
+			{
+				name	  = ElectricCharge
+				amount	  = 43200
+				maxAmount = 43200
+			}
+
+			TANK
+			{
+				name	  = Food
+				amount	  = 35.095
+				maxAmount = 19300.000
+			}
+
+			TANK
+			{
+				name	  = Water
+				amount	  = 23.986
+				maxAmount = 25.000
+			}
+
+			TANK
+			{
+				name	  = Oxygen
+				amount	  = 3551.000
+				maxAmount = 3600.000
+			}
+
+			TANK
+			{
+				name	  = CarbonDioxide
+				amount	  = 0.000
+				maxAmount = 3085.714
+			}
+
+			TANK
+			{
+				name	  = Waste
+				amount	  = 0.000
+				maxAmount = 3.193
+			}
+
+			TANK
+			{
+				name	  = WasteWater
+				amount	  = 0.000
+				maxAmount = 29.548
+			}
+
+			TANK
+			{
+				name	  = LqdMethane
+				amount	  = 0.000
+				maxAmount = 5.000
+			}
+		}
+
+		MODULE
+		{
+			name		    = TacGenericConverter
+			converterName   = Sabatier Reactor Unit
+			conversionRate  = 2.0
+			inputResources  = CarbonDioxide, 0.0172683775, ElectricCharge, 0.8, Hydrogen, 0.0647212460
+			outputResources = LqdMethane, 0.0000271941, true, Water, 0.0000259988, true
+		}
+
+		MODULE
+		{
+			name			= TacGenericConverter
+			converterName   = Water Purifier Unit
+			conversionRate  = 6.0
+			inputResources  = WasteWater, 0.00004059709561, ElectricCharge, 0.3
+			outputResources = Water, 0.0000383361, false, Waste, 0.00000365912, true
+		}
+
+		MODULE
+		{
+			name			= TacGenericConverter
+			converterName	= Water Electrolysis Unit
+			conversionRate  = 6.0
+			inputResources  = Water, 0.0000053129, ElectricCharge, 0.5
+			outputResources = Hydrogen, 0.0066129570, true, Oxygen, 0.003116887, false
+		}
+
+		!RESOURCE[ElectricCharge]{}
+
+		!RESOURCE[MonoPropellant]{}
+	}
+
 @PART[SHABLANDER-SLR]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -175,7 +175,7 @@
 //	SP-600 deep space habitation module (TransHab II).
 
 //	Dimensions: 8.300 x 11.700 m
-//	Gross Mass: 27372.000 Kg
+//	Gross Mass: 22372.000 Kg
 //	==================================================
 
 	@PART[MonkeyPodOrionTypeS22]:FOR[RealismOverhaul]
@@ -207,7 +207,7 @@
 		%manufacturer = Bigelow Aerospace
 		%description  = The evolution of the inflatable SP-300 TransHab concept. SP-600 "TransHab II" is a hard shell, long term habitation module, designed for either deep space or planetary surface applications. Can support up to 6 crew for 18 months.
 
-		%mass		  	  = 27.372
+		%mass		  	  = 22.372
 		%dragModelType 	  = default
 		%maximum_drag  	  = 0.25
 		%minimum_drag  	  = 0.25
@@ -228,7 +228,7 @@
 			RESOURCE
 			{
 				name = ElectricCharge
-				rate = 0.864
+				rate = 1.864
 			}
 		}
 
@@ -248,7 +248,7 @@
 		MODULE
 		{
 			name	 = ModuleFuelTanks
-			volume	 = 19400
+			volume	 = 25000
 			basemass = -1
 			type	 = ServiceModule
 
@@ -262,50 +262,50 @@
 			TANK
 			{
 				name	  = Food
-				amount	  = 35.095
-				maxAmount = 19300.000
+				amount	  = 19300
+				maxAmount = 19300
 			}
 
 			TANK
 			{
 				name	  = Water
-				amount	  = 23.986
-				maxAmount = 25.000
+				amount	  = 25
+				maxAmount = 25
 			}
 
 			TANK
 			{
 				name	  = Oxygen
-				amount	  = 3551.000
-				maxAmount = 3600.000
+				amount	  = 3550
+				maxAmount = 3550
 			}
 
 			TANK
 			{
 				name	  = CarbonDioxide
-				amount	  = 0.000
-				maxAmount = 3085.714
+				amount	  = 0
+				maxAmount = 3085
 			}
 
 			TANK
 			{
 				name	  = Waste
-				amount	  = 0.000
-				maxAmount = 3.193
+				amount	  = 0
+				maxAmount = 1755.6
 			}
 
 			TANK
 			{
 				name	  = WasteWater
-				amount	  = 0.000
-				maxAmount = 29.548
+				amount	  = 0
+				maxAmount = 29.55
 			}
 
 			TANK
 			{
 				name	  = LqdMethane
-				amount	  = 0.000
-				maxAmount = 5.000
+				amount	  = 0
+				maxAmount = 5
 			}
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -363,9 +363,9 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 		@node_stack_bottom = 0.000, -0.270, 0.000, 0.000, -1.000, 0.000, 3
 
 		@TechRequired = spaceExploration
-		@title		  = Orion EFT LES decoupler.
+		@title		  = Orion EFT LAS coupler.
 		@manufacturer = Lockheed Martin
-		@description  = The Launch Escape System (LES) explosive bolt decoupler for the Orion EFT Crew Module.
+		@description  = The Launch Abort System (LAS) structural coupler of the Orion EFT Crew Module.
 
 		@mass			  = 0.600
 		@crashTolerance   = 12
@@ -377,13 +377,6 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 		%childStageOffset = 1
 		%emissiveConstant = 0.700
 		%bulkheadProfiles = size2, size3
-
-		MODULE
-		{
-			name 			= ModuleDecouple
-			ejectionForce 	= 1.000
-			explosiveNodeID = top
-		}
 
 		!MODULE[ModuleDockingNode]{}
 
@@ -489,20 +482,80 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 			%rotation = 0.000, 0.000, 0.000
 		}
 
+		//	Linear negative pitch thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   0.000, 0.880, -1.390
+			rotation = -90.000, 0.000,  0.000
+		}
+
+		//	Linear positive pitch thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   0.000, 0.070, -1.950
+			rotation = -55.000, 0.000,  0.000
+		}
+
+		//	Linear negative yaw thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 = 0.100, 0.100,   0.100
+			position = 1.900, 0.040,   0.000
+			rotation = 0.000, 0.000, -55.000
+		}
+
+		//	Linear positive yaw thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100, 0.100,  0.100
+			position = -1.900, 0.040,  0.000
+			rotation =  0.000, 0.000, 55.000
+		}
+
+		//	Linear negative roll thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =  -1.450, 0.030, -1.320
+			rotation = -90.000, 0.000,  0.000
+		}
+
+		//	Linear positive roll thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   1.450, 0.030, -1.320
+			rotation = -90.000, 0.000,  0.000
+		}
+
 		!mesh		   = NULL
 		@scale		   = 1.000
 		@rescaleFactor = 1.000
 
 		@node_stack_bottom = 0.000, -1.045, 0.000, 0.000, -1.000, 0.000, 3
 		@node_stack_top	   = 0.000,  0.960, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_1	   = 0.000,  0.930, 0.000, 0.000,  1.000, 0.000, 2
+		@node_stack_1	   = 0.000,  1.250, 0.000, 0.000,  1.000, 0.000, 2
 
 		@TechRequired = spaceExploration
 		@title		  = Orion MPCV EFT
 		@manufacturer = Lockheed Martin
 		@description  = The Exploration Flight Test (EFT) article for the Orion MPCV.
 
-		@mass		    = 5.500
+		@mass		    = 6.925
 		@crashTolerance = 12
 		@breakingForce  = 250
 		@breakingTorque = 250
@@ -554,6 +607,25 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 
 		MODULE
 		{
+			name				  = ModuleRCSFX
+			thrusterTransformName = RCSthruster
+			thrusterPower		  = 0.237
+
+			PROPELLANT
+			{
+				name  = Hydrazine
+				ratio = 1.000
+			}
+
+			atmosphereCurve
+			{
+				key = 0 242
+				key = 1 84
+			}
+		}
+
+		MODULE
+		{
 			name		   = CoMShifter
 			DescentModeCoM = 0.000, 0.000, -0.300
 		}
@@ -576,7 +648,7 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 			name	 = ModuleFuelTanks
 			basemass = -1
 			type	 = ServiceModule
-			volume	 = 1000
+			volume	 = 150
 
 			TANK
 			{
@@ -587,16 +659,9 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 
 			TANK
 			{
-				name	  = MMH
-				amount	  = 45
-				maxAmount = 45
-			}
-
-			TANK
-			{
-				name	  = NTO
-				amount	  = 45
-				maxAmount = 45
+				name	  = Hydrazine
+				amount	  = 85
+				maxAmount = 85
 			}
 		}
 
@@ -633,20 +698,80 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 			%rotation = 0.000, 0.000, 0.000
 		}
 
+		//	Linear negative pitch thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   0.000, 0.880, -1.390
+			rotation = -90.000, 0.000,  0.000
+		}
+
+		//	Linear positive pitch thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   0.000, 0.070, -1.950
+			rotation = -55.000, 0.000,  0.000
+		}
+
+		//	Linear negative yaw thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 = 0.100, 0.100,   0.100
+			position = 1.900, 0.040,   0.000
+			rotation = 0.000, 0.000, -55.000
+		}
+
+		//	Linear positive yaw thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100, 0.100,  0.100
+			position = -1.900, 0.040,  0.000
+			rotation =  0.000, 0.000, 55.000
+		}
+
+		//	Linear negative roll thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =  -1.450, 0.030, -1.320
+			rotation = -90.000, 0.000,  0.000
+		}
+
+		//	Linear positive roll thruster.
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   1.450, 0.030, -1.320
+			rotation = -90.000, 0.000,  0.000
+		}
+
 		!mesh		   = NULL
 		@scale		   = 1.000
 		@rescaleFactor = 1.000
 
 		@node_stack_bottom = 0.000, -1.045, 0.000, 0.000, -1.000, 0.000, 3
 		@node_stack_top	   = 0.000,  0.960, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_1	   = 0.000,  0.930, 0.000, 0.000,  1.000, 0.000, 2
+		@node_stack_1	   = 0.000,  1.250, 0.000, 0.000,  1.000, 0.000, 2
 
 		@TechRequired = spaceExploration
 		@title		  = Orion MPCV Crew Module (CM)
 		@manufacturer = Lockheed Martin
 		@description  = The next - generation NASA spacecraft for beyond LEO exploration. Can support 6 crew for up to 21 days of active time.
 
-		@mass		    = 5.500
+		@mass		    = 6.831
 		@crashTolerance = 12
 		@breakingForce  = 250
 		@breakingTorque = 250
@@ -700,6 +825,25 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 
 		MODULE
 		{
+			name				  = ModuleRCSFX
+			thrusterTransformName = RCSthruster
+			thrusterPower		  = 0.237
+
+			PROPELLANT
+			{
+				name  = Hydrazine
+				ratio = 1.000
+			}
+
+			atmosphereCurve
+			{
+				key = 0 242
+				key = 1 84
+			}
+		}
+
+		MODULE
+		{
 			name		   = CoMShifter
 			DescentModeCoM = 0.000, 0.000, -0.300
 		}
@@ -722,7 +866,7 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 			name	 = ModuleFuelTanks
 			basemass = -1
 			type	 = ServiceModule
-			volume	 = 1450
+			volume	 = 1700
 
 			TANK
 			{
@@ -734,57 +878,50 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 			TANK
 			{
 				name	  = Food
-				amount	  = 245.670
-				maxAmount = 737.100
+				amount	  = 737
+				maxAmount = 737
 			}
 
 			TANK
 			{
 				name	  = Water
-				amount	  = 162.570
-				maxAmount = 162.570
+				amount	  = 23.22
+				maxAmount = 23.22
 			}
 
 			TANK
 			{
 				name	  = Oxygen
-				amount	  = 1775.500
-				maxAmount = 24857.300
+				amount	  = 3550
+				maxAmount = 3550
 			}
 
 			TANK
 			{
 				name	  = CarbonDioxide
 				amount	  = 0
-				maxAmount = 767.200
+				maxAmount = 1530
 			}
 
 			TANK
 			{
 				name	  = Waste
 				amount	  = 0
-				maxAmount = 22.354
+				maxAmount = 67.06
 			}
 
 			TANK
 			{
 				name	  = WasteWater
 				amount	  = 0
-				maxAmount = 206.842
+				maxAmount = 650.53
 			}
 
 			TANK
 			{
-				name	  = MMH
-				amount	  = 45
-				maxAmount = 45
-			}
-
-			TANK
-			{
-				name	  = NTO
-				amount	  = 45
-				maxAmount = 45
+				name	  = Hydrazine
+				amount	  = 85
+				maxAmount = 85
 			}
 
 			TANK

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -336,126 +336,534 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 	@node_stack_back = -0.20539, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = -0.20539, 0.0, 0.0, -1.0, 0.0, 0.0
 }
-@PART[OrionDockingPortXx]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@MODEL
+
+//	==================================================
+//	Orion EFT LES decoupler system.
+
+//	Dimensions: 2.700 x 1.000 m
+//	Gross Mass: ~600.000 Kg
+//	==================================================
+
+	@PART[OrionDockingPortXx]:FOR[RealismOverhaul]
 	{
-	  @scale = 1.5829333, 1.466667, 1.5829333
+		%RSSROConfig = true
+
+		@MODEL
+		{
+			@scale	  = 1.458, 1.350, 1.458
+			%position = 0.000, 0.000, 0.000
+			%rotation = 0.000, 0.000, 0.000
+		}
+
+		!mesh		   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_top    = 0.000,  0.625, 0.000, 0.000,  1.000, 0.000, 2
+		@node_stack_bottom = 0.000, -0.270, 0.000, 0.000, -1.000, 0.000, 3
+
+		@TechRequired = spaceExploration
+		@title		  = Orion EFT LES decoupler.
+		@manufacturer = Lockheed Martin
+		@description  = The Launch Escape System (LES) explosive bolt decoupler for the Orion EFT Crew Module.
+
+		@mass			  = 0.600
+		@crashTolerance   = 12
+		@breakingForce    = 250
+		@breakingTorque   = 250
+		@maxTemp		  = 1973.15
+		@fuelCrossFeed    = False
+		%stageOffset	  = 1
+		%childStageOffset = 1
+		%emissiveConstant = 0.700
+		%bulkheadProfiles = size2, size3
+
+		MODULE
+		{
+			name 			= ModuleDecouple
+			ejectionForce 	= 1.000
+			explosiveNodeID = top
+		}
+
+		!MODULE[ModuleDockingNode]{}
+
+		!MODULE[ModuleCommand]{}
+
+		!MODULE[ModuleSAS],*{}
+
+		!MODULE[ModuleReactionWheel]{}
+	
+		!MODULE[MechJebCore]{}
+
+		!RESOURCE[ElectricCharge]{}
+
+		!RESOURCE[MonoPropellant]{}
 	}
 
-	@node_stack_top = 0.0, 0.6576, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.285333, 0.0, 0, -1, 0, 1
-	
-	@title = Orion APAS EFT
-	@description = Docking port for the Orion MPCV program.
-	@manufacturer = NASA
-	
-	@mass = 0.6
-	
-	!MODULE[ModuleReactionWheels]
+//	==================================================
+//	Orion MPCV docking system.
+
+//	Dimensions: 2.700 x 1.000 m
+//	Gross Mass: ~600.000 Kg
+//	==================================================
+
+	@PART[OrionDockingPortXWSTANDARDDOCKPORT]:FOR[RealismOverhaul]
 	{
-	}
-	!MODULE[ModuleCommand]
-	{
-	}
-		!MODULE[MechJebCore]
+		%RSSROConfig = true
+
+		@MODEL
 		{
+			@scale	  = 1.458, 1.350, 1.458
+			%position = 0.000, 0.000, 0.000
+			%rotation = 0.000, 0.000, 0.000
 		}
-		!MODULE[ModuleGenerator]
+
+		!mesh		   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_top    = 0.000,  0.625, 0.000, 0.000,  1.000, 0.000, 2
+		@node_stack_bottom = 0.000, -0.270, 0.000, 0.000, -1.000, 0.000, 3
+
+		@TechRequired = spaceExploration
+		@title		  = Orion CM Docking System
+		@manufacturer = Lockheed Martin
+		@description  = The NASA docking system for the Orion MPCV Crew Module.
+
+		@mass			  = 0.600
+		@crashTolerance   = 12
+		@breakingForce    = 250
+		@breakingTorque   = 250
+		@maxTemp		  = 1973.15
+		@fuelCrossFeed    = False
+		%stageOffset	  = 1
+		%childStageOffset = 1
+		%emissiveConstant = 0.700
+		%bulkheadProfiles = size2, size3
+
+		@MODULE[ModuleDockingNode]
 		{
+			@nodeType			   = NASADock
+			%acquireForce		   = 0.500
+			%acquireMinFwdDot	   = 0.800
+			%acquireminRollDot	   = -3.40282347E+38
+			%acquireRange		   = 0.250
+			%acquireTorque		   = 0.500
+			%captureMaxRvel		   = 0.100
+			%captureMinFwdDot	   = 0.998
+			%captureMinRollDot 	   = -3.40282347E+38
+			%captureRange		   = 0.050
+			%minDistanceToReEngage = 0.250
+			%undockEjectionForce   = 0.100
 		}
-		!MODULE[ModuleSAS]
-		{
-		}
-		!MODULE[ModuleReactionWheel]
-		{
-		}
-		!RESOURCE[MonoPropellant]
-		{
-		}
-}
-@PART[OrionDockingPortXWSTANDARDDOCKPORT]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@MODEL
-	{
-	  @scale = 1.5829333, 1.46667, 1.5829333
+
+		!MODULE[ModuleCommand]{}
+
+		!MODULE[ModuleSAS],*{}
+
+		!MODULE[ModuleReactionWheel]{}
+	
+		!MODULE[MechJebCore]{}
+
+		!RESOURCE[ElectricCharge]{}
+
+		!RESOURCE[MonoPropellant]{}
 	}
 
-	@node_stack_top = 0.0, 0.6576, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.285333, 0.0, 0, -1, 0, 1
-	
-	@title = Orion APAS
-	@description = Block 1 test vehicle docking port for the Orion MPCV program.
-	@manufacturer = NASA
-	
-	@mass = 0.6
-	
-	!MODULE[ModuleReactionWheels]
+//	==================================================
+//	Orion MPCV EFT (Realism Overhaul configuration).
+//
+/	Dimensions: 3.300 x 5.030 m
+//	Gross Mass: ~8900.000 Kg
+//	==================================================
+
+	@PART[XOrionPodXbb31]:FOR[RealismOverhaul]
 	{
-	}
-	!MODULE[ModuleCommand]
-	{
-	}
-}
-@PART[XOrionPodXbb31]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@MODEL
-	{
-	  @scale = 1.5829333, 1.466667, 1.5829333
+		@module		 = Part
+		%RSSROConfig = true
+
+		@MODEL
+		{
+			@scale	  = 1.458, 1.200, 1.458
+			%position = 0.000, 0.000, 0.000
+			%rotation = 0.000, 0.000, 0.000
+		}
+
+		!mesh		   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_bottom = 0.000, -1.045, 0.000, 0.000, -1.000, 0.000, 3
+		@node_stack_top	   = 0.000,  0.960, 0.000, 0.000,  1.000, 0.000, 3
+		@node_stack_1	   = 0.000,  0.930, 0.000, 0.000,  1.000, 0.000, 2
+
+		@TechRequired = spaceExploration
+		@title		  = Orion MPCV EFT
+		@manufacturer = Lockheed Martin
+		@description  = The Exploration Flight Test (EFT) article for the Orion MPCV.
+
+		@mass		    = 5.500
+		@crashTolerance = 12
+		@breakingForce  = 250
+		@breakingTorque = 250
+		@maxTemp	    = 800
+		%skinMaxTemp	= 2300
+		%emissiveConst	= 0.850
+		@CrewCapacity   = 0
+		@vesselType		= Probe
+		%fuelCrossFeed  = true
+		@CoMOffset 		= 0.000, -0.670, 0.000
+		!CoLOffset 		= NULL
+		!CoDOffset 		= NULL
+
+		!INTERNAL[ALCOR_Monley_Internals]{}
+
+		@MODULE[ModuleCommand]
+		{
+			RESOURCE
+			{
+				name = ElectricCharge
+				rate = 1.350
+			}
+		}
+
+		@MODULE[ModuleSAS]
+		{
+			%SASServiceLevel = 3
+		}
+
+		!MODULE[ModuleReactionWheel]{}
+
+		!MODULE[ModuleScienceContainer]{}
+
+		!MODULE[ModuleScienceLab]{}
+
+		!MODULE[ModuleDataTransmitter]{}
+
+		!MODULE[MechJebCore]{}
+
+		!MODULE[ModuleGenerator]{}
+
+		!MODULE[RasterPropMonitorComputer]{}
+
+		!MODULE[ModuleAblator]{}
+
+		!MODULE[ModuleHeatShield]{}
+
+		!MODULE[ModuleAeroReentry]{}
+
+		MODULE
+		{
+			name		   = CoMShifter
+			DescentModeCoM = 0.000, 0.000, -0.300
+		}
+
+		MODULE
+		{
+			name			 	= ModuleAblator
+			ablativeResource 	= Ablator
+			lossExp 			= -6000
+			lossConst 			= 0.007
+			pyrolysisLossFactor = 2000
+			ablationTempThresh 	= 400
+			reentryConductivity = 0.010
+			charMax 			= 1
+			charMin 			= 1
+		}
+
+		MODULE
+		{
+			name	 = ModuleFuelTanks
+			basemass = -1
+			type	 = ServiceModule
+			volume	 = 1000
+
+			TANK
+			{
+				name	  = ElectricCharge
+				amount	  = 43200
+				maxAmount = 43200
+			}
+
+			TANK
+			{
+				name	  = MMH
+				amount	  = 45
+				maxAmount = 45
+			}
+
+			TANK
+			{
+				name	  = NTO
+				amount	  = 45
+				maxAmount = 45
+			}
+		}
+
+		RESOURCE
+		{
+			name	  = Ablator
+			amount	  = 1500
+			maxAmount = 1500
+		}
+
+		!RESOURCE[AblativeShielding]{}
+
+		!RESOURCE[ElectricCharge]{}
+
+		!RESOURCE[MonoPropellant]{}
 	}
 
-	@node_stack_bottom = 0.0, -1.5426667, 0.0, 0, -1, 0, 2
-	@node_stack_top = 0.0, 1.18, 0.0, 0.0, 1.0, 0.0, 1
-	
-	@title = Orion MPCV EFT
-	@description = Block 1 test vehicle for the Orion MPCV program.
-	@manufacturer = NASA
-	
-        %CoMOffset = 0.0, -0.67, 0.0
-	
-	@mass = 5
-	
-	!MODULE[ModuleReactionWheel]
+//	==================================================
+//	Orion MPCV Crew Module (Realism Overhaul configuration).
+//
+/	Dimensions: 3.300 x 5.030 m
+//	Gross Mass: ~8900.000 Kg
+//	==================================================
+
+	@PART[XOrionPodX]:FOR[RealismOverhaul]
 	{
-	}
-        !RESOURCE[MonoPropellant]
-        {
-        }
-		!MODULE[ModuleGenerator]
+		@module		 = Part
+		%RSSROConfig = true
+
+		@MODEL
 		{
+			@scale	  = 1.458, 1.200, 1.458
+			%position = 0.000, 0.000, 0.000
+			%rotation = 0.000, 0.000, 0.000
 		}
-}
-@PART[XOrionPodX]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@MODEL
-	{
-	  @scale = 1.5829333, 1.466667, 1.5829333
+
+		!mesh		   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_bottom = 0.000, -1.045, 0.000, 0.000, -1.000, 0.000, 3
+		@node_stack_top	   = 0.000,  0.960, 0.000, 0.000,  1.000, 0.000, 3
+		@node_stack_1	   = 0.000,  0.930, 0.000, 0.000,  1.000, 0.000, 2
+
+		@TechRequired = spaceExploration
+		@title		  = Orion MPCV Crew Module (CM)
+		@manufacturer = Lockheed Martin
+		@description  = The next - generation NASA spacecraft for beyond LEO exploration. Can support 6 crew for up to 21 days of active time.
+
+		@mass		    = 5.500
+		@crashTolerance = 12
+		@breakingForce  = 250
+		@breakingTorque = 250
+		@maxTemp	    = 800
+		%skinMaxTemp	= 2300
+		%emissiveConst	= 0.850
+		@CrewCapacity   = 6
+		%fuelCrossFeed  = true
+		@CoMOffset 		= 0.000, -0.670, 0.000
+		!CoLOffset 		= NULL
+		!CoDOffset 		= NULL
+
+		!INTERNAL[ALCOR_Monley_Internals]{}
+
+		@MODULE[ModuleCommand]
+		{
+			RESOURCE
+			{
+				name = ElectricCharge
+				rate = 1.350
+			}
+		}
+
+		@MODULE[ModuleSAS]
+		{
+			%SASServiceLevel = 3
+		}
+
+		!MODULE[ModuleReactionWheel]{}
+
+		@MODULE[ModuleScienceContainer]
+		{
+			@storageRange = 2.600
+		}
+
+		!MODULE[ModuleScienceLab]{}
+
+		!MODULE[ModuleDataTransmitter]{}
+
+		!MODULE[MechJebCore]{}
+
+		!MODULE[ModuleGenerator]{}
+
+		!MODULE[RasterPropMonitorComputer]{}
+
+		!MODULE[ModuleAblator]{}
+
+		!MODULE[ModuleHeatShield]{}
+
+		!MODULE[ModuleAeroReentry]{}
+
+		MODULE
+		{
+			name		   = CoMShifter
+			DescentModeCoM = 0.000, 0.000, -0.300
+		}
+
+		MODULE
+		{
+			name			 	= ModuleAblator
+			ablativeResource 	= Ablator
+			lossExp 			= -6000
+			lossConst 			= 0.007
+			pyrolysisLossFactor = 2000
+			ablationTempThresh 	= 400
+			reentryConductivity = 0.010
+			charMax 			= 1
+			charMin 			= 1
+		}
+
+		MODULE
+		{
+			name	 = ModuleFuelTanks
+			basemass = -1
+			type	 = ServiceModule
+			volume	 = 1450
+
+			TANK
+			{
+				name	  = ElectricCharge
+				amount	  = 43200
+				maxAmount = 43200
+			}
+
+			TANK
+			{
+				name	  = Food
+				amount	  = 245.670
+				maxAmount = 737.100
+			}
+
+			TANK
+			{
+				name	  = Water
+				amount	  = 162.570
+				maxAmount = 162.570
+			}
+
+			TANK
+			{
+				name	  = Oxygen
+				amount	  = 1775.500
+				maxAmount = 24857.300
+			}
+
+			TANK
+			{
+				name	  = CarbonDioxide
+				amount	  = 0
+				maxAmount = 767.200
+			}
+
+			TANK
+			{
+				name	  = Waste
+				amount	  = 0
+				maxAmount = 22.354
+			}
+
+			TANK
+			{
+				name	  = WasteWater
+				amount	  = 0
+				maxAmount = 206.842
+			}
+
+			TANK
+			{
+				name	  = MMH
+				amount	  = 45
+				maxAmount = 45
+			}
+
+			TANK
+			{
+				name	  = NTO
+				amount	  = 45
+				maxAmount = 45
+			}
+
+			TANK
+			{
+				name	  = LithiumHydroxide
+				amount	  = 63
+				maxAmount = 63
+			}
+		}
+
+		MODULE
+		{
+			name		    = TacGenericConverter
+			converterName   = CO2 Scrubber
+			conversionRate  = 6.0
+			inputResources  = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+			outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+		}
+
+		RESOURCE
+		{
+			name	  = Ablator
+			amount	  = 1500
+			maxAmount = 1500
+		}
+
+		!RESOURCE[AblativeShielding]{}
+
+		!RESOURCE[ElectricCharge]{}
+
+		!RESOURCE[MonoPropellant]{}
 	}
 
-	@node_stack_bottom = 0.0, -1.5426667, 0.0, 0, -1, 0, 2
-	@node_stack_top = 0.0, 1.18, 0.0, 0.0, 1.0, 0.0, 1
-	
-	@title = Orion MPCV
-	@description = NASAs beyond low earth orbit Crew Exploration Vehicle
-	@manufacturer = NASA
-        @CoMOffset = 0.0, -0.67, 0.0
-	
-	@mass = 5
-	
-	!MODULE[ModuleReactionWheel]
+//	==================================================
+//	Orion Crew Module (RemoteTech configuration).
+//	==================================================
+
+	@PART[XOrionPodX|XOrionPodXbb31]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 	{
-	}
-        !RESOURCE[MonoPropellant]
-        {
-        }
-		!MODULE[ModuleGenerator]
+		MODULE
 		{
+			name = ModuleSPU
 		}
-}
+
+		MODULE
+		{
+			name		 = ModuleRTAntennaPassive
+			TechRequired = start
+			OmniRange	 = 2000000
+
+			TRANSMITTER
+			{
+				PacketInterval	   = 0.400
+				PacketSize		   = 0.270
+				PacketResourceCost = 0.025
+			}
+		}
+	}
+
+//	==================================================
+//	Orion Crew Module (DeadlyReentry configuration).
+//	==================================================
+
+	@PART[XOrionPodX|XOrionPodXbb31]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
+	{
+		@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+		{
+			@name			= ModuleHeatShield
+			depletedMaxTemp = 1200
+		}
+
+		MODULE
+		{
+			name 				 = ModuleAeroReentry
+			%skinMaxTemp 		 = 2500
+			%skinThicknessFactor = 0.050
+		}
+	}
+
 @PART[XOrionLES]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -1001,17 +1001,210 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 		}
 	}
 
-@PART[XOrionLES]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@rescaleFactor = 1.6
-	
-	@title = Orion LES
-	@description = Crew vehicle launch escape system.
-	@manufacturer = NASA
-	
-	@mass = 1.8
-	
-	
+//	==================================================
+//	Orion Launch Abort System (LAS).
 
-}
+//	Dimensions: 4.800 x 13.300 m
+//	Gross Mass: 6176.00 Kg
+//  Throttle Range: N/A
+//	Burn Time: 3 s
+//	==================================================
+
+	@PART[XOrionLES]:FOR[RealismOverhaul]
+	{
+		%RSSROConfig = true
+
+		@MODEL
+		{
+			@scale	  = 1.470, 1.410, 1.470
+			%position = 0.000, 0.000, 0.000
+			%rotation = 0.000, 0.000, 0.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100, 0.100,  0.100
+			position =   0.000, 8.775, -0.340
+			rotation = -90.000, 0.000,  0.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100, 0.100, 0.100
+			position =  0.000, 8.775, 0.340
+			rotation = 90.000, 0.000, 0.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 = 0.100, 0.100,   0.100
+			position = 0.340, 8.775,   0.000
+			rotation = 0.000, 0.000, -90.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100, 0.100,  0.100
+			position = -0.340, 8.775,  0.000
+			rotation =  0.000, 0.000, 90.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100,  0.100,  0.100
+			position = -0.230,  8.775, -0.230
+			rotation = -90.000, 45.000, 0.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100, 0.100,  0.100
+			position =  0.250, 8.775,  0.250
+			rotation = 90.000, 45.000, 0.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =  0.100,   0.100, 0.100
+			position = -0.225,   8.775, 0.225
+			rotation = 90.000, -45.000, 0.000
+		}
+
+		MODEL
+		{
+			model	 = RealismOverhaul/Models/LinearRCS
+			scale	 =   0.100,   0.100,  0.100
+			position =   0.225,   8.775, -0.225
+			rotation = -90.000, -45.000,  0.000
+		}
+
+		!mesh		   = NULL
+		%scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_bottom = 0.000, -0.600, 0.000, 0.000, -1.000, 0.000, 3
+
+		@TechRequired = aerodynamicSystems
+		@category 	  = Engines
+		@title		  = Orion Launch Abort System (LAS)
+		@manufacturer = ATK (Alliant Techsystems)
+		@description  = The launch escape tower of the Orion command module. Activates in the case of an emergency and carries the crew of the Orion safely away from the launch vehicle.
+
+		@mass			  = 4.1290
+		@crashTolerance   = 12
+		@breakingForce    = 250
+		@breakingTorque   = 250
+		@maxTemp		  = 1973.15
+		%fuelCrossFeed 	  = false
+		%stageOffset	  = 1
+		%childStageOffset = 1
+		%emissiveConstant = 0.700
+		%bulkheadProfiles = size3
+
+		@MODULE[ModuleEngines]
+		{
+			@minThrust 		= 1760.00
+			@maxThrust	 	= 1760.00
+			@heatProduction = 100
+			!fxOffset 		= NULL
+			%ullage			= false
+			%pressureFed 	= false
+			%ignitions		= 1
+
+			@PROPELLANT[SolidFuel]
+			{
+				@name = HTPB
+			}
+
+			@atmosphereCurve
+			{
+				@key,0 = 0 290
+				@key,1 = 1 245
+			}
+		}
+
+		!MODULE[ModuleDecouple]{}
+
+		MODULE
+		{
+			name				  = ModuleRCSFX
+			thrusterTransformName = RCSthruster
+			thrusterPower		  = 22.300
+
+			PROPELLANT
+			{
+				name  = Hydrazine
+				ratio = 1.000
+			}
+
+			atmosphereCurve
+			{
+				key = 0 237
+				key = 1 84
+			}
+		}
+
+		MODULE
+		{
+			name	 = ModuleFuelTanks
+			volume	 = 150
+			type	 = Fuselage
+			basemass = -1
+
+			TANK
+			{
+				name	  = Hydrazine
+				amount	  = 150
+				maxAmount = 150
+			}
+		}
+
+		MODULE
+		{
+			name	 = ModuleFuelTanks
+			volume   = 1071.42
+			type	 = HTPB
+			basemass = -1
+		}
+
+		MODULE
+		{
+			name		  = ModuleEngineConfigs
+			type		  = ModuleEngines
+			configuration = Orion-LAS
+			modded		  = false
+
+			CONFIG
+			{
+				name		   = Orion-LAS
+				minThrust 	   = 1760.00
+				maxThrust	   = 1760.00
+				heatProduction = 100
+				%ullage		   = false
+				%pressureFed   = false
+				%ignitions	   = 1
+
+				PROPELLANT
+				{
+					name	  = HTPB
+					ratio	  = 1.000
+					DrawGauge = True
+				}
+
+				atmosphereCurve
+				{
+					key = 0 290
+					key = 1 245
+				}
+			}
+		}
+
+		!RESOURCE[SolidFuel]{}
+	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -192,7 +192,7 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 		{
 			name	 = ModuleFuelTanks
 			type	 = ServiceModule
-			volume   = 10000
+			volume   = 5150
 			basemass = -1
 
 			TANK

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -29,206 +29,255 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
     
 }
 
-@PART[altairPod]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Pod/altairPod/altairPod
-		scale = 0.93333, 0.93333, 0.93333
-	}
-	@rescaleFactor = 1
-    
-        @title = Altair Ascent Module
-        @manufacturer = NASA
-        @description = Crewed Ascent Vehicle for the Altair lander system.
-    
-        @mass = 5.8
-    
-    
-        !MODULE[ModuleAlternator]
-        {
-        }
-        !MODULE[ModuleReactionWheel]
-        {
-        }
-        !MODULE[ModuleGenerator]
-        {
-        }
-        !RESOURCE[MonoPropellant]
-        {
-        }
-    
-        
-        MODULE
-	{
-		name = ModuleFuelTanks
-		type = ServiceModule
-		volume = 500.0
-		basemass = -1
-		TANK
-		{
-			name = ElectricCharge
-			amount = 14871.6
-			maxAmount = 14871.6
-		}
-		TANK
-		{
-			name = Aerozine50
-			amount = 2015
-			maxAmount = 2015
-		}
-		TANK
-		{
-			name = NTO
-			amount = 1997.5
-			maxAmount = 1997.5
-		}        
+//	==================================================
+//	Altair lunar lander (ascent module).
 
-		TANK
-		{
-			name = Oxygen
-			amount = 5600
-			maxAmount = 5600
-		}
-		TANK
-		{
-			name = Water
-			amount = 17.7
-			maxAmount = 17.7
-		}
-		TANK
-		{
-			name = Food
-			amount = 42
-			maxAmount = 42
-		}
-	}
-        
+//	Dimensions: 5.500 x 6.000 m
+//	Gross Mass: 10800.00 Kg
+//	==================================================
 
-        @MODULE[ModuleEngines*]
+	@PART[altairPod]:FOR[RealismOverhaul]
 	{
-		%maxThrust = 43
-		%minThrust = 43
-		%heatProduction = 100
-		@atmosphereCurve
+		%RSSROConfig = true
+
+		MODEL
 		{
-			@key,0 = 0 319
-			@key,1 = 1 112
+			model	 = CMES/Pod/altairPod/altairPod
+			scale	 = 1.000, 1.000, 1.000
+			position = 0.000, 0.000, 0.000 
+			rotation = 0.000, 0.000, 0.000
 		}
-		@PROPELLANT[LiquidFuel]
+
+		!MODEL		   = NULL
+		!mesh		   = NULL
+		%scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_bottom = 0.000, -3.800, 0.000, 0.000, -1.000, 0.000, 3
+		@node_stack_top	   = 0.000,  2.220, 0.000, 0.000,  1.000, 0.000, 3
+
+		@title		  = Altair Ascent Module (AM)
+		@manufacturer = NASA & Northrop Grumman
+		@description  = The ascent module for the Altair lunar lander. Can support a 4 crew lunar sortie for up to 7 days of active time.
+
+		@mass			  = 4.900
+		%crashTolerance   = 12
+		%breakingForce    = 250
+		%breakingTorque   = 250
+		@maxTemp		  = 1973.15
+		%fuelCrossFeed	  = true
+		%stageOffset	  = 1
+		%childStageOffset = 1
+		%stagingIcon	  = LIQUID_ENGINE
+		%bulkheadProfiles = size2, size3
+		@CrewCapacity	  = 4
+
+		!INTERNAL[ALCOR_Monley_Internals]{}
+
+		@MODULE[ModuleCommand]
 		{
-			@name = Aerozine50
-			@ratio = 0.472
+			@minimumCrew = 0
+
+			RESOURCE
+			{
+				name = ElectricCharge
+				rate = 1.125
+			}
 		}
-		@PROPELLANT[Oxidizer]
+
+		@MODULE[ModuleEngines*]
 		{
-			@name = NTO
-			@ratio = 0.528
+			%maxThrust	 	= 43.38
+			%minThrust	 	= 43.38
+			%heatProduction = 100
+			%ullage			= false
+			%ignitions		= -1
+			%pressureFed	= true
+
+			@PROPELLANT[LiquidFuel]
+			{
+				@name  = Aerozine50
+				@ratio = 0.472
+			}
+
+			@PROPELLANT[Oxidizer]
+			{
+				@name  = NTO
+				@ratio = 0.528
+			}
+
+			@atmosphereCurve
+			{
+				@key,0 = 0 321.0
+				@key,1 = 1 212.5
+			}
 		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 7
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		configuration = AJ10-118K
-		modded = false
-		CONFIG
+
+		@MODULE[ModuleGimbal]
 		{
-			name = AJ10-118K
-			maxThrust = 43
-			minThrust = 43
+			@gimbalRange		 	= 7.000
+			%useGimbalResponseSpeed = true
+			%gimbalResponseSpeed 	= 16
+		}
+
+		MODULE
+		{
+			name		  = ModuleEngineConfigs
+			configuration = AJ10-118K
+			modded		  = false
+
+			CONFIG
+			{
+				name	  = AJ10-118K
+				maxThrust = 43.38
+				minThrust = 43.38
+
+				PROPELLANT
+				{
+					name	  = Aerozine50
+					ratio	  = 0.472
+					DrawGauge = true
+				}
+
+				PROPELLANT
+				{
+					name  = NTO
+					ratio = 0.528
+				}
+
+				atmosphereCurve
+				{
+					key = 0 321.0
+					key = 1 212.5
+				}
+			}
+		}
+
+        @MODULE[ModuleRCS]
+        {
+			@name		   = ModuleRCSFX
+			@thrusterPower = 0.207
+			!resourceName  = NULL
+
 			PROPELLANT
 			{
-				name = Aerozine50
+				name  = Aerozine50
 				ratio = 0.472
-				DrawGauge = true
 			}
+
 			PROPELLANT
 			{
-				name = NTO
+				name  = NTO
 				ratio = 0.528
 			}
-			atmosphereCurve
+
+			@atmosphereCurve
 			{
-				key = 0 319
-				key = 1 112
+				@key,0 = 0 319
+				@key,1 = 1 112
 			}
 		}
-	}
-        !MODULE[ModuleEngineIgnitor]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		ignitionsAvailable = -1
-		autoIgnitionTemperature = 800
-		ignitorType = Electric
-		useUllageSimulation = false
-		isPressureFed = true
-		IGNITOR_RESOURCE
+
+		!MODULE[RasterPropMonitorComputer]{}
+
+		!MODULE[MechJebCore]{}
+	
+        !MODULE[ModuleAlternator]{}
+
+        !MODULE[ModuleReactionWheel]{}
+
+        !MODULE[ModuleGenerator]{}
+
+		MODULE
 		{
-			name = Aerozine50
-			amount = 0.502
-		}
-		IGNITOR_RESOURCE
-		{
-			name = NTO
-			amount = 0.498
-		}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-	}
-        !MODULE[ModuleRCS]
-        {
-        }
-	MODULE
-	{
-		name = ModuleRCSFX
-		thrusterTransformName = RCSthruster
-		thrusterPower = 0.207
-			PROPELLANT
+			name	 = ModuleFuelTanks
+			type	 = ServiceModule
+			volume   = 10000
+			basemass = -1
+
+			TANK
 			{
-				name = NTO
-				ratio = 0.528
+				name	  = ElectricCharge
+				amount	  = 43200
+				maxAmount = 43200
 			}
-			atmosphereCurve
+
+			TANK
 			{
-				key = 0 319
-				key = 1 112
+				name	  = Aerozine50
+				amount	  = 2197
+				maxAmount = 2197
 			}
-		atmosphereCurve
-		{
-			key = 0 137.175
-			key = 1 47.082
+
+			TANK
+			{
+				name	  = NTO
+				amount	  = 2459
+				maxAmount = 2459
+			} 
+
+			TANK
+			{
+				name	  = Food
+				amount	  = 163.8
+				maxAmount = 163.8
+			}
+
+			TANK
+			{
+				name	  = Water
+				amount	  = 15.5
+				maxAmount = 15.5
+			}
+
+			TANK
+			{
+				name	  = Oxygen
+				amount	  = 2367.5
+				maxAmount = 2367.5
+			}
+
+			TANK
+			{
+				name	  = CarbonDioxide
+				amount	  = 0
+				maxAmount = 2048
+			}
+
+			TANK
+			{
+				name	  = Waste
+				amount	  = 0
+				maxAmount = 14.91
+			}
+
+			TANK
+			{
+				name	  = WasteWater
+				amount	  = 0
+				maxAmount = 137.9
+			}
+
+			TANK
+			{
+				name	  = LithiumHydroxide
+				amount	  = 63
+				maxAmount = 63
+			}
 		}
-	}
-        
-}
-@PART[CHAKAPOD]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@MODEL
-	{
-		@scale = 1.9333, 1.06667, 1.9333
+
+		MODULE
+		{
+			name		    = TacGenericConverter
+			converterName   = CO2 Scrubber
+			conversionRate  = 4.0
+			inputResources  = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+			outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+		}
+
+        !RESOURCE[MonoPropellant]{}
 	}
 
-	@node_stack_top = 0.0, 1, 0.0, 0.0, 1.0, 0.0
-	@node_stack_bottom = 0.0, -1.04, 0.0, 0, -1, 0
-}
-@PART[CHAKAPOD]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@rescaleFactor = 1.3333
-}
 @PART[xLERroverXBodyxX]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -338,7 +387,7 @@ PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
 }
 
 //	==================================================
-//	Orion EFT LES decoupler system.
+//	Orion EFT LAS decoupler system.
 
 //	Dimensions: 2.700 x 1.000 m
 //	Gross Mass: ~600.000 Kg

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1,187 +1,221 @@
-@PART[XAltair2descent2stageX]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/Altair_descent_stage/model
-		scale = 1.4, 1.4, 1.4
-	}
-	@scale = 1
-	@rescaleFactor = 1
+//	==================================================
+//	Altair lunar lander (descent module).
 
+//	Dimensions: 7.800 x 6.200 m (stowed)
+//	Gross Mass: 35055.00 Kg
+//	==================================================
 
-	// --- node definitions ---
-	@node_stack_top = 0.0, -1.05, 0.0, 0.0, 1.0, 0.0,2
-	@node_stack_bottom = 0.0, -2.62378, 0.0, 0, -1, 0,2
+	@PART[XAltair2descent2stageX]:FOR[RealismOverhaul]
+	{
+		%RSSROConfig = True	
 
-	// --- FX definitions ---
-	@fx_exhaustFlame_yellow_tiny = 0.0, -4.2, 0.0, 0.0, 1.0, 0.0, running
-	@fx_exhaustLight_blue = 0.0, -3.0, 4.2, 0.0, 0.0, 1.0, running
+		MODEL
+		{
+			model	 = CMES/Structural/Altair_descent_stage/model
+			scale	 = 1.750, 1.750, 1.750
+			position = 0.000, 0.000, 0.000
+			rotation = 0.000, 0.000, 0.000
+		}
+
+		!MODEL		   = NULL
+		!mesh		   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_top	   = 0.000, -1.000, 0.000, 0.000,  1.000, 0.000, 3
+		@node_stack_bottom = 0.000, -3.350, 0.000, 0.000, -1.000, 0.000, 3
     
-        @title = Altair Lander Descent Module
-	%manufacturer = NASA
-	@description = The lunar descent and exploration stage of the Altair.
-        @mass = 10.8
+        @title		  = Altair Descent Module (DM)
+		%manufacturer = Northrop Grumman & NASA
+		@description  = Altair (or Lunar Surface Access Module - LSAM) was a Constellation program asset designed for Moon landings. The descent module would be used to decelerate into a lunar orbit, undock from Orion and then land on the surface. Payload includes either a crewed outpost or cargo.
+
+		@mass			  = 15.545
+		%crashTolerance   = 12
+		%breakingForce    = 250
+		%breakingTorque   = 250
+		%maxTemp		  = 1973.15
+		%fuelCrossFeed	  = true
+		%bulkheadProfiles = size3
+		%stageOffset	  = 1
+		%childStageOffset = 1
+		%stagingIcon	  = LIQUID_ENGINE
     
-    RESOURCE
-    {
-        name = Food
-        amount = 1.097
-        maxAmount = 1.097
-        @amount *= 16
-        @maxAmount *= 16
-    }
-    RESOURCE
-    {
-        name = Water
-        amount = 0.725
-        maxAmount = 0.725
-        @amount *= 16
-        @maxAmount *= 16
-    }
-    RESOURCE
-    {
-        name = Oxygen
-        amount = 111.038
-        maxAmount = 111.038
-        @amount *= 16
-        @maxAmount 16
-    }
- 	!RESOURCE[LiquidFuel]
-	{
-	}
-	!RESOURCE[Oxidizer]
-	{
-	}
+		!MODULE[ModuleSAS]{}
+
+		!MODULE[ModuleReactionWheel]{}
     
-        @RESOURCE[ElectricCharge]
-	{
-            amount = 10000
-            maxaAmount = 10000
-	}
-    
-	!RESOURCE[MonoPropellant]
-	{
-	}
-    
-        !MODULE[ModuleReactionWheel]
-        {
-        }
-    
-        !MODULE[ModuleGenerator]
-        {
-        }
-        
-    
-        RESOURCE
-        {
-            name = Hydrazine
-            amount = 1200
-            maxAmount = 1200
-        }
-    
-        @MODULE[ModuleRCS]
-        {
-            @resourceName = Hydrazine
-        }
-    
-        RESOURCE
-        {
-            name = LqdHydrogen
-            amount = 36894
-            maxAmount = 36894
-        }
-    
-        RESOURCE
-        {
-            name = LqdOxygen
-            amount = 13466
-            maxAmount = 13466
-        }
+		!MODULE[ModuleGenerator]{}
+
+		!MODULE[ModuleDecouple]{}
+
+		MODULE
+		{
+			name  	 = ModuleFuelTanks
+			type  	 = ServiceModule
+			volume 	 = 59764
+			basemass = -1
+
+			TANK
+			{
+				name	  = ElectricCharge
+				amount	  = 43200
+				maxAmount = 43200
+			}
+
+			TANK
+			{
+				name	  = LqdHydrogen
+				amount	  = 45303.97
+				maxAmount = 45303.97
+			}
+
+			TANK
+			{
+				name	  = LqdOxygen
+				amount	  = 14072.14
+				maxAmount = 14072.14
+			}
+
+			TANK
+			{
+				name	  = Hydrazine
+				amount	  = 150
+				maxAmount = 150
+			}
+
+			TANK
+			{
+				name	  = Water
+				amount	  = 0
+				maxAmount = 95
+			}
+		}
+
         @MODULE[ModuleEngines*]
-	{
-		@minThrust = 350
-		@maxThrust = 444
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
 		{
-			@name = LqdHydrogen
-			@ratio = 0.734
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.266
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 462
-			@key,1 = 1 235
-		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 4.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = RL-10B-2
-		modded = false
-		CONFIG
-		{
-			name = RL-10B-2
-			minThrust = 350
-			maxThrust = 444
-			heatProduction = 100
-			PROPELLANT
+			@minThrust	 	= 21.34
+			@maxThrust	 	= 266.80
+			@heatProduction = 100
+			%ullage		    = true
+			%ignitions	    = 9
+			%pressureFed	= false
+
+			IGNITOR_RESOURCE
 			{
-				name = LqdHydrogen
-				ratio = 0.734
-				DrawGauge = True
+				name   = ElectricCharge
+				amount = 0.500
 			}
-			PROPELLANT
+
+			IGNITOR_RESOURCE
 			{
-				name = LqdOxygen
-				ratio = 0.266
+				name   = LqdHydrogen
+				amount = 0.734
 			}
-			atmosphereCurve
+
+			IGNITOR_RESOURCE
 			{
-				key = 0 462
-				key = 1 235
+				name   = LqdOxygen
+				amount = 0.266
+			}
+
+			@PROPELLANT[LiquidFuel]
+			{
+				@name  = LqdHydrogen
+				@ratio = 0.734
+			}
+
+			@PROPELLANT[Oxidizer]
+			{
+				@name  = LqdOxygen
+				@ratio = 0.266
+			}
+
+			@atmosphereCurve
+			{
+				@key,0 = 0 460
+				@key,1 = 1 100
 			}
 		}
 
+		MODULE
+		{
+			name		  = ModuleEngineConfigs
+			type		  = ModuleEngines
+			configuration = CECE
+			modded		  = false
+
+			CONFIG
+			{
+				name		   = CECE
+				minThrust	   = 21.34
+				maxThrust	   = 266.80
+				heatProduction = 100
+
+				PROPELLANT
+				{
+					name  = LqdHydrogen
+					ratio = 0.763
+				}
+
+				PROPELLANT
+				{
+					name  = LqdOxygen
+					ratio = 0.237
+				}
+
+				atmosphereCurve
+				{
+					key = 0 460
+					key = 1 100
+				}
+
+			}
+		}
+
+		@MODULE[ModuleGimbal]
+		{
+			@gimbalRange			= 4.000
+			%useGimbalResponseSpeed = true
+			%gimbalResponseSpeed 	= 16
+		}
+
+		@MODULE[ModuleRCS]
+		{
+			@name		   = ModuleRCSFX
+			@thrusterPower = 0.250
+			!resourceName  = NULL
+
+			PROPELLANT
+			{
+				ratio = 1.000
+				name  = Hydrazine
+			}
+
+			@atmosphereCurve
+			{
+				@key,0 = 0 254
+				@key,1 = 1 84
+			}
+		}
+
+		MODULE
+		{
+			name		    = TacGenericConverter
+			converterName   = Fuel Cell
+			conversionRate  = 2.0
+			inputResources  = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
+			outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
+		}
+
+		!RESOURCE[LiquidFuel]{}
+
+		!RESOURCE[Oxidizer]{}
+    
+		!RESOURCE[ElectricCharge]{}
+
+		!RESOURCE[MonoPropellant]{}
 	}
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		ignitionsAvailable = 5
-		autoIgnitionTemperature = 800
-		ignitorType = Electric
-		useUllageSimulation = true
-		isPressureFed = false
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.005
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdHydrogen
-			amount = 0.734
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 0.266
-		}
-	}
-}
+
 @PART[XlpAltairDockingPortX]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True	
@@ -254,23 +288,47 @@
 		!MODULE[MechJebCore]{}
 	}
 
-@PART[XwheelMedX]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
+//	==================================================
+//	Exploration rover wheel (high strength).
+
+//	Dimensions: 1.600 x 1.500 m
+//	Gross Mass: 200.00 Kg
+//	==================================================
+
+	@PART[XwheelMedX]:FOR[RealismOverhaul]
 	{
-		model = CMES/Structural/CHAKA WHEEL/model
-		scale = 1.3333, 1.3333, 1.3333
-	}
-	@scale = 1
-	@rescaleFactor = 1
-	@node_attach = 0.0, 0.0, 0.0, 1.0, 0.0, 0.0
+		%RSSROConfig = True
+
+		MODEL
+		{
+			model	 = CMES/Structural/CHAKA WHEEL/model
+			scale	 = 1.333, 1.333, 1.333
+			position = 0.000, 0.000, 0.000
+			rotation = 0.000, 0.000, 0.000
+		}
+
+		!MODEL		   = NULL
+		!mesh		   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
     
-        @title = Exploration Rover Wheel
-	@manufacturer = NASA
-	@description = Rover wheel for NASA surface exploration vehciles.
-}
+        @title		  = Exploration Rover Wheel
+		@manufacturer = NASA
+		@description  = Rover wheel for the NASA surface exploration vehicles.
+
+		@mass			  = 0.200
+		%bulkheadProfiles = size2, surf
+
+		@MODULE[ModuleWheel]
+		{
+			@impactTolerance		 = 300
+			@overSpeedDamage		 = 60
+			@resourceConsumptionRate = 0.001
+		}
+	}
+
 @PART[nosMonkeyExplorerUtilityHAB]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True	
@@ -1168,14 +1226,29 @@
 	@node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, 0.00, 0.0, 0, -1, 0, 0
 }
-@PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-}
-@PART[SUPERSTRUTCONNECTOR]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-}
+
+//	==================================================
+//	Strut connector (medium strength).
+//	==================================================
+
+	@PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
+	{
+		%RSSROConfig = True
+
+		@mass = 0.0140
+	}
+
+//	==================================================
+//	Strut connector (high strength).
+//	==================================================
+
+	@PART[SUPERSTRUTCONNECTOR]:FOR[RealismOverhaul]
+	{
+		%RSSROConfig = True
+
+		@mass = 0.0560
+	}
+
 @PART[Xtrusslrg_argonX]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -193,27 +193,67 @@
 	@node_stack_top = 0.0, 0.10394, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.012, 0.0, 0, -1, 0, 1
 }
-@PART[XAltairDockingPortX]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/Altair_dockport/model
-		scale = 1.586667, 1.586667, 1.586667
-	}
-	@scale = 1
-	@rescaleFactor = 1
 
-	@node_stack_top = 0.0, 0.309225, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.037701, 0.0, 0, -1, 0, 1
-    
-        @title = APAS Orion/Constellation
-	@manufacturer = NASA
-	@description = APAS docking system for ARES/Constellation/SLS exploration systems
-    
-        @mass = 0.2
-}
+//	==================================================
+//	NASA Docking & Berthing Mechanism (NDS).
+
+//	Dimensions: 1.225 x 0.500 m
+//	Gross Mass: 200.00 Kg
+//	==================================================
+
+	@PART[XAltairDockingPortX]:FOR[RealismOverhaul]
+	{
+		%RSSROConfig = true
+
+		MODEL
+		{
+			model	 = CMES/Structural/Altair_dockport/model
+			scale	 = 1.000, 1.000, 1.000
+			position = 0.000, 0.000, 0.000
+			rotation = 0.000, 0.000, 0.000
+		}
+
+		!mesh	 	   = NULL
+		@scale		   = 1.000
+		@rescaleFactor = 1.000
+
+		@node_stack_top	   = 0.000,  0.195, 0.000, 0.000,  1.000, 0.000, 2
+		@node_stack_bottom = 0.000, -0.024, 0.000, 0.000, -1.000, 0.000, 2
+		@attachRules	   = 1,1,1,1,0
+
+		@TechRequired = basicRocketry
+		@title		  = NASA Docking System (NDS)
+		@manufacturer = Boeing
+		@description  = The NDS is an androgynous spacecraft docking and berthing mechanism, developed for the Orion MPCV and the Commercial Crew vehicles.
+
+		@mass			  = 0.200
+		@crashTolerance   = 12
+		@breakingForce    = 250
+		@breakingTorque   = 250
+		@maxTemp	 	  = 1073.15
+		%bulkheadProfiles = size2
+
+		@MODULE[ModuleDockingNode]
+		{
+			@nodeType			   = NASADock
+			%acquireForce		   = 0.5
+			%acquireMinFwdDot	   = 0.8
+			%acquireminRollDot	   = -3.40282347E+38
+			%acquireRange		   = 0.25
+			%acquireTorque		   = 0.5
+			%captureMaxRvel	 	   = 0.1
+			%captureMinFwdDot 	   = 0.998
+			%captureMinRollDot 	   = -3.40282347E+38
+			%captureRange		   = 0.05
+			%minDistanceToReEngage = 0.25
+			%undockEjectionForce   = 0.1
+		}
+
+		!MODULE[ModuleCommand]{}
+
+		!MODULE[MechJebCore]{}
+	}
+
 @PART[XwheelMedX]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True	


### PR DESCRIPTION
Added the ability for the Procedural Fairings to become transparent when hovering above them in the VAB (like the stock ones, although it's not perfect).

Updated the CMES MTV habitation module as a "TransHab II", derived by the original TransHab concept.

Updated the CMES Orion configurations to better differentiate between the Orion EFT and the Orion MPCV versions. Still need to implement the RCS system on both of them.