### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -202,8 +202,8 @@
 	@MODEL,0
 	{
 		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
-		%scale = 1.219, 2.00, 1.219
-		%position = 0.0, 8.2, 0.0
+		%scale = 1.219, 1.850, 1.219
+		%position = 0.0, 8.5, 0.0
 	}
 	@MODEL,1
 	{
@@ -211,7 +211,7 @@
 		%scale = 1.219, 1.219, 1.219
 		%position = 0.0, 0.0, 0.0
 	}
-	@node_stack_top = 0.0, 10.7848, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_top = 0.0, 10.905, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, -1.0, 0.0, 3
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas SLV-3C Fuel Tank


### PR DESCRIPTION
Clean up Atlas SLV-3A composite tank by adjusting size and placement of the "LFT_Gemini_Short" tank.  New model, with LR-105 engine results in a 21.4m height.