### PR TITLE
Add M55 Minuteman config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RO_M55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_M55_Config.cfg
@@ -1,0 +1,47 @@
+//M55 (Minuteman)
+//Squad
+//From Squad config
+@PART[*]:HAS[#engineType[M55]]:FOR[RealismOverhaulEngines]
+{
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = M55
+		modded = false
+		CONFIG
+		{
+			name = M55
+			maxThrust = 876
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 262
+				key = 1 237
+			}
+			curveResource = PBAN
+			// guesses (note: max is above nominal * thrust_curve_max)
+			%chamberNominalTemp  = 2200
+			%maxEngineTemp = 2430
+			thrustCurve
+			{
+				key = 	0.0		0.2 	0.0 20.0
+				key = 	0.01	0.25 	20.0 10.0
+				key = 	0.064	0.64	10.0 0.8
+				key = 	0.1		0.80	0.8 0.2
+				key = 	0.56	0.90	0.2 0.3
+				key = 	0.85	1.00	0.3 2.0
+				key = 	0.9		1.10	2.0 -0.9
+				key = 	0.96	1.05	-0.9 3.0
+				key = 	0.99	1.15	3.0 -10.0
+				key = 	1.0		0.70	-10.0 0.0
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
@@ -62,12 +62,13 @@
 		@volume = 11729.7
 		%type = PBAN
 	}
-	@MODULE[ModuleEngineConfigs]
+	!engineType = DELETE
+	MODULE
 	{
-		@configuration = M55
-		!CONFIG,*
-		{
-		}
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = M55
+		modded = false
 		CONFIG
 		{
 			name = M55

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
@@ -34,9 +34,9 @@
 	@cost = 800
 	@TechRequired = start
 	@entryCost = 0
-	@title = M55 (Minuteman) Solid Rocket Motor [1.7 m]
+	@title = M55 (Minuteman) SRM
 	@manufacturer = Thiokol
-	@description = First stage of the Minuteman ICBM, used in various proposed NASA launch vehicles as a solid booster.
+	@description = First stage of the Minuteman ICBM, used in various proposed NASA launch vehicles as a solid booster. Burn time 60 seconds, 1.7 m diameter.
 	@mass = 2.292
 	@MODULE[ModuleAnimateHeat]:NEEDS[!VenStockRevamp]
 	{
@@ -49,7 +49,7 @@
 	}
 	@MODULE[ModuleEngines]
 	{
-		@maxThrust = 875.54
+		@maxThrust = 876
 		@heatProduction = 100
 		@atmosphereCurve
 		{
@@ -62,48 +62,7 @@
 		@volume = 11729.7
 		%type = PBAN
 	}
-	!engineType = DELETE
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = M55
-		modded = false
-		CONFIG
-		{
-			name = M55
-			maxThrust = 875.54
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = PBAN
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 262
-				key = 1 237
-			}
-			curveResource = PBAN
-			// guesses (note: max is above nominal * thrust_curve_max)
-			%chamberNominalTemp  = 2200
-			%maxEngineTemp = 2430
-			thrustCurve
-			{
-				key = 	0.0		0.2 	0.0 20.0
-				key = 	0.01	0.25 	20.0 10.0
-				key = 	0.064	0.64	10.0 0.8
-				key = 	0.1		0.80	0.8 0.2
-				key = 	0.56	0.90	0.2 0.3
-				key = 	0.85	1.00	0.3 2.0
-				key = 	0.9		1.10	2.0 -0.9
-				key = 	0.96	1.05	-0.9 3.0
-				key = 	0.99	1.15	3.0 -10.0
-				key = 	1.0		0.70	-10.0 0.0
-			}
-		}
-	}
+	%engineType = M55
 	!MODULE[ModuleJettison] {} // if copying from a VSR booster
 	MODULE:NEEDS[VenStockRevamp]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
@@ -36,7 +36,7 @@
 	@entryCost = 0
 	@title = M55 (Minuteman) SRM
 	@manufacturer = Thiokol
-	@description = First stage of the Minuteman ICBM, used in various proposed NASA launch vehicles as a solid booster. Burn time 60 seconds, 1.7 m diameter.
+	@description = First stage of the Minuteman ICBM, used in various proposed NASA launch vehicles as a solid booster. Burn time 75 seconds, 1.7 m diameter.
 	@mass = 2.292
 	@MODULE[ModuleAnimateHeat]:NEEDS[!VenStockRevamp]
 	{


### PR DESCRIPTION
Clone of part that was switched to engineType so there was no longer ModuleEngineConfigs to modify. Fixed by deleting engineType, adding ModuleEngineConfigs.