### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -268,6 +268,48 @@
 		}
 	}
 }
++PART[FASAMercuryAtlasLFTLong]:AFTER[RealismOverhaul]
+{
+	@name = FASAAtlasH
+	@MODEL,0
+	{
+		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
+		%scale = 1.219, 1.327, 1.219
+		%position = 0.0, 11.2703, 0.0
+	}
+	@MODEL,1
+	{
+		%model = FASA/Gemini2/FASA_Gemini_LFT/LFT_Gemini_Short
+		%scale = 1.219, 1.327, 1.219
+		%position = 0.0, 7.8201, 0.0
+	}
+	MODEL
+	{
+		model = FASA/Mercury/FASA_Mercury_Atlas/Mercury_Atlas_LFT_Long
+		scale = 1.219, 1.219, 1.219
+		position = 0.0, 0.0, 0.0
+	}
+	@node_stack_top = 0.0, 12.9954, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, -1.0, 0.0, 3
+	CoMOffset = 0, 2.0, 0
+	@title = Atlas G/H/I Fuel Tank
+	@description = The fuel tank for the Atlas G/H/I. Historically used with the Centaur D1A to send up to 2.375T to GTO.  
+	@mass = 3.334
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 124804.2
+		@TANK[Kerosene]
+		{
+			@amount = 40877.2
+			@maxAmount = 40877.2
+		}
+		@TANK[LqdOxygen]
+		{
+			@amount = 83927.0
+			@maxAmount = 83927.0
+		}
+	}
+}
 @PART[FASAMercuryAtlasEng]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
Added composite model for Atlas G/H/I first stage tank.  I noticed that there is a reference to a "FASAAtlasH" already in RP-0 even though no corresponding tank exists in RO so I've re-used that name for this new part.  The resulting part has the same basic fuel capacity as the Atlas SLV-3A with a height (when LR-105 engine is attached) of 23.5m.