### PR TITLE
Bpc fix for SSTU

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
@@ -14,69 +14,10 @@
 	@mass = 2.574
 	@maxTemp = 1973.15
 	%stagingIcon = DECOUPLER_VERT
-	!RESOURCE[SolidFuel]
+	@RESOURCE,*
 	{
-	}
-//	!RESOURCE[SSTUJettisonFuel]
-//	{
-//	}
-	@MODULE[ModuleEngines*],0
-	{
-		@minThrust = 689.5
-		@maxThrust = 689.5
-		@heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 190
-			@key,1 = 1 176
-		}
-		@PROPELLANT[SolidFuel]
-		{
-			name = HTPB
-		}
-	}
-//	@MODULE[ModuleEngines*],1
-//	{
-//		@minThrust = 20
-//		@maxThrust = 20
-//		@PROPELLANT[SSTUJettisonFuel]
-//		{
-//			name = HTPB
-//		}
-//	}
-	@MODULE[SSTUAutoDepletionDecoupler]
-	{
-		@ejectionForce = 100
-	}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		type = HTPB
-		volume = 903.38
-		basemass = -1
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = False
-		configuration = Solid
-		CONFIG
-		{
-			name = Solid
-			minThrust = 0
-			maxThrust = 689.5
-			PROPELLANT
-			{
-				name = HTPB
-				ratio = 1.0
-			}
-			atmosphereCurve
-			{
-				key = 0 190
-				key = 1 176
-			}
-		}
+		@amount *= 6.4
+		@maxAmount *= 6.4
 	}
 }
 @PART[SSTU_ShipCore_A_CM]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -14,59 +14,10 @@
 	@mass = 2.051
 	@maxTemp = 1973.15
 	%stagingIcon = DECOUPLER_VERT
-	!RESOURCE[SolidFuel]
+	@RESOURCE,*
 	{
-	}
-	@MODULE[ModuleEngines*],0
-	{
-		@minThrust = 1779
-		@maxThrust = 1779
-	}
-	@MODULE[ModuleEngines*],1
-	{
-		@minThrust = 20
-		@maxThrust = 20
-
-		@PROPELLANT[SolidFuel]
-		{
-			name = HTPB
-		}
-	}
-	@MODULE[ModuleDecouple]
-	{
-		@ejectionForce = 100
-		@explosiveNodeID = bottom
-		%staged = true
-	}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		type = HTPB
-		volume = 903.38
-		basemass = -1
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = False
-		configuration = Solid
-		CONFIG
-		{
-			name = Solid
-			minThrust = 0
-			maxThrust = 1779
-			PROPELLANT
-			{
-				name = HTPB
-				ratio = 1.0
-			}
-			atmosphereCurve
-			{
-				key = 0 190
-				key = 1 176
-			}
-		}
+		@amount *= 6.4
+		@maxAmount *= 6.4
 	}
 }
 


### PR DESCRIPTION
Alter the Apollo and Orion BPC to function as they do in stock, with the unique SSTU modules.