### PR TITLE
FASAGeminiEngineFuel2 upgrade

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -643,7 +643,7 @@ PART
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 3
 	@title = FASA Advanced Gemini Equipment Section
-	@description = This IMAGINARY part contains everything the real part did, with the addition of 4x 100lb thruster propulsion units.
+	@description = This equipment section models the thrusters as an engine, rather than as RCS.
 	@mass = 0.67688
 	@MODULE[ModuleDecouple]
 	{
@@ -684,20 +684,20 @@ PART
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 515
+		volume = 2148
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
 			name = LqdHydrogen
-			amount = 37.132
-			maxAmount = 37.132
+			amount = 358.5
+			maxAmount = 358.5
 		}
 		TANK
 		{
 			name = LqdOxygen
-			amount = 42.139
-			maxAmount = 42.139
+			amount = 264.7
+			maxAmount = 264.710
 		}
 		TANK
 		{
@@ -714,20 +714,26 @@ PART
 		TANK
 		{
 			name = Water
-			amount = 0.0
-			maxAmount = 0.5
+			amount = 101.8
+			maxAmount = 101.8
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 228.7
 		}
 		TANK
 		{
 			name = Oxygen
 			amount = 0
-			maxAmount = 1
+			maxAmount = 10
 		}
 		TANK
 		{
 			name = ElectricCharge
-			amount = 0
-			maxAmount = 28
+			amount = 552096
+			maxAmount = 762048
 		}
 	}
 	MODULE
@@ -735,8 +741,8 @@ PART
 		name = TacGenericConverter
 		converterName = Fuel Cell
 		conversionRate = 1.0
-		inputResources = LqdHydrogen, 0.0001074421, LqdOxygen, 0.0000266869
-		outputResources = Water, 0.00018899683, true, ElectricCharge, 1.573, true
+		inputResources = LqdHydrogen, 0.000296379, LqdOxygen, 0.000210317
+		outputResources = WasteWater, 0.000261, true, ElectricCharge, 2.2, true
 	}
 	MODULE
 	{
@@ -745,16 +751,6 @@ PART
 		conversionRate = 2.0
 		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
 		outputResources = Oxygen, 0.006883126, false
-	}
-	MODULE
-	{
-		name = ModuleGenerator
-		isAlwaysActive = true
-		OUTPUT_RESOURCE
-		{
-			name = ElectricCharge
-			rate = -0.2 //200W for life support base
-		}
 	}
 }
 @PART[FASAGeminiDecDark125]:FOR[RealismOverhaul]


### PR DESCRIPTION
Once TACLS no longer causes the engine on this part to stage, it will be a viable alternative to the RCS modelled service module.

This will cause the part to have matching specs to the existing Gemini equipment/service module.