### PR TITLE
Change to SXT Station and Base parts configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -4,7 +4,7 @@
 //  Realism Overhaul configuration.
 
 //  Dimensions: 6.0 m x 4.0 m
-//  Gross Mass: 7815.0 Kg
+//  Gross Mass: 5800.0 Kg
 //  ==================================================
 
 @PART[SXTSPKTRCabin]:FOR[RealismOverhaul]
@@ -22,13 +22,12 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 1.912, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
-    @node_stack_bottom,2 = 0.0, -1.843, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.843, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = SPKTR-10 Lacuga Storage Container
     @description = Hold 2 people with 30 days of supplies. An extension adapter for the PPD-10 Hitchhiker storage container.
 
-    @mass = 7.8
+    @mass = 4.8
     @maxTemp = 1073.15
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
@@ -111,7 +110,7 @@
 			amount = 45
 			maxAmount = 45
 		}
-	}
+    }
 	
 	MODULE
 	{
@@ -128,8 +127,8 @@
 
 //  Realism Overhaul configuration.
 
-//  Dimensions: 3.0 m x 1.6 m
-//  Gross Mass: 3600.0 Kg
+//  Dimensions: 3.0 m x 1.8 m
+//  Gross Mass: 3200.0 Kg
 //  ==================================================
 
 
@@ -139,34 +138,22 @@
 
     !mesh = NULL
 
-    @MODEL,0
+    @MODEL
     {
-        %scale = 1.2336, 1.2336, 1.2336
+        %scale = 1.23, 1.23, 1.23
     }
-	@MODEL,1
-	{
-		%scale = 1.2, 1.2, 1.2
-		@position = 0, 0.3768, 0
-	}
-	@MODEL,2
-	{
-		%scale = 1.2, 1.2, 1.2
-		@position = 0, 0.3768, 0
-	}
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.798, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -0.798, 0.0, 0.0, -1.0, 0.0, 3
-    @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.80, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.82, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = PPD-4 Crew Cabin
-    @description = Hold 2 people with 14 days of supplies. A slightly cramped early station module. Features usable handle bars around the side.
+    @description = Hold 2 people with 23 days of supplies. A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
 
-    @mass = 3.6
-    @maxTemp = 600
-	%skinMaxTemp = 800
+    @mass = 2.5
+    @maxTemp = 1073.15
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 
@@ -191,65 +178,66 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1300
+        volume = 1125
         basemass = -1
 
         TANK
         {
             name = ElectricCharge
-            amount = 21600
-            maxAmount = 21600
+            amount = 12000
+            maxAmount = 12000
         }
 		
 		TANK
 		{
 			name = Food
-			amount = 175
-			maxAmount = 175
+			amount =274
+			maxAmount = 274
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 116
-			maxAmount = 116
+			amount = 184
+			maxAmount = 184
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 17755
-			maxAmount = 17755
+			amount = 27750
+			maxAmount = 27750
 		}
 
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 15344.5
+			maxAmount = 17265
 		}
 
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 16
+			maxAmount = 18
 		}
 
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 147.75
+			maxAmount = 166.5
 		}
 
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 22.5
-			maxAmount = 22.5
+			amount = 26
+			maxAmount = 26
 		}
-	}
+    }
+	
 	MODULE
 	{
 		name = TacGenericConverter
@@ -261,12 +249,12 @@
 }
 
 //  ==================================================
-//  SSP-20 storage container.
+//  PPD-6 storage container.
 
 //  Realism Overhaul configuration.
 
-//  Dimensions: 3.0 m x 2.5 m
-//  Gross Mass: 6800.0 Kg
+//  Dimensions: 3.0 m x 3.8 m
+//  Gross Mass: 5500.0 Kg
 //  ==================================================
 
 @PART[SXTCrewCabSSP20]:FOR[RealismOverhaul]
@@ -275,28 +263,23 @@
 
     !mesh = NULL
 
-    @MODEL,0
+    @MODEL
     {
         %scale = 1.2, 1.2, 1.2
     }
-	@MODEL,1
-	{
-		%scale = 1.2, 1.2, 1.2
-	}
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.22796, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -1.22796, 0.0, 0.0, -1.0, 0.0, 3
-    @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.22, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = PPD-6 Crew Cabin
-    @description = Hold 4 people with one month of supplies. A slightly cramped early station module. Features usable handle bars around the side.
-
-    @mass = 7.0 // not quite 2x the PPD-4
-    @maxTemp = 600
-	%skinMaxTemp = 800
+    @description = Hold 3 people with 31 days of supplies. A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
+	@CrewCapacity = 3
+	
+    @mass = 5
+    @maxTemp = 1073.15
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 
@@ -313,7 +296,7 @@
 		OUTPUT_RESOURCE
 		{
 			name = ElectricCharge
-			rate = -0.8 //0.2 per person
+			rate = -0.6 //0.2 per person
 		}
 	}
 	
@@ -321,71 +304,71 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 3000
+        volume = 2250
         basemass = -1
 
         TANK
         {
             name = ElectricCharge
-            amount = 32000
-            maxAmount = 32000
+            amount = 24000
+            maxAmount = 24000
         }
 		
 		TANK
 		{
 			name = Food
-			amount =730
-			maxAmount = 730
+			amount =548
+			maxAmount = 548
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 490
-			maxAmount = 490
+			amount = 368
+			maxAmount = 368
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 74000
-			maxAmount = 74000
+			amount = 55500
+			maxAmount = 55500
 		}
 
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 46034
+			maxAmount = 34530
 		}
 
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 47.91
+			maxAmount = 36
 		}
 
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 443.235
+			maxAmount = 333
 		}
 
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 67.5
-			maxAmount = 67.5
+			amount = 52
+			maxAmount = 52
 		}
-	}
+    }
 	
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 4.0 // # of people - Figures based on per/person
+		conversionRate = 3.0 // # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
@@ -415,21 +398,21 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 3.35, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
-    @node_stack_bottom,2 = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 2
 
-    @title = Skylab Heavy Orbital Habitat
-    @description = Hold 8 peole with 155 days (5 months) of supplies. A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies.
+    @title = Skylab Orbital Workshop
+    @description = Hold 8 peole with 155 days (5 months) of supplies. A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies. It even features a orbital laboratory!
 
     @mass = 28
     @maxTemp = 1073.15
-    !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
-
-    @MODULE[ModuleScienceContainer]
-    {
-        @storageRange = 3.25
-    }
+	!MODULE[ModuleScienceExperiment] {}
+	
+	MODULE
+ 	{ 
+		name = ModuleCommand
+		minimumCrew = 1 
+	}
 	
 	MODULE
 	{
@@ -439,7 +422,7 @@
 		OUTPUT_RESOURCE
 		{
 			name = ElectricCharge
-			rate = -1.6 //0.2 per person
+			rate = -2.0 //Skylab is heavier and need more energy to be sustained
 		}
 	}
 
@@ -447,14 +430,14 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 32000
+        volume = 40000
         basemass = -1
 
         TANK
         {
             name = ElectricCharge
-            amount = 77000
-            maxAmount = 77000
+            amount = 705600
+            maxAmount = 705600
         }
 		
 		TANK
@@ -505,15 +488,47 @@
 			amount = 450
 			maxAmount = 450
 		}
-    	}
+    }
 	
 	MODULE
 	{
 		name = TacGenericConverter
-		converterName = CO2 Scrubber
-		conversionRate = 8.0 // # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+		converterName = CO2-O2 Converter
+		conversionRate = 8.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010	// See RO Github #844 for explanation of values
+		outputResources = Oxygen, 0.0071565375, true, Waste, 0.0000027155975, true	// See RO Github #844 for explanation of values
+	}
+	
+	MODULE
+	{
+		name = ModuleScienceLab
+		containerModuleIndex = 0
+		dataStorage = 1000
+		crewsRequired = 1
+		canResetConnectedModules = True
+		canResetNearbyModules = True
+		interactionRange = 5
+		SurfaceBonus = 0.1
+		ContextBonus = 0.25
+		homeworldMultiplier = 0.1
+		RESOURCE_PROCESS
+		{
+			name = ElectricCharge
+			amount = 2.72
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleScienceConverter
+		scientistBonus = 0.25	//Bonus per scientist star - need at least one! So 0.25x - 2.5x 
+		researchTime = 6	    //Larger = slower.  Exponential!
+		scienceMultiplier = 5	//How much science does data turn into?
+		scienceCap = 1000	    //How much science can we store before having to transmit?		
+		powerRequirement = 1.36	//EC/Sec to research
+		ConverterName = Research
+		StartActionName = Start Research
+		StopActionName = Stop Research
 	}
 }
 
@@ -541,23 +556,21 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
-    @node_stack_bottom,2 = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = Ares LK-S3E Heavy Planetary Habitat
-    @description = Hold 8 people with 45 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, and even a home gym.
+    @description = Hold 8 people with 45 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, laboratory, and even a home gym.
 
     @mass = 12.0
     @maxTemp = 1073.15
-    !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 	!MODULE[ModuleReactionWheel] {}
-
-    @MODULE[ModuleScienceContainer]
-    {
-        @storageRange = 3.25
-    }
 	
+	@MODULE[ModuleCommand]
+	{
+		@minimumCrew = 0
+	}
+
 	MODULE
 	{
 		name = ModuleGenerator
@@ -566,10 +579,10 @@
 		OUTPUT_RESOURCE
 		{
 			name = ElectricCharge
-			rate = -1.6 //0.2 per person
+			rate = -1.2 //0.2 per person
 		}
 	}
-
+	
     MODULE
     {
         name = ModuleFuelTanks
@@ -632,7 +645,7 @@
 			amount = 135
 			maxAmount = 135
 		}
-    	}
+    }
 	
 	MODULE
 	{
@@ -668,11 +681,10 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 2.25, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
-    @node_stack_bottom,2 = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = CANIOT-7 Crew Cabin
-    @description = Hold 6 people with 53 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
+    @description = Hold 6 people with 107 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5
     @maxTemp = 1073.15
@@ -700,7 +712,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 6000
+        volume = 12000
         basemass = -1
 
         TANK
@@ -713,59 +725,59 @@
 		TANK
 		{
 			name = Food
-			amount = 1880
-			maxAmount = 1880
+			amount = 3760
+			maxAmount = 3760
 		}
 
 		TANK
 		{
 			name = Water
-			amount = 1250
-			maxAmount = 1250
+			amount = 2500
+			maxAmount = 2500
 		}
 
 		TANK
 		{
 			name = Oxygen
-			amount = 190000
-			maxAmount = 190000
+			amount = 380000
+			maxAmount = 380000
 		}
 
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 157829
+			maxAmount = 315658
 		}
 
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 82.1314
+			maxAmount = 164.263
 		}
 
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 759.831
+			maxAmount = 1519.66
 		}
 
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 115.7
-			maxAmount = 115.7
+			amount = 231.4
+			maxAmount = 231.4
 		}
-    	}
+    }
 	
 	MODULE
 	{
 		name = TacGenericConverter
-		converterName = CO2 Scrubber
-		conversionRate = 6.0 // # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+		converterName = CO2-O2 Converter
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010	// See RO Github #844 for explanation of values
+		outputResources = Oxygen, 0.0071565375, true, Waste, 0.0000027155975, true	// See RO Github #844 for explanation of values
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -165,7 +165,7 @@
     @title = PPD-4 Crew Cabin
     @description = Hold 2 people with 23 days of supplies. A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
 
-    @mass = 2.5
+    @mass = 3.5
     @maxTemp = 600
 	%skinMaxTemp = 800
     !vesselType = NULL
@@ -297,7 +297,7 @@
     @description = Hold 3 people with 31 days of supplies. A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
 	@CrewCapacity = 3
 	
-    @mass = 5
+    @mass = 6
     @maxTemp = 600
 	%skinMaxTemp = 800
     !vesselType = NULL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -22,13 +22,15 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 1.912, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -1.843, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom,2 = 0.0, -1.843, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = SPKTR-10 Lacuga Storage Container
     @description = Hold 2 people with 30 days of supplies. An extension adapter for the PPD-10 Hitchhiker storage container.
 
     @mass = 4.8
-    @maxTemp = 1073.15
+    @maxTemp = 600
+	%skinMaxTemp = 800
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 
@@ -127,7 +129,7 @@
 
 //  Realism Overhaul configuration.
 
-//  Dimensions: 3.0 m x 1.8 m
+//  Dimensions: 3.0 m x 1.6 m
 //  Gross Mass: 3200.0 Kg
 //  ==================================================
 
@@ -138,22 +140,34 @@
 
     !mesh = NULL
 
-    @MODEL
+    @MODEL,0
     {
-        %scale = 1.23, 1.23, 1.23
+        %scale = 1.2336, 1.2336, 1.2336
     }
+	@MODEL,1
+	{
+		%scale = 1.2, 1.2, 1.2
+		@position = 0, 0.3768, 0
+	}
+	@MODEL,2
+	{
+		%scale = 1.2, 1.2, 1.2
+		@position = 0, 0.3768, 0
+	}
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.80, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -0.82, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.798, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.798, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
 
     @title = PPD-4 Crew Cabin
     @description = Hold 2 people with 23 days of supplies. A slightly cramped ruggadised cabin. Designed for both stations and surface operations. Features usable handle bars around the side.
 
     @mass = 2.5
-    @maxTemp = 1073.15
+    @maxTemp = 600
+	%skinMaxTemp = 800
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 
@@ -263,23 +277,29 @@
 
     !mesh = NULL
 
-    @MODEL
+    @MODEL,0
     {
         %scale = 1.2, 1.2, 1.2
     }
+	@MODEL,1
+	{
+		%scale = 1.2, 1.2, 1.2
+	}
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -1.22, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.22796, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.22796, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
 
     @title = PPD-6 Crew Cabin
     @description = Hold 3 people with 31 days of supplies. A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
 	@CrewCapacity = 3
 	
     @mass = 5
-    @maxTemp = 1073.15
+    @maxTemp = 600
+	%skinMaxTemp = 800
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 
@@ -399,14 +419,34 @@
 
     @node_stack_top = 0.0, 3.35, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 2
-
+    @node_attach = 0.0, 0.0, 3.1, 0.0, -1.0, 0.0, 2
+	
     @title = Skylab Orbital Workshop
     @description = Hold 8 peole with 155 days (5 months) of supplies. A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies. It even features a orbital laboratory!
 
     @mass = 28
-    @maxTemp = 1073.15
+    @maxTemp = 600
+	%skinMaxTemp = 800
 	!RESOURCE[ElectricCharge]{}
 	!MODULE[ModuleScienceExperiment] {}
+	
+	MODULE
+	{
+		name = ModuleScienceExperiment	
+	
+		experimentID = crewReport
+	
+		experimentActionName = Crew Report
+		resetActionName = Discard Crew Report
+		reviewActionName = Review Report
+	
+		useStaging = False	
+		useActionGroups = True
+		hideUIwhenUnavailable = True	
+		rerunnable = True
+	
+		xmitDataScalar = 1.0	
+	}
 	
 	MODULE
  	{ 
@@ -562,7 +602,8 @@
     @description = Hold 8 people with 45 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, laboratory, and even a home gym.
 
     @mass = 12.0
-    @maxTemp = 1073.15
+    @maxTemp = 600
+	%skinMaxTemp = 800
 	!RESOURCE[ElectricCharge]{}
 	!MODULE[ModuleReactionWheel] {}
 	
@@ -658,7 +699,7 @@
 }
 
 //  ==================================================
-//  Caniot Heavy Orbital Habitat.
+//  Turtle Heavy Orbital Habitat.
 
 //  Realism Overhaul configuration.
 
@@ -680,14 +721,15 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 2.25, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 2.28, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -2.28, 0.0, 0.0, -1.0, 0.0, 2
 
-    @title = CANIOT-7 Crew Cabin
+    @title = Turtle Crew Cabin
     @description = Hold 6 people with 107 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5
-    @maxTemp = 1073.15
+    @maxTemp = 600
+	%skinMaxTemp = 800
     !vesselType = NULL
 	!RESOURCE[ElectricCharge]{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -294,8 +294,7 @@
     @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
 
     @title = PPD-6 Crew Cabin
-    @description = Hold 3 people with 31 days of supplies. A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
-	@CrewCapacity = 3
+    @description = Hold 3 people with 23 days of supplies. A cruder, but more sturdy forebearer to the the PPD-10. The design specified a tougher skeleton and skin surface, due after a series of 'dicey' touchdowns.
 	
     @mass = 6
     @maxTemp = 600
@@ -699,7 +698,7 @@
 }
 
 //  ==================================================
-//  Turtle Heavy Orbital Habitat.
+//  PPD-H Heavy Orbital Habitat.
 
 //  Realism Overhaul configuration.
 
@@ -724,7 +723,7 @@
     @node_stack_top = 0.0, 2.28, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -2.28, 0.0, 0.0, -1.0, 0.0, 2
 
-    @title = Turtle Crew Cabin
+    @title = PPD-H Crew Cabin
     @description = Hold 6 people with 107 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5


### PR DESCRIPTION
A patch to #892 as @NathanKell requested.

Changed the node configs, it should be fine now.
Rescaled the PDD4 and PDD6 to 3m witdh (The Salyut Command Desk were 2.9m width; it's not exactly a counterpart but it will give more flexibility for building station).
PDD6 now holds just 3 crew (as Salyut/Almaz stations)
The Skylab now features an orbital lab.
[Station Part Sheet](https://onedrive.live.com/redir?page=view&resid=9AE39A0EBF42E208!360496&authkey=!AOv701J1tt1oiA8) : if you want to add some details or ideas about the config you can do it there.