### PR TITLE
SM bottom node adjustment

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
@@ -229,6 +229,8 @@
 
 @PART[SSTU_ShipCore_B_SM]:FOR[RealismOverhaul]
 {
+	@node_stack_bottom = 0, -1.8910, 0, 0, -1, 0, 2
+
 	@MODEL
 	{
 		@scale = 1.118,1.118,1.118


### PR DESCRIPTION
with the new SSTU release, the bottom SM node has moved. it is easier to move it back, rather than re-tune all of the associated fairings.