### PR TITLE
Update RO_FASA_ApolloCSM.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -651,6 +651,25 @@
 			key = 1 100
 		}
 	}
+	MODULE
+	{
+		name = ModuleScienceExperiment
+		experimentID = mobileMaterialsLab
+		experimentActionName = Observe Materials Bay
+		resetActionName = Reset Materials Bay
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		xmitDataScalar = 0.35
+		FxModules = 0
+		dataIsCollectable = True
+		collectActionName = Collect Data
+		interactionRange = 1.2
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 8
+		experimentLimit = 5
+		resetLevel = 1
+	}
 	
 }
 @PART[FASAApollo_SM_RCS]:FOR[RealismOverhaul]


### PR DESCRIPTION
We know from historical records that the Apollo CSM had a camera system.  My guess is they had a lot of other scientific equipment as well but most of that can be added into the equipment bays.  We don't have a camera (or material lab in stock) that will properly fit into the equipment bay so I think adding the experiment to the SM directly is a valid way to correct this issue.