### PR TITLE
Calculating Mk2 Cargo Bay node placements relative to their original placements

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -90,7 +90,7 @@
 		@type = Fuselage
 	}
 }
-@PART[mk2CargoBayL]:FOR[RealismOverhaul]
+@PART[mk2CargoBayL|mk2CargoBayS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -107,39 +107,67 @@
 		rescaleY = 1.722222
 		rescaleZ = 1.722222
 	}
-	@node_stack_top = 0.0, 3.22916625, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_top2 = 0.0, 3.22916625, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -3.22916625, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_bottom2 = 0.0, -3.22916625, 0.0, 0, -1, 0, 1
+	
 	@mass = 1.75
 	//%maxTemp = 2273.15
 	%skinMaxTemp = 2500
+	
+	stack_top0 = #$node_stack_top[0]$
+	stack_top1 = #$node_stack_top[1]$
+	stack_top2 = #$node_stack_top[2]$
+	@stack_top0 *= 1.722222
+	@stack_top1 *= 1.722222
+	@stack_top2 *= 1.722222
+	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,3
+	@node_stack_top = #$stack_top_new$
+	!stack_top0 = DEL
+	!stack_top1 = DEL
+	!stack_top2 = DEL
+	!stack_top_new = DEL
+	
+	stack_top0 = #$node_stack_top2[0]$
+	stack_top1 = #$node_stack_top2[1]$
+	stack_top2 = #$node_stack_top2[2]$
+	@stack_top0 *= 1.722222
+	@stack_top1 *= 1.722222
+	@stack_top2 *= 1.722222
+	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top2[3]$,$node_stack_top2[4]$,$node_stack_top2[5]$,2
+	@node_stack_top2 = #$stack_top_new$
+	!stack_top0 = DEL
+	!stack_top1 = DEL
+	!stack_top2 = DEL
+	!stack_top_new = DEL
+	
+	stack_bottom0 = #$node_stack_bottom[0]$
+	stack_bottom1 = #$node_stack_bottom[1]$
+	stack_bottom2 = #$node_stack_bottom[2]$
+	@stack_bottom0 *= 1.722222
+	@stack_bottom1 *= 1.722222
+	@stack_bottom2 *= 1.722222
+	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,3
+	@node_stack_bottom = #$stack_bottom_new$
+	!stack_bottom0 = DEL
+	!stack_bottom1 = DEL
+	!stack_bottom2 = DEL
+	!stack_bottom_new = DEL
+	
+	stack_bottom0 = #$node_stack_bottom2[0]$
+	stack_bottom1 = #$node_stack_bottom2[1]$
+	stack_bottom2 = #$node_stack_bottom2[2]$
+	@stack_bottom0 *= 1.722222
+	@stack_bottom1 *= 1.722222
+	@stack_bottom2 *= 1.722222
+	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom2[3]$,$node_stack_bottom2[4]$,$node_stack_bottom2[5]$,2
+	@node_stack_bottom2 = #$stack_bottom_new$
+	!stack_bottom0 = DEL
+	!stack_bottom1 = DEL
+	!stack_bottom2 = DEL
+	!stack_bottom_new = DEL
 }
 @PART[mk2CargoBayS]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	@MODEL
-	{
-		scale = 1.722222, 1.722222, 1.722222
-	}
-	rescaleCube = 2
-	@DRAG_CUBE
-	{
-		rescaleX = 1.722222
-		rescaleY = 1.722222
-		rescaleZ = 1.722222
-	}
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.614583125, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_top2 = 0.0, 1.614583125, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.614583125, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_bottom2 = 0.0, -1.614583125, 0.0, 0, -1, 0, 1
-	@mass = 0.875
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
+	@mass /= 2.0
 }
 @PART[mk2Cockpit_Inline]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Fixes reversed Mk2 Cargo interior nodes #806
Enlarges Mk2 Cargo interior nodes for easier connections relative to their size
Applies the same dynamic node relocation from the Mk2 Cargo Bays to the Mk2 Cargo Bays