### PR TITLE
changes to radiator

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -917,12 +917,14 @@
     %breakingTorque = 250
     @maxTemp = 1073.15
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.25
+    @radiatorHeadroom = 0.29 	// 0.2702 sets the limit to 17C/290K which is the ISS, this relies on maxtemp as 1073.15
+    				// this means 'the max temp the radiator will rise to is MaxTemp * radiatorHeadroom'
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 1750
-        @overcoolFactor = 0
+        @maxEnergyTransfer = 50000 	// how many KJ per sec (or tick?) the part can transfer, NathanKell recommended this
+        @overcoolFactor = 0.0186367 	// minimum temp to lower parts to = maxTemp * overcoolFactor
+        				// here that is 20K, so cool enough to keep LH2 liquid
 
         RESOURCE[ElectricCharge]
         {


### PR DESCRIPTION
based on in-game experience and discussion with NathanKell

@NathanKell, please point out of any of my comments are incorrect. I figured it would be useful to have some documentation of these variables.

Also, according to NathanKell (if I interpreted this correctly) radiatorMax sets the priority of a part to be cooled, higher is better. above 0.01, below 0.99. I set some tanks to 0.9 (2 tanks on one craft) and the habitation module to 0.35 and it didn't seem to behave as expected, so I didn't commit that to this PR