### PR TITLE
Changes to Centaur

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
@@ -184,7 +184,7 @@
 	@title = Centaur A/B/C/D/D1
 	@description = Tank and thrust structure for the Centaur A/B/C/D/D1 models. Add two RL10A series engines to complete the stage.
 	@attachRules = 1,0,1,1,0
-	@mass = 1.726
+	@mass = 1.125	// From Astronautix, based on the Centaur I or Centaur D-1B.  Add leadbalast to duplicate older versions of this model Centaur
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -204,17 +204,17 @@
 	@name = FASAGeminiLFTCentarCSM_D2
 	@MODEL,1
 	{
-		@scale = 1.219, 1.582167, 1.219
-		@position = 0.0, 1.7972008, 0.0
+		@scale = 1.219, 1.49467, 1.219
+		@position = 0.0, 1.587208, 0.0
 	}
-	@node_stack_top = 0.0, 5.5944, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_top = 0.0, 5.174416, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -4.9256, 0.0, 0.0, -1.0, 0.0, 3
 	@node_stack_bottom1 = 0.0, -2.6095, 0.0, 0, -1, 0, 1
 	@node_stack_bottom2 = -0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	@node_stack_bottom3 = 0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	@title = Centaur D2
-	@description = Tank and thrust structure for the Centaur D2 models. Add two RL10A series engines to complete the stage.
-	@mass = 1.8285
+	@description = Tank and thrust structure for the Centaur D2 models. Used on the Atlas II and IIIA. Add one or two RL10A series engines to complete the stage.
+	@mass = 1.6555	// from Astronautix.  b14643.de shows same weight for all D2 models even though engine type/weight changes.
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume = 49317.5
@@ -226,6 +226,28 @@
 	@MODEL,1
 	{
 		@model = Squad/Parts/FuelTank/fuelTankJumbo-64/model
+		@scale = 1.219, 1.16725, 1.219
+		@position = 0.0, 2.37719, 0.0
+	}
+	@node_stack_top = 0.0, 6.754375, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -4.9256, 0.0, 0.0, -1.0, 0.0, 3
+	@node_stack_bottom1 = 0.0, -2.6095, 0.0, 0, -1, 0, 1
+	@node_stack_bottom2 = -0.660698, -3.04834, 0.0, 0, -1, 0, 1
+	@node_stack_bottom3 = 0.660698, -3.04834, 0.0, 0, -1, 0, 1
+	@title = Centaur D3
+	@description = Tank and thrust structure for the Centaur D3 models. Used on the Atlas IIIB. Add one or two RL10A series engines to complete the stage.
+	@mass = 1.494	// from Astronautix.  b14643.de shows same weight for SEC and DEC versions.
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 62000
+	}
+}
++PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
+{
+	@name = FASAGeminiLFTCentarCSM_D5
+	@MODEL,1
+	{
+		@model = Squad/Parts/FuelTank/fuelTankJumbo-64/model
 		@scale = 1.219, 1.300587, 1.219
 		@position = 0.0, 2.877201, 0.0
 	}
@@ -234,12 +256,65 @@
 	@node_stack_bottom1 = 0.0, -2.6095, 0.0, 0, -1, 0, 1
 	@node_stack_bottom2 = -0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	@node_stack_bottom3 = 0.660698, -3.04834, 0.0, 0, -1, 0, 1
-	@title = Centaur D3
-	@description = Tank and thrust structure for the Centaur D3 models. Add one or two RL10A series engines to complete the stage.
-	@mass = 1.922
+	%TechRequired = hydroloxTL7
+	@title = Centaur D5
+	@description = Tank and thrust structure for the Centaur D5 used on the Atlas V. Add one or two RL10A series engines to complete the stage.
+	@mass = 1.557	// from Astronautix for the sack of consistency
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume = 60678.3
+	}
+}
++PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
+{
+	@name = FASAGeminiLFTCentarCSM_T
+	@MODEL,0
+	{
+		@scale = 1.728, 1.219, 1.728
+		@position = 0.0, -2.2438, 0.0
+	}
+	@MODEL,1
+	{
+		@scale = 1.728, 1.2613, 1.728
+		@position = 0.0, 1.02712, 0.0
+	}
+	@node_stack_top = 0.0, 4.05424, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -4.9256, 0.0, 0.0, -1.0, 0.0, 3
+	@node_stack_bottom1 = 0.0, -2.6095, 0.0, 0, -1, 0, 1
+	@node_stack_bottom2 = -0.936576, -3.04834, 0.0, 0, -1, 0, 1
+	@node_stack_bottom3 = 0.936576, -3.04834, 0.0, 0, -1, 0, 1
+	%TechRequired = hydroloxTL4
+	@title = Centaur T
+	@description = 4.32m Tank and thrust structure for the Centaur T used on the Titan IV. Add a single RL10A series engines to complete the stage.
+	@mass = 1.825	// from Astronautix for the sack of consistency
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 63000
+	}
+}
++PART[FASA_Gemini_RCS_Thrusters]:AFTER[RealismOverhaul]
+{
+	@name = RO_Centaur_RCS
+	!mesh = DEL
+	%RSSROConfig = True
+	%TechRequired = flightControl
+	%cost = 60
+	%entryCost = 3000
+	@title = Centaur Attitude Jet
+	@manufacturer = Generic
+	@description = These thrusters are for roll control of the Centaur upper stage rocket.
+	@mass = 0.006
+	@maxTemp = 1200
+	%useRcsConfig = RCSBlockQuarter
+	%useRcsMass = True
+	%useRcsCostMult = 0.25
+	@MODULE[ModuleRCSFX]
+	{
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.138
+	}
+	!MODULE[ModuleEngineConfigs]
+	{
 	}
 }
 @PART[FASAApolloLFERL10]:FOR[RealismOverhaul]


### PR DESCRIPTION
Adjusted the dimensions and weight on the Centaur D/D1, D2 and D3 tanks.  I've used values as presented in astronautix  for the sake of consistency.  I did compare values to what is presented in b14643.de and my results are comparable.  But I did notice that b14643.de uses the same basic statistics for similar, but not identical, stages.  For instance, there are five different versions of the Atlas II presented, each with their own slightly different Centaur stage (each uses a different RL10A engine set) but the life off weights and propellant weights never change.  Seems unlikely that the RL10A-3-3A had the exact same weight as the RL10A-4-1N.  In the end, I tried to be consistent but also went with lower weight values on the assumption that minor changes could be dealt with by including a small amount of leadbalast.
The final tank height includes the tank and engines.
The final tank weight includes the tank, engines, payload fairing base and 0.03t worth of RCS thrusters.

I've also added a configuration for the Centaur D5 (used with the Atlas V) and the Centaur T (used with the Titan IV).  Information is based on the already existing Centaur tanks with weights and dimensions coming from astronautix and b14643.de

Finally, I've included a RCS thrusters for centaur roll control.  From various wiki sites, it seems that a standard Centaur setup included 8 thrusters for roll and attitude control and 4 slightly more powerful thrusters for ullage.  The ullage thrusters can easily be recreated using existing Attitude Jets but I've always run into problems properly positioning single jets for roll/attitude control.  To resolve this, I've used the FASA_Gemini_RCS_Thrusters as a model for small, Hydrazine powered attitude thrusters for the Centaur.  I've reduced the weight of the original (0.015 down to 0.006) since the centaur versions are weaker but I have no documentation for how much they should actually weigh.