### PR TITLE
Added new SSTU tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -7,7 +7,7 @@
 	}
 	%breakingForce = 250
 	%breakingTorque = 250
-	@title = SSTU - SC-D8-TANK
+	@title = SSTU - SC-TANK - 8.4m
 	@manufacturer = SSTU
 	@description = 8.4 diameter tank for Shuttle ET, SLS, Jupiter and Jarvis tanks
 	@node_stack_top = 0,4.2,0,0,1,0,8
@@ -172,7 +172,7 @@
 	}
 	%breakingForce = 250
 	%breakingTorque = 250
-	@title = SSTU - SC-C6-TANK
+	@title = SSTU - SC-TANK - 6.6m
 	@manufacturer = SSTU
 	@description = 6.61 diameter tank for Saturn S-IVB and S-IB based tanks
 	@node_stack_top = 0,3.3,0,0,1,0,6
@@ -337,7 +337,7 @@
 	}
 	%breakingForce = 250
 	%breakingTorque = 250
-	@title = SSTU - SC-E10-TANK
+	@title = SSTU - SC-TANK - 10m
 	@manufacturer = SSTU
 	@description = 10M diameter tank for Saturn V sized tanks
 	@node_stack_top = 0,5.0,0,0,1,0,10
@@ -597,5 +597,182 @@
 	@MODULE[SSTUCustomFuelTank]
 	{
 		useRF = true
+	}
+}
+@PART[SSTU_ShipCore_A0_TANK]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 98000
+		utilizationTweakable = true
+		type = Default
+		typeAvailable = Default
+		typeAvailable = Cryogenic
+		typeAvailable = ServiceModule
+		typeAvailable = Fuselage
+		typeAvailable = Balloon
+		typeAvailable = BalloonCryo
+		typeAvailable = Structural
+	}
+	@MODULE[SSTUCustomFuelTank]
+	{
+		useRF = true
+	}
+}
+@PART[SSTU_ShipCore_A4_TANK]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 98000
+		utilizationTweakable = true
+		type = Default
+		typeAvailable = Default
+		typeAvailable = Cryogenic
+		typeAvailable = ServiceModule
+		typeAvailable = Fuselage
+		typeAvailable = Balloon
+		typeAvailable = BalloonCryo
+		typeAvailable = Structural
+	}
+	@MODULE[SSTUCustomFuelTank]
+	{
+		useRF = true
+	}
+}
+@PART[SSTU_ShipCore_B_TANK2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 98000
+		utilizationTweakable = true
+		type = Default
+		typeAvailable = Default
+		typeAvailable = Cryogenic
+		typeAvailable = ServiceModule
+		typeAvailable = Fuselage
+		typeAvailable = Balloon
+		typeAvailable = BalloonCryo
+		typeAvailable = Structural
+	}
+	@MODULE[SSTUCustomFuelTank]
+	{
+		useRF = true
+	}
+}
++PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = SSTU_ShipCore_B5_5_TANK
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	@title = SSTU - SC-TANK - 5.5m
+	@manufacturer = SSTU
+	@description = 5.5 diameter tank for Early Saturn projects and Pyros Boosters tanks
+	@node_stack_top = 0,2.75,0,0,1,0,5
+	@node_stack_bottom =  0,-2.75,0,0,-1,0,5
+	@node_attach = 2.75, 0, 0, 1, 0, 0
+	@MODULE[SSTUCustomFuelTank]
+	{
+		%useRF = true
+		@fuelTypes = LFO, LF, MP
+		@defaultTankName = 5.5m Tank
+		@defaultTopCapName = None
+		@defaultBottomCapName = None
+		@defaultFuelType = LFO
+		@tankDiameter = 5.5
+		@TANK,0
+		{
+			@name = 5.5m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK05
+			%scale = 1.1
+		}
+		@TANK,1
+		{
+			@name = 11m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK10
+			%scale = 1.1
+		}
+		@TANK,2
+		{
+			@name = 16.5m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK15
+			%scale = 1.1
+		}
+		@TANK,3
+		{
+			@name = 22m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK20
+			%scale = 1.1
+		}
+		@TANK,4
+		{
+			@name = 27.5m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK25
+			%scale = 1.1
+		}
+		@TANK,5
+		{
+			@name = 33m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK30
+			%scale = 1.1
+		}
+		@TANK,6
+		{
+			@name = 38.5m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK35
+			%scale = 1.1
+		}
+		@TANK,7
+		{
+			@name = 44m Tank
+			@volume *= 1.331
+			@height *= 1.1
+			@mesh = SSTU/Assets/SC-B-TANK40
+			%scale = 1.1
+		}
+		@CAP,*
+		{
+			@height *= 1.1
+			%scale = 1.1
+			@volume *= 1.331
+		}
 	}
 }


### PR DESCRIPTION
added a new 5.5m tank, and added RO support for three new tanks that come with the SSTU pack (0.625m, 1.875m and 6.25m) aswell

also changed the 6.6m, 8.4m and 10m tanks name to match the name for the default mod tanks (I didn't change the part name to avoid breaking any craft, only the in-game name)