### PR TITLE
CO2 Scrubber for Skylab

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -79,8 +79,8 @@
 			TANK
 			{
 				name = ElectricCharge
-				amount = 30000
-				maxAmount = 30000
+				amount = 100000
+				maxAmount = 100000
 			}
 			TANK
 			{
@@ -97,54 +97,48 @@
 			TANK
 			{
 				name = Oxygen
-				amount = 1065312
-				maxAmount = 1065312
+				amount = 177552	//50 days for 6 crew
+				maxAmount = 177552
 			}
 			TANK
 			{
 				name = Water
-				amount = 6967.3
+				amount = 6967.3	//300 days for 6 crew
 				maxAmount = 6967.3
 			}
 			TANK
 			{
 				name = Food
-				amount = 10528.7
+				amount = 10528.7	//300 days for 6 crew
 				maxAmount = 10528.7
-			}
-			TANK
-			{
-				name = LithiumHydroxide
-				amount = 1849.1
-				maxAmount = 1849.1
 			}
 			TANK
 			{
 				name = CarbonDioxide
 				amount = 0
-				maxAmount = 3069
+				maxAmount = 3069	//1 day for 6 crew
 			}
 			TANK
 			{
 				name = Waste
 				amount = 0
-				maxAmount = 6940.9
+				maxAmount = 1380.3	//300 days for 6 crew including CO2-O2 Converter
 			}
 			TANK
 			{
 				name = WasteWater
 				amount = 0
-				maxAmount = 8864.6
+				maxAmount = 8864.6	//300 days for 6 crew
 			}
 	}
 
 	MODULE
 	{
 		name = TacGenericConverter
-		converterName = CO2 Scrubber
+		converterName = CO2-O2 Converter
 		conversionRate = 6.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
-		outputResources = Waste, 0.00003847, false
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010	// See RO Github #844 for explanation of values
+		outputResources = Oxygen, 0.0071565375, true, Waste, 0.0000027155975, true	// See RO Github #844 for explanation of values
 	}
 
 	@MODULE[ModuleRCS]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -97,39 +97,54 @@
 			TANK
 			{
 				name = Oxygen
-				amount = 1070000
-				maxAmount = 1070000
+				amount = 1065312
+				maxAmount = 1065312
 			}
 			TANK
 			{
 				name = Water
-				amount = 7700
-				maxAmount = 7700
+				amount = 6967.3
+				maxAmount = 6967.3
 			}
 			TANK
 			{
 				name = Food
-				amount = 7384.10
-				maxAmount = 7384.10
+				amount = 10528.7
+				maxAmount = 10528.7
+			}
+			TANK
+			{
+				name = LithiumHydroxide
+				amount = 1849.1
+				maxAmount = 1849.1
 			}
 			TANK
 			{
 				name = CarbonDioxide
 				amount = 0
-				maxAmount = 1040
+				maxAmount = 3069
 			}
 			TANK
 			{
 				name = Waste
 				amount = 0
-				maxAmount = 893
+				maxAmount = 6940.9
 			}
 			TANK
 			{
 				name = WasteWater
 				amount = 0
-				maxAmount = 735
+				maxAmount = 8864.6
 			}
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003847, false
 	}
 
 	@MODULE[ModuleRCS]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -79,8 +79,8 @@
 			TANK
 			{
 				name = ElectricCharge
-				amount = 100000
-				maxAmount = 100000
+				amount = 705600	//http://pages.erau.edu/~ericksol/projects/issa/skylab.html#Skylab%20Systems
+				maxAmount = 705600
 			}
 			TANK
 			{
@@ -97,38 +97,38 @@
 			TANK
 			{
 				name = Oxygen
-				amount = 177552	//50 days for 6 crew
-				maxAmount = 177552
+				amount = 1588652.5	//2240kg   http://pages.erau.edu/~ericksol/projects/futurspcrft/sp/intro.html
+				maxAmount = 1588652.5
 			}
 			TANK
 			{
 				name = Water
-				amount = 6967.3	//300 days for 6 crew
-				maxAmount = 6967.3
+				amount = 2700	//2700kg   http://pages.erau.edu/~ericksol/projects/futurspcrft/sp/intro.html
+				maxAmount = 2700
 			}
 			TANK
 			{
 				name = Food
-				amount = 10528.7	//300 days for 6 crew
-				maxAmount = 10528.7
+				amount = 2384.1	//670kg   http://pages.erau.edu/~ericksol/projects/futurspcrft/sp/intro.html
+				maxAmount = 2384.1
 			}
 			TANK
 			{
 				name = CarbonDioxide
 				amount = 0
-				maxAmount = 3069	//1 day for 6 crew
+				maxAmount = 3068.9	//1 day for 6 crew
 			}
 			TANK
 			{
 				name = Waste
 				amount = 0
-				maxAmount = 1380.3	//300 days for 6 crew including CO2-O2 Converter
+				maxAmount = 391.1	//170 days for 3 crew including CO2-O2 Converter
 			}
 			TANK
 			{
 				name = WasteWater
 				amount = 0
-				maxAmount = 8864.6	//300 days for 6 crew
+				maxAmount = 2511.7	//170 days for 3 crew
 			}
 	}
 


### PR DESCRIPTION
Adding a TACLS CO2 Scrubber to the Skylab since I have to assume it had one.  I've used the same scrubber that we have on the FASAApollo_CM part, though I've adjusted the conversaionRate up to 6 to account for the 6 crew capacity on the Skylab.  This will result in twice as much CO2 and LithiumHydroxide being used, with twice as much Waste being generated.

I've also reset the LS quantities so there should be 300 days worth of LS (1 day worth of CO2), including running the scrubber.