### PR TITLE
Gemini L/D modification

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -302,7 +302,7 @@
 	MODULE
 	{
 		name = CoMShifter
-		DescentModeCoM = 0.0, 0.0, -0.12
+		DescentModeCoM = 0.0, 0.0, -0.06
 	}
 	MODULE
 	{


### PR DESCRIPTION
I haven't seen a citation for the AoA for Gemini, but Braeunig reports a Gemini L/D of 0.16, which to be honest is new to me.

http://www.braeunig.us/space/specs/gemini.htm

This appears to achieve that