### PR TITLE
Increase Gemini chute cover maxSkinTemp

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -62,6 +62,7 @@
 	@title = Gemini Rendezvous and Recovery Section Fairing
 	@description = This section contains all the necessary equipment for rendezvous and docking with the Agena Target Vehicle. After re-entry jettison this section to deploy the drogue parachute, after which the main parachute can then be deployed as well.
 	@mass = 0.077
+	%skinMaxTemp = 3200
 	%stagingIcon = DECOUPLER_VERT
 	@MODULE[ModuleDockingNode]
 	{
@@ -95,6 +96,7 @@
 	@title = Gemini Rendezvous and Recovery Section Fairing
 	@description = This section contains all the necessary equipment for rendezvous and docking with the Agena Target Vehicle. After re-entry this section is jettisoned with deployment of the drogue parachute, after which the main parachute can then be deployed. Made of new lightweight material and painted white to match the white rescue Gemini pod.
 	@mass = 0.06545
+	%skinMaxTemp = 3200
 	%stagingIcon = DECOUPLER_VERT
 	!MODULE[ModuleGrappleNode]
 	{


### PR DESCRIPTION
When in re-entry mode, the Gemini capsule bobs around a bit (and also changes pitch as the atmosphere thickens). This causes the nose cone to be intermittently exposed to re-entry heat, and often explode, leading to the whole craft to be lost.

By increasing the maxSkinTemp of this part, it won't explode. Tested during controlled LEO and lunar-return velocity returns.