### PR TITLE
Update RO_FASA_ApolloCSM.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -336,8 +336,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key, 0 = 0 260
-			@key, 1 = 1 100
+			@key,0 = 0 260
+			@key,1 = 1 100
 		}
 	}
 	


### PR DESCRIPTION
The space after "@key," was apparently keeping the changes from properly taking effect.  This resulted in the CM's RCS thrusters having an isp of 100sl, 100vac.  By removing the space, the CM will now have the correct 100sl, 260vac isp.