### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -21,7 +21,7 @@
 	@cost = 2600
 	@title = Mercury - Atlas Launch Vehicle Fuel Tank
 	@description = The fuel tank for the Mercury - Atlas Launch Vehicle, aka Atlas D Mercury Launch Vehicle, aka Atlas LV-3B.
-	@mass = 1.506
+	@mass = 1.502
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -34,20 +34,20 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 97313.5
+		volume = 97705.4
 		type = Balloon
 		basemass = -1
 		TANK
 		{
 			name = Kerosene
-			amount = 30375.8
-			maxAmount = 30375.8
+			amount = 30525.5
+			maxAmount = 30525.5
 		}
 		TANK
 		{
 			name = LqdOxygen
-			amount = 66937.7
-			maxAmount = 66937.7
+			amount = 67179.9
+			maxAmount = 67179.9
 		}
 	}
 }
@@ -128,7 +128,7 @@
 	@title = Atlas SLV-3 Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3 launcher. Used with the Gemini Agena Target Vehicle.
 	@attachRules = 1,0,1,1,0
-	@mass = 1.566
+	@mass = 1.481
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -138,20 +138,20 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 101771.7
+		volume = 101629.3
 		type = Balloon
 		basemass = -1
 		TANK
 		{
 			name = Kerosene
-			amount = 32078.8
-			maxAmount = 32078.8
+			amount = 32024.4
+			maxAmount = 32024.4
 		}
 		TANK
 		{
 			name = LqdOxygen
-			amount = 69692.9
-			maxAmount = 69692.9
+			amount = 69604.9
+			maxAmount = 69604.9
 		}
 	}
 }
@@ -180,19 +180,19 @@
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas SLV-3A Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3A launcher.  Extended fuel tank for larger payloads.
-	@mass = 3.426
+	@mass = 2.798
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 124789.5
+		@volume = 124804.2
 		@TANK[Kerosene]
 		{
-			@amount = 40871.6
-			@maxAmount = 40871.6
+			@amount = 40877.2
+			@maxAmount = 40877.2
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 83917.9
-			@maxAmount = 83917.9
+			@amount = 83927.0
+			@maxAmount = 83927.0
 		}
 	}
 }
@@ -216,19 +216,19 @@
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas SLV-3C Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3C. Historically used with the Centaur D1 to send 1.75T to GTO.  
-	@mass = 4.296
+	@mass = 3.098
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 110323
+		@volume = 111252.9
 		@TANK[Kerosene]
 		{
-			@amount = 35345
-			@maxAmount = 35345
+			@amount = 35700.2
+			@maxAmount = 35700.2
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 74978
-			@maxAmount = 74978
+			@amount = 75552.7
+			@maxAmount = 75552.7
 		}
 	}
 }
@@ -252,19 +252,19 @@
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas LV-3C Fuel Tank
 	@description = The fuel tank for the Atlas LV-3C. Historically used to loft the Centaur D1 into orbit, but has many uses.
-	@mass = 3.726
+	@mass = 2.855
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 104860
+		@volume = 100491.3
 		@TANK[Kerosene]
 		{
-			@amount = 32918.6
-			@maxAmount = 32918.6
+			@amount = 31249.8
+			@maxAmount = 31249.8
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 71941.4
-			@maxAmount = 71941.4
+			@amount = 69241.5
+			@maxAmount = 69241.5
 		}
 	}
 }


### PR DESCRIPTION
Dry and Wet mass adjustments.  These new masses are taken from astronautix.com which I know it's wholly reliable but it is the only source I can find with even marginally accurate data on the older Atlas rockets.  The proposed mass and fuel alterations will result in matching wet and dry masses taken from that website assuming two LR-101 Verner engines and the correct LR-105 sustainer engine are included in the final craft.