### PR TITLE
RS-88 global engine config update

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RO_RS88_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RS88_Config.cfg
@@ -22,6 +22,17 @@
 
 @PART[*]:HAS[#engineType[RS88]]:FOR[RealismOverhaulEngines]
 {
+    %title = RS-88 Series
+    %manufacturer = Rocketdyne
+    %description = High thrust pressure-fed hypergolic engine. Initially designed and built as a part of the NASA Bantam System Technology program, aiming for a low cost, high power propulsion system. It was later modified by Lockheed Martin for use as a launch abort engine. A derivative of the RS-88 is used by the Boeing CST-100 "Starliner" spacecraft for launch aborts under the name "Launch Abort Engine - LAE".
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleGimbal]{}
+
     MODULE
     {
         name = ModuleEngineConfigs
@@ -48,14 +59,14 @@
             PROPELLANT
             {
                 name = Ethanol75
-                ratio = 0.529
+                ratio = 0.5285
                 DrawGauge = true
             }
 
             PROPELLANT
             {
                 name = LqdOxygen
-                ratio = 0.471
+                ratio = 0.4715
                 DrawGauge = False
             }
 
@@ -85,14 +96,14 @@
             PROPELLANT
             {
                 name = MMH
-                ratio = 0.4990
+                ratio = 0.499
                 DrawGauge = True
             }
 
             PROPELLANT
             {
                 name = MON3
-                ratio = 0.5010
+                ratio = 0.501
                 DrawGauge = False
             }
 
@@ -111,4 +122,8 @@
             }
         }
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE[ElectricCharge]{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RS88_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RS88_Config.cfg
@@ -1,65 +1,105 @@
-// CST-100 propulsion
-// RLA
-//  Source 1: http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
-//  Source 2: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
-//  Source 3: http://astronautix.com/engines/rs88.htm
-// http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
-//FIXME: no sources for some values
+//  ==================================================
+//  RS-88.
+
+//  Inert Mass: 250 Kg
+//  Throttle Range: N/A
+//  Burn Time: -
+//  O/F Ratio: 1.29 (Ethanol version), 1.65 (Hypergolic version)
+
+//  Sources:
+//  http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
+//  http://astronautix.com/engines/rs88.htm
+//  http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+
+//  Used by:
+//      CST - 100 pack
+//      RLA
+
+//  FIXME:
+//      No sources for some values (inert mass, rated burn time and ignition count).
+//  ==================================================
+
 @PART[*]:HAS[#engineType[RS88]]:FOR[RealismOverhaulEngines]
 {
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		configuration = RS88
-		modded = false
-		origMass = 0.250
-		CONFIG
-		{
-			name = RS88
-			maxThrust = 220
-			minThrust = 220
-			PROPELLANT
-			{
-				name = Ethanol75
-				ratio = 0.529
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.471
-			}
-			atmosphereCurve
-			{
-				key = 0 324
-				key = 1 273
-			}
-		} 
-		CONFIG
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RS-88
+        modded = False
+        origMass = 0.25
+
+        CONFIG
+        {
+            name = RS-88
+            maxThrust = 220
+            minThrust = 220
+            ullage = True
+            pressureFed = True
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
+
+            PROPELLANT
+            {
+                name = Ethanol75
+                ratio = 0.529
+                DrawGauge = true
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.471
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 324
+                key = 1 273
+            }
+        }
+
+        CONFIG
         {
             name = LAE
             minThrust = 258
             maxThrust = 258
             heatProduction = 0.88 //0.220
+            ullage = True
+            pressureFed = True
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
 
             PROPELLANT
             {
                 name = MMH
-                ratio = 0.499
+                ratio = 0.4990
                 DrawGauge = True
             }
 
             PROPELLANT
             {
                 name = MON3
-                ratio = 0.501
+                ratio = 0.5010
                 DrawGauge = False
             }
 
             PROPELLANT
             {
                 name = Helium
-                ratio = 150.0
+                ratio = 10.0
                 DrawGauge = False
                 ignoreForIsp = True
             }


### PR DESCRIPTION
* Add global title, manufacturer and description fields.
* Add ullage simulation and ignitions.
* Fix the Helium pressurization ratio (hypergolic version only).

Note: might need more than one ignition count.