### PR TITLE
Saturn SLA

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -41,28 +41,28 @@
 	MODEL
 	{
 		model = FASA/Gemini2/FASA_Gemini_LR91_Pack/FairingWall3m
-		scale = 1.761, 0.69, 1.761
+		scale = 1.761, 1.0, 1.761
 		position = 0.0, 1.492, 0.0
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = FASA/Gemini2/FASA_Gemini_LR91_Pack/FairingWall3m
-		scale = 1.761, 0.69, 1.761
+		scale = 1.761, 1.0, 1.761
 		position = 0.0, 1.492, 0.0
 		rotation = 0, 180, 0
 	}
-	%node_stack_top = 0.0, 6.081, 0.0, 0.0, 1.0, 0.0, 4
-	%node_stack_bottom = 0.0, 0.457, 0.0, 0.0, -1.0, 0.0, 6
-	%node_stack_fairing1 = 0.0, 2.527, 3.302, 0.0, 1.0, 0.0, 1
-	%node_stack_fairing2 = 0.0, 2.527, -3.302, 0.0, 1.0, 0.0, 1
-	%node_stack_fairing3 = 3.302, 2.527, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_fairing4 = -3.302, 2.527, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_connect1 = 0.0, -0.10, 0.0, 0.0, 1.0, 0.0, 3
+	%node_stack_top = 0.0, 6.551, 0.0, 0.0, 1.0, 0.0, 3
+	%node_stack_bottom = 0.0, -0.008, 0.0, 0.0, -1.0, 0.0, 2
+	%node_stack_fairing1 = 0.0, 2.997, 3.302, 0.0, 1.0, 0.0, 1
+	%node_stack_fairing2 = 0.0, 2.997, -3.302, 0.0, 1.0, 0.0, 1
+	%node_stack_fairing3 = 3.302, 2.997, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_fairing4 = -3.302, 2.997, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_connect1 = 0.0, 0.37, 0.0, 0.0, 1.0, 0.0, 2
 	@category = Structural
 	%stackSymmetry = 3
 	@title = Spacecraft Lunar Module Adapter - Base
-	@description = This part is the Spacecraft Lunar Module Adapter base used to cover the Lunar Module during ascent.
+	@description = This part is the Spacecraft Lunar Module Adapter base used to cover the Lunar Module during ascent.  It has two decouplers: stage active decouple to separate CSM.  Inactive decouple to release LM.
 	@stagingIcon = DECOUPLER_VERT
 	@mass = 0.651
 	%fuelCrossFeed = False
@@ -70,6 +70,13 @@
 	{
 		@ejectionForce = 1
 		@explosiveNodeID = top
+	}
+	MODULE
+	{
+		name = ModuleDecouple
+		ejectionForce = 1
+		explosiveNodeID = connect1
+		stagingEnabled = False
 	}
 	!MODULE[ModuleEngines]
 	{


### PR DESCRIPTION
With the current FASA/Saturn V setup when you separate the LM from the S-IVB stage, the LM is launched away from the rest of the rocket at up to 22m/s.  As far as I can tell, this appears to be because the collisions for the Saturn IU treat the part as a solid object instead of the ring shaped object that the graphic appears to be.  The existing SLA ring is sized so that the folded landing struts on the LM sit inside the IU.  So when the LM is separated, the "solid" IU collides with the legs of the LM which appears to be causing the LM to fly away from the rest of the rocket at a high rate.  Since I don't have the skill/ability to mess about with the collisions for a part, I decided to modify the existing SLA.  The resulting part is a bit longer than the original part, resulting in the entire Saturn V rocket being a bit taller (by about the height of the IU).  Otherwise these changes resolve the problem so the LM can now separate from the rest of the rocket without any artificial acceleration occurring.
I wanted to say that I didn't change the texture for the SLA so it's still using the current "FairingWall3m".  I tried using the texture for the default part from FASA (FairingPlateApollo375m) but that part includes a crossbar and when I increase the scale of the part, the crossbar takes up too much space resulting in the need to mess with the scale of the SLA fairings.  Since I didn't want to mess with those, I left the existing texture.

I've also setup the SLA so it now has two decouplers.  The first decoupler is setup by default to activate with staging and will separate the CSM from the SLA.  The second decoupler is setup by default to not be active to staging and will separate the LM from the SLA.  With this setup, if you put the SLA-Base and SLA-Fairings into one stage, staging will eject the fairings and separate the CSM from the Saturn V, while leaving the LM connected to the Saturn V.  From there you can dock the CSM to the LM, then right click on the SLA to manually decouple the LM from the Saturn V.  This removes the need to add an extra decoupler to the SLA.

The only thing I can't figure out is a way to setup the decoupler names so they are easier to identify.  If anyone knows a way to do that, I'd love to hear from you.  For now, both decouplers are just listed as "Decouple".  The first is for the top (CSM) decoupler and the second is for the bottom (LM) decoupler.