### PR TITLE
SSTU Feb 13 fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_J2X.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_J2X.cfg
@@ -1,0 +1,482 @@
+@PART[SSTU_ShipCore_ENG-J-2X]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	%category = Propulsion
+	@mass = 2.47
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 1072
+		@maxThrust = 1308
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 424
+			@key,1 = 1 200
+		}
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 3
+		!IGNITOR_RESOURCE,* {}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.500
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdHydrogen
+			amount = 0.745
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.255
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	engineType = J2X
+	@MODULE[SSTUEngineCluster]
+	{
+		%engineScale = 1.5625
+		@diameterMainIncrement = 1.0
+		@MOUNT,*
+		{
+			@size = 6.6
+			@maxSize = 10
+		}
+	}
+	@MODULE[SSTUNodeFairing]
+	{
+		%maxTopRadius = 10
+		%maxBottomRadius = 10
+		@FAIRING
+		{
+			@topRadius = 3.3
+			@bottomRadius = 3.3
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-J-2Xx2]:AFTER[SSTU_ENGINES]
+{
+	@category = none
+	@title = J-2X Series 2 Engine Mount [6.6m]
+	@description = Engine cluster for general use.  Includes two (2) J-2X motors on a selectable mount. Mount size can be adjusted from 2.5m to 10m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = Double
+		@defaultMount = Mount-S-II
+		@defaultEngineSpacing *= 1.5625
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-None
+			canAdjustSize = false
+		}
+		MOUNT
+		{
+			name = Mount-S-II
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-S-IVB
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+	}
+	engineTypeMult = 2
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 3.3
+			@bottomRadius = 3.3
+			%maxRadius = 10.0
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-J-2Xx3]:AFTER[SSTU_ENGINES]
+{
+	@category = none
+	@title = J-2X Series 3 Engine Mount [6.6m]
+	@description = Engine cluster for general use.  Includes three (3) J-2X motors on a selectable mount. Mount size can be adjusted from 2.5m to 10m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = Triple
+		@defaultMount = Mount-S-II
+		@defaultEngineSpacing *= 1.5625
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-None
+			canAdjustSize = false
+		}
+		MOUNT
+		{
+			name = Mount-S-II
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			size = 6.6
+			minSize = 2.5
+			maxSize = 10
+		}
+	}
+	engineTypeMult = 3
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 3.3
+			@bottomRadius = 3.3
+			%maxRadius = 10.0
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-J-2Xx4]:AFTER[SSTU_ENGINES]
+{
+	@category = none
+	@title = J-2X Series 4 Engine Mount [8.4m]
+	@description = Engine cluster for general use.  Includes four (4) J-2X motors on a selectable mount. Mount size can be adjusted from 2.5m to 10m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = Quad
+		@defaultMount = Mount-S-II
+		@defaultEngineSpacing *= 1.5625
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-None
+			layoutName = Quad
+			layoutName = Quad-X
+			layoutName = QuadInline
+			canAdjustSize = false
+		}
+		MOUNT
+		{
+			name = Mount-S-II
+			layoutName = Quad
+			layoutName = Quad-X
+			layoutName = QuadInline
+			size = 8.4
+			minSize = 3.75
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			layoutName = Quad
+			layoutName = Quad-X
+			layoutName = QuadInline
+			size = 8.4
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			layoutName = Quad
+			layoutName = Quad-X
+			layoutName = QuadInline
+			size = 8.4
+			minSize = 2.5
+			maxSize = 10
+		}
+	}
+	engineTypeMult = 4
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 4.2
+			@bottomRadius = 4.2
+			%maxRadius = 10.0
+		}
+	}
+}
+
+@PART[SSTU_ShipCore_ENG-J-2Xx5]:AFTER[SSTU_ENGINES]
+{
+	@category = none
+	@title = J-2X Series 5 Engine Mount [10m]
+	@description = Engine cluster for general use.  Includes five (5) J-2X motors on a selectable mount. Mount size can be adjusted from 2.5m to 10m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = FiveCross
+		@defaultMount = Mount-S-II
+		%defaultEngineSpacing = 3.3
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-None
+			layoutName = FiveCross
+			layoutName = Five-X
+			layoutName = FiveRadial
+			canAdjustSize = false
+		}
+		MOUNT
+		{
+			name = Mount-S-II
+			layoutName = FiveCross
+			layoutName = Five-X
+			layoutName = FiveRadial
+			size = 10
+			minSize = 3.75
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			layoutName = FiveCross
+			layoutName = Five-X
+			layoutName = FiveRadial
+			size = 10
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			layoutName = FiveCross
+			layoutName = Five-X
+			layoutName = FiveRadial
+			size = 10
+			minSize = 2.5
+			maxSize = 10
+		}
+	}
+	engineTypeMult = 5
+	minActiveEngines = 4
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 5
+			@bottomRadius = 5
+			%maxRadius = 10.0
+		}
+	}
+}
+
+// broke, need to be generated new
+
+@PART[SSTU_ShipCore_ENG-J-2Xx6]:AFTER[SSTU_ENGINES]
+{
+	@category = none
+	@title = J-2X Series 6 Engine Mount [10m]
+	@description = Engine cluster for general use.  Includes six (6) J-2X motors on a selectable mount. Mount size can be adjusted from 2.5m to 10m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = SixRadial
+		@defaultMount = Mount-S-II
+		@defaultEngineSpacing *= 1.5625
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-None
+			layoutName = SixRadial
+			layoutName = SixCenter
+			layoutName = SixDoubleCenter
+			canAdjustSize = false
+		}
+		MOUNT
+		{
+			name = Mount-S-II
+			layoutName = SixRadial
+			layoutName = SixCenter
+			layoutName = SixDoubleCenter
+			size = 10
+			minSize = 3.75
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			layoutName = SixRadial
+			layoutName = SixCenter
+			layoutName = SixDoubleCenter
+			size = 10
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			layoutName = SixRadial
+			layoutName = SixCenter
+			layoutName = SixDoubleCenter
+			size = 10
+			minSize = 2.5
+			maxSize = 10
+		}
+	}
+	engineTypeMult = 6
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 5
+			@bottomRadius = 5
+			%maxRadius = 10.0
+		}
+	}
+}
+
+// broke, need to be generated new
+
+@PART[SSTU_ShipCore_ENG-J-2Xx7]:AFTER[SSTU_ENGINES]
+{
+	@category = none
+	@title = J-2X Series 7 Engine Mount [10m]
+	@description = Engine cluster for general use.  Includes seven (7) J-2X motors on a selectable mount. Mount size can be adjusted from 2.5m to 10m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = SevenCenter
+		@defaultMount = Mount-S-II
+		@defaultEngineSpacing *= 1.5625
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-None
+			canAdjustSize = false
+		}
+		MOUNT
+		{
+			name = Mount-S-II
+			size = 10
+			minSize = 3.75
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			size = 10
+			minSize = 2.5
+			maxSize = 10
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			size = 10
+			minSize = 2.5
+			maxSize = 10
+		}
+	}
+	engineTypeMult = 7
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 5
+			@bottomRadius = 5
+			%maxRadius = 10.0
+		}
+	}
+}
+
++PART[SSTU_ShipCore_ENG-J-2X]:AFTER[SSTU_ENGINES]
+{
+	//  NEEDS[SSTU]:FOR[RealismOverhaul]
+	@name = SSTU_ShipCore_ENG-J-2x8
+	@category = none
+	@title = J-2X Series 8 Engine Mount [10m]
+	@description = Engine cluster for general use.  Includes eight (8) J-2X motors on a selectable mount. Mount size can be adjusted from 10m to 20m in 1m increments.
+	@MODULE[SSTUEngineCluster]
+	{
+		@defaultLayoutName = EightRadial
+		@defaultMount = Mount-S-II
+		!MOUNT,*{}
+		MOUNT
+		{
+			name = Mount-S-II
+			size = 10
+			minSize = 10
+			maxSize = 20
+			engineSpacing = 2.856
+		}
+		MOUNT
+		{
+			name = Mount-Nova
+			size = 10
+			minSize = 10
+			maxSize = 20
+			engineSpacing = 2.856
+		}
+		MOUNT
+		{
+			name = Mount-Generic
+			size = 10
+			minSize = 10
+			maxSize = 20
+			engineSpacing = 2.856
+		}
+		MOUNT
+		{
+			name = Mount-None
+			size = 10
+			minSize = 10
+			maxSize = 20
+			engineSpacing = 2.856
+		}
+	}
+	engineTypeMult = 8
+	@MODULE[SSTUNodeFairing]
+	{
+		@FAIRING
+		{
+			@topRadius = 5
+			@bottomRadius = 6.1
+			%maxRadius = 10.0
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -63,7 +63,7 @@
 		@maxAmount *= 3 //needed to give more time to separate the SRBs, that now are very heavy even empty
 	}
 }
-@PART[SSTU_SC-A-107b-RCS4A]:FOR[RealismOverhaul]
+@PART[SSTU-SC-GEN-RCS-4A-V]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -95,7 +95,7 @@
 		}
 	}
 }
-@PART[SSTU_SC-A-107a-RCS4F]:FOR[RealismOverhaul]
+@PART[SSTU-SC-GEN-RCS-4F-T]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -127,7 +127,7 @@
 		}
 	}
 }
-@PART[SSTU_SC-A-107c-RCS5F]:FOR[RealismOverhaul]
+@PART[SSTU-SC-GEN-RCS-5F-V]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -159,6 +159,40 @@
 		}
 	}
 }
+
+@PART[SSTU-SC-GEN-RCS-4F-V]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		%scale = 1.333333,1.333333,1.333333
+	}
+	//%rescaleFactor = 1.25
+	@node_attach = 0,0,0.06666665,0,0,-1,1
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCS
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.712
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+		@atmosphereCurve
+		{
+			key = 0 300
+			key = 1 100
+		}
+	}
+}
+
 
 @PART[SSTU_LanderCore_LC-ISA]:FOR[RealismOverhaul] // Petal Adapter
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -201,11 +201,13 @@
 		{
 			name = MMH
 			ratio = 0.456
+			%resourceFlowMode = NO_FLOW
 		}
 		PROPELLANT
 		{
 			name = NTO
 			ratio = 0.544
+			%resourceFlowMode = NO_FLOW
 		}
 		@atmosphereCurve
 		{
@@ -290,11 +292,13 @@
 		{
 			@name = MMH
 			@ratio = 0.456
+			%resourceFlowMode = NO_FLOW
 		}
 		PROPELLANT
 		{
 			name = NTO
 			ratio = 0.544
+			%resourceFlowMode = NO_FLOW
 		}
 	}
 	
@@ -307,11 +311,13 @@
 		{
 			name = MMH
 			ratio = 0.456
+			%resourceFlowMode = NO_FLOW
 		}
 		PROPELLANT
 		{
 			name = NTO
 			ratio = 0.544
+			%resourceFlowMode = NO_FLOW
 		}
 		@atmosphereCurve
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS_Upper_Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS_Upper_Stages.cfg
@@ -164,6 +164,7 @@
 	}
 	//%rescaleFactor = 1.68
 	@node_stack_top = 0,8.3804112,0,0,1,0,5
+	@node_stack_top2 = 0,6.25,0,0,1,0,5
 	@node_stack_bottom = 0,-10.1177664,0,0,-1,0,8
 	%RSSROConfig = True
 	@mass = 11.8786

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -5,6 +5,7 @@
 	{
 		%maxTankDiameter = 20
 		%useRF = true
+		%defaultRcsThrust = 0.1
 	}
 	@MODULE[SSTUNodeFairing],*
 	{
@@ -14,6 +15,33 @@
 	!MODULE[ModuleResourceConverter]
 	{
 	}
+	!MODULE[ModuleRCS] {}
+	MODULE
+	{
+		name = ModuleRCS
+		thrusterTransformName = SC-GEN-RCS-4F-T-ThrustTransform
+		thrusterPower = 0.1 // does not seem to have an impact
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+		atmosphereCurve
+		{
+			key = 0 270
+			key = 1 100
+			key = 4 0.001
+		}
+		PROPELLANT
+		{
+			ratio = 0.495
+			name = MMH
+			%resourceFlowMode = NO_FLOW
+		}
+		PROPELLANT
+		{
+			ratio = 0.505
+			name = MON3
+			%resourceFlowMode = NO_FLOW
+		}
+	}
+	!MODULE[ModuleSAS] {}
 }
 @PART[SSTU_ShipCore_MUS-ST]:FOR[SSTU]:NEEDS[RealFuels]
 {
@@ -22,6 +50,7 @@
 	{
 		%maxTankDiameter = 20
 		%useRF = true
+		%defaultRcsThrust = 0.1
 	}
 	@MODULE[SSTUNodeFairing],*
 	{
@@ -31,6 +60,33 @@
 	!MODULE[ModuleResourceConverter]
 	{
 	}
+	!MODULE[ModuleRCS] {}
+	MODULE
+	{
+		name = ModuleRCS
+		thrusterTransformName = SC-GEN-RCS-4F-T-ThrustTransform
+		thrusterPower = 0.1 // does not seem to have an impact
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+		atmosphereCurve
+		{
+			key = 0 270
+			key = 1 100
+			key = 4 0.001
+		}
+		PROPELLANT
+		{
+			ratio = 0.495
+			name = MMH
+			%resourceFlowMode = NO_FLOW
+		}
+		PROPELLANT
+		{
+			ratio = 0.505
+			name = MON3
+			%resourceFlowMode = NO_FLOW
+		}
+	}
+	!MODULE[ModuleSAS] {}
 }
 @PART[SSTU_ShipCore_MFT-A|SSTU_ShipCore_MFT-B]:FOR[SSTU]:NEEDS[RealFuels]
 {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
@@ -18,10 +18,9 @@
         name = Hypergolic-OMS-White
         transformName = SC-B-SM-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.25
-		//adjust these directly to rescale/etc the plume
-        fixedScale = 2
+		plumePosition = 0,0,0.25
+        plumeScale = 2
         energy = 1
         speed = 1.2
     }
-} 
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_A_SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_A_SM.cfg
@@ -18,24 +18,9 @@
         name = Hypergolic-OMS-White
         transformName = SC-A-SM-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.9
+        localPosition = 0,0,0.6
         fixedScale = 5.1
         energy = 1
         speed = 1.2
     }
-}
-
-@PART[SSTU_ShipCore_A_SM]:FOR[RealPlume]:NEEDS[zzRealPlume]
-{
-	@EFFECTS
-		{
-			@Hypergolic-OMS-White
-			{
-				@MODEL_MULTI_PARTICLE_PERSIST[flare]
-				{
-					@localPosition = 0,0,0.9
-					@fixedScale = 5.0
-				}
-			}
-		}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1.cfg
@@ -10,12 +10,11 @@
         name = Kerolox-Lower-F1
         transformName = F1-ThrustTransform
 		localRotation = 0,0,0
-        localPosition = 0,0,3.0
-        fixedScale = 1.5
-        energy = 0.7
-        speed = 1
-		
+		plumePosition = 0,0,3.0
+        plumeScale = 1.5
 		flarePosition = 0,0,3.0
 		flareScale = 1.2
+        energy = 0.7
+        speed = 1
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1B.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1B.cfg
@@ -11,11 +11,10 @@
         transformName = F1B-ThrustTransform
         localRotation = 0,0,0
         plumePosition = 0,0,2.5
-        fixedScale = 1.0
-        energy = 0.7
-        speed = 1
-		
+        plumeScale = 1.0
 		flarePosition = 0,0,2.8
 		flareScale = 1.0
+        energy = 0.7
+        speed = 1
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2.cfg
@@ -11,11 +11,10 @@
         transformName = J-2-ThrustTransform
         localRotation = 0,0,0
         plumePosition = 0,0,2.1
-        fixedScale = 2.2
-        energy = 1.0
-        speed = 1
-		
+        plumeScale = 2.2
 		flarePosition = 0,0,1.9
 		flareScale = 2.2
+        energy = 1.0
+        speed = 1
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2X.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2X.cfg
@@ -1,0 +1,20 @@
+@PART[SSTU_ShipCore_ENG-J-2X]:BEFORE[SSTU_ENGINES]:FIRST
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = Hydrolox-Upper
+    }
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = J-2X-ThrustTransform
+        localRotation = 0,0,0
+        plumePosition = 0,0,3.5
+        plumeScale = 3.5
+		flarePosition = 0,0,3.0
+		flareScale = 3.5
+        energy = 1.0
+        speed = 1
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10A-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10A-3.cfg
@@ -1,0 +1,28 @@
+@PART[SSTU_ShipCore_ENG-RL10A-3]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		!runningEffectName = DELETE
+	}
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = RL10A-3-ThrustTransform
+        localRotation = 0,0,0
+		plumePosition = 0,0,1.3
+        plumeScale = 1.3
+        flarePosition = 0,0,1.2
+        flareScale = 1.3
+        energy = 1
+        speed = 1.2
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10B-2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10B-2.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-B-HUS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_ShipCore_ENG-RL10B-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -18,24 +18,11 @@
         name = Hydrolox-Upper
         transformName = RL10B-2-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,2.7
-        fixedScale = 2 // 0.8
+		plumePosition = 0,0,2.0
+        plumeScale = 2		
+        flarePosition = 0,0,2.3
+        flareScale = 1.9
         energy = 1
         speed = 1.2
     }
-}
-
-@PART[SSTU-SC-B-HUS]:FOR[RealPlume]:NEEDS[zzRealPlume]
-{
-	@EFFECTS
-		{
-			@Hydrolox-Upper
-			{
-				@MODEL_MULTI_PARTICLE_PERSIST[flare]
-				{
-					@localPosition = 0,0,2.3
-					@fixedScale = 1.9
-				}
-			}
-		}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RS-25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RS-25.cfg
@@ -10,12 +10,11 @@
         name = Hydrolox-Lower
         transformName = RS-25-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,2.5
-        fixedScale = 3.0
-        energy = 1.0
-        speed = 1
-		
+		plumePosition = 0,0,2.5
+        plumeScale = 3.0
 		flarePosition = 0,0,2.0
 		flareScale = 2.8
+        energy = 1.0
+        speed = 1
     }
 }


### PR DESCRIPTION
Moved HUS/EUS node for petal adapter attachment (addressing #888)

Added NO_FLOW for Orion SM & CM, so they don't steal fuel from each other (addressing #888)

Add prototype ullage RCS for the proc upper stages (will likely move it
to the standard fuel choices of the standard RCS later)

Standardizes a few of the RealPlume configs. Add a couple RL10
RealPlumes as well.
