### PR TITLE
Science lab for Skylab

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -132,6 +132,37 @@
 			}
 	}
 
+	MODULE
+	{
+		name = ModuleScienceLab
+		containerModuleIndex = 3
+		dataStorage = 1000
+		crewsRequired = 1
+		canResetConnectedModules = True
+		canResetNearbyModules = True
+		interactionRange = 5
+		SurfaceBonus = 0.1
+		ContextBonus = 0.25
+		homeworldMultiplier = 0.1
+		RESOURCE_PROCESS
+		{
+			name = ElectricCharge
+			amount = 2.72
+		}
+	}
+	MODULE
+	{
+		name = ModuleScienceConverter
+		scientistBonus = 0.25	//Bonus per scientist star - need at least one! So 0.25x - 2.5x 
+		researchTime = 6	    //Larger = slower.  Exponential!
+		scienceMultiplier = 5	//How much science does data turn into?
+		scienceCap = 1000	    //How much science can we store before having to transmit?		
+		powerRequirement = 1.36	//EC/Sec to research
+		ConverterName = Research
+		StartActionName = Start Research
+		StopActionName = Stop Research
+	}
+
 	@MODULE[ModuleRCS]
 	{
 		@name = ModuleRCS


### PR DESCRIPTION
This adds a ScienceLab and ScienceConverter to Skylab.  I've pulled the config from Squad Large_Crewed_Lab with a couple modifications.
1) I doubled the dataStorage and scienceCap since Skylab has twice the crew capacity.
2) I've reduced the researchTime to 6 so that science will be produced slightly faster then the Squad lab.
3) I've reduced the ElectricCharge need for the lab and converter to 27.2% of the Squad lab.  I used 27.2% because the main skylab solar panels in RO are producing 27.2% of the EC they do in "stock" (6.8/s vs 25/s)

I've run a few tests and these values seem to work but they may require a bit of fine tuning.