### PR TITLE
Squad MMRTG update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
@@ -168,7 +168,7 @@
         INPUT_RESOURCE
         {
             ResourceName = Plutonium-238
-            Ratio = 1e-13
+            Ratio = 1.6428e-10
         }
 
         OUTPUT_RESOURCE
@@ -180,7 +180,7 @@
         OUTPUT_RESOURCE
         {
             ResourceName = DepletedFuel
-            Ratio = 1e-13
+            Ratio = 1.6428e-10
         }
     }
 
@@ -188,6 +188,13 @@
     {
         name = Plutonium-238
         amount = 0.227
+        maxAmount = 0.227
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
         maxAmount = 0.227
     }
 }


### PR DESCRIPTION
* Fix a major bug where KSP cannot output to a non - existent resource
(missing DepletedFuel resource) and the converter cannot operate.
* Adjust the consumption values so that the generator will last ~43
years (instead of several thousand), half the time of one half life of
Plutonium 238.