### PR TITLE
XLR81 (Agena) global config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
@@ -11,17 +11,17 @@
 {
 	@title = XLR81 (Agena) Vacuum Engine
 	@manufacturer = Bell Aerosystems Company
-	@description = Gas-generator nitric acid/UDMH vacuum engine for the Agena upper stage / spacecraft. Uses storable propellants and starting with the 8081 model it can be restarted. The 8247 model was used for the Gemini Agena Target Vehicle flights (GATV was a modified Agena D). It is a modified 8096 (Agena D) engine with support for more than two restarts (rated for 14), but otherwise largely identical.
+	@description = Gas-generator nitric acid/UDMH vacuum engine used on Agena. The XLR81 family was derived from the Bell Hustler Rocket Engine, which was developed for use on an air-to-surface missile. Early engines were nearly identical to the Hustler engine, while later variants offered new capabilities and improved performance. Engine restart was introduced on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D used propellant sumps to eliminate the need for ullage thrust. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Bell-8247
+		configuration = XLR81-BA-5
 		modded = false
 		CONFIG
 		{
-			name = Bell-8048
-			description = Used on Agena A
+			name = XLR81-BA-5
+			description = BAC Model 8048, used on Agena A.
 			maxThrust = 67 //15 klbf
 			minThrust = 67
 			heatProduction = 100
@@ -52,8 +52,8 @@
 		}
 		CONFIG
 		{
-			name = Bell-8081
-			description = Used on Agena B, can restart once.
+			name = XLR81-BA-7
+			description = BAC Model 8081, used on Agena B. One restart.
 			maxThrust = 71 //16 klbf
 			minThrust = 71
 			heatProduction = 100
@@ -85,8 +85,8 @@
 
 		CONFIG
 		{
-			name	       = Bell-8096
-			description    = Used on Agena D, which eliminated ullage requirement.
+			name	       = XLR81-BA-11
+			description    = BAC Model 8096, used on Agena D. Does not require ullage.
 			maxThrust      = 71 //16 klbf
 			minThrust      = 71
 			heatProduction = 100
@@ -123,8 +123,8 @@
 		
 		CONFIG
 		{
-			name	       = Bell-8096-39
-			description    = Used on late Agena D / Ascent Agena, can restart once.
+			name	       = BAC Model 8096-39
+			description    = Used on some later Agena D flights. IRFNA-III replaced with HDA for improved performance.
 			maxThrust      = 76 //17 klbf
 			minThrust      = 76
 			heatProduction = 100
@@ -161,10 +161,10 @@
 
 		CONFIG
 		{
-			name = Bell-8247
-			description = Used on Gemini Agena Target Vehicle, capable of multiple restarts.
+			name = XLR81-BA-13
+			description = BAC Model 8247, used on Gemini Agena Target Vehicle. Modified to allow multiple restarts.
 			maxThrust = 71 //16 klbf
-			minThrust = 71 //16 klbf
+			minThrust = 71
 			heatProduction = 100
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
@@ -1,9 +1,12 @@
-//Agena engine
-//FASA
-//Sources:
-//(1) Agena Payload Users Handbook
-//(2) Shuttle/Agena study Vol 1 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720013175.pdf
-//(3) NASA Aegna D Mission Capabilities and Restraints Catalog Vol 2 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
+//  XLR81 family of engines.
+//
+//	FASA, VSR
+//
+// ------Sources--------
+//	(1) Agena Payload Users Handbook
+//	(2) Shuttle/Agena study Vol 1 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720013175.pdf
+//	(3) NASA Aegna D Mission Capabilities and Restraints Catalog Vol 2 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
+//
 @PART[*]:HAS[#engineType[Agena]]:FOR[RealismOverhaulEngines]
 {
 	MODULE

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
@@ -6,6 +6,7 @@
 //	(1) Agena Payload Users Handbook
 //	(2) Shuttle/Agena study Vol 1 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720013175.pdf
 //	(3) NASA Aegna D Mission Capabilities and Restraints Catalog Vol 2 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
+//	(4) The Agena Rocket Engine... Six Generations of Reliability in Space Propulsion - http://forum.nasaspaceflight.com/index.php?topic=16154.msg373040#msg373040
 //
 @PART[*]:HAS[#engineType[Agena]]:FOR[RealismOverhaulEngines]
 {
@@ -21,7 +22,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-5
-			description = BAC Model 8048, used on Agena A.
+			description = Model 8048, used on Agena A.
 			maxThrust = 67 //15 klbf
 			minThrust = 67
 			heatProduction = 100
@@ -53,7 +54,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-7
-			description = BAC Model 8081, used on Agena B. One restart.
+			description = Model 8081, used on Agena B. One restart.
 			maxThrust = 71 //16 klbf
 			minThrust = 71
 			heatProduction = 100
@@ -86,7 +87,7 @@
 		CONFIG
 		{
 			name	       = XLR81-BA-11
-			description    = BAC Model 8096, used on Agena D. Does not require ullage.
+			description    = Model 8096, used on Agena D. Does not require ullage.
 			maxThrust      = 71 //16 klbf
 			minThrust      = 71
 			heatProduction = 100
@@ -120,10 +121,41 @@
 				amount = 0.2
 			}
 		}
-		
 		CONFIG
 		{
-			name	       = BAC Model 8096-39
+			name = XLR81-BA-13
+			description = Model 8247, used on Gemini Agena Target Vehicle. Modified to allow multiple restarts.
+			maxThrust = 71 //16 klbf
+			minThrust = 71
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.449
+			}
+			PROPELLANT
+			{
+				name = IRFNA-III
+				ratio = 0.551
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 291
+				key = 1 100
+			}
+			ullage = False //(3) p 14-7
+			pressureFed = False
+			ignitions = 15 //(2) p 1-1, (3) p 14-7
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.050
+			}
+		}
+		CONFIG
+		{
+			name	       = Model 8096-39
 			description    = Used on some later Agena D flights. IRFNA-III replaced with HDA for improved performance.
 			maxThrust      = 76 //17 klbf
 			minThrust      = 76
@@ -158,39 +190,18 @@
 				amount = 0.2
 			}
 		}
-
-		CONFIG
-		{
-			name = XLR81-BA-13
-			description = BAC Model 8247, used on Gemini Agena Target Vehicle. Modified to allow multiple restarts.
-			maxThrust = 71 //16 klbf
-			minThrust = 71
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.449
-			}
-			PROPELLANT
-			{
-				name = IRFNA-III
-				ratio = 0.551
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 291
-				key = 1 100
-			}
-			ullage = False //(3) p 14-7
-			pressureFed = False
-			ignitions = 15 //(2) p 1-1, (3) p 14-7
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.050
-			}
-		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 5 //(4) p 28
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Bell-8048]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
@@ -22,7 +22,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-5
-			description = Model 8048, used on Agena A.
+			description = Model 8048, Agena A
 			maxThrust = 67 //15 klbf
 			minThrust = 67
 			heatProduction = 100
@@ -54,7 +54,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-7
-			description = Model 8081, used on Agena B. One restart.
+			description = Model 8081, Agena B
 			maxThrust = 71 //16 klbf
 			minThrust = 71
 			heatProduction = 100
@@ -87,7 +87,7 @@
 		CONFIG
 		{
 			name	       = XLR81-BA-11
-			description    = Model 8096, used on Agena D. Does not require ullage.
+			description    = Model 8096, Agena D
 			maxThrust      = 71 //16 klbf
 			minThrust      = 71
 			heatProduction = 100
@@ -124,7 +124,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-13
-			description = Model 8247, used on Gemini Agena Target Vehicle. Modified to allow multiple restarts.
+			description = Model 8247, Gemini ATV
 			maxThrust = 71 //16 klbf
 			minThrust = 71
 			heatProduction = 100
@@ -156,7 +156,7 @@
 		CONFIG
 		{
 			name	       = Model 8096-39
-			description    = Used on some later Agena D flights. IRFNA-III replaced with HDA for improved performance.
+			description    = Improved propellant
 			maxThrust      = 76 //17 klbf
 			minThrust      = 76
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
@@ -1,5 +1,9 @@
 //Agena engine
 //FASA
+//Sources:
+//(1) Agena Payload Users Handbook
+//(2) Shuttle/Agena study Vol 1 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720013175.pdf
+//(3) NASA Aegna D Mission Capabilities and Restraints Catalog Vol 2 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
 @PART[*]:HAS[#engineType[Agena]]:FOR[RealismOverhaulEngines]
 {
 	MODULE
@@ -12,8 +16,8 @@
 		{
 			name = Bell-8048
 			description = Used on Agena A
-			maxThrust = 68.9
-			minThrust = 68.9
+			maxThrust = 67 //15 klbf
+			minThrust = 67
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -44,8 +48,8 @@
 		{
 			name = Bell-8081
 			description = Used on Agena B, can restart once.
-			maxThrust = 71.2
-			minThrust = 71.2
+			maxThrust = 71 //16 klbf
+			minThrust = 71
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -76,11 +80,11 @@
 		CONFIG
 		{
 			name	       = Bell-8096
-			description    = Used on Agena D, can restart once.
-			maxThrust      = 75.3
-			minThrust      = 75.3
+			description    = Used on Agena D, which eliminated ullage requirement.
+			maxThrust      = 71 //16 klbf
+			minThrust      = 71
 			heatProduction = 100
-			ullage 	       = True
+			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 2
 
@@ -115,10 +119,10 @@
 		{
 			name	       = Bell-8096-39
 			description    = Used on late Agena D / Ascent Agena, can restart once.
-			maxThrust      = 75.3
-			minThrust      = 75.3
+			maxThrust      = 76 //17 klbf
+			minThrust      = 76
 			heatProduction = 100
-			ullage 	       = True
+			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 2
 
@@ -152,9 +156,9 @@
 		CONFIG
 		{
 			name = Bell-8247
-			description = Used on Gemini Agena Target Vehicle, can multi-restart.
-			maxThrust = 70.7
-			minThrust = 70.7
+			description = Used on Gemini Agena Target Vehicle, capable of multiple restarts.
+			maxThrust = 71 //16 klbf
+			minThrust = 71 //16 klbf
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -172,9 +176,9 @@
 				key = 0 291
 				key = 1 100
 			}
-			ullage = True
+			ullage = False //(3) p 14-7
 			pressureFed = False
-			ignitions = 16
+			ignitions = 15 //(2) p 1-1, (3) p 14-7
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_Config.cfg
@@ -9,6 +9,9 @@
 //
 @PART[*]:HAS[#engineType[Agena]]:FOR[RealismOverhaulEngines]
 {
+	@title = XLR81 (Agena) Vacuum Engine
+	@manufacturer = Bell Aerosystems Company
+	@description = Gas-generator nitric acid/UDMH vacuum engine for the Agena upper stage / spacecraft. Uses storable propellants and starting with the 8081 model it can be restarted. The 8247 model was used for the Gemini Agena Target Vehicle flights (GATV was a modified Agena D). It is a modified 8096 (Agena D) engine with support for more than two restarts (rated for 14), but otherwise largely identical.
 	MODULE
 	{
 		name = ModuleEngineConfigs

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
@@ -3,6 +3,9 @@
 // Working hypothesis: there were two Agena D marks, the early (with 8096 engine, 291s, 6.11t prop)
 // and the late, with 6.148t prop and a 300s upgrade (8096-39). That would explain the dry mass
 // change, if the later model was significantly lighter.
+//	The 1966 NASA Agena D Mission Capabilities and Restraints Catalog gives the mass of Agena D
+//	with the as Model 8096 as 658 kg, the same ballpark as most sources. The mass given by
+//	b14643 is likely incorect.
 @PART[FASAAgenaDocking]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
@@ -372,48 +372,8 @@
 	@scale = 1.219
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1
-	@title = LR81 (Agena / 80xx) Vacuum Engine
-	@manufacturer = Bell
-	@description = Gas-generator Nitric Acid/UDMH vacuum engine for the Agena upper stage / spacecraft. Uses storable propellants and starting with the 8081 model it can be restarted. The 8247 model was used for the Gemini Agena Target Vehicle flights (GATV was a modified Agena D). It is a modified 8096 (Agena D) engine with support for more than two restarts (rated for 15), but otherwise largely identical.
+
 	@mass = 0.132
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 70.7
-		@maxThrust = 70.7
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = UDMH
-			@ratio = 0.449
-			@DrawGauge = False
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = IRFNA-III
-			@ratio = 0.551
-			DrawGauge = True
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 291
-			@key,1 = 1 100
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 16
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.050
-		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		%gimbalRange = 5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
 	!MODULE[ModuleEngineConfigs]
 	{
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -603,12 +603,12 @@
 	
 }
 
-// Bell 8xxx engine (Agena), clone from LVT15
+// XLR81 (Agena), clone from LVT15
 +PART[LVT15]:FIRST:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = RO-AgenaEngine
 }
-@PART[RO-AgenaEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+@PART[RO-AgenaEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] //XLR81 (Agena)
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -623,11 +623,7 @@
 	%scale = 1.0
 	%node_stack_bottom = 0.0, -1.48, 0.0, 0.0, -1.0, 0.0, 0
 	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
-	
-	@title = LR81 (Agena / 80xx) Vacuum Engine
-	@manufacturer = Bell
-	@description = Gas-generator Nitric Acid/UDMH vacuum engine for the Agena upper stage / spacecraft. Uses storable propellants and starting with the 8081 model it can be restarted. The 8247 model was used for the Gemini Agena Target Vehicle flights (GATV was a modified Agena D). It is a modified 8096 (Agena D) engine with support for more than two restarts (rated for 15), but otherwise largely identical.
-	
+
 	@mass = 0.132
 	
 	// make radially attachable
@@ -646,35 +642,6 @@
 	
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 70.7
-		@maxThrust = 70.7
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = UDMH
-			@ratio = 0.451
-			@DrawGauge = False
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = IRFNA-III
-			@ratio = 0.549
-			DrawGauge = True
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 276
-			@key,1 = 1 100
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.050
-		}
 		@useEngineResponseTime = False
 	}
 	
@@ -685,9 +652,6 @@
 		gimbalRange = 5
 		useGimbalResponseSpeed = true
 		gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleAlternator]
-	{
 	}
 	engineType = Agena
 }


### PR DESCRIPTION
* change name to military designation like other contemporary engines
* add sources
* adjust thrust (engines variants rated at 15 klbf, 16 klbf, and 17 klbf)
* rename configs to use their XLR designations where appropriate (unknown designation for Model 8096-39)
* update FASA Agena and VSR Agena to remove fields handled by master config
* remove ullage requirement from Agena D engines (which used propellant sumps):
![agena ullage 2](https://cloud.githubusercontent.com/assets/11747970/13419023/e7aa91e0-df2f-11e5-80c6-8bc54510b715.png)
* change XLR81-BA-13 (8247) to 15 total ignitions per sources
* add title, manufacturer, and description to global config
* add modulegimbal to global config