### PR TITLE
RO RSB Atlas V

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -1,11 +1,11 @@
 //  ==================================================
 //  Sources:
 
-//  1: http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
-//  2: http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
-//  3: http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
-//  4: http://www.ulalaunch.com/products_atlasv.aspx
-//  5: http://spaceflight101.com/spacerockets/atlas-v-401/
+//  http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
+//  http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
+//  http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
+//  http://www.ulalaunch.com/products_atlasv.aspx
+//  http://spaceflight101.com/spacerockets/atlas-v-401/
 
 //  ==================================================
 //  Atlas V 400 series LPF.
@@ -31,7 +31,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = 1300
+        @ejectionForce = 6000
     }
 
     !MODULE[ModuleEngines*]{}
@@ -63,7 +63,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = 1300
+        @ejectionForce = 6000
     }
 
     !MODULE[ModuleEngines*]{}
@@ -95,7 +95,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = 1300
+        @ejectionForce = 6000
     }
 
     !MODULE[ModuleEngines*]{}
@@ -126,7 +126,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = 3000
+        @ejectionForce = 9000
     }
 
     !MODULE[ModuleEngines*]{}
@@ -157,7 +157,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = 3000
+        @ejectionForce = 9000
     }
 
     !MODULE[ModuleEngines*]{}
@@ -188,7 +188,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = 3000
+        @ejectionForce = 9000
     }
 
     !MODULE[ModuleEngines*]{}
@@ -219,7 +219,7 @@
 
     @MODULE[ModuleAnchoredDecoupler]
     {
-        @ejectionForce = -600
+        @ejectionForce = -500
     }
 
     !MODULE[ModuleEngines*]{}
@@ -402,6 +402,8 @@
         basemass = -1
 
         //  Batteries 4.3 kWh.
+        //  Can support the Centaur for flights up to 6 hours in duration.
+        //  Assumes that the electricity consumption of the DCSS avionics is 200 W.
 
         TANK
         {
@@ -462,7 +464,7 @@
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.15
+            @rate = 0.175
         }
     }
 
@@ -480,7 +482,7 @@
         %IsRTActive = True
         %Mode0OmniRange = 0
         %Mode1OmniRange = 1000000
-        %EnergyCost = 0.05
+        %EnergyCost = 0.025
     }
 }
 
@@ -597,6 +599,17 @@
         volume = 275182
         basemass = -1
 
+        //  Batteries 50 Wh.
+        //  Supports the CCB for the initial duration of the flight (approximately 5 minutes).
+        //  Assumes that the electricity consumption of the CBC avionics is 200 W.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 180
+            maxAmount = 180
+        }
+
         //  CCB fuel 76367 Kg.
 
         TANK
@@ -626,12 +639,6 @@
         %pressureFed = False
         %ignitions = 1
 
-        IGNITOR_RESOURCE
-        {
-            name = ElectricCharge
-            amount = 1
-        }
-
         @PROPELLANT[SolidFuel]
         {
             @name = HTPB
@@ -639,15 +646,6 @@
     }
 
     !RESOURCE,*{}
-
-    //  Batteries 150 Wh.
-
-    RESOURCE
-    {
-        name = ElectricCharge
-        amount = 150
-        maxAmount = 150
-    }
 
     RESOURCE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -18,7 +18,7 @@
 {
     %RSSROConfig = True
 
-    @title = Atlas V 400 LPF
+    @title = Atlas V 400 Series LPF
     @manufacturer = RUAG Space
     @description = The Large Payload Fairing (LPF) for the Atlas V 400 series.
 
@@ -29,31 +29,14 @@
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
 
-    @MODULE[ModuleEngines*]
+    @MODULE[ModuleAnchoredDecoupler]
     {
-        @minThrust = 0
-        @minThrust = 40
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
-
-        @PROPELLANT[SolidFuel]
-        {
-            @name = HTPB
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 250
-            @key,1 = 1 230
-        }
+        @ejectionForce = 1300
     }
 
-    @RESOURCE[SolidFuel]
-    {
-        @name = HTPB
-        @amount = 3
-        @maxAmount = 3
-    }
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -67,9 +50,9 @@
 {
     %RSSROConfig = True
 
-    @title = Atlas V 400 EPF
+    @title = Atlas V 400 Series EPF
     @manufacturer = RUAG Space
-    @description  = The Extended Payload Fairing (EPF) for the Atlas V 400 series.
+    @description = The Extended Payload Fairing (EPF) for the Atlas V 400 series.
 
     @mass = 1.147
     @crashTolerance = 16
@@ -78,31 +61,14 @@
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
 
-    @MODULE[ModuleEngines*]
+    @MODULE[ModuleAnchoredDecoupler]
     {
-        @minThrust = 0
-        @minThrust = 40
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
-
-        @PROPELLANT[SolidFuel]
-        {
-            @name = HTPB
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 250
-            @key,1 = 1 230
-        }
+        @ejectionForce = 1300
     }
 
-    @RESOURCE[SolidFuel]
-    {
-        @name = HTPB
-        @amount = 3
-        @maxAmount = 3
-    }
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -116,7 +82,7 @@
 {
     %RSSROConfig = True
 
-    @title = Atlas V 400 XEPF
+    @title = Atlas V 400 Series XEPF
     @manufacturer = RUAG Space
     @description = The Extra Extended Payload Fairing (XEPF) for the Atlas V 400 series.
 
@@ -127,31 +93,138 @@
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
 
-    @MODULE[ModuleEngines*]
+    @MODULE[ModuleAnchoredDecoupler]
     {
-        @minThrust = 0
-        @minThrust = 40
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
-
-        @PROPELLANT[SolidFuel]
-        {
-            @name = HTPB
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 250
-            @key,1 = 1 230
-        }
+        @ejectionForce = 1300
     }
 
-    @RESOURCE[SolidFuel]
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Atlas V 500 series SPLF.
+
+//  Dimensions: 5.4 m x 20.7 m
+//  Inert Mass: 1762 Kg (per halve)
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV500_1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 500 Series SPLF
+    @manufacturer = RUAG Space
+    @description = The Short Payload Fairing (SPLF) for the Atlas V 500 series.
+
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleAnchoredDecoupler]
     {
-        @name = HTPB
-        @amount = 3
-        @maxAmount = 3
+        @ejectionForce = 3000
     }
+
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Atlas V 500 series MPLF.
+
+//  Dimensions: 5.4 m x 23.4 m
+//  Inert Mass: 2001 Kg (per halve)
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV500_2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 500 Series MPLF
+    @manufacturer = RUAG Space
+    @description = The Medium Payload Fairing (MPLF) for the Atlas V 500 series.
+
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 3000
+    }
+
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Atlas V 500 series LPLF.
+
+//  Dimensions: 5.4 m x 26.5 m
+//  Inert Mass: 2189 Kg (per halve)
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV500_3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 500 Series LPLF
+    @manufacturer = RUAG Space
+    @description = The Large Payload Fairing (LPLF) for the Atlas V 500 series.
+
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 3000
+    }
+
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Atlas V Forward Load Reactor.
+
+//  Dimensions: 5.4 m
+//  Inert Mass: 200 Kg
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV500_CFLR]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Centaur Forward Load Reactor
+    @manufacturer = United Launch Alliance (ULA)
+
+    @mass = 0.2
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = -600
+    }
+
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -214,6 +287,52 @@
 }
 
 //  ==================================================
+//  Atlas V CCB nose cone.
+
+//  Dimensions: 3.81 m x 2.8 m
+//  Inert Mass: 415 Kg
+//  ==================================================
+
+@PART[RSBnosecone381]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V CCB Nose Cone
+    @manufacturer = Orbital ATK
+    @description = A 3.8m aerodynamic nose cone for the Atlas V HLV.
+
+    @mass = 0.415
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  Common Centaur nose cone.
+
+//  Dimensions: 3.05 m x 2.3 m
+//  Inert Mass: 260 Kg
+//  ==================================================
+
+@PART[RSBnosecone305]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Common Centaur Nose Cone
+    @manufacturer = Orbital ATK
+    @description = A 3m aerodynamic nose cone for the Common Centaur upper stage.
+
+    @mass = 0.26
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
 //  Common Centaur.
 
 //  Dimensions: 3.05 m x 10.5 m
@@ -271,7 +390,7 @@
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.15
+            @rate = 0.2
         }
     }
 
@@ -339,6 +458,14 @@
 
 @PART[RSBtankAtlasCentaur]:AFTER[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.15
+        }
+    }
+
     @MODULE[ModuleSPU]
     {
         @IsRTCommandStation = False
@@ -489,6 +616,28 @@
         }
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 49.8
+        @maxThrust = 49.8
+        @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 1
+        }
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+    }
+
     !RESOURCE,*{}
 
     //  Batteries 150 Wh.
@@ -498,5 +647,12 @@
         name = ElectricCharge
         amount = 150
         maxAmount = 150
+    }
+
+    RESOURCE
+    {
+        name = HTPB
+        amount = 17.25
+        maxAmount = 17.25
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -528,7 +528,7 @@
 {
     %RSSROConfig = True
 
-    @title = Atlas V 500 Series C-ISA
+    @title = Atlas V 500 Series Forward Interstage Adapter
     @manufacturer = Orbital ATK
     @description = The forward Conical Interstage Structural Adapter for Atlas V 500 series. Simply attach the 500 series interstage to the Centaur upper stage first, then snap this onto it. Payload fairing panels can then be attached to this base.
 
@@ -553,7 +553,7 @@
 {
     %RSSROConfig = True
 
-    @title = Atlas V 500 Series CIA
+    @title = Atlas V 500 Series Aft Interstage Adapter
     @manufacturer = United Launch Alliance (ULA)
     @description = The aft Centaur Interstage Adapter for the Atlas V 500 series. Typically used with a 500 series Atlas V fairing base encapsulating the entire Centaur upper stage. Place this interstage first, then snap the 500 series fairing base onto the "gap".
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -4,6 +4,155 @@
 //  1: http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
 //  2: http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
 //  3: http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
+//  4: http://www.ulalaunch.com/products_atlasv.aspx
+//  5: http://spaceflight101.com/spacerockets/atlas-v-401/
+
+//  ==================================================
+//  Atlas V 400 series LPF.
+
+//  Dimensions: 4.2 m x 12 m
+//  Inert Mass: 1064 Kg (per halve)
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV400_1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 400 LPF
+    @manufacturer = RUAG Space
+    @description = The Large Payload Fairing (LPF) for the Atlas V 400 series.
+
+    @mass = 1.058
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 0
+        @minThrust = 40
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 230
+        }
+    }
+
+    @RESOURCE[SolidFuel]
+    {
+        @name = HTPB
+        @amount = 3
+        @maxAmount = 3
+    }
+}
+
+//  ==================================================
+//  Atlas V 400 series EPF.
+
+//  Dimensions: 4.2 m x 12.9 m
+//  Inert Mass: 1153 Kg (per halve)
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV400_2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 400 EPF
+    @manufacturer = RUAG Space
+    @description  = The Extended Payload Fairing (EPF) for the Atlas V 400 series.
+
+    @mass = 1.147
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 0
+        @minThrust = 40
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 230
+        }
+    }
+
+    @RESOURCE[SolidFuel]
+    {
+        @name = HTPB
+        @amount = 3
+        @maxAmount = 3
+    }
+}
+
+//  ==================================================
+//  Atlas V 400 series XEPF.
+
+//  Dimensions: 4.2 m x 13.8 m
+//  Inert Mass: 1244 Kg (per halve)
+//  ==================================================
+
+@PART[RSB_PLF_AtlasV400_3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 400 XEPF
+    @manufacturer = RUAG Space
+    @description = The Extra Extended Payload Fairing (XEPF) for the Atlas V 400 series.
+
+    @mass = 1.238
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 0
+        @minThrust = 40
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 230
+        }
+    }
+
+    @RESOURCE[SolidFuel]
+    {
+        @name = HTPB
+        @amount = 3
+        @maxAmount = 3
+    }
+}
 
 //  ==================================================
 //  Atlas V 400 series payload fairing base.
@@ -18,7 +167,7 @@
 
     @title = Centaur Payload Fairing Base (3.75m)
     @manufacturer = United United Launch Alliance (ULA)
-    @description = A 3.75m diameter payload fairing base designed for the Atlas V 400 series Common Centaur.
+    @description = A 3.75m diameter procedural payload fairing base designed for the Atlas V 400 series Common Centaur.
 
     @mass = 0.045
     @crashTolerance = 14
@@ -29,12 +178,48 @@
 }
 
 //  ==================================================
+//  Atlas 500 series payload attach fitting.
+
+//  Dimensions: 3.05 m x 1.1 m
+//  Inert Mass: 180 Kg
+//  ==================================================
+
+@PART[RSBdecouplerAtlas500Payload]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.375, 1.0
+    }
+
+    @node_stack_top = 0.0, 0.55, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.55, 0.0, 0.0, -1.0, 0.0, 3
+
+    @title = Centaur Payload Attach Fitting T3302
+    @manufacturer = United Launch Alliance (ULA)
+    @description = A 3.05m diameter payload attach fitting designed for the Atlas V 500 series Common Centaur.
+
+    @mass = 0.18
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5
+    }
+}
+
+//  ==================================================
 //  Common Centaur.
 
 //  Dimensions: 3.05 m x 10.5 m
 //  Gross Mass: 23075 Kg
 
-//  Stage includes the missing Helium bottles that are
+//  Stage includes the missing Helium mass that is
 //  used for propellant pressurization.
 //  ==================================================
 
@@ -46,11 +231,13 @@
     @manufacturer = United United Launch Alliance (ULA)
     @description = The second stage of an Atlas V. Contains the necessary avionics, communications and power supply for mission times of up to 6 hours.
 
+    @mass = 2.05
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
+    %vesselIcon = Probe
 
     //  Centaur includes different RCS thrusters, for axis control (40 N) and ullage control (27 N).
     //  We pick the higher thrust for game - play reasons.
@@ -171,10 +358,10 @@
 }
 
 //  ==================================================
-//  Atlas 400 series interstage adapter.
+//  Atlas 400 series ISA/ASA.
 
 //  Dimensions: 3.81 m x 4.1 m
-//  Inert Mass: 955 Kg
+//  Inert Mass: 1140 Kg
 
 //  The mass is the average value between the SEC and
 //  the DEC versions.
@@ -184,11 +371,64 @@
 {
     %RSSROConfig = True
 
-    @title = Atlas V 400 Interstage Adapter
-    @manufacturer = United United Launch Alliance (ULA)
-    @description = The interstage structural adapter for the Atlas V 400 series.
+    @title = Atlas V 400 Series Interstage Adapter
+    @manufacturer = Orbital ATK
+    @description = The Interstage Structural Adapter for the Atlas V 400 series.
 
-    @mass = 0.955
+    @mass = 1.14
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
+}
+
+//  ==================================================
+//  Atlas 500 series C-ISA.
+
+//  Dimensions: 5.41 m x 2.2 m
+//  Inert Mass: 980 Kg
+//  ==================================================
+
+@PART[RSBatlasVboattail]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 500 Series C-ISA
+    @manufacturer = Orbital ATK
+    @description = The forward Conical Interstage Structural Adapter for Atlas V 500 series. Simply attach the 500 series interstage to the Centaur upper stage first, then snap this onto it. Payload fairing panels can then be attached to this base.
+
+    @mass = 0.98
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    !stageOffset = NULL
+    !childStageOffset = NULL
+}
+
+//  ==================================================
+//  Atlas 500 series aft stub adapter.
+
+//  Dimensions: 3.81 m x 4.1 m
+//  Inert Mass: 1240 Kg
+//  ==================================================
+
+@PART[RSBinterstageAtlasCentaur500]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 500 Series CIA
+    @manufacturer = United Launch Alliance (ULA)
+    @description = The aft Centaur Interstage Adapter for the Atlas V 500 series. Typically used with a 500 series Atlas V fairing base encapsulating the entire Centaur upper stage. Place this interstage first, then snap the 500 series fairing base onto the "gap".
+
+    @mass = 1.24
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
@@ -216,7 +456,7 @@
     @manufacturer = United United Launch Alliance (ULA)
     @description = This common booster core can either function as a single core, or center core, or strap-on booster.
 
-    @mass = 15.4
+    @mass = 15.075
     @crashTolerance = 12
     @maxTemp = 773.15
     %skinMaxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -1,0 +1,262 @@
+//  ==================================================
+//  Sources:
+
+//  1: http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
+//  2: http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
+//  3: http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
+
+//  ==================================================
+//  Atlas V 400 series payload fairing base.
+
+//  Dimensions: 3.75 m x 0.8 m
+//  Inert Mass: 45 Kg
+//  ==================================================
+
+@PART[RSBfairingAtlasCentaur305]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Centaur Payload Fairing Base (3.75m)
+    @manufacturer = United United Launch Alliance (ULA)
+    @description = A 3.75m diameter payload fairing base designed for the Atlas V 400 series Common Centaur.
+
+    @mass = 0.045
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  Common Centaur.
+
+//  Dimensions: 3.05 m x 10.5 m
+//  Gross Mass: 23075 Kg
+
+//  Stage includes the missing Helium bottles that are
+//  used for propellant pressurization.
+//  ==================================================
+
+@PART[RSBtankAtlasCentaur]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Common Centaur
+    @manufacturer = United United Launch Alliance (ULA)
+    @description = The second stage of a Atlas V. Contains guidance capability.
+
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    //  Centaur includes different RCS thrusters, for axis control (40 N) and ullage control (27 N).
+    //  We pick the higher thrust for game - play reasons.
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.04
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 235
+            @key,1 = 1 85
+        }
+    }
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.15
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 58672
+        basemass = -1
+
+        //  Centaur fuel 3041 Kg.
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 42920
+            maxAmount = 42920
+        }
+
+        //  Centaur oxidizer 17788 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 15590
+            maxAmount = 15590
+        }
+
+        //  ACS propellant 155 Kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 155
+            maxAmount = 155
+        }
+
+        // ACS pressurization ~0.28 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 1550
+            maxAmount = 1550
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Batteries 4.3 kWh.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 4300
+        maxAmount = 4300
+    }
+}
+
+//  ==================================================
+//  Common Centaur.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[RSBtankAtlasCentaur]:AFTER[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @MODULE[ModuleSPU]
+    {
+        @IsRTCommandStation = False
+        @RTCommandMinCrew = 0
+    }
+	
+    @MODULE[ModuleRTAntennaPassive]
+    {
+        @name = ModuleRTAntenna
+        !OmniRange = NULL
+        !TechRequired = NULL
+        %IsRTActive = True
+        %Mode0OmniRange = 0
+        %Mode1OmniRange = 1000000
+        %EnergyCost = 0.05
+    }
+}
+
+//  ==================================================
+//  Atlas 400 series interstage adapter.
+
+//  Dimensions: 3.81 m x 4.1 m
+//  Inert Mass: 955 Kg
+
+//  The mass is the average value between the SEC and
+//  the DEC versions.
+//  ==================================================
+
+@PART[RSBinterstageAtlasCentaur400]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Atlas V 400 Interstage Adapter
+    @manufacturer = United United Launch Alliance (ULA)
+    @description = The interstage structural adapter for the Atlas V 400 series.
+
+    @mass = 0.955
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
+}
+
+//  ==================================================
+//  Atlas V Common Core Booster (CCB).
+
+//  Dimensions: 3.81 m x 29 m
+//  Gross Mass: 299490 Kg
+//  ==================================================
+
+@PART[RSBtankAtlasVcore]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title =  Atlas V Common Core Booster
+    @manufacturer = United United Launch Alliance (ULA)
+    @description = This common booster core can either function as a single core, or center core, or strap-on booster.
+
+    @mass = 15.4
+    @crashTolerance = 12
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @breakingForce = 250
+    @breakingTorque = 250
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 275182
+        basemass = -1
+
+        //  CCB fuel 76367 Kg.
+
+        TANK
+        {
+            name = Kerosene
+            amount = 93131
+            maxAmount = 93131
+        }
+
+        //  CCB oxidizer 207720 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 182051
+            maxAmount = 182051
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Batteries 150 Wh.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 150
+        maxAmount = 150
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -44,7 +44,7 @@
 
     @title = Common Centaur
     @manufacturer = United United Launch Alliance (ULA)
-    @description = The second stage of a Atlas V. Contains guidance capability.
+    @description = The second stage of an Atlas V. Contains the necessary avionics, communications and power supply for mission times of up to 6 hours.
 
     @crashTolerance = 10
     @breakingForce = 250
@@ -92,8 +92,17 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 58672
+        volume = 58678
         basemass = -1
+
+        //  Batteries 4.3 kWh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 4300
+            maxAmount = 4300
+        }
 
         //  Centaur fuel 3041 Kg.
 
@@ -133,15 +142,6 @@
     }
 
     !RESOURCE,*{}
-
-    //  Batteries 4.3 kWh.
-
-    RESOURCE
-    {
-        name = ElectricCharge
-        amount = 4300
-        maxAmount = 4300
-    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAtlasSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAtlasSRB.cfg
@@ -1,0 +1,69 @@
+//  ==================================================
+//  AJ-60A plume configuration.
+//  ==================================================
+
+@PART[RSBengineAtlasSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Solid-Lower
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.1
+        fixedScale = 1.25
+        energy = 1.0
+        speed = 1.25
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Lower
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Lower
+        }
+    }
+}
+
+//  ==================================================
+//  AJ-60A engine flare configuration.
+//  ==================================================
+
+@PART[RSBengineAtlasSRB]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.2
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  AJ-60A engine smoke configuration.
+//  ==================================================
+
+@PART[RSBengineAtlasSRB]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[smoke]
+            {
+                @localPosition = 0.0, 0.0, -1.1
+                @fixedScale = 0.4
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRD180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRD180.cfg
@@ -1,0 +1,69 @@
+//  ==================================================
+//  RD-180 engine plume configuration.
+//  ==================================================
+
+@PART[RSBengineRD180]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.45
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}
+
+//  ==================================================
+//  RD-180 engine flare configuration.
+//  ==================================================
+
+@PART[RSBengineRD180]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.15
+                @fixedScale = 1.15
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  RD-180 engine smoke configuration.
+//  ==================================================
+
+@PART[RSBengineRD180]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[smoke]
+            {
+                @localPosition = 0.0, 0.0, -0.6
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10A42.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10A42.cfg
@@ -1,0 +1,50 @@
+//  ==================================================
+//  RL10 engine plume configuration.
+//  ==================================================
+
+@PART[RSBengineRL10A42]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.9
+        fixedScale = 1.25
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hydrolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+
+//  ==================================================
+//  RL10 engine flare configuration.
+//  ==================================================
+
+@PART[RSBengineRL10A42]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.4
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankAtlasVcore.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankAtlasVcore.cfg
@@ -1,0 +1,32 @@
+//  ==================================================
+//  STAR 5F retro motor plume configuration.
+//  ==================================================
+
+@PART[RSBtankAtlasVcore]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Solid-Sepmotor
+        transformName = thrustTransform
+        localRotation = 10.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 0.4
+        energy = 0.5
+        speed = 2.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Sepmotor
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Sepmotor
+        }
+    }
+}


### PR DESCRIPTION
* Add RO support for the Real Scale Boosters Atlas V (only for the 401 version for now).