### PR TITLE
RO squad engines update

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RO_H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_H1_Config.cfg
@@ -1,12 +1,48 @@
-// this engine is the H-1 and RS27
-// Squad, FASA, KW
+//  ==================================================
+//  H-1/RS-27
+
+//  Throttle Range: N/A
+//  Burn Time: 165 s (H-1), 275 s (RS-27/A)
+//  O/F Ratio: 2.23
+
+//  Sources:
+//      http://www.rocket.com/rs-27a-engine
+//      http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//      http://www.apollosaturn.com/sibnews/sec4.htm
+//      https://web.archive.org/web/20041022144943/http://history.nasa.gov/SP-4206/ch4.htm
+//      http://www.astronautix.com/engines/rs27a.htm
+
+//  Used by:
+//      FASA
+//      KW Rocketry
+//      Squad
+//  ==================================================
+
 @PART[*]:HAS[#engineType[H1]]:FOR[RealismOverhaulEngines]
 {
+    %title = H-1/RS-27 Series
+    %manufacturer = Rocketdyne
+    %description = The H-1 is an upgrade to the LR-79 engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1/RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters and the core burns rather longer. [1.0m]
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 8
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAlternator]{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = H-1b
+		configuration = H-1
 		origMass = 0.988
 		CONFIG
 		{
@@ -14,63 +50,109 @@
 			minThrust = 947
 			maxThrust = 947
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.384
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.616
-			}
-			atmosphereCurve
-			{
-				key = 0 289
-				key = 1 255
-			}
 			massMult = 0.643
+
+			techRequired = advRocketry // Saturn I Block I/II engine
 			entryCost = 33750 // there's actually a source for this one!
+			cost = 700
+
 			entryCostSubtractors
 			{
 				LR79-NA-9 = 2000
 				LR79-NA-11 = 1000
 			}
-			cost = 700
-			techRequired = advRocketry // Saturn I Block I/II engine
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3842
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6158
+                DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 289
+				key = 1 255
+			}
 		}
+
 		CONFIG
 		{
 			name = H-1b
 			minThrust = 1030.2
 			maxThrust = 1030.2
 			heatProduction = 100
+			massMult = 1
+
+			techRequired = heavyRocketry
+			entryCost = 39750
+			cost = 1000
+
+			entryCostSubtractors
+			{
+				H-1-SaturnI = 33750
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.384
+				ratio = 0.3842
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.616
+				ratio = 0.6158
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 296
 				key = 1 265
 			}
-			techRequired = heavyRocketry
-			entryCost = 39750
-			entryCostSubtractors
-			{
-				H-1-SaturnI = 33750
-			}
-			cost = 1000
-			massMult = 1
 		}
+
 		CONFIG
 		{
 			name = RS-27
@@ -78,31 +160,54 @@
 			minThrust = 1023
 			heatProduction = 100
 			massMult = 1.0395
+
+			techRequired = heavierRocketry
+			cost = 800
+			entryCost = 40750
+
+			entryCostSubtractors
+			{
+				H-1-SaturnIB = 39750
+				H-1B = 39750 // legacy name for the config
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.38264
 				DrawGauge = true
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.61736
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 295
 				key = 1 264
 			}
-			cost = 800
-			entryCost = 40750
-			entryCostSubtractors
-			{
-				H-1-SaturnIB = 39750
-				H-1B = 39750 // legacy name for the config
-			}
-			techRequired = heavierRocketry
 		}
+
 		CONFIG
 		{
 			name = RS-27A
@@ -110,29 +215,60 @@
 			minThrust = 1054
 			heatProduction = 100
 			massMult = 1.10425
+
+			techRequired = veryHeavyRocketry
+			cost = 850
+			entryCost = 41750
+
+			entryCostSubtractors
+			{
+				RS-27 = 40750
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.38264
 				DrawGauge = true
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.61736
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 302
 				key = 1 255
 			}
-			cost = 850
-			entryCost = 41750
-			entryCostSubtractors
-			{
-				RS-27 = 40750
-			}
-			techRequired = veryHeavyRocketry
-		}
+        }
 	}
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = TEATEB
+        amount = 1
+        maxAmount = 1
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LMAE_Config.cfg
@@ -1,30 +1,99 @@
-// LMAE
-// AIES, Squad, FASA
+//  ==================================================
+//  Lunar Module Ascent Engine (LMAE)
+
+//  Throttle Range: N/A
+//  Burn Time: 465 s
+//  O/F Ratio: 1.6
+
+//  Sources:
+//      http://www.alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
+//      https://www.hq.nasa.gov/alsj/LM10HandbookVol1.pdf
+//      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700026405.pdf
+//      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027314.pdf
+
+//  Used by:
+//      AIES
+//      FASA
+//      Squad
+
+//  FIXME: Number of ignitions (10 instead of 2).
+//  FIXME: Inert mass (NASA references indicate a value of 210 pounds)
+//  ==================================================
+
 @PART[*]:HAS[#engineType[LMAE]]:FOR[RealismOverhaulEngines]
 {
+    @mass = 0.095
+    %title = Lunar Module Ascent Engine
+    %manufacturer = Bell
+    %description = Pressure-fed engine used for the ascent module of the Apollo lunar lander.
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleGimbal]{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = LMAE
+        origMass = 0.095
 		modded = false
+
 		CONFIG
 		{
 			name = LMAE
 			minThrust = 15.57
 			maxThrust = 15.57
 			heatProduction = 100
+            massMult = 1.0
+
+            ullage = True
+            pressureFed = True
+            ignitions = 10
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Aerozine50
+                amount = 5.017
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = NTO
+                amount = 4.983
+            }
+
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.502
+				ratio = 0.5017
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.498
+				ratio = 0.4983
+                DrawGauge = False
 			}
+
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 10.0
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
 			atmosphereCurve
 			{
 				key = 0 311
@@ -32,4 +101,8 @@
 			}
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LMDE_Config.cfg
@@ -82,6 +82,14 @@
                 DrawGauge = False
 			}
 
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 10.0
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
 			atmosphereCurve
 			{
 				key = 0 311
@@ -125,6 +133,14 @@
                 DrawGauge = False
 			}
 
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 10.0
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
 			atmosphereCurve
 			{
 				key = 0 313.5
@@ -138,7 +154,7 @@
 			minThrust = 43.8
 			maxThrust = 43.8
 			heatProduction = 100
-			massMult = 0.632 //mass is 0.113
+			massMult = 0.7151 //mass is 0.113
 
 			techRequired = heavierRocketry
 			cost = -400
@@ -157,6 +173,14 @@
 				ratio = 0.4983
                 DrawGauge = False
 			}
+
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 10.0
+                DrawGauge = False
+                ignoreForIsp = True
+            }
 
 			atmosphereCurve
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LMDE_Config.cfg
@@ -1,82 +1,137 @@
-// Lunar module descent engine, LMDE
-// Squad, Tantares, FASA, AIES, OLDD.
-// http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  ==================================================
+// Lunar module descent engine (LMDE)
+
+//  Throttle Range: 10% to 100%
+//  Burn Time: 1030 s
+//  O/F Ratio: 1.6
+
+//  Sources:
+//      http://heroicrelics.org/info/lm/mech-design-lmde.html
+//      https://www.hq.nasa.gov/alsj/LM10HandbookVol1.pdf
+//      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700026405.pdf
+//      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027314.pdf
+//      http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+
+//  Used by:
+//      AIES
+//      FASA
+//      OLDD
+//      Squad
+//      Tantares
+
+//  FIXME: What is the correct inert mass?
+//  FIXME: Why 3 ignitions instead of the stated 2?
+//  ==================================================
+
 @PART[*]:HAS[#engineType[LMDE]]:FOR[RealismOverhaulEngines]
 {
+    @mass = 0.158
+    %title = Lunar Module Descent Engine
+    %manufacturer = TRW
+    %description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability.
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 6.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = LMDE-H
 		modded = false
-		origMass = 0.179 //FIXME?? nathankell set it to .135 for some reason.
+		origMass = 0.158
+
 		CONFIG
 		{
 			name = LMDE-H
 			minThrust = 4.67
 			maxThrust = 43.9
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			atmosphereCurve
-			{
-				key = 0 311
-				key = 1 116
-			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 3
-			!IGNITOR_RESOURCE,* {}
+            massMult = 1.0
+
+			ullage = True
+			pressureFed = True
+			ignitions = 3
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.2
 			}
+
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.5017
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4983
+                DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 311
+				key = 1 116
+			}
 		}
+
 		CONFIG
 		{
 			name = LMDE-J
 			minThrust = 4.67
 			maxThrust = 45.04
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			atmosphereCurve
-			{
-				key = 0 313.5
-				key = 1 116
-			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 3
-			!IGNITOR_RESOURCE,* {}
+            massMult = 1.0
+
+			techRequired = heavierRocketry
+			cost = 150
+			entryCost = 3000
+
+			ullage = True
+			pressureFed = True
+			ignitions = 3
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.2
 			}
-			techRequired = heavierRocketry
-			cost = 150
-			entryCost = 3000
+
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.5017
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4983
+                DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 313.5
+				key = 1 116
+			}
 		}
+
 		CONFIG
 		{
 			name = TR-201
@@ -84,25 +139,34 @@
 			maxThrust = 43.8
 			heatProduction = 100
 			massMult = 0.632 //mass is 0.113
+
+			techRequired = heavierRocketry
+			cost = -400
+			entryCost = 2000
+
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.502
+				ratio = 0.5017
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.498
+				ratio = 0.4983
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 303
 				key = 1 130
 			}
-			techRequired = heavierRocketry
-			cost = -400
-			entryCost = 2000
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LR101_Config.cfg
@@ -1,7 +1,32 @@
-// LR101 Vernier
-// Squad, FASA, FIXME do KK
+//  ==================================================
+//  LR101 vernier
+
+//  Throttle Range: N/A
+//  Burn Time: 323 s
+//  O/F Ratio: ~2.25 (differs between versions)
+
+//  Sources:
+//      http://heroicrelics.org/info/lr-101/lr-101.html
+
+//  Used by:
+//      FASA
+//      Squad
+
+//  FIXME: Add KK.
+//  FIXME: These engines were pressure-fed but it might be difficult to combine them with MFT.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[LR101]]:FOR[RealismOverhaulEngines]
 {
+    %title = LR-101 Series
+    %manufacturer = Rocketdyne
+    %description = Pump or pressure-fed kerolox vernier engine. Used for attitude control and final velocity adjustment in the MA-x system (2x LR89 + LR105 + 2x LR101) on Atlas, and MB-x system (LR79 or RS-27 + 2xLR101) on Thor-Able / Thor-Agena / Thor-Delta / Delta.
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -9,54 +34,85 @@
 		modded = false
 		configuration = LR101-NA-3
 		origMass = 0.024
+
 		CONFIG
 		{
 			name = LR101-NA-3
 			minThrust = 5.1144
 			maxThrust = 5.1144
 			heatProduction = 10
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.382
+				ratio = 0.3821
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.618
+				ratio = 0.6179
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 238
 				key = 1 207
 			}
 		}
+
 		CONFIG
 		{
 			name = LR101-NA-11
 			minThrust = 5.369
 			maxThrust = 5.369
 			heatProduction = 10
+
+			techRequired = advRocketry
+			cost = 15
+			entryCost = 300
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.3929
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.6071
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 249
 				key = 1 209.8
 			}
-			techRequired = advRocketry
-			cost = 15
-			entryCost = 300
 		}
 		CONFIG
 		{
@@ -64,26 +120,41 @@
 			minThrust = 2.976
 			maxThrust = 2.976
 			heatProduction = 10
+			massMult = 0.8
+
+			techRequired = heavyRocketry
+			cost = -10
+			entryCost = 0
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.38264
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.61736
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 224.3
 				key = 1 190.5
 			}
-			massMult = 0.8
-			cost = -10
-			entryCost = 0
-			techRequired = heavyRocketry
 		}
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LR105_Config.cfg
@@ -1,16 +1,48 @@
-// LR105(Atlas sustainer)
-// Squad, FASA
-// Sources http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//  ==================================================
+//  LR105 (Atlas sustainer)
+
+//  Throttle Range: N/A
+//  Burn Time: 266 s
+//  O/F Ratio: 2.27
+
+//  Sources:
+
+//  http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 //  http://www.b14643.de/Spacerockets/Diverse/Atlas_MA-drive-system/index.htm
+
+//  Used by:
+//      FASA
+//      Squad
+
+//  FIXME: Did the engines use TEATEB for ignition?
+//  ==================================================
+
 @PART[*]:HAS[#engineType[LR105]]:FOR[RealismOverhaulEngines]
 {
+    %title = LR105 Series
+    %manufacturer = Rocketdyne
+    %description = Kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s) are lit on the ground, but after a bit over 2 minutes' flight the boosters are dropped and the Atlas core continues to orbit under the power of the sustainer engine (and the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for increased performance. As a sustainer engine, the LR105 has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine. [1.5m]
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 3.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+	}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
 		configuration = LR105-NA-3
-		origMass = 0.460
+		origMass = 0.46
+
 		CONFIG
 		{
 			name = LR105-NA-3
@@ -18,6 +50,16 @@
 			maxThrust = 352.2
 			heatProduction = 100
 			massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -43,6 +85,16 @@
 			maxThrust = 366.1
 			heatProduction = 100
 			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -75,6 +127,16 @@
 			maxThrust = 385.2
 			heatProduction = 100
 			massMult = 1.02174 // 470kg engine, same source
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -108,6 +170,16 @@
 			maxThrust = 386.4
 			heatProduction = 100
 			massMult = 1.02174 // 470kg engine, same source
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -140,6 +212,16 @@
 			maxThrust = 386.4
 			heatProduction = 100
 			massMult = 1.0 // total guess, lower than above because H-1 was lighter...?
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -166,4 +248,8 @@
 			techRequired = experimentalRocketry
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LR105_Config.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  LR105 (Atlas sustainer)
+//  LR-105 (Atlas sustainer)
 
 //  Throttle Range: N/A
 //  Burn Time: 266 s
@@ -19,7 +19,7 @@
 
 @PART[*]:HAS[#engineType[LR105]]:FOR[RealismOverhaulEngines]
 {
-    %title = LR105 Series
+    %title = LR-105 Series
     %manufacturer = Rocketdyne
     %description = Kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s) are lit on the ground, but after a bit over 2 minutes' flight the boosters are dropped and the Atlas core continues to orbit under the power of the sustainer engine (and the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for increased performance. As a sustainer engine, the LR105 has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine. [1.5m]
 

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LR79_Config.cfg
@@ -1,41 +1,90 @@
-// LR79
-// Squad, FASA
-// SOURCES:
-// http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-// http://www.alternatewars.com/BBOW/Space_Engines/YLR79-NA-13_Specs.pdf
+//  ==================================================
+//  LR-79 series
+
+//  Throttle Range: N/A
+//  Burn Time: 165 s
+//  O/F Ratio: 2.15
+
+//  Sources:
+//      http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//      http://www.alternatewars.com/BBOW/Space_Engines/YLR79-NA-13_Specs.pdf
+
+//  Used by:
+//      FASA
+//      Squad
+
+//  FIXME: Did LR-79 had the same gimbal range as the H-1 (8 degrees)?
+//  ==================================================
+
 @PART[*]:HAS[#engineType[LR79]]:FOR[RealismOverhaulEngines]
 {
+    %title = LR-79 Series 
+    %manufacturer = Rocketdyne
+    %description = Long-lasting US Kerolox gas-generator booster engine. The same components and broadly the same performance as the LR-89, the LR-79 (also known as S-3D in Jupiter / Juno II) powered Jupiter, Thor, and Thor-Delta (Delta) rockets.
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 8
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = LR79-NA-9
+		configuration = LR79-NA-3
 		origMass = 0.907
+
 		CONFIG
 		{
 			name = LR79-NA-3
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
+			massMult = 1.0 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (others give only 630kg! My guess is 900 is for the whole propulsion system)
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.3929
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.6071
 			}
+
 			atmosphereCurve
 			{
 				key = 0 282
 				key = 1 248
 			}
-			massMult = 1.0 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (others give only 630kg! My guess is 900 is for the whole propulsion system)
-			cost = 0
 		}
+
 		CONFIG
 		{
 			name = LR79-NA-9
@@ -43,29 +92,50 @@
 			minThrust = 774	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 774	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			heatProduction = 100
+			massMult = 1.03 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (guesstimate between S-3D and LR79-NA-11)
+
+			//cost = 100
+			//entryCost = 2000
+			// no, it's actually same level as LR89-3, so TL1ish instead of techRequired = advRocketry
+			// so let's put it in basicConstruction
+			//techRequired = basicConstruction
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.3929
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.6071
 			}
+
 			atmosphereCurve
 			{
 				key = 0 284	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 				key = 1 245	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			}
-			massMult = 1.03 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (guesstimate between S-3D and LR79-NA-11)
-			//cost = 100
-			//entryCost = 2000
-			// no, it's actually same level as LR89-3, so TL1ish instead of techRequired = advRocketry
-			// so let's put it in basicConstruction
-			//techRequired = basicConstruction
 		}
+
 		CONFIG
 		{
 			name = LR79-NA-11
@@ -73,32 +143,54 @@
 			minThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			heatProduction = 100
+			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+
+			techRequired = generalRocketry
+			cost = 200
+			entryCost = 3000
+
+			entryCostSubtractors
+			{
+			//	LR79-NA-9 = 2000
+				H-1 = 1000
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.3929
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.6071
 			}
+
 			atmosphereCurve
 			{
 				key = 0 286.2	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 				key = 1 248.3	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			}
-			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-			cost = 200
-			entryCost = 3000
-			entryCostSubtractors
-			{
-			//	LR79-NA-9 = 2000
-				H-1 = 1000
-			}
-			techRequired = generalRocketry
 		}
+
 		CONFIG
 		{
 			name = LR79-NA-13
@@ -106,32 +198,64 @@
 			minThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
 			maxThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.3929
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.6071
-			}
-			atmosphereCurve
-			{
-				key = 0 290	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
-				key = 1 252	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
-			}
 			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+
+			techRequired = advRocketry
 			cost = 500
 			entryCost = 10000
+
 			entryCostSubtractors
 			{
 				LR79-NA-11 = 3000 //FIXME: SQUAD had it at 4000
 				//H-1 = 2000
 				//H-1b = 1000
 			}
-			techRequired = advRocketry
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3929
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6071
+			}
+
+			atmosphereCurve
+			{
+				key = 0 290	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
+				key = 1 252	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
+			}
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = TEATEB
+        amount = 1
+        maxAmount = 1
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LR89_Config.cfg
@@ -26,8 +26,6 @@
         %EngineType = LiquidFuel
     }
 
-    !MODULE[ModuleJettison]{}
-
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 5.0

--- a/GameData/RealismOverhaul/Engine_Configs/RO_LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_LR89_Config.cfg
@@ -1,14 +1,48 @@
-// LR89
-// FASA(FASAMercuryAtlasEngBooster), Squad(RO-LR-89)
+//  ==================================================
+//  LR89 series
+
+//  Throttle Range: N/A
+//  Burn Time: 120 s
+//  O/F Ratio: 2.25
+
+//  Sources:
+//      http://www.b14643.de/Spacerockets/Diverse/Atlas_MA-drive-system/index.htm
+//      http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//      http://www.astronautix.com/engines/lr895.htm
+
+//  Used by:
+//      FASA (FASAMercuryAtlasEngBooster)
+//      Squad (RO-LR-89)
+//  ==================================================
+
 @PART[*]:HAS[#engineType[LR89]]:FOR[RealismOverhaulEngines]
 {
+    %title = LR-89 Series
+    %manufacturer = Rocketdyne
+    %description = Kerolox gas-generator engine that served as booster for Atlas. Late model LR89s were upgraded with RS-27 components for higher efficiency. Very similar to LR79 (this was the pure-booster variant). [1.0m]
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleJettison]{}
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 5.0
+        %useGimbalResponseSpeed = true
+        %gimbalResponseSpeed = 16
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		modded = false
+		modded = False
 		configuration = LR89-NA-3
 		origMass = 0.72
+
 		CONFIG
 		{
 			name = LR89-NA-3
@@ -16,86 +50,186 @@
 			maxThrust = 758.7
 			heatProduction = 100
 			massMult = 0.89
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.82
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.18
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.382
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.618
 			}
+
 			atmosphereCurve
 			{
 				key = 0 282
 				key = 1 248
 			}
 		}
+
 		CONFIG
 		{
 			name = LR89-NA-5
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
-			massMult = 1.0	// astronautix.com MA-2.  With a 1.61t skirt, this should result in each booster weighing 0.720t resulting in a 3.050t total weight  
+			massMult = 1.0      // astronautix.com MA-2. With a 1.61t skirt, this should result in each booster weighing 0.720t resulting in a 3.050t total weight.
+
+			techRequired = generalRocketry
+			cost = 200
+			entryCost = 4000
+
+			entryCostSubtractors
+			{
+				LR105-NA-5/6 = 1000
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.82
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.18
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.382
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.618
 			}
+
 			atmosphereCurve
 			{
 				key = 0 282
 				key = 1 248
 			}
-			cost = 200
-			entryCost = 4000
-			entryCostSubtractors
-			{
-				LR105-NA-5/6 = 1000
-			}
-			techRequired = generalRocketry
 		}
+
 		CONFIG
 		{
 			name = LR89-NA-6
 			minThrust = 831.4
 			maxThrust = 831.4
 			heatProduction = 100
-			massMult = 1.086	// astronautix.com MA-3.  With a 1.61t skirt, this should result in each booster weighing 0.782t resulting in a 3.174t total weight
+			massMult = 1.086        // astronautix.com MA-3. With a 1.61t skirt, this should result in each booster weighing 0.782t resulting in a 3.174t total weight.
+
+			techRequired = advRocketry
+			cost = 300
+			entryCost = 7500
+
+			entryCostSubtractors
+			{
+				LR105-NA-5/6 = 1000
+				LR89-NA-5 = 3000
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.82
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.18
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.382
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.618
 			}
+
 			atmosphereCurve
 			{
 				key = 0 290
 				key = 1 256
 			}
-			cost = 300
-			entryCost = 7500
-			entryCostSubtractors
-			{
-				LR105-NA-5/6 = 1000
-				LR89-NA-5 = 3000
-			}
-			techRequired = advRocketry
 		}
+
 		CONFIG
 		{
 			name = LR89-NA-7.1
@@ -103,7 +237,46 @@
 			minThrust = 931.7
 			maxThrust = 931.7
 			heatProduction = 100
-			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
+			massMult = 1.414        // astronautix.com MA-5. With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
+
+			techRequired = advRocketry
+			cost = 500
+			entryCost = 10000
+
+			entryCostSubtractors
+			{
+				LR105-NA-7.1 = 2000
+				LR89-NA-6 = 4000
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.82
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.18
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -120,16 +293,8 @@
 				key = 0 292.2
 				key = 1 258.0
 			}
-			massMult = 0.99
-			cost = 500
-			entryCost = 10000
-			entryCostSubtractors
-			{
-				LR105-NA-7.1 = 2000
-				LR89-NA-6 = 4000
-			}
-			techRequired = advRocketry
 		}
+
 		CONFIG
 		{
 			name = LR89-NA-7.2
@@ -137,41 +302,113 @@
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
-			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
+			massMult = 1.414        // astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
+
+			techRequired = heavierRocketry
+			cost = 500
+			entryCost = 10000
+
+			entryCostSubtractors
+			{
+				LR105-NA-7.2 = 3000
+				LR89-NA-7.1 = 6000
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.82
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.18
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.382
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.618
 			}
+
 			atmosphereCurve
 			{
 				key = 0 293.4
 				key = 1 259.1
 			}
-			massMult = 0.99
-			cost = 500
-			entryCost = 10000
-			entryCostSubtractors
-			{
-				LR105-NA-7.2 = 3000
-				LR89-NA-7.1 = 6000
-			}
-			techRequired = heavierRocketry
 		}
+
 		CONFIG
 		{
 			name = RS-56-OBA
 			minThrust = 1077.6
 			maxThrust = 1077.6
 			heatProduction = 100
-			massMult = 1.7896	// astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
-			//massMult = 1.11805 FIXME maybe revert to this value?
+			massMult = 1.7896       // astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
+			//massMult = 1.11805    FIXME maybe revert to this value?
+
+			techRequired = experimentalRocketry
+			cost = 800
+			entryCost = 75000
+
+			entryCostSubtractors
+			{
+				LR89-NA-7.2 = 20000
+				RS-27 = 39000
+			}
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 1
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.82
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.18
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
@@ -188,14 +425,17 @@
 				key = 0 296.4
 				key = 1 262.1
 			}
-			cost = 800
-			entryCost = 75000
-			entryCostSubtractors
-			{
-				LR89-NA-7.2 = 20000
-				RS-27 = 39000
-			}
-			techRequired = experimentalRocketry
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = TEATEB
+        amount = 1
+        maxAmount = 1
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_NSTAR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_NSTAR_Config.cfg
@@ -1,25 +1,52 @@
-//NSTAR series engine
-Squad
+//  ==================================================
+//  NSTAR series
+
+//  Throttle Range: 20% to 100%
+//  Burn Time: >420 d
+//  O/F Ratio: N/A
+
+//  Sources:
+
+//  http://www.grc.nasa.gov/WWW/ion/past/90s/nstar.htm
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000003023.pdf
+//  http://www.astronautix.com/engines/nstar.htm
+
+//  Used by:
+//      Squad
+//  ==================================================
+
 @PART[*]:HAS[#engineType[NSTAR]]:FOR[RealismOverhaulEngines]
 {
+    %title = NSTAR Ion Thruster
+    %manufacturer = L-3 Electron Industries
+    %description = Small lightweight efficient ion engine. Takes a bit of power though and doesn't provide much thrust.
+
+    @MODULE[ModuleEngines]
+    {
+        %EngineType = Electric
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
 		configuration = NSTAR
+
 		CONFIG
 		{
 			name = NSTAR
 			minThrust = 0.000019
 			maxThrust = 0.000092
 			heatProduction = 0
+
 			PROPELLANT
 			{
 				name = XenonGas
 				ratio = 1.0
 				DrawGauge = True
 			}
+
 			atmosphereCurve
 			{
 				key = 0 3100

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RD0105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RD0105_Config.cfg
@@ -1,83 +1,154 @@
-// RD-0109 vostok upper
-// Squad, Tantares. FIXME tantares has separate verniers.
+//  ==================================================
+//  RD-0105/0109
+
+//  Throttle Range: N/A
+//  Burn Time: 440 s (RD-0105), 454 s (RD-0109)
+//  O/F Ratio: 2.48
+
+//  Sources:
+//  http://www.kbkha.ru/?p=8&cat=8&prod=38
+//  http://www.astronautix.com/engines/rd0105.htm
+
+//  Used by:
+//      Squad
+//      Tantares
+
+//  FIXME: Tantares has separate verniers.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[RD0105]]:FOR[RealismOverhaulEngines]
 {
+    @mass = 0.13
+    %title = RD-0105/0109 Series
+    %manufacturer = KB Khimavtomatiki (Kosberg)
+    %description = Kerolox gas generator vacuum engine which served in R-7 upper stages (Luna, Vostok). The RD-0105 was designed for Luna launches; it was the first upper stage for the R-7 series and was reused for uncrewed Vostok tests. An enhanced version, the RD-0109, was used for crewed Vostok launches.
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 6.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = RD-0105
 		modded = false
-		origMass = 0.1
+		origMass = 0.13
+
 		CONFIG
 		{
 			name = RD-0105
 			minThrust = 49.4
 			maxThrust = 49.4
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 257
-			}
-			cost = 0
-			massMult = 1.25
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			!IGNITOR_RESOURCE,* {}
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
 			}
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.594
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.406
+            }
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3594
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6406
+			}
+
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 257
+			}
 		}
+
 		CONFIG
 		{
 			name = RD-0109
 			minThrust = 54.5
 			maxThrust = 54.5
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 323.5
-				key = 1 264
-			}
-			massMult = 1.21
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			!IGNITOR_RESOURCE,* {}
+			massMult = 0.9307
+
+			techRequired = survivability // yes, not a rocketry node. Ah well.
+			cost = 100
+			entryCost = 2000
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
 			}
-			cost = 100
-			entryCost = 2000
-			techRequired = survivability // yes, not a rocketry node. Ah well.
+
+            IGNITOR_RESOURCE
+            {
+                name = Kerosene
+                amount = 3.594
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = LqdOxygen
+                amount = 6.406
+            }
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3594
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6406
+			}
+
+			atmosphereCurve
+			{
+				key = 0 323.5
+				key = 1 264
+			}
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RD0210_Config.cfg
@@ -1,7 +1,39 @@
-//RD-0210 engine
-//Squad, Tantares
+//  ==================================================
+//  RD-0210
+
+//  Throttle Range: N/A
+//  Burn Time: 230 s
+//  O/F Ratio: 2.6
+
+//  Sources:
+//      http://www.lpre.de/kbkha/RD-0203/index.htm
+//      http://www.russianspaceweb.com/rd0210.html
+//      http://www.astronautix.com/engines/rd0210.htm
+
+//  Used by:
+//      Squad
+//      Tantares
+//  ==================================================
+
 @PART[*]:HAS[#engineType[RD0210]]:FOR[RealismOverhaulEngines]
 {
+    @mass = 0.566
+    %title = RD-0210
+    %manufacturer = KB Khimavtomatika
+    %description = A series of engines found on the second stage of the Proton series launcher. All the four second stage engines gimbal.
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 3.25
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -9,23 +41,50 @@
 		configuration = RD-0210
 		origMass = 0.566
 		modded = false
+
+        ullage = True
+        pressureFed = False
+        ignitions = 1
+
+        IGNITOR_RESOURCE
+        {
+            name = UDMH
+            amount = 4.135
+        }
+
+        IGNITOR_RESOURCE
+        {
+            name = NTO
+            amount = 5.865
+        }
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 1
+        }
+
 		CONFIG
 		{
 			name = RD-0210
 			minThrust = 582.1
 			maxThrust = 582.1
-			heatProduction = 90
+			heatProduction = 100
+
 			PROPELLANT
 			{
 				name = UDMH
-				ratio = 0.413 //2.6 OF ratio
+				ratio = 0.4135
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.587
+				ratio = 0.5865
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 327
@@ -33,4 +92,6 @@
 			}
 		}
 	}
+
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RD0210_Config.cfg
@@ -93,5 +93,7 @@
 		}
 	}
 
+    !MODULE[ModuleAlternator]{}
+
     !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RD253_Config.cfg
@@ -1,18 +1,31 @@
-//RD-253/275 for Proton
-// Squad, RLA, OLDD
-// Sources:
-// http://lpre.de/energomash/img/prospects/RD-253_2.jpg
-// http://www.russianspaceweb.com/rd253.html
-// http://www.npoenergomash.ru/eng/dejatelnost/engines/rd253/
+//  ==================================================
+//  RD-253/275 for Proton
+
+//  Throttle Range: N/A
+//  Burn Time: 130 s
+//  O/F Ratio: 2.67
+
+//  Sources:
+//  http://lpre.de/energomash/img/prospects/RD-253_2.jpg
+//  http://www.russianspaceweb.com/rd253.html
+//  http://www.npoenergomash.ru/eng/dejatelnost/engines/rd253/
+
+//  Used by:
+//      OLDD
+//      RLA
+//      Squad
+//  ==================================================
+
 @PART[*]:HAS[#engineType[RD253]]:FOR[RealismOverhaulEngines]
 {
 	%title = RD-253/RD-275
 	%manufacturer = NPO Energomash
 	%description = A high thrust engine designed for use with storable propellants. In use with the Proton series of rockets. [2.0m]
 
-	@crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
 	
 	MODULE
 	{
@@ -44,9 +57,9 @@
 				key = 1 285
 			}
 			
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 			
 			IGNITOR_RESOURCE
 			{
@@ -78,9 +91,9 @@
 				key = 1 287
 			}
 			
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 			
 			IGNITOR_RESOURCE
 			{
@@ -112,9 +125,9 @@
 				key = 1 288
 			}
 			
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 			
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RD58_Config.cfg
@@ -28,8 +28,6 @@
         %EngineType = LiquidFuel
     }
 
-    !MODULE[ModuleJettison]{}
-
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 7.0

--- a/GameData/RealismOverhaul/Engine_Configs/RO_RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RD58_Config.cfg
@@ -1,7 +1,42 @@
-// RD-58 engine for Block-D
-// Squad/ FIXME maybe can't be for Tantares as includes rcs mass. 
+//  ==================================================
+//  RD-58 series
+
+//  Throttle Range: N/A
+//  Burn Time: 600 s
+//  O/F Ratio: ~2.5 (differs between versions)
+
+//  Sources:
+//      http://www.energia.ru/english/energia/launchers/engines.html
+//      http://www.k204.ru/books/vrd/wiki2/PDF/Energia.pdf
+//      http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//      http://www.astronautix.com/engines/rd58.htm
+
+//  Used by:
+//      Squad
+
+//  FIXME: maybe can't be for Tantares as includes rcs mass.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[RD58]]:FOR[RealismOverhaulEngines]
 {
+    %title = S1.5400/RD-58 Series
+    %manufacturer = RKK Energiya
+    %description = World's first closed-cycle kerolox vacuum engine. The S1.5400 served as an R-7 upper stage and the RD-58 (an upgrade) as upper stage / OMS for many Soviet and Russian launchers and spacecraft (Proton, N1, Zenit, Buran...). The S1.5400 was designed for the Blok L stage which was the final stage for the Molniya configuration of the R-7, used to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (this was needed to perform apogee kick to place Molniya satellites in their final orbits). It was given the industry designation 11D33. An upgraded version, termed 11D33M, had slightly improved performance. The RD-58 is a derivative of the 11D33M engine with higher performance (industry designation 11D58); it has been used on many Russian launchers and is still in use today on Proton and Zenit. In comparison to hydrolox upper stages, kerolox ones do not suffer boiloff as badly and need far less volume (kerosene being far denser than liquid hydrogen), but have much lower specific impulse. [2.0m]
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleJettison]{}
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 7.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -9,153 +44,198 @@
 		origMass = 0.15
 		modded = false
 		configuration = 11D33
+
 		CONFIG
 		{
 			name = 11D33
 			minThrust = 63.7
 			maxThrust = 63.7
 			heatProduction = 100
+			massMult = 1.02
+
+			techRequired = fuelSystems
+
+			ullage = True
+			pressureFed = False
+			ignitions = 5
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 0.5
+			}
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.359
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.641
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 338.6
 				key = 1 100
 			}
-			massMult = 1.02
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			techRequired = fuelSystems
 		}
+
 		CONFIG
 		{
 			name = 11D33M
 			minThrust = 67.3
 			maxThrust = 67.3
 			heatProduction = 100
+			massMult = 0.9867
+
+			techRequired = propulsionSystems        //  Tier 2 of staged combustion.
+			cost = 100
+			entryCost = 2000
+
+			ullage = True
+			pressureFed = False
+			ignitions = 5
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 0.5
+			}
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.359
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.641
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 342.2
 				key = 1 100
 			}
-			massMult = 0.9867
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			cost = 100
-			entryCost = 2000
-			techRequired = propulsionSystems // tier 2 of staged
 		}
+
 		CONFIG
 		{
 			name = RD-58
 			maxThrust = 83.36
 			minThrust = 83.36
+            heatProduction = 100
+			massMult = 1.534
+
+			techRequired = precisionPropulsion      //  Tier 2 of staged combustion.
+			cost = 500
+			entryCost = 10000
+
+			entryCostSubtractors
+			{
+				11D33M = 2000
+			}
+
+			ullage = True
+			pressureFed = False
+			ignitions = 5
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 0.5
+			}
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.359
 				DrawGauge = true
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.641
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 352
 				key = 1 105
 			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			massMult = 1.534
-			cost = 500
-			entryCost = 10000
-			entryCostSubtractors
-			{
-				11D33M = 2000
-			}
-			techRequired = precisionPropulsion // tier 3 of staged
 		}
+
 		CONFIG
 		{
 			name = RD-58S
 			maxThrust = 86.3
 			minThrust = 86.3
+            heatProduction = 100
+			massMult = 1.534
+
+			techRequired = veryHeavyRocketry
+			cost = 800
+			entryCost = 25000
+
+			entryCostSubtractors
+			{
+				RD-58 = 10000
+			}
+
+			ullage = True
+			pressureFed = False
+			ignitions = 15
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 0.1666
+			}
+
 			PROPELLANT
 			{
 				name = Syntin
 				ratio = 0.35652
 				DrawGauge = true
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.64348
+                DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 361
 				key = 1 107
 			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 15
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			massMult = 1.534
-			cost = 800
-			entryCost = 25000
-			entryCostSubtractors
-			{
-				RD-58 = 10000
-			}
-			techRequired = veryHeavyRocketry
 		}
 	}
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
+
+    //  Engine configurations will use the same amount of TEATEB regardless of the ignition count.
+
+    RESOURCE
+    {
+        name = TEATEB
+        amount = 2.5
+        maxAmount = 2.5
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -121,6 +121,11 @@
 	@maxTemp = 773.15
     %skinMaxTemp = 873.15
 
+    %engineType = NSTAR
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 0.000019
@@ -178,6 +183,11 @@
 	@maxTemp = 1023.15
     %skinMaxTemp = 1773.15
 
+    %engineType = LR101
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 366.1
@@ -197,13 +207,6 @@
 		{
 			@name = LqdOxygen
 			@ratio = 0.618
-		}
-		ullage = True
-		ignitions = 1
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
 		}
 	}
 
@@ -559,6 +562,11 @@
 	@mass = 0.72
 	@maxTemp = 1023.15
     %skinMaxTemp = 1773.15
+
+    %engineType = LR89
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -114,12 +114,13 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.2135562, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.1872844, 0.0, 0.0, -1.0, 0.0, 1
-	@category = Propulsion
-	@title = NSTAR Ion Engine
-	@manufacturer = L-3 Electron Industries
-	@description = Small lighter weight efficient engine, takes a bit of power though, and doesn't provide much force. [0.6m]
+
+	@category = Engine
+
 	@mass = 0.0495
-	@maxTemp = 1973.15
+	@maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 0.000019
@@ -141,31 +142,7 @@
 	!MODULE[ElectricEngineThrustLimiter]
 	{
 	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = false
-		configuration = NSTAR
-		CONFIG
-		{
-			name = NSTAR
-			minThrust = 0.000019
-			maxThrust = 0.000092
-			heatProduction = 0
-			PROPELLANT
-			{
-				name = XenonGas
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 3100
-				key = 1 1
-			}
-		}
-	}
+
 	MODULE
 	{
 		name = ModuleAlternator

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -604,12 +604,18 @@
 	@node_stack_top = 0.0, 1.172374125, 0.0, 0.0, 1.0, 0.0, 1
 	%node_attach = 0.0, 1.172374125, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.93329925, 0.0, 0.0, -1.0, 0.0, 1
-	@title = S1.5400/RD-58 Series
-	@manufacturer = RKK Energiya
-	@description = World's first closed-cycle kerolox vacuum engine. The S1.5400 served as an R-7 upper stage and the RD-58 (an upgrade) as upper stage / OMS for many Soviet and Russian launchers and spacecraft (Proton, N1, Zenit, Buran...). The S1.5400 was designed for the Blok L stage which was the final stage for the Molniya configuration of the R-7, used to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (this was needed to perform apogee kick to place Molniya satellites in their final orbits). It was given the industry designation 11D33. An upgraded version, termed 11D33M, had slightly improved performance. The RD-58 is a derivative of the 11D33M engine with higher performance (industry designation 11D58); it has been used on many Russian launchers and is still in use today on Proton and Zenit. In comparison to hydrolox upper stages, kerolox ones do not suffer boiloff as badly and need far less volume (kerosene being far denser than liquid hydrogen), but have much lower specific impulse. [2.0m]
+
 	@attachRules = 1,1,1,0,0
+
 	@mass = 0.15
-	@maxTemp = 1973.15
+	@maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = RD58
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 63.7
@@ -630,180 +636,6 @@
 			@name = LqdOxygen
 			@ratio = 0.641
 		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 7.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		origMass = 0.15
-		modded = false
-		configuration = 11D33
-		CONFIG
-		{
-			name = 11D33
-			minThrust = 63.7
-			maxThrust = 63.7
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 338.6
-				key = 1 100
-			}
-			massMult = 1.02
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			techRequired = fuelSystems
-		}
-		CONFIG
-		{
-			name = 11D33M
-			minThrust = 67.3
-			maxThrust = 67.3
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 342.2
-				key = 1 100
-			}
-			massMult = 0.9867
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			cost = 100
-			entryCost = 2000
-			techRequired = propulsionSystems // tier 2 of staged
-		}
-		CONFIG
-		{
-			name = RD-58
-			maxThrust = 83.36
-			minThrust = 83.36
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 352
-				key = 1 105
-			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 5
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			massMult = 1.534
-			cost = 500
-			entryCost = 10000
-			entryCostSubtractors
-			{
-				11D33M = 2000
-			}
-			techRequired = precisionPropulsion // tier 3 of staged
-		}
-		CONFIG
-		{
-			name = RD-58S
-			maxThrust = 86.3
-			minThrust = 86.3
-			PROPELLANT
-			{
-				name = Syntin
-				ratio = 0.35652
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.64348
-			}
-			atmosphereCurve
-			{
-				key = 0 361
-				key = 1 107
-			}
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 15
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 0.5
-			}
-			massMult = 1.534
-			cost = 800
-			entryCost = 25000
-			entryCostSubtractors
-			{
-				RD-58 = 10000
-			}
-			techRequired = veryHeavyRocketry
-		}
-	}
-	RESOURCE
-	{
-		name = TEATEB
-		amount = 2.5
-		maxAmount = 2.5
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -766,6 +766,11 @@
 	%maxTemp = 1023.15
     %skinMaxTemp = 1773.15
 
+    %engineType = LMAE
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 15.57

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1450,9 +1450,6 @@
 	{
 	}
 	
-	@title = LR101 [Radial]
-	%manufacturer = Rocketdyne
-	@description = Pump or pressure-fed kerolox vernier engine. Used for attitude control and final velocity adjustment in the MA-x system (2x LR89 + LR105 + 2x LR101) on Atlas, and MB-x system (LR79 or RS-27 + 2xLR101) on Thor-Able / Thor-Agena / Thor-Delta / Delta.
 	%attachRules = 0,1,0,0,0
 	%mass = 0.024
 	%maxTemp = 1973.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -183,7 +183,11 @@
 		}
 	}
 }
-// LR105
+
+//  ==================================================
+//  LR105
+//  ==================================================
+
 @PART[liquidEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
@@ -208,7 +212,7 @@
 	@maxTemp = 1023.15
     %skinMaxTemp = 1773.15
 
-    %engineType = LR101
+    %engineType = LR105
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -171,12 +171,13 @@
 	%rescaleFactor = 1.0
 	%node_stack_top = 0.0, 1.3707759, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.3820657, 0.0, 0.0, -1.0, 0.0, 2
-	@title = LR105 Series
-	@manufacturer = Rocketdyne
-	@description = Kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s) are lit on the ground, but after a bit over 2 minutes' flight the boosters are dropped and the Atlas core continues to orbit under the power of the sustainer engine (and the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for increased performance. As a sustainer engine, the LR105 has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine. [1.5m]
+
 	@attachRules = 1,0,1,0,0
+
 	@mass = 0.460 // I think 844kg was for the engine + tank.
-	@maxTemp = 1973.15
+	@maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 366.1
@@ -205,174 +206,7 @@
 			amount = 0.5
 		}
 	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = false
-		origMass = 0.460
-		configuration = LR105-NA-3
-		CONFIG
-		{
-			name = LR105-NA-3
-			minThrust = 352.2
-			maxThrust = 352.2
-			heatProduction = 100
-			massMult = 1.0
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 309
-				key = 1 215
-			}
-			cost = 0
-		}
-		CONFIG
-		{
-			name = LR105-NA-5/6
-			minThrust = 366.1
-			maxThrust = 366.1
-			heatProduction = 100
-			massMult = 0.8978 // 413kg engine, source http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for -5
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 311
-				key = 1 215
-			}
-			cost = 100
-			entryCost = 2000
-			entryCostSubtractors
-			{
-				LR89-NA-6 = 1000
-			}
-			techRequired = generalRocketry
-		}
-		CONFIG
-		{
-			name = LR105-NA-7.1
-			description = MA-5.1 engine for Atlas-Agena launches
-			minThrust = 385.2
-			maxThrust = 385.2
-			heatProduction = 100
-			massMult = 1.02174 // 470kg engine, same source
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 220
-			}
-			cost = 300
-			entryCost = 4000
-			entryCostSubtractors
-			{
-				LR105-NA-5/6 = 2000
-				LR89-NA-7.1 = 1000
-			}
-			techRequired = heavyRocketry
-		}
-		CONFIG
-		{
-			name = LR105-NA-7.2
-			description = MA-5.2 engine for Atlas-Centaur launches
-			minThrust = 386.4
-			maxThrust = 386.4
-			heatProduction = 100
-			massMult = 1.02174 // 470kg engine, same source
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 220
-			}
-			cost = 350
-			entryCost = 5000
-			entryCostSubtractors
-			{
-				LR105-NA-7.1 = 3000
-				LR89-NA-7.2 = 2000
-			}
-			techRequired = heavierRocketry
-		}
-		CONFIG
-		{
-			name = RS-56-OSA
-			minThrust = 386.4
-			maxThrust = 386.4
-			heatProduction = 100
-			massMult = 1.0 // guess
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 220.4
-			}
-			cost = 250
-			entryCost = 55000
-			entryCostSubtractors
-			{
-				LR105-NA-7.2 = 10000
-				RS-27 = 39000
-			}
-			techRequired = experimentalRocketry
-		}
-	}
+
 	MODULE
 	{
 		name = ModuleGimbal

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -63,7 +63,11 @@
 		}
 	}
 }
-// RL10
+
+//  ==================================================
+//  RL10
+//  ==================================================
+
 @PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
@@ -87,7 +91,14 @@
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	%attachRules = 1,1,1,1,0
 	%mass = 0.167
-	%maxTemp = 1973.15
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = RL10
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 65.6
@@ -109,8 +120,8 @@
 			@ratio = 0.237
 		}
 	}
-	engineType = RL10
 }
+
 @PART[ionEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -736,91 +736,64 @@
     !MODULE[TweakScale]{}
 }
 
+//  ==================================================
+//  LMAE
+//  ==================================================
+
 @PART[liquidEngineMini]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
-	%title = Lunar Module Ascent Engine
-	%manufacturer = Bell
-	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander. [1.4m]
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngine48-7S/model
 		scale = 2.0, 4.1, 2.0
 	}
+
+    %scale = 1.0
 	%rescaleFactor = 1.0
+
 	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -1.353, 0.0, 0.0, -1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -1.605, 0.0, 0.0, -1.0, 0.0, 2
+
 	%attachRules = 1,0,1,0,0
-	%mass = 0.0816
-	%maxTemp = 1973.15
+
+	%mass = 0.095
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 15.57
 		%minThrust = 15.57
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 311
 			@key,1 = 1 100
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Aerozine50
-			@ratio = 0.502
+			@ratio = 0.5017
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
-			@ratio = 0.498
-		}
-		ullage = False
-		pressureFed = True
-		ignitions = 10 // FASA's has 10.
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.1
+			@ratio = 0.4983
 		}
 	}
-	!MODULE[ModuleGimbal]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = LMAE
-		modded = false
-		CONFIG
-		{
-			name = LMAE
-			minThrust = 15.57
-			maxThrust = 15.57
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			atmosphereCurve
-			{
-				key = 0 311
-				key = 1 100
-			}
-		}
-	}
+
+    !MODULE[TweakScale]{}
 }
+
 +PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = RO-SurveyorVernier

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -668,147 +668,74 @@
 	}
 }
 
-// RD-0105/0109
+//  ==================================================
+//  RD-0105/0109
+//  ==================================================
+
 @PART[liquidEngine3]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-909/model
 		scale = 2.0, 2.0, 2.0
 	}
+
 	@MODEL:NEEDS[VenStockRevamp]
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909B
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	%node_stack_top = 0.0, 0.432996, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -0.756502, 0.0, 0.0, -1.0, 0.0, 2
-	%title = RD-0105/0109 Series
-	%manufacturer = KB Khimavtomatiki (Kosberg)
-	%description = Kerolox gas generator vacuum engine which served in R-7 upper stages (Luna, Vostok). The RD-0105 was designed for Luna launches; it was the first upper stage for the R-7 series and was reused for uncrewed Vostok tests. An enhanced version, the RD-0109, was used for crewed Vostok launches. [2.0m]
+
+	%node_stack_top = 0.0, 0.46, 0.0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 2
+
 	%attachRules = 1,0,1,0,0
+
 	%mass = 0.125
-	%maxTemp = 1973.15
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = RD0105
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		%minThrust = 49.4
 		%maxThrust = 49.4
 		%heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.359
+			@ratio = 0.3594
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.641
+			@ratio = 0.6406
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 316
 			@key,1 = 1 100
 		}
-		ullage = True
-		ignitions = 1
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.3
-		}
 	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 6.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = RD-0105
-		modded = false
-		origMass = 0.1
-		CONFIG
-		{
-			name = RD-0105
-			minThrust = 49.4
-			maxThrust = 49.4
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 100
-			}
-			cost = 0
-			massMult = 1.25
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-		}
-		CONFIG
-		{
-			name = RD-0109
-			minThrust = 54.5
-			maxThrust = 54.5
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.359
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.641
-			}
-			atmosphereCurve
-			{
-				key = 0 323.5
-				key = 1 100
-			}
-			massMult = 1.21
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-			cost = 100
-			entryCost = 2000
-			techRequired = survivability // yes, not a rocketry node. Ah well.
-		}
-	}
+
+    !MODULE[TweakScale]{}
 }
+
 @PART[liquidEngineMini]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -10,24 +10,29 @@
 @PART[RO-RD-253]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineSkipper/model
 		scale = 1.82, 1.82, 1.82
 	}
+
 	@MODEL:NEEDS[VenStockRevamp]
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
 	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -4.3225, 0.0, 0.0, -1.0, 0.0, 2
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.02, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -3.74, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
+
 	%attachRules = 1,1,1,1,0
 
 	%mass = 1.28
@@ -44,6 +49,7 @@
 		@minThrust = 1635
 		@maxThrust = 1635
 		@heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = UDMH
@@ -62,6 +68,8 @@
 			@key,1 = 1 285
 		}
 	}
+
+    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
@@ -71,11 +79,11 @@
 @PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineSkipper/model
@@ -85,11 +93,16 @@
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
 	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.9985625, 0.0, 0.0, -1.0, 0.0, 2
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.725, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
+
 	%attachRules = 1,1,1,1,0
+
 	%mass = 0.167
 	%maxTemp = 1023.15
     %skinMaxTemp = 1773.15
@@ -104,41 +117,52 @@
 		%maxThrust = 65.6
 		%minThrust = 65.6
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 444
 			@key,1 = 1 255
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
 			@ratio = 0.763
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.237
 		}
 	}
+
+    !MODULE[TweakScale]{}
 }
+
+//  ==================================================
+//  NSTAR
+//  ==================================================
 
 @PART[ionEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/ionEngine/model
 		scale = 1.0, 1.0, 1.0
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.2135562, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.1872844, 0.0, 0.0, -1.0, 0.0, 1
+
+	@node_stack_top = 0.0, 0.195, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.185, 0.0, 0.0, -1.0, 0.0, 1
 
 	@category = Engine
 
@@ -156,22 +180,24 @@
 		@minThrust = 0.000019
 		@maxThrust = 0.000092
 		@heatProduction = 0	
+
 		!PROPELLANT[ElectricCharge]
 		{
 		}
+
 		@PROPELLANT[XenonGas]
 		{
 			@ratio = 1.0
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 3280
 			@key,1 = 1 1
 		}
 	}
-	!MODULE[ElectricEngineThrustLimiter]
-	{
-	}
+
+	!MODULE[ElectricEngineThrustLimiter]{}
 
 	MODULE
 	{
@@ -182,33 +208,37 @@
 			rate = -2.3
 		}
 	}
+
+    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  LR105
+//  LR-105
 //  ==================================================
 
 @PART[liquidEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-T30/model
 		scale = 1.9, 1.9, 1.9
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	%node_stack_top = 0.0, 1.3707759, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -1.3820657, 0.0, 0.0, -1.0, 0.0, 2
+
+	%node_stack_top = 0.0, 1.44, 0.0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -1.375, 0.0, 0.0, -1.0, 0.0, 2
 
 	@attachRules = 1,0,1,0,0
 
-	@mass = 0.460 // I think 844kg was for the engine + tank.
+	@mass = 0.46 // I think 844kg was for the engine + tank.
 	@maxTemp = 1023.15
     %skinMaxTemp = 1773.15
 
@@ -222,16 +252,19 @@
 		@maxThrust = 366.1
 		@minThrust = 366.1
 		@heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 311
 			@key,1 = 1 215
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
 			@ratio = 0.382
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
@@ -243,9 +276,7 @@
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
-		gimbalRange = 3 // source: http://www.b14643.de/Spacerockets/Diverse/Atlas_MA-drive-system/index.htm
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
+		gimbalRange = 3
 	}
 }
 
@@ -271,7 +302,7 @@
 	%rescaleFactor = 1.0
 
 	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.26, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
 	@attachRules = 1,0,1,0,0
 
@@ -339,7 +370,7 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.26, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 0.907
     @maxTemp = 1023.15
@@ -378,7 +409,10 @@
     !MODULE[TweakScale]{}
 }
 
-// Mainsail Clone, now LR89
+//  ==================================================
+//  LR-89
+//  ==================================================
+
 +PART[liquidEngine1-2]:BEFORE[RealismOverhaul]
 {
 	@name = RO-LR-89
@@ -390,7 +424,7 @@
 
 	!mesh = DELETE
 
-	!MODEL {}
+	!MODEL,*{}
 
 	MODEL
 	{
@@ -398,16 +432,11 @@
 		scale = 0.6755, 0.6755, 0.6755
 	}
 
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		texture = Cover_CLR, VenStockRevamp/Squad/Parts/Propulsion/Cover_CLR
-		texture = Cover_NRM, VenStockRevamp/Squad/Parts/Propulsion/Cover_NRM
-	}
-
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.7196156, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.3042473, 0.0, 0.0, -1.0, 0.0, 2
+
+	@node_stack_top = 0.0, 0.735, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.235, 0.0, 0.0, -1.0, 0.0, 2
 
 	@attachRules = 1,0,1,0,0
 
@@ -425,16 +454,19 @@
 		%maxThrust = 758.7
 		%minThrust = 758.7
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 282
 			@key,1 = 1 248
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
 			@ratio = 0.382
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
@@ -445,25 +477,30 @@
     !MODULE[TweakScale]{}
 }
 
-// S1.5400/11D33, RD-58
+//  ==================================================
+//  S1.5400/11D33, RD-58
+//  ==================================================
+
 @PART[liquidEngine2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-T45/model
 		scale = 1.625, 1.625, 1.625
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.172374125, 0.0, 0.0, 1.0, 0.0, 1
-	%node_attach = 0.0, 1.172374125, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.93329925, 0.0, 0.0, -1.0, 0.0, 1
+
+	@node_stack_top = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.315, 0.0, 0.0, -1.0, 0.0, 1
+	%node_attach = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 1
 
 	@attachRules = 1,1,1,0,0
 
@@ -497,6 +534,8 @@
 			@ratio = 0.641
 		}
 	}
+
+    !MODULE[TweakScale]{}
 }
 
 //RD-0210

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1,7 +1,14 @@
-//RD-253
-+PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+//  ==================================================
+//  RD-253
+//  ==================================================
+
++PART[engineLargeSkipper]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	%name = RO-RD-253
+    %name = RO-RD-253
+}
+
+@PART[RO-RD-253]:FOR[RealismOverhaul]
+{
 	%RSSROConfig = True
 	!MODULE[TweakScale]
 	{
@@ -22,8 +29,16 @@
 	@node_stack_bottom = 0.0, -4.3225, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	%attachRules = 1,1,1,1,0
+
 	%mass = 1.28
-	%maxTemp = 1973.15	
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = RD253
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 1635
@@ -33,21 +48,20 @@
 		{
 			@name = UDMH
 			@ratio = 0.4071
-			%DrawGauge = True
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
 			@ratio = 0.5929
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 316
 			@key,1 = 1 285
 		}
-		!IGNITOR_RESOURCE,* {}
 	}
-	engineType = RD253
 }
 // RL10
 @PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -524,24 +524,42 @@
 }
 
 // Mainsail Clone, now LR89
-+PART[liquidEngine1-2]:AFTER[RealismOverhaul]
++PART[liquidEngine1-2]:BEFORE[RealismOverhaul]
 {
 	@name = RO-LR-89
+}
+
+@PART[RO-LR-89]:FOR[RealismOverhaul]
+{
 	%RSSROConfig = True
-	@MODEL
+
+	!mesh = DELETE
+
+	!MODEL {}
+
+	MODEL
 	{
-		@scale = 0.6755, 0.6755, 0.6755
+		model = RealismOverhaul/Parts/Engines/OldVSRMainsail/Mainsail
+		scale = 0.6755, 0.6755, 0.6755
 	}
+
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+		texture = Cover_CLR, VenStockRevamp/Squad/Parts/Propulsion/Cover_CLR
+		texture = Cover_NRM, VenStockRevamp/Squad/Parts/Propulsion/Cover_NRM
+	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.7196156, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.3042473, 0.0, 0.0, -1.0, 0.0, 2
-	@title = LR89 Series
-	@manufacturer = Rocketdyne
-	@description = Kerolox gas-generator engine that served as booster for Atlas. Late model LR89s were upgraded with RS-27 components for higher efficiency. Very similar to LR79 (this was the pure-booster variant). [1.0m]
+
 	@attachRules = 1,0,1,0,0
+
 	@mass = 0.72
-	@maxTemp = 1973.15
+	@maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 758.7
@@ -562,236 +580,9 @@
 			@name = LqdOxygen
 			@ratio = 0.618
 		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-		IGNITOR_RESOURCE
-		{
-			name = Kerosene
-			amount = 3.82
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 6.18
-		}
 	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 5.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleEngineConfigs] {}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = false
-		origMass = 0.720
-		configuration = LR89-NA-3
-		CONFIG
-		{
-			name = LR89-NA-3
-			minThrust = 758.7
-			maxThrust = 758.7
-			heatProduction = 100
-			massMult = 0.89
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 282
-				key = 1 248
-			}
-		}
-		CONFIG
-		{
-			name = LR89-NA-5
-			minThrust = 758.7
-			maxThrust = 758.7
-			heatProduction = 100
-			massMult = 1.0	// astronautix.com MA-2.  With a 1.61t skirt, this should result in each booster weighing 0.720t resulting in a 3.050t total weight  
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 282
-				key = 1 248
-			}
-			cost = 200
-			entryCost = 4000
-			entryCostSubtractors
-			{
-				LR105-NA-5/6 = 1000
-			}
-			techRequired = generalRocketry
-		}
-		CONFIG
-		{
-			name = LR89-NA-6
-			minThrust = 831.4
-			maxThrust = 831.4
-			heatProduction = 100
-			massMult = 1.086	// astronautix.com MA-3.  With a 1.61t skirt, this should result in each booster weighing 0.782t resulting in a 3.174t total weight
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 290
-				key = 1 256
-			}
-			cost = 300
-			entryCost = 7500
-			entryCostSubtractors
-			{
-				LR105-NA-5/6 = 1000
-				LR89-NA-5 = 3000
-			}
-			techRequired = advRocketry
-		}
-		CONFIG
-		{
-			name = LR89-NA-7.1
-			description = MA-5.1 engine for Atlas-Agena launches
-			minThrust = 931.7
-			maxThrust = 931.7
-			heatProduction = 100
-			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 292.2
-				key = 1 258.0
-			}
-			massMult = 0.99
-			cost = 500
-			entryCost = 10000
-			entryCostSubtractors
-			{
-				LR105-NA-7.1 = 2000
-				LR89-NA-6 = 4000
-			}
-			techRequired = heavyRocketry
-		}
-		CONFIG
-		{
-			name = LR89-NA-7.2
-			description = MA-5.2 engine for Atlas-Centaur launches
-			minThrust = 950.8
-			maxThrust = 950.8
-			heatProduction = 100
-			massMult = 1.414	// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight  
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 293.4
-				key = 1 259.1
-			}
-			massMult = 0.99
-			cost = 600
-			entryCost = 15000
-			entryCostSubtractors
-			{
-				LR105-NA-7.2 = 3000
-				LR89-NA-7.1 = 6000
-			}
-			techRequired = heavierRocketry
-		}
-		CONFIG
-		{
-			name = RS-56-OBA
-			minThrust = 1077.6
-			maxThrust = 1077.6
-			heatProduction = 100
-			massMult = 1.7896	// astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.382
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.618
-			}
-			atmosphereCurve
-			{
-				key = 0 296.4
-				key = 1 262.1
-			}
-			cost = 800
-			entryCost = 75000
-			entryCostSubtractors
-			{
-				LR89-NA-7.2 = 20000
-				RS-27 = 39000
-			}
-			massMult = 1.11805
-			techRequired = experimentalRocketry
-		}
-	}
-	!RESOURCE[TEATEB] {}
+
+    !MODULE[TweakScale]{}
 }
 
 // S1.5400/11D33, RD-58

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -538,107 +538,73 @@
     !MODULE[TweakScale]{}
 }
 
-//RD-0210
-+PART[liquidEngine2-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+//  ==================================================
+//  RD-0210
+//  ==================================================
+
++PART[liquidEngine2-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	%name = RO-RD-0210
-	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+    @name = RO-RD-0210
+}
+
+@PART[RO-RD-0210]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEnginePoodle/model
 		scale = 1.2, 1.2, 1.2
 	}
-	%rescaleFactor = 1.0
-	%node_stack_top = 0.0, 0.8723286, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -0.88252272, 0.0, 0.0, -1.0, 0.0, 2
-	@title = RD-0210
-	%manufacturer = KB Khimavtomatika
-	@description = A series of engines found on the second stage of the Proton series launcher. All the four second stage engines gimbal. [1.5m]
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
+
 	%attachRules = 1,0,1,0,0
+
 	%mass = 0.566
-	%maxTemp = 1973.15
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = RD0210
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 582.1
 		@maxThrust = 582.1
 		@heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = UDMH
-			@ratio = 0.478
+			@ratio = 0.4135
 			%DrawGauge = True
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
-			@ratio = 0.522
+			@ratio = 0.5865
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 327
 			@key,1 = 1 225
 		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = UDMH
-			amount = 0.413
-		}
-		IGNITOR_RESOURCE
-		{
-			name = NTO
-			amount = 0.587
-		}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 1.0
-		}
 	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 3.25 //source: http://www.lpre.de/kbkha/RD-0203/index.htm
-		//useGimbalResponseSpeed = true
-		//gimbalResponseSpeed = 16
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = RD-0210
-		modded = false
-		CONFIG
-		{
-			name = RD-0210
-			minThrust = 582.1
-			maxThrust = 582.1
-			heatProduction = 90
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.413
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.587
-			}
-			atmosphereCurve
-			{
-				key = 0 327
-				key = 1 225
-			}
-		}
-	}
+
+    !MODULE[TweakScale]{}
 }
 
 // LMDE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -607,160 +607,63 @@
     !MODULE[TweakScale]{}
 }
 
-// LMDE
+//  ==================================================
+//  LMDE
+//  ==================================================
+
 @PART[liquidEngine2-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEnginePoodle/model
 		scale = 1.2, 1.2, 1.2
 	}
+
+    %scale = 1.0
 	%rescaleFactor = 1.0
-	%node_stack_top = 0.0, 0.8723286, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -0.88252272, 0.0, 0.0, -1.0, 0.0, 2
-	%title = Lunar Module Descent Engine
-	%manufacturer = TRW
-	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability. [1.5m]
+
+	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
+
 	%attachRules = 1,0,1,0,0
+
 	%mass = 0.135
-	%maxTemp = 1973.15
+	%maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = LMDE
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass False
+
 	@MODULE[ModuleEngines*]
 	{
 		%minThrust = 4.67
 		%maxThrust = 43.9
 		%heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Aerozine50
-			@ratio = 0.502
+			@ratio = 0.5017
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
-			@ratio = 0.498
+			@ratio = 0.4983
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 311
 			@key,1 = 1 100
-		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 6.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = LMDE-H
-		modded = false
-		CONFIG
-		{
-			name = LMDE-H
-			minThrust = 4.67
-			maxThrust = 43.9
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			atmosphereCurve
-			{
-				key = 0 311
-				key = 1 116
-			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 3
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.2
-			}
-		}
-		CONFIG
-		{
-			name = LMDE-J
-			minThrust = 4.67
-			maxThrust = 45.04
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			atmosphereCurve
-			{
-				key = 0 313.5
-				key = 1 116
-			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 3
-			!IGNITOR_RESOURCE,* {}
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.2
-			}
-			techRequired = heavierRocketry
-			cost = 150
-			entryCost = 3000
-		}
-		CONFIG
-		{
-			name = TR-201
-			minThrust = 43.8
-			maxThrust = 43.8
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Aerozine50
-				ratio = 0.502
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.498
-			}
-			atmosphereCurve
-			{
-				key = 0 303
-				key = 1 130
-			}
-			techRequired = heavierRocketry
-			cost = -400
-			entryCost = 2000
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -249,310 +249,133 @@
 	}
 }
 
-// LR79/H-1/RS-27
+//  ==================================================
+//  LR-79
+//  ==================================================
+
 @PART[liquidEngine1-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = RealismOverhaul/Parts/Engines/OldVSRMainsail/Mainsail
 		scale = 0.69, 0.69, 0.69
 	}
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		texture = Cover_CLR, VenStockRevamp/Squad/Parts/Propulsion/Cover_CLR
-		texture = Cover_NRM, VenStockRevamp/Squad/Parts/Propulsion/Cover_NRM
-	}
+
+    @scale = 1.0
 	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.7350625, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.332244, 0.0, 0.0, -1.0, 0.0, 2
-	@title = LR79/H-1/RS-27 Series
-	@description = Long-lasting US Kerolox gas-generator booster engine. The same components and broadly the same performance as the LR89, the LR79 (also known as S-3D in Jupiter / Juno II) powered Jupiter, Thor, and Thor-Delta (Delta) rockets. An upgrade to it was named H-1 and that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The LR79/H-1/RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters and the core burns rather longer. [1.0m]
+
+	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.26, 0.0, 0.0, -1.0, 0.0, 2
+
 	@attachRules = 1,0,1,0,0
+
 	@mass = 0.907
-	@maxTemp = 1973.15
+	@maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = LR79
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 947
 		%minThrust = 947
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 289
 			@key,1 = 1 255
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.384
+			@ratio = 0.3842
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.616
-		}
-		ullage = True
-		ignitions = 1
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 1
+			@ratio = 0.6158
 		}
 	}
-	@MODULE[ModuleGimbal]
-	{
-		!gimbalRange = DEL // just in case
-		%gimbalTransformName = thrustTransform
-		%gimbalRange = 10
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = H-1-SaturnIB
-		origMass = 0.907
-		CONFIG
-		{
-			name = LR79-NA-9
-			description = Main engine for MB-3-I propulsion system
-			minThrust = 774	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			maxThrust = 774	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.3929
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.6071
-			}
-			atmosphereCurve
-			{
-				key = 0 284	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-				key = 1 245	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			}
-			massMult = 1.03 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm (guesstimate between S-3D and LR79-NA-11)
-			cost = 0
-		}
-		CONFIG
-		{
-			name = LR79-NA-11
-			description = Main engine for MB-3-II propulsion system
-			minThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.3929
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.6071
-			}
-			atmosphereCurve
-			{
-				key = 0 286.2	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-				key = 1 248.3	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			}
-			massMult = 1.08 // source:http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-			cost = 200
-			entryCost = 3000
-			entryCostSubtractors
-			{
-				H-1-SaturnI = 1000
-			}
-			techRequired = generalRocketry
-		}
-		CONFIG
-		{
-			name = LR79-NA-13
-			description = Main engine for MB-3-III propulsion system
-			minThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
-			maxThrust = 868	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.3929
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.6071
-			}
-			atmosphereCurve
-			{
-				key = 0 290	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
-				key = 1 252	// Guess based on b14643, astronautix, alternatewars and comparable LR89 Atlas engine.  See RO/Github #804 for details
-			}
-			massMult = 1.08 // source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-			cost = 500
-			entryCost = 10000
-			entryCostSubtractors
-			{
-				LR79-NA-11 = 4000
-				H-1-SaturnI = 2000
-				H-1-SaturnIB = 1000
-			}
-			techRequired = advRocketry
-		}
-		CONFIG
-		{
-			name = H-1-SaturnI
-			minThrust = 947
-			maxThrust = 947
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.384
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.616
-			}
-			atmosphereCurve
-			{
-				key = 0 289
-				key = 1 255
-			}
-			massMult = 0.700
-			entryCost = 33750 // there's actually a source for this one!
-			entryCostSubtractors
-			{
-				LR79-NA-11 = 3000
-			}
-			cost = 700
-			techRequired = advRocketry // Saturn I Block I/II engine
-		}
-		CONFIG
-		{
-			name = H-1-SaturnIB
-			minThrust = 1030.2
-			maxThrust = 1030.2
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.384
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.616
-			}
-			atmosphereCurve
-			{
-				key = 0 296
-				key = 1 265
-			}
-			techRequired = heavyRocketry
-			entryCost = 39750
-			entryCostSubtractors
-			{
-				H-1-SaturnI = 33750
-			}
-			cost = 1000
-			massMult = 1
-		}
-		CONFIG
-		{
-			name = RS-27
-			maxThrust = 1023
-			minThrust = 1023
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.38264
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.61736
-			}
-			atmosphereCurve
-			{
-				key = 0 295
-				key = 1 264
-			}
-			massMult = 1.132
-			cost = 800
-			entryCost = 40750
-			entryCostSubtractors
-			{
-				H-1-SaturnIB = 39750
-				H-1B = 39750 // legacy name for the config
-			}
-			techRequired = heavierRocketry
-		}
-		CONFIG
-		{
-			name = RS-27A
-			maxThrust = 1054
-			minThrust = 1054
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.38264
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.61736
-			}
-			atmosphereCurve
-			{
-				key = 0 302
-				key = 1 255
-			}
-			cost = 850
-			entryCost = 41750
-			entryCostSubtractors
-			{
-				RS-27 = 40750
-			}
-			techRequired = experimentalRocketry
-			massMult = 1.265
-		}
-	}
-	RESOURCE
-	{
-		name = TEATEB
-		amount = 1
-		maxAmount = 1
-	}
+
+    !MODULE[TweakScale]{}
+}
+
+//  ==================================================
+//  H1/RS-27
+//  ==================================================
+
++PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+    @name = RO-H1-RS27
+}
+
+@PART[RO-H1-RS27]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    !MODEL,*{}
+
+    MODEL
+    {
+        model = RealismOverhaul/Parts/Engines/OldVSRMainsail/Mainsail
+        scale = 0.69, 0.69, 0.69
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.26, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 0.907
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = H1
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @maxThrust = 947
+        @minThrust = 947
+        @heatProduction = 100
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3842
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6158
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 289
+            @key,1 = 1 255
+        }
+    }
+
+    !MODULE[TweakScale]{}
 }
 
 // Mainsail Clone, now LR89


### PR DESCRIPTION
Note: still a WIP, do not merge yet.

* Update the Squad engines to the new centralized engine system.
* Update the global engine configs wherever required.
* Separated the LR-79 and H-1/RS-27 as per @SirKeplan (https://github.com/KSP-RO/RealismOverhaul/issues/939)
* General cleanup.