### PR TITLE
FASA fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_New_Fairings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_New_Fairings.cfg
@@ -1236,20 +1236,20 @@
     %RSSROConfig = True
     @name = FASAFairingNoseconeHalf_10m
 
-	@MODEL
-	{
-		%scale = 4.023, 4.224, 4.023
-	}
+    @MODEL
+    {
+        %scale = 4.023, 4.224, 4.023
+    }
 
-	@scale = 1.32
-	@rescaleFactor = 1.0
+    @scale = 1.32
+    @rescaleFactor = 1.0
 
-	@node_stack_bottom = -3.77952, -6.4, 0.0, 0.0, -1.0, 0.0, 2
-	@attachRules = 1,0,1,1,1
+    @node_stack_bottom = -3.77952, -6.4, 0.0, 0.0, -1.0, 0.0, 2
+    @attachRules = 1,0,1,1,1
 
-	@TechRequired = aerodynamicSystems
-	@title = 396" Fairing Half
-	@description = This 396 PLF (payload launch fairing) half is for Saturn V-sized payloads
+    @TechRequired = aerodynamicSystems
+    @title = 396" Fairing Half
+    @description = This 396 PLF (payload launch fairing) half is for Saturn V-sized payloads
 
     @mass = 2.1
     @maxTemp = 1073.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_New_Fairings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_New_Fairings.cfg
@@ -1231,76 +1231,43 @@
 	}
 }
 
-PART
++PART[FASANoseconeWallHalf2m]:BEFORE[RealismOverhaul]
 {
-	//yearIntroduced = 1957
-	name = FASAFairingNoseconeHalf_10m
-	module = Part
-	author = Frizzank
-	RSSROConfig = True
-	MODEL
+    %RSSROConfig = True
+    @name = FASAFairingNoseconeHalf_10m
+
+	@MODEL
 	{
-		model = FASA/Gemini2/FASA_Gemini_LR91_Pack/FairingNoseconeHalf2m
-		scale = 4.023, 4.224, 4.023
+		%scale = 4.023, 4.224, 4.023
 	}
-	scale = 1.32
-	rescaleFactor = 1.0
-	TechRequired = aerodynamicSystems
-	entryCost = 320
-	cost = 50
-	category = Aero
-	subcategory = 0
-	title = 396" Fairing Half
-	manufacturer = FASA
-	description = This 396 PLF (payload launch fairing) half is for Saturn V-sized payloads
-	attachRules = 1,0,1,1,1
-	stackSymmetry = 1
-	node_stack_bottom = -3.77952, -6.4, 0.0, 0.0, -1.0, 0.0, 2
-	mass = 2.1
-	crashTolerance = 12
-	maxTemp = 1073.15
-	explosionPotential = 0.0
-	breakingForce = 250
-	breakingTorque = 250
-	stagingIcon = DECOUPLER_VERT
-	stageOffset = 1
-	childStageOffset = 1
-	MODULE
-	{
-		name = ModuleDecouple
-		ejectionForce = 1
-		explosiveNodeID = bottom
-	}
-	MODULE
-	{
-		name = ModuleEngines
-		thrustVectorTransformName = thrustTransform
-		throttleLocked = True
-		exhaustDamage = False
-		ignitionThreshold = 0.01
-		minThrust = 0
-		maxThrust = 21
-		heatProduction = 30
-		useEngineResponseTime = True
-		engineAccelerationSpeed = 50.0
-		allowShutdown = False
-		fxOffset = 0, 0, 0.0
-		PROPELLANT
-		{
-			name = SolidFuel
-			ratio = 1.0
-			DrawGauge = False
-		}
-		atmosphereCurve
-		{
-			key = 0 290
-			key = 1 220
-		}		
-	}
-	RESOURCE
-	{
-		name = SolidFuel
-		amount = 2.1
-		maxAmount = 2.1
-	}
+
+	@scale = 1.32
+	@rescaleFactor = 1.0
+
+	@node_stack_bottom = -3.77952, -6.4, 0.0, 0.0, -1.0, 0.0, 2
+	@attachRules = 1,0,1,1,1
+
+	@TechRequired = aerodynamicSystems
+	@title = 396" Fairing Half
+	@description = This 396 PLF (payload launch fairing) half is for Saturn V-sized payloads
+
+    @mass = 2.1
+    @maxTemp = 1073.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 1
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        @maxThrust = 1
+        @heatProduction = 10
+    }
+
+    @RESOURCE[SolidFuel]
+    {
+        @amount = 0.002
+        @maxAmount = 0.002
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -199,39 +199,39 @@
 
     @node_stack_top = 0.0, 4.88, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -4.88, 0.0, 0.0, -1.0, 0.0, 3
-	@attachRules = 1,0,1,1,1
+    @attachRules = 1,0,1,1,1
 
-	@TechRequired = heavyRocketry
+    @TechRequired = heavyRocketry
     @cost = 10000
     @category = FuelTank
     @title = Titan 1 Series Fuel Tank
     @description = This fuel tank can be used for the lower stage in Titan 1 series builds.
 
-	@mass = 3.17
+    @mass = 3.17
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 1073.15
     @bulkheadProfiles = size3
 
-	@MODULE[ModuleFuelTanks]
+    @MODULE[ModuleFuelTanks]
     {
-		@volume = 71793.16
+        @volume = 71793.16
 
-		TANK
-		{
-			name = Kerosene
-			amount = 30258.57
-			maxAmount = 30258.57
-		}
+        TANK
+        {
+            name = Kerosene
+            amount = 30258.57
+            maxAmount = 30258.57
+        }
 
-		TANK
-		{
-			name = LqdOxygen
-			amount = 41534.59
-			maxAmount = 41534.59
-		}
-	}
+        TANK
+        {
+            name = LqdOxygen
+            amount = 41534.59
+            maxAmount = 41534.59
+        }
+    }
 }
 
 @PART[FASAGemini4X800Mini]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -181,56 +181,50 @@
 		}		
 	}
 }
-PART
+
++PART[FASAGeminiLFTLong]:AFTER[RealismOverhaul]
 {
-	name = FASAGeminiLFTTitan1
-	module = Part
-	author = Frizzank
-	RSSROConfig = True
-	MODEL
-	{
-		model = FASA/Gemini2/FASA_Gemini_LFTLong/LFT_Gemini_Long
-		scale = 1.219, 1.28, 1.219
-	}
+    @name = FASAGeminiLFTTitan1
 
-	scale = 1.28
-	rescaleFactor = 1.0
+    !MODEL,*{}
 
-	node_stack_top = 0.0, 4.88, 0.0, 0.0, 1.0, 0.0, 3
-	node_stack_bottom = 0.0, -4.88, 0.0, 0.0, -1.0, 0.0, 3
-	
-	TechRequired = heavyRocketry
-	entryCost = 3200
-	cost = 10000
-	category = Propulsion
-	subcategory = 0
-	title = Titan 1 Series Fuel Tank
-	description = This fuel tank can be used for the lower stage in Titan 1 series builds.
-	attachRules = 1,0,1,1,1
-	mass = 3.17
-	dragModelType = default
-	maximum_drag = 0.2
-	minimum_drag = 0.3
-	angularDrag = 2
-	explosionPotential = 15
-	crashTolerance = 18
-	breakingForce = 240
-	breakingTorque = 240
+    MODEL
+    {
+        model = FASA/Gemini2/FASA_Gemini_LFTLong/LFT_Gemini_Long
+        scale = 1.219, 1.28, 1.219
+    }
 
-	maxTemp = 3573.15
+    @scale = 1.28
+    @rescaleFactor = 1.0
 
-	MODULE
-	{
-		name=ModuleFuelTanks
-		type = Default
-		basemass = -1
-		volume = 71793.16
+    @node_stack_top = 0.0, 4.88, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -4.88, 0.0, 0.0, -1.0, 0.0, 3
+	@attachRules = 1,0,1,1,1
+
+	@TechRequired = heavyRocketry
+    @cost = 10000
+    @category = FuelTank
+    @title = Titan 1 Series Fuel Tank
+    @description = This fuel tank can be used for the lower stage in Titan 1 series builds.
+
+	@mass = 3.17
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1073.15
+    @bulkheadProfiles = size3
+
+	@MODULE[ModuleFuelTanks]
+    {
+		@volume = 71793.16
+
 		TANK
 		{
 			name = Kerosene
 			amount = 30258.57
 			maxAmount = 30258.57
 		}
+
 		TANK
 		{
 			name = LqdOxygen
@@ -239,6 +233,65 @@ PART
 		}
 	}
 }
+
+//PART
+//{
+//	name = FASAGeminiLFTTitan1
+//	module = Part
+//	author = Frizzank
+//	RSSROConfig = True
+//	MODEL
+//	{
+//		model = FASA/Gemini2/FASA_Gemini_LFTLong/LFT_Gemini_Long
+//		scale = 1.219, 1.28, 1.219
+//	}
+
+//	scale = 1.28
+//	rescaleFactor = 1.0
+
+//	node_stack_top = 0.0, 4.88, 0.0, 0.0, 1.0, 0.0, 3
+//	node_stack_bottom = 0.0, -4.88, 0.0, 0.0, -1.0, 0.0, 3
+	
+//	TechRequired = heavyRocketry
+//	entryCost = 3200
+//	cost = 10000
+//	category = Propulsion
+//	subcategory = 0
+//	title = Titan 1 Series Fuel Tank
+//	description = This fuel tank can be used for the lower stage in Titan 1 series builds.
+//	attachRules = 1,0,1,1,1
+//	mass = 3.17
+//	dragModelType = default
+//	maximum_drag = 0.2
+//	minimum_drag = 0.3
+//	angularDrag = 2
+//	explosionPotential = 15
+//	crashTolerance = 18
+//	breakingForce = 240
+//	breakingTorque = 240
+
+//	maxTemp = 3573.15
+
+//	MODULE
+//	{
+//		name=ModuleFuelTanks
+//		type = Default
+//		basemass = -1
+//		volume = 71793.16
+//		TANK
+//		{
+//			name = Kerosene
+//			amount = 30258.57
+//			maxAmount = 30258.57
+//		}
+//		TANK
+//		{
+//			name = LqdOxygen
+//			amount = 41534.59
+//			maxAmount = 41534.59
+//		}
+//	}
+//}
 @PART[FASAGemini4X800Mini]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -234,64 +234,6 @@
 	}
 }
 
-//PART
-//{
-//	name = FASAGeminiLFTTitan1
-//	module = Part
-//	author = Frizzank
-//	RSSROConfig = True
-//	MODEL
-//	{
-//		model = FASA/Gemini2/FASA_Gemini_LFTLong/LFT_Gemini_Long
-//		scale = 1.219, 1.28, 1.219
-//	}
-
-//	scale = 1.28
-//	rescaleFactor = 1.0
-
-//	node_stack_top = 0.0, 4.88, 0.0, 0.0, 1.0, 0.0, 3
-//	node_stack_bottom = 0.0, -4.88, 0.0, 0.0, -1.0, 0.0, 3
-	
-//	TechRequired = heavyRocketry
-//	entryCost = 3200
-//	cost = 10000
-//	category = Propulsion
-//	subcategory = 0
-//	title = Titan 1 Series Fuel Tank
-//	description = This fuel tank can be used for the lower stage in Titan 1 series builds.
-//	attachRules = 1,0,1,1,1
-//	mass = 3.17
-//	dragModelType = default
-//	maximum_drag = 0.2
-//	minimum_drag = 0.3
-//	angularDrag = 2
-//	explosionPotential = 15
-//	crashTolerance = 18
-//	breakingForce = 240
-//	breakingTorque = 240
-
-//	maxTemp = 3573.15
-
-//	MODULE
-//	{
-//		name=ModuleFuelTanks
-//		type = Default
-//		basemass = -1
-//		volume = 71793.16
-//		TANK
-//		{
-//			name = Kerosene
-//			amount = 30258.57
-//			maxAmount = 30258.57
-//		}
-//		TANK
-//		{
-//			name = LqdOxygen
-//			amount = 41534.59
-//			maxAmount = 41534.59
-//		}
-//	}
-//}
 @PART[FASAGemini4X800Mini]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
* Update the 10 m Saturn fairing RO config to use a copy of the Gemini fairing configuration.
* Update the Titan I first stage propellant tank to use a copy of the Titan II propellant tank configuration.

Previously these parts were created by "PART" and not "+PART" tags. If the mod that supplied the part was not installed, then it spammed the KSP log with errors.

Part functionality was not affected.