### PR TITLE
VSR structural parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
@@ -20,7 +20,7 @@
 }
 
 //	==================================================
-//  Shorter Rockomax Brand Decoupler.
+//  Shorter Rockomax Brand decoupler.
 //	==================================================
 
 @PART[shortDecoupler1-2]:FOR[RealismOverhaul]
@@ -32,7 +32,7 @@
 }
 
 //	==================================================
-//	Small radial decoupler.
+//	TT-8A small radial decoupler.
 //	==================================================
 
 @PART[smallRadialDecoupler]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
@@ -20,22 +20,24 @@
 }
 
 //	==================================================
-//	Small radial decoupler.
+//  Shorter Rockomax Brand Decoupler.
+//	==================================================
 
-//	Dimensions: 0.180 x 0.350 m
-//	Gross Mass: 3.70 Kg
+@PART[shortDecoupler1-2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @mass = 0.325
+    @maxTemp = 1073.15
+}
+
+//	==================================================
+//	Small radial decoupler.
 //	==================================================
 
 	@PART[smallRadialDecoupler]:FOR[RealismOverhaul]
 	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			%scale	  = 1.000, 1.000, 1.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+		%RSSROConfig = True
 
 		@description = A small radial decoupler.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
@@ -35,12 +35,11 @@
 //	Small radial decoupler.
 //	==================================================
 
-	@PART[smallRadialDecoupler]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
+@PART[smallRadialDecoupler]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@description = A small radial decoupler.
-
-		@mass	 = 0.0037
-		@maxTemp = 1073.15
-	}
+    @description = A small radial decoupler.
+    @mass = 0.0037
+    @maxTemp = 1073.15
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Structural.cfg
@@ -43,3 +43,19 @@
     @mass = 0.0037
     @maxTemp = 1073.15
 }
+
+//	==================================================
+//	Extra - large Rockomax HubMax Multi - Point connector.
+//	==================================================
+
+@PART[stationHubLarge]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Large Rockomax HubMax Multi-Point Connector
+
+    @mass = 2.2
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 1073.15
+}


### PR DESCRIPTION
* Add RO support for the VSR Shorter Rockomax Brand decoupler.
* Update the VSR TT-8A small radial decoupler to conform to the formatting standards.