### PR TITLE
Update Adjustable Landing Gear.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BahamutoD/Adjustable Landing Gear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BahamutoD/Adjustable Landing Gear.cfg
@@ -16,7 +16,7 @@
 
 +PART[BD_Adj_LG_Side]:AFTER[RealismOverhaul]
 {
-  @name = BD_Adj_LG_Side_Supesonic
+  @name = BD_Adj_LG_Side_Supersonic
   %maxTemp = 600
   %skinMaxTemp = 800
   @description = An adjustable landing gear with a single wheel. Rated for supersonic aircrafts.


### PR DESCRIPTION
Fixed typo. Now the name is the same as in the RP-0 tech tree.