### PR TITLE
VenVen Gimbal fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -2258,7 +2258,7 @@
 	
 	@MODULE[ModuleGimbal]
 	{
-		%gimbalTransformName = Nozzle
+		%gimbalTransformName = Gimbal
 	}
 }
 


### PR DESCRIPTION
For #788

Changes the RO file to match the change of the gimbal transform name in VSR.