### PR TITLE
Squad Engines updates from RP-0 issue 417

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -915,8 +915,8 @@
 		CONFIG
 		{
 			name = LR79-NA-9
-			minThrust = 774	// 1961 NASA Launch Vehicle Handbook
-			maxThrust = 774	// 1961 NASA Launch Vehicle Handbook
+			minThrust = 774	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
+			maxThrust = 774	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -931,8 +931,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 284	// 1961 NASA Launch Vehicle Handbook
-				key = 1 245	// 1961 NASA Launch Vehicle Handbook
+				key = 0 284	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
+				key = 1 245	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			}
 			massMult = 1.03 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (guesstimate between S-3D and LR79-NA-11)
 			cost = 100
@@ -944,8 +944,8 @@
 		CONFIG
 		{
 			name = LR79-NA-11
-			minThrust = 850	// 1961 NASA Launch Vehicle Handbook
-			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook
+			minThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
+			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -960,8 +960,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 286	// 1961 NASA Launch Vehicle Handbook
-				key = 1 248	// 1961 NASA Launch Vehicle Handbook
+				key = 0 286.2	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
+				key = 1 248.3	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			cost = 200
@@ -976,8 +976,8 @@
 		CONFIG
 		{
 			name = LR79-NA-13
-			minThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
-			maxThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
+			minThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
+			maxThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -992,8 +992,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 290	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
-				key = 1 252	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
+				key = 0 290	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
+				key = 1 252	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
 			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			cost = 500

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -640,7 +640,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		origMass = 0.844
+		origMass = 0.460
 		configuration = LR105-NA-3
 		CONFIG
 		{
@@ -673,7 +673,7 @@
 			minThrust = 366.1
 			maxThrust = 366.1
 			heatProduction = 100
-			massMult = 0.9443 // 413kg engine, source http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for -5
+			massMult = 0.8978 // 413kg engine, source http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for -5
 			PROPELLANT
 			{
 				name = Kerosene
@@ -705,7 +705,7 @@
 			minThrust = 385.2
 			maxThrust = 385.2
 			heatProduction = 100
-			massMult = 1.01185 // same source
+			massMult = 1.02174 // 470kg engine, same source
 			PROPELLANT
 			{
 				name = Kerosene
@@ -738,7 +738,7 @@
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
-			massMult = 1.01185 // same source
+			massMult = 1.02174 // 470kg engine, same source
 			PROPELLANT
 			{
 				name = Kerosene
@@ -915,8 +915,8 @@
 		CONFIG
 		{
 			name = LR79-NA-9
-			minThrust = 756.2
-			maxThrust = 756.2
+			minThrust = 774	// 1961 NASA Launch Vehicle Handbook
+			maxThrust = 774	// 1961 NASA Launch Vehicle Handbook
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -931,8 +931,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 283.9 // source: b14643.de
-				key = 1 250.4
+				key = 0 284	// 1961 NASA Launch Vehicle Handbook
+				key = 1 245	// 1961 NASA Launch Vehicle Handbook
 			}
 			massMult = 1.03 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (guesstimate between S-3D and LR79-NA-11)
 			cost = 100
@@ -944,8 +944,8 @@
 		CONFIG
 		{
 			name = LR79-NA-11
-			minThrust = 831.8
-			maxThrust = 831.8
+			minThrust = 850	// 1961 NASA Launch Vehicle Handbook
+			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -960,8 +960,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 283.9 // source: b14643.de to keep sources the same
-				key = 1 250.4 // source: b14643.de to keep sources the same
+				key = 0 286	// 1961 NASA Launch Vehicle Handbook
+				key = 1 248	// 1961 NASA Launch Vehicle Handbook
 			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			cost = 200
@@ -976,8 +976,8 @@
 		CONFIG
 		{
 			name = LR79-NA-13
-			minThrust = 858.5 // source: b14643.de
-			maxThrust = 858.5 // source: b14643.de
+			minThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
+			maxThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -992,8 +992,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 283.9 // source: b14643.de
-				key = 1 250.4 // source: b14643.de to keep sources the same
+				key = 0 290	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
+				key = 1 252	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine
 			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			cost = 500

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -640,8 +640,8 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
+		origMass = 0.844
 		configuration = LR105-NA-3
-		origMass = 0.460
 		CONFIG
 		{
 			name = LR105-NA-3
@@ -669,11 +669,11 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-6
+			name = LR105-NA-5/6
 			minThrust = 366.1
 			maxThrust = 366.1
 			heatProduction = 100
-			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
+			massMult = 0.9443 // 413kg engine, source http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for -5
 			PROPELLANT
 			{
 				name = Kerosene
@@ -696,15 +696,16 @@
 			{
 				LR89-NA-6 = 1000
 			}
-			techRequired = advRocketry
+			techRequired = generalRocketry
 		}
 		CONFIG
 		{
-			name = LR105-NA-7
-			minThrust = 386.4
-			maxThrust = 386.4
+			name = LR105-NA-7.1
+			description = MA-5.1 engine for Atlas-Agena launches
+			minThrust = 385.2
+			maxThrust = 385.2
 			heatProduction = 100
-			massMult = 1.0226 // same source
+			massMult = 1.01185 // same source
 			PROPELLANT
 			{
 				name = Kerosene
@@ -726,7 +727,40 @@
 			entryCostSubtractors
 			{
 				LR105-NA-6 = 2000
-				LR89-NA-7 = 1000
+				LR89-NA-7.1 = 1000
+			}
+			techRequired = heavyRocketry
+		}
+		CONFIG
+		{
+			name = LR105-NA-7.2
+			description = MA-5.2 engine for Atlas-Centaur launches
+			minThrust = 386.4
+			maxThrust = 386.4
+			heatProduction = 100
+			massMult = 1.01185 // same source
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 220
+			}
+			cost = 300
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-6 = 2000
+				LR89-NA-7.2 = 1000
 			}
 			techRequired = heavierRocketry
 		}
@@ -736,7 +770,7 @@
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
-			massMult = 1.0 // total guess, lower than above because H-1 was lighter...?
+			massMult = 1.0 // guess
 			PROPELLANT
 			{
 				name = Kerosene
@@ -905,7 +939,7 @@
 			entryCost = 2000
 			// no, it's actually same level as LR89-3, so TL1ish instead of techRequired = advRocketry
 			// so let's put it in basicConstruction
-			techRequired = basicConstruction
+			techRequired = generalRocketry
 		}
 		CONFIG
 		{
@@ -926,8 +960,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 290 // (copy from comparable LR89, since SL change is same)
-				key = 1 256 // b14643.de claims same as -9, but http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm says 256 (from a NASA pdf).
+				key = 0 283.9 // source: b14643.de to keep sources the same
+				key = 1 250.4 // source: b14643.de to keep sources the same
 			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			cost = 200
@@ -937,13 +971,13 @@
 				LR79-NA-9 = 2000
 				H-1-SaturnI = 1000
 			}
-			techRequired = advRocketry
+			techRequired = generalRocketry
 		}
 		CONFIG
 		{
 			name = LR79-NA-13
-			minThrust = 831.8
-			maxThrust = 831.8
+			minThrust = 858.5 // source: b14643.de
+			maxThrust = 858.5 // source: b14643.de
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -958,8 +992,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 292 // See note above, stolen from comparable Atlas again
-				key = 1 258 // (though USAF pdf claims -13's total engine Isp is still only 252.4 at sea level http://www.alternatewars.com/BBOW/Space_Engines/YLR79-NA-13_Specs.pdf )
+				key = 0 283.9 // source: b14643.de
+				key = 1 250.4 // source: b14643.de to keep sources the same
 			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			cost = 500
@@ -970,7 +1004,7 @@
 				H-1-SaturnI = 2000
 				H-1-SaturnIB = 1000
 			}
-			techRequired = heavyRocketry
+			techRequired = advRocketry
 		}
 		CONFIG
 		{
@@ -1095,7 +1129,7 @@
 			{
 				RS-27 = 40750
 			}
-			techRequired = veryHeavyRocketry
+			techRequired = experimentalRocketry
 			massMult = 1.265
 		}
 	}
@@ -1184,14 +1218,15 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
+		origMass = 0.720
 		configuration = LR89-NA-3
-		origMass = 0.72
 		CONFIG
 		{
 			name = LR89-NA-3
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
+			massMult = 0.89
 			PROPELLANT
 			{
 				name = Kerosene
@@ -1208,7 +1243,37 @@
 				key = 0 282
 				key = 1 248
 			}
-			massMult = 0.89
+		}
+		CONFIG
+		{
+			name = LR89-NA-5
+			minThrust = 758.7
+			maxThrust = 758.7
+			heatProduction = 100
+			massMult = 1.0	// astronautix.com MA-2.  With a 1.61t skirt, this should result in each booster weighing 0.720t resulting in a 3.050t total weight  
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 282
+				key = 1 248
+			}
+			cost = 200
+			entryCost = 4000
+			entryCostSubtractors
+			{
+				LR105-NA-5/6 = 1000
+			}
+			techRequired = generalRocketry
 		}
 		CONFIG
 		{
@@ -1216,6 +1281,7 @@
 			minThrust = 831.4
 			maxThrust = 831.4
 			heatProduction = 100
+			massMult = 1.086	// astronautix.com MA-3.  With a 1.61t skirt, this should result in each booster weighing 0.782t resulting in a 3.174t total weight
 			PROPELLANT
 			{
 				name = Kerosene
@@ -1232,20 +1298,57 @@
 				key = 0 290
 				key = 1 256
 			}
-			cost = 200
-			entryCost = 4000
+			cost = 300
+			entryCost = 7500
 			entryCostSubtractors
 			{
-				LR105-NA-6 = 1000
+				LR105-NA-5/6 = 1000
+				LR89-NA-5 = 3000
 			}
 			techRequired = advRocketry
 		}
 		CONFIG
 		{
-			name = LR89-NA-7
+			name = LR89-NA-7.1
+			description = MA-5.1 engine for Atlas-Agena launches
+			minThrust = 931.7
+			maxThrust = 931.7
+			heatProduction = 100
+			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 292.2
+				key = 1 258.0
+			}
+			massMult = 0.99
+			cost = 500
+			entryCost = 10000
+			entryCostSubtractors
+			{
+				LR105-NA-7.1 = 2000
+				LR89-NA-6 = 4000
+			}
+			techRequired = heavyRocketry
+		}
+		CONFIG
+		{
+			name = LR89-NA-7.2
+			description = MA-5.2 engine for Atlas-Centaur launches
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
+			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
 			PROPELLANT
 			{
 				name = Kerosene
@@ -1267,7 +1370,7 @@
 			entryCost = 10000
 			entryCostSubtractors
 			{
-				LR105-NA-7 = 2000
+				LR105-NA-7.2 = 2000
 				LR89-NA-6 = 4000
 			}
 			techRequired = heavierRocketry
@@ -1278,6 +1381,7 @@
 			minThrust = 1077.6
 			maxThrust = 1077.6
 			heatProduction = 100
+			massMult = 1.7896	// astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
 			PROPELLANT
 			{
 				name = Kerosene
@@ -2852,7 +2956,7 @@
 				key = 0 249
 				key = 1 209.8
 			}
-			techRequired = heavyRocketry
+			techRequired = advRocketry
 			cost = 15
 			entryCost = 300
 		}


### PR DESCRIPTION
The are changes as discussed in RP-0 issue 417.  The changes include:
1- Update the LR89 and LR105 engines to match the FASA versions
2- Adjust tech node placement for the LR101-11 engine config