### PR TITLE
Update RSB engines

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -1,10 +1,98 @@
 //  ==================================================
+//  P241A EAP (Étages d’Accélération à Poudre)
+
+//  Dimensions: 3.07 x 27 m
+//  Gross Mass: 275500 Kg
+
+//  Sources:
+
+//  http://www.avio.com/files/catalog/pdf/booster_per_il_lanciatore_ariane_5_23.pdf
+//  http://www.esa.int/Our_Activities/Launchers/Launch_vehicles/Boosters_EAP
+//  http://spacelaunchreport.com/ariane5.html
+
+//  The gross mass value excludes the mass of the attachment 
+//  and decoupling system (400 Kg) and the mass of the nose
+//  cone (2100 Kg).
+//  ==================================================
+
+@PART[RSBengineArianeVSRB]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Engine
+    @title = P241A EAP
+    @manufacturer = Avio/Regulus/SABCA
+    @description = A steel casing solid rocket motor used in pairs by the Ariane 5 launch vehicle for the initial phases of the flight.
+
+    @mass = 35.5
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+    %stageOffset = 1
+    %childStageOffset = 1
+
+    %engineType = EAP-241
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 0
+        @maxThrust = 6709
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 271
+            @key,1 = 1 250
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 7.3
+        @gimbalResponseSpeed = 16
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 135593
+        basemass = -1
+
+        //  HTPB/AP propellant mixture 240000 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 135593
+            maxAmount = 135593
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
 //  GEM-60 solid rocket motor.
 
 //  Dimensions: 1.58 m x 16 m
 //  Gross Mass: 3550 Kg (w/ TVC), 3080 Kg (w/o TVC)
 
 //  Sources:
+
 //  http://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
 
 //  The gross mass value excludes the mass of the attachment 
@@ -135,14 +223,14 @@
         }
     }
 
-    //  HTPB/AP propellant mixture mass 42550 Kg.
-
     MODULE
     {
         name = ModuleFuelTanks
         type = HTPB
         volume = 24040
         basemass = -1
+
+        //  HTPB/AP propellant mixture mass 42550 Kg.
 
         TANK
         {
@@ -165,7 +253,7 @@
 
 //  Sources:
 
-//  1: http://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
+//  http://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
 //  ==================================================
 
 @PART[RSBengineAresSRB]:FOR[RealismOverhaul]
@@ -211,14 +299,21 @@
         }
     }
 
-    //  PBAN/APCP propellant mixture mass 647640 Kg.
-
     MODULE
     {
         name = ModuleFuelTanks
         type = PBAN
         volume = 365485
         basemass = -1
+
+        //  PBAN/APCP propellant mixture mass 647640 Kg.
+
+        TANK
+        {
+            name = PBAN
+            amount = 365485
+            maxAmount = 365485
+        }
     }
 
     !RESOURCE,*{}
@@ -281,29 +376,12 @@
             @ratio = 0.620
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 6.0
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
-
-    RESOURCE
-    {
-        name = TEATEB
-        amount = 1
-        maxAmount = 1
-    }
 }
 
 //  ==================================================
 //  F-1B engine.
 
-//  Dimensions: -
+//  Dimensions: 3.4 m x 4.5 m
 //  Inert Mass: 9660 Kg
 
 //  Sources:
@@ -362,23 +440,6 @@
             @key,1 = 1 272.3
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 6.0
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
-
-    RESOURCE
-    {
-        name = TEATEB
-        amount = 1
-        maxAmount = 1
-    }
 }
 
 //  ==================================================
@@ -389,7 +450,7 @@
 
 //  Sources:
 
-//  1: http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
 //  ==================================================
 
 @PART[RSBengineH1]:FOR[RealismOverhaul]
@@ -434,16 +495,68 @@
             @ratio = 0.616
         }
     }
+}
 
-    @MODULE[ModuleGimbal]
+//  ==================================================
+//  HM-7 series engine.
+
+//  Dimensions: 1 m x 2 m
+//  Inert Mass: 165 Kg
+
+//  Sources:
+
+//  http://www.arianespace.com/wp-content/uploads/2015/09/Ariane5_users_manual_Issue5_July2011.pdf
+//  https://web.archive.org/web/20130714113757/http://www.snecma.com/IMG/files/fiche_hm7b_ang_2011_modulvoir_file_fr.pdf
+//  ==================================================
+
+@PART[RSBengineHM7B]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
     {
-        @gimbalRange = 10.0
-        @gimbalResponseSpeed = 16
+        @scale = 1.0, 1.175, 1.0
     }
 
-    !MODULE[ModuleAlternator]{}
+    @node_stack_top = 0.0, 0.235, 0.0, 0.0, 1.0, 0.0, 2
 
-    !RESOURCE[ElectricCharge]{}
+    @title = HM-7 Series
+    @manufacturer = Snecma S.A.
+    @description = Hydrolox gas generator upper stage engine. Direct descendant of the HM4 engine, the first non-American cryogenic engine. Used on the Ariane 4 H10 and the Ariane 5 ESC-A upper stages.
+
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+
+    %engineType = HM7
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 64.8
+        @maxThrust = 64.8
+        @heatProduction = 100
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 0.7630
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2370
+        }
+    }
 }
 
 //  ==================================================
@@ -454,11 +567,11 @@
 
 //  Sources:
 
-//  1: http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
-//  2: https://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf
-//  3: http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//  4: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19940016798.pdf
-//  5: http://www.alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
+//  http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
+//  https://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf
+//  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19940016798.pdf
+//  http://www.alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
 //  ==================================================
 
 @PART[RSBengineJ2]:FOR[RealismOverhaul]
@@ -510,22 +623,12 @@
         }
     }
 
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 7.5
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
-
-    RESOURCE
-    {
-        name = Helium
-        amount = 92000
-        maxAmount = 92000
-    }
+    //RESOURCE
+    //{
+    //    name = Helium
+    //    amount = 92000
+    //    maxAmount = 92000
+    //}
 }
 
 //  ==================================================
@@ -536,9 +639,9 @@
 
 //  Sources:
 
-//  1: http://rocket.com/j-2x-engine
-//  2: http://www.astronautix.com/engines/j2x.htm
-//  3: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100034922.pdf
+//  http://rocket.com/j-2x-engine
+//  http://www.astronautix.com/engines/j2x.htm
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100034922.pdf
 //  ==================================================
 
 @PART[RSBengineJ2X]:FOR[RealismOverhaul]
@@ -582,16 +685,6 @@
             @ratio = 0.255
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 7.5
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
 }
 
 //  ==================================================
@@ -605,11 +698,11 @@
 
 //  Sources:
 
-//  Source 1: http://www.lpre.de/energomash/RD-180/index.htm
-//  Source 2: http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
-//  Source 3: http://www.ulalaunch.com/products_atlasv.aspx
-//  Source 5: http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
-//  Source 6: http://spacelaunchreport.com/atlas5.html
+//  http://www.lpre.de/energomash/RD-180/index.htm
+//  http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//  http://www.ulalaunch.com/products_atlasv.aspx
+//  http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
+//  http://spacelaunchreport.com/atlas5.html
 //  ==================================================
 
 @PART[RSBengineRD180]:FOR[RealismOverhaul]
@@ -657,21 +750,12 @@
         }
     }
 
+    //  The RSB RD-180 uses separate gimbal transforms for each nozzle.
+
     @MODULE[ModuleGimbal],*
     {
         @gimbalRange = 8.0
         @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
-
-    RESOURCE
-    {
-        name = TEATEB
-        amount = 1
-        maxAmount = 1
     }
 }
 
@@ -683,12 +767,12 @@
 
 //  Sources:
 
-//  1: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110015783.pdf
-//  2: https://www.rocket.com/rl10-engine
-//  3: http://www.b14643.de/Spacerockets/Diverse/P&W_RL10_engine/index.htm
-//  4: http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4.pdf
-//  4: http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4-1_-2.pdf
-//  5: http://www.braeunig.us/space/specs/atlas.htm
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110015783.pdf
+//  https://www.rocket.com/rl10-engine
+//  http://www.b14643.de/Spacerockets/Diverse/P&W_RL10_engine/index.htm
+//  http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4.pdf
+//  http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4-1_-2.pdf
+//  http://www.braeunig.us/space/specs/atlas.htm
 //  ==================================================
 
 @PART[RSBengineRL10A42]:FOR[RealismOverhaul]
@@ -738,16 +822,6 @@
             @key,1 = 1 200
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 4.0
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
 }
 
 //  ==================================================
@@ -758,6 +832,8 @@
 
 @PART[RSBengineRL10A42]:AFTER[RealismOverhaulEngines]
 {
+    @title = RL10-A/C Series
+
     @MODULE[ModuleEngineConfigs]
     {
         @configuration = RL10A-1
@@ -830,16 +906,6 @@
             @ratio = 0.2665
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 4.0
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
 }
 
 //  ==================================================
@@ -850,6 +916,8 @@
 
 @PART[RSBengineRL10B2]:AFTER[RealismOverhaulEngines]
 {
+    @title = RL10-B/CECE Series
+
     @MODULE[ModuleEngineConfigs]
     {
         @configuration = RL10B-2
@@ -935,16 +1003,6 @@
             @key,1 = 1 366
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 10.5
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE[ElectricCharge]{}
 }
 
 //  ==================================================
@@ -1073,13 +1131,6 @@
         }
     }
 
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 8.0
-        %useGimbalResponseSpeed = True
-        %gimbalResponseSpeed = 16
-    }
-
     MODULE
     {
         name = ModuleFuelTanks
@@ -1098,4 +1149,69 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Vulcain series engine.
+
+//  Dimensions: 2.1 m x 3.44 m
+//  Inert Mass: 1800 Kg
+
+//  Sources:
+
+//  http://www.space-propulsion.com/brochures/launcher-propulsion/Vulcain2.pdf
+//  http://www.arianespace.com/wp-content/uploads/2015/09/Ariane5_users_manual_Issue5_July2011.pdf
+//  http://www.braeunig.us/space/specs/ariane.htm
+//  ==================================================
+
+@PART[RSBengineVulcain2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Vulcain Series
+    @manufacturer = Snecma S.A.
+    @description = Hydrolox gas generator booster engine. Used in the first stage of the Ariane 5 launch vehicle.
+
+    @mass = 1.8
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+
+    %engineType = Vulcain
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1359
+        @maxThrust = 1359
+        @heatProduction = 100
+        !engineAccelerationSpeed = NULL
+        !engineDecelerationSpeed = NULL
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 0.7049
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2951
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 429
+            @key,1 = 1 310
+        }
+    }
 }


### PR DESCRIPTION
* Add the Ariane 5 P241A EAP, the HM-7 and the Vulcain.
* Remove redundant modules & resources (included by the global engine
configs).
* Fix the titles of the RL10 variants.
* Other minor fixes.