### PR TITLE
Shorten MaxDeltaTime

### DIFF
--- a/GameData/ThunderAerospace/TacLifeSupport/PluginData/TacLifeSupport/LifeSupport.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupport/PluginData/TacLifeSupport/LifeSupport.cfg
@@ -1,6 +1,6 @@
 GlobalSettings
 {
-	MaxDeltaTime = 86400
+	MaxDeltaTime = 3600
 	ElectricityMaxDeltaTime = 1
 	FoodResource = Food
 	WaterResource = Water


### PR DESCRIPTION
From 1 day to 1 hour. For some resources the FASA Gemini & Apollo don't have 1 day of LS resources in reserve at all times.