### PR TITLE
VSR engines update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -669,99 +669,6 @@
 	!nodeScaleZ = DEL
 }
 
-@PART[Ks25]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RS-25D/E
-{
-	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	@MODEL
-	{
-		// Size3 cluster has 2.2352 but the real engine should only scale up this much.
-		%scale = 1.947, 1.947, 1.947
-	}
-	%scale = 1.0
-	%rescaleFactor = 1.0
-	// bottom is 1.554m below top when unscaled
-	%node_stack_bottom = 0.0, -3.025638, 0.0 , 0.0, -1.0, 0.0, 1
-	@mass = 3.527
-	@maxTemp = 1800
-	@title = RS-25D (SSME)
-	@manufacturer = Rocketdyne
-	@description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. Though complex and expensive, these engines provide very high performance and are extremely reliable. Three of these engines powered each Shuttle Orbiter and four will be used on the core stage of the SLS.
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 1400
-		@maxThrust = 2280
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 0.728
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.272
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 452
-			@key,1 = 1 366
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 8.5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = RS-25D
-		modded = false
-		CONFIG
-		{
-			name = RS-25D // http://www.rocket.com/space-shuttle-main-engine
-			minThrust = 1400
-			maxThrust = 2280
-			PROPELLANT // MR = 6.0
-			{
-				name = LqdHydrogen
-				ratio = 0.728
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.272
-			}
-			atmosphereCurve
-			{
-				key = 0 452
-				key = 1 366
-			}
-		}
-	}
-}
-
 // Castor II
 @PART[RT2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
@@ -1308,4 +1215,168 @@
 		amount = 1.0
 		maxAmount = 1.0
 	}
+}
+
+//  ==================================================
+//  NPO Energomash RD-108 engine.
+
+//  The referred gross mass and diameter are lower than
+//  the actual part gross mass and diameter because of
+//  the structural components of the engine (aerodynamic
+//  cover & tubing).
+
+//  Dimensions: 2.578 m x 1.85 m
+//  Gross Mass: 1278.0 Kg
+//  Throttle Range: N/A
+//  Burn Time: 286 s
+//  O/F Ratio: 2.39
+
+//  Source 1: http://www.npoenergomash.ru/dejatelnost/engines/rd107/
+//  Source 2: http://www.lpre.de/energomash/RD-107/index.htm
+//  Source 3: http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//  ==================================================
+
+@PART[Size2MedEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines,VenStockRevamp]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.18, 1.18, 1.18
+    }
+
+    @node_stack_top = 0.0, 1.738, 0.0, 0.0, 1.0, 0.0, 2
+    @category = Engine
+    @title = RD-108 Series
+    @manufacturer = NPO Energomash [Glushko]
+    @description = After discovering the success of the RE-M3 and the RE-I5 rocket engines, the Rockomax Conglomerate created a new engine to bridge the gap between the two lines. This engine features a unique thrust vector system; instead of gimballing all of the engine nozzles, smaller thrust vectoring engines provide control while the larger sustainer's provide the rest of the thrust.
+    @mass = 1.6614
+    @maxTemp = 1973.15
+
+    @MODULE[ModuleEngines*]
+    {
+        !engineID = NULL
+        !runningEffectName = NULL
+        @minThrust = 744.3
+        @maxThrust = 744.3
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+        	@ratio = 0.3679
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6320
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 315
+            @key,1 = 1 248
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        config = RD-108
+        modded = false
+
+        CONFIG
+        {
+            name = RD-108
+            minThrust = 744.3
+            maxThrust = 744.3
+
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.3679
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6320
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 315
+                key = 1 248
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-108MM
+            minThrust = 777.8
+            maxThrust = 777.8
+
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.3679
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6320
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 253
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-108A
+            minThrust = 792.4
+            maxThrust = 792.4
+
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.3679
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6320
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 320.6
+                key = 1 257.7
+            }
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 4.5
+        @gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAlternator]{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -1249,7 +1249,7 @@
     @category = Engine
     @title = RD-108 Series
     @manufacturer = NPO Energomash [Glushko]
-    @description = After discovering the success of the RE-M3 and the RE-I5 rocket engines, the Rockomax Conglomerate created a new engine to bridge the gap between the two lines. This engine features a unique thrust vector system; instead of gimballing all of the engine nozzles, smaller thrust vectoring engines provide control while the larger sustainer's provide the rest of the thrust.
+    @description = Core engine for the R-7 Semyorka and its derivatives, including the Sputnik, Luna, Voskhod, Vostok, Soyuz, and Molniya launch vehicles.  Differs from the booster engine series (RD-107) with a lower chamber pressure, thrust, and a wider vernier layout.  Powers the R-7 family core through a very long (roughly) five minute burn that starts on the pad alongside the boosters.
     @mass = 1.6614
     @maxTemp = 1973.15
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -1287,7 +1287,7 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-        config = RD-108
+        configuration = RD-108
         modded = false
 
         CONFIG

--- a/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
@@ -1,0 +1,34 @@
+//  ==================================================
+//  RD-107 / RD-108 engine plume configuration.
+//  ==================================================
+
+@PART[Size2MedEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -0.35
+        fixedScale = 0.4
+        energy = 1.0
+        speed = 1.35
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        !runningEffectName = NULL
+        %powerEffectName = Kerolox-Lower
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}


### PR DESCRIPTION
* Remove the deprecated VSR RS-25 engine RO config (replaced by stock).
* Add RO support for the VSR RE-D7 "Bollard" engine (modeled after the
RD-107/RD-108 engines - https://github.com/VenVen/Stock-Revamp/issues/46).

NOTE: RD-108 part dry mass might be not balanced and the gimbal range is WIP. If anyone has a source for the vernier gimbal range please let me know.

Also, do we need to create a copy for the RD-107 series?