### PR TITLE
Update RO_FASA_ApolloCSM.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -573,10 +573,26 @@
 	MODULE
 	{
 		name = TacGenericConverter
-		converterName = Fuel Cell
+		converterName = Fuel Cell 1
 		conversionRate = 1.0
-		inputResources = LqdHydrogen, 0.000296379, LqdOxygen, 0.000210317
-		outputResources = Water, 0.000261, true, ElectricCharge, 2.2, true
+		inputResources = LqdHydrogen, 0.0001347177, LqdOxygen, 0.0000955986
+		outputResources = Water, 0.0001186364, true, ElectricCharge, 1.0, true
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = Fuel Cell 2
+		conversionRate = 1.0
+		inputResources = LqdHydrogen, 0.0001347177, LqdOxygen, 0.0000955986
+		outputResources = Water, 0.0001186364, true, ElectricCharge, 1.0, true
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = Fuel Cell 3
+		conversionRate = 1.0
+		inputResources = LqdHydrogen, 0.0001347177, LqdOxygen, 0.0000955986
+		outputResources = Water, 0.0001186364, true, ElectricCharge, 1.0, true
 	}
 	MODULE
 	{


### PR DESCRIPTION
Instead of a single fuel cell that produces 2.2ec/s, this change sets up 3 separate fuel cells which matches what was on the actual CSM.  I've set each fuel cell so that they create 1ec/s while using 2.2x less LOX/LH2 and generating 2.2x less Water.  This means each fuel cell should have the same efficiency that the original.
Only 2 fuel cells are needed to maintain ElectricCharge for the entire duration of a flight which, with the LOX-O2 generator running, gives the default CSM about 15.3 days worth of operating fuel.
I did set the power generation of each fuel cell to be less than half of what the original fuel cell could produce (1.0 vs 2.2).  This means that while 2 fuel cells can produce enough EC to cover the per second usage, they don't generate anything extra so if you use additional EC (like running the high gain antenna, transmitting data or running power hungry science experiments), you cut into the crafts battery.
You can also turn on the 3rd fuel cell which increases power generation enough to have a small surplus even while running the high gain antenna but at a cost of longevity.  Based on the default craft, running all three fuel cells (plus the LOX-O2 generator) means you only have enough fuel for a 10.3 day flight.