### PR TITLE
Vanguard probe science core

### DIFF
--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -38,10 +38,6 @@
 			@rate = 0.001
 		}
 	}
-	MODULE:NEEDS[RP-0]
-	{
-		name = ModuleScienceCore
-	}
 }
 
 // Have RemoteTech? Then have an SPU, with an integrated antenna


### PR DESCRIPTION
* Remove the science core module from the Vanguard probe core (should be
part of RP-0).