### PR TITLE
SXT Engines updates from RP-0 issue 417

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -1108,6 +1108,46 @@
 		}
 		CONFIG
 		{
+			name = AJ10-101A
+			minThrust = 33.4
+			maxThrust = 33.4
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.406
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.594
+			}
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 1
+			!IGNITOR_RESOURCE,* {}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			atmosphereCurve
+			{
+				key = 0 270
+				key = 1 240
+			}
+			massMult = 1.0
+			techRequired = basicConstruction
+			cost = 0 // better, but mass production, so same cost as Vanguard.
+			entryCost = 1000
+			entryCostSubtractors
+			{
+				AJ10-42 = 600
+			}
+		}
+		CONFIG
+		{
 			name = AJ10-142
 			minThrust = 34.25
 			maxThrust = 34.25
@@ -1143,7 +1183,48 @@
 			entryCost = 1000
 			entryCostSubtractors
 			{
-				AJ10-42 = 600
+				AJ10-101A = 600
+			}
+		}
+		CONFIG
+		{
+			name = AJ10-118
+			minThrust = 33.1
+			maxThrust = 33.1
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.406
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.594
+			}
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 1
+			!IGNITOR_RESOURCE,* {}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			atmosphereCurve
+			{
+				key = 0 263.0
+				key = 1 241.5
+			}
+			massMult = 1.0
+			techRequired = advRocketry
+			cost = 10
+			entryCost = 1500
+			entryCostSubtractors
+			{
+				AJ10-101A = 600
+				AJ10-142 = 400
 			}
 		}
 		CONFIG
@@ -1183,8 +1264,7 @@
 			entryCost = 1500
 			entryCostSubtractors
 			{
-				AJ10-42 = 600
-				AJ10-142 = 400
+				AJ10-118 = 600
 			}
 		}
 	}
@@ -1326,7 +1406,149 @@
 				key = 1 215
 			}
 			massMult = 1.0
-			techRequired = advRocketry
+			techRequired = heavyRocketry
+			cost = 30
+			entryCost = 600
+		}
+	}
+}
+// AJ10 adv, i.e. 118F & 118K
++PART[SXTAJ10Mid]:FOR[RealismOverhaul]
+{
+	@name = SXTAJ10Adv
+	%RSSROConfig = True
+	@MODEL
+	{
+		@scale = 2.1, 2.1, 2.1
+	}
+	%rescaleFactor = 1.0
+	//%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+	
+	@node_stack_top = 0.0, 0.5964, 0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.97944, 0.0, 0.0, -1.0, 0.0, 0
+	
+	%title = AJ10 Upper Stage Engine (Advanced)
+	%manufacturer = Aerojet
+	%description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents advanced era AJ10s with a nozzle extension and restart capability. Used on the Delta F and Delta K 2nd stages.
+	%attachRules = 1,0,1,0,0
+	%mass = 0.09
+	%maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 42.3
+		%maxThrust = 42.3
+		%heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+			@ratio = 0.502
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.498
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 315
+			@key,1 = 1 215
+		}
+		%ullage = True
+		%pressureFed = True
+		%ignitions = 10
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.2
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 3.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 8
+	}
+	@MODULE[ModuleJettison],*
+	{
+		@bottomNodeName = bottom
+	}
+	!MODULE[ModuleEngineConfigs] {}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = AJ10-118F
+		modded = false
+		origMass = 0.09
+		CONFIG
+		{
+			name = AJ10-118F	// Delta F 2nd stage
+			minThrust = 42.3
+			maxThrust = 42.3
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.502
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.498
+			}
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 10 // some high number, also no source...
+			!IGNITOR_RESOURCE,* {}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			atmosphereCurve
+			{
+				key = 0 315
+				key = 1 215
+			}
+			massMult = 1.0
+			techRequired = heavierRocketry
+			cost = 30
+			entryCost = 600
+		}
+		CONFIG
+		{
+			name = AJ10-118K	// Delta K 2nd stage
+			minThrust = 43.7
+			maxThrust = 43.7
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.502
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.498
+			}
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 10 // some high number, also no source...
+			!IGNITOR_RESOURCE,* {}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			atmosphereCurve
+			{
+				key = 0 319.2
+				key = 1 215
+			}
+			massMult = 1.0
+			techRequired = veryHeavyRocketry
 			cost = 30
 			entryCost = 600
 		}


### PR DESCRIPTION
The are changes as discussed in RP-0 issue 417.  The changes include:
1- Add configs for early AJ10-101A and AJ10-118 engines
2-Added new SXTAJ10Adv engine to represent the AJ10-118F & 118K used on later era Delta 2nd stages