### PR TITLE
Fix VSR Castor 30B gimbal

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -226,10 +226,10 @@
 	MODULE:NEEDS[!VenStockRevamp]
 	{
 		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
 	}
 	@MODULE[ModuleGimbal]
 	{
+		%gimbalTransformName = thrustTransform
 		%gimbalRange = 3.5
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16


### PR DESCRIPTION
Previously used incorrect gimbalTransformName when loaded with VSR. Fixed and tested with and without VSR.