### PR TITLE
Small SSTU Fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Landers.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Landers.cfg
@@ -1004,7 +1004,7 @@
 		name = ModuleRCS
 		thrusterTransformName = RCSThrustTransform
 		resourceFlowMode = STAGE_PRIORITY_FLOW
-		thrusterPower = 0.1045332
+		thrusterPower = 0.5
 		PROPELLANT
 		{
 			name = MMH
@@ -1258,7 +1258,7 @@
 		name = ModuleRCS
 		thrusterTransformName = RCSThrustTransform
 		resourceFlowMode = STAGE_PRIORITY_FLOW
-		thrusterPower = 0.1045332
+		thrusterPower = 1
 		PROPELLANT
 		{
 			name = MMH
@@ -1512,7 +1512,7 @@
 		name = ModuleRCS
 		thrusterTransformName = RCSThrustTransform
 		resourceFlowMode = STAGE_PRIORITY_FLOW
-		thrusterPower = 0.2090664
+		thrusterPower = 1.5
 		PROPELLANT
 		{
 			name = MMH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -120,7 +120,10 @@
 		name = CoMShifter
 		DescentModeCoM = 0, 0, -0.192
 	}
-	
+	@MODULE[ModuleDockingNode]
+	{
+		%nodeType = NASADock
+	}
 	!RESOURCE[ElectricCharge]
 	{
 	}


### PR DESCRIPTION
Now that the docking node/chute model is baked into Orion, changing it to NASADock like the Landers are.