### PR TITLE
Correct Gemini SM dry mass

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -589,7 +589,7 @@
 	!node_stack_bottom1 = DELETE
 	@title = Gemini Adapter Equipment Section	
 	@description = The Gemini Adapter Equipment Section.  It contains O2 and H2 for fuel cell consumption and life support.  It also contains fuel for manoeuvring and attitude control thrusters.  This is the configuration as found on Gemini 10+. RCS O/F Ratio 1.3:1.
-	@mass = 0.67688
+	@mass = 0.177
 	@MODULE[ModuleDecouple]
 	{
 		@ejectionForce = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -589,7 +589,7 @@
 	!node_stack_bottom1 = DELETE
 	@title = Gemini Adapter Equipment Section	
 	@description = The Gemini Adapter Equipment Section.  It contains O2 and H2 for fuel cell consumption and life support.  It also contains fuel for manoeuvring and attitude control thrusters.  This is the configuration as found on Gemini 10+. RCS O/F Ratio 1.3:1.
-	@mass = 0.177
+	@mass = 0.367
 	@MODULE[ModuleDecouple]
 	{
 		@ejectionForce = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -644,7 +644,7 @@ PART
 	@node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 3
 	@title = FASA Advanced Gemini Equipment Section
 	@description = This equipment section models the thrusters as an engine, rather than as RCS.
-	@mass = 0.67688
+	@mass = 0.177
 	@MODULE[ModuleDecouple]
 	{
 		@ejectionForce = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -644,7 +644,7 @@ PART
 	@node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 3
 	@title = FASA Advanced Gemini Equipment Section
 	@description = This equipment section models the thrusters as an engine, rather than as RCS.
-	@mass = 0.177
+	@mass = 0.367
 	@MODULE[ModuleDecouple]
 	{
 		@ejectionForce = 10


### PR DESCRIPTION
I ran the numbers for a very light and very heavy mission (Gemini 3 and Gemini 11 respectively) and found the craft was over mass about the same amount in both cases, by approximately 500kg.