### PR TITLE
Updates for SSTU 0.3.29

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU-RD-10X.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU-RD-10X.cfg
@@ -1,0 +1,128 @@
+@PART[SSTU-SC-ENG-RD-107A]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = RD107-117
+	@mass = 1.090
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*],0
+	{
+		@minThrust = 1040
+		@maxThrust = 1040
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 313
+			@key,1 = 1 256
+		}
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		@minThrust = 40
+		@maxThrust = 40
+		@heatProduction = 10
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 313
+			@key,1 = 1 256
+		}
+	}
+}
+
+@PART[SSTU-SC-ENG-RD-107X]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	// %engineType = RD107-117 //no clue what to do for this one...
+	@mass = 1.090
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 1040
+		@maxThrust = 1040
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 313
+			@key,1 = 1 256
+		}
+	}
+}
+
+@PART[SSTU-SC-ENG-RD-108A]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = RD108-118
+	@mass = 1.075
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*],0
+	{
+		@minThrust = 1010
+		@maxThrust = 1010
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 315
+			@key,1 = 1 248
+		}
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		@minThrust = 80
+		@maxThrust = 80
+		@heatProduction = 10
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 315
+			@key,1 = 1 248
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_AJ10-137.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_AJ10-137.cfg
@@ -1,3 +1,38 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-AJ10-137]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%engineType = AJ10_137	
+	%RSSROConfig = True
+	@mass = 0.650
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 97.86
+		@maxThrust = 97.86
+		@heatProduction = 100
+		!PROPELLANT[MonoPropellant]
+		{
+		}
+		PROPELLANT[Aerozine50]
+		{
+			ratio = 0.502
+			DrawGauge = True
+		}
+		PROPELLANT[NTO]
+		{
+			ratio = 0.498
+			DrawGauge = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 314
+			@key,1 = 1 150
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-AJ10-137]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_AJ10-190.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_AJ10-190.cfg
@@ -1,0 +1,33 @@
+@PART[SSTU-SC-ENG-AJ10-190]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%engineType = AJ10_190	
+	%RSSROConfig = True
+	%category = Propulsion
+	@mass = 0.118
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 26.7
+		@maxThrust = 26.7
+		@heatProduction = 100
+		!PROPELLANT[MonoPropellant]
+		{
+		}
+		PROPELLANT[Aerozine50]
+		{
+			ratio = 0.502
+			DrawGauge = True
+		}
+		PROPELLANT[NTO]
+		{
+			ratio = 0.498
+			DrawGauge = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 330
+			@key,1 = 1 260//unsure...
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_EnginesBasePatch.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_EnginesBasePatch.cfg
@@ -1,0 +1,104 @@
+@PART[*]:HAS[@MODULE[SSTUModularEngineCluster]]:NEEDS[SSTU]:BEFORE[RealismOverhaul]
+{
+	%category = Propulsion
+	!MODULE[ModuleAlternator] {}
+	!MODULE[TweakScale]{}
+	!RESOURCE[ElectricCharge]{}
+	@MODULE[SSTUModularEngineCluster]
+	{		
+		// Blanket rescale of all engine scales; as they are modeled at 64%, a 1.56 scale factor
+		// will place them very close to real size.
+		// A few engines will override this value manually in their RO patch order to lineup 
+		// better with their special mount sizes at a reasonable stack-size (RS-68, RD-107X); 
+		// but it should generally be very close to a 1-1 'real' scale
+		%engineScale = 1.56
+		// Blanket rescale of all engine spacing to accomodate for the engine rescale
+		@engineSpacing *= 1.56
+		// Set diameter increment to whole diameter value, will attempt to use whole meter diameters
+		// for most engine/mount stack sizes where possible.  Exceptions to this will be those
+		// special mounts -- SLS at 8.4m, others?
+		@diameterIncrement = 1.0
+		// this set of patches is a blanket setup to increase mount sizes for the RO rescale
+		@LAYOUT[*],*
+		{
+			@MOUNT[*],*
+			{
+				%maxSize = 20
+			}
+			@MOUNT[*],*:HAS[#size[0.625]]
+			{
+				@size = 1.25
+				@minSize = 0.625
+			}
+			@MOUNT[*],*:HAS[#size[1.25]]
+			{
+				@size = 1.875
+				@minSize = 1.25
+			}
+			@MOUNT[*],*:HAS[#size[1.4375]]
+			{
+				@size = 2.25
+				@minSize = 1.875
+			}
+			@MOUNT[*],*:HAS[#size[1.875]]
+			{
+				@size = 3.125
+				@minSize = 2.5
+			}
+			@MOUNT[*],*:HAS[#size[2.5]]
+			{
+				@size = 3.9375
+				@minSize = 3.75
+			}
+			@MOUNT[*],*:HAS[#size[3.75]]
+			{
+				@size = 5.875
+				@minSize = 5
+			}
+			@MOUNT[*],*:HAS[#size[5]]
+			{
+				@size = 8
+				@minSize = 7.5
+			}
+			@MOUNT[*],*:HAS[#size[6.25]]
+			{
+				@size = 10
+				@minSize = 7.5
+			}
+			@MOUNT[*],*:HAS[#size[7.5]]
+			{
+				@size = 12.5
+				@minSize = 10
+			}
+		}
+	}	
+	@MODULE[SSTUNodeFairing]
+	{
+		//match up the fairing increment to the mount increment (1m)
+		%topRadiusAdjustSize = 0.5
+		%bottomRadiusAdjustSize = 0.5
+		//and set blanket default values for RO scales
+		%minTopRadius = 0.5
+		%minBottomRadius = 0.5
+		%maxTopRadius = 10
+		%maxBottomRadius = 10
+	}
+}
+@PART[*]:HAS[@MODULE[SSTUModularEngineCluster]]:NEEDS[SSTU]:AFTER[RealismOverhaul]
+{
+	@MODULE[SSTUModularEngineCluster]
+	{
+		@engineMass = #$../mass$
+		@engineCost = #$../cost$
+	}
+}
+
+//remove old parts from editor lists
+@PART[*]:HAS[@MODULE[SSTUEngineCluster]]:FINAL
+{
+	%category = none
+}
+
+//remove the placeholder engines
+-PART[SSTU-SC-ENG-Merlin-1B]{}
+-PART[SSTU-SC-ENG-H1]{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_F1.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_F1.cfg
@@ -1,9 +1,59 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-F1]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = F1	
+	@mass = 8.391459
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 7740.5
+		@maxThrust = 7740.5
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.380
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.620
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 304
+			@key,1 = 1 263
+		}
+		!IGNITOR_RESOURCE,* {}
+	}	
+}
++PART[SSTU-SC-ENG-F1]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	@name = SSTU-SC-ENG-F1x5
+	@MODULE[SSTUModularEngineCluster]
+	{
+		@currentEngineLayoutName = FiveCross
+		!LAYOUT,*:HAS[~name[FiveCross]]{}
+		@LAYOUT[FiveCross]
+		{
+			@defaultMount = Mount-Saturn-V
+			!MOUNT,*:HAS[~name[Mount-Saturn-V]]{}
+			@MOUNT[Mount-SLS]
+			{
+				%size = 10
+				%canAdjustSize = false
+			}
+		}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-F1]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+	!MODULE[TweakScale]{}
 	//@rescaleFactor = 1.5625
 	%category = Propulsion
 	@mass = 8.391459

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_F1B.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_F1B.cfg
@@ -1,3 +1,36 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-F1B]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = F1B
+	@mass = 9.656 // vacuum TWR = 93.1
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 6390
+		@maxThrust = 8815
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.380
+			@DrawGauge = True
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.620
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 299
+			@key,1 = 1 272.3
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-F1B]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_J2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_J2.cfg
@@ -1,3 +1,35 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-J-2]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = J2
+	@mass = 1.578501
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 778.4388
+		@maxThrust = 1023.091
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 424
+			@key,1 = 1 200
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-J-2]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_J2X.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_J2X.cfg
@@ -1,3 +1,34 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-J-2X]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = J2X
+	@mass = 2.47
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 1072
+		@maxThrust = 1308
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.745
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.255
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 424
+			@key,1 = 1 200
+		}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-J-2X]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -40,10 +40,6 @@
 {
 	%RSSROConfig = True
 }
-@PART[SSTU_LanderCore_LC-ISA]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-}
 @PART[SSTU_ShipCore_B_PM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -192,7 +188,6 @@
 		}
 	}
 }
-
 
 @PART[SSTU_LanderCore_LC-ISA]:FOR[RealismOverhaul] // Petal Adapter
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RL10A-3.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RL10A-3.cfg
@@ -1,3 +1,46 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-RL10A-3]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = RL10
+	@mass = 0.167
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 65.6
+		@maxThrust = 65.6
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.763
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.237
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 444
+			@key,1 = 1 255
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+}
+//remove some engine configs
+@PART[SSTU-SC-ENG-RL10A-3]:AFTER[RealismOverhaulEngines] 
+{
+	@MODULE[ModuleEngineConfigs] 
+	{ 
+		!CONFIG[RL10A-4] {} 
+		!CONFIG[RL10A-4-1/2] {} 
+		!CONFIG[RL10B-2] {} 
+		!CONFIG[RL10C-1] {} 
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-RL10A-3]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RL10A-4.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RL10A-4.cfg
@@ -1,3 +1,54 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-RL10A-4]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = RL10 //See removed configs below
+	@mass = 0.167
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 92.5
+		@maxThrust = 92.5
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.751
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.249
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 449
+			@key,1 = 1 255
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+}
+//remove some engine configs
+@PART[SSTU-SC-ENG-RL10A-4]:AFTER[RealismOverhaulEngines] 
+{
+	@title = RL10A-4 Series Vacuum Engine [2.5m]
+	%manufacturer = Pratt & Whitney
+	@description = Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators. Mount size can be adjusted from 1.25m to 10m in 1m increments.
+	@MODULE[ModuleEngineConfigs] 
+	{ 
+		!CONFIG[RL10A-1] {} 
+		!CONFIG[RL10A-3-1] {} 
+		!CONFIG[RL10A-3-3] {} 
+		!CONFIG[RL10A-3-3A] {} 
+		!CONFIG[RL10A-5] {} 
+		!CONFIG[RL10B-2] {} 
+		!CONFIG[CECE-Base] {} 
+		!CONFIG[CECE-High] {} 
+		!CONFIG[CECE-Methane] {} 
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-RL10A-4]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RL10B-2_Vinci.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RL10B-2_Vinci.cfg
@@ -1,3 +1,97 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-RL10B-2]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = RL10
+	%mass = 0.273
+	%maxTemp = 1970
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 111.2
+		@maxThrust = 111.2
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.733
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.267
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 462
+			@key,1 = 1 235
+		}
+	}
+}
+//remove all configs apart from the B-2
+@PART[SSTU-SC-ENG-RL10B-2]:AFTER[RealismOverhaulEngines] 
+{
+	%title = RL10B-2 Vacuum Engine [2.5 m]
+	%manufacturer = Pratt and Whitney
+	%description = Developed for the Delta Cryogenic Second Stage (DCSS), which was first used on the Delta III then modified for the Delta IV. Its extending nozzle increases specific impulse compared to the RL10A, at the cost of greater dry mass. Boeing purchased a large number of these engines for the Delta IV, but the launcher's low flight rate led to ULA converting many of them to RL10C-1 engines for use on the Atlas V's Centaur upper stage. Also includes a config for the European Vinci 180kN engine. Mount size can be adjusted from 1.25m to 10m in 1m increments.
+	@MODULE[ModuleEngineConfigs] 
+	{ 
+		!CONFIG,*:HAS[~name[RL10B-2]] {} 
+	}
+}
+
++PART[SSTU-SC-ENG-RL10B-2]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	@name = SSTU-SC-ENG-Vinci
+	%RSSROConfig = True
+	%engineType = RL60 //dont worry, actually using the Vinci config not RL60
+	%mass = 0.498
+	%maxTemp = 1970
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 180
+		@maxThrust = 180
+		%heatProduction = 100
+		@atmosphereCurve
+		{
+			@key,0 = 0 465
+			@key,1 = 1 230
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			%ratio = 0.733
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			%name = LqdOxygen
+			%ratio = 0.267
+		}
+	}		
+	@MODULE[SSTUModularEngineCluster]
+	{
+		%engineScale = 1.676
+	}
+}
+//remove all configs apart from the Vinci
+@PART[SSTU-SC-ENG-Vinci]:AFTER[RealismOverhaulEngines] 
+{
+	%title = Vinci Vacuum Engine [2.5 m]
+	%manufacturer = Snecma
+	%description = Vinci is a European Space Agency cryogenic liquid rocket engine currently under development. It is designed to power the new upper stage of Ariane 5, ESC-B, and will be the first European re-ignitable cryogenic upper stage engine, raising the launcher's GTO performances to 12 t. Mount size can be adjusted from 1.25m to 10m in 1m increments.
+	@MODULE[ModuleEngineConfigs] 
+	{ 
+		!CONFIG,*:HAS[~name[Vinci-180]] {} 
+	}
+}
+
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-RL10B-2]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-25.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-25.cfg
@@ -1,3 +1,55 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-RS-25]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True	
+	%engineType = SSME
+	@mass = 3.526681
+	@crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	%maxTemp = 3588.15
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 1358.5
+		%maxThrust = 2278.824
+		%heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 0.728
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.272
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 453
+			@key,1 = 1 363
+		}
+	}
+}
++PART[SSTU-SC-ENG-RS-25]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	@name = SSTU-SC-ENG-RS-25x5
+	@MODULE[SSTUModularEngineCluster]
+	{
+		@currentEngineLayoutName = Five-X
+		!LAYOUT,*:HAS[~name[Five-X]]{}
+		@LAYOUT[Five-X]
+		{
+			!MOUNT,*:HAS[~name[Mount-SLS]]{}
+			@MOUNT[Mount-SLS]
+			{
+				%size = 8.4
+				%canAdjustSize = false
+			}
+		}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-RS-25]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-68.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-68.cfg
@@ -1,3 +1,159 @@
+//New engine/cluster plugin patch
+@PART[SSTU-SC-ENG-RS-68]:NEEDS[SSTU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = RS-68 Rocket Engine [3.75m]
+	@manufacturer = Aerojet Rocketdyne
+	@description = 1990s Medium TWR atmospheric engine. The RS-68 powers the Delta IV launch vehicle family and is the most powerful LH2/LOX engine ever flown. Exhaust from the gas generator is used for roll control.
+	%mass = 6.597
+	@crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+	%maxTemp = 3588.15
+	@MODULE[ModuleEngines*],0
+	{
+		%maxThrust = 3370
+		%minThrust = 1890
+		%heatProduction = 100
+		@atmosphereCurve
+		{
+			@key,0 = 0 409
+			@key,1 = 1 357
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			%name = LqdHydrogen
+			%ratio = 0.729
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			%name = LqdOxygen
+			%ratio = 0.271
+		}
+		ullage = True
+		ignitions = 1
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.500
+		}
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		%maxThrust = 300
+		%minThrust = 150
+		%heatProduction = 10
+		@atmosphereCurve
+		{
+			@key,0 = 0 409
+			@key,1 = 1 357
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			%name = LqdHydrogen
+			%ratio = 0.729
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			%name = LqdOxygen
+			%ratio = 0.271
+		}
+		ullage = True
+		ignitions = 1
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.500
+		}
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesFX
+		origMass = 6.597
+		configuration = RS-68A
+		modded = false
+		CONFIG
+		{
+			name = RS-68
+			maxThrust = 3370
+			minThrust = 1890
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.729
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.271
+			}
+			atmosphereCurve
+			{
+				key = 0 409
+				key = 1 357
+			}
+		}
+		CONFIG
+		{
+			name = RS-68A
+			maxThrust = 3570
+			minThrust = 1820
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.729
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.271
+			}
+			atmosphereCurve
+			{
+				key = 0 412
+				key = 1 362
+			}
+		}
+	}
+	@MODULE[ModleGimbal],0
+	{
+		@gimbalRange = 6
+	}
+	@MODULE[ModleGimbal],1
+	{
+		@gimbalRange = 6
+	}
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		ignitionsAvailable = 1
+		autoIgnitionTemperature = 700
+		ignitorType = Electric
+		useUllageSimulation = True
+		isPressureFed = False
+		IGNITOR_RESOURCE
+		{
+			name = LqdHydrogen
+			amount = 0.729
+		}
+		IGNITOR_RESOURCE
+		{
+			name = LqdOxygen
+			amount = 0.271
+		}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 1.0
+		}
+	}
+}
+
+//Old patches, remove with 1.1
 @PART[SSTU_ShipCore_ENG-RS-68]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
* Add basic patch for all engines for new SSTU engine-cluster plugin
* Move patching of mount sizes, scales, and spacings over to a more generic system, greatly decreasing the per-engine config work necessary, while still allowing for per-engine specialization of configs where needed
* Keep all old engine patches/parts/configs around for now, but remove them from the editor (new parts have new names)
* Remove placeholder engines from RO use (Merlin-1B, H-1), others with RO configs already exist in the stock install
* Add RD-107, 107X, 108 engine type configs/patches.  107A and 108A use the RO-EngineTypes setup; 107X is WIP; initial thrust, mass, and ISP may need adjustment.  Mount configs/sizes are WIP.
* Add AJ10-190 RO engine config
* Add example stand-alone part RS-25 x 5 cluster config
* Add example stand-alone part F-1 x 5 cluster config
* _Mostly_ adapt RS-68 for added roll-exhaust thrust and engine module; needs testing and possible patch adjustment.
* Does not update RealPlumes configs (those should mostly need a name-change for new part-naming)

### Known Issues:
* Mass displayed on the pre-built clusters both in the parts-list and editor-menu is incorrect.  It is correct in flight/on the pad however.  Will need to adjust plugin to allow for instances of -not- scaling the mass and cost, expect this to be fixed in the next couple of releases.
* Mount-rescaling is done by a pretty generic setup, and a few sizes may be off a bit for some engines in some layouts.  Some of the rescaling may need adjusting across the board as well.
* RS-68 and RD-107/8 should be considered WIP with the new gimbal/engine changes, and have not been tested.