### PR TITLE
SSTU-Orion-CM/SM-Fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -159,3 +159,18 @@
 		}
 	}
 }
+
+@PART[SSTU_LanderCore_LC-ISA]:FOR[RealismOverhaul] // Petal Adapter
+{
+	%RSSROConfig = True
+
+	@MODULE[SSTUInterstageFairing]
+	{
+		@currentHeight = 10
+		@bottomRadius = 4.2
+		@topRadius = 2.75
+		
+		@massPerBaseCubicMeter = 0.05
+		@massPerPanelArea = 0.0025
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -97,6 +97,8 @@
 	@maxTemp = 500
 	@CoMOffset = 0.0, -0.5, 0.0
 	
+	!MODULE[ModuleReactionWheel] {}
+	
 	@MODULE[ModuleCommand]
 	{
 		@minimumCrew = 0
@@ -342,7 +344,7 @@
 		}
 	}
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS],*
 	{
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		@thrusterPower = 0.712


### PR DESCRIPTION
Remove reaction wheel from Orion CM

Fix SM RCS, all directions should now work.