### PR TITLE
RN bobcat remove

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -57,7 +57,6 @@
 		{ "name" : "NearFutureSolar" },
 		{ "name" : "NearFutureSpacecraft" },
 		{ "name" : "PorkjetHabitats" },
-		{ "name" : "Proton-Bobcat" },
 		{ "name" : "Proton-OLDD" },
 		{ "name" : "RLA-Stockalike" },
 		{ "name" : "RocketdyneF-1" },


### PR DESCRIPTION
-Remove bobcat's proton for broken concave colliders in ksp 1.0.5+ until
such a time as they are fixed.