### PR TITLE
RO CST-100 pack updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -157,6 +157,14 @@
 
 @PART[CST-100?capsule]:AFTER[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.71
+        }
+    }
+
     MODULE
     {
         name = ModuleSPU
@@ -168,7 +176,7 @@
         IsRTActive = False
         Mode0OmniRange = 0
         Mode1OmniRange = 1000000
-        EnergyCost = 0.005
+        EnergyCost = 0.015
         DeployFxModules = 0
         ProgressFxModules = 1
 
@@ -193,7 +201,7 @@
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 550
+        @volume = 510
 
         TANK
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -1,8 +1,8 @@
 //  ==================================================
-//  Aerojet Rocketdyne RS - 88 engine.
+//  RS-88 quad engine block
 
 //  Dimensions: 0.65 m x 0.7 m
-//  Gross Mass: 1000 Kg (four engine block)
+//  Gross Mass: 1000 Kg
 
 //  Sources:
 
@@ -11,7 +11,7 @@
 //  http://astronautix.com/engines/rs88.htm
 //  ==================================================
 
-@PART[RS88]:FOR[RealismOverhaul]
+@PART[RS88]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
     %RSSROConfig = True
 
@@ -27,10 +27,6 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
-
-    @title = CST-100 LAE
-    @manufacturer = Aerojet Rocketdyne
-    @description = A hypergolic pressure - fed engine using MMH and NTO. Else known as Launch Abort Engine (LAE). Four of these engines are used by the CST-100 "Starliner" spacecraft for launch aborts and for orbital maneuvers.
 
     @mass = 1.0
     @crashTolerance = 10
@@ -55,12 +51,6 @@
         @maxThrust = 907.2
         @heatProduction = 100
 
-        IGNITOR_RESOURCE
-        {
-            name = ElectricCharge
-            amount = 0.14
-        }
-
         @PROPELLANT[LiquidFuel]
         {
             @name = MMH
@@ -79,4 +69,16 @@
             @key,1 = 1 220
         }
     }
+}
+
+//  ==================================================
+//  RS-88 quad engine block
+
+//  Custom engine configuration.
+//  ==================================================
+
+@PART[RS88]:AFTER[RealismOverhaulEngines]
+{
+    @title = CST-100 LAE
+    @description = Four of these engines are used by the CST-100 "Starliner" spacecraft for launch aborts and orbital maneuvering.
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -2,14 +2,13 @@
 //  Aerojet Rocketdyne RS - 88 engine.
 
 //  Dimensions: 0.65 m x 0.7 m
-//  Gross Mass: 220 Kg
-//  Throttle Range: N/A
-//  Burn Time: 110 s
-//  O/F Ratio: 1.65
+//  Gross Mass: 1000 Kg (four engine block)
 
-//  Source 1: http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
-//  Source 2: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
-//  Source 3: http://astronautix.com/engines/rs88.htm
+//  Sources:
+
+//  http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
+//  http://astronautix.com/engines/rs88.htm
 //  ==================================================
 
 @PART[RS88]:FOR[RealismOverhaul]
@@ -37,26 +36,26 @@
     @crashTolerance = 10
     @maxTemp = 1023.15
     %skinMaxTemp = 1773.15
-	%heatConductivity = 0.06
-	@skinInternalConductionMult = 4.0
-	@emissiveConstant = 0.8
+    %heatConductivity = 0.06
+    @skinInternalConductionMult = 4.0
+    @emissiveConstant = 0.8
     %stageOffset = 1
     %chileStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    //%engineType = RS88
-    //%engineTypeMult = 4
-    //%ignoreMass = False
+
+    %engineType = RS88
+    %engineTypeMult = 4
+    %massOffset = 0
+    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
+        @name = ModuleEnginesRF
         @minThrust = 907.2
         @maxThrust = 907.2
         @heatProduction = 100
         !fxOffset = NULL
-        %ullage = True
-        %pressureFed = True
-        %ignitions = 6
 
         IGNITOR_RESOURCE
         {
@@ -76,64 +75,10 @@
             @ratio = 0.501
         }
 
-        PROPELLANT
-        {
-            name = Helium
-            ratio = 150.0
-            DrawGauge = False
-            ignoreForIsp = True
-        }
-
         @atmosphereCurve
         {
             @key,0 = 0 290
             @key,1 = 1 220
-        }
-    }
-
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        type = ModuleEngines
-        configuration = RS-88
-        modded = False
-        origMass = 0.22
-
-        CONFIG
-        {
-            name = RS-88
-            minThrust = 907.2
-            maxThrust = 907.2
-            heatProduction = 100
-            massMult = 1.0
-
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.499
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = MON3
-                ratio = 0.501
-                DrawGauge = False
-            }
-
-            PROPELLANT
-            {
-                name = Helium
-                ratio = 150.0
-                DrawGauge = False
-                ignoreForIsp = True
-            }
-
-            atmosphereCurve
-            {
-                key = 0 290
-                key = 1 220
-            }
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -28,11 +28,11 @@
 
     @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 
-    @title = RS - 88
+    @title = CST-100 LAE
     @manufacturer = Aerojet Rocketdyne
     @description = A hypergolic pressure - fed engine using MMH and NTO. Else known as Launch Abort Engine (LAE). Four of these engines are used by the CST-100 "Starliner" spacecraft for launch aborts and for orbital maneuvers.
 
-    @mass = 0.22
+    @mass = 1.0
     @crashTolerance = 10
     @maxTemp = 1023.15
     %skinMaxTemp = 1773.15
@@ -51,11 +51,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 907.2
         @maxThrust = 907.2
         @heatProduction = 100
-        !fxOffset = NULL
 
         IGNITOR_RESOURCE
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
@@ -4,8 +4,10 @@
 //  Dimensions: 5.4 m x 2.5 m
 //  Gross Mass: 7340 Kg
 
-//  Source 1: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
-//  Source 2: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  Sources:
+
+//  http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//  http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
 //  ==================================================
 
 @PART[CST-100?Service?Module]:FOR[RealismOverhaul]
@@ -31,7 +33,7 @@
     @manufacturer = Boeing Co.
     @description = The service module for the CST-100 spacecraft.
 
-    @mass = 1.1
+    @mass = 4.7
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -52,13 +54,13 @@
         PROPELLANT
         {
             name = MMH
-            ratio = 0.4989
+            ratio = 0.499
         }
 
         PROPELLANT
         {
             name = MON3
-            ratio = 0.5066
+            ratio = 0.501
         }
 
         PROPELLANT
@@ -71,7 +73,7 @@
         @atmosphereCurve
         {
             @key,0 = 0 220
-            @key,1 = 1 100
+            @key,1 = 1 85
         }
     }
 
@@ -84,10 +86,10 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 4750
+        volume = 2100
         basemass = -1
 
-        //  Electricity 45 kWh
+        //  Electricity 12.5 kWh
 
         TANK
         {
@@ -105,31 +107,31 @@
             maxAmount = 200
         }
 
-        //  Fuel 1920 Kg.
+        //  RS-88 fuel 680 Kg.
 
         TANK
         {
             name = MMH
-            amount = 2180
-            maxAmount = 2180
+            amount = 871
+            maxAmount = 871
         }
 
-        //  Oxidizer 3115 Kg.
+        //  RS-88 oxidizer 1120 Kg.
 
         TANK
         {
             name = MON3
-            amount = 2190
-            maxAmount = 2190
+            amount = 875
+            maxAmount = 875
         }
 
-        //  Helium 116 Kg.
+        //  RS-88 & ACS pressurization ~3.2 Kg.
 
         TANK
         {
             name = Helium
-            amount = 25000
-            maxAmount = 25000
+            amount = 18000
+            maxAmount = 18000
         }
     }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
@@ -31,7 +31,7 @@
     @manufacturer = Boeing Co.
     @description = The service module for the CST-100 spacecraft.
 
-    @mass = 2.1
+    @mass = 1.1
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -64,7 +64,7 @@
         PROPELLANT
         {
             name = Helium
-            ratio = 150.0
+            ratio = 10.0
             ignoreForIsp = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
@@ -316,7 +316,7 @@
     %skinMaxTemp = 773.15
     @bulkheadProfiles = srf, size1
 
-    @MODULE[ModuleDockingNode]
+    @MODULE[ModuleDockingNode],1
     {
         @nodeType = APAS8995
         %acquireForce = 0.5
@@ -333,7 +333,7 @@
         @stagingEnabled = False
     }
 
-    @MODULE[ModuleDockingNode]
+    @MODULE[ModuleDockingNode],2
     {
         @nodeType = NDS
         %acquireForce = 0.5

--- a/GameData/RealismOverhaul/RealPlume_Configs/CST/RS88.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CST/RS88.cfg
@@ -1,0 +1,31 @@
+//  ==================================================
+//  CST-100 LAE plume configuration.
+//  ==================================================
+
+@PART[RS88]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -2.0
+        fixedScale = 1.75
+        energy = 1.25
+        speed = 1.75
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}


### PR DESCRIPTION
* Balance the CM electricity consumption to be the same with or without RemoteTech installed.
* Update the LAE engine block to the new engine system (requires the update engine config from https://github.com/KSP-RO/RealismOverhaul/pull/909).
* Fix the SM inert and propellant masses due to the engine mass changes.
* Fix an issue regarding the docking node patching of IDA.
* Add a Real Plume config for the LAE engine block.