### PR TITLE
BE-4 mass adjusted

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -1220,7 +1220,7 @@
 	%manufacturer = Blue Origin
 	%description = Although it was initially planned to be used exclusively on a Blue Origin proprietary launch vehicle, it is currently planned that the engine will also be used on the United Launch Alliance Vulcan launch vehicle as well, the successor to the Atlas V launch vehicle.
 	%attachRules = 1,0,1,1,0
-	%mass = 1.5 //FIX ME
+	%mass = 4.5 //FIX ME total guess but now it is realistic
 	%maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
 	{


### PR DESCRIPTION
BE-4 engine mass increased 3x times. Previous number was completely unrealistic with TWR 2,5x bigger than Merlin 1D..