### PR TITLE
RN tks/terra fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_TKS.cfg
@@ -224,6 +224,29 @@
 	!MODULE[ModuleGenerator]
 	{
 	}
+	@MODULE[ModuleRCS]
+	{
+		%name = ModuleRCS
+		%thrusterPower = 0.13
+		%thrusterTransformName = RCSthruster
+		%resourceFlowMode = STACK_PRIORITY_SEARCH
+		!resourceName = MonoPropellant
+		PROPELLANT
+		{
+			ratio = 0.5
+			name = NTO
+		}
+		PROPELLANT
+		{
+			ratio = 0.5
+			name = Hydrazine
+		}
+		@atmosphereCurve
+		{
+			@key = 0 312
+			@key = 1 82.08
+		}
+	}
 	@MODULE[ModuleAblator]
 	{
 		@ablativeResource = Ablator

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
@@ -213,9 +213,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.98, 1.0, 0.98
 	}
-	@scale = 1.0
+	@scale = 0.98
 	@mass = 4.814
 	%maxTemp = 1073.15
 	%crashTolerance = 12
@@ -318,9 +318,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.98, 1.0, 0.98
 	}
-	@scale = 1.0
+	@scale = 0.98
 	@mass = 0.05
 	%maxTemp = 1073.15
 	%crashTolerance = 12


### PR DESCRIPTION
-Add invisible rcs thrusters to va to help with descent mode rolls for
skip reentry. This seems to be a limit with the rcs in ksp, when so close to the center of mass(like on the va tks top cone) it just gives little puffs and almost no thrust/toqrue to the pod at all. Moving the rcs further from the CoM seems to fix it.

-fix terra scale