### PR TITLE
Add Atlas D (MA-2) engine setup

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -651,7 +651,7 @@
 			entryCost = 4000
 			entryCostSubtractors
 			{
-				LR105-NA-5 (-6) = 1000
+				LR105-NA-5/6 = 1000
 			}
 			techRequired = advRocketry
 		}
@@ -677,11 +677,12 @@
 				key = 0 290
 				key = 1 256
 			}
-			cost = 200
-			entryCost = 4000
+			cost = 300
+			entryCost = 7500
 			entryCostSubtractors
 			{
 				LR105-NA-5/6 = 1000
+				LR89-NA-5 = 3000
 			}
 			techRequired = heavyRocketry
 		}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -420,7 +420,7 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-6
+			name = LR105-NA-5 (-6)
 			minThrust = 366.1
 			maxThrust = 366.1
 			heatProduction = 100
@@ -626,6 +626,37 @@
 		}
 		CONFIG
 		{
+			name = LR89-NA-5
+			minThrust = 758.7
+			maxThrust = 758.7
+			heatProduction = 100
+			massMult = 1.0	// astronautix.com MA-2.  With a 1.61t skirt, this should result in each booster weighing 0.720t resulting in a 3.050t total weight  
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 282
+				key = 1 248
+			}
+			cost = 200
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-5 (-6) = 1000
+			}
+			techRequired = advRocketry
+		}
+		CONFIG
+		{
 			name = LR89-NA-6
 			minThrust = 831.4
 			maxThrust = 831.4
@@ -650,7 +681,7 @@
 			entryCost = 4000
 			entryCostSubtractors
 			{
-				LR105-NA-6 = 1000
+				LR105-NA-5 (-6) = 1000
 			}
 			techRequired = advRocketry
 		}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -683,7 +683,7 @@
 			{
 				LR105-NA-5/6 = 1000
 			}
-			techRequired = advRocketry
+			techRequired = heavyRocketry
 		}
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -420,7 +420,7 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-5 (-6)
+			name = LR105-NA-5/6
 			minThrust = 366.1
 			maxThrust = 366.1
 			heatProduction = 100
@@ -681,7 +681,7 @@
 			entryCost = 4000
 			entryCostSubtractors
 			{
-				LR105-NA-5 (-6) = 1000
+				LR105-NA-5/6 = 1000
 			}
 			techRequired = advRocketry
 		}


### PR DESCRIPTION
Added a configuration for the LA89-NA-5 which is part of the Atlas MA-2 engine.  While the booster is only slightly more powerful than the NA-3 version (the MA-1 engine), it is the correct values for recreating the Atlas D rocket.
I've also relabeled the LR105-NA-6 to (hopefully) show that it was basically used in both the MA-2 and MA-3 engines.  There is no game difference between the LR105-NA-5 and LR105-NA-6 (the NA6 had a slightly higher chamber pressure) so no reason to actually include a separate configuration.