### PR TITLE
Three ignitions for J-2

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -56,7 +56,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 2 //Definately a FIXME right here
+			%ignitions = 3 //Definately a FIXME right here
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -96,7 +96,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 2 //Definately a FIXME right here
+			%ignitions = 3 //was to carry three starter cartriges, http://www.astronautix.com/engines/j2s.htm
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -130,7 +130,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 2 //Definately a FIXME right here
+			%ignitions = 3 //Definately a FIXME right here
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge


### PR DESCRIPTION
Opening that can of worms again. Under the current system, three ignitions is less wrong than two.

See http://ksp.schnobs.de/stuff/notes.txt for the time being. I'm aware that there's supposed to be a proper solution someday, these notes were compiled for the issue/discussion about the would-be proper solution, but that fails to happen and I'm growing impatient.