### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -414,6 +414,37 @@
 		}
 		CONFIG
 		{
+			name = LR105-NA-5
+			minThrust = 366.1
+			maxThrust = 366.1
+			heatProduction = 100
+			massMult = 0.9443 // 413kg engine, source http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for -5
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 311
+				key = 1 215
+			}
+			cost = 100
+			entryCost = 2000
+			entryCostSubtractors
+			{
+				LR89-NA-5 = 1000
+			}
+			techRequired = advRocketry
+		}
+		CONFIG
+		{
 			name = LR105-NA-6
 			minThrust = 366.1
 			maxThrust = 366.1
@@ -445,7 +476,39 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-7
+			name = LR105-NA-7.1
+			minThrust = 385.2
+			maxThrust = 385.2
+			heatProduction = 100
+			massMult = 1.01185 // same source
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 220
+			}
+			cost = 300
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-6 = 2000
+				LR89-NA-7.1 = 1000
+			}
+			techRequired = heavierRocketry
+		}
+		CONFIG
+		{
+			name = LR105-NA-7.2
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
@@ -471,15 +534,15 @@
 			entryCostSubtractors
 			{
 				LR105-NA-6 = 2000
-				LR89-NA-7 = 1000
+				LR89-NA-7.2 = 1000
 			}
 			techRequired = heavierRocketry
 		}
 		CONFIG
 		{
 			name = RS-56-OSA
-			minThrust = 386.4
-			maxThrust = 386.4
+			minThrust = 385.2
+			maxThrust = 385.2
 			heatProduction = 100
 			massMult = 1.0 // guess
 			PROPELLANT
@@ -508,7 +571,6 @@
 			techRequired = experimentalRocketry
 		}
 	}
-	
 }
 @PART[FASAMercuryFairing]:FOR[RealismOverhaul]
 {
@@ -597,6 +659,30 @@
 		CONFIG
 		{
 			name = LR89-NA-3
+			minThrust = 748.7
+			maxThrust = 748.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 282
+				key = 1 248
+			}
+			massMult = 0.89
+		}
+		CONFIG
+		{
+			name = LR89-NA-5
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
@@ -616,7 +702,13 @@
 				key = 0 282
 				key = 1 248
 			}
-			massMult = 0.89
+			cost = 200
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-5 = 1000
+			}
+			techRequired = advRocketry
 		}
 		CONFIG
 		{
@@ -650,7 +742,39 @@
 		}
 		CONFIG
 		{
-			name = LR89-NA-7
+			name = LR89-NA-7.1
+			minThrust = 931.7
+			maxThrust = 931.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 292.2
+				key = 1 258.0
+			}
+			massMult = 0.99
+			cost = 500
+			entryCost = 10000
+			entryCostSubtractors
+			{
+				LR105-NA-7.1 = 2000
+				LR89-NA-6 = 4000
+			}
+			techRequired = heavierRocketry
+		}
+		CONFIG
+		{
+			name = LR89-NA-7.2
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
@@ -675,7 +799,7 @@
 			entryCost = 10000
 			entryCostSubtractors
 			{
-				LR105-NA-7 = 2000
+				LR105-NA-7.2 = 2000
 				LR89-NA-6 = 4000
 			}
 			techRequired = heavierRocketry

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -21,7 +21,7 @@
 	@cost = 2600
 	@title = Mercury - Atlas Launch Vehicle Fuel Tank
 	@description = The fuel tank for the Mercury - Atlas Launch Vehicle, aka Atlas D Mercury Launch Vehicle, aka Atlas LV-3B.
-	@mass = 1.506
+	@mass = 1.455
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -74,7 +74,7 @@
 	@title = Atlas-E/F Fuel Tank
 	@description = The fuel tank for the Atlas-E/F series.
 	@attachRules = 1,0,1,1,0
-	@mass = 1.506
+	@mass = 4.206
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -128,7 +128,7 @@
 	@title = Atlas SLV-3 Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3 launcher. Used with the Gemini Agena Target Vehicle.
 	@attachRules = 1,0,1,1,0
-	@mass = 1.566
+	@mass = 1.606
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -180,7 +180,7 @@
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas SLV-3A Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3A launcher.  Extended fuel tank for larger payloads.
-	@mass = 3.426
+	@mass = 3.394
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume = 124789.5
@@ -202,8 +202,8 @@
 	@MODEL,0
 	{
 		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
-		%scale = 1.219, 2.00, 1.219
-		%position = 0.0, 8.2, 0.0
+		%scale = 1.219, 1.70, 1.219
+		%position = 0.0, 8.3.05, 0.0
 	}
 	@MODEL,1
 	{
@@ -211,12 +211,12 @@
 		%scale = 1.219, 1.219, 1.219
 		%position = 0.0, 0.0, 0.0
 	}
-	@node_stack_top = 0.0, 10.7848, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_top = 0.0, 10.515, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, -1.0, 0.0, 3
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas SLV-3C Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3C. Historically used with the Centaur D1 to send 1.75T to GTO.  
-	@mass = 4.296
+	@mass = 3.694
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume = 110323
@@ -252,7 +252,7 @@
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas LV-3C Fuel Tank
 	@description = The fuel tank for the Atlas LV-3C. Historically used to loft the Centaur D1 into orbit, but has many uses.
-	@mass = 3.726
+	@mass = 2.980
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume = 104860
@@ -265,6 +265,42 @@
 		{
 			@amount = 71941.4
 			@maxAmount = 71941.4
+		}
+	}
+}
++PART[FASAMercuryAtlasLFTLong]:AFTER[RealismOverhaul]
+{
+	@name = FASAAtlasH
+	@MODEL,0
+	{
+		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
+		%scale = 1.219, 2.00, 1.219
+		%position = 0.0, 8.695, 0.0
+	}
+	@MODEL,1
+	{
+		%model = FASA/Mercury/FASA_Mercury_Atlas/Mercury_Atlas_LFT_Long
+		%scale = 1.219, 1.219, 1.219
+		%position = 0.0, 0.0, 0.0
+	}
+	@node_stack_top = 0.0, 11.295, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, -1.0, 0.0, 3
+	CoMOffset = 0, 2.0, 0
+	@title = Atlas G/H/I Fuel Tank
+	@description = The fuel tank for the Atlas G/H/I. Historically used with the Centaur D1A to send up to 2.375T to GTO.  
+	@mass = 3.336
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 124789.5
+		@TANK[Kerosene]
+		{
+			@amount = 40871.6
+			@maxAmount = 40871.6
+		}
+		@TANK[LqdOxygen]
+		{
+			@amount = 83917.9
+			@maxAmount = 83917.9
 		}
 	}
 }


### PR DESCRIPTION
Clean up graphic defect on SLV-3C tank due to overlap of LFT_Gemini_Short and Mercury_Atlas_LFT_Long components.
Adjusted the dry weight of most of the Atlas tanks.  Although most references seem to contradict each other relating to the dry/wet mass of various Atlas tanks, I think these corrections come close.
Added the Atlas G/H/I tank.  I'm having trouble finding reliable specifications for this tank but most references seem to imply that its dry mass was slightly heavier, and that it was slightly taller, than the SLV-3C.  Most references also seem to imply that it's fuel mass was similar to the SLV-3A.  I've tried to reflect this in the provided stats.