### PR TITLE
 VSR radial RW & Rockomax X200-48

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Control.cfg
@@ -12,15 +12,15 @@
     @mass = 0.075
     @maxTemp = 1073.15
 
-	@MODULE[ModuleReactionWheel]
+    @MODULE[ModuleReactionWheel]
     {
-		@PitchTorque = 0.015
-		@YawTorque = 0.015
-		@RollTorque = 0.015
+        @PitchTorque = 0.015
+        @YawTorque = 0.015
+        @RollTorque = 0.015
 
-		@RESOURCE[ElectricCharge]
+        @RESOURCE[ElectricCharge]
         {
-			@rate = 0.015
-		}
-	}
+            @rate = 0.015
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Control.cfg
@@ -1,0 +1,26 @@
+//  ==================================================
+//  Radial reaction wheel.
+
+//  Dimensions: 0.21 m x 0.25 m
+//  Gross Mass: 7.5 Kg
+//  ==================================================
+
+@PART[RadialReactionWheel]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @mass = 0.075
+    @maxTemp = 1073.15
+
+	@MODULE[ModuleReactionWheel]
+    {
+		@PitchTorque = 0.015
+		@YawTorque = 0.015
+		@RollTorque = 0.015
+
+		@RESOURCE[ElectricCharge]
+        {
+			@rate = 0.015
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
@@ -34,7 +34,7 @@
 
 @PART[fuelTank1-5]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
+    %RSSROConfig = True
 
     MODULE
     {
@@ -44,13 +44,13 @@
     }
 
     %MODULE[TweakScale]
-	{
+    {
         %name = TweakScale
         %type = RealismOverhaulStackSolid
         %defaultScale = 2.5
-	}
+    }
 
-	!RESOURCE[LiquidFuel]{}
+    !RESOURCE[LiquidFuel]{}
 
-	!RESOURCE[Oxidizer]{}
+    !RESOURCE[Oxidizer]{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
@@ -31,3 +31,26 @@
 	{
 	}
 }
+
+@PART[fuelTank1-5]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 25300
+    }
+
+    %MODULE[TweakScale]
+	{
+        %name = TweakScale
+        %type = RealismOverhaulStackSolid
+        %defaultScale = 2.5
+	}
+
+	!RESOURCE[LiquidFuel]{}
+
+	!RESOURCE[Oxidizer]{}
+}


### PR DESCRIPTION
* Add RO support for the radial reaction wheel & the Rockomax X200-48 fuel tank.