### PR TITLE
RO_Global_Config update

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -16,11 +16,12 @@
 	@PhysicsSignificance = 0
 }
 
-@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[MechJebCore],!MODULE[BuildEngineer],!MODULE[FlightEngineer]]:FOR[RealismOverhaul]
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[MechJebCore]]:NEEDS[MechJeb]:FOR[RealismOverhaul]
 {
     MODULE
     {
         name = MechJebCore
+
         MechJebLocalSettings {
             MechJebModuleCustomWindowEditor { unlockTechs = start }
             MechJebModuleSmartASS { unlockTechs = start }
@@ -40,21 +41,17 @@
             MechJebModuleRendezvousGuidance { unlockTechs = start }
         }
     }
-	MODULE
-	{
-		name = BuildEngineer
-	}
+}
 
-	MODULE
-	{
-		name = FlightEngineer
-	}
-	MODULE
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[FlightEngineerModule]]:NEEDS[KerbalEngineer]:FOR[RealismOverhaul]
+{
+    MODULE
 	{
 		name = FlightEngineerModule
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[kOSProcessor]]:FINAL
+
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[kOSProcessor]]:NEEDS[kOS]:FINAL
 {
 	MODULE
 	{
@@ -62,12 +59,14 @@
 		diskSpace = 5000
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive]|@MODULE[ModuleRTAntenna],!MODULE[TelemachusDataLink]]:NEEDS[RemoteTech]:FINAL
+
+@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive]|@MODULE[ModuleRTAntenna]|@MODULE[ModuleDataTransmitter],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:FINAL
 {
 	MODULE
 	{
 		name = TelemachusDataLink
 	}
+
 	MODULE
 	{
 		name = TelemachusPowerDrain
@@ -75,18 +74,16 @@
 		powerConsumptionIncrease = 0.001
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleDataTransmitter],!MODULE[TelemachusDataLink]]:NEEDS[!RemoteTech]:FINAL
+
+@PART[*]:HAS[@MODULE[ModuleAnchoredDecoupler]|@MODULE[ModuleDecouple],!MODULE[ModuleToggleCrossfeed]]:BEFORE[RealismOverhaul]
 {
-	MODULE
-	{
-		name = TelemachusDataLink
-	}
-	MODULE
-	{
-		name = TelemachusPowerDrain
-		powerConsumptionBase = 0.00
-		powerConsumptionIncrease = 0.001
-	}
+    MODULE
+    {
+        name = ModuleToggleCrossfeed
+        crossfeedStatus = false
+        toggleEditor = true
+        toggleFlight = true
+    }
 }
 
 // RSSROConfig stuff
@@ -106,7 +103,7 @@
     %category = 9
 }
 // DRE don't change temps
-@PART[*]:HAS[#RSSROConfig[*],!MODULE[ModuleAeroReentry],!MODULE[ModuleHeatShield]]:FINAL
+@PART[*]:HAS[#RSSROConfig[*],!MODULE[ModuleAeroReentry],!MODULE[ModuleHeatShield]]:NEEDS[DeadlyReentry]:FINAL
 {
 	MODULE
 	{


### PR DESCRIPTION
* Add mod dependency checking to minimize log spam with errors.
* Remove deprecated Kerbal Engineer modules.
* Merge Telemachus patches.
* Add fuel cross feed patch for radial & inline decouplers.

1. Mod dependency check: currently the selected modules are added without checking if the mod that provides them is installed. This leads to excessive log spam with harmless but annoying nonetheless error messages.

2. Deprecated KER modules: since the 1.0 KER release, the only existent and valid KER module is the "FlightEngineerModule", a combination of both the "BuildEngineer" and "FlightEngineer" modules. Source: https://github.com/CYBUTEK/KerbalEngineer/blob/master/Output/KerbalEngineer/Parts/EngineerChip/part.cfg

4. Telemachus patches: merged since the they are making the same changes regardless if RemoteTech is installed or not (i do not think that there is a problem when making multiple OR checks with MM with different requested modules).

4. Decoupler cross feed patch: this takes care of the missing cross feed modules for the decouplers. As requested by @NathanKell at PR #689. Using the BEFORE MM tag so that it can be overridden by select RO part configs if ever required.

All points are a subject of discussion.