### PR TITLE
ASET Portable Rover Components compatibility patch for RO

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_PRC.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_PRC.cfg
@@ -1,5 +1,6 @@
 // ASET PRC Patch for Realism Overhaul
-// by Cytosine
+// For KSP v1.0.5
+//   by Cytosine
 //
 // This RO patch relies on these components:
 // 1. The ASET PRC Mod (Built for KSP v1.0.4):

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_PRC.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_PRC.cfg
@@ -1,0 +1,109 @@
+// ASET PRC Patch for Realism Overhaul
+// by Cytosine
+//
+// This RO patch relies on these components:
+// 1. The ASET PRC Mod (Built for KSP v1.0.4):
+//    - http://forum.kerbalspaceprogram.com/index.php?/topic/77943-portable-rover-components-new-project-from-aset-up-290714/&page=1
+// 2. The ASET PRC updated config files (for KSP v1.0.5 compatibility):
+//    - https://dl.dropboxusercontent.com/u/72893034/Test%20Parts/ASET.zip
+// 3. KAS - Grab this via CKAN
+//
+// Install Process:
+// 1.  Install ASET PRC from #1 above
+// 2.  Overwrite #1 cfg files with the files from #2 above
+// 3.  Install KAS via CKAN
+// 4.  Profit!!!
+//
+// To-Do (maybe):
+// 1.  Update bumper Solar Panels so they are more RO-like
+//
+
+
+@PART[ASET_PRC_Bumper]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	// !mesh = DELETE
+	// MODEL
+	// {
+		// model = ASET/PRC/KRoverBumper
+		// scale = 1.6, 1.6, 1.6
+	// }
+
+	// @scale = 1.6
+	// @rescaleFactor = 1.0
+	@mass = 0.025
+	@crashTolerance = 7
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+
+	@RESOURCE[ElectricCharge]
+	{
+		@maxAmount=5000	
+	}
+}
+
+@PART[ASET_PRC_Seat]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	// !mesh = DELETE
+	// MODEL
+	// {
+		// model = ASET/PRC/KRoverSeat
+		// scale = 1.6, 1.6, 1.6
+	// }
+
+	// @scale = 1.6
+	// @rescaleFactor = 1.0
+	@mass = 0.035
+	@crashTolerance = 6
+	@breakingForce = 20
+	@breakingTorque = 20
+	@maxTemp = 1200
+
+	@RESOURCE[ElectricCharge]
+	{
+		@amount=5000	
+		@maxAmount=5000	
+	}
+}
+
+@PART[ASET_PRC_Wheel]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	// !mesh = DELETE
+	// MODEL
+	// {
+		// model = ASET/PRC/KRoverWheel
+		// scale = 1.6, 1.6, 1.6
+	// }
+
+	// @scale = 1.6
+	// @rescaleFactor = 1.0
+	@mass = 0.05
+	@crashTolerance = 50
+	@breakingForce = 50
+	@breakingTorque = 50
+	@maxTemp = 1200
+
+}
+
+@PART[ASET_PRC_Platform]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	// !mesh = DELETE
+	// MODEL
+	// {
+		// model = ASET/PRC/KRoverPlatform
+		// scale = 1.6, 1.6, 1.6
+	// }
+
+	// @scale = 1.6
+	// @rescaleFactor = 1.0
+	@mass = 0.1
+	@crashTolerance = 7
+	@breakingForce = 20
+	@breakingTorque = 20
+	@maxTemp = 1200
+}
+


### PR DESCRIPTION
The ASET PRC mod hasn't been 'officially' updated since KSP v1.0.4, but MeCripp updated the config files and it seems to work just fine with 1.0.5.

This patch changes some of the basic attributes like Electric Charge and crash tolerance making them more RO-like.