### PR TITLE
CST-100 "Starliner" RO support

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
@@ -1,0 +1,102 @@
+//  ==================================================
+//  CST-100 main heat shield.
+
+//  Dimensions: 4.65 m x 0.9 m
+//  Gross Mass: 930 kg
+//  ==================================================
+
+@PART[CST-100?Heat?Shield]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/heatShield/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+	
+    @node_stack_top = 0.0, 0.465, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.515, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = CST-100 Heat Shield
+    @manufacturer = Boeing Co.
+    @description =  The main heat shield for CST-100 command module.
+
+    @mass = 0.13
+    @crashTolerance = 12
+    @maxTemp = 873.15
+    %skinMaxTemp = 3773.15
+    %stageOffset = 1
+    %chilStageOffset = 1
+    %stagingIcon = DECOUPLER_HOR
+    @bulkheadProfiles = size3
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 15
+    }
+
+    @MODULE[ModuleAblator]
+    {
+        @lossExp = -8000
+        @lossConst = 0.06
+        @pyrolysisLossFactor = 26000
+        %charMin = 0
+        %charMax = 1
+    }
+
+    @RESOURCE[Ablator]
+    {
+        @amount = 800
+        @maxAmount = 800
+    }	
+}
+
+//  ==================================================
+//  CST-100 forward nose cone.
+
+//  Dimensions: 2.03 m x 0.6 m
+//  Gross Mass: 70 Kg
+//  ==================================================
+
+@PART[cstNoseCone]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/noseCone/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = CST-100 Nose Cone
+    @manufacturer = Boeing Co.
+    @description = A protective nose cone for the CST-100 NASA Docking System.
+
+    @mass = 0.07
+    @crashTolerance = 14
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %fuelCrossFeed = False
+    %stageOffset = 1
+    %chilStageOffset = 1
+    %stagingIcon = DECOUPLER_HOR
+    @bulkheadProfiles = size2
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
@@ -20,8 +20,8 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 	
-    @node_stack_top = 0.0, 0.465, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.515, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.465, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.515, 0.0, 0.0, -1.0, 0.0, 3
 
     @title = CST-100 Heat Shield
     @manufacturer = Boeing Co.
@@ -93,7 +93,7 @@
     %stageOffset = 1
     %chilStageOffset = 1
     %stagingIcon = DECOUPLER_HOR
-    @bulkheadProfiles = size2
+    @bulkheadProfiles = size1
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -24,7 +24,7 @@
 
     @node_stack_top_1 = 0.0, 1.58, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_top_2 = 0.0, 1.289, 0.0, 0.0, 1.0, 0.0, 1
-    @node_stack_bottom = 0.0, -0.604, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.604, 0.0, 0.0, -1.0, 0.0, 3
 
     @title = CST-100 Command Module
     @manufacturer = Boeing Co.
@@ -36,7 +36,7 @@
     %breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
-    @bulkheadProfiles = size2, size1
+    @bulkheadProfiles = size1, size3
 
     @MODULE[ModuleCommand]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -1,0 +1,256 @@
+//  ==================================================
+//  CST-100 command module.
+
+//  Dimensions: 4.65 m x 2.6 m
+//  Gross Mass: 4500 Kg
+
+//  Source 1: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  ==================================================
+
+@PART[CST-100?capsule]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/commandModule/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top_1 = 0.0, 1.58, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_top_2 = 0.0, 1.289, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.604, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = CST-100 Command Module
+    @manufacturer = Boeing Co.
+    @description = The CST-100 command module is designed to be reusable for up to 10 times.
+
+    @mass = 4.3
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @bulkheadProfiles = size2, size1
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.725
+        }
+    }
+
+    !MODULE[ModuleReactionWheel]{}
+
+    MODULE
+    {
+        name = ModuleSAS
+        SASServiceLevel = 3
+    }
+
+    MODULE
+    {
+        name = CoMShifter
+        DescentModeCoM = 0.0, 0.0, -0.3
+    }
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 2.5
+    }
+
+    !MODULE[ModuleConductionMultiplier]{}
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.445
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 150.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 220
+            @key,1 = 1 82
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 350
+        basemass = -1
+
+        //  Electricity 45 kWh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 45000
+            maxAmount = 45000
+        }
+
+        //  Hydrazine 150 Kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 150
+            maxAmount = 150
+        }
+
+        //  Helium 4 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 22500
+            maxAmount = 22500
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  Connected Living Space compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:HAS[!MODULE[ModuleConnectedLivingSpace]]:AFTER[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
+{
+    MODULE
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = bottom
+    }
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:AFTER[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    MODULE
+    {
+        name = ModuleSPU
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1000000
+        EnergyCost = 0.005
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.2
+            PacketSize = 0.47
+            PacketResourceCost = 0.05
+        }
+    }
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:AFTER[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a crew of 7 for 2 days.:
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 550
+
+        TANK
+        {
+            name = Food
+            amount = 40.94
+            maxAmount = 81.88
+        }
+
+        TANK
+        {
+            name = Water
+            amount = 27.1
+            maxAmount = 27.1
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 4150
+            maxAmount = 4150
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 7.45
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 34.47
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 3580
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 5.18
+            maxAmount = 10.4
+        }
+    }
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        conversionRate = 7.0
+        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -1,0 +1,139 @@
+//  ==================================================
+//  Aerojet Rocketdyne RS - 88 engine.
+
+//  Dimensions: 0.65 m x 0.7 m
+//  Gross Mass: 220 Kg
+//  Throttle Range: N/A
+//  Burn Time: 110 s
+//  O/F Ratio: 1.65
+
+//  Source 1: http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
+//  Source 2: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
+//  Source 3: http://astronautix.com/engines/rs88.htm
+//  ==================================================
+
+@PART[RS88]:FOR[RealismOverhaul]
+{
+    %RSSROConfig - True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/RS88/model
+        scale = 1.26, 1.25, 1.26
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+
+    @title = RS - 88
+    @manufacturer = Aerojet Rocketdyne
+    @description = A hypergolic pressure - fed engine using MMH and NTO. Else known as Launch Abort Engine (LAE). Four of these engines are used by the CST-100 "Starliner" spacecraft for launch aborts and for orbital maneuvers.
+
+    @mass = 0.22
+    @crashTolerance = 10
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+	%heatConductivity = 0.06
+	@skinInternalConductionMult = 4.0
+	@emissiveConstant = 0.8
+    %stageOffset = 1
+    %chileStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
+    //%engineType = RS88
+    //%engineTypeMult = 4
+    //%ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 907.2
+        @maxThrust = 907.2
+        @heatProduction = 100
+        !fxOffset = NULL
+        %ullage = True
+        %pressureFed = True
+        %ignitions = 6
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 0.14
+        }
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+            @ratio = 0.499
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = MON3
+            @ratio = 0.501
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 150.0
+            DrawGauge = False
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 290
+            @key,1 = 1 220
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RS-88
+        modded = False
+        origMass = 0.22
+
+        CONFIG
+        {
+            name = RS-88
+            minThrust = 907.2
+            maxThrust = 907.2
+            heatProduction = 100
+            massMult = 1.0
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.499
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = MON3
+                ratio = 0.501
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 150.0
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 290
+                key = 1 220
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -14,7 +14,7 @@
 
 @PART[RS88]:FOR[RealismOverhaul]
 {
-    %RSSROConfig - True
+    %RSSROConfig = True
 
     !mesh = NULL
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
@@ -23,8 +23,8 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.195, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.85, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.195, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.85, 0.0, 0.0, -1.0, 0.0, 3
     @node_stack_bottom_2 = 0.0, -1.445, 0.0, 0.0, -1.0, 0.0, 1
 
     @title = CST-100 Service Module
@@ -37,7 +37,7 @@
     @breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
-    @bulkheadProfiles = size2
+    @bulkheadProfiles = size1, size3
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
@@ -1,0 +1,137 @@
+//  ==================================================
+//  CST-100 service module.
+
+//  Dimensions: 5.4 m x 2.5 m
+//  Gross Mass: 7340 Kg
+
+//  Source 1: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//  Source 2: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  ==================================================
+
+@PART[CST-100?Service?Module]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/serviceModule/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.195, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.85, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom_2 = 0.0, -1.445, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = CST-100 Service Module
+    @manufacturer = Boeing Co.
+    @description = The service module for the CST-100 spacecraft.
+
+    @mass = 2.1
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @bulkheadProfiles = size2
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5
+    }
+	
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.22
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.4989
+        }
+
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.5066
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 150.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 220
+            @key,1 = 1 100
+        }
+    }
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 1.0
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4750
+        basemass = -1
+
+        //  Electricity 45 kWh
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 45000
+            maxAmount = 45000
+        }
+
+        //  Water 200 Kg.
+
+        TANK
+        {
+            name = Water
+            amount = 200
+            maxAmount = 200
+        }
+
+        //  Fuel 1920 Kg.
+
+        TANK
+        {
+            name = MMH
+            amount = 2180
+            maxAmount = 2180
+        }
+
+        //  Oxidizer 3115 Kg.
+
+        TANK
+        {
+            name = MON3
+            amount = 2190
+            maxAmount = 2190
+        }
+
+        //  Helium 116 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 25000
+            maxAmount = 25000
+        }
+    }
+
+    !RESOURCE,*{}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
@@ -1,0 +1,125 @@
+//  ==================================================
+//  CST-100 structural adapter (3.05 m).
+
+//  Dimensions: 5.4 m x 2.7 m
+//  Gross Mass: 120 Kg
+//  ==================================================
+
+@PART[2.5mAdapter]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/2.5mAdapter/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.16, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.51, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = CST-100 Atlas Adapter
+    @manufacturer = Boeing Co.
+    @description = A structural adapter to connect the service module of the CST-100 to the Atlas V launch vehicles.
+
+    @mass = 0.12
+    @crashTolerance = 14
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size2
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5
+    }
+}
+
+//  ==================================================
+//  CST-100 structural adapter (4.6 m).
+
+//  Dimensions: 5.4 m x 2 m
+//  Gross Mass: 90 Kg
+//  ==================================================
+
+@PART[3.75mAdapter]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/3.75mAdapter/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.84, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.11, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = CST-100 4M Adapter
+    @manufacturer = Boeing Co.
+    @description = A structural adapter to connect the service module of the CST-100 to 4.65m parts.
+
+    @mass = 0.09
+    @crashTolerance = 14
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size2
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5
+    }
+}
+
+//  ==================================================
+//  CST-100 structural adapter (3.75 m).
+
+//  Dimensions: 5.4 m x 2.5 m
+//  Gross Mass: 100 Kg
+//  ==================================================
+
+@PART[AtlasVAdapter]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/atlasVAdapter/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.16, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.325, 0.0, 0.0, -1.0, 0.0, 3
+
+    @title = CST-100 3M Adapter
+    @manufacturer = Boeing Co.
+    @description = A structural adapter to connect the service module of the CST-100 to 3.75m parts.
+
+    @mass = 0.1
+    @crashTolerance = 14
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size3
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
@@ -20,8 +20,8 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.16, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.51, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.16, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.51, 0.0, 0.0, -1.0, 0.0, 3
 
     @title = CST-100 Atlas Adapter
     @manufacturer = Boeing Co.
@@ -32,7 +32,7 @@
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
     %stagingIcon = DECOUPLER_HOR
-    %bulkheadProfiles = size2
+    %bulkheadProfiles = size3
 
     @MODULE[ModuleDecouple]
     {
@@ -62,8 +62,8 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.84, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.11, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.84, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.11, 0.0, 0.0, -1.0, 0.0, 3
 
     @title = CST-100 4M Adapter
     @manufacturer = Boeing Co.
@@ -74,7 +74,7 @@
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
     %stagingIcon = DECOUPLER_HOR
-    %bulkheadProfiles = size2
+    %bulkheadProfiles = size3
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
@@ -1,0 +1,365 @@
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
+
+!PART[ndsport2]:FOR[RealismOverhaul]{}
+
+//  ==================================================
+//  CST-100 parachute pack.
+
+//  Dimensions: 2.7 m x 0.65 m
+//  Gross Mass: 280 Kg
+//  ==================================================
+
+@PART[cstparachute]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/cstParachute/model
+        scale = 1.24, 1.24, 1.24
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = CST-100 Parachute Pack
+    @manufacturer = Boeing Co.
+    @description = The parachute pack for the CST-100 command module.
+
+    @mass = 0.28
+    %crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @stageOffset = 1
+    @childStageOffset = 1
+    %stagingIcon = PARACHUTES
+    @bulkheadProfiles = size2
+
+    @MODULE[ModuleParachute]
+    {
+        @deployAltitude = 1000
+        @chuteMaxTemp = 400
+    }
+
+    MODULE
+    {
+        name = ModuleDragModifier
+        dragCubeName = SEMIDEPLOYED
+        dragModifier = 15
+    }
+
+    @MODULE[ModuleDragModifier]
+    {
+        @dragModifier = 150
+    }
+}
+
+//  ==================================================
+//  CST-100 parachute pack.
+
+//  Real Chute compatibility.
+//  ==================================================
+
+@PART[cstparachute]:AFTER[RealismOverhaul]:NEEDS[RealChute]
+{
+    !sound_parachute_open = NULL
+
+    @category = none
+
+    !MODULE[ModuleParachute]{}
+
+    MODULE
+    {
+        name = RealChuteModule
+        caseMass = 0.2
+        timer = 0
+        mustGoDown = True
+        spareChutes = 0
+        cutSpeed = 0.5
+        secondaryChute = False
+
+        PARACHUTE
+        {
+            material = Nylon
+            preDeployedDiameter = 3.5
+            deployedDiameter = 41
+            minIsPressure = False
+            minDeployment = 3200
+            deploymentAlt = 750
+            cutAlt = -1
+            preDeploymentSpeed = 2
+            deploymentSpeed = 6
+            preDeploymentAnimation = semiDeploy
+            deploymentAnimation = fullyDeploy
+            parachuteName = canopy
+            capName = cap
+        }
+    }
+
+    EFFECTS
+    {
+        rcpredeploy
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_parachute_open
+                volume = 1
+            }
+        }
+
+        rcdeploy
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_parachute_single
+                volume = 1
+            }
+        }
+
+        rccut
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealChute/Sounds/sound_parachute_cut
+                volume = 1
+            }
+        }
+
+        rcrepack
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealChute/Sounds/sound_parachute_repack
+                volume = 1
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  NASA Docking System (passive).
+
+//  Dimensions: 1.72 m x 0.5 m
+//  Gross Mass: 200 Kg
+//  ==================================================
+
+@PART[ndsport1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/nds/NDS1/ndsport1
+        scale = 0.69, 0.69, 0.69
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.25, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+    @title = NASA Docking System [Passive]
+    @manufacturer = Boeing Co.
+    @description = The NASA Docking System (NDS) is a spacecraft docking and berthing mechanism for US human spaceflight vehicles, such as the Orion Multi-Purpose Crew Vehicle and the Commercial Crew vehicles.
+
+    @mass = 0.2
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 773.15
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NASADock
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+        @stagingEnabled = False
+	}
+}
+
+//  ==================================================
+//  NASA Docking System (active).
+
+//  Dimensions: 1.72 m x 0.5 m
+//  Gross Mass: 200 Kg
+//  ==================================================
+
+@PART[ndsport3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/nds/NDS1/ndsport3
+        scale = 1.295, 1.295, 1.295
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.336, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+    @title = NASA Docking System [Active]
+    @manufacturer = Boeing Co.
+    @description = The NASA Docking System (NDS) is a spacecraft docking and berthing mechanism for US human spaceflight vehicles, such as the Orion Multi-Purpose Crew Vehicle and the Commercial Crew vehicles.
+
+    @mass = 0.2
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 773.15
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NASADock
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+        @stagingEnabled = False
+	}
+}
+
+//  ==================================================
+//  NASA Docking System (NDS).
+
+// Connected Living Space compatibility.
+//  ==================================================
+
+@PART[ndsport1|ndsport3]:HAS[!MODULE[ModuleConnectedLivingSpace]]:AFTER[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
+{
+    MODULE
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        passableWhenSurfaceAttached = True
+    }
+}
+
+//  ==================================================
+//  International Docking Adapter.
+
+//  Dimensions: 1.72 m x 0.65 m
+//  Gross Mass: 530 Kg
+
+//  Source 1: https://www.nasa.gov/sites/default/files/atoms/files/spacex_crs7_mission_overview.pdf
+//  ==================================================
+
+@PART[idaONE]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CST-100/Parts/ida/idaONE
+        scale = 1.295, 1.295, 1.295
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, -0.03, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.545, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = NASA International Docking Adapter
+    @manufacturer = NASA
+    @description = The International Docking Adapter (IDA) is a spacecraft docking system adapter being developed to convert APAS-95 to the NASA Docking System (NDS)/ International Docking System Standard (IDSS).
+
+    @mass = 0.53
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 773.15
+    @bulkheadProfiles = size1, srf
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = APAS8995
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+        @stagingEnabled = False
+    }
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NDS
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+        @stagingEnabled = False
+    }
+}
+
+//  ==================================================
+//  International Docking Adapter.
+
+// Connected Living Space compatibility.
+//  ==================================================
+
+@PART[idaONE]:HAS[!MODULE[ModuleConnectedLivingSpace]]:AFTER[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
+{
+    MODULE
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
@@ -42,7 +42,7 @@
     @stageOffset = 1
     @childStageOffset = 1
     %stagingIcon = PARACHUTES
-    @bulkheadProfiles = size2
+    @bulkheadProfiles = size1
 
     @MODULE[ModuleParachute]
     {
@@ -185,6 +185,7 @@
     %breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 773.15
+    %bulkheadProfiles = srf, size1
 
     @MODULE[ModuleDockingNode]
     {
@@ -240,6 +241,7 @@
     %breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 773.15
+    %bulkheadProfiles = srf, size1
 
     @MODULE[ModuleDockingNode]
     {
@@ -312,7 +314,7 @@
     %breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 773.15
-    @bulkheadProfiles = size1, srf
+    @bulkheadProfiles = srf, size1
 
     @MODULE[ModuleDockingNode]
     {


### PR DESCRIPTION
* Add RO support for the CST-100 "Starliner" pack.

NOTE 1: Due to the SM collider, the CM separation might be a bit energetic.
NOTE 2: The NDS aerodynamic cover colliders are convex so be careful with it's extreme lag.