### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -74,7 +74,7 @@
 	@title = Atlas-E/F Fuel Tank
 	@description = The fuel tank for the Atlas-E/F series.
 	@attachRules = 1,0,1,1,0
-	@mass = 1.506
+	@mass = 4.081
 	!RESOURCE[LiquidFuel]
 	{
 	}


### PR DESCRIPTION
Based on the astronautix site (where I got all the masses for all the old Atlas missiles/rockets) the Atlas E/F dry weight is about 210% the dry weight of the Atlas D.  I can't find any information as to why the Atlas E/F is +2,579kg heavier.  It has been suggested that maybe the source has included the weight of the boosters as well, but if that's happened the Atlas E/F would only weigh in at 1,752kg which is only 75% of the dry weight of the Atlas D.  Presumably if the Atlas E/F was a more advanced design (which it was) that also weighed less, you'd expect that all future models of the Atlas would have been based on the E/F design.  Instead, all future Atlas models (SLV-3, SLV-3A, LV-3C, SLV-3C, G, H & I) appear to be based on the older Atlas D.  Considering how important weight is in a launch vehicle, if the E/F were heavier (as astronautix claims it is) that would certainly explain why the older version was ultimately used as the design template.