### PR TITLE
B9AerospaceProceduralParts

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -20,7 +20,7 @@
 		{ "name" : "SmokeScreen" }
     ],
     "recommends" : [
-		{ "name" : "B9AerospaceProceduralParts" },
+		{ "name" : "B9-PWings-Fork" },
 		{ "name" : "ConnectedLivingSpace" },
 		{ "name" : "DeadlyReentry" },
 		{ "name" : "FilterExtensions" },


### PR DESCRIPTION
`B9AerospaceProceduralParts` is only compatible till 1.0.4. Crzyrndm forked and updated it to 1.0.5, so we need to make a new netkan file. The new id is `B9-PWings-Fork`.

Merge after KSP-CKAN/NetKAN/pull/2827