### PR TITLE
SSTU Orion Config 1

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
@@ -1,0 +1,78 @@
+@PART[SSTU_ShipCore_B_ENG4]:FOR[RealismOverhaul]
+{
+	@mass = 12.71
+	
+	@rescaleFactor = 1.676
+	
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 5600
+		@maxThrust = 8680
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.729
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.271
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 453
+			@key,1 = 1 363
+		}
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 8.5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RS-25D/E
+		modded = false
+		CONFIG
+		{
+			name = RS-25D/E
+			minThrust = 5600
+			maxThrust = 8680
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.729
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.271
+			}
+			atmosphereCurve
+			{
+				key = 0 453
+				key = 1 363
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
@@ -1,0 +1,410 @@
+@PART[SSTU_ShipCore_B_BPC]:FOR[RealismOverhaul]
+{
+	%category = Engine
+
+	%RSSROConfig = True
+	@MODEL
+	{
+		@scale = 1.118,1.118,1.118
+	}
+	%rescaleFactor = 1.25
+	@title = Orion Launch Escape Assembly
+	@description = The LEA provides the means for separation the CM from the launch vehicle during pad or suborbital aborts. This assembly consists of a Q-ball instrumentation assembly, ballast compartment, canard surfaces, pitch control motor, tower jettison motor, launch escape motor, a structural skirt, an open-frame tower, and a boost protective cover.
+	@mass = 2.051
+	@maxTemp = 1973.15
+	%stagingIcon = DECOUPLER_VERT
+	!RESOURCE[SolidFuel]
+	{
+	}
+	@MODULE[ModuleEngines*],0
+	{
+		@minThrust = 1779
+		@maxThrust = 1779
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		@minThrust = 20
+		@maxThrust = 20
+
+		@PROPELLANT[SolidFuel]
+		{
+			name = HTPB
+		}
+	}
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 100
+		@explosiveNodeID = bottom
+		%staged = true
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = HTPB
+		volume = 903.38
+		basemass = -1
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = False
+		configuration = Solid
+		CONFIG
+		{
+			name = Solid
+			minThrust = 0
+			maxThrust = 1779
+			PROPELLANT
+			{
+				name = HTPB
+				ratio = 1.0
+			}
+			atmosphereCurve
+			{
+				key = 0 190
+				key = 1 176
+			}
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_B_CM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		@scale = 1.118,1.118,1.118
+	}
+	%rescaleFactor = 1.25
+	@title = Orion Command Module
+	@description = Orion Command Module. Contains between 2 and 6 astronauts.
+	@mass = 6.2471
+	%skinMaxTemp = 3200
+	@maxTemp = 500
+	@CoMOffset = 0.0, -0.5, 0.0
+	
+	@MODULE[ModuleCommand]
+	{
+		@minimumCrew = 0
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 1.895 // needs to be adjusted to match Orion avionics/LS draw
+		}
+	}
+	MODULE
+	{
+		name = CoMShifter
+		DescentModeCoM = 0, 0, -0.192
+	}
+	
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 700.0
+		basemass = -1
+		TANK
+		{
+			name = ElectricCharge
+			amount = 72000
+			maxAmount = 72000
+		}
+		TANK
+		{
+			name = MMH
+			amount = 46.9
+			maxAmount = 46.9
+		}
+		TANK
+		{
+			name = NTO
+			amount = 56.1
+			maxAmount = 56.1
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 2663
+			maxAmount = 2663
+		}
+		TANK
+		{
+			name = Water
+			amount = 12
+			maxAmount = 163
+		}
+		TANK
+		{
+			name = Food
+			amount = 245.7
+			maxAmount = 245.7
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 43.2
+			maxAmount = 43.2
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 767.2
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 162
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 206.8
+		}
+	}
+	
+	!RESOURCE[Ablator]
+	!MODULE[SSTUAblator] { }
+	
+	%skinMaxTemp = 3500 // 3200
+	%maxTemp = 2273.15
+	@emissiveConst = 0.85 // pretty much black, but not perfect emitter
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 0.6
+	
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		lossExp = -12000 // more negative values yield small increases in skin temp
+		lossConst = 0.0035 // lower values yield more ablative loss
+		pyrolysisLossFactor = 600 // 6000
+		ablationTempThresh = 400
+		reentryConductivity = 0.01
+		charMax = 1
+		charMin = 1
+	}
+	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+	{
+		@name = ModuleHeatShield
+		depletedMaxTemp = 1200
+	}
+	RESOURCE
+	{
+		name = Ablator
+		amount = 848
+		maxAmount = 848
+	}
+	
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCSFX
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.712
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 300
+			@key,1 = 1 100
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_B_SM]:FOR[RealismOverhaul]
+{
+	@MODEL
+	{
+		@scale = 1.118,1.118,1.118
+	}
+	%rescaleFactor = 1.25
+	
+	@mass = 3.7 // ?
+
+	!MODULE[ModuleReactionWheel] {}
+
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 7000
+		basemass = -1
+		TANK
+		{
+			name = Water
+			amount = 210
+			maxAmount = 410
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 20
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = NTO
+			amount = 3722
+			maxAmount = 3722
+		}
+		TANK
+		{
+			name = MMH
+			amount = 3119
+			maxAmount = 3119
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 2880
+			maxAmount = 2880
+		}
+	}
+	
+	@MODULE[ModuleEnginesFX],*	
+	{
+		@PROPELLANT[MonoPropellant]
+		{
+			@name = MMH
+			@ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+	}
+	
+	@MODULE[ModuleEnginesFX],0
+	{
+		@minThrust = 33.362
+		@maxThrust = 33.362
+	}
+	
+	@MODULE[ModuleEnginesFX],1
+	{
+		@maxThrust = 3.362
+	}
+	
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCSFX
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.712
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 300
+			@key,1 = 1 100
+		}
+	}
+	
+	@MODULE[SSTUSolarPanelDeployable]
+	{
+		@resourceAmount = 1.55
+	}
+	
+	@MODULE[SSTUNodeFairing],0
+	{
+		@shieldTopY = 1.25
+		@shieldBottomY = -1.84125
+		@shieldTopRadius = 2.554
+		@shieldBottomRadius = 2.554
+		
+		!FAIRING { }
+		!FAIRING { }
+		
+		FAIRING
+		{
+			topY = 1.25
+			bottomY = -1.84125	
+			topRadius = 2.554
+			bottomRadius = 2.554
+			capSize = 0
+			wallThickness = 0.025
+			maxPanelHeight = 1
+			cylinderSides = 24
+			numOfSections = 4
+			jettisonDirection = 0,0,1
+		}
+	}
+	@MODULE[SSTUNodeFairing],1
+	{
+		!FAIRING { }
+		!FAIRING { }
+		
+		FAIRING
+		{
+			topY = -1.1084
+			bottomY = -1.47298
+			topRadius = 1.5
+			bottomRadius = 2.0435
+		}
+		FAIRING
+		{
+			topY = -1.47298
+			bottomY = -2.391
+			topRadius = 2.554
+			bottomRadius = 2.9 // 2.44
+			canAdjustHeight = true
+			canAdjustTop = true
+			canAdjustBottom = true
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_B_DPM]:FOR[RealismOverhaul]
+{
+	@MODEL
+	{
+		@scale = 1.118,1.118,1.118
+	}
+	%rescaleFactor = 1.25
+	
+	@title = Orion Docking Port and Parachute
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
@@ -381,18 +381,16 @@
 		FAIRING
 		{
 			topY = -1.1084
-			bottomY = -1.47298
+			bottomY = -2.391 // -1.47298
 			topRadius = 1.5
 			bottomRadius = 2.0435
 		}
 		FAIRING
 		{
-			topY = -1.47298
+			topY = -1.43298 // -1.47298
 			bottomY = -2.391
-			topRadius = 2.554
-			bottomRadius = 2.9 // 2.44
-			canAdjustHeight = true
-			canAdjustTop = true
+			topRadius = 1.875
+			bottomRadius = 2.44
 			canAdjustBottom = true
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Upper Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Upper Stages.cfg
@@ -1,0 +1,134 @@
+@PART[SSTU_ShipCore_B_ICPS]:FOR[RealismOverhaul]
+{
+	%rescaleFactor = 1.316
+	
+	@mass = 3.51
+	
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}	
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Default
+		volume = 76186
+		basemass = -1
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 55820
+			maxAmount = 55820
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 20366
+			maxAmount = 20366
+		}
+	}
+	
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 111.2
+		@maxThrust = 111.2
+		
+		PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.733
+		}
+		PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.267
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 462
+			@key,1 = 1 255
+		}
+		
+		ullage = True
+		ignitions = 10
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.5
+		}
+		throttleResponseRate = 1
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = RL10B-2
+		CONFIG
+		{
+			name = RL10B-2
+			minThrust = 111.2055
+			maxThrust = 111.2055
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.733
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.267
+			}
+			atmosphereCurve
+			{
+				key = 0 462
+				key = 1 235
+			}
+			cost = 2000
+			entryCost = 80000
+			entryCostSubtractors
+			{
+				RL10A-4 = 45000
+			}
+			techRequired = hydroloxTL7
+			massMult = 1.659
+		}
+	}
+	
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	
+	@MODULE[SSTUNodeFairing],0
+	{
+		!FAIRING {}
+		
+		FAIRING
+		{
+			topY = 3.21748 // 3.01748 // 2.51748
+			bottomY = 2.25587 // 1.75587
+			topRadius = 2.5
+			bottomRadius = 2.5
+			canAdjustTop = true
+		}
+	}
+	
+	@MODULE[SSTUNodeFairing],1
+	{
+		!FAIRING {}
+		
+		FAIRING
+		{
+			topY = 0.45588 // -0.04412
+			bottomY = -8.56338 // -6.36338
+			topRadius = 2.5
+			bottomRadius = 2.5
+			canAdjustBottom = true
+		}
+	}
+}


### PR DESCRIPTION
Start configuration of Orion CM, SM, LAS from SSTU.

Real scaling done, burns RealFuel. Fuel and masses still need tweaking,
TACLS not added yet.