### PR TITLE
RN epsilon fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
@@ -3353,7 +3353,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = 2
+		%ignitions = -1
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge


### PR DESCRIPTION
-give the epsilon aj-10 unlimited restarts because of extra helium tanks