### PR TITLE
Atmosphere Analysis instrument RO support

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
@@ -7,6 +7,33 @@
 		@type = RealismOverhaulStackSolid
 	}
 }
+
+//  ==================================================
+//  Gas Chromatograph - Mass Spectrometer.
+
+//  Comparable to the instruments found in the Vega 1 &
+//  2 landers. Mass is kept the same as of the other
+//  instruments for gameplay purposes.
+
+//  Dimensions: 0.1 m x 0.195 m
+//  Gross Mass: 1 Kg
+
+//  Source 1: http://mentallandscape.com/V_Vega.htm
+//  Source 2: http://www.lpi.usra.edu/vexag/oct2009/presentations/zasovaVeneraD.pdf
+//  ==================================================
+
+@PART[sensorAtmosphere]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@rescaleFactor = 0.175
+	@title = GC-MS
+	@manufacturer = Generic
+	@description = The Gas Chromatograph - Mass Spectrometer (GC-MS) is an analytical instrument used for identification of multiple different substances in a selected gas sample, capable of detecting even trace amounts of them. Ideal of analyzing the atmospheric composition of unknown environments.
+	@mass = 0.001
+	@maxTemp = 1073.15
+}
+
 @PART[GooExperiment]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
* Add RO support for the Atmospheric Fluid Spectro-Variometer (now operating as a Gas Chromatograph - Mass Spectrometer).