### PR TITLE
Add Castor 4

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Solids.cfg
@@ -14,8 +14,8 @@
 	@node_attach = 0.0, 0.0, -0.50927, 0.0, 0.0, 0.0
 	@title = Castor 4A
 	%manufacturer = Thiokol ATK
-	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads. Burn time: 53 seconds.
-	@mass = 1.565347
+	@description = The Castor 4A, an upgraded variant of the Castor 4, was introduced in 1989 to power the first generation of Delta II launchers. The switch to a more energetic HTPB binder allowed a return to the more efficient 6-3 staggered booster ignition and jettison sequence. Burn time: 53 seconds.
+	@mass = 1.46
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
 	{
@@ -125,6 +125,269 @@
 		}
 	}
 }
+
+// ##########################################################################################	Castor 4
++PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
+{
+	@name = RO_KWsrbGlobeI_Castor4
+	@MODEL,0
+	{
+		@scale = 2.62697, 1.864719, 2.62697
+	}
+	@title = Castor 4
+	%manufacturer = Thiokol ATK
+	@description = An evolution of the Castor line of solid motors, which were originally developed to power the Scout and Little Joe vehicles, the Castor 4 was introduced in 1969. It was later adapted as a booster for the Delta family of launchers, first appearing on the Delta 3000-series in 1975. The nine Castor 4 motors used on the Delta 3000-series were used in a staggered 5-4 sequence, with the five ground-lit motors jettisoned as the four remaining motors ignited. Previous Delta vehicles burned their motors in a 6-3 sequence, but jettisoned all SRMs at once after burnout of the air-lit motors.
+	@mass = 1.27
+	@MODULE[ModuleEngines*]
+	{
+		%maxThrust = 460
+		@atmosphereCurve
+		{
+			@key,0 = 0 261
+			@key,1 = 1 228
+		}
+	}
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 5230
+		@type = PBAN
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Castor-4
+		@CONFIG[Castor-4A]
+		{
+			@name = Castor-4
+			@maxThrust = 460
+			@PROPELLANT[HTPB]
+			{
+				@name = PBAN
+			}
+			@atmosphereCurve
+			{
+				@key,0 = 0 261
+				@key,1 = 1 228
+			}
+			@curveResource = PBAN
+			!thrustCurve
+			{
+			}
+			thrustCurve //Guess, based on constraint that Castor 4A curve was shaped to provide similar sea-level thrust at ignition
+			{
+				key = 	1	0.825
+				key = 	0.995	0.828
+				key = 	0.99	0.831525
+				key = 	0.985	0.83505
+				key = 	0.98	0.839625
+				key = 	0.975	0.844275
+				key = 	0.97	0.848925
+				key = 	0.965	0.85245
+				key = 	0.96	0.855825
+				key = 	0.955	0.8592
+				key = 	0.95	0.86325
+				key = 	0.945	0.86745
+				key = 	0.94	0.87165
+				key = 	0.935	0.875325
+				key = 	0.93	0.87855
+				key = 	0.925	0.881775
+				key = 	0.92	0.885675
+				key = 	0.915	0.89085
+				key = 	0.91	0.896025
+				key = 	0.905	0.9012
+				key = 	0.9	0.90495
+				key = 	0.895	0.9087
+				key = 	0.89	0.91245
+				key = 	0.885	0.916275
+				key = 	0.88	0.920175
+				key = 	0.875	0.924075
+				key = 	0.87	0.92805
+				key = 	0.865	0.93285
+				key = 	0.86	0.93765
+				key = 	0.855	0.94245
+				key = 	0.85	0.94695
+				key = 	0.845	0.951225
+				key = 	0.84	0.9555
+				key = 	0.835	0.959775
+				key = 	0.83	0.962175
+				key = 	0.825	0.964575
+				key = 	0.82	0.966975
+				key = 	0.815	0.96855
+				key = 	0.81	0.96855
+				key = 	0.805	0.96805
+				key = 	0.8	0.96775
+				key = 	0.795	0.96775
+				key = 	0.79	0.96755
+				key = 	0.785	0.96805
+				key = 	0.78	0.96775
+				key = 	0.775	0.96775
+				key = 	0.77	0.96755
+				key = 	0.765	0.96805
+				key = 	0.76	0.96805
+				key = 	0.755	0.96805
+				key = 	0.75	0.96805
+				key = 	0.745	0.96765
+				key = 	0.74	0.96825
+				key = 	0.735	0.96805
+				key = 	0.73	0.96845
+				key = 	0.725	0.96845
+				key = 	0.72	0.96845
+				key = 	0.715	0.96845
+				key = 	0.71	0.96845
+				key = 	0.705	0.96815
+				key = 	0.7	0.96815
+				key = 	0.695	0.96815
+				key = 	0.69	0.96845
+				key = 	0.685	0.96895
+				key = 	0.68	0.96905
+				key = 	0.675	0.96995
+				key = 	0.67	0.97015
+				key = 	0.665	0.97075
+				key = 	0.66	0.97115
+				key = 	0.655	0.97185
+				key = 	0.65	0.97235
+				key = 	0.645	0.97285
+				key = 	0.64	0.97335
+				key = 	0.635	0.97385
+				key = 	0.63	0.97435
+				key = 	0.625	0.97485
+				key = 	0.62	0.97535
+				key = 	0.615	0.97595
+				key = 	0.61	0.97665
+				key = 	0.605	0.97735
+				key = 	0.6	0.97805
+				key = 	0.595	0.97875
+				key = 	0.59	0.97925
+				key = 	0.585	0.97975
+				key = 	0.58	0.98025
+				key = 	0.575	0.98075
+				key = 	0.57	0.98125
+				key = 	0.565	0.98175
+				key = 	0.56	0.98225
+				key = 	0.555	0.98285
+				key = 	0.55	0.98355
+				key = 	0.545	0.98425
+				key = 	0.54	0.98495
+				key = 	0.535	0.98525
+				key = 	0.53	0.98575
+				key = 	0.525	0.98585
+				key = 	0.52	0.98675
+				key = 	0.515	0.98695
+				key = 	0.51	0.98755
+				key = 	0.505	0.98795
+				key = 	0.5	0.98825
+				key = 	0.495	0.98875
+				key = 	0.49	0.98885
+				key = 	0.485	0.98975
+				key = 	0.48	0.98995
+				key = 	0.475	0.99055
+				key = 	0.47	0.99095
+				key = 	0.465	0.99145
+				key = 	0.46	0.99195
+				key = 	0.455	0.99245
+				key = 	0.45	0.99295
+				key = 	0.445	0.99345
+				key = 	0.44	0.99395
+				key = 	0.435	0.99445
+				key = 	0.43	0.99505
+				key = 	0.425	0.99575
+				key = 	0.42	0.99645
+				key = 	0.415	0.99715
+				key = 	0.41	0.99775
+				key = 	0.405	0.99825
+				key = 	0.4	0.99875
+				key = 	0.395	0.99925
+				key = 	0.39	0.99955
+				key = 	0.385	1
+				key = 	0.38	1
+				key = 	0.375	1
+				key = 	0.37	1
+				key = 	0.365	1
+				key = 	0.36	1
+				key = 	0.355	1
+				key = 	0.35	1
+				key = 	0.345	1
+				key = 	0.34	1
+				key = 	0.335	1
+				key = 	0.33	1
+				key = 	0.325	1
+				key = 	0.32	1
+				key = 	0.315	1
+				key = 	0.31	1
+				key = 	0.305	1
+				key = 	0.3	1
+				key = 	0.295	1
+				key = 	0.29	1
+				key = 	0.285	1
+				key = 	0.28	1
+				key = 	0.275	1
+				key = 	0.27	1
+				key = 	0.265	1
+				key = 	0.26	1
+				key = 	0.255	1
+				key = 	0.25	1
+				key = 	0.245	0.9996
+				key = 	0.24	0.9991
+				key = 	0.235	0.9986
+				key = 	0.23	0.9981
+				key = 	0.225	0.9974
+				key = 	0.22	0.9967
+				key = 	0.215	0.996
+				key = 	0.21	0.9953
+				key = 	0.205	0.9944
+				key = 	0.2	0.9934
+				key = 	0.195	0.9924
+				key = 	0.19	0.9914
+				key = 	0.185	0.9903
+				key = 	0.18	0.9891
+				key = 	0.175	0.9879
+				key = 	0.17	0.9867
+				key = 	0.165	0.9859
+				key = 	0.16	0.9854
+				key = 	0.155	0.9849
+				key = 	0.15	0.9844
+				key = 	0.145	0.9837
+				key = 	0.14	0.983
+				key = 	0.135	0.9821
+				key = 	0.13	0.9811
+				key = 	0.125	0.9801
+				key = 	0.12	0.9791
+				key = 	0.115	0.978
+				key = 	0.11	0.9768
+				key = 	0.105	0.9756
+				key = 	0.1	0.9744
+				key = 	0.095	0.9736
+				key = 	0.09	0.9729
+				key = 	0.085	0.9722
+				key = 	0.08	0.9713
+				key = 	0.075	0.9703
+				key = 	0.07	0.9693
+				key = 	0.065	0.9683
+				key = 	0.06	0.9672
+				key = 	0.055	0.966
+				key = 	0.05	0.9648
+				key = 	0.045	0.9636
+				key = 	0.04	0.9628
+				key = 	0.035	0.9623
+				key = 	0.03	0.9618
+				key = 	0.025	0.9618
+				key = 	0.02	0.9218
+				key = 	0.015	0.8018
+				key = 	0.01	0.6518
+				key = 	0.009	0.6168
+				key = 	0.008	0.5718
+				key = 	0.007	0.5187
+				key = 	0.006	0.4637
+				key = 	0.005	0.3987
+				key = 	0.004	0.3287
+				key = 	0.003	0.2537
+				key = 	0.002	0.1837
+				key = 	0.001	0.0837
+				key = 	0	0.0007
+			}
+		}
+	}
+}
+
 // ##########################################################################################	***NEW*** Castor 4AXL
 +PART[KWsrbGlobeI]:AFTER[RealismOverhaul]
 {
@@ -133,7 +396,7 @@
 	{
 		@scale = 2.607462, 2.345010, 2.607462
 	}
-	@title = Castor 4 AXL
+	@title = Castor 4AXL
 	%manufacturer = Thiokol (ATK)
 	@description = Small booster attached to larger rockets to give that extra thrust needed to get off the ground and/or with larger payloads. Slightly larger than it's siblings produces a bit more thrust. Burn time: 57 seconds.
 	@mass = 1.871069
@@ -238,7 +501,7 @@
 	}
 	@title = GEM 40
 	%manufacturer = Thiokol ATK
-	@description = The Graphite-Epoxy Motor (GEM) replaced the Castor 4's steel case with a lighter composite case. The 40-inch (1-meter) diameter GEM 40 was used on the Delta II 7000-series in sets of three, four, or nine. When nine boosters were used, six were ignited at liftoff and the remaining three were ignited after burnout and jettison of the first six. Burn time: 58 seconds.
+	@description = The Graphite-Epoxy Motor (GEM) replaced the steel case used on earlier Castor-series boosters with a lighter composite case. The 40-inch (1-meter) diameter GEM 40 was used on the Delta II 7000-series in sets of three, four, or nine. When nine boosters were used, six were ignited at liftoff and the remaining three were ignited after burnout and jettison of the first six. Burn time: 58 seconds.
 	@mass = 1.196123
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeI.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeI.cfg
@@ -18,6 +18,28 @@
         speed = 1
     }
 }
+
+@PART[RO_KWsrbGlobeI_Castor4]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+        %powerEffectName = Solid-Lower
+	}
+    PLUME
+    {
+        name = Solid-Lower
+        transformName = NozzleTransform
+        localRotation = 0,0,0
+        flarePosition = 0,0,-0.3
+        plumePosition = 0,0,-0.1
+        fixedScale = 0.8
+        energy = 1
+        speed = 1
+    }
+}
+
 @PART[RO_KWsrbGlobeI_GEM60]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]


### PR DESCRIPTION
Curve based on Castor 4A, which was designed to produce similar ignition sea-level thrust levels