### PR TITLE
Pioneer Antenna 80kg (was 800)

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
@@ -106,7 +106,7 @@
 	//http://www.bernd-leitenberger.de/pioneer10-11.shtml
 	//2.75m dia, 3.3° 38dB
 	//Pioneer dry mass 230kg; incl. 4x SNAP-19 á 15.4kg & 29.6kg science (140kg left for everything else)
-	@mass = 0.80
+	@mass = 0.080
 	@description = Dish approximating those found on Pioneer 10/11; effective range ~1500Gm (good for Jupiter and beyond), high power demands and comparatively low bandwidth.
 	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1


### PR DESCRIPTION
Oops.

Btw, 80kg is still rather heavy; but otherwise there's just too little room for later models to be better.