### PR TITLE
RSB Ares I bugfixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
@@ -1,13 +1,13 @@
 //  ==================================================
 //  Sources:
 
-//  1: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120015782.pdf
-//  2: http://spacelaunchreport.com/ares1.html
-//  3: https://www.nasa.gov/pdf/146764main_CLV_CaLV_Description.pdf
-//  4: https://www.nasa.gov/pdf/396682main_Ares_I-X-pk.pdf
-//  5: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110007275.pdf
-//  6: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110007275.pdf
-//  7: http://www.moog.com/literature/Space_Defense/Spacecraft/Propulsion/Monopropellant_Thrusters_Rev_0613.pdf
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120015782.pdf
+//  http://spacelaunchreport.com/ares1.html
+//  https://www.nasa.gov/pdf/146764main_CLV_CaLV_Description.pdf
+//  https://www.nasa.gov/pdf/396682main_Ares_I-X-pk.pdf
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110007275.pdf
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110007275.pdf
+//  http://www.moog.com/literature/Space_Defense/Spacecraft/Propulsion/Monopropellant_Thrusters_Rev_0613.pdf
 
 //  ==================================================
 //  Ares I payload fairing base.
@@ -96,7 +96,7 @@
         volume = 403000
         basemass = -1
 
-        //  Batteries 5145 Wh.
+        //  Batteries 1.43 kWh.
 
         TANK
         {
@@ -153,6 +153,14 @@
 
 @PART[RSBtankAresIstage2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2
+        }
+    }
+
     @MODULE[ModuleSPU]
     {
         @IsRTCommandStation = False
@@ -167,7 +175,7 @@
         %IsRTActive = True
         %Mode0OmniRange = 0
         %Mode1OmniRange = 500
-        %EnergyCost = 0.03
+        %EnergyCost = 0.05
     }
 }
 
@@ -289,8 +297,8 @@
 
         PROPELLANT
         {
-            name = ElectricCharge
-            amount = 0.06
+            name = Helium
+            ratio = 10.0
             ignoreForIsp = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
@@ -97,6 +97,7 @@
         basemass = -1
 
         //  Batteries 1.43 kWh.
+        //  Enough storage for powering the upper stage up to orbital insertion (~20 minutes) and until it is deorbited (approximately 5 hours).
 
         TANK
         {
@@ -174,7 +175,7 @@
         !OmniRange = NULL
         %IsRTActive = True
         %Mode0OmniRange = 0
-        %Mode1OmniRange = 500
+        %Mode1OmniRange = 500000
         %EnergyCost = 0.05
     }
 }


### PR DESCRIPTION
* Fix the commented battery amount of the Ares I upper stage.
* Make the avionics electricity consumption be the same with or without Remote
Tech installed.
* Increase a bit the electricity consumption of the upper stage antenna.
* Fix a wrong required resource by the Ares I 5 meter interstage adapter
RCS thrusters.