### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -619,6 +619,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
+		origMass = 0.720
 		configuration = LR89-NA-3
 		CONFIG
 		{
@@ -626,6 +627,7 @@
 			minThrust = 748.7
 			maxThrust = 748.7
 			heatProduction = 100
+			massMult = 1.0
 			PROPELLANT
 			{
 				name = Kerosene
@@ -642,7 +644,6 @@
 				key = 0 282
 				key = 1 248
 			}
-			massMult = 0.89
 		}
 		CONFIG
 		{
@@ -650,6 +651,7 @@
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
+			massMult = 1.0
 			PROPELLANT
 			{
 				name = Kerosene
@@ -680,6 +682,7 @@
 			minThrust = 831.4
 			maxThrust = 831.4
 			heatProduction = 100
+			massMult = 1.086
 			PROPELLANT
 			{
 				name = Kerosene
@@ -710,6 +713,7 @@
 			minThrust = 931.7
 			maxThrust = 931.7
 			heatProduction = 100
+			massMult = 1.414
 			PROPELLANT
 			{
 				name = Kerosene
@@ -742,6 +746,7 @@
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
+			massMult = 1.414
 			PROPELLANT
 			{
 				name = Kerosene
@@ -774,6 +779,7 @@
 			minThrust = 1077.6
 			maxThrust = 1077.6
 			heatProduction = 100
+			massMult = 1.783
 			PROPELLANT
 			{
 				name = Kerosene

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -378,6 +378,37 @@
 		}
 		CONFIG
 		{
+			name = LR105-NA-5
+			minThrust = 366.1
+			maxThrust = 366.1
+			heatProduction = 100
+			massMult = 0.9443 // 413kg engine, source http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for -5
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 311
+				key = 1 215
+			}
+			cost = 100
+			entryCost = 2000
+			entryCostSubtractors
+			{
+				LR89-NA-5 = 1000
+			}
+			techRequired = advRocketry
+		}
+		CONFIG
+		{
 			name = LR105-NA-6
 			minThrust = 366.1
 			maxThrust = 366.1
@@ -409,7 +440,39 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-7
+			name = LR105-NA-7.1
+			minThrust = 385.2
+			maxThrust = 385.2
+			heatProduction = 100
+			massMult = 1.01185 // same source
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 220
+			}
+			cost = 300
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-6 = 2000
+				LR89-NA-7.1 = 1000
+			}
+			techRequired = heavierRocketry
+		}
+		CONFIG
+		{
+			name = LR105-NA-7.2
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
@@ -435,15 +498,15 @@
 			entryCostSubtractors
 			{
 				LR105-NA-6 = 2000
-				LR89-NA-7 = 1000
+				LR89-NA-7.2 = 1000
 			}
 			techRequired = heavierRocketry
 		}
 		CONFIG
 		{
 			name = RS-56-OSA
-			minThrust = 386.4
-			maxThrust = 386.4
+			minThrust = 385.2
+			maxThrust = 385.2
 			heatProduction = 100
 			massMult = 1.0 // guess
 			PROPELLANT
@@ -472,7 +535,6 @@
 			techRequired = experimentalRocketry
 		}
 	}
-	
 }
 @PART[FASAMercuryFairing]:FOR[RealismOverhaul]
 {
@@ -561,6 +623,30 @@
 		CONFIG
 		{
 			name = LR89-NA-3
+			minThrust = 748.7
+			maxThrust = 748.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 282
+				key = 1 248
+			}
+			massMult = 0.89
+		}
+		CONFIG
+		{
+			name = LR89-NA-5
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
@@ -580,7 +666,13 @@
 				key = 0 282
 				key = 1 248
 			}
-			massMult = 0.89
+			cost = 200
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-5 = 1000
+			}
+			techRequired = advRocketry
 		}
 		CONFIG
 		{
@@ -614,7 +706,39 @@
 		}
 		CONFIG
 		{
-			name = LR89-NA-7
+			name = LR89-NA-7.1
+			minThrust = 931.7
+			maxThrust = 931.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 292.2
+				key = 1 258.0
+			}
+			massMult = 0.99
+			cost = 500
+			entryCost = 10000
+			entryCostSubtractors
+			{
+				LR105-NA-7.1 = 2000
+				LR89-NA-6 = 4000
+			}
+			techRequired = heavierRocketry
+		}
+		CONFIG
+		{
+			name = LR89-NA-7.2
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
@@ -639,7 +763,7 @@
 			entryCost = 10000
 			entryCostSubtractors
 			{
-				LR105-NA-7 = 2000
+				LR105-NA-7.2 = 2000
 				LR89-NA-6 = 4000
 			}
 			techRequired = heavierRocketry


### PR DESCRIPTION
Update engine configurations for the Atlas LR-89 and LR-105 engines.  All engine data was pulled from b14643.de site.  I considered altering the configuration names to also include the "MA-x" designation but I wasn't sure if that would be confusing or not.