### PR TITLE
Separate MA-5 Atlas engine into Agena and Centaur varients

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -452,6 +452,7 @@
 		CONFIG
 		{
 			name = LR105-NA-7.1
+			description = MA-5.1 engine for Atlas-Agena launches
 			minThrust = 385.2
 			maxThrust = 385.2
 			heatProduction = 100
@@ -484,6 +485,7 @@
 		CONFIG
 		{
 			name = LR105-NA-7.2
+			description = MA-5.2 engine for Atlas-Centaur launches
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
@@ -689,6 +691,7 @@
 		CONFIG
 		{
 			name = LR89-NA-7.1
+			description = MA-5.1 engine for Atlas-Agena launches
 			minThrust = 931.7
 			maxThrust = 931.7
 			heatProduction = 100
@@ -722,6 +725,7 @@
 		CONFIG
 		{
 			name = LR89-NA-7.2
+			description = MA-5.2 engine for Atlas-Centaur launches
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -451,7 +451,39 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-7
+			name = LR105-NA-7.1
+			minThrust = 385.2
+			maxThrust = 385.2
+			heatProduction = 100
+			massMult = 1.01185 // same source
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 220
+			}
+			cost = 300
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-6 = 2000
+				LR89-NA-7.1 = 1000
+			}
+			techRequired = heavierRocketry
+		}
+		CONFIG
+		{
+			name = LR105-NA-7.2
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
@@ -477,7 +509,7 @@
 			entryCostSubtractors
 			{
 				LR105-NA-6 = 2000
-				LR89-NA-7 = 1000
+				LR89-NA-7.2 = 1000
 			}
 			techRequired = heavierRocketry
 		}
@@ -656,10 +688,44 @@
 		}
 		CONFIG
 		{
-			name = LR89-NA-7
+			name = LR89-NA-7.1
+			minThrust = 931.7
+			maxThrust = 931.7
+			heatProduction = 100
+			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 292.2
+				key = 1 258.0
+			}
+			massMult = 0.99
+			cost = 500
+			entryCost = 10000
+			entryCostSubtractors
+			{
+				LR105-NA-7.1 = 2000
+				LR89-NA-6 = 4000
+			}
+			techRequired = heavierRocketry
+		}
+		CONFIG
+		{
+			name = LR89-NA-7.2
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
+			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
 			PROPELLANT
 			{
 				name = Kerosene
@@ -681,7 +747,7 @@
 			entryCost = 10000
 			entryCostSubtractors
 			{
-				LR105-NA-7 = 2000
+				LR105-NA-7.2 = 2000
 				LR89-NA-6 = 4000
 			}
 			techRequired = heavierRocketry


### PR DESCRIPTION
Based on what I'm finding on astronautix.com and b14643.de, there were two difference versions of the MA-5 engines: LR89/105-NA7.1 and LR89/105-NA7.2.  The 7.1 version appears to have been used exclusively on Atlas-Agena rockets while the 7.2 version was used on Atlas-Centaur.  The 7.1 version had less thrust and isp but resulted in slightly higher dV (about +2% based on in game mechjeb data) than the 7.2 version.  Presumably the lighter, less powerful Agena needed less SLT to get off the pad and needed the MA-5.1 engines to do a bit more of the work.  While the heavier, higher dV Centaur needed more initial SLT for launch but didn't need the MA-5.2 engines to do all the work of getting something into orbit.