### PR TITLE
Sstu updates 0.3.26

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Orion.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_B_BPC]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-BPC]:FOR[RealismOverhaul] 
 {
 	%category = Engine
 	%RSSROConfig = True
@@ -70,7 +70,7 @@
 	}
 }
 
-@PART[SSTU_ShipCore_B_CM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-CM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -248,7 +248,7 @@
 	}
 }
 
-@PART[SSTU_ShipCore_B_SM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-SM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -433,7 +433,7 @@
 	}
 }
 
-@PART[SSTU_ShipCore_B_DPM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-GEN-DP-0P|SSTU-SC-GEN-DP-1P]:FOR[RealismOverhaul]
 {
 	@MODEL
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Upper Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU Upper Stages.cfg
@@ -386,7 +386,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 2
 		@maxThrust *= 2
@@ -445,7 +445,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 3
 		@maxThrust *= 3
@@ -504,7 +504,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 4
 		@maxThrust *= 4
@@ -575,7 +575,7 @@
 			layoutName = Five-X
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 5
 		@maxThrust *= 5
@@ -634,10 +634,19 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 2
 		@maxThrust *= 2
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+		@CONFIG,*
+		{
+			@minThrust *= 2
+			@maxThrust *= 2
+		}
 	}
 	@MODULE[SSTUNodeFairing]
 	{
@@ -693,7 +702,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 3
 		@maxThrust *= 3
@@ -752,7 +761,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 4
 		@maxThrust *= 4
@@ -823,7 +832,7 @@
 			layoutName = Five-X
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 5
 		@maxThrust *= 5
@@ -884,7 +893,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 7
 		@maxThrust *= 7
@@ -940,7 +949,7 @@
 			maxSize = 10
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 3
 		@maxThrust *= 3
@@ -1008,7 +1017,7 @@
 			layoutName = Five-X
 		}
 	}
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust *= 5
 		@maxThrust *= 5

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
@@ -998,6 +998,35 @@
 			amount = 0.500
 		}
 	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		configuration = RL10B-2
+		modded = false
+		type = ModuleEnginesRF
+		CONFIG
+		{
+			name = RL10B-2
+			minThrust = 111.2
+			maxThrust = 111.2
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.733
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.267
+			}
+			atmosphereCurve
+			{
+				key = 0 462
+				key = 1 235
+			}
+		}
+	}
 	@MODULE[ModuleGimbal]
 	{
 		%gimbalRange = 6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines.cfg
@@ -901,7 +901,7 @@
 	@description = Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators. Mount size can be adjusted from 1.25m to 10m in 1m increments.
 	@mass = 0.167
 	@maxTemp = 1973.15
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 92.5
 		@maxThrust = 92.5
@@ -970,7 +970,7 @@
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 111.2
 		@maxThrust = 111.2
@@ -1041,7 +1041,7 @@
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[SSTUDeployableEngine]
+	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 180
 		@maxThrust = 180

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_B_ICPS]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-ICPS]:FOR[RealismOverhaul]
 {
 	@MODEL
 	{
@@ -136,7 +136,7 @@
 		}
 	}
 }
-@PART[SSTU_ShipCore_B_HUS]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-HUS]:FOR[RealismOverhaul]
 {
 	@MODEL
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Saturn.cfg
@@ -1,7 +1,8 @@
-!PART[SSTU_ShipCore_ENG-J-2x5]:FOR[SSTU]
+!PART[SSTU_ShipCore_ENG-J-2x5]:BEFORE[RealismOverhaul]
 {
 }
-+PART[SSTU_ShipCore_ENG-J-2]:NEEDS[SSTU]:FINAL
+
++PART[SSTU_ShipCore_ENG-J-2]:NEEDS[SSTU]:FOR[RealismOverhaul]:FINAL
 {
 	@name = SSTU_ShipCore_ENG-J-2x5
 	@category = none
@@ -13,7 +14,7 @@
 	{
 		@defaultLayoutName = FiveCross
 		@defaultMount = S-II
-		@defaultEngineSpacing *= 1.5625
+		@defaultEngineSpacing *= 2.4414 // 1.5625 
 		!MOUNT,*{}
 		MOUNT
 		{
@@ -56,14 +57,16 @@
 	}
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust *= 5
 		@maxThrust *= 5
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
+		@origMass *= 5
 		@CONFIG,*
 		{
-		@minThrust *= 5
-		@maxThrust *= 5
+			@minThrust *= 5
+			@maxThrust *= 5
 		}
 	}
 	@MODULE[SSTUNodeFairing]
@@ -76,7 +79,7 @@
 		}
 	}
 }
-!PART[SSTU_ShipCore_ENG-J-2x4]:FOR[SSTU]
+!PART[SSTU_ShipCore_ENG-J-2x4]:BEFORE[RealismOverhaul]
 {
 }
 +PART[SSTU_ShipCore_ENG-J-2]:NEEDS[SSTU]:FINAL
@@ -134,14 +137,16 @@
 	}
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust *= 4
 		@maxThrust *= 4
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
+		@origMass *= 4
 		@CONFIG,*
 		{
-		@minThrust *= 4
-		@maxThrust *= 4
+			@minThrust *= 4
+			@maxThrust *= 4
 		}
 	}
 	@MODULE[SSTUNodeFairing]
@@ -154,7 +159,7 @@
 		}
 	}
 }
-!PART[SSTU_ShipCore_ENG-J-2x6]:FOR[SSTU]
+!PART[SSTU_ShipCore_ENG-J-2x6]:BEFORE[RealismOverhaul]
 {
 }
 +PART[SSTU_ShipCore_ENG-J-2]:NEEDS[SSTU]:FINAL
@@ -212,14 +217,16 @@
 	}
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust *= 6
 		@maxThrust *= 6
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
+		@origMass *= 6
 		@CONFIG,*
 		{
-		@minThrust *= 6
-		@maxThrust *= 6
+			@minThrust *= 6
+			@maxThrust *= 6
 		}
 	}
 	@MODULE[SSTUNodeFairing]
@@ -232,7 +239,7 @@
 		}
 	}
 }
-!PART[SSTU_ShipCore_ENG-J-2x7]:FOR[SSTU]
+!PART[SSTU_ShipCore_ENG-J-2x7]:BEFORE[RealismOverhaul]
 {
 }
 +PART[SSTU_ShipCore_ENG-J-2]:NEEDS[SSTU]:FINAL
@@ -278,14 +285,16 @@
 	}
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust *= 7
 		@maxThrust *= 7
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
+		@origMass *= 7
 		@CONFIG,*
 		{
-		@minThrust *= 7
-		@maxThrust *= 7
+			@minThrust *= 7
+			@maxThrust *= 7
 		}
 	}
 	@MODULE[SSTUNodeFairing]
@@ -298,7 +307,7 @@
 		}
 	}
 }
-!PART[SSTU_ShipCore_ENG-RL10A-3x6]:FOR[SSTU]
+!PART[SSTU_ShipCore_ENG-RL10A-3x6]:BEFORE[RealismOverhaul]
 {
 }
 +PART[SSTU_ShipCore_ENG-RL10A-3]:NEEDS[SSTU]:FINAL
@@ -356,14 +365,16 @@
 	}
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust *= 6
 		@maxThrust *= 6
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
+		@origMass *= 6
 		@CONFIG,*
 		{
-		@minThrust *= 6
-		@maxThrust *= 6
+			@minThrust *= 6
+			@maxThrust *= 6
 		}
 	}
 	@MODULE[SSTUNodeFairing]
@@ -376,7 +387,7 @@
 		}
 	}
 }
-!PART[SSTU_ShipCore_ENG-F1x2]:FOR[SSTU]
+!PART[SSTU_ShipCore_ENG-F1x2]:BEFORE[RealismOverhaul]
 {
 }
 +PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FINAL
@@ -439,8 +450,8 @@
 	{
 		@CONFIG,*
 		{
-		@minThrust *= 2
-		@maxThrust *= 2
+			@minThrust *= 2
+			@maxThrust *= 2
 		}
 	}
 	@MODULE[SSTUNodeFairing]
@@ -707,14 +718,15 @@
 	}
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust *= 5
 		@maxThrust *= 5
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
 		@CONFIG,*
 		{
-		@minThrust *= 5
-		@maxThrust *= 5
+			@minThrust *= 5
+			@maxThrust *= 5
 		}
 	}
 	@MODULE[SSTUNodeFairing]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -745,7 +745,7 @@
 	{
 	}
 }
-@PART[SSTU_ShipCore_MFT-A]:FOR[SSTU]:NEEDS[RealFuels]
+@PART[SSTU_ShipCore_MFT-A|SSTU_ShipCore_MFT-B]:FOR[SSTU]:NEEDS[RealFuels]
 {
 	%RSSROConfig = True
 	@MODULE[SSTUModularFuelTank]


### PR DESCRIPTION
Some (certainly not all) updates necessary to bring the RO up to date with the current version of SSTU.

A number of parts have changed names, and the deployable engine RL10's no longer use a custom module.

A number of issues still to be sorted, some I couldn't figure out.

The ICPS and HUS parts now seem to have the engine's separate, so they need to be moved from their current positions to sit proper and possibly be scaled.

There appear to be some duplicate engine clusters in the VAB, that might be conflicts between the code we have in RO to create the engine clusters and the code that is now in SSTU to generate clusters.

Many engine clusters now seem to be in a state of broken-ness. Most don't have the properly scaled thrust, many don't have the proper scaled mass, etc, etc. The J-2 x6 appears to be mostly sane, so I was studying that a bit, but to no avail.

@FFCJoseEduardo  ? 