### PR TITLE
Add SXT Station and Base parts configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -661,7 +661,7 @@
     @node_stack_bottom,2 = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = CANIOT-7 Crew Cabin
-    @description = Probodobodyne Inc's first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
+    @description = Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5
     @maxTemp = 1073.15
@@ -691,7 +691,7 @@
 }
 
 //  ==================================================
-//  Ares LK-S3E Heavy Habitat.
+//  Caniot Heavy Orbital Habitat.
 
 //  TAC Life Support configuration.
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -145,7 +145,7 @@
     @node_stack_bottom,2 = 0.0, -1.09, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = PPD-4 Crew Cabin
-    @description = A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
+    @description = Hold 2 people with one month of supplies. A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
 
     @mass = 3.5
     @maxTemp = 1073.15
@@ -160,7 +160,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 20
+        volume = 50
         basemass = -1
 
         TANK
@@ -189,21 +189,21 @@
 		TANK
 		{
 			name = Food
-			amount = 11.7
+			amount = 175
 			maxAmount = 175
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 7.75
+			amount = 116
 			maxAmount = 116
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 1183.7
+			amount = 17755
 			maxAmount = 17755
 		}
 
@@ -231,7 +231,7 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 1.5
+			amount = 22.5
 			maxAmount = 22.5
 		}
 	}
@@ -274,7 +274,7 @@
     @node_stack_bottom,2 = 0.0, -1.63, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = PPD-6 Crew Cabin
-    @description = A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
+    @description = Hold 4 people with one month of supplies. A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
 
     @mass = 6.8
     @maxTemp = 1073.15
@@ -289,7 +289,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 40
+        volume = 100
         basemass = -1
 
         TANK
@@ -318,22 +318,22 @@
 		TANK
 		{
 			name = Food
-			amount = 11.7
+			amount = 525
 			maxAmount = 525
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 7.75
+			amount = 348
 			maxAmount = 348
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 1183.7
-			maxAmount = 53265
+			amount = 74000
+			maxAmount = 74000
 		}
 
 		TANK
@@ -360,7 +360,7 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 1.5
+			amount = 67.5
 			maxAmount = 67.5
 		}
 	}
@@ -403,7 +403,7 @@
     @node_stack_bottom,2 = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = Skylab Heavy Orbital Habitat
-    @description = A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies.
+    @description = Hold 8 peole with 155 days (5 months) of supplies. A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies.
 
     @mass = 28
     @maxTemp = 1073.15
@@ -418,7 +418,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 100
+        volume = 2000
         basemass = -1
 
         TANK
@@ -447,22 +447,22 @@
 		TANK
 		{
 			name = Food
-			amount = 117
-			maxAmount = 6418
+			amount = 7050
+			maxAmount = 7050
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 77.5
+			amount = 4644
 			maxAmount = 4644
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 11837
-			maxAmount = 710208
+			amount = 735000
+			maxAmount = 735000
 		}
 
 		TANK
@@ -489,7 +489,7 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 15
+			amount = 450
 			maxAmount = 450
 		}
 	}
@@ -532,7 +532,7 @@
     @node_stack_bottom,2 = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = Ares LK-S3E Heavy Planetary Habitat
-    @description = A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, and even a home gym.
+    @description = Hold 8 people with 50 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, and even a home gym.
 
     @mass = 12.0
     @maxTemp = 1073.15
@@ -547,7 +547,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 100
+        volume = 1000
         basemass = -1
 
         TANK
@@ -576,22 +576,22 @@
 		TANK
 		{
 			name = Food
-			amount = 11.7
+			amount = 2100
 			maxAmount = 2100
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 7.75
+			amount = 1393.5
 			maxAmount = 1393.5
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 1183.7
-			maxAmount = 213060
+			amount = 235000
+			maxAmount = 235000
 		}
 
 		TANK
@@ -618,7 +618,7 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 1.5
+			amount = 135
 			maxAmount = 135
 		}
 	}
@@ -661,7 +661,7 @@
     @node_stack_bottom,2 = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = CANIOT-7 Crew Cabin
-    @description = Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
+    @description = Hold 6 people with 60 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5
     @maxTemp = 1073.15
@@ -676,7 +676,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 100
+        volume = 800
         basemass = -1
 
         TANK
@@ -705,22 +705,22 @@
 		TANK
 		{
 			name = Food
-			amount = 11.7
-			maxAmount = 1800
+			amount = 1880
+			maxAmount = 1880
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 7.75
-			maxAmount = 1194.43
+			amount = 1250
+			maxAmount = 1250
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 1183.7
-			maxAmount = 182623
+			amount = 212000
+			maxAmount = 212000
 		}
 
 		TANK
@@ -747,7 +747,7 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 1.5
+			amount = 115.7
 			maxAmount = 115.7
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -126,3 +126,638 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+@PART[SXTCrewCabSSP10]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 1.640, 1.640, 1.640
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.01, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom,2 = 0.0, -1.09, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = PPD-4 Crew Cabin
+    @description = A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
+
+    @mass = 3.5
+    @maxTemp = 1073.15
+    !vesselType = NULL
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 3.25
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 20
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 21600
+            maxAmount = 21600
+        }
+    }
+
+    !RESOURCE[ElectricCharge]{}
+}
+
+//  ==================================================
+//  SSP-10 storage container.
+
+//  TAC Life Support configuration.
+//  ==================================================
+
+@PART[SXTCrewCabSSP10]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 1300
+
+		TANK
+		{
+			name = Food
+			amount = 11.7
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 7.75
+			maxAmount = 116
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 1183.7
+			maxAmount = 17755
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 15344.5
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 16
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 147.75
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 1.5
+			maxAmount = 22.5
+		}
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0
+		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+//  ==================================================
+//  SSP-20 storage container.
+
+//  Realism Overhaul configuration.
+
+//  Dimensions: 4.0 m x 5.0 m
+//  Gross Mass: 6800.0 Kg
+//  ==================================================
+
+@PART[SXTCrewCabSSP20]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.59, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom,2 = 0.0, -1.63, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = PPD-6 Crew Cabin
+    @description = A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
+
+    @mass = 6.8
+    @maxTemp = 1073.15
+    !vesselType = NULL
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 3.25
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 40
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 32000
+            maxAmount = 32000
+        }
+    }
+
+    !RESOURCE[ElectricCharge]{}
+}
+
+//  ==================================================
+//  SSP-20 storage container.
+
+//  TAC Life Support configuration.
+//  ==================================================
+
+@PART[SXTCrewCabSSP20]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 3000
+
+		TANK
+		{
+			name = Food
+			amount = 11.7
+			maxAmount = 525
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 7.75
+			maxAmount = 348
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 1183.7
+			maxAmount = 53265
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 46034
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 47.91
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 443.235
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 1.5
+			maxAmount = 67.5
+		}
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0
+		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+//  ==================================================
+//  Skylab storage container.
+
+//  Realism Overhaul configuration.
+
+//  Dimensions: 6.6 m x 7.0 m
+//  Gross Mass: 28000.0 Kg
+//  ==================================================
+
+@PART[SXTISSHabISK30]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 1.762, 1.762, 1.762
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 3.35, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom,2 = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Skylab Heavy Orbital Habitat
+    @description = A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies.
+
+    @mass = 28
+    @maxTemp = 1073.15
+    !vesselType = Station
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 3.25
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 100
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 77000
+            maxAmount = 77000
+        }
+    }
+
+    !RESOURCE[ElectricCharge]{}
+}
+
+//  ==================================================
+//  Skylab storage container.
+
+//  TAC Life Support configuration.
+//  ==================================================
+
+@PART[SXTISSHabISK30]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 32000
+
+		TANK
+		{
+			name = Food
+			amount = 117
+			maxAmount = 6418
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 77.5
+			maxAmount = 4644
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 11837
+			maxAmount = 710208
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 306893
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 638.8
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 5909.8
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 15
+			maxAmount = 450
+		}
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0
+		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+//  ==================================================
+//  Ares LK-S3E Heavy Habitat.
+
+//  Realism Overhaul configuration.
+
+//  Dimensions: 5.0 m x 4.2 m
+//  Gross Mass: 12000.0 Kg
+//  ==================================================
+
+@PART[SXTDLK83EHabitat]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 0.89, 0.89, 0.89
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom,2 = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Ares LK-S3E Heavy Planetary Habitat
+    @description = A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, and even a home gym.
+
+    @mass = 12.0
+    @maxTemp = 1073.15
+    !vesselType = Lander
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 3.25
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 100
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 45000
+            maxAmount = 45000
+        }
+    }
+
+    !RESOURCE[ElectricCharge]{}
+}
+
+//  ==================================================
+//  Ares LK-S3E Heavy Habitat.
+
+//  TAC Life Support configuration.
+//  ==================================================
+
+@PART[SXTDLK83EHabitat]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 7000
+
+		TANK
+		{
+			name = Food
+			amount = 11.7
+			maxAmount = 2100
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 7.75
+			maxAmount = 1393.5
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 1183.7
+			maxAmount = 213060
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 184134
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 95.82
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 886.47
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 1.5
+			maxAmount = 135
+		}
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0
+		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+//  ==================================================
+//  Caniot Heavy Orbital Habitat.
+
+//  Realism Overhaul configuration.
+
+//  Dimensions: 5.0 m x 5.0 m
+//  Gross Mass: 9500.0 Kg
+//  ==================================================
+
+@PART[STXCANIOT]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 1.33, 1.33, 1.33
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 2.25, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom,2 = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = CANIOT-7 Crew Cabin
+    @description = Probodobodyne Inc's first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
+
+    @mass = 9.5
+    @maxTemp = 1073.15
+    !vesselType = Station
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 3.25
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 100
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 45000
+            maxAmount = 45000
+        }
+    }
+
+    !RESOURCE[ElectricCharge]{}
+}
+
+//  ==================================================
+//  Ares LK-S3E Heavy Habitat.
+
+//  TAC Life Support configuration.
+//  ==================================================
+
+@PART[STXCANIOT]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume = 6000
+
+		TANK
+		{
+			name = Food
+			amount = 11.7
+			maxAmount = 1800
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 7.75
+			maxAmount = 1194.43
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 1183.7
+			maxAmount = 182623
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 157829
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 82.1314
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 759.831
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 1.5
+			maxAmount = 115.7
+		}
+	}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 4.0
+		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -145,7 +145,7 @@
     @node_stack_bottom,2 = 0.0, -1.09, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = PPD-4 Crew Cabin
-    @description = Hold 2 people with one month of supplies. A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
+    @description = Hold 2 people with 14 days of supplies. A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
 
     @mass = 3.5
     @maxTemp = 1073.15
@@ -318,15 +318,15 @@
 		TANK
 		{
 			name = Food
-			amount = 525
-			maxAmount = 525
+			amount =730
+			maxAmount = 730
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 348
-			maxAmount = 348
+			amount = 490
+			maxAmount = 490
 		}
 
 		TANK
@@ -447,15 +447,15 @@
 		TANK
 		{
 			name = Food
-			amount = 7050
-			maxAmount = 7050
+			amount = 7280
+			maxAmount = 7280
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 4644
-			maxAmount = 4644
+			amount = 4800
+			maxAmount = 4800
 		}
 
 		TANK
@@ -532,7 +532,7 @@
     @node_stack_bottom,2 = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = Ares LK-S3E Heavy Planetary Habitat
-    @description = Hold 8 people with 50 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, and even a home gym.
+    @description = Hold 8 people with 45 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, and even a home gym.
 
     @mass = 12.0
     @maxTemp = 1073.15
@@ -576,22 +576,22 @@
 		TANK
 		{
 			name = Food
-			amount = 2100
-			maxAmount = 2100
+			amount = 2150
+			maxAmount = 2150
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 1393.5
-			maxAmount = 1393.5
+			amount = 1400
+			maxAmount = 1400
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 235000
-			maxAmount = 235000
+			amount = 215000
+			maxAmount = 215000
 		}
 
 		TANK
@@ -661,7 +661,7 @@
     @node_stack_bottom,2 = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = CANIOT-7 Crew Cabin
-    @description = Hold 6 people with 60 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
+    @description = Hold 6 people with 53 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5
     @maxTemp = 1073.15
@@ -719,8 +719,8 @@
 		TANK
 		{
 			name = Oxygen
-			amount = 212000
-			maxAmount = 212000
+			amount = 190000
+			maxAmount = 190000
 		}
 
 		TANK

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -26,22 +26,35 @@
     @node_stack_bottom,2 = 0.0, -1.843, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = SPKTR-10 Lacuga Storage Container
-    @description = An extension adapter for the PPD-10 Hitchhiker storage container. Supports up to two crew.
+    @description = Hold 2 people with 30 days of supplies. An extension adapter for the PPD-10 Hitchhiker storage container.
 
     @mass = 7.8
     @maxTemp = 1073.15
     !vesselType = NULL
+	!RESOURCE[ElectricCharge]{}
 
     @MODULE[ModuleScienceContainer]
     {
         @storageRange = 3.25
     }
+	
+	MODULE
+	{
+		name = ModuleGenerator
+		isAlwaysActive = true
+
+		OUTPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = -0.4 //0.2 per person
+		}
+	}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 25
+        volume = 1400
         basemass = -1
 
         TANK
@@ -50,41 +63,24 @@
             amount = 21600
             maxAmount = 21600
         }
-    }
-
-    !RESOURCE[ElectricCharge]{}
-}
-
-//  ==================================================
-//  SPKTR-10 storage container.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[SXTSPKTRCabin]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 1400
-
 		TANK
 		{
 			name = Food
-			amount = 11.7
+			amount = 350.96
 			maxAmount = 350.96
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 7.75
+			amount = 232.25
 			maxAmount = 232.25
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 1183.7
+			amount = 35510.4
 			maxAmount = 35510.4
 		}
 
@@ -112,20 +108,31 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 1.5
+			amount = 45
 			maxAmount = 45
 		}
-	}
-
+    	}
+	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 4.0
+		conversionRate = 2.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+//  ==================================================
+//  PPD-4 storage container.
+
+//  Realism Overhaul configuration.
+
+//  Dimensions: 4.0 m x 2.5 m
+//  Gross Mass: 3600.0 Kg
+//  ==================================================
+
+
 @PART[SXTCrewCabSSP10]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
@@ -150,17 +157,30 @@
     @mass = 3.5
     @maxTemp = 1073.15
     !vesselType = NULL
+	!RESOURCE[ElectricCharge]{}
 
     @MODULE[ModuleScienceContainer]
     {
         @storageRange = 3.25
     }
+	
+	MODULE
+	{
+		name = ModuleGenerator
+		isAlwaysActive = true
+
+		OUTPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = -0.4 //0.2 per person
+		}
+	}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 50
+        volume = 1300
         basemass = -1
 
         TANK
@@ -169,23 +189,7 @@
             amount = 21600
             maxAmount = 21600
         }
-    }
-
-    !RESOURCE[ElectricCharge]{}
-}
-
-//  ==================================================
-//  SSP-10 storage container.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[SXTCrewCabSSP10]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 1300
-
+		
 		TANK
 		{
 			name = Food
@@ -234,13 +238,13 @@
 			amount = 22.5
 			maxAmount = 22.5
 		}
-	}
-
+    	}
+	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 4.0
+		conversionRate = 2.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
@@ -279,17 +283,30 @@
     @mass = 6.8
     @maxTemp = 1073.15
     !vesselType = NULL
+	!RESOURCE[ElectricCharge]{}
 
     @MODULE[ModuleScienceContainer]
     {
         @storageRange = 3.25
     }
+	
+	MODULE
+	{
+		name = ModuleGenerator
+		isAlwaysActive = true
 
+		OUTPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = -0.8 //0.2 per person
+		}
+	}
+	
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 100
+        volume = 3000
         basemass = -1
 
         TANK
@@ -298,23 +315,7 @@
             amount = 32000
             maxAmount = 32000
         }
-    }
-
-    !RESOURCE[ElectricCharge]{}
-}
-
-//  ==================================================
-//  SSP-20 storage container.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[SXTCrewCabSSP20]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 3000
-
+		
 		TANK
 		{
 			name = Food
@@ -363,13 +364,13 @@
 			amount = 67.5
 			maxAmount = 67.5
 		}
-	}
-
+    	}
+	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 4.0
+		conversionRate = 4.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
@@ -407,18 +408,31 @@
 
     @mass = 28
     @maxTemp = 1073.15
-    !vesselType = Station
+    !vesselType = NULL
+	!RESOURCE[ElectricCharge]{}
 
     @MODULE[ModuleScienceContainer]
     {
         @storageRange = 3.25
     }
+	
+	MODULE
+	{
+		name = ModuleGenerator
+		isAlwaysActive = true
+
+		OUTPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = -1.6 //0.2 per person
+		}
+	}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 2000
+        volume = 32000
         basemass = -1
 
         TANK
@@ -427,23 +441,7 @@
             amount = 77000
             maxAmount = 77000
         }
-    }
-
-    !RESOURCE[ElectricCharge]{}
-}
-
-//  ==================================================
-//  Skylab storage container.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[SXTISSHabISK30]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 32000
-
+		
 		TANK
 		{
 			name = Food
@@ -492,13 +490,13 @@
 			amount = 450
 			maxAmount = 450
 		}
-	}
-
+    	}
+	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 6.0
+		conversionRate = 8.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
@@ -536,18 +534,32 @@
 
     @mass = 12.0
     @maxTemp = 1073.15
-    !vesselType = Lander
+    !vesselType = NULL
+	!RESOURCE[ElectricCharge]{}
+	!MODULE[ModuleReactionWheel] {}
 
     @MODULE[ModuleScienceContainer]
     {
         @storageRange = 3.25
     }
+	
+	MODULE
+	{
+		name = ModuleGenerator
+		isAlwaysActive = true
+
+		OUTPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = -1.6 //0.2 per person
+		}
+	}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1000
+        volume = 7000
         basemass = -1
 
         TANK
@@ -556,23 +568,7 @@
             amount = 45000
             maxAmount = 45000
         }
-    }
-
-    !RESOURCE[ElectricCharge]{}
-}
-
-//  ==================================================
-//  Ares LK-S3E Heavy Habitat.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[SXTDLK83EHabitat]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 7000
-
+		
 		TANK
 		{
 			name = Food
@@ -621,13 +617,13 @@
 			amount = 135
 			maxAmount = 135
 		}
-	}
-
+    	}
+	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 4.0
+		conversionRate = 8.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
@@ -665,18 +661,31 @@
 
     @mass = 9.5
     @maxTemp = 1073.15
-    !vesselType = Station
+    !vesselType = NULL
+	!RESOURCE[ElectricCharge]{}
 
     @MODULE[ModuleScienceContainer]
     {
         @storageRange = 3.25
     }
+	
+	MODULE
+	{
+		name = ModuleGenerator
+		isAlwaysActive = true
+
+		OUTPUT_RESOURCE
+		{
+			name = ElectricCharge
+			rate = -1.2 //0.2 per person
+		}
+	}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 800
+        volume = 6000
         basemass = -1
 
         TANK
@@ -685,23 +694,7 @@
             amount = 45000
             maxAmount = 45000
         }
-    }
-
-    !RESOURCE[ElectricCharge]{}
-}
-
-//  ==================================================
-//  Caniot Heavy Orbital Habitat.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[STXCANIOT]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 6000
-
+		
 		TANK
 		{
 			name = Food
@@ -750,13 +743,13 @@
 			amount = 115.7
 			maxAmount = 115.7
 		}
-	}
-
+    	}
+	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 4.0
+		conversionRate = 6.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}


### PR DESCRIPTION
I added configs for SXT's base and stations parts. For example, the IKS30 is now 6.6m width, as a Skylab OWS counterpart.
(I hope everything's fine; that's my third attempt to post it in the correct branch and I'm new on GitHub).