### PR TITLE
Update RO_FASA_Saturn.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -107,6 +107,28 @@
 		@maxAmount = 36450
 	}
 }
+@PART[FASAApolloIU]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+{
+    MODULE
+    {
+        name = ModuleSPU
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntennaPassive
+        TechRequired = start
+
+        OmniRange = 2000000
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.27
+            PacketResourceCost = 0.025
+        }
+    }
+}
 @PART[FASAApalloLFTJ2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
Historically, once the Apollo CSM and LEM have left the Saturn IVB stage behind (at least on the mid and late Apollo flights), Houston was able to remotely control the stage to alter it's trajectory so that it could impact the lunar surface.  This change adds remote control capability and antenna (the same Omni that the CM has) to the Saturn Instrument Unit to allow for this capability.