### PR TITLE
Add LVT1C Config for RO

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSLO/engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSLO/engines.cfg
@@ -5,38 +5,38 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%title = HM-7 Vacuum Engine [1.0m]
-	%manufacturer = EADS Astrium
-	%description = Upper stage of the Ariane 2 - 4 vehicles that launched satellites into GTO. A gas-generator cycle engine that uses cryogenic propellants. A 5m version is still used in the Ariane 5 ECA as a second stage.
+	%title = Merlin 1C
+	%manufacturer = SpaceX
+	%description = Merlin 1C
 	
-	%rescaleFactor = 0.75
+	%rescaleFactor = 1.0
 	%scale = 1.0
 
 	%attachRules = 1,0,1,0,0
-	%mass = 0.2475
+	%mass = 0.760
 	%maxTemp = 1973.15
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
 	@MODULE[ModuleEngines*]
 	{
-		%maxThrust = 65
-		%minThrust = 65
+		%maxThrust = 482.632
+		%minThrust = 482.632
 		%heatProduction = 100
 		@atmosphereCurve
 		{
-			@key,0 = 0 446
-			@key,1 = 1 156
+			@key,0 = 0 304.8
+			@key,1 = 1 267
 		}
 		@PROPELLANT[LiquidFuel]
 		{
-			@name = LqdHydrogen
-			@ratio = 0.781
+			@name = Kerosene
+			@ratio = 0.391
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-@ratio = 0.219
+			@ratio = 0.609
 		}
 		%ullage = True
 		%pressureFed = False
@@ -44,13 +44,13 @@
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
-			name = LqdHydrogen
-			amount = 0.781
+			name = Kerosene
+			amount = 0.391
 		}
 		IGNITOR_RESOURCE
 		{
 			name = LqdOxygen
-			amount = 0.219
+			amount = 0.609
 		}
 		IGNITOR_RESOURCE
 		{
@@ -58,9 +58,13 @@
 			amount = 0.5
 		}
 	}
-	@MODULE[ModuleGimbal]
+	!MODULE[ModuleGimbal] {}
+	MODULE
 	{
-		@gimbalRange = 5.0
+		name = ModuleGimbal
+		gimbalRange = 7.0
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
 	}
 	!MODULE[ModuleAlternator]
 	{
@@ -72,50 +76,29 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		configuration = HM-7B
+		configuration = MerlinC
 		modded = false
 		CONFIG
 		{
-			name = HM-7
-			maxThrust = 61.7
-			minThrust = 61.7
+			name = Merlin1C
+			minThrust = 482.632
+			maxThrust = 482.632
+			heatProduction = 100
 			PROPELLANT
 			{
-				name = LqdHydrogen
-				ratio = 0.781
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.219
-			}
-			atmosphereCurve
-			{
-				key = 0 443
-				key = 1 308
-			}
-		}
-		CONFIG
-		{
-			name = HM-7B
-			maxThrust = 70
-			minThrust = 70
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.758
-				DrawGauge = true
+				name = Kerosene
+				ratio = 0.391
+				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.242
+				ratio = 0.609
 			}
 			atmosphereCurve
 			{
-				key = 0 447
-				key = 1 310
+				key = 0 304.8
+				key = 1 267
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KSLO/LVT1C.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KSLO/LVT1C.cfg
@@ -1,0 +1,23 @@
+@PART[LVT1C]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%powerEffectName = Kerolox-Lower
+		!fxOffset = DELETE
+
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+	}
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.1
+        fixedScale = 0.45
+        energy = 1
+        speed = 1
+    }


### PR DESCRIPTION
Also did basic RealPlume config.

As @eggrobin requested / suggested.

These engines are nice, stock-like models of the actual Merlin engines.