### PR TITLE
AJ10-118F/K Delta configurations

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -1330,6 +1330,78 @@
 			cost = 30
 			entryCost = 600
 		}
+		CONFIG
+		{
+			name = AJ10-118F	// Delta F 2nd stage
+			minThrust = 42.3
+			maxThrust = 42.3
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.502
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.498
+			}
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 10 // some high number, also no source...
+			!IGNITOR_RESOURCE,* {}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			atmosphereCurve
+			{
+				key = 0 315
+				key = 1 215
+			}
+			massMult = 1.0
+			techRequired = heavierRocketry
+			cost = 30
+			entryCost = 600
+		}
+		CONFIG
+		{
+			name = AJ10-118K	// Delta K 2nd stage
+			minThrust = 43.7
+			maxThrust = 43.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.502
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.498
+			}
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 10 // some high number, also no source...
+			!IGNITOR_RESOURCE,* {}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			atmosphereCurve
+			{
+				key = 0 319.2
+				key = 1 215
+			}
+			massMult = 1.0
+			techRequired = heavierRocketry
+			cost = 30
+			entryCost = 600
+		}
 	}
 }
 @PART[SXTCastor30]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]


### PR DESCRIPTION
Add engine configurations for the AJ10-118F and AJ10-118K.  These engines were used on the "Delta F" and "Delta K" second stages for Delta I and Delta II rockets.  I've added these configurations to the existing SXTAJ10Mid engine because they were advances on the older AJ10-118E.  That may be accurate for the 118F since the Delta F second stage was similar in size to the older Delta E second stage.  But it's possible the 118K should be a completely separate engine since the Delta K was larger.  Trouble is I can't find documentation that shows the dimensions of the engine itself.