### PR TITLE
SSTU: fix SRB nodes, added 2,3 seg configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU SRB.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU SRB.cfg
@@ -1,44 +1,507 @@
 @PART[SSTU_ShipCore_B_SRB2]:FOR[RealismOverhaul]
 {
-        %RSSROConfig = True
-        @rescaleFactor = 1.484
-        !MODULE[TweakScale]
-        {
-        }
-        @title = 2-Segment SRB
-        %manufacturer = Orbital ATK
-        //@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
-        @maxTemp = 1973.15
+	//%RSSROConfig = True
+	@rescaleFactor = 1.484
+	!MODULE[TweakScale]
+	{
+	}
+	@title = 2-Segment SRB
+	%manufacturer = Orbital ATK
+	//@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
+	@mass = 57.849
+	@maxTemp = 550
+	@MODULE[ModuleEngine*]
+	{
+			@maxThrust = 6705.75
+			@heatProduction = 100
+			@PROPELLANT[SolidFuel]
+			{
+				@name = PBAN
+			}
+			@atmosphereCurve
+			{
+				@key = 0 268.5
+				@key = 1 243
+			}
+	}
+		
+	!RESOURCE[SolidFuel]
+	{
+	}
+		
+	@MODULE[ModuleGimbal]
+	{
+			%gimbalRange = 3.5
+			%useGimbalResponseSpeed = true
+			%gimbalResponseSpeed = 16
+	}
+		
+	MODULE
+		{
+			name = ModuleFuelTanks
+			volume = 140926.95
+			basemass = -1
+			type = PBAN
+		}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PBAN
+		modded = false
+		CONFIG
+		{
+			name = PBAN
+			maxThrust = 6705.75
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 268.5
+				key = 1 243
+			}
+			curveResource = PBAN
+			thrustCurve
+			{
+				key = 0.98942 0.945
+				key = 0.97888 0.942
+				key = 0.96834 0.942
+				key = 0.95773 0.948
+				key = 0.947 0.959
+				key = 0.93618 0.967
+				key = 0.92524 0.978
+				key = 0.91426 0.981
+				key = 0.90323 0.986
+				key = 0.89216 0.989
+				key = 0.8811 0.989
+				key = 0.87 0.992
+				key = 0.8589 0.992
+				key = 0.84777 0.994
+				key = 0.83665 0.994
+				key = 0.82552 0.994
+				key = 0.81439 0.994
+				key = 0.80323 0.997
+				key = 0.79207 0.997
+				key = 0.78088 1
+				key = 0.7697 1
+				key = 0.75851 1
+				key = 0.74744 0.989
+				key = 0.73665 0.964
+				key = 0.7261 0.942
+				key = 0.71568 0.932
+				key = 0.70544 0.915
+				key = 0.69526 0.91
+				key = 0.68518 0.901
+				key = 0.67521 0.89
+				key = 0.66537 0.88
+				key = 0.65562 0.871
+				key = 0.64599 0.86
+				key = 0.63649 0.849
+				key = 0.62711 0.838
+				key = 0.61782 0.83
+				key = 0.60862 0.822
+				key = 0.59952 0.814
+				key = 0.59047 0.808
+				key = 0.58152 0.8
+				key = 0.57269 0.789
+				key = 0.56392 0.784
+				key = 0.55527 0.773
+				key = 0.54672 0.765
+				key = 0.53823 0.759
+				key = 0.52976 0.756
+				key = 0.52136 0.751
+				key = 0.51302 0.745
+				key = 0.5048 0.734
+				key = 0.49671 0.723
+				key = 0.48868 0.718
+				key = 0.4807 0.713
+				key = 0.47273 0.713
+				key = 0.46476 0.713
+				key = 0.45675 0.715
+				key = 0.44869 0.721
+				key = 0.44056 0.726
+				key = 0.43241 0.729
+				key = 0.42422 0.732
+				key = 0.416 0.734
+				key = 0.40772 0.74
+				key = 0.39941 0.743
+				key = 0.39107 0.745
+				key = 0.3827 0.748
+				key = 0.3743 0.751
+				key = 0.36586 0.754
+				key = 0.3574 0.756
+				key = 0.34891 0.759
+				key = 0.34035 0.765
+				key = 0.33176 0.767
+				key = 0.32315 0.77
+				key = 0.31453 0.77
+				key = 0.30588 0.773
+				key = 0.29723 0.773
+				key = 0.28855 0.776
+				key = 0.27987 0.776
+				key = 0.2712 0.776
+				key = 0.26252 0.776
+				key = 0.25387 0.773
+				key = 0.24531 0.765
+				key = 0.23682 0.759
+				key = 0.22841 0.751
+				key = 0.2201 0.743
+				key = 0.21185 0.737
+				key = 0.20376 0.724
+				key = 0.19575 0.715
+				key = 0.18781 0.71
+				key = 0.18005 0.694
+				key = 0.17241 0.683
+				key = 0.16493 0.669
+				key = 0.1575 0.663
+				key = 0.15011 0.661
+				key = 0.14278 0.655
+				key = 0.13548 0.652
+				key = 0.12824 0.647
+				key = 0.12115 0.633
+				key = 0.11416 0.625
+				key = 0.10726 0.617
+				key = 0.10045 0.609
+				key = 0.0937 0.603
+				key = 0.08704 0.595
+				key = 0.08051 0.584
+				key = 0.07406 0.576
+				key = 0.06771 0.568
+				key = 0.06155 0.551
+				key = 0.05556 0.535
+				key = 0.0497 0.524
+				key = 0.04387 0.521
+				key = 0.03804 0.521
+				key = 0.03231 0.513
+				key = 0.0269 0.483
+				key = 0.02193 0.444
+				key = 0.01751 0.395
+				key = 0.0138 0.332
+				key = 0.01085 0.264
+				key = 0.00863 0.198
+				key = 0.00682 0.162
+				key = 0.00528 0.138
+				key = 0.00396 0.118
+				key = 0.00294 0.091
+				key = 0.0022 0.066
+				key = 0.00164 0.05
+				key = 0.00126 0.033
+				key = 0.00098 0.025
+				key = 0.00073 0.023
+				key = 0.00051 0.02
+				key = 0.00041 0.009
+			}
+		}
+	}
+	!MODULE[SSTUMeshSwitch]
+	{
+	}
+	%MODULE[SSTUMeshSwitch]
+	{
+		name = SSTUMeshSwitch
+		defaultVariantName = Nose 1
+		moduleID = 0
+		variantLabel = Nose Type
+		MESHVARIANT
+		{
+			variantName = Nose 1		
+			meshNames = SC-B-SRBNose1
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName = Nose 2	
+			meshNames = SC-B-SRBNose2
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName  = Flat Cap
+			meshNames = SC-B-SRBNose3
+			MESHNODE
+			{
+				name = top
+				enabled = true
+				position = 0, 10.00958, 0
+				orientation = 0, 1, 0
+				size = 3
+			}
+		}
+	}
 }
  
 @PART[SSTU_ShipCore_B_SRB3]:FOR[RealismOverhaul]
 {
-        %RSSROConfig = True
-        @rescaleFactor = 1.484
-        !MODULE[TweakScale]
-        {
-        }
-        @title = 3-Segment SRB
-        %manufacturer = Orbital ATK
-        //@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
-        @maxTemp = 1973.15
+	//%RSSROConfig = True
+	@rescaleFactor = 1.484
+	!MODULE[TweakScale]
+	{
+	}
+	@title = 3-Segment SRB
+	%manufacturer = Orbital ATK
+	//@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
+	@mass = 72.016
+	@maxTemp = 550
+	@MODULE[ModuleEngine*]
+	{
+			@maxThrust = 10058.625
+			@heatProduction = 100
+			@PROPELLANT[SolidFuel]
+			{
+				@name = PBAN
+			}
+			@atmosphereCurve
+			{
+				@key = 0 268.5
+				@key = 1 243
+			}
+	}
+		
+		!RESOURCE[SolidFuel]
+		{
+		}
+		
+	@MODULE[ModuleGimbal]
+	{
+			%gimbalRange = 3.5
+			%useGimbalResponseSpeed = true
+			%gimbalResponseSpeed = 16
+	}
+		
+	MODULE
+		{
+			name = ModuleFuelTanks
+			volume = 211390.425
+			basemass = -1
+			type = PBAN
+		}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PBAN
+		modded = false
+		CONFIG
+		{
+			name = PBAN
+			maxThrust = 10058.625
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 268.5
+				key = 1 243
+			}
+			curveResource = PBAN
+			thrustCurve
+			{
+				key = 0.98942 0.945
+				key = 0.97888 0.942
+				key = 0.96834 0.942
+				key = 0.95773 0.948
+				key = 0.947 0.959
+				key = 0.93618 0.967
+				key = 0.92524 0.978
+				key = 0.91426 0.981
+				key = 0.90323 0.986
+				key = 0.89216 0.989
+				key = 0.8811 0.989
+				key = 0.87 0.992
+				key = 0.8589 0.992
+				key = 0.84777 0.994
+				key = 0.83665 0.994
+				key = 0.82552 0.994
+				key = 0.81439 0.994
+				key = 0.80323 0.997
+				key = 0.79207 0.997
+				key = 0.78088 1
+				key = 0.7697 1
+				key = 0.75851 1
+				key = 0.74744 0.989
+				key = 0.73665 0.964
+				key = 0.7261 0.942
+				key = 0.71568 0.932
+				key = 0.70544 0.915
+				key = 0.69526 0.91
+				key = 0.68518 0.901
+				key = 0.67521 0.89
+				key = 0.66537 0.88
+				key = 0.65562 0.871
+				key = 0.64599 0.86
+				key = 0.63649 0.849
+				key = 0.62711 0.838
+				key = 0.61782 0.83
+				key = 0.60862 0.822
+				key = 0.59952 0.814
+				key = 0.59047 0.808
+				key = 0.58152 0.8
+				key = 0.57269 0.789
+				key = 0.56392 0.784
+				key = 0.55527 0.773
+				key = 0.54672 0.765
+				key = 0.53823 0.759
+				key = 0.52976 0.756
+				key = 0.52136 0.751
+				key = 0.51302 0.745
+				key = 0.5048 0.734
+				key = 0.49671 0.723
+				key = 0.48868 0.718
+				key = 0.4807 0.713
+				key = 0.47273 0.713
+				key = 0.46476 0.713
+				key = 0.45675 0.715
+				key = 0.44869 0.721
+				key = 0.44056 0.726
+				key = 0.43241 0.729
+				key = 0.42422 0.732
+				key = 0.416 0.734
+				key = 0.40772 0.74
+				key = 0.39941 0.743
+				key = 0.39107 0.745
+				key = 0.3827 0.748
+				key = 0.3743 0.751
+				key = 0.36586 0.754
+				key = 0.3574 0.756
+				key = 0.34891 0.759
+				key = 0.34035 0.765
+				key = 0.33176 0.767
+				key = 0.32315 0.77
+				key = 0.31453 0.77
+				key = 0.30588 0.773
+				key = 0.29723 0.773
+				key = 0.28855 0.776
+				key = 0.27987 0.776
+				key = 0.2712 0.776
+				key = 0.26252 0.776
+				key = 0.25387 0.773
+				key = 0.24531 0.765
+				key = 0.23682 0.759
+				key = 0.22841 0.751
+				key = 0.2201 0.743
+				key = 0.21185 0.737
+				key = 0.20376 0.724
+				key = 0.19575 0.715
+				key = 0.18781 0.71
+				key = 0.18005 0.694
+				key = 0.17241 0.683
+				key = 0.16493 0.669
+				key = 0.1575 0.663
+				key = 0.15011 0.661
+				key = 0.14278 0.655
+				key = 0.13548 0.652
+				key = 0.12824 0.647
+				key = 0.12115 0.633
+				key = 0.11416 0.625
+				key = 0.10726 0.617
+				key = 0.10045 0.609
+				key = 0.0937 0.603
+				key = 0.08704 0.595
+				key = 0.08051 0.584
+				key = 0.07406 0.576
+				key = 0.06771 0.568
+				key = 0.06155 0.551
+				key = 0.05556 0.535
+				key = 0.0497 0.524
+				key = 0.04387 0.521
+				key = 0.03804 0.521
+				key = 0.03231 0.513
+				key = 0.0269 0.483
+				key = 0.02193 0.444
+				key = 0.01751 0.395
+				key = 0.0138 0.332
+				key = 0.01085 0.264
+				key = 0.00863 0.198
+				key = 0.00682 0.162
+				key = 0.00528 0.138
+				key = 0.00396 0.118
+				key = 0.00294 0.091
+				key = 0.0022 0.066
+				key = 0.00164 0.05
+				key = 0.00126 0.033
+				key = 0.00098 0.025
+				key = 0.00073 0.023
+				key = 0.00051 0.02
+				key = 0.00041 0.009
+			}
+		}
+	}
+	!MODULE[SSTUMeshSwitch]
+	{
+	}
+	%MODULE[SSTUMeshSwitch]
+	{
+		name = SSTUMeshSwitch
+		defaultVariantName = Nose 1
+		moduleID = 0
+		variantLabel = Nose Type
+		MESHVARIANT
+		{
+			variantName = Nose 1		
+			meshNames = SC-B-SRBNose1
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName = Nose 2	
+			meshNames = SC-B-SRBNose2
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName  = Flat Cap
+			meshNames = SC-B-SRBNose3
+			MESHNODE
+			{
+				name = top
+				enabled = true
+				position = 0, 14.31318, 0
+				orientation = 0, 1, 0
+				size = 3
+			}
+		}
+	}
 }
  
 @PART[SSTU_ShipCore_B_SRB4]:FOR[RealismOverhaul]
 {
-        %RSSROConfig = True
-        @rescaleFactor = 1.484
-        !MODULE[TweakScale]
-        {
-        }
-        @title = 4-Segment ATK SRB
-        %manufacturer = Orbital ATK
-        @description = The 4-segment Reusable Solid Rocket Motor (RSRMV) was used by the Space Shuttle.
-        @mass = 86.183
-		@maxTemp = 550
-		
-        @MODULE[ModuleEngine*]
-        {
+	%RSSROConfig = True
+	@rescaleFactor = 1.484
+	!MODULE[TweakScale]
+	{
+	}
+	@title = 4-Segment ATK SRB
+	%manufacturer = Orbital ATK
+	@description = The 4-segment Reusable Solid Rocket Motor (RSRMV) was used by the Space Shuttle.
+	@mass = 86.183
+	@maxTemp = 550
+	@MODULE[ModuleEngine*]
+	{
 			@maxThrust = 14781.35
 			@heatProduction = 100
 			@PROPELLANT[SolidFuel]
@@ -50,394 +513,479 @@
 				@key = 0 268.5
 				@key = 1 243
 			}
-        }
+	}
 		
 		!RESOURCE[SolidFuel]
 		{
 		}
 		
-        @MODULE[ModuleGimbal]
-        {
+	@MODULE[ModuleGimbal]
+	{
 			%gimbalRange = 3.5
 			%useGimbalResponseSpeed = true
 			%gimbalResponseSpeed = 16
-        }
+	}
 		
-        MODULE
+	MODULE
 		{
 			name = ModuleFuelTanks
 			volume = 281853.9
 			basemass = -1
 			type = PBAN
 		}
-        MODULE
-        {
-                name = ModuleEngineConfigs
-                type = ModuleEngines
-                configuration = PBAN
-                modded = false
-                CONFIG
-                {
-                        name = PBAN
-                        maxThrust = 14781.35
-                        heatProduction = 100
-                        PROPELLANT
-                        {
-                                name = PBAN
-                                ratio = 1
-                                DrawGauge = True
-                        }
-                        atmosphereCurve
-                        {
-                                key = 0 268.5
-                                key = 1 243
-                        }
-                        curveResource = PBAN
-                        thrustCurve
-                        {
-                                key = 0.98942 0.945
-                                key = 0.97888 0.942
-                                key = 0.96834 0.942
-                                key = 0.95773 0.948
-                                key = 0.947 0.959
-                                key = 0.93618 0.967
-                                key = 0.92524 0.978
-                                key = 0.91426 0.981
-                                key = 0.90323 0.986
-                                key = 0.89216 0.989
-                                key = 0.8811 0.989
-                                key = 0.87 0.992
-                                key = 0.8589 0.992
-                                key = 0.84777 0.994
-                                key = 0.83665 0.994
-                                key = 0.82552 0.994
-                                key = 0.81439 0.994
-                                key = 0.80323 0.997
-                                key = 0.79207 0.997
-                                key = 0.78088 1
-                                key = 0.7697 1
-                                key = 0.75851 1
-                                key = 0.74744 0.989
-                                key = 0.73665 0.964
-                                key = 0.7261 0.942
-                                key = 0.71568 0.932
-                                key = 0.70544 0.915
-                                key = 0.69526 0.91
-                                key = 0.68518 0.901
-                                key = 0.67521 0.89
-                                key = 0.66537 0.88
-                                key = 0.65562 0.871
-                                key = 0.64599 0.86
-                                key = 0.63649 0.849
-                                key = 0.62711 0.838
-                                key = 0.61782 0.83
-                                key = 0.60862 0.822
-                                key = 0.59952 0.814
-                                key = 0.59047 0.808
-                                key = 0.58152 0.8
-                                key = 0.57269 0.789
-                                key = 0.56392 0.784
-                                key = 0.55527 0.773
-                                key = 0.54672 0.765
-                                key = 0.53823 0.759
-                                key = 0.52976 0.756
-                                key = 0.52136 0.751
-                                key = 0.51302 0.745
-                                key = 0.5048 0.734
-                                key = 0.49671 0.723
-                                key = 0.48868 0.718
-                                key = 0.4807 0.713
-                                key = 0.47273 0.713
-                                key = 0.46476 0.713
-                                key = 0.45675 0.715
-                                key = 0.44869 0.721
-                                key = 0.44056 0.726
-                                key = 0.43241 0.729
-                                key = 0.42422 0.732
-                                key = 0.416 0.734
-                                key = 0.40772 0.74
-                                key = 0.39941 0.743
-                                key = 0.39107 0.745
-                                key = 0.3827 0.748
-                                key = 0.3743 0.751
-                                key = 0.36586 0.754
-                                key = 0.3574 0.756
-                                key = 0.34891 0.759
-                                key = 0.34035 0.765
-                                key = 0.33176 0.767
-                                key = 0.32315 0.77
-                                key = 0.31453 0.77
-                                key = 0.30588 0.773
-                                key = 0.29723 0.773
-                                key = 0.28855 0.776
-                                key = 0.27987 0.776
-                                key = 0.2712 0.776
-                                key = 0.26252 0.776
-                                key = 0.25387 0.773
-                                key = 0.24531 0.765
-                                key = 0.23682 0.759
-                                key = 0.22841 0.751
-                                key = 0.2201 0.743
-                                key = 0.21185 0.737
-                                key = 0.20376 0.724
-                                key = 0.19575 0.715
-                                key = 0.18781 0.71
-                                key = 0.18005 0.694
-                                key = 0.17241 0.683
-                                key = 0.16493 0.669
-                                key = 0.1575 0.663
-                                key = 0.15011 0.661
-                                key = 0.14278 0.655
-                                key = 0.13548 0.652
-                                key = 0.12824 0.647
-                                key = 0.12115 0.633
-                                key = 0.11416 0.625
-                                key = 0.10726 0.617
-                                key = 0.10045 0.609
-                                key = 0.0937 0.603
-                                key = 0.08704 0.595
-                                key = 0.08051 0.584
-                                key = 0.07406 0.576
-                                key = 0.06771 0.568
-                                key = 0.06155 0.551
-                                key = 0.05556 0.535
-                                key = 0.0497 0.524
-                                key = 0.04387 0.521
-                                key = 0.03804 0.521
-                                key = 0.03231 0.513
-                                key = 0.0269 0.483
-                                key = 0.02193 0.444
-                                key = 0.01751 0.395
-                                key = 0.0138 0.332
-                                key = 0.01085 0.264
-                                key = 0.00863 0.198
-                                key = 0.00682 0.162
-                                key = 0.00528 0.138
-                                key = 0.00396 0.118
-                                key = 0.00294 0.091
-                                key = 0.0022 0.066
-                                key = 0.00164 0.05
-                                key = 0.00126 0.033
-                                key = 0.00098 0.025
-                                key = 0.00073 0.023
-                                key = 0.00051 0.02
-                                key = 0.00041 0.009
-                        }
-                }
-        }
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PBAN
+		modded = false
+		CONFIG
+		{
+			name = PBAN
+			maxThrust = 14781.35
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 268.5
+				key = 1 243
+			}
+			curveResource = PBAN
+			thrustCurve
+			{
+				key = 0.98942 0.945
+				key = 0.97888 0.942
+				key = 0.96834 0.942
+				key = 0.95773 0.948
+				key = 0.947 0.959
+				key = 0.93618 0.967
+				key = 0.92524 0.978
+				key = 0.91426 0.981
+				key = 0.90323 0.986
+				key = 0.89216 0.989
+				key = 0.8811 0.989
+				key = 0.87 0.992
+				key = 0.8589 0.992
+				key = 0.84777 0.994
+				key = 0.83665 0.994
+				key = 0.82552 0.994
+				key = 0.81439 0.994
+				key = 0.80323 0.997
+				key = 0.79207 0.997
+				key = 0.78088 1
+				key = 0.7697 1
+				key = 0.75851 1
+				key = 0.74744 0.989
+				key = 0.73665 0.964
+				key = 0.7261 0.942
+				key = 0.71568 0.932
+				key = 0.70544 0.915
+				key = 0.69526 0.91
+				key = 0.68518 0.901
+				key = 0.67521 0.89
+				key = 0.66537 0.88
+				key = 0.65562 0.871
+				key = 0.64599 0.86
+				key = 0.63649 0.849
+				key = 0.62711 0.838
+				key = 0.61782 0.83
+				key = 0.60862 0.822
+				key = 0.59952 0.814
+				key = 0.59047 0.808
+				key = 0.58152 0.8
+				key = 0.57269 0.789
+				key = 0.56392 0.784
+				key = 0.55527 0.773
+				key = 0.54672 0.765
+				key = 0.53823 0.759
+				key = 0.52976 0.756
+				key = 0.52136 0.751
+				key = 0.51302 0.745
+				key = 0.5048 0.734
+				key = 0.49671 0.723
+				key = 0.48868 0.718
+				key = 0.4807 0.713
+				key = 0.47273 0.713
+				key = 0.46476 0.713
+				key = 0.45675 0.715
+				key = 0.44869 0.721
+				key = 0.44056 0.726
+				key = 0.43241 0.729
+				key = 0.42422 0.732
+				key = 0.416 0.734
+				key = 0.40772 0.74
+				key = 0.39941 0.743
+				key = 0.39107 0.745
+				key = 0.3827 0.748
+				key = 0.3743 0.751
+				key = 0.36586 0.754
+				key = 0.3574 0.756
+				key = 0.34891 0.759
+				key = 0.34035 0.765
+				key = 0.33176 0.767
+				key = 0.32315 0.77
+				key = 0.31453 0.77
+				key = 0.30588 0.773
+				key = 0.29723 0.773
+				key = 0.28855 0.776
+				key = 0.27987 0.776
+				key = 0.2712 0.776
+				key = 0.26252 0.776
+				key = 0.25387 0.773
+				key = 0.24531 0.765
+				key = 0.23682 0.759
+				key = 0.22841 0.751
+				key = 0.2201 0.743
+				key = 0.21185 0.737
+				key = 0.20376 0.724
+				key = 0.19575 0.715
+				key = 0.18781 0.71
+				key = 0.18005 0.694
+				key = 0.17241 0.683
+				key = 0.16493 0.669
+				key = 0.1575 0.663
+				key = 0.15011 0.661
+				key = 0.14278 0.655
+				key = 0.13548 0.652
+				key = 0.12824 0.647
+				key = 0.12115 0.633
+				key = 0.11416 0.625
+				key = 0.10726 0.617
+				key = 0.10045 0.609
+				key = 0.0937 0.603
+				key = 0.08704 0.595
+				key = 0.08051 0.584
+				key = 0.07406 0.576
+				key = 0.06771 0.568
+				key = 0.06155 0.551
+				key = 0.05556 0.535
+				key = 0.0497 0.524
+				key = 0.04387 0.521
+				key = 0.03804 0.521
+				key = 0.03231 0.513
+				key = 0.0269 0.483
+				key = 0.02193 0.444
+				key = 0.01751 0.395
+				key = 0.0138 0.332
+				key = 0.01085 0.264
+				key = 0.00863 0.198
+				key = 0.00682 0.162
+				key = 0.00528 0.138
+				key = 0.00396 0.118
+				key = 0.00294 0.091
+				key = 0.0022 0.066
+				key = 0.00164 0.05
+				key = 0.00126 0.033
+				key = 0.00098 0.025
+				key = 0.00073 0.023
+				key = 0.00051 0.02
+				key = 0.00041 0.009
+			}
+		}
+	}
+	!MODULE[SSTUMeshSwitch]
+	{
+	}
+	%MODULE[SSTUMeshSwitch]
+	{
+		name = SSTUMeshSwitch
+		defaultVariantName = Nose 1
+		moduleID = 0
+		variantLabel = Nose Type
+		MESHVARIANT
+		{
+			variantName = Nose 1		
+			meshNames = SC-B-SRBNose1
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName = Nose 2	
+			meshNames = SC-B-SRBNose2
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName  = Flat Cap
+			meshNames = SC-B-SRBNose3
+			MESHNODE
+			{
+				name = top
+				enabled = true
+				position = 0, 18.61678, 0
+				orientation = 0, 1, 0
+				size = 3
+			}
+		}
+	}
 }
  
 @PART[SSTU_ShipCore_B_SRB5]:FOR[RealismOverhaul]
 {
-        %RSSROConfig = True
-        @rescaleFactor = 1.484
-        !MODULE[TweakScale]
-        {
-        }
-        @title = 5-Segment ATK SRB
-        %manufacturer = Orbital ATK
-        @description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
-        @mass = 100.350
-        @maxTemp = 550
+	%RSSROConfig = True
+	@rescaleFactor = 1.484
+	!MODULE[TweakScale]
+	{
+	}
+	@title = 5-Segment ATK SRB
+	%manufacturer = Orbital ATK
+	@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
+	@mass = 100.350
+	@maxTemp = 550
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 17885.99
+		@heatProduction = 100
+		@PROPELLANT[SolidFuel]
+		{
+			@name = PBAN
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 268
+			@key,1 = 1 242
+		}
+	}
 		
-        @MODULE[ModuleEngines*]
-        {
-                @maxThrust = 17885.99
-                @heatProduction = 100
-				@PROPELLANT[SolidFuel]
-				{
-					@name = PBAN
-				}
-                @atmosphereCurve
-                {
-					@key,0 = 0 268
-					@key,1 = 1 242
-                }
-        }
+	!RESOURCE[SolidFuel]
+	{
+	}
 		
-        !RESOURCE[SolidFuel]
-        {
-        }
-		
-        @MODULE[ModuleGimbal]
-        {
-                %gimbalRange = 3.5
-                %useGimbalResponseSpeed = true
-                %gimbalResponseSpeed = 16
-        }
-        MODULE
-        {
-                name = ModuleFuelTanks
-                volume = 365486.64
-                basemass = -1
-                type = PBAN
-        }
-        MODULE
-        {
-                name = ModuleEngineConfigs
-                type = ModuleEngines
-                configuration = RSRM5Seg
-                modded = false
-                CONFIG
-                {
-                        name = RSRM5Seg
-                        maxThrust = 17885.99
-                        heatProduction = 100
-                        PROPELLANT
-                        {
-                                name = PBAN
-                                ratio = 1
-                                DrawGauge = True
-                        }
-                        atmosphereCurve
-                        {
-                                key = 0 268
-                                key = 1 242
-                        }
-                        curveResource = PBAN
-                        thrustCurve
-                        {
-                                key = 0.99986 0.950
-                                key = 0.9887 0.961
-                                key = 0.97757 0.961
-                                key = 0.96646 0.961
-                                key = 0.95535 0.963
-                                key = 0.94419 0.97
-                                key = 0.93296 0.978
-                                key = 0.92167 0.985
-                                key = 0.91034 0.991
-                                key = 0.89901 0.994
-                                key = 0.88768 0.996
-                                key = 0.87632 1
-                                key = 0.86499 1
-                                key = 0.85368 1
-                                key = 0.8424 1
-                                key = 0.83114 1
-                                key = 0.81993 0.998
-                                key = 0.8088 0.993
-                                key = 0.79778 0.985
-                                key = 0.78689 0.976
-                                key = 0.77616 0.963
-                                key = 0.76566 0.945
-                                key = 0.75529 0.935
-                                key = 0.74509 0.922
-                                key = 0.73504 0.911
-                                key = 0.72512 0.9
-                                key = 0.71535 0.889
-                                key = 0.70576 0.874
-                                key = 0.69632 0.863
-                                key = 0.68703 0.85
-                                key = 0.67789 0.839
-                                key = 0.66888 0.828
-                                key = 0.65998 0.819
-                                key = 0.65127 0.804
-                                key = 0.64267 0.795
-                                key = 0.63414 0.791
-                                key = 0.62576 0.778
-                                key = 0.61749 0.769
-                                key = 0.60936 0.758
-                                key = 0.60131 0.752
-                                key = 0.59336 0.745
-                                key = 0.58546 0.741
-                                key = 0.5777 0.73
-                                key = 0.57002 0.724
-                                key = 0.56247 0.713
-                                key = 0.55505 0.702
-                                key = 0.54772 0.695
-                                key = 0.54047 0.689
-                                key = 0.53328 0.684
-                                key = 0.52613 0.682
-                                key = 0.51902 0.68
-                                key = 0.51187 0.684
-                                key = 0.5047 0.689
-                                key = 0.49749 0.693
-                                key = 0.49025 0.697
-                                key = 0.48299 0.702
-                                key = 0.47569 0.706
-                                key = 0.46834 0.712
-                                key = 0.46091 0.721
-                                key = 0.45344 0.728
-                                key = 0.44595 0.73
-                                key = 0.43839 0.738
-                                key = 0.43078 0.745
-                                key = 0.4231 0.753
-                                key = 0.41539 0.758
-                                key = 0.40765 0.762
-                                key = 0.39986 0.769
-                                key = 0.39202 0.775
-                                key = 0.38412 0.782
-                                key = 0.3762 0.786
-                                key = 0.36825 0.79
-                                key = 0.36024 0.797
-                                key = 0.35218 0.801
-                                key = 0.34408 0.805
-                                key = 0.33592 0.812
-                                key = 0.32768 0.818
-                                key = 0.31941 0.823
-                                key = 0.31109 0.827
-                                key = 0.30277 0.827
-                                key = 0.29443 0.829
-                                key = 0.28609 0.829
-                                key = 0.27775 0.829
-                                key = 0.26944 0.827
-                                key = 0.26116 0.823
-                                key = 0.25298 0.814
-                                key = 0.24486 0.807
-                                key = 0.23682 0.799
-                                key = 0.22886 0.792
-                                key = 0.22098 0.783
-                                key = 0.21316 0.777
-                                key = 0.20544 0.768
-                                key = 0.19782 0.757
-                                key = 0.19032 0.746
-                                key = 0.1829 0.738
-                                key = 0.17559 0.727
-                                key = 0.16839 0.716
-                                key = 0.16132 0.703
-                                key = 0.15433 0.694
-                                key = 0.14746 0.683
-                                key = 0.14066 0.677
-                                key = 0.13389 0.672
-                                key = 0.12715 0.67
-                                key = 0.12046 0.666
-                                key = 0.11382 0.659
-                                key = 0.10726 0.653
-                                key = 0.10078 0.644
-                                key = 0.09437 0.638
-                                key = 0.08805 0.629
-                                key = 0.08179 0.622
-                                key = 0.07559 0.616
-                                key = 0.06949 0.607
-                                key = 0.06347 0.598
-                                key = 0.05754 0.59
-                                key = 0.05176 0.574
-                                key = 0.04608 0.566
-                                key = 0.04052 0.553
-                                key = 0.03507 0.542
-                                key = 0.02977 0.527
-                                key = 0.0247 0.505
-                                key = 0.0199 0.477
-                                key = 0.01557 0.431
-                                key = 0.01218 0.337
-                                key = 0.00959 0.257
-                                key = 0.00762 0.196
-                                key = 0.00593 0.168
-                                key = 0.00465 0.127
-                                key = 0.00371 0.094
-                                key = 0.00294 0.077
-                                key = 0.00236 0.057
-                                key = 0.00187 0.048
-                                key = 0.00147 0.04
-                                key = 0.00114 0.033
-                                key = 0.00087 0.027
-                                key = 0.00065 0.022
-                                key = 0.00047 0.018
-                                key = 0.00033 0.014
-                                key = 0.00022 0.011
-                                key = 0.00013 0.009
-                                key = 0.00006 0.007
-                                key = 0.00001 0.005
-                        }
-                }
-        }
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 3.5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 365486.64
+		basemass = -1
+		type = PBAN
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RSRM5Seg
+		modded = false
+		CONFIG
+		{
+			name = RSRM5Seg
+			maxThrust = 17885.99
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 268
+				key = 1 242
+			}
+			curveResource = PBAN
+			thrustCurve
+			{
+				key = 0.99986 0.950
+				key = 0.9887 0.961
+				key = 0.97757 0.961
+				key = 0.96646 0.961
+				key = 0.95535 0.963
+				key = 0.94419 0.97
+				key = 0.93296 0.978
+				key = 0.92167 0.985
+				key = 0.91034 0.991
+				key = 0.89901 0.994
+				key = 0.88768 0.996
+				key = 0.87632 1
+				key = 0.86499 1
+				key = 0.85368 1
+				key = 0.8424 1
+				key = 0.83114 1
+				key = 0.81993 0.998
+				key = 0.8088 0.993
+				key = 0.79778 0.985
+				key = 0.78689 0.976
+				key = 0.77616 0.963
+				key = 0.76566 0.945
+				key = 0.75529 0.935
+				key = 0.74509 0.922
+				key = 0.73504 0.911
+				key = 0.72512 0.9
+				key = 0.71535 0.889
+				key = 0.70576 0.874
+				key = 0.69632 0.863
+				key = 0.68703 0.85
+				key = 0.67789 0.839
+				key = 0.66888 0.828
+				key = 0.65998 0.819
+				key = 0.65127 0.804
+				key = 0.64267 0.795
+				key = 0.63414 0.791
+				key = 0.62576 0.778
+				key = 0.61749 0.769
+				key = 0.60936 0.758
+				key = 0.60131 0.752
+				key = 0.59336 0.745
+				key = 0.58546 0.741
+				key = 0.5777 0.73
+				key = 0.57002 0.724
+				key = 0.56247 0.713
+				key = 0.55505 0.702
+				key = 0.54772 0.695
+				key = 0.54047 0.689
+				key = 0.53328 0.684
+				key = 0.52613 0.682
+				key = 0.51902 0.68
+				key = 0.51187 0.684
+				key = 0.5047 0.689
+				key = 0.49749 0.693
+				key = 0.49025 0.697
+				key = 0.48299 0.702
+				key = 0.47569 0.706
+				key = 0.46834 0.712
+				key = 0.46091 0.721
+				key = 0.45344 0.728
+				key = 0.44595 0.73
+				key = 0.43839 0.738
+				key = 0.43078 0.745
+				key = 0.4231 0.753
+				key = 0.41539 0.758
+				key = 0.40765 0.762
+				key = 0.39986 0.769
+				key = 0.39202 0.775
+				key = 0.38412 0.782
+				key = 0.3762 0.786
+				key = 0.36825 0.79
+				key = 0.36024 0.797
+				key = 0.35218 0.801
+				key = 0.34408 0.805
+				key = 0.33592 0.812
+				key = 0.32768 0.818
+				key = 0.31941 0.823
+				key = 0.31109 0.827
+				key = 0.30277 0.827
+				key = 0.29443 0.829
+				key = 0.28609 0.829
+				key = 0.27775 0.829
+				key = 0.26944 0.827
+				key = 0.26116 0.823
+				key = 0.25298 0.814
+				key = 0.24486 0.807
+				key = 0.23682 0.799
+				key = 0.22886 0.792
+				key = 0.22098 0.783
+				key = 0.21316 0.777
+				key = 0.20544 0.768
+				key = 0.19782 0.757
+				key = 0.19032 0.746
+				key = 0.1829 0.738
+				key = 0.17559 0.727
+				key = 0.16839 0.716
+				key = 0.16132 0.703
+				key = 0.15433 0.694
+				key = 0.14746 0.683
+				key = 0.14066 0.677
+				key = 0.13389 0.672
+				key = 0.12715 0.67
+				key = 0.12046 0.666
+				key = 0.11382 0.659
+				key = 0.10726 0.653
+				key = 0.10078 0.644
+				key = 0.09437 0.638
+				key = 0.08805 0.629
+				key = 0.08179 0.622
+				key = 0.07559 0.616
+				key = 0.06949 0.607
+				key = 0.06347 0.598
+				key = 0.05754 0.59
+				key = 0.05176 0.574
+				key = 0.04608 0.566
+				key = 0.04052 0.553
+				key = 0.03507 0.542
+				key = 0.02977 0.527
+				key = 0.0247 0.505
+				key = 0.0199 0.477
+				key = 0.01557 0.431
+				key = 0.01218 0.337
+				key = 0.00959 0.257
+				key = 0.00762 0.196
+				key = 0.00593 0.168
+				key = 0.00465 0.127
+				key = 0.00371 0.094
+				key = 0.00294 0.077
+				key = 0.00236 0.057
+				key = 0.00187 0.048
+				key = 0.00147 0.04
+				key = 0.00114 0.033
+				key = 0.00087 0.027
+				key = 0.00065 0.022
+				key = 0.00047 0.018
+				key = 0.00033 0.014
+				key = 0.00022 0.011
+				key = 0.00013 0.009
+				key = 0.00006 0.007
+				key = 0.00001 0.005
+			}
+		}
+	}
+	!MODULE[SSTUMeshSwitch]
+	{
+	}
+	%MODULE[SSTUMeshSwitch]
+	{
+		name = SSTUMeshSwitch
+		defaultVariantName = Nose 1
+		moduleID = 0
+		variantLabel = Nose Type
+		MESHVARIANT
+		{
+			variantName = Nose 1		
+			meshNames = SC-B-SRBNose1
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName = Nose 2	
+			meshNames = SC-B-SRBNose2
+			MESHNODE
+			{
+				name = top
+				enabled = false
+			}
+		}
+		MESHVARIANT
+		{
+			variantName  = Flat Cap
+			meshNames = SC-B-SRBNose3
+			MESHNODE
+			{
+				name = top
+				enabled = true
+				position = 0, 22.92038, 0
+				orientation = 0, 1, 0
+				size = 3
+			}
+		}
+	}
 }


### PR DESCRIPTION
fixed the node config for the flat cap configs for the SRBs, allowing for using it in a Ares I/Liberty config or adding a nosecone with separatrons

also added preliminary configs for the 2 and 3 segment SRBs