### PR TITLE
Updated RO SSTU Engines

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
@@ -313,3 +313,411 @@
 		}
 	}
 }
+
+!PART[SSTU_ShipCore_ENG-F1Bx2]:FOR[SSTU]
+{
+}
+
+!PART[SSTU_ShipCore_ENG-F1x2]:FOR[SSTU]
+{
+}
+
+!PART[SSTU_ShipCore_ENG-F1x4]:FOR[SSTU]
+{
+}
+
+!PART[SSTU_ShipCore_ENG-F1x5]:FOR[SSTU]
+{
+}
+
+!PART[SSTU_ShipCore_ENG-RS-25x3]:FOR[SSTU]
+{
+}
+
+!PART[SSTU_ShipCore_ENG-RS-25-SLS4]:FOR[SSTU]
+{
+}
+
+!PART[SSTU_ShipCore_ENG-RS-25-SLS5]:FOR[SSTU]
+{
+}
+
++PART[SSTU_ShipCore_ENG-F1B]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1Bx2
+	@title = SSTU - SC-ENG-F1B Pyrios
+	@description = Engine cluster intended for Pyrios Liquid Booster.
+	@mass *= 2
+	@cost *= 2
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Double
+		@mountSpacing = 3.0
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Pyrios
+			scale = 1.1
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 2
+	}
+}
+
++PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1x2
+	@title = SSTU - SC-ENG-F1 MS-LRB
+	@description = Engine cluster for Saturn MS Liquid Rocket Boosters.
+	@mass *= 2
+	@cost *= 2
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Double
+		@mountSpacing = 3.5
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Pyrios
+			scale = 1.32
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 2
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 2
+		@maxThrust *= 2
+		}
+	}
+}
+
++PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1_Jarvis
+	@title = SSTU - SC-ENG-F1 Jarvis
+	@mass *= 2
+	@description = F1 Engine cluster intended for Jarvis, but can also be used for Saturn C-3.
+	@cost *= 2
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Double
+		@mountSpacing = 2.725
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Generic
+			scale = 1.68
+		}
+		MOUNT
+		{
+			name = None
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 2
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 2
+		@maxThrust *= 2
+		}
+	}
+}
+
++PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1x4
+	@title = SSTU - SC-ENG-F1x4
+	@description = F1 Engine cluster for Saturn V 4 Engine configuration.
+	@mass *= 4
+	@cost *= 4
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Saturn_C4B
+		@mountSpacing = 3.225
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Saturn-V
+			scale = 2.0
+			//6.25m saturn-V style mount
+		}
+		MOUNT
+		{
+			name = Generic
+			//5m generic mount
+		}
+		MOUNT
+		{
+			name = None
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 4
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 4
+		@maxThrust *= 4
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-F1x4]:NEEDS[KWRocketry]:FINAL
+{
+	%node_stack_bottom1 = -4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom2 = 4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom3 = -4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom4 = 4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%stackSymmetry = 3
+}
+
++PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1x5
+	@title = SSTU - SC-ENG-F1 S-IC
+	@description = F1 Engine cluster for Saturn V 5 Engine configuration.
+	@mass *= 5
+	@cost *= 5
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = FiveCross
+		@mountSpacing = 3.225
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Saturn-V
+			scale = 2.0
+			//6.25m saturn-V style mount
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 5
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 5
+		@maxThrust *= 5
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-F1x5]:NEEDS[KWRocketry]:FINAL
+{
+	%node_stack_bottom1 = -4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom2 = 4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom3 = -4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom4 = 4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%stackSymmetry = 3
+}
+
++PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1_MSIC1A
+	@title = SSTU - SC-ENG-F1 MS-IC-1A
+	@description = F1 Engine cluster for Saturn V 5 Engine configuration.
+	@mass *= 6
+	@cost *= 6
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Saturn_MS-IC-1A
+		@mountSpacing = 3.225
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Saturn-V
+			scale = 2.0
+			//6.25m saturn-V style mount
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 6
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 6
+		@maxThrust *= 6
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-F1_MSIC1A]:NEEDS[KWRocketry]:FINAL
+{
+	%node_stack_bottom1 = -4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom2 = 4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom3 = -4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom4 = 4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%stackSymmetry = 3
+}
+
++PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-F1_Saturn_C-3B
+	@title = SSTU - SC-ENG-F1 Saturn C-3B
+	@description = F1 Engine cluster for Saturn C-3B or other Saturn V 3 engine configurations.
+	@mass *= 3
+	@cost *= 3
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = TripleInline
+		@mountSpacing = 3.225
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Pyrios
+			scale = 2.0
+		}
+		MOUNT
+		{
+			name = Saturn-V
+			scale = 2.0
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 3
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 3
+		@maxThrust *= 3
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-F1_Saturn_C-3B]:NEEDS[KWRocketry]:FINAL
+{
+	%node_stack_bottom1 = -4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom2 = 4.4194173825, -2.5, -4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom3 = -4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%node_stack_bottom4 = 4.4194173825, -2.5, 4.4194173825, 0, -1, 0, 1
+	%stackSymmetry = 3
+}
+
++PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-RS-25x3
+	@title = SSTU - SC-ENG-RS-25 x 3
+	@description = Engine cluster for general use.  Includes three (3) RS-25 motors on a selectable mount.
+	@mass *= 3
+	@cost *= 3
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Triple
+		@mountSpacing = 1.75
+		!MOUNT,*{}		
+		MOUNT
+		{
+			name = Pyrios			
+			scale = 1.1
+			layoutName = TripleInline
+			mountSpacing = 2.2
+		}
+		MOUNT
+		{
+			name = Generic
+			scale = 1.1
+		}
+		MOUNT
+		{
+			name = None
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 3
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 3
+		@maxThrust *= 3
+		}
+	}
+}
+
++PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-RS-25-SLS4
+	@title = SSTU - SC-ENG-RS-25-SLS4
+	@description = Engine cluster for SC-B Core stage.  Includes four (4) RS-25 motors on a 5m mount, with aerodynamic engine shrouds.
+	@mass *= 4
+	@cost *= 4	
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Quad-X
+		!MOUNT[None]{}
+		!MOUNT[Generic],*{}
+		MOUNT
+		{
+			name = SLS			
+			scale = 1.68
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 4
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 4
+		@maxThrust *= 4
+		}
+	}
+}
+
++PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FINAL
+{
+	@name = SSTU_ShipCore_ENG-RS-25-SLS5
+	@title = SSTU - SC-ENG-RS-25-SLS5
+	@description = Engine cluster for SC-B Core stage.  Includes five (5) RS-25 motors on a 5m mount, with aerodynamic engine shrouds.
+	@mass *= 5
+	@cost *= 5	
+	@MODULE[SSTUEngineCluster]
+	{
+		@layoutName = Five-X
+		!MOUNT[None]{}
+		!MOUNT[Generic],*{}
+		MOUNT
+		{
+			name = SLS			
+			scale = 1.68
+		}
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 5
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+		@minThrust *= 5
+		@maxThrust *= 5
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
@@ -531,7 +531,7 @@
 {
 	@name = SSTU_ShipCore_ENG-F1_MSIC1A
 	@title = SSTU - SC-ENG-F1 MS-IC-1A [10m]
-	@description = F1 Engine cluster for Saturn V 5 Engine configuration.
+	@description = F1 Engine cluster for Saturn MLV-V-1A 6 Engine configuration.
 	@mass *= 6
 	@cost *= 6
 	@MODULE[SSTUEngineCluster]
@@ -625,18 +625,18 @@
 	@MODULE[SSTUEngineCluster]
 	{
 		@layoutName = Triple
-		@mountSpacing = 1.75
+		@mountSpacing = 2.2
 		!MOUNT,*{}		
 		MOUNT
 		{
 			name = Pyrios			
 			scale = 1.1
 			layoutName = TripleInline
-			mountSpacing = 2.2
 		}
 		MOUNT
 		{
 			name = Generic
+			mountSpacing = 1.75
 			scale = 1.1
 		}
 		MOUNT

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Lower Stages.cfg
@@ -1,9 +1,9 @@
 @PART[SSTU_ShipCore_B_ENG2]:FOR[RealismOverhaul]
 {
 	@mass = 6.355
+	@title = SSTU - SC-B-ENG2 [8.4m]
 	%RSSROConfig = True
 	@rescaleFactor = 1.676
-	
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 2800
@@ -80,9 +80,9 @@
 @PART[SSTU_ShipCore_B_ENG3]:FOR[RealismOverhaul]
 {
 	@mass = 9.5325
+	@title = SSTU - SC-B-ENG3 [8.4m]
 	%RSSROConfig = True
 	@rescaleFactor = 1.676
-	
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 4200
@@ -159,9 +159,9 @@
 @PART[SSTU_ShipCore_B_ENG4]:FOR[RealismOverhaul]
 {
 	@mass = 12.71
+	@title = SSTU - SC-B-ENG4 [8.4m]
 	%RSSROConfig = True
 	@rescaleFactor = 1.676
-	
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 5600
@@ -238,9 +238,9 @@
 @PART[SSTU_ShipCore_B_ENG5]:FOR[RealismOverhaul]
 {
 	@mass = 15.8875
+	@title = SSTU - SC-B-ENG5 [8.4m]
 	%RSSROConfig = True
 	@rescaleFactor = 1.676
-	
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 7000
@@ -345,7 +345,7 @@
 +PART[SSTU_ShipCore_ENG-F1B]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1Bx2
-	@title = SSTU - SC-ENG-F1B Pyrios
+	@title = SSTU - SC-ENG-F1B Pyrios [5.5m]
 	@description = Engine cluster intended for Pyrios Liquid Booster.
 	@mass *= 2
 	@cost *= 2
@@ -369,7 +369,7 @@
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1x2
-	@title = SSTU - SC-ENG-F1 MS-LRB
+	@title = SSTU - SC-ENG-F1 MS-LRB [6.6m]
 	@description = Engine cluster for Saturn MS Liquid Rocket Boosters.
 	@mass *= 2
 	@cost *= 2
@@ -401,7 +401,7 @@
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1_Jarvis
-	@title = SSTU - SC-ENG-F1 Jarvis
+	@title = SSTU - SC-ENG-F1 Jarvis [8.4m]
 	@mass *= 2
 	@description = F1 Engine cluster intended for Jarvis, but can also be used for Saturn C-3.
 	@cost *= 2
@@ -437,7 +437,7 @@
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1x4
-	@title = SSTU - SC-ENG-F1x4
+	@title = SSTU - SC-ENG-F1x4 [10m]
 	@description = F1 Engine cluster for Saturn V 4 Engine configuration.
 	@mass *= 4
 	@cost *= 4
@@ -488,7 +488,7 @@
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1x5
-	@title = SSTU - SC-ENG-F1 S-IC
+	@title = SSTU - SC-ENG-F1 S-IC [10m]
 	@description = F1 Engine cluster for Saturn V 5 Engine configuration.
 	@mass *= 5
 	@cost *= 5
@@ -530,7 +530,7 @@
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1_MSIC1A
-	@title = SSTU - SC-ENG-F1 MS-IC-1A
+	@title = SSTU - SC-ENG-F1 MS-IC-1A [10m]
 	@description = F1 Engine cluster for Saturn V 5 Engine configuration.
 	@mass *= 6
 	@cost *= 6
@@ -572,7 +572,7 @@
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-F1_Saturn_C-3B
-	@title = SSTU - SC-ENG-F1 Saturn C-3B
+	@title = SSTU - SC-ENG-F1 Saturn C-3B [10m]
 	@description = F1 Engine cluster for Saturn C-3B or other Saturn V 3 engine configurations.
 	@mass *= 3
 	@cost *= 3
@@ -618,7 +618,7 @@
 +PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-RS-25x3
-	@title = SSTU - SC-ENG-RS-25 x 3
+	@title = SSTU - SC-ENG-RS-25 x 3 [5.5m]
 	@description = Engine cluster for general use.  Includes three (3) RS-25 motors on a selectable mount.
 	@mass *= 3
 	@cost *= 3
@@ -661,7 +661,7 @@
 +PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-RS-25-SLS4
-	@title = SSTU - SC-ENG-RS-25-SLS4
+	@title = SSTU - SC-ENG-RS-25-SLS4 [8.4m]
 	@description = Engine cluster for SC-B Core stage.  Includes four (4) RS-25 motors on a 5m mount, with aerodynamic engine shrouds.
 	@mass *= 4
 	@cost *= 4	
@@ -693,7 +693,7 @@
 +PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-RS-25-SLS5
-	@title = SSTU - SC-ENG-RS-25-SLS5
+	@title = SSTU - SC-ENG-RS-25-SLS5 [8.4m]
 	@description = Engine cluster for SC-B Core stage.  Includes five (5) RS-25 motors on a 5m mount, with aerodynamic engine shrouds.
 	@mass *= 5
 	@cost *= 5	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
@@ -8,7 +8,7 @@
 	%category = Propulsion
 	@title = RS-25 (SSME) Rocket Engine
 	@manufacturer = Rocketdyne
-	@description = The Space Shuttle Main Engine (SSME), or RS-25 is a cryogenic-fed, throttleable engine that powered the Space Shuttle Orbiter and it is planned to be used with the upcoming Space Launch System (SLS). The not so crooked version.
+	@description = The Space Shuttle Main Engine (SSME), or RS-25 is a cryogenic-fed, throttleable engine that powered the Space Shuttle Orbiter and it is planned to be used with the upcoming Space Launch System (SLS). The not so crooked version. Mount sizes included: 2.5m, 3.75m, 5m, 5.5m and 6.6m.
 	@mass = 3.526681
 	@crashTolerance = 12
 	%breakingForce = 250
@@ -167,9 +167,15 @@
 	@MODULE[SSTUEngineCluster]
 	{
 		%engineScale = 1.676
-		@MOUNT,1
+		MOUNT
 		{
-			@scale = 1.3827
+			name = Generic
+			scale = 1.1
+		}
+		MOUNT
+		{
+			name = Generic
+			scale = 1.32
 		}
 	}
 }
@@ -183,6 +189,7 @@
 	%category = Propulsion
 	@title = F-1 Series
 	%manufacturer = Rocketdyne
+	@description = The most powerful single-combustion chamber engine ever produced*, the F1 is often a good choice when you need to land skyscrapers on the Mun.  Even more impressive when used in engine clusters.  While its efficiency might be lacking by modern standards it more than compensates for it with its incredible thrust output.  Due to this it is most useful in the lowest stage of a rocket where the most thrust is needed. Mount sizes included: 3.75m, 5m and 6.6m.
 	@mass = 8.391459
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
@@ -322,6 +329,7 @@
 	%category = Propulsion
 	@title = F-1B Series
 	%manufacturer = Rocketdyne
+	@description = Currently undergoing final testing and certification, the F1B engine is a highly modified version of the F1 that uses modern manufacturing techniques and a simpler exhaust arrangment, greatly decreasing manufacturing costs while increasing thrust at a slight cost of efficiency.  While this engine is still in certification, Werhner Von Kerman made a special appeal to allow some of the test engines to be shipped to the KSC for 'test fitting and crew familiarization', with the promise that they would absolutely not be used for launches. Mount sizes included: 3.75m, 5m and 6.6m.
 	@mass = 8.19618974907
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
@@ -4,6 +4,7 @@
 	!MODULE[TweakScale]
 	{
 	}
+	//@rescaleFactor = 1.676
 	%category = Propulsion
 	@title = RS-25 (SSME) Rocket Engine
 	@manufacturer = Rocketdyne
@@ -169,6 +170,258 @@
 		@MOUNT,1
 		{
 			@scale = 1.3827
+		}
+	}
+}
+@PART[SSTU_ShipCore_ENG-F1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	//@rescaleFactor = 1.5625
+	%category = Propulsion
+	@title = F-1 Series
+	%manufacturer = Rocketdyne
+	@mass = 8.391459
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 7740.5
+		@maxThrust = 7740.5
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.380
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.620
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 304
+			@key,1 = 1 263
+		}
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 0.380
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.620
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 1
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesFX
+		configuration = F-1
+		modded = false
+		CONFIG
+		{
+			name = F-1
+			minThrust = 7740.5
+			maxThrust = 7740.5
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.380
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.620
+			}
+			atmosphereCurve
+			{
+				key = 0 304
+				key = 1 263
+			}
+		}
+		CONFIG
+		{
+			name = F-1A
+			minThrust = 9189.6
+			maxThrust = 9189.6
+			massMult = 0.97673
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.380
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.620
+			}
+			atmosphereCurve
+			{
+				key = 0 310
+				key = 1 270
+			}
+			techRequired = heavierRocketry
+			cost = 2000 // total guess for now
+		}
+	}
+	RESOURCE
+	{
+		name = TEATEB
+		amount = 1
+		maxAmount = 1
+	}
+	@MODULE[SSTUEngineCluster]
+	{
+		%engineScale = 1.425
+		MOUNT
+		{
+			name = Generic
+			scale = 1.32
+		}
+	}
+}
+@PART[SSTU_ShipCore_ENG-F1B]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	//@rescaleFactor = 1.5625
+	%category = Propulsion
+	@title = F-1B Series
+	%manufacturer = Rocketdyne
+	@mass = 8.19618974907
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 9189.6
+		@maxThrust = 9189.6
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.380
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.620
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 304
+			@key,1 = 1 263
+		}
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.005
+		}
+		IGNITOR_RESOURCE
+		{
+			name = Kerosene
+			amount = 0.380
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.620
+		}
+		IGNITOR_RESOURCE
+		{
+			name = TEATEB
+			amount = 1
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesFX
+		configuration = F-1B
+		modded = false
+		CONFIG
+		{
+			name = F-1B
+			minThrust = 9189.6
+			maxThrust = 9189.6
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.380
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.620
+			}
+			atmosphereCurve
+			{
+				key = 0 310
+				key = 1 270
+			}
+		}
+	}
+	RESOURCE
+	{
+		name = TEATEB
+		amount = 1
+		maxAmount = 1
+	}
+	@MODULE[SSTUEngineCluster]
+	{
+		%engineScale = 1.425
+		MOUNT
+		{
+			name = Generic
+			scale = 1.32
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_Engine_Layouts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_Engine_Layouts.cfg
@@ -1,0 +1,68 @@
+SSTU_ENGINELAYOUT
+{
+	name = Saturn_C4B
+	POSITION
+	{
+		x = 0.70711
+		z = 0.70711
+		rotation = 315
+	}
+	POSITION
+	{
+		x = -0.70711
+		z = 0.70711
+		rotation = 225
+	}
+	POSITION
+	{
+		x = -0.70711
+		z = -0.70711
+		rotation = 135
+	}
+	POSITION
+	{
+		x = 0.70711
+		z = -0.70711
+		rotation = 45
+	}
+}
+SSTU_ENGINELAYOUT
+{
+	name = Saturn_MS-IC-1A
+	POSITION
+	{
+		x = 0
+		z = -0.385
+		rotation = 45
+	}
+	POSITION
+	{
+		x = 0
+		z = 0.385
+		rotation = 45
+	}
+	POSITION
+	{
+		x = 0.70711
+		z = 0.70711
+		rotation = 315
+	}
+	POSITION
+	{
+		x = -0.70711
+		z = 0.70711
+		rotation = 225
+	}
+	POSITION
+	{
+		x = -0.70711
+		z = -0.70711
+		rotation = 135
+	}
+	POSITION
+	{
+		x = 0.70711
+		z = -0.70711
+		rotation = 45
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -1,498 +1,3 @@
-+PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@name = SSTU_ShipCore_D8_TANK
-	!MODULE[TweakScale]
-	{
-	}
-	%breakingForce = 250
-	%breakingTorque = 250
-	@title = SSTU - SC-TANK - 8.4m
-	@manufacturer = SSTU
-	@description = 8.4 diameter tank for Shuttle ET, SLS, Jupiter and Jarvis tanks
-	@node_stack_top = 0,4.2,0,0,1,0,8
-	@node_stack_bottom =  0,-4.2,0,0,-1,0,8
-	@node_attach = 4.2, 0, 0, 1, 0, 0
-	!MODULE[SSTUCustomFuelTank]
-	{
-	}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 465000
-		utilizationTweakable = true
-		type = Default
-		typeAvailable = Default
-		typeAvailable = Cryogenic
-		typeAvailable = ServiceModule
-		typeAvailable = Fuselage
-		typeAvailable = Balloon
-		typeAvailable = BalloonCryo
-		typeAvailable = Structural
-	}
-	%MODULE[SSTUCustomFuelTank]
-	{
-		useRF = true
-		fuelTypes = LFO, LF, MP
-		defaultTankName = 8.4m Tank
-		defaultTopCapName = None
-		defaultBottomCapName = None
-		defaultFuelType = LFO
-		tankDiameter = 8.4
-		TANK
-		{
-			name = 8.4m Tank
-			volume = 465
-			height = 8.4
-			mesh = SSTU/Assets/SC-B-TANK05
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 16.8m Tank
-			volume = 930
-			height = 16.8
-			mesh = SSTU/Assets/SC-B-TANK10
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 25.2m Tank
-			volume = 1395
-			height = 25.2
-			mesh = SSTU/Assets/SC-B-TANK15
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 33.6m Tank
-			volume = 1861
-			height = 33.6
-			mesh = SSTU/Assets/SC-B-TANK20
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 42m Tank
-			volume = 2326
-			height = 42
-			mesh = SSTU/Assets/SC-B-TANK25
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 50.4m Tank
-			volume = 2791
-			height = 50.4
-			mesh = SSTU/Assets/SC-B-TANK30
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 58.8m Tank
-			volume = 3256
-			height = 58.8
-			mesh = SSTU/Assets/SC-B-TANK35
-			scale = 1.68
-		}
-		TANK
-		{
-			name = 67.2m Tank
-			volume = 3722
-			height = 67.2
-			mesh = SSTU/Assets/SC-B-TANK40
-			scale = 1.68
-		}
-		NODEGROUP
-		{
-			name = top
-			nodes = top, top2, top3, top4
-		}
-		NODEGROUP
-		{
-			name = bottom
-			nodes = bottom, bottom2, bottom3, bottom4
-		}
-		CAP
-		{
-			name = None
-			height = 0
-			volume = 0
-			node_stack_top = 0, 0, 0, 0, 1, 0, 8
-			node_stack_bottom = 0, 0, 0, 0, -1, 0, 8
-		}
-		CAP
-		{
-			name = Nosecone 1
-			mesh = SSTU/Assets/SC-ADPT-NOSE1
-			scale = 1.68
-			height = 3.36
-			volume = 315.3185
-		}
-		CAP
-		{
-			name = Nosecone 2
-			mesh = SSTU/Assets/SC-ADPT-NOSE2
-			scale = 1.68
-			height = 3.36
-			volume = 410.1511
-		}
-		CAP
-		{
-			name = Nosecone 3
-			mesh = SSTU/Assets/SC-ADPT-NOSE3
-			scale = 1.68
-			height = 3.36
-			volume = 161.2154
-		}
-		CAP
-		{
-			name = Nosecone 4
-			mesh = SSTU/Assets/SC-ADPT-NOSE4
-			scale = 1.68
-			height = 3.36
-			volume = 118.5408
-		}
-		CAP
-		{
-			name = Nosecone 5
-			mesh = SSTU/Assets/SC-ADPT-NOSE5
-			scale = 1.68
-			height = 3.36
-			volume = 286.8687
-		}
-	}
-}
-+PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@name = SSTU_ShipCore_C6_TANK
-	!MODULE[TweakScale]
-	{
-	}
-	%breakingForce = 250
-	%breakingTorque = 250
-	@title = SSTU - SC-TANK - 6.6m
-	@manufacturer = SSTU
-	@description = 6.61 diameter tank for Saturn S-IVB and S-IB based tanks
-	@node_stack_top = 0,3.3,0,0,1,0,6
-	@node_stack_bottom =  0,-3.3,0,0,-1,0,6
-	@node_attach = 3.3, 0, 0, 1, 0, 0
-	!MODULE[SSTUCustomFuelTank]
-	{
-	}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 465000
-		utilizationTweakable = true
-		type = Default
-		typeAvailable = Default
-		typeAvailable = Cryogenic
-		typeAvailable = ServiceModule
-		typeAvailable = Fuselage
-		typeAvailable = Balloon
-		typeAvailable = BalloonCryo
-		typeAvailable = Structural
-	}
-	%MODULE[SSTUCustomFuelTank]
-	{
-		useRF = true
-		fuelTypes = LFO, LF, MP
-		defaultTankName = 6.6m Tank
-		defaultTopCapName = None
-		defaultBottomCapName = None
-		defaultFuelType = LFO
-		tankDiameter = 6.6
-		TANK
-		{
-			name = 6.6m Tank
-			volume = 225
-			height = 6.6
-			mesh = SSTU/Assets/SC-B-TANK05
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 13.2m Tank
-			volume = 451
-			height = 13.2
-			mesh = SSTU/Assets/SC-B-TANK10
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 19.8m Tank
-			volume = 677
-			height = 19.8
-			mesh = SSTU/Assets/SC-B-TANK15
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 26.4m Tank
-			volume = 902
-			height = 26.4
-			mesh = SSTU/Assets/SC-B-TANK20
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 33m Tank
-			volume = 1128
-			height = 33
-			mesh = SSTU/Assets/SC-B-TANK25
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 39.6m Tank
-			volume = 1354
-			height = 39.6
-			mesh = SSTU/Assets/SC-B-TANK30
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 46.2m Tank
-			volume = 1579
-			height = 46.2
-			mesh = SSTU/Assets/SC-B-TANK35
-			scale = 1.32
-		}
-		TANK
-		{
-			name = 52.8m Tank
-			volume = 1805
-			height = 52.8
-			mesh = SSTU/Assets/SC-B-TANK40
-			scale = 1.32
-		}
-		NODEGROUP
-		{
-			name = top
-			nodes = top, top2, top3, top4
-		}
-		NODEGROUP
-		{
-			name = bottom
-			nodes = bottom, bottom2, bottom3, bottom4
-		}
-		CAP
-		{
-			name = None
-			height = 0
-			volume = 0
-			node_stack_top = 0, 0, 0, 0, 1, 0, 6
-			node_stack_bottom = 0, 0, 0, 0, -1, 0, 6
-		}
-		CAP
-		{
-			name = Nosecone 1
-			mesh = SSTU/Assets/SC-ADPT-NOSE1
-			scale = 1.32
-			height = 2.64
-			volume = 152.9478
-		}
-		CAP
-		{
-			name = Nosecone 2
-			mesh = SSTU/Assets/SC-ADPT-NOSE2
-			scale = 1.32
-			height = 2.64
-			volume = 198.9472
-		}
-		CAP
-		{
-			name = Nosecone 3
-			mesh = SSTU/Assets/SC-ADPT-NOSE3
-			scale = 1.32
-			height = 2.64
-			volume = 78.1989
-		}
-		CAP
-		{
-			name = Nosecone 4
-			mesh = SSTU/Assets/SC-ADPT-NOSE4
-			scale = 1.32
-			height = 2.64
-			volume = 57.4991
-		}
-		CAP
-		{
-			name = Nosecone 5
-			mesh = SSTU/Assets/SC-ADPT-NOSE5
-			scale = 1.32
-			height = 2.64
-			volume = 139.148
-		}
-	}
-}
-+PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@name = SSTU_ShipCore_E10_TANK
-	!MODULE[TweakScale]
-	{
-	}
-	%breakingForce = 250
-	%breakingTorque = 250
-	@title = SSTU - SC-TANK - 10m
-	@manufacturer = SSTU
-	@description = 10M diameter tank for Saturn V sized tanks
-	@node_stack_top = 0,5.0,0,0,1,0,10
-	@node_stack_bottom =  0,-5.0,0,0,-1,0,10
-	@node_attach = 5.0, 0, 0, 1, 0, 0
-	!MODULE[SSTUCustomFuelTank]
-	{
-	}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 465000
-		utilizationTweakable = true
-		type = Default
-		typeAvailable = Default
-		typeAvailable = Cryogenic
-		typeAvailable = ServiceModule
-		typeAvailable = Fuselage
-		typeAvailable = Balloon
-		typeAvailable = BalloonCryo
-		typeAvailable = Structural
-	}
-	%MODULE[SSTUCustomFuelTank]
-	{
-		useRF = true
-		fuelTypes = LFO, LF, MP
-		defaultTankName = 10m Tank
-		defaultTopCapName = None
-		defaultBottomCapName = None
-		defaultFuelType = LFO
-		tankDiameter = 10.0
-		TANK
-		{
-			name = 10m Tank
-			volume = 785
-			height = 10
-			mesh = SSTU/Assets/SC-B-TANK05
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 20m Tank
-			volume = 1570
-			height = 20
-			mesh = SSTU/Assets/SC-B-TANK10
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 30m Tank
-			volume = 2355
-			height = 30
-			mesh = SSTU/Assets/SC-B-TANK15
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 40m Tank
-			volume = 3140
-			height = 40
-			mesh = SSTU/Assets/SC-B-TANK20
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 50m Tank
-			volume = 3925
-			height = 50
-			mesh = SSTU/Assets/SC-B-TANK25
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 60m Tank
-			volume = 4710
-			height = 60
-			mesh = SSTU/Assets/SC-B-TANK30
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 70m Tank
-			volume = 5495
-			height = 70
-			mesh = SSTU/Assets/SC-B-TANK35
-			scale = 2.0
-		}
-		TANK
-		{
-			name = 80m Tank
-			volume = 6280
-			height = 80
-			mesh = SSTU/Assets/SC-B-TANK40
-			scale = 2.0
-		}
-		NODEGROUP
-		{
-			name = top
-			nodes = top, top2, top3, top4
-		}
-		NODEGROUP
-		{
-			name = bottom
-			nodes = bottom, bottom2, bottom3, bottom4
-		}
-		CAP
-		{
-			name = None
-			height = 0
-			volume = 0
-			node_stack_top = 0, 0, 0, 0, 1, 0, 10
-			node_stack_bottom = 0, 0, 0, 0, -1, 0, 10
-		}
-		CAP
-		{
-			name = Nosecone 1
-			mesh = SSTU/Assets/SC-ADPT-NOSE1
-			scale = 2
-			height = 4
-			volume = 532
-		}
-		CAP
-		{
-			name = Nosecone 2
-			mesh = SSTU/Assets/SC-ADPT-NOSE2
-			scale = 2
-			height = 4
-			volume = 692
-		}
-		CAP
-		{
-			name = Nosecone 3
-			mesh = SSTU/Assets/SC-ADPT-NOSE3
-			scale = 2
-			height = 4
-			volume = 272
-		}
-		CAP
-		{
-			name = Nosecone 4
-			mesh = SSTU/Assets/SC-ADPT-NOSE4
-			scale = 2
-			height = 4
-			volume = 200
-		}
-		CAP
-		{
-			name = Nosecone 5
-			mesh = SSTU/Assets/SC-ADPT-NOSE5
-			scale = 2
-			height = 4
-			volume = 484
-		}
-	}
-}
 @PART[SSTU_ShipCore_A1_TANK]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -678,6 +183,294 @@
 	@MODULE[SSTUCustomFuelTank]
 	{
 		useRF = true
+	}
+}
++PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = SSTU_ShipCore_D8_TANK
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	@title = SSTU - SC-TANK - 8.4m
+	@manufacturer = SSTU
+	@description = 8.4 diameter tank for Shuttle ET, SLS, Jupiter and Jarvis tanks
+	@node_stack_top = 0,4.2,0,0,1,0,8
+	@node_stack_bottom =  0,-4.2,0,0,-1,0,8
+	@node_attach = 4.2, 0, 0, 1, 0, 0
+	@MODULE[SSTUCustomFuelTank]
+	{
+		%useRF = true
+		@fuelTypes = LFO, LF, MP
+		@defaultTankName = 8.4m Tank
+		@defaultTopCapName = None
+		@defaultBottomCapName = None
+		@defaultFuelType = LFO
+		@tankDiameter = 8.4
+		@TANK,0
+		{
+			@name = 8.4m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK05
+			%scale = 1.68
+		}
+		@TANK,1
+		{
+			@name = 16.8m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK10
+			%scale = 1.68
+		}
+		@TANK,2
+		{
+			@name = 25.2m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK15
+			%scale = 1.68
+		}
+		@TANK,3
+		{
+			@name = 33.6m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK20
+			%scale = 1.68
+		}
+		@TANK,4
+		{
+			@name = 42m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK25
+			%scale = 1.68
+		}
+		@TANK,5
+		{
+			@name = 50.4m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK30
+			%scale = 1.68
+		}
+		@TANK,6
+		{
+			@name = 58.8m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK35
+			%scale = 1.68
+		}
+		@TANK,7
+		{
+			@name = 67.2m Tank
+			@volume *= 4.741632
+			@height *= 1.68
+			@mesh = SSTU/Assets/SC-B-TANK40
+			%scale = 1.68
+		}
+		@CAP,*
+		{
+			@height *= 1.68
+			%scale = 1.68
+			@volume *= 4.741632
+		}
+	}
+}
++PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = SSTU_ShipCore_C6_TANK
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	@title = SSTU - SC-TANK - 6.6m
+	@manufacturer = SSTU
+	@description = 6.61 diameter tank for Saturn S-IVB and S-IB based tanks
+	@node_stack_top = 0,3.3,0,0,1,0,6
+	@node_stack_bottom =  0,-3.3,0,0,-1,0,6
+	@node_attach = 3.3, 0, 0, 1, 0, 0
+	@MODULE[SSTUCustomFuelTank]
+	{
+		%useRF = true
+		@fuelTypes = LFO, LF, MP
+		@defaultTankName = 6.6m Tank
+		@defaultTopCapName = None
+		@defaultBottomCapName = None
+		@defaultFuelType = LFO
+		@tankDiameter = 6.6
+		@TANK,0
+		{
+			@name = 6.6m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK05
+			%scale = 1.32
+		}
+		@TANK,1
+		{
+			@name = 13.2m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK10
+			%scale = 1.32
+		}
+		@TANK,2
+		{
+			@name = 19.8m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK15
+			%scale = 1.32
+		}
+		@TANK,3
+		{
+			@name = 26.4m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK20
+			%scale = 1.32
+		}
+		@TANK,4
+		{
+			@name = 33m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK25
+			%scale = 1.32
+		}
+		@TANK,5
+		{
+			@name = 39.6m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK30
+			%scale = 1.32
+		}
+		@TANK,6
+		{
+			@name = 46.2m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK35
+			%scale = 1.32
+		}
+		@TANK,7
+		{
+			@name = 52.8m Tank
+			@volume *= 2.299968
+			@height *= 1.32
+			@mesh = SSTU/Assets/SC-B-TANK40
+			%scale = 1.32
+		}
+		@CAP,*
+		{
+			@height *= 1.32
+			%scale = 1.32
+			@volume *= 2.299968
+		}
+	}
+}
++PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = SSTU_ShipCore_E10_TANK
+	!MODULE[TweakScale]
+	{
+	}
+	%breakingForce = 250
+	%breakingTorque = 250
+	@title = SSTU - SC-TANK - 10m
+	@manufacturer = SSTU
+	@description = 10M diameter tank for Saturn V sized tanks
+	@node_stack_top = 0,5.0,0,0,1,0,10
+	@node_stack_bottom =  0,-5.0,0,0,-1,0,10
+	@node_attach = 5.0, 0, 0, 1, 0, 0
+	@MODULE[SSTUCustomFuelTank]
+	{
+		%useRF = true
+		@fuelTypes = LFO, LF, MP
+		@defaultTankName = 10m Tank
+		@defaultTopCapName = None
+		@defaultBottomCapName = None
+		@defaultFuelType = LFO
+		@tankDiameter = 10.0
+		@TANK,0
+		{
+			@name = 10m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK05
+			%scale = 2
+		}
+		@TANK,1
+		{
+			@name = 20m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK10
+			%scale = 2
+		}
+		@TANK,2
+		{
+			@name = 30m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK15
+			%scale = 2
+		}
+		@TANK,3
+		{
+			@name = 40m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK20
+			%scale = 2
+		}
+		@TANK,4
+		{
+			@name = 50m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK25
+			%scale = 2
+		}
+		@TANK,5
+		{
+			@name = 60m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK30
+			%scale = 2
+		}
+		@TANK,6
+		{
+			@name = 70m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK35
+			%scale = 2
+		}
+		@TANK,7
+		{
+			@name = 80m Tank
+			@volume *= 8
+			@height *= 2
+			@mesh = SSTU/Assets/SC-B-TANK40
+			%scale = 2
+		}
+		@CAP,*
+		{
+			@height *= 2
+			%scale = 2
+			@volume *= 8
+		}
 	}
 }
 +PART[SSTU_ShipCore_B_TANK]:FOR[RealismOverhaul]


### PR DESCRIPTION
Added F-1 and F-1B, added new lower stage clusters and updated the tank codes (they needed a revamp)

also worth noting, the F-1, F-1B and RS-25 engines need RealPlumes to be added to them, but they need to be added just for the single engine versions (namely the ones in the SSTU_Engines patch), as the cluster multiplies the effect (in other words, if you add RealPlumes to the single engine all clusters automatically get the effect too)