### PR TITLE
Add Orion TACLS

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
@@ -141,8 +141,8 @@
 		TANK
 		{
 			name = Oxygen
-			amount = 33150
-			maxAmount = 33150
+			amount = 3551
+			maxAmount = 3551
 		}
 		TANK
 		{
@@ -160,13 +160,13 @@
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 28650
+			maxAmount = 1023
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 30
+			maxAmount = 218
 		}
 		TANK
 		{
@@ -174,11 +174,26 @@
 			amount = 0
 			maxAmount = 280
 		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 57.6
+			maxAmount = 57.6
+		}
 	}
 	
 	!RESOURCE[Ablator]
 	!MODULE[SSTUAblator] { }
-	
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003847, false
+	}
+
 	%skinMaxTemp = 3500 // 3200
 	%maxTemp = 2273.15
 	@emissiveConst = 0.85 // pretty much black, but not perfect emitter
@@ -257,6 +272,8 @@
 	{
 	}
 	
+	!MODULE[ModuleReactionWheel] {}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -281,6 +298,21 @@
 			amount = 2880
 			maxAmount = 2880
 		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 41
+			maxAmount = 41
+		}
+	}
+	
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = LOX-O2
+		conversionRate = 4.0
+		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
+		outputResources = Oxygen, 0.006883126, false
 	}
 	
 	@MODULE[ModuleEnginesFX],*	


### PR DESCRIPTION
Orion now contains TACLS modules (CO2 scrubber, LOX -> O2) and enough resources to carry 4 crew members for 2 weeks.