### PR TITLE
RO VSR RD-108 updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -930,7 +930,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        !runningEffectName = NULL
+        @name = ModuleEnginesRF
         @maxThrust = 941.44
         @minThrust = 941.44
         @heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -930,7 +930,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @maxThrust = 941.44
         @minThrust = 941.44
         @heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -892,14 +892,13 @@
 //  cover & tubing).
 
 //  Dimensions: 2.578 m x 1.85 m
-//  Gross Mass: 1278.0 Kg
-//  Throttle Range: N/A
-//  Burn Time: 286 s
-//  O/F Ratio: 2.39
+//  Gross Mass: 1278 Kg
 
-//  Source 1: http://www.npoenergomash.ru/dejatelnost/engines/rd107/
-//  Source 2: http://www.lpre.de/energomash/RD-107/index.htm
-//  Source 3: http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//  Sources:
+
+//  http://www.npoenergomash.ru/dejatelnost/engines/rd107/
+//  http://www.lpre.de/energomash/RD-107/index.htm
+//  http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
 
 //  HTP usage and fuel ratios based on mass flow rates through turbopump given in [3]
 //  ==================================================
@@ -907,7 +906,6 @@
 @PART[Size2MedEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines,VenStockRevamp]
 {
     %RSSROConfig = True
-    engineType = RD108-118
 
     @MODEL
     {
@@ -915,204 +913,58 @@
     }
 
     @node_stack_top = 0.0, 1.738, 0.0, 0.0, 1.0, 0.0, 2
+
     @category = Engine
     @title = RD-108 Series
     @manufacturer = NPO Energomash [Glushko]
     @description = Core engine for the R-7 Semyorka and its derivatives, including the Sputnik, Luna, Voskhod, Vostok, Soyuz, and Molniya launch vehicles.  Differs from the booster engine series (RD-107) with a lower chamber pressure, thrust, and a wider vernier layout.  Powers the R-7 family core through a very long (roughly) five minute burn that starts on the pad alongside the boosters.
+
     @mass = 1.278
-    @maxTemp = 1973.15
+    @maxTemp = 1024.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = RD108-118
+    %engineTypeMult = 1
+    %massOffset = 0.15
+    %ignoreMass = True
 
     @MODULE[ModuleEngines*]
     {
-        !engineID = NULL
         !runningEffectName = NULL
-		@maxThrust = 941.44
-		@minThrust = 941.44
+        @maxThrust = 941.44
+        @minThrust = 941.44
         @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[LiquidFuel]
         {
             @name = Kerosene
-        	@ratio = 0.3531
+            @ratio = 0.3531
         }
+
         @PROPELLANT[Oxidizer]
         {
             @name = LqdOxygen
             @ratio = 0.6274
         }
+
         PROPELLANT
         {
             name = HTP
-        	ratio = 0.0195
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
         }
 
         @atmosphereCurve
         {
-            @key = 0 314.79
-            @key = 1 247.79
+            @key,0 = 0 314.79
+            @key,1 = 1 247.79
         }
     }
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		origMass = 1.278
-		configuration = RD-108_(8D75)
-		modded = false
-		CONFIG
-		{
-			name = RD-108_(8D75)
-			maxThrust = 941.44
-			minThrust = 941.44
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3531
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6274
-            }
-            PROPELLANT
-            {
-                name = HTP
-    			ignoreForIsp = True
-                ratio = 0.0195
-            }
-			atmosphereCurve
-			{
-				key = 0 314.79
-				key = 1 247.79
-			}
-			massMult = 1.0
-		}
-		CONFIG
-		{
-			name = RD-108_(8D75K)
-			maxThrust = 941.44
-			minThrust = 941.44
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3531
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6274
-            }
-            PROPELLANT
-            {
-                name = HTP
-    			ignoreForIsp = True
-                ratio = 0.0195
-            }
-			atmosphereCurve
-			{
-				key = 0 314.07
-				key = 1 248.10
-			}
-			massMult = 1.0
-		}
-		CONFIG
-		{
-			name = RD-108mm_(8D727)
-			maxThrust = 973.8
-			minThrust = 973.8
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3531
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6274
-            }
-            PROPELLANT
-            {
-                name = HTP
-    			ignoreForIsp = True
-                ratio = 0.0195
-            }
-			atmosphereCurve
-			{
-				key = 0 315.81
-				key = 1 252.79
-			}
-			massMult = 0.895
-		}
-		CONFIG
-		{
-			name = RD-118_(11D512)
-			maxThrust = 999.3
-			minThrust = 999.3
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3531
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6274
-            }
-            PROPELLANT
-            {
-                name = HTP
-    			ignoreForIsp = True
-                ratio = 0.0195
-            }
-			atmosphereCurve
-			{
-				key = 0 314.58
-				key = 1 256.87
-			}
-			massMult = 0.904
-		}
-		CONFIG
-		{
-			name = RD-108A_(14D21)
-			maxThrust = 990.47
-			minThrust = 990.47
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3531
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6274
-            }
-            PROPELLANT
-            {
-                name = HTP
-    			ignoreForIsp = True
-                ratio = 0.0195
-            }
-			atmosphereCurve
-			{
-				key = 0 320.39
-				key = 1 257.48
-			}
-			massMult = 0.84
-		}
-	}
 
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 4.5
         @gimbalResponseSpeed = 16
     }
-
-    !MODULE[ModuleAlternator]{}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
@@ -23,8 +23,6 @@
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  RD-107/108 plume configuration.
+//  RD-108 plume configuration.
 //  ==================================================
 
 @PART[Size2MedEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -31,7 +31,7 @@
 }
 
 //  ==================================================
-//  RD-107/108 flare configuration.
+//  RD-108 flare configuration.
 //  ==================================================
 
 @PART[Size2MedEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
@@ -50,7 +50,7 @@
 }
 
 //  ==================================================
-//  RD-107/108 smoke configuration.
+//  RD-108 smoke configuration.
 //  ==================================================
 
 @PART[Size2MedEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]

--- a/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  RD-107 / RD-108 engine plume configuration.
+//  RD-107/108 plume configuration.
 //  ==================================================
 
 @PART[Size2MedEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -9,10 +9,10 @@
         name = Kerolox-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, -0.35
+        localPosition = 0.0, 0.0, 0.0
         fixedScale = 0.4
-        energy = 1.0
-        speed = 1.35
+        energy = 1.25
+        speed = 1.5
     }
 
     @MODULE[ModuleEngines*]
@@ -26,6 +26,44 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
+        }
+    }
+}
+
+//  ==================================================
+//  RD-107/108 flare configuration.
+//  ==================================================
+
+@PART[Size2MedEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.15
+                @fixedScale = 0.2
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  RD-107/108 smoke configuration.
+//  ==================================================
+
+@PART[Size2MedEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[smoke]
+            {
+                @localPosition = 0.0, 0.0, -2.25
+                @fixedScale = 0.5
+            }
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/Size2MedEngine.cfg
@@ -17,7 +17,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         !runningEffectName = NULL
         %powerEffectName = Kerolox-Lower
     }


### PR DESCRIPTION
* Correct an issue with the HTP propellant (just to be safe).
* Fix the ISP key patching.
* Fix the inert mass (engine model includes a heat shield around the engine).
* Remove the ModuleEngineConfigs block (not needed, gets overriden by the global engine config).
* Improve the RealPlume FX effects.