### PR TITLE
Skylab TRS

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -237,7 +237,113 @@
 }
 
 
-@PART[skylab_docking_cone,fairing1,fairing3,mm_shield1,mm_shield2,skylab-trs,sl_left_panel,sl_right_panel,skylab_trs_docking,rn_skylab_telescope]:FOR[RealismOverhaul]
+@PART[skylab-trs]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+
+	@MODEL
+	{
+		@scale = 1.00, 1.00, 1.00
+	}
+	
+	@scale = 1.00
+	@rescaleFactor = 1
+	@mass = 1.594
+	!RESOURCE[ElectricCharge]{}
+	!RESOURCE[MonoPropellant]{}
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
+	!MODULE[ModuleEngines]{}
+	!MODULE[ModuleRCS]{}
+	!MODULE[ModuleReactionWheel]{}
+	MODULE
+	{
+		name = ModuleEngines
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		minThrust = 0
+		maxThrust = 3.5	// http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19780011828.pdf
+		heatProduction = 15
+		fxOffset = 0, 0, -0.1
+		EngineType = LiquidFuel
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 1.0
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 310	// total guess.  Used "stock" value
+			key = 1 265	// total guess.  Used "stock" value
+		}
+		ullage = False
+		pressureFed = True
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.01
+		}
+	}
+	MODULE
+	{
+		name = ModuleRCS
+		thrusterTransformName = RCSthruster 
+		thrusterPower = .035	// Total guess but set to 1/100th the thrust of the TRS engines as seen http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19780011828.pdf
+		resourceName = Hydrazine
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+		atmosphereCurve
+		{
+			key = 0 260	// total guess.  Used "stock" value
+			key = 1 100	// total guess.  Used "stock" value
+		}
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 2825
+		basemass = -1
+		TANK
+		{
+			name = ElectricCharge
+			amount = 28500
+			maxAmount = 28500
+		}
+		TANK
+		{
+			name = Hydrazine
+			amount = 2796.5	// based on wet weights shown on the graphic found at https://en.wikipedia.org/wiki/File:Teleoperator_Retrieval_System.jpg
+			maxAmount = 2796.5
+		}
+	}
+}
+@PART[skylab-trs]:NEEDS[RemoteTech]
+{
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = false
+	}
+	MODULE
+	{
+		name = ModuleRTAntenna
+		Mode0OmniRange = 500000
+		Mode1OmniRange = 3000000
+		MaxQ = 6000
+		EnergyCost = 0.005
+		DeployFxModules = 0
+		TRANSMITTER
+		{
+			PacketInterval = 0.3
+			PacketSize = 0.05
+			PacketResourceCost = 0.05
+		}
+	}
+}
+
+@PART[skylab_docking_cone,fairing1,fairing3,mm_shield1,mm_shield2,sl_left_panel,sl_right_panel,skylab_trs_docking,rn_skylab_telescope]:FOR[RealismOverhaul]
 {
 
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -290,7 +290,7 @@
 	{
 		name = ModuleRCS
 		thrusterTransformName = RCSthruster 
-		thrusterPower = .035	// Total guess but set to 1/100th the thrust of the TRS engines as seen http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19780011828.pdf
+		thrusterPower = .35	// Total guess but set to 1/10th the thrust of the TRS engines as seen http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19780011828.pdf
 		resourceName = Hydrazine
 		resourceFlowMode = STAGE_PRIORITY_FLOW
 		atmosphereCurve


### PR DESCRIPTION
I noticed that the Skylab TRS says it's setup for RO/RP-0 (doesn't have a non-RO or non-RPO notice) but its still setup to use "LiquidFuel" and "Oxidizer" and the mass is totally off.  These changes should set it to realistic values.  Unfortunately I couldn't find a whole lot of documentation about the TRS but I did find a graphic that included some weight values (https://en.wikipedia.org/wiki/File:Teleoperator_Retrieval_System.jpg) and a NASA write up with some further information (http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19780011828.pdf).