### PR TITLE
Add draw gauge to CECE configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RO_RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RO_RL10_Config.cfg
@@ -325,6 +325,7 @@
 			{
 				name = LqdHydrogen
 				ratio = 0.735 //5.8 mix ratio, FIXME actual ratio is variable from 3 to 6, 5.8 is possibly the standard one
+				DrawGauge = True
 			}
 			PROPELLANT
 			{
@@ -356,6 +357,7 @@
 			{
 				name = LqdHydrogen
 				ratio = 0.735 //5.8 mix ratio
+				DrawGauge = True
 			}
 			PROPELLANT
 			{
@@ -388,6 +390,7 @@
 			{
 				name = LqdMethane
 				ratio = 0.4922
+				DrawGauge = True
 			}
 			PROPELLANT
 			{


### PR DESCRIPTION
Add draw gauge to LH2 and LNG CECE RL10 variants.