### PR TITLE
Fix root rescale bug in ROMini + helper script.

### DIFF
--- a/ROMini.cfg
+++ b/ROMini.cfg
@@ -142,6 +142,7 @@
 }
 // This _should_ work, but scale seems to fail in 1.0.4...
 // It DOES work in 1.0.5 in all aspects but for not catching attach nodes... doh!
+// Based on the above comments, I expect it *should* work in 1.1, but i'm editing blind at work at the moment...
 @PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
 	@MODEL,*:HAS[~scale[]]
@@ -160,18 +161,11 @@
 	}
 }
 // We need to DISABLE this one so we don't scale twice.
+// I don't see why we wouldn't have to keep this disabled/removed under the new 1.1 conditions.
+// Is this not redundant with the @scale in the model node above?
 //@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 //{
 //	@scale *= #$rescaleFactor$
-//}
-
-// If this worked, it'd be a miracle, but MM doesn't support this sort of wildcarding, as far as I can tell. LEAVE DISABLED, hope for new features in the future.
-//@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
-//{
-//	testnode = #$rescaleFactor$
-//	@node_*,*[0] *= #$rescaleFactor$
-//	@node_*,*[1] *= #$rescaleFactor$
-//	@node_*,*[2] *= #$rescaleFactor$
 //}
 
 @PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
@@ -307,39 +301,39 @@
 	}
 }
 // Handle proc fairings.
+// Reenabled the node scaling. I *don't* know if it is still needed (NEEDS TESTING), or if the general model scaling above catches it. These guys are always weird... 
 @PART[*]:HAS[@MODULE[ModuleProceduralFairing]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
-// We handle the nodes externally now... This can go away, but it's good to leave for a reference for the time being. (As it's what I based the new script off of in the first place!)
-//	%rescaleFactor = 1.0
-//	@MODEL
-//	{
-//		%scale = 1.6, 1.6, 1.6
-//	}
-//	stack_top0 = #$node_stack_top[0]$
-//	stack_top1 = #$node_stack_top[1]$
-//	stack_top2 = #$node_stack_top[2]$
-//	@stack_top0 *= 1.6
-//	@stack_top1 *= 1.6
-//	@stack_top2 *= 1.6
-//	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
-//	@node_stack_top = #$stack_top_new$
-//	!stack_top0 = DEL
-//	!stack_top1 = DEL
-//	!stack_top2 = DEL
-//	!stack_top_new = DEL
-//	
-//	stack_bottom0 = #$node_stack_bottom[0]$
-//	stack_bottom1 = #$node_stack_bottom[1]$
-//	stack_bottom2 = #$node_stack_bottom[2]$
-//	@stack_bottom0 *= 1.6
-//	@stack_bottom1 *= 1.6
-//	@stack_bottom2 *= 1.6
-//	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
-//	@node_stack_bottom = #$stack_bottom_new$
-//	!stack_bottom0 = DEL
-//	!stack_bottom1 = DEL
-//	!stack_bottom2 = DEL
-//	!stack_bottom_new = DEL
+	%rescaleFactor = 1.0
+	@MODEL
+	{
+		%scale = 1.6, 1.6, 1.6
+	}
+	stack_top0 = #$node_stack_top[0]$
+	stack_top1 = #$node_stack_top[1]$
+	stack_top2 = #$node_stack_top[2]$
+	@stack_top0 *= 1.6
+	@stack_top1 *= 1.6
+	@stack_top2 *= 1.6
+	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+	@node_stack_top = #$stack_top_new$
+	!stack_top0 = DEL
+	!stack_top1 = DEL
+	!stack_top2 = DEL
+	!stack_top_new = DEL
+	
+	stack_bottom0 = #$node_stack_bottom[0]$
+	stack_bottom1 = #$node_stack_bottom[1]$
+	stack_bottom2 = #$node_stack_bottom[2]$
+	@stack_bottom0 *= 1.6
+	@stack_bottom1 *= 1.6
+	@stack_bottom2 *= 1.6
+	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+	@node_stack_bottom = #$stack_bottom_new$
+	!stack_bottom0 = DEL
+	!stack_bottom1 = DEL
+	!stack_bottom2 = DEL
+	!stack_bottom_new = DEL
 	
 	@MODULE[ModuleProceduralFairing]
 	{

--- a/ROMini.cfg
+++ b/ROMini.cfg
@@ -85,7 +85,50 @@
 }
 
 // RESCALE
-@PART[*]:HAS[#rescaleFactor[*]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
+// This one handles Procedural Fairings nicely.
+@PART[*]:HAS[MODULE[KzNodeNumberTweaker]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
+{
+	@MODULE[KzFairingBaseResizer]
+    	{
+      		@size *= 1.6
+		%diameterStepLarge = #$size$
+		dss = #$size$
+		//@dss *= 0.625  // Why did we do this?
+		@dss *= 0.1
+		%diameterStepSmall = #$dss$
+		!dss = DEL
+
+    	}
+	@MODULE[ProceduralFairingAdapter]
+    	{
+      		@baseSize *= 1.6
+        	@topSize *= 1.6
+    	}
+	@MODULE[KzThrustPlateResizer]
+	{
+		@size *= 1.6
+	}
+}
+// These are needed to make the above work sensibly with the PF stock settings. The tech tree adjustement from RP0 is what I personally use, but it seems excessive to include here.
+@PROCFAIRINGS_MINDIAMETER
+{
+	start = 0.1
+}
+@PROCFAIRINGS_MAXDIAMETER
+{
+	@start = 2.0
+}
+@PROCROCKET_MINDIAMETER
+{
+	@start = 0.1
+}
+@PROCROCKET_MAXDIAMETER
+{
+	%start = 2.0
+}
+// /PF
+
+@PART[*]:HAS[#rescaleFactor[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
 	@rescaleFactor *= 1.6
 }
@@ -96,33 +139,45 @@
 @PART[*]:HAS[~scale[]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
 	scale = 1.0
-}
+}	
 // This _should_ work, but scale seems to fail in 1.0.4...
-//@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
-//{
-//	@MODEL,*:HAS[~scale[]]
-//	{
-//		scale = 1, 1, 1
-//	}
-//	@MODEL,*
-//	{
-//		scaleX = #$scale[0]$
-//		scaleY = #$scale[1]$
-//		scaleZ = #$scale[2]$
-//		@scaleX *= #$../rescaleFactor$
-//		@scaleY *= #$../rescaleFactor$
-//		@scaleZ *= #$../rescaleFactor$
-//		@scale = #$scaleX$,$scaleY$,$scaleZ$
-//	}
-//}
+// It DOES work in 1.0.5 in all aspects but for not catching attach nodes... doh!
+@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
+{
+	@MODEL,*:HAS[~scale[]]
+	{
+		scale = 1.0, 1.0, 1.0
+	}
+	@MODEL,*
+	{
+		scaleX = #$scale[0]$
+		scaleY = #$scale[1]$
+		scaleZ = #$scale[2]$
+		@scaleX *= #$../rescaleFactor$
+		@scaleY *= #$../rescaleFactor$
+		@scaleZ *= #$../rescaleFactor$
+		@scale = #$scaleX$,$scaleY$,$scaleZ$
+	}
+}
+// We need to DISABLE this one so we don't scale twice.
 //@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 //{
 //	@scale *= #$rescaleFactor$
 //}
+
+// If this worked, it'd be a miracle, but MM doesn't support this sort of wildcarding, as far as I can tell. LEAVE DISABLED, hope for new features in the future.
 //@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 //{
-//	@rescaleFactor = 1.0
+//	testnode = #$rescaleFactor$
+//	@node_*,*[0] *= #$rescaleFactor$
+//	@node_*,*[1] *= #$rescaleFactor$
+//	@node_*,*[2] *= #$rescaleFactor$
 //}
+
+@PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]
+{
+	@rescaleFactor = 1.0
+}
 // Parachutes, special case
 @PART[*]:HAS[@MODULE[ModuleDragModifier],@MODULE[ModuleParachute]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
@@ -254,36 +309,37 @@
 // Handle proc fairings.
 @PART[*]:HAS[@MODULE[ModuleProceduralFairing]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
-	%rescaleFactor = 1.0
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
-	stack_top0 = #$node_stack_top[0]$
-	stack_top1 = #$node_stack_top[1]$
-	stack_top2 = #$node_stack_top[2]$
-	@stack_top0 *= 1.6
-	@stack_top1 *= 1.6
-	@stack_top2 *= 1.6
-	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
-	@node_stack_top = #$stack_top_new$
-	!stack_top0 = DEL
-	!stack_top1 = DEL
-	!stack_top2 = DEL
-	!stack_top_new = DEL
-	
-	stack_bottom0 = #$node_stack_bottom[0]$
-	stack_bottom1 = #$node_stack_bottom[1]$
-	stack_bottom2 = #$node_stack_bottom[2]$
-	@stack_bottom0 *= 1.6
-	@stack_bottom1 *= 1.6
-	@stack_bottom2 *= 1.6
-	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
-	@node_stack_bottom = #$stack_bottom_new$
-	!stack_bottom0 = DEL
-	!stack_bottom1 = DEL
-	!stack_bottom2 = DEL
-	!stack_bottom_new = DEL
+// We handle the nodes externally now... This can go away, but it's good to leave for a reference for the time being. (As it's what I based the new script off of in the first place!)
+//	%rescaleFactor = 1.0
+//	@MODEL
+//	{
+//		%scale = 1.6, 1.6, 1.6
+//	}
+//	stack_top0 = #$node_stack_top[0]$
+//	stack_top1 = #$node_stack_top[1]$
+//	stack_top2 = #$node_stack_top[2]$
+//	@stack_top0 *= 1.6
+//	@stack_top1 *= 1.6
+//	@stack_top2 *= 1.6
+//	stack_top_new = #$stack_top0$,$stack_top1$,$stack_top2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+//	@node_stack_top = #$stack_top_new$
+//	!stack_top0 = DEL
+//	!stack_top1 = DEL
+//	!stack_top2 = DEL
+//	!stack_top_new = DEL
+//	
+//	stack_bottom0 = #$node_stack_bottom[0]$
+//	stack_bottom1 = #$node_stack_bottom[1]$
+//	stack_bottom2 = #$node_stack_bottom[2]$
+//	@stack_bottom0 *= 1.6
+//	@stack_bottom1 *= 1.6
+//	@stack_bottom2 *= 1.6
+//	stack_bottom_new = #$stack_bottom0$,$stack_bottom1$,$stack_bottom2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+//	@node_stack_bottom = #$stack_bottom_new$
+//	!stack_bottom0 = DEL
+//	!stack_bottom1 = DEL
+//	!stack_bottom2 = DEL
+//	!stack_bottom_new = DEL
 	
 	@MODULE[ModuleProceduralFairing]
 	{

--- a/ROMini.cfg
+++ b/ROMini.cfg
@@ -139,7 +139,7 @@
 @PART[*]:HAS[~scale[]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
 	scale = 1.0
-}	
+}
 // This _should_ work, but scale seems to fail in 1.0.4...
 // It DOES work in 1.0.5 in all aspects but for not catching attach nodes... doh!
 @PART[*]:HAS[@MODEL]:FOR[zROMini]:NEEDS[!RealismOverhaul]

--- a/ROMini.cfg
+++ b/ROMini.cfg
@@ -85,7 +85,7 @@
 }
 
 // RESCALE
-// This one handles Procedural Fairings nicely.
+// These should handle Procedural Fairings nicely, but seem to fail. No errors, just no results.
 @PART[*]:HAS[MODULE[KzNodeNumberTweaker]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
 	@MODULE[KzFairingBaseResizer]
@@ -127,7 +127,7 @@
 	%start = 2.0
 }
 // /PF
-
+// If we do not exclude PF here, they get very weird about their scaling and nodes. PP is not handled here, as I am not an avid user.
 @PART[*]:HAS[#rescaleFactor[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
 {
 	@rescaleFactor *= 1.6

--- a/generateNodes.py
+++ b/generateNodes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+import os
+import re
+#import sys
+import fnmatch
+import argparse
+
+parser = argparse.ArgumentParser(description='Generate Rescaled Attach Nodes.')
+
+parser.add_argument("-p", "--path", help="KSP or Gamedata Directory. (Defaults to Current Directory)", default=".")
+parser.add_argument("cfgfile", help="File to Write the New Scaled Nodes Into.", default="ROMiniNodes.cfg")
+args = parser.parse_args()
+
+
+#~ print "****" * 20
+
+def getnodes(path):
+    """Function to get cfg file list"""
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            if fnmatch.fnmatch(name, '*.cfg'):
+                with open(os.path.join(root, name), 'r') as f:
+                    for line in f:
+                        if re.match("^node*", line):
+                            node = line.split(' ',1)[0]
+                            yield node
+#~ print "****" *20
+#~ uniq = sorted(list(set(getnodes(dir))))
+#~ print "****" *20
+
+
+def writenodecfg(path):
+	cfg = header
+	with open((args.cfgfile), "w") as out:
+		for i in sorted(list(set(getnodes(path)))):
+			cfg += body.format(i)
+		out.write(cfg)
+		#~ print "{}".format(args.cfgfile)
+	
+
+
+#~ print "****" *20
+
+header = """RESCALEFACTOR
+{
+	rescaleFactor = 1.6
+}
+"""
+
+body = """
+@PART[*]:HAS[@MODEL,#{0}[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
+{{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #${0}[0]$
+nya = #${0}[1]$
+nza = #${0}[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@{0} = #$nxa$,$nya$,$nza$,${0}[3]$,${0}[4]$,${0}[5]$,${0}[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@{0}[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}}
+"""
+
+if args.path:
+	writenodecfg(args.path)

--- a/generateNodes.py
+++ b/generateNodes.py
@@ -35,7 +35,7 @@ header = """RESCALEFACTOR
 """
 
 body = """
-@PART[*]:HAS[@MODEL,#{0}[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer]]:FOR[zROMini]:NEEDS[!RealismOverhaul]
+@PART[*]:HAS[@MODEL,#{0}[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer]]:FOR[zzzzzzROMini]:NEEDS[!RealismOverhaul]
 {{
 //         0    1    2    3     4    5    6
 //$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
@@ -58,6 +58,6 @@ nza = #${0}[2]$
 """
 if args.cfgfile:
 	writenodecfg(args.path)
-	print("Sucess! {} written!").format(args.cfgfile)
+	print(("Sucess! {} written!").format(args.cfgfile))
 else:
 	parser.print_help()

--- a/generateNodes.py
+++ b/generateNodes.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
 import os
 import re
-#import sys
 import fnmatch
 import argparse
 
 parser = argparse.ArgumentParser(description='Generate Rescaled Attach Nodes.')
 
 parser.add_argument("-p", "--path", help="KSP or Gamedata Directory. (Defaults to Current Directory)", default=".")
-parser.add_argument("cfgfile", help="File to Write the New Scaled Nodes Into.", default="ROMiniNodes.cfg")
+parser.add_argument("cfgfile", nargs='?', help="File to Write the New Scaled Nodes Into.")
 args = parser.parse_args()
-
-
-#~ print "****" * 20
 
 def getnodes(path):
     """Function to get cfg file list"""
@@ -24,10 +20,6 @@ def getnodes(path):
                         if re.match("^node*", line):
                             node = line.split(' ',1)[0]
                             yield node
-#~ print "****" *20
-#~ uniq = sorted(list(set(getnodes(dir))))
-#~ print "****" *20
-
 
 def writenodecfg(path):
 	cfg = header
@@ -35,11 +27,6 @@ def writenodecfg(path):
 		for i in sorted(list(set(getnodes(path)))):
 			cfg += body.format(i)
 		out.write(cfg)
-		#~ print "{}".format(args.cfgfile)
-	
-
-
-#~ print "****" *20
 
 header = """RESCALEFACTOR
 {
@@ -69,6 +56,8 @@ nza = #${0}[2]$
 !n*a = DEL
 }}
 """
-
-if args.path:
+if args.cfgfile:
 	writenodecfg(args.path)
+	print("Sucess! {} written!").format(args.cfgfile)
+else:
+	parser.print_help()

--- a/generatedNodes.cfg
+++ b/generatedNodes.cfg
@@ -1,0 +1,1600 @@
+RESCALEFACTOR
+{
+	rescaleFactor = 1.6
+}
+
+@PART[*]:HAS[@MODEL,#node_attach[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_attach[0]$
+nya = #$node_attach[1]$
+nza = #$node_attach[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_attach = #$nxa$,$nya$,$nza$,$node_attach[3]$,$node_attach[4]$,$node_attach[5]$,$node_attach[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_attach[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_attach_srf[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_attach_srf[0]$
+nya = #$node_attach_srf[1]$
+nza = #$node_attach_srf[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_attach_srf = #$nxa$,$nya$,$nza$,$node_attach_srf[3]$,$node_attach_srf[4]$,$node_attach_srf[5]$,$node_attach_srf[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_attach_srf[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_Cargo_1[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_Cargo_1[0]$
+nya = #$node_stack_Cargo_1[1]$
+nza = #$node_stack_Cargo_1[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_Cargo_1 = #$nxa$,$nya$,$nza$,$node_stack_Cargo_1[3]$,$node_stack_Cargo_1[4]$,$node_stack_Cargo_1[5]$,$node_stack_Cargo_1[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_Cargo_1[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_Cargo_2[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_Cargo_2[0]$
+nya = #$node_stack_Cargo_2[1]$
+nza = #$node_stack_Cargo_2[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_Cargo_2 = #$nxa$,$nya$,$nza$,$node_stack_Cargo_2[3]$,$node_stack_Cargo_2[4]$,$node_stack_Cargo_2[5]$,$node_stack_Cargo_2[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_Cargo_2[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_SAS[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_SAS[0]$
+nya = #$node_stack_SAS[1]$
+nza = #$node_stack_SAS[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_SAS = #$nxa$,$nya$,$nza$,$node_stack_SAS[3]$,$node_stack_SAS[4]$,$node_stack_SAS[5]$,$node_stack_SAS[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_SAS[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach[0]$
+nya = #$node_stack_attach[1]$
+nza = #$node_stack_attach[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach = #$nxa$,$nya$,$nza$,$node_stack_attach[3]$,$node_stack_attach[4]$,$node_stack_attach[5]$,$node_stack_attach[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach01[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach01[0]$
+nya = #$node_stack_attach01[1]$
+nza = #$node_stack_attach01[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach01 = #$nxa$,$nya$,$nza$,$node_stack_attach01[3]$,$node_stack_attach01[4]$,$node_stack_attach01[5]$,$node_stack_attach01[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach01[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach02[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach02[0]$
+nya = #$node_stack_attach02[1]$
+nza = #$node_stack_attach02[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach02 = #$nxa$,$nya$,$nza$,$node_stack_attach02[3]$,$node_stack_attach02[4]$,$node_stack_attach02[5]$,$node_stack_attach02[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach02[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach03[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach03[0]$
+nya = #$node_stack_attach03[1]$
+nza = #$node_stack_attach03[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach03 = #$nxa$,$nya$,$nza$,$node_stack_attach03[3]$,$node_stack_attach03[4]$,$node_stack_attach03[5]$,$node_stack_attach03[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach03[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach04[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach04[0]$
+nya = #$node_stack_attach04[1]$
+nza = #$node_stack_attach04[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach04 = #$nxa$,$nya$,$nza$,$node_stack_attach04[3]$,$node_stack_attach04[4]$,$node_stack_attach04[5]$,$node_stack_attach04[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach04[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach05[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach05[0]$
+nya = #$node_stack_attach05[1]$
+nza = #$node_stack_attach05[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach05 = #$nxa$,$nya$,$nza$,$node_stack_attach05[3]$,$node_stack_attach05[4]$,$node_stack_attach05[5]$,$node_stack_attach05[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach05[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach06[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach06[0]$
+nya = #$node_stack_attach06[1]$
+nza = #$node_stack_attach06[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach06 = #$nxa$,$nya$,$nza$,$node_stack_attach06[3]$,$node_stack_attach06[4]$,$node_stack_attach06[5]$,$node_stack_attach06[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach06[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach07[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach07[0]$
+nya = #$node_stack_attach07[1]$
+nza = #$node_stack_attach07[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach07 = #$nxa$,$nya$,$nza$,$node_stack_attach07[3]$,$node_stack_attach07[4]$,$node_stack_attach07[5]$,$node_stack_attach07[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach07[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach08[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach08[0]$
+nya = #$node_stack_attach08[1]$
+nza = #$node_stack_attach08[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach08 = #$nxa$,$nya$,$nza$,$node_stack_attach08[3]$,$node_stack_attach08[4]$,$node_stack_attach08[5]$,$node_stack_attach08[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach08[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_attach09[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_attach09[0]$
+nya = #$node_stack_attach09[1]$
+nza = #$node_stack_attach09[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_attach09 = #$nxa$,$nya$,$nza$,$node_stack_attach09[3]$,$node_stack_attach09[4]$,$node_stack_attach09[5]$,$node_stack_attach09[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_attach09[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_back[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_back[0]$
+nya = #$node_stack_back[1]$
+nza = #$node_stack_back[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_back = #$nxa$,$nya$,$nza$,$node_stack_back[3]$,$node_stack_back[4]$,$node_stack_back[5]$,$node_stack_back[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_back[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom[0]$
+nya = #$node_stack_bottom[1]$
+nza = #$node_stack_bottom[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom = #$nxa$,$nya$,$nza$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom01[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom01[0]$
+nya = #$node_stack_bottom01[1]$
+nza = #$node_stack_bottom01[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom01 = #$nxa$,$nya$,$nza$,$node_stack_bottom01[3]$,$node_stack_bottom01[4]$,$node_stack_bottom01[5]$,$node_stack_bottom01[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom01[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom02[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom02[0]$
+nya = #$node_stack_bottom02[1]$
+nza = #$node_stack_bottom02[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom02 = #$nxa$,$nya$,$nza$,$node_stack_bottom02[3]$,$node_stack_bottom02[4]$,$node_stack_bottom02[5]$,$node_stack_bottom02[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom02[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom03[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom03[0]$
+nya = #$node_stack_bottom03[1]$
+nza = #$node_stack_bottom03[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom03 = #$nxa$,$nya$,$nza$,$node_stack_bottom03[3]$,$node_stack_bottom03[4]$,$node_stack_bottom03[5]$,$node_stack_bottom03[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom03[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom04[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom04[0]$
+nya = #$node_stack_bottom04[1]$
+nza = #$node_stack_bottom04[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom04 = #$nxa$,$nya$,$nza$,$node_stack_bottom04[3]$,$node_stack_bottom04[4]$,$node_stack_bottom04[5]$,$node_stack_bottom04[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom04[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom05[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom05[0]$
+nya = #$node_stack_bottom05[1]$
+nza = #$node_stack_bottom05[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom05 = #$nxa$,$nya$,$nza$,$node_stack_bottom05[3]$,$node_stack_bottom05[4]$,$node_stack_bottom05[5]$,$node_stack_bottom05[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom05[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom06[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom06[0]$
+nya = #$node_stack_bottom06[1]$
+nza = #$node_stack_bottom06[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom06 = #$nxa$,$nya$,$nza$,$node_stack_bottom06[3]$,$node_stack_bottom06[4]$,$node_stack_bottom06[5]$,$node_stack_bottom06[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom06[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom07[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom07[0]$
+nya = #$node_stack_bottom07[1]$
+nza = #$node_stack_bottom07[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom07 = #$nxa$,$nya$,$nza$,$node_stack_bottom07[3]$,$node_stack_bottom07[4]$,$node_stack_bottom07[5]$,$node_stack_bottom07[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom07[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom08[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom08[0]$
+nya = #$node_stack_bottom08[1]$
+nza = #$node_stack_bottom08[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom08 = #$nxa$,$nya$,$nza$,$node_stack_bottom08[3]$,$node_stack_bottom08[4]$,$node_stack_bottom08[5]$,$node_stack_bottom08[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom08[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom09[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom09[0]$
+nya = #$node_stack_bottom09[1]$
+nza = #$node_stack_bottom09[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom09 = #$nxa$,$nya$,$nza$,$node_stack_bottom09[3]$,$node_stack_bottom09[4]$,$node_stack_bottom09[5]$,$node_stack_bottom09[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom09[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom1[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom1[0]$
+nya = #$node_stack_bottom1[1]$
+nza = #$node_stack_bottom1[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom1 = #$nxa$,$nya$,$nza$,$node_stack_bottom1[3]$,$node_stack_bottom1[4]$,$node_stack_bottom1[5]$,$node_stack_bottom1[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom1[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom10[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom10[0]$
+nya = #$node_stack_bottom10[1]$
+nza = #$node_stack_bottom10[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom10 = #$nxa$,$nya$,$nza$,$node_stack_bottom10[3]$,$node_stack_bottom10[4]$,$node_stack_bottom10[5]$,$node_stack_bottom10[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom10[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom11[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom11[0]$
+nya = #$node_stack_bottom11[1]$
+nza = #$node_stack_bottom11[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom11 = #$nxa$,$nya$,$nza$,$node_stack_bottom11[3]$,$node_stack_bottom11[4]$,$node_stack_bottom11[5]$,$node_stack_bottom11[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom11[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom12[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom12[0]$
+nya = #$node_stack_bottom12[1]$
+nza = #$node_stack_bottom12[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom12 = #$nxa$,$nya$,$nza$,$node_stack_bottom12[3]$,$node_stack_bottom12[4]$,$node_stack_bottom12[5]$,$node_stack_bottom12[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom12[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom13[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom13[0]$
+nya = #$node_stack_bottom13[1]$
+nza = #$node_stack_bottom13[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom13 = #$nxa$,$nya$,$nza$,$node_stack_bottom13[3]$,$node_stack_bottom13[4]$,$node_stack_bottom13[5]$,$node_stack_bottom13[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom13[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom14[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom14[0]$
+nya = #$node_stack_bottom14[1]$
+nza = #$node_stack_bottom14[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom14 = #$nxa$,$nya$,$nza$,$node_stack_bottom14[3]$,$node_stack_bottom14[4]$,$node_stack_bottom14[5]$,$node_stack_bottom14[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom14[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom15[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom15[0]$
+nya = #$node_stack_bottom15[1]$
+nza = #$node_stack_bottom15[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom15 = #$nxa$,$nya$,$nza$,$node_stack_bottom15[3]$,$node_stack_bottom15[4]$,$node_stack_bottom15[5]$,$node_stack_bottom15[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom15[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom16[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom16[0]$
+nya = #$node_stack_bottom16[1]$
+nza = #$node_stack_bottom16[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom16 = #$nxa$,$nya$,$nza$,$node_stack_bottom16[3]$,$node_stack_bottom16[4]$,$node_stack_bottom16[5]$,$node_stack_bottom16[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom16[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottom2[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottom2[0]$
+nya = #$node_stack_bottom2[1]$
+nza = #$node_stack_bottom2[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottom2 = #$nxa$,$nya$,$nza$,$node_stack_bottom2[3]$,$node_stack_bottom2[4]$,$node_stack_bottom2[5]$,$node_stack_bottom2[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottom2[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottomleft[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottomleft[0]$
+nya = #$node_stack_bottomleft[1]$
+nza = #$node_stack_bottomleft[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottomleft = #$nxa$,$nya$,$nza$,$node_stack_bottomleft[3]$,$node_stack_bottomleft[4]$,$node_stack_bottomleft[5]$,$node_stack_bottomleft[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottomleft[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_bottomtopright[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_bottomtopright[0]$
+nya = #$node_stack_bottomtopright[1]$
+nza = #$node_stack_bottomtopright[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_bottomtopright = #$nxa$,$nya$,$nza$,$node_stack_bottomtopright[3]$,$node_stack_bottomtopright[4]$,$node_stack_bottomtopright[5]$,$node_stack_bottomtopright[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_bottomtopright[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_center[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_center[0]$
+nya = #$node_stack_center[1]$
+nza = #$node_stack_center[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_center = #$nxa$,$nya$,$nza$,$node_stack_center[3]$,$node_stack_center[4]$,$node_stack_center[5]$,$node_stack_center[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_center[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect[0]$
+nya = #$node_stack_connect[1]$
+nza = #$node_stack_connect[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect = #$nxa$,$nya$,$nza$,$node_stack_connect[3]$,$node_stack_connect[4]$,$node_stack_connect[5]$,$node_stack_connect[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect01[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect01[0]$
+nya = #$node_stack_connect01[1]$
+nza = #$node_stack_connect01[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect01 = #$nxa$,$nya$,$nza$,$node_stack_connect01[3]$,$node_stack_connect01[4]$,$node_stack_connect01[5]$,$node_stack_connect01[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect01[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect02[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect02[0]$
+nya = #$node_stack_connect02[1]$
+nza = #$node_stack_connect02[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect02 = #$nxa$,$nya$,$nza$,$node_stack_connect02[3]$,$node_stack_connect02[4]$,$node_stack_connect02[5]$,$node_stack_connect02[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect02[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect03[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect03[0]$
+nya = #$node_stack_connect03[1]$
+nza = #$node_stack_connect03[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect03 = #$nxa$,$nya$,$nza$,$node_stack_connect03[3]$,$node_stack_connect03[4]$,$node_stack_connect03[5]$,$node_stack_connect03[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect03[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect04[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect04[0]$
+nya = #$node_stack_connect04[1]$
+nza = #$node_stack_connect04[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect04 = #$nxa$,$nya$,$nza$,$node_stack_connect04[3]$,$node_stack_connect04[4]$,$node_stack_connect04[5]$,$node_stack_connect04[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect04[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect05[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect05[0]$
+nya = #$node_stack_connect05[1]$
+nza = #$node_stack_connect05[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect05 = #$nxa$,$nya$,$nza$,$node_stack_connect05[3]$,$node_stack_connect05[4]$,$node_stack_connect05[5]$,$node_stack_connect05[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect05[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect06[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect06[0]$
+nya = #$node_stack_connect06[1]$
+nza = #$node_stack_connect06[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect06 = #$nxa$,$nya$,$nza$,$node_stack_connect06[3]$,$node_stack_connect06[4]$,$node_stack_connect06[5]$,$node_stack_connect06[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect06[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect07[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect07[0]$
+nya = #$node_stack_connect07[1]$
+nza = #$node_stack_connect07[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect07 = #$nxa$,$nya$,$nza$,$node_stack_connect07[3]$,$node_stack_connect07[4]$,$node_stack_connect07[5]$,$node_stack_connect07[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect07[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect08[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect08[0]$
+nya = #$node_stack_connect08[1]$
+nza = #$node_stack_connect08[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect08 = #$nxa$,$nya$,$nza$,$node_stack_connect08[3]$,$node_stack_connect08[4]$,$node_stack_connect08[5]$,$node_stack_connect08[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect08[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_connect1[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_connect1[0]$
+nya = #$node_stack_connect1[1]$
+nza = #$node_stack_connect1[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_connect1 = #$nxa$,$nya$,$nza$,$node_stack_connect1[3]$,$node_stack_connect1[4]$,$node_stack_connect1[5]$,$node_stack_connect1[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_connect1[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_core01[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_core01[0]$
+nya = #$node_stack_core01[1]$
+nza = #$node_stack_core01[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_core01 = #$nxa$,$nya$,$nza$,$node_stack_core01[3]$,$node_stack_core01[4]$,$node_stack_core01[5]$,$node_stack_core01[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_core01[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_core02[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_core02[0]$
+nya = #$node_stack_core02[1]$
+nza = #$node_stack_core02[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_core02 = #$nxa$,$nya$,$nza$,$node_stack_core02[3]$,$node_stack_core02[4]$,$node_stack_core02[5]$,$node_stack_core02[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_core02[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_ctrMount[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_ctrMount[0]$
+nya = #$node_stack_ctrMount[1]$
+nza = #$node_stack_ctrMount[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_ctrMount = #$nxa$,$nya$,$nza$,$node_stack_ctrMount[3]$,$node_stack_ctrMount[4]$,$node_stack_ctrMount[5]$,$node_stack_ctrMount[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_ctrMount[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_disabled[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_disabled[0]$
+nya = #$node_stack_disabled[1]$
+nza = #$node_stack_disabled[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_disabled = #$nxa$,$nya$,$nza$,$node_stack_disabled[3]$,$node_stack_disabled[4]$,$node_stack_disabled[5]$,$node_stack_disabled[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_disabled[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_fairing[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_fairing[0]$
+nya = #$node_stack_fairing[1]$
+nza = #$node_stack_fairing[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_fairing = #$nxa$,$nya$,$nza$,$node_stack_fairing[3]$,$node_stack_fairing[4]$,$node_stack_fairing[5]$,$node_stack_fairing[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_fairing[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_fairing1[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_fairing1[0]$
+nya = #$node_stack_fairing1[1]$
+nza = #$node_stack_fairing1[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_fairing1 = #$nxa$,$nya$,$nza$,$node_stack_fairing1[3]$,$node_stack_fairing1[4]$,$node_stack_fairing1[5]$,$node_stack_fairing1[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_fairing1[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_fairing2[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_fairing2[0]$
+nya = #$node_stack_fairing2[1]$
+nza = #$node_stack_fairing2[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_fairing2 = #$nxa$,$nya$,$nza$,$node_stack_fairing2[3]$,$node_stack_fairing2[4]$,$node_stack_fairing2[5]$,$node_stack_fairing2[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_fairing2[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_front[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_front[0]$
+nya = #$node_stack_front[1]$
+nza = #$node_stack_front[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_front = #$nxa$,$nya$,$nza$,$node_stack_front[3]$,$node_stack_front[4]$,$node_stack_front[5]$,$node_stack_front[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_front[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_left[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_left[0]$
+nya = #$node_stack_left[1]$
+nza = #$node_stack_left[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_left = #$nxa$,$nya$,$nza$,$node_stack_left[3]$,$node_stack_left[4]$,$node_stack_left[5]$,$node_stack_left[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_left[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_mount[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_mount[0]$
+nya = #$node_stack_mount[1]$
+nza = #$node_stack_mount[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_mount = #$nxa$,$nya$,$nza$,$node_stack_mount[3]$,$node_stack_mount[4]$,$node_stack_mount[5]$,$node_stack_mount[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_mount[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_platform[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_platform[0]$
+nya = #$node_stack_platform[1]$
+nza = #$node_stack_platform[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_platform = #$nxa$,$nya$,$nza$,$node_stack_platform[3]$,$node_stack_platform[4]$,$node_stack_platform[5]$,$node_stack_platform[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_platform[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_right[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_right[0]$
+nya = #$node_stack_right[1]$
+nza = #$node_stack_right[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_right = #$nxa$,$nya$,$nza$,$node_stack_right[3]$,$node_stack_right[4]$,$node_stack_right[5]$,$node_stack_right[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_right[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_side[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_side[0]$
+nya = #$node_stack_side[1]$
+nza = #$node_stack_side[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_side = #$nxa$,$nya$,$nza$,$node_stack_side[3]$,$node_stack_side[4]$,$node_stack_side[5]$,$node_stack_side[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_side[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_side_1[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_side_1[0]$
+nya = #$node_stack_side_1[1]$
+nza = #$node_stack_side_1[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_side_1 = #$nxa$,$nya$,$nza$,$node_stack_side_1[3]$,$node_stack_side_1[4]$,$node_stack_side_1[5]$,$node_stack_side_1[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_side_1[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_side_2[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_side_2[0]$
+nya = #$node_stack_side_2[1]$
+nza = #$node_stack_side_2[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_side_2 = #$nxa$,$nya$,$nza$,$node_stack_side_2[3]$,$node_stack_side_2[4]$,$node_stack_side_2[5]$,$node_stack_side_2[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_side_2[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_side_3[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_side_3[0]$
+nya = #$node_stack_side_3[1]$
+nza = #$node_stack_side_3[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_side_3 = #$nxa$,$nya$,$nza$,$node_stack_side_3[3]$,$node_stack_side_3[4]$,$node_stack_side_3[5]$,$node_stack_side_3[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_side_3[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_side_4[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_side_4[0]$
+nya = #$node_stack_side_4[1]$
+nza = #$node_stack_side_4[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_side_4 = #$nxa$,$nya$,$nza$,$node_stack_side_4[3]$,$node_stack_side_4[4]$,$node_stack_side_4[5]$,$node_stack_side_4[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_side_4[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_top[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_top[0]$
+nya = #$node_stack_top[1]$
+nza = #$node_stack_top[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_top = #$nxa$,$nya$,$nza$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_top[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_top01[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_top01[0]$
+nya = #$node_stack_top01[1]$
+nza = #$node_stack_top01[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_top01 = #$nxa$,$nya$,$nza$,$node_stack_top01[3]$,$node_stack_top01[4]$,$node_stack_top01[5]$,$node_stack_top01[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_top01[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_top02[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_top02[0]$
+nya = #$node_stack_top02[1]$
+nza = #$node_stack_top02[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_top02 = #$nxa$,$nya$,$nza$,$node_stack_top02[3]$,$node_stack_top02[4]$,$node_stack_top02[5]$,$node_stack_top02[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_top02[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_top03[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_top03[0]$
+nya = #$node_stack_top03[1]$
+nza = #$node_stack_top03[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_top03 = #$nxa$,$nya$,$nza$,$node_stack_top03[3]$,$node_stack_top03[4]$,$node_stack_top03[5]$,$node_stack_top03[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_top03[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_top1[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_top1[0]$
+nya = #$node_stack_top1[1]$
+nza = #$node_stack_top1[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_top1 = #$nxa$,$nya$,$nza$,$node_stack_top1[3]$,$node_stack_top1[4]$,$node_stack_top1[5]$,$node_stack_top1[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_top1[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_top2[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_top2[0]$
+nya = #$node_stack_top2[1]$
+nza = #$node_stack_top2[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_top2 = #$nxa$,$nya$,$nza$,$node_stack_top2[3]$,$node_stack_top2[4]$,$node_stack_top2[5]$,$node_stack_top2[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_top2[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_topleft[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_topleft[0]$
+nya = #$node_stack_topleft[1]$
+nza = #$node_stack_topleft[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_topleft = #$nxa$,$nya$,$nza$,$node_stack_topleft[3]$,$node_stack_topleft[4]$,$node_stack_topleft[5]$,$node_stack_topleft[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_topleft[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_topright[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_topright[0]$
+nya = #$node_stack_topright[1]$
+nza = #$node_stack_topright[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_topright = #$nxa$,$nya$,$nza$,$node_stack_topright[3]$,$node_stack_topright[4]$,$node_stack_topright[5]$,$node_stack_topright[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_topright[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_wheel[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_wheel[0]$
+nya = #$node_stack_wheel[1]$
+nza = #$node_stack_wheel[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_wheel = #$nxa$,$nya$,$nza$,$node_stack_wheel[3]$,$node_stack_wheel[4]$,$node_stack_wheel[5]$,$node_stack_wheel[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_wheel[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_wheel01[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_wheel01[0]$
+nya = #$node_stack_wheel01[1]$
+nza = #$node_stack_wheel01[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_wheel01 = #$nxa$,$nya$,$nza$,$node_stack_wheel01[3]$,$node_stack_wheel01[4]$,$node_stack_wheel01[5]$,$node_stack_wheel01[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_wheel01[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}
+
+@PART[*]:HAS[@MODEL,#node_stack_wheel02[*],!MODULE[ProceduralFairing*],!MODULE[KzThrustPlateResizer],!#manufacturer[Real?Scale?Boosters]]:FOR[zzzzzzzzzzzzzzROMini]:NEEDS[!RealismOverhaul]
+{
+//         0    1    2    3     4    5    6
+//$node = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+//We only need to adjust the first three values...
+nxa = #$node_stack_wheel02[0]$
+nya = #$node_stack_wheel02[1]$
+nza = #$node_stack_wheel02[2]$
+@nxa *= #$@RESCALEFACTOR/rescaleFactor$
+@nya *= #$@RESCALEFACTOR/rescaleFactor$
+@nza *= #$@RESCALEFACTOR/rescaleFactor$
+//And then reassemble the node definition.
+@node_stack_wheel02 = #$nxa$,$nya$,$nza$,$node_stack_wheel02[3]$,$node_stack_wheel02[4]$,$node_stack_wheel02[5]$,$node_stack_wheel02[6]$
+//This one is curious. The last key defines the size of the green node, and is optional.
+//However, the code as written here barfs if the last key is optioned out. A trailing comma is left behind, and partloader says "**** that!"
+//I am attemting to strip out the trailing comma and replace it with a whitespace. (That didn't work so well, so maybe we can set it to "1")
+@node_stack_wheel02[5] ^= :,$:,1:
+//clean up our mess...
+!n*a = DEL
+}


### PR DESCRIPTION
Hello!
Thanks to an unexpected snow day, I finally managed to do as I have been threatening to, which is to clean up and submit this code for a PR!

Several things to note: 

- The "fix" here is to uncomment some existing code which was said to have failed in 1.0.4. It did indeed fail, such that while the models were rescaled correctly, the attach nodes were not. This is somewhat less then satisfactory from a gameplay standpoint.

- By using this method, we avoid entirely bug where a root part scaled with rescaleFactor will revert to its original size on load/quickload.

- This brings us to part two: The python script. This is a reimplemented shell script I posted on the forums a while ago. This script walks through a directory tree, opens each .cfg file found and does a regex match for any line starting with "node". We collect that into an internal list, remove duplicates, and sort it, yielding a list of every unique type of node_* in your Gamedata folder. We then feed that into a template for a MM script to rescale the nodes based on a chosen rescaleFactor. 
It sounds complicated, but trust me, it works *very* well. (NOTE! In testing tonight, I had it blow up on a "node_collider = node_collider" line; I hadn't ever seen that before, except in one old part mod I was testing, so I hope it isn't TOO common... I will have to handle that in the code if it is.)

The usage is simple, simply run it from Gamedata/ (or KSP root, it doesn't care), and specify an output file for your generated MM config. Example: ./generateNodes.py Gamedata/zROMini/scaledNodes.cfg
It was written in python 2.7, but I honestly can't think of anything that would goof in python 3. (No promises, but let me know if it does, and i'll look into it.)
It should be perfectly content to run under windows thanks to the magic of python, as well!

- Of further note: I have spent a fair amount of time going back and forth with procedural fairings vs rescaling. At the top of ROMini you will find a section of code intended to bring PF into line, but it seems to fail at this time. No errors result, just no... results result. I have left it in so that someone else may either find my silly mistake, or else please feel free to cut it from the patch if it is out of scope for this project. 
However, the main rescaling code explicitly excludes PF in order to make them work at all. The result is a game which has all it's dimensions seemlessly scaled by 1.6 in this implementation, but for the PF numbers. (They are unscaled, but working correctly in all other aspects.)

- ... There is no last bullet point. 
The code was a GREAT help to build off of, i'm sure I would be still on the starting blocks rescaling if I started from scratch. It seems quite stable in my testing. Balance wise, the only thing I would try to look at is the SRBs, but that is out of scope for this PR.

I will leave it at that, as this note has gone on far too long! Licensing! The python script is for all practical purposes public domain, but CC-BY-4.0 as indicated in the guidelines works as well too.

Thanks all!