### PR TITLE
Update RO_FASA_ApolloCSM.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -576,7 +576,7 @@
 		converterName = Fuel Cell
 		conversionRate = 1.0
 		inputResources = LqdHydrogen, 0.000296379, LqdOxygen, 0.000210317
-		outputResources = Water, 0.000261, true, ElectricCharge, 2.8, true
+		outputResources = Water, 0.000261, true, ElectricCharge, 2.2, true
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -314,7 +314,7 @@
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
 		conversionRate = 3.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
 		outputResources = Waste, 0.00003847, false
 	}
 	@MODULE[ModuleRCS]
@@ -576,7 +576,7 @@
 		converterName = Fuel Cell
 		conversionRate = 1.0
 		inputResources = LqdHydrogen, 0.000296379, LqdOxygen, 0.000210317
-		outputResources = Water, 0.000261, true, ElectricCharge, 2.2, true
+		outputResources = Water, 0.000261, true, ElectricCharge, 2.8, true
 	}
 	MODULE
 	{


### PR DESCRIPTION
For the CM change, as it stood the CO2 Scrubber only scrubbed about 95% of the CO2 out of the air.  That meant you were constantly building up CO2 with no way to actually remove it.  And if the scrubber every stopped working for a short time, you'd never be able to recover from that.  We know from historical events (Apollo 13) that the scrubbers were actually able to reduce the amount of CO2 in the air.  The new value will convert 105% of CO2 while generating the same amount of O2.

For the SM change, the old fuel cell did not produce enough electricity to power the CSM plus the high gain antennae.  The new values should be enough for both.