### PR TITLE
RO LR-87 LH2 update

### DIFF
--- a/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
@@ -18,33 +18,47 @@
 	@node_stack_bottom = 0.0, -1.629, 0.0, 0.0, -1.0, 0.0, 1
 	%node_attach = 0.0, 1.0101, 0.0, 0.0, 1.0, 0.0, 1
 	@attachRules = 1,1,1,0,0
-	!fx_exhaustFlame_blue = f
-	!fx_gasJet_white =f
-	!fx_exhaustFlames_yellow_tiny =f
-	!fx_exhaustFlames_white_tiny =f
-	!fx_exhaustLight_blue =f
-	!fx_smokeTrail_light =f
-	!fx_exhaustSparks_flameout = f
-	!sound_vent_medium =f
-	!sound_rocket_hard =f 
-	!sound_vent_soft =f
-	!sound_explosion_low =f
 	
 	@mass = 0.74
 	@maxTemp = 1973.15
+	%heatConductivity = 0.060
+	%skinInternalConductionMult = 4.000
+	%emissiveConstant = 0.800
+	%stageOffset = 1
+	%childStageOffset = 1
+	%stagingIcon = LIQUID_ENGINE
 	
 	@title = LR87-LH2 Vacuum
 	@description = Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. NASA selected the J-2 over the LR87-LH2, however, and it was canceled in 1961. This version represents a version of the engine with a larger nozzle optimized for vacuum use.
-	
+
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesFX
-		//%runningEffectName = powersmoke
-		!runningEffectName = DELETE
-		%powerEffectName = powerflame
 		@maxThrust = 667
 		@minThrust = 667
 		@heatProduction = 175
+        %EngineType = LiquidEngine
+		%ullage = true
+		%pressureFed = false
+		%ignitions = 1
+
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.500
+		}
+
+		IGNITOR_RESOURCE
+		{
+			name = LqdHydrogen
+			amount = 0.7454
+		}
+
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.2545
+		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
@@ -71,7 +85,7 @@
 	{
 		name = ModuleEngineConfigs
 		engineType = L+
-		configuration = TitanC
+		configuration = LR87-LH2-TitanC
 		origMass = 0.74
 		modded = false
 		CONFIG
@@ -95,29 +109,6 @@
 			{
 				key = 0 403
 				key = 1 350
-			}
-			ModuleEngineIgnitor
-			{
-				ignitionsAvailable = 1
-				autoIgnitionTemperature = 700
-				ignitorType = Electric
-				useUllageSimulation = True
-				isPressureFed = False
-				IGNITOR_RESOURCE
-				{
-					name = ElectricCharge
-					amount = 0.500
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdHydrogen
-					amount = 0.745
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdOxygen
-					amount = 0.255
-				}
 			}
 		}
 		CONFIG
@@ -146,29 +137,6 @@
 				key = 0 414
 				key = 1 160
 			}
-			ModuleEngineIgnitor
-			{
-				ignitionsAvailable = 1
-				autoIgnitionTemperature = 700
-				ignitorType = Electric
-				useUllageSimulation = True
-				isPressureFed = False
-				IGNITOR_RESOURCE
-				{
-					name = ElectricCharge
-					amount = 0.500
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdHydrogen
-					amount = 0.745
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdOxygen
-					amount = 0.255
-				}
-			}
 		}
 		CONFIG
 		{
@@ -177,6 +145,7 @@
 			maxThrust = 800.68
 			heatProduction = 175
 			massMult = 0.95946
+            ignitions = 2
 			cost = 1200
 			techRequired = hydroloxTL4
 			entryCost = 36000
@@ -200,29 +169,6 @@
 				key = 0 418
 				key = 1 363
 			}
-			ModuleEngineIgnitor
-			{
-				ignitionsAvailable = 2
-				autoIgnitionTemperature = 700
-				ignitorType = Electric
-				useUllageSimulation = True
-				isPressureFed = False
-				IGNITOR_RESOURCE
-				{
-					name = ElectricCharge
-					amount = 0.500
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdHydrogen
-					amount = 0.745
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdOxygen
-					amount = 0.255
-				}
-			}
 		}
 		CONFIG
 		{
@@ -231,6 +177,7 @@
 			maxThrust = 814.09
 			heatProduction = 175
 			massMult = 1.0271
+            ignitions = 3
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -254,53 +201,10 @@
 			{
 				LR87-LH2-SustainerUpgrade = 30000
 			}
-			ModuleEngineIgnitor
-			{
-				ignitionsAvailable = 3
-				autoIgnitionTemperature = 700
-				ignitorType = Electric
-				useUllageSimulation = True
-				isPressureFed = False
-				IGNITOR_RESOURCE
-				{
-					name = ElectricCharge
-					amount = 0.500
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdHydrogen
-					amount = 0.745
-				}
-				IGNITOR_RESOURCE
-				{
-					name = LqdOxygen
-					amount = 0.255
-				}
-			}
 		}
 	}
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		ignitionsAvailable = 1
-		autoIgnitionTemperature = 800
-		ignitorType = Electric
-		useUllageSimulation = true
-		isPressureFed = false
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.500
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdHydrogen
-			amount = 0.745
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 0.255
-		}
-	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE[ElectricCharge]{}
 }

--- a/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
@@ -21,9 +21,6 @@
 	
 	@mass = 0.74
 	@maxTemp = 1973.15
-	%heatConductivity = 0.06
-	%skinInternalConductionMult = 4.0
-	%emissiveConstant = 0.8
 	%stageOffset = 1
 	%childStageOffset = 1
 	%stagingIcon = LIQUID_ENGINE

--- a/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
@@ -33,10 +33,11 @@
 
 	@MODULE[ModuleEngines*]
 	{
+		@name = ModuleEnginesFX
 		@maxThrust = 667
 		@minThrust = 667
 		@heatProduction = 175
-        	%EngineType = LiquidEngine
+        	%EngineType = LiquidFuel
 		%ullage = true
 		%pressureFed = false
 		%ignitions = 1

--- a/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
@@ -36,7 +36,7 @@
 		@maxThrust = 667
 		@minThrust = 667
 		@heatProduction = 175
-        %EngineType = LiquidEngine
+        	%EngineType = LiquidEngine
 		%ullage = true
 		%pressureFed = false
 		%ignitions = 1
@@ -145,7 +145,7 @@
 			maxThrust = 800.68
 			heatProduction = 175
 			massMult = 0.95946
-            ignitions = 2
+            		ignitions = 2
 			cost = 1200
 			techRequired = hydroloxTL4
 			entryCost = 36000
@@ -177,7 +177,7 @@
 			maxThrust = 814.09
 			heatProduction = 175
 			massMult = 1.0271
-            ignitions = 3
+            		ignitions = 3
 			PROPELLANT
 			{
 				name = LqdHydrogen

--- a/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Parts/Engines/LR87LH2.cfg
@@ -11,7 +11,7 @@
 		//rotation = 0 , 180 , 0
 		scale = 1.4, 1.4, 1.4
 	}
-	%RSSROConfig = true
+	%RSSROConfig = True
 	%rescaleFactor = 1.0
 	%scale = 1.0
 	@node_stack_top = 0.0, 1.0101, 0.0, 0.0, 1.0, 0.0, 1
@@ -21,14 +21,15 @@
 	
 	@mass = 0.74
 	@maxTemp = 1973.15
-	%heatConductivity = 0.060
-	%skinInternalConductionMult = 4.000
-	%emissiveConstant = 0.800
+	%heatConductivity = 0.06
+	%skinInternalConductionMult = 4.0
+	%emissiveConstant = 0.8
 	%stageOffset = 1
 	%childStageOffset = 1
 	%stagingIcon = LIQUID_ENGINE
 	
 	@title = LR87-LH2 Vacuum
+	@manufacturer = Aerojet
 	@description = Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. NASA selected the J-2 over the LR87-LH2, however, and it was canceled in 1961. This version represents a version of the engine with a larger nozzle optimized for vacuum use.
 
 	@MODULE[ModuleEngines*]
@@ -38,8 +39,8 @@
 		@minThrust = 667
 		@heatProduction = 175
         	%EngineType = LiquidFuel
-		%ullage = true
-		%pressureFed = false
+		%ullage = True
+		%pressureFed = False
 		%ignitions = 1
 
 		IGNITOR_RESOURCE


### PR DESCRIPTION
* Remove redundant FX (already taken care by the RealPlume
configuration) and duplicated EFFECTS definitions.
* Add support for the KSP 1.0.5 engine thermal changes.
* Fix a null reference exception caused by a wrong default engine config name.
* Replace the deprecated EngineIgnitor modules with the RealFuels fuel & ullage functionality.
* Remove the leftover engine alternator module and ElectricCharge
resource.