### PR TITLE
SSTU-updates 0.3.27

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
@@ -263,6 +263,10 @@
 		@mainRetractedScale = 0.0078, 0.0078, 0.0078
 		@mainSemiDeployedScale = 0.468, 2.34, 0.468
 		@mainFullDeployedScale = 2.34, 2.34, 2.34
+		@drogueSemiDeployArea = 10
+		@drogueFullDeployArea = 103
+		@mainSemiDeployArea = 258
+		@mainFullDeployArea = 2586
 		@DROGUECHUTE[Generic],0
 		{
 			@localPosition = 0.2886, 0.8268, 0.7644

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -402,22 +402,6 @@
 	}
 	MODULE
 	{
-		name = SSTUSelectableNodes
-		nodeName = ICPS1
-		startsEnabled = true
-		nodeDefaultOrientation = 0,-1,0
-		nodeDefaultPosition = 0,-3.5727991068,0
-	}
-	MODULE
-	{
-		name = SSTUSelectableNodes
-		nodeName = EUS1
-		startsEnabled = false
-		nodeDefaultOrientation = 0,-1,0
-		nodeDefaultPosition = 0,-2.5178660372,0
-	}
-	MODULE
-	{
 		name = SSTUNodeFairing
 		diffuseTextureName = SSTU/Assets/LC-ISA-DIFF
 		normalTextureName = SSTU/Assets/LC-ISA-NRM
@@ -435,6 +419,22 @@
 			numOfSections = 4
 			jettisonDirection = 0,0,1
 		}
+	}
+	MODULE
+	{
+		name = SSTUSelectableNodes
+		nodeName = ICPS1
+		startsEnabled = true
+		nodeDefaultOrientation = 0,-1,0
+		nodeDefaultPosition = 0,-3.5727991068,0
+	}
+	MODULE
+	{
+		name = SSTUSelectableNodes
+		nodeName = EUS1
+		startsEnabled = false
+		nodeDefaultOrientation = 0,-1,0
+		nodeDefaultPosition = 0,-2.5178660372,0
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -7,6 +7,7 @@
 		%scale = 1.333333,1.333333,1.333333
 	}
 	//%rescaleFactor = 1.25
+	@node_stack_bottom = 0,-1.15290666637844,0,0,-1,0,5
 	@title = Orion Launch Escape Assembly
 	%manufacturer = ATK
 	@description = The LEA provides the means for separation the CM from the launch vehicle during pad or suborbital aborts. This assembly consists of a Q-ball instrumentation assembly, ballast compartment, canard surfaces, pitch control motor, tower jettison motor, launch escape motor, a structural skirt, an open-frame tower, and a boost protective cover.
@@ -104,6 +105,13 @@
 			name = ElectricCharge
 			rate = 2.00 // needs to be adjusted to match Orion avionics/LS draw
 		}
+	}
+	@MODULE[SSTUModularParachute]
+	{
+		@drogueSemiDeployArea = 13
+		@drogueFullDeployArea = 130
+		@mainSemiDeployArea = 320
+		@mainFullDeployArea = 3261
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Soyuz.cfg
@@ -1,0 +1,64 @@
+@PART[SSTU-SC-C-BPC]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL,*
+	{
+		%scale = 1.333333,1.333333,1.333333
+	}
+	@node_stack_bottom = 0,-2.778983857,0,0,-1,0,2
+	@mass = 2
+	@title = Soyuz SAS (WIP)
+}
+
+@PART[SSTU-SC-C-OM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL,0
+	{
+		%scale = 1.333333,1.333333,1.333333
+	}
+	@MODEL,1
+	{
+		@position = 0, 1.0531840337, 0
+		@scale = 0.666665, 0.666665, 0.666665
+	}
+	@node_stack_top = 0,1.11179,0,0,1,0,2
+	@node_stack_bottom = 0,-1.03544078,0,0,-1,0,2
+	@mass = 1.3
+	@title = Soyuz Orbital Module (WIP)
+	@CrewCapacity = 3
+}
+
+@PART[SSTU-SC-C-DM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL,*
+	{
+		%scale = 1.333333,1.333333,1.333333
+	}
+	@node_stack_top = 0,1.224609,0,0,1,0,2
+	@node_stack_bottom = 0,-0.40702,0,0,-1,0,2
+	@mass = 2.6
+	@title = Soyuz Descent Module (WIP)
+	@CrewCapacity = 3
+	@MODULE[SSTUModularParachute]
+	{
+		@drogueSemiDeployArea = 5
+		@drogueFullDeployArea = 51
+		@mainSemiDeployArea = 129
+		@mainFullDeployArea = 1295
+	}
+}
+
+@PART[SSTU-SC-C-SM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL,*
+	{
+		%scale = 1.333333,1.333333,1.333333
+	}
+	@node_stack_top = 0,1.6474650,0,0,1,0,2
+	@node_stack_bottom = 0,-0.75411,0,0,-1,0,2
+	@mass = 1.8
+	@title = Soyuz Service Module (WIP)	
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
@@ -1,11 +1,10 @@
 @PART[SSTU-SC-B-SM]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-     !EFFECTS{}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-	}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        %powerEffectName = Hypergolic-OMS-White
+    }
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
@@ -19,24 +18,10 @@
         name = Hypergolic-OMS-White
         transformName = SC-B-SM-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,2.0
-        fixedScale = 2 // 0.8
+        localPosition = 0,0,0.25
+		//adjust these directly to rescale/etc the plume
+        fixedScale = 2
         energy = 1
         speed = 1.2
     }
-}
-
-@PART[SSTU-SC-B-SM]:FOR[RealPlume]:NEEDS[zzRealPlume]
-{
-	@EFFECTS
-		{
-			@Hypergolic-OMS-White
-			{
-				@MODEL_MULTI_PARTICLE_PERSIST[flare]
-				{
-					@localPosition = 0,0,2.3
-					@fixedScale = 1.9
-				}
-			}
-		}
-}
+} 


### PR DESCRIPTION
* Fix Orion Service Module RealPlumes config
* Fix fairing attach setup for selectable nodes for Orion Service Module
  * WARNING - This change re-orders some modules and may break existing craft using this part
* add parachute area stats for Apollo CM parachute module for RO scaled mass (FAR and stock compatible)
* add parachute area stats for Orion CM parachute module for RO scaled mass (FAR and stock compatible)
* fix Orion Launch Abort System lower node position being too far up
* add WIP config for Series-C (Soyuz) parts.  I'm a bit lost on most of it, but they are scaled properly, attach nodes are in the right positions, mass is... close...; DM parachute is set for 6m/s touchdown at 2.9t total mass (need to account for that in the ablator mass/etc)