### PR TITLE
RO global configuration update

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -16,78 +16,101 @@
 	@PhysicsSignificance = 0
 }
 
-@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[MechJebCore],!MODULE[BuildEngineer],!MODULE[FlightEngineer]]:FOR[RealismOverhaul]
-{
-    MODULE
+//  ==================================================
+//  Add the MechJeb Core module to all parts that are
+//  command modules (either manned or unmanned).
+//  ==================================================
+
+    @PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[MechJebCore]]:NEEDS[MechJeb]:AFTER[RealismOverhaul]
     {
-        name = MechJebCore
-        MechJebLocalSettings {
-            MechJebModuleCustomWindowEditor { unlockTechs = start }
-            MechJebModuleSmartASS { unlockTechs = start }
-            MechJebModuleManeuverPlanner { unlockTechs = start }
-            MechJebModuleNodeEditor { unlockTechs = start }
-            MechJebModuleTranslatron { unlockTechs = start }
-            MechJebModuleWarpHelper { unlockTechs = start }
-            MechJebModuleAttitudeAdjustment { unlockTechs = start }
-            MechJebModuleThrustWindow { unlockTechs = start }
-            MechJebModuleRCSBalancerWindow { unlockTechs = start }
-            MechJebModuleRoverWindow { unlockTechs = start }
-            MechJebModuleAscentGuidance { unlockTechs = start }
-            MechJebModuleLandingGuidance { unlockTechs = start }
-            MechJebModuleSpaceplaneGuidance { unlockTechs = start }
-            MechJebModuleDockingGuidance { unlockTechs = start }
-            MechJebModuleRendezvousAutopilotWindow { unlockTechs = start }
-            MechJebModuleRendezvousGuidance { unlockTechs = start }
-        }
-    }
-	MODULE
-	{
-		name = BuildEngineer
+        MODULE
+        {
+            name = MechJebCore
+
+            MechJebLocalSettings
+            {
+                MechJebModuleCustomWindowEditor { unlockTechs = start }
+                MechJebModuleSmartASS { unlockTechs = start }
+                MechJebModuleManeuverPlanner { unlockTechs = start }
+                MechJebModuleNodeEditor { unlockTechs = start }
+                MechJebModuleTranslatron { unlockTechs = start }
+                MechJebModuleWarpHelper { unlockTechs = start }
+                MechJebModuleAttitudeAdjustment { unlockTechs = start }
+                MechJebModuleThrustWindow { unlockTechs = start }
+                MechJebModuleRCSBalancerWindow { unlockTechs = start }
+                MechJebModuleRoverWindow { unlockTechs = start }
+                MechJebModuleAscentGuidance { unlockTechs = start }
+                MechJebModuleLandingGuidance { unlockTechs = start }
+                MechJebModuleSpaceplaneGuidance { unlockTechs = start }
+                MechJebModuleDockingGuidance { unlockTechs = start }
+                MechJebModuleRendezvousAutopilotWindow { unlockTechs = start }
+                MechJebModuleRendezvousGuidance { unlockTechs = start }
+			}
+		}
 	}
 
-	MODULE
-	{
-		name = FlightEngineer
-	}
-	MODULE
-	{
-		name = FlightEngineerModule
-	}
-}
-@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[kOSProcessor]]:FINAL
-{
-	MODULE
-	{
-		name = kOSProcessor
-		diskSpace = 5000
-	}
-}
-@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive]|@MODULE[ModuleRTAntenna],!MODULE[TelemachusDataLink]]:NEEDS[RemoteTech]:FINAL
-{
-	MODULE
-	{
-		name = TelemachusDataLink
-	}
-	MODULE
-	{
-		name = TelemachusPowerDrain
-		powerConsumptionBase = 0.00
-		powerConsumptionIncrease = 0.001
-	}
-}
-@PART[*]:HAS[@MODULE[ModuleDataTransmitter],!MODULE[TelemachusDataLink]]:NEEDS[!RemoteTech]:FINAL
-{
-	MODULE
-	{
-		name = TelemachusDataLink
-	}
-	MODULE
-	{
-		name = TelemachusPowerDrain
-		powerConsumptionBase = 0.00
-		powerConsumptionIncrease = 0.001
-	}
-}
+//  ==================================================
+//  Add the Kerbal Engineer modules to all parts that
+//  are command modules (either manned or unmanned).
+//  ==================================================
+
+    @PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[FlightEngineerModule]]:NEEDS[KerbalEngineer]:AFTER[RealismOverhaul]
+    {
+        MODULE
+        {
+            name = FlightEngineerModule
+        }
+    }
+
+//  ==================================================
+//  Add the kOS module to all parts that are command
+//  modules (either manned or unmanned).
+//  ==================================================
+
+    @PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[kOSProcessor]]:NEEDS[kOS]:AFTER[RealismOverhaul]
+    {
+        MODULE
+        {
+            name      = kOSProcessor
+            diskSpace = 5000
+        }
+    }
+
+//	==================================================
+//	Add the Telemachus module to all parts that are
+//	antennas (either stock or RemoteTech).
+//	==================================================
+
+    @PART[*]:HAS[@MODULE[ModuleDataTransmitter],|@MODULE[ModuleRTAntennaPassive]|@MODULE[ModuleRTAntenna],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:AFTER[RealismOverhaul]
+    {
+        MODULE
+        {
+            name = TelemachusDataLink
+        }
+
+        MODULE
+        {
+            name                     = TelemachusPowerDrain
+            powerConsumptionBase     = 0
+            powerConsumptionIncrease = 0.001
+        }
+    }
+
+//	==================================================
+//	Add fuel cross feed capability to all decouplers
+//  (inline and radial).
+//	==================================================
+
+    @PART[*]:HAS[@MODULE[ModuleAnchoredDecoupler]|@MODULE[ModuleDecouple],!MODULE[ModuleToggleCrossfeed]]:BEFORE[RealismOverhaul]
+    {
+        MODULE
+        {
+            name            = ModuleToggleCrossfeed
+            crossfeedStatus = false
+            toggleEditor    = true
+            toggleFlight    = true
+        }
+    }
 
 // RSSROConfig stuff
 @PART[*]:HAS[~RSSROConfig[]]:FINAL
@@ -105,16 +128,21 @@
 {
     %category = 9
 }
-// DRE don't change temps
-@PART[*]:HAS[#RSSROConfig[*],!MODULE[ModuleAeroReentry],!MODULE[ModuleHeatShield]]:FINAL
-{
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinHeatConductivity = 0.001
-		leaveTemp = True
-	}
-}
+
+//  ==================================================
+//  DeadlyReentry: do not let other MM patches to
+//  modify the max part temperature value.
+//  ==================================================
+
+    @PART[*]:HAS[#RSSROConfig[*],!MODULE[ModuleAeroReentry],!MODULE[ModuleHeatShield]]:NEEDS[DeadlyReentry]:FINAL
+    {
+	    MODULE
+	    {
+		    name                 = ModuleAeroReentry
+		    skinHeatConductivity = 0.001
+		    leaveTemp            = True
+        }
+    }
 
 @PART[*]:HAS[#RSSROConfig[*]]:FINAL
 {

--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -77,11 +77,11 @@
     }
 
 //	==================================================
-//	Add the Telemachus module to all parts that are
+//	Add the Telemachus module to all parts that have
 //	antennas (either stock or RemoteTech).
 //	==================================================
 
-    @PART[*]:HAS[@MODULE[ModuleDataTransmitter],|@MODULE[ModuleRTAntennaPassive]|@MODULE[ModuleRTAntenna],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:AFTER[RealismOverhaul]
+    @PART[*]:HAS[@MODULE[ModuleDataTransmitter]|@MODULE[ModuleRTAntennaPassive]|@MODULE[ModuleRTAntenna],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:AFTER[RealismOverhaul]
     {
         MODULE
         {
@@ -96,10 +96,10 @@
         }
     }
 
-//	==================================================
-//	Add fuel cross feed capability to all decouplers
+//  ==================================================
+//  Add fuel cross feed capability to all decouplers
 //  (inline and radial).
-//	==================================================
+//  ==================================================
 
     @PART[*]:HAS[@MODULE[ModuleAnchoredDecoupler]|@MODULE[ModuleDecouple],!MODULE[ModuleToggleCrossfeed]]:BEFORE[RealismOverhaul]
     {


### PR DESCRIPTION
* Add dependency checking before applying patches (reduce log spam with
errors & warnings).
* Remove deprecated Kerbal Engineer modules from patching (non existent
after version 1.0).
* Add fuel cross feed toggling capability to all decouplers (radial &
inline). BEFORE tag so that we can override specific parts with the main
RO configs.