### PR TITLE
range of first dish increased, a lot

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
@@ -61,11 +61,11 @@
 	@mass = 0.025  //heavy!
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
-	@description = An early, small high-gain antenna. Rather wide cone and high bandwidth for Comm satellites in GEO, live video from the Moon, and similar tasks. Effective range approx. 40Gm, not suitable for interplanetary missions.
+	@description = An early, small high-gain antenna. Rather wide cone and high bandwidth for Comm satellites in GEO, live video from the Moon, and similar tasks. Effective range approx. 90Gm, barely suitable for interplanetary missions.
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
-		@Mode1DishRange = 16e6
+		@Mode1DishRange = 75e6
 		@EnergyCost = 0.05  //equals early return core
 		@MaxQ = 6000
 		@DishAngle = 25


### PR DESCRIPTION
16Mm was just too little, not even worth it's weight in Comm-16s.
75Mm requires 3xComm-16 on the other end for a GEO-LEO link, and already allows interplanetary. Which may be a bit early, but then again why not? With ~90Gm, Venus should be doable with a standard hohmann transfer.