### PR TITLE
Centaur insulation

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
@@ -195,7 +195,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 42511.0
-		type = ServiceModule
+		type = Balloon
 		basemass = -1
 	}
 }


### PR DESCRIPTION
It was set to ServiceModule, which gave it really, really low boiloff along with the historically low mass.

NathanKell suggested that Balloon will best match the actual insulation characteristics of the Centaur tank