### PR TITLE
Dependency check

### DIFF
--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -37,7 +37,7 @@
 			@rate = 0.001
 		}
 	}
-	MODULE:NEEDS[RP0]
+	MODULE:NEEDS[RP-0]
 	{
 		name = ModuleScienceCore
 	}

--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -37,7 +37,7 @@
 			@rate = 0.001
 		}
 	}
-	MODULE
+	MODULE:NEEDS[RP0]
 	{
 		name = ModuleScienceCore
 	}


### PR DESCRIPTION
* Just a small check for the Vanguard probe when RP-0 is not installed.