### PR TITLE
Update VSR Engines SSME and BE-4

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -202,7 +202,7 @@
 	%scale = 1.0
 	%node_stack_bottom = 0, -1.656, 0, 0, -1, 0, 1
 	
-	@title = RD-103 Booster [1 m]
+	@title = RD-103
 	@manufacturer = NPO Energomash
 	@description = Early Russian ethanol/LOX booster engine, derived from the V-2 engine. Broadly similar to the (similar pedigree) NAA75-110 engine used on the American Redstone, this engine powered the R-5 'Victory' theater ballistic missile.
 	
@@ -328,7 +328,7 @@
 	@node_stack_bottom = 0.0, -8.240668, 0.0, 0.0, -2.0, 0.0, 2
 	@node_stack_top = 0.0, 14.0348321, 0.0, 0.0, 2.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.524, 0.0, 0.0, 2.0
-	@title = UA1205 SRM
+	@title = UA1205
 	%manufacturer = United Technologies
 	@description = Strap-on booster for Titan IIIC, IIID, IIIE, proposed for Saturn IB derivatives. Burn time 115s.
 	@mass = 33.6
@@ -516,7 +516,7 @@
 @PART[LargeOMS]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%title = Astris Vacuum Engine [1m]
+	%title = Astris
 	%manufacturer = EADS Astrium
 	%description = German pressure-fed vacuum engine burning Aerozine50 and NTO. Used on the stage of the same name on the Europa I and II launch vehicles.
 	@MODEL
@@ -684,30 +684,30 @@
 	%rescaleFactor = 1.0
 	// bottom is 1.554m below top when unscaled
 	%node_stack_bottom = 0.0, -3.025638, 0.0 , 0.0, -1.0, 0.0, 1
-	@mass = 3.177
+	@mass = 3.527
 	@maxTemp = 1800
-	@title = RS-25D/E SSME Sustainer[3m]
+	@title = RS-25D (SSME)
 	@manufacturer = Rocketdyne
-	@description = Closed-cycle / staged combustion hydrolox sustainer engine for the US Space Transportation System ("Shuttle"). Also known as Space Shuttle Main Engine (SSME). Very high performance engine, though also exceedingly complex and expensive. Will also be used as the sustainer for the new SLS.
+	@description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. Though complex and expensive, these engines provide very high performance and are extremely reliable. Three of these engines powered each Shuttle Orbiter and four will be used on the core stage of the SLS.
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 1400.3
-		@maxThrust = 2170
+		@minThrust = 1400
+		@maxThrust = 2280
 		@heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
-			@ratio = 0.729
+			@ratio = 0.728
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.271
+			@ratio = 0.272
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 453
-			@key,1 = 1 363
+			@key,0 = 0 452
+			@key,1 = 1 366
 		}
 		%ullage = True
 		%pressureFed = False
@@ -735,28 +735,28 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = RS-25D/E
+		configuration = RS-25D
 		modded = false
 		CONFIG
 		{
-			name = RS-25D/E
-			minThrust = 1400.3
-			maxThrust = 2170
-			PROPELLANT
+			name = RS-25D // http://www.rocket.com/space-shuttle-main-engine
+			minThrust = 1400
+			maxThrust = 2280
+			PROPELLANT // MR = 6.0
 			{
 				name = LqdHydrogen
-				ratio = 0.729
+				ratio = 0.728
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.271
+				ratio = 0.272
 			}
 			atmosphereCurve
 			{
-				key = 0 453
-				key = 1 363
+				key = 0 452
+				key = 1 366
 			}
 		}
 	}
@@ -778,7 +778,7 @@
 	@node_attach = 0.0, 0.0, -0.395, 0.0, 0.0, 1.0, 1
 	%node_stack_top = 0.0, 3.20144, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -3.05592, 0.0, 0.0, -1.0, 0.0, 0
-	@title = Castor II Solid Motor
+	@title = Castor II
 	%manufacturer = Thiokol
 	@description = A derivative of the Castor I motor, the Castor II featured higher specific impulse and propellant load and lower dry mass fraction as well as a longer burntime. It was used as strapon booster starting with Delta E and was also used in all but the early Scouts. Burn time 37s.
 	@attachRules = 1,1,1,1,0
@@ -867,7 +867,7 @@
 	%node_stack_bottom = 0.0, -1.48, 0.0, 0.0, -1.0, 0.0, 0
 	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	
-	@title = Agena 80xx Vacuum Engine [0.7m]
+	@title = Agena 80xx
 	@manufacturer = Bell
 	@description = Gas-generator Nitric Acid/UDMH vacuum engine for the Agena upper stage / spacecraft. Uses storable propellants and starting with the 8081 model it can be restarted. The 8247 model was used for the Gemini Agena Target Vehicle flights (GATV was a modified Agena D). It is a modified 8096 (Agena D) engine with support for more than two restarts (rated for 15), but otherwise largely identical.
 	
@@ -1130,7 +1130,7 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 0.432996, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.756502, 0.0, 0.0, -1.0, 0.0, 2
-	%title = XLR99 Spaceplane Engine [1.25 m]
+	%title = XLR99 Spaceplane Engine
 	%manufacturer = Reaction Motors
 	%description = LOX/Ammonia gas generator engine which powered the X-15 spaceplane. The first large, throttleable, restartable liquid fuel rocket engine.
 	%attachRules = 1,0,1,0,0
@@ -1216,30 +1216,30 @@
 	%node_stack_top    = 0.0,  0.0, 0.0, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -3.5568, 0.0, 0.0, -1.0, 0.0, 4
 	%category = Propulsion
-	%title = BE-4 [3.5m]
+	%title = BE-4
 	%manufacturer = Blue Origin
-	%description = Although it was initially planned to be used exclusively on a Blue Origin proprietary launch vehicle, it is currently planned that the engine will also be used on the United Launch Alliance Vulcan launch vehicle as well, the successor to the Atlas V launch vehicle.
+	%description = The BE-4 is an oxidizer-rich staged combustion engine that burns LNG/LOX. Though initially developed for use on a Blue Origin launch vehicle, in 2014 United Launch Alliance announced that their new Vulcan booster, the successor to the Atlas V and Delta IV, will be powered by a pair of BE-4 engines.
 	%attachRules = 1,0,1,1,0
-	%mass = 4.5 //FIX ME total guess but now it is realistic
+	%mass = 4.5 //Guess (TWR 120)
 	%maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
 	{
-		%minThrust = 5524.4
-		%maxThrust = 5524.4
+		%minThrust = 5295
+		%maxThrust = 5295
 		%heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
 			%name = LqdMethane
-			%ratio = 0.67
+			%ratio = 0.452
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			%name = LqdOxygen
-			%ratio = 0.33
+			%ratio = 0.548
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 350
+			@key,0 = 0 335
 			@key,1 = 1 310
 		}
 		%ullage = True
@@ -1262,7 +1262,7 @@
 	}
 	@MODULE[ModuleGimbal]
 	{
-		%gimbalRange = 7
+		%gimbalRange = 8 // Guess, same as RD-180
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}
@@ -1281,22 +1281,22 @@
 		CONFIG
 		{
 			name = BE-4
-			maxThrust = 5524.4
-			minThrust = 5524.4
-			PROPELLANT
+			maxThrust = 5295
+			minThrust = 5295
+			PROPELLANT // Guess MR = 3.25, typical for first-stage LNG/LOX
 			{
 				name = LqdMethane
-				ratio = 0.67
+				ratio = 0.452
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.33
+				ratio = 0.548
 			}
-			atmosphereCurve
+			atmosphereCurve // http://www.spacelaunchreport.com/vulcan.html, 2015-11-16, generally agrees with NasaSpaceflight.com L2
 			{
-				key = 0 350
+				key = 0 335
 				key = 1 310
 			}
 			massMult = 1.0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -1225,7 +1225,7 @@
 	@MODULE[ModuleEngines*]
 	{
 		%minThrust = 5295
-		%maxThrust = 5295
+		%maxThrust = 2120
 		%heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
@@ -1282,7 +1282,7 @@
 		{
 			name = BE-4
 			maxThrust = 5295
-			minThrust = 5295
+			minThrust = 2120 // Guess 40% throttle
 			PROPELLANT // Guess MR = 3.25, typical for first-stage LNG/LOX
 			{
 				name = LqdMethane


### PR DESCRIPTION
Titles (size and role removed)
SSME - adjust mass, Isp, description, MR, and thrust (from AerojetRocketdyne website, 109% (SLS thrust))
BE-4 - adjust description, thrust, Isp, MR & gimbal range