### PR TITLE
RN DM fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
@@ -772,6 +772,8 @@
 	%skinMaxTemp = 3900
 	!MODULE[ModuleReactionWheel]
 	{ }
+	!MODULE[DescentModeModule]
+	{ }
 	
 	@MODULE[ModuleCommand]
 	{
@@ -895,6 +897,11 @@
 	
 		
 		
+	}
+	MODULE
+	{
+		name = CoMShifter
+		DescentModeCoM = 0, -0.4, -0.57
 	}
 
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
@@ -1577,6 +1577,8 @@
 	%skinMaxTemp = 2900
 	!MODULE[ModuleReactionWheel]
 	{ }
+	!MODULE[DescentModeModule]
+	{ }
 	!RESOURCE[Food]
 	{ }
 	!RESOURCE[Water]
@@ -1717,9 +1719,10 @@
 			key = 1 144.1
 		}
 	}
-	@MODULE[DescentModeModule]
+	MODULE
 	{
-       @DescentModeCoM = 0, -0.4, -0.15
+		name = CoMShifter
+		DescentModeCoM = 0, -0.4, -0.15
 	}
 }
 @PART[ok_sa]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
@@ -1808,6 +1811,8 @@
 	%maxTemp = 1073.5
 	%skinMaxTemp = 2900
 	!MODULE[ModuleReactionWheel]
+	{ }
+	!MODULE[DescentModeModule]
 	{ }
 	!RESOURCE[SolidFuel]
 	{
@@ -1940,9 +1945,10 @@
 			key = 1 144.1
 		}
 	}
-	@MODULE[DescentModeModule]
+	MODULE
 	{
-       @DescentModeCoM = 0, -0.4, -0.15
+		name = CoMShifter
+		DescentModeCoM = 0, -0.4, -0.15
 	}
 }
 @PART[rn_zond_sa]:NEEDS[RemoteTech]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_TKS.cfg
@@ -204,6 +204,9 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
+	!MODULE[DescentModeModule]
+	{
+	}
 	@RESOURCE[AblativeShielding]
 	{
 		@amount = 250
@@ -224,10 +227,6 @@
 	!RESOURCE[AblativeShielding] {}
 	!MODULE[ModuleGenerator]
 	{
-	}
-	%MODULE[DescentModeModule]
-	{
-       %DescentModeCoM = 0, -0.4, -0.25
 	}
 	%skinMassPerArea = 4
 	@MODULE[ModuleAblator]
@@ -293,6 +292,11 @@
 			amount = Full
 			maxAmount = 10000
 		}
+	}
+	MODULE
+	{
+		name = CoMShifter
+		DescentModeCoM = 0, -0.4, -0.25
 	}
 }
 @PART[rn_tks_rcs_block]:FOR[RealismOverhaul]


### PR DESCRIPTION
-Changed descent mode to use the built in RO module instead of bobcats
when RO is installed