### PR TITLE
Update RO_FASA_Atlas.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -599,6 +599,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
+		origMass = 0.720
 		configuration = LR89-NA-3
 		CONFIG
 		{
@@ -606,6 +607,7 @@
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
+			massMult = 0.89
 			PROPELLANT
 			{
 				name = Kerosene
@@ -622,7 +624,6 @@
 				key = 0 282
 				key = 1 248
 			}
-			massMult = 0.89
 		}
 		CONFIG
 		{
@@ -630,6 +631,7 @@
 			minThrust = 831.4
 			maxThrust = 831.4
 			heatProduction = 100
+			massMult = 1.086	// astronautix.com MA-3.  With a 1.61t skirt, this should result in each booster weighing 0.782t resulting in a 3.174t total weight
 			PROPELLANT
 			{
 				name = Kerosene
@@ -660,6 +662,7 @@
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
+			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight
 			PROPELLANT
 			{
 				name = Kerosene
@@ -692,6 +695,7 @@
 			minThrust = 1077.6
 			maxThrust = 1077.6
 			heatProduction = 100
+			massMult = 1.7896	// astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
 			PROPELLANT
 			{
 				name = Kerosene


### PR DESCRIPTION
It appears someone tried to have the mass of the LR89-NA3 be different from the mass of the other LR89 engines (they included a massMult = 0.89) but massMult will apparently not do anything if "origMass" isn't included in the ModuleEngineConfigs so I've added the line.
I moved the massMult for the LR89-NA-3 configuration to just below heatProduction just to be consistent with where I see this tag being used elsewhere.  I should point out that I can find no weight data on the LR89-NA-3 so I've simply left the massMult as it already was.
I've based the weights on the MA-3, MA-5 and Atlas II information from the astronautix website.  When combined with the correct LR-105 sustainer, two LR-101 verner engines, and the correct tank, the take off weights line up with what I see on both the astronautix.com and b14643.de websites.
I should note that I used the Atlas II site from astronautix instead of the MA-5A site because it appears that the MA-5A site is using the weight of each individual booster instead of the engine and skirt as a whole.  Since I can find no weight specifically for the skirt, I made the assumption that the 1.61t we currently have was correct and uniform across all versions of the Atlas (which is likely not correct but I doubt we want to have multiple parts for the skirt).  I therefore adjusted the weights of the boosters to cover the difference.