### PR TITLE
SSTU Increase max decoupler size.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -33,7 +33,7 @@
 	@MODULE[SSTUProceduralDecoupler]
 	{
 		@radius = 2.5
-		@maxRadius = 10.0
+		%maxRadius = 10.0
 	}
 }
 @PART[SSTU_SC-A-116a-RMB]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -33,6 +33,7 @@
 	@MODULE[SSTUProceduralDecoupler]
 	{
 		@radius = 2.5
+		@maxRadius = 10.0
 	}
 }
 @PART[SSTU_SC-A-116a-RMB]:FOR[RealismOverhaul]


### PR DESCRIPTION
Will allow the SSTU Decouple to scale up to a radius of 10 metres.