### PR TITLE
ASDecoupler mass adjustment

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Structure.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Structure.cfg
@@ -52,6 +52,7 @@
 {
 	%RSSROConfig = True
 	maxTemp = 1073.15
+	@mass = 0.15
 	MODULE
 	{
 		name = TweakScale


### PR DESCRIPTION
I adjusted mass of the ASdecoupler because it was way too heavy compared to stock decouplers.