### PR TITLE
RO RSB Ariane 5

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
@@ -1,0 +1,506 @@
+//  ==================================================
+//  Sources:
+
+//  http://www.arianespace.com/wp-content/uploads/2015/09/Ariane5_users_manual_Issue5_July2011.pdf
+//  http://spaceflight101.com/spacerockets/ariane-5-eca/
+//  http://www.b14643.de/Spacerockets_1/West_Europe/Ariane-5/Description/Frame.htm
+//  http://esamultimedia.esa.int/multimedia/publications/ariane5/offline/download.pdf
+//  http://www.space-propulsion.com/spacecraft-propulsion/showcase/ariane5-attitude-control-system.html
+//  http://www.space-propulsion.com/brochures/hydrazine-thrusters/hydrazine-thrusters.pdf
+
+//  ==================================================
+//  Ariane 5 PAS 1194VS.
+
+//  Dimensions: 1.25 m x 0.75 m
+//  Inert Mass: 150 Kg
+//  ==================================================
+
+@PART[RSBdecouplerArianeVpayload1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.25, 1.0
+    }
+
+    @node_stack_top = 0.0, 0.375, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.3125, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Ariane 5 PAS 1194VS
+    @manufacturer = Airbus Defence and Space
+    @description = A 1.25 m Payload Adapter System for the Ariane 5 launch vehicle family.
+
+    @mass = 0.15
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 10
+    }
+}
+
+//  ==================================================
+//  Ariane 5 PAS 1663.
+
+//  Dimensions: 1.875 m x 0.9 m
+//  Inert Mass: 165 Kg
+//  ==================================================
+
+@PART[RSBdecouplerArianeVpayload2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.5, 1.0
+    }
+
+    @node_stack_top = 0.0, 0.45, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.375, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Ariane 5 PAS 1663
+    @manufacturer = Airbus Defence and Space
+    @description = A 1.875 m Payload Adapter System for the Ariane 5 launch vehicle family.
+
+    @mass = 0.165
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 10
+    }
+}
+
+//  ==================================================
+//  Ariane 5 PAS 2624VS.
+
+//  Dimensions: 2.5 m x 0.325 m
+//  Inert Mass: 125 Kg
+//  ==================================================
+
+@PART[RSBdecouplerArianeVpayload3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 0.55, 1.0
+    }
+
+    @node_stack_top = 0.0, 0.165, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.1375, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Ariane 5 PAS 2624VS
+    @manufacturer = Airbus Defence and Space
+    @description = A 2.5 m Payload Adapter System for the Ariane 5 launch vehicle family.
+
+    @mass = 0.125
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 10
+    }
+}
+
+//  ==================================================
+//  Ariane 5 generic payload adapter.
+
+//  Dimensions: 2.5 m x 1 m
+//  Inert Mass: 230 Kg
+//  ==================================================
+
+@PART[RSBadapterArianeV5m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Ariane 5 ECA Payload Adapter
+    @manufacturer = Airbus Defence and Space
+    @description = A 5.4 m to 5 m generic payload adapter for the Ariane 5 launch vehicle family. Note: it does not include a decoupler!
+
+    @mass = 0.23
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  Ariane 5 SYLDA5 (standard).
+
+//  Dimensions: 4.56 m x 4.9 m
+//  Inert Mass: 425 Kg
+//  ==================================================
+
+@PART[RSBdecouplerSylda5x49]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Ariane V SYLDA5 (Standard)
+    @manufacturer = Airbus Defence and Space
+    @description = The standard version of the SYLDA5 carrying structure (4.9 m).
+
+    @mass = 0.425
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 5
+    }
+
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Ariane 5 SYLDA5 (+2100 mm).
+
+//  Dimensions: 4.56 m x 4.4 m
+//  Inert Mass: 538 Kg
+//  ==================================================
+
+@PART[RSBdecouplerSylda5x70]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Ariane V SYLDA5 (Extra Extended)
+    @manufacturer = Airbus Defence and Space
+    @description = The extra extended version of the SYLDA5 carrying structure (7 m).
+
+    @mass = 0.538
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 5
+    }
+
+    !MODULE[ModuleEngines*]{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Ariane 5 ESC-A (Étage Supérieur Cryotechnique).
+
+//  Dimensions: 5.4 m x 4.7 m
+//  Gross Mass: 19350 Kg
+//  ==================================================
+
+@PART[RSBtankArianeVescA]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Ariane V ESC-A
+    @manufacturer = Airbus Defence and Space
+    @description = The second stage of the Ariane 5 launch vehicle family (ESC-A variant). Contains guidance capability.
+
+    @mass = 4.375
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.4
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 216
+            @key,1 = 1 85
+        }
+    }
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 46095
+        basemass = -1
+
+        //  Avionics batteries 600 Wh.
+        //  Can support the ESC-A for flights up to 3 hours in duration (25 minutes of powered flight plus 2.6 hours for payload separation/ESC-A deorbiting operations).
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 2160
+            maxAmount = 2160
+        }
+
+        //  ESC-A fuel 2483 Kg.
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 35050
+            maxAmount = 35050
+        }
+
+        //  ESC-A oxidizer 12416 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 10880
+            maxAmount = 10880
+        }
+
+        //  ACS propellant 156 Kg (maximum).
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 78
+            maxAmount = 156
+        }
+
+        //  ACS pressurization ~0.2 Kg.
+
+        TANK
+        {
+            name = Nitrogen
+            amount = 1600
+            maxAmount = 1600
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Ariane 5 ESC-A (Étage Supérieur Cryotechnique).
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[RSBtankArianeVescA]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.175
+        }
+    }
+
+    @MODULE[ModuleSPU]
+    {
+        @IsRTCommandStation = False
+        @RTCommandMinCrew = 0
+    }
+	
+    @MODULE[ModuleRTAntennaPassive]
+    {
+        @name = ModuleRTAntenna
+        !TechRequired = NULL
+        !OmniRange = NULL
+        %IsRTActive = True
+        %Mode0OmniRange = 0
+        %Mode1OmniRange = 1500000
+        %EnergyCost = 0.025
+    }
+}
+
+//  ==================================================
+//  Ariane 5 EPC/ESC-A interstage adapter.
+
+//  Dimensions: 5.4 m x 2.7 m
+//  Inert Mass: 720 Kg
+//  ==================================================
+
+@PART[RSBdecouplerArianeV]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 0.9, 1.0
+    }
+
+    @node_stack_top = 0.0, 1.35, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.35, 0.0, 0.0, -1.0, 0.0, 3
+
+    @title = Ariane 5 Interstage Adapter
+    @manufacturer = Airbus Defence and Space
+    @description = The EPC/ESC-A interstage adapter for the Ariane 5 launch vehicle family.
+
+    @mass = 0.72
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+}
+
+//  ==================================================
+//  Ariane 5 EPC (Étage Principal Cryotechnique).
+
+//  Dimensions: 5.4 m x 24 m
+//  Gross Mass: 187700 Kg
+//  ==================================================
+
+@PART[RSBtankArianeVcore]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %rotation = 0.0, -90.0, 0.0
+    }
+
+    @title = Ariane 5 EPC-E
+    @manufacturer = Airbus Defence and Space/Dutch Space
+    @description = The evolved cryogenic main stage of the Ariane 5 launch vehicle.
+
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 447505
+        basemass = -1
+
+        //  EPC-E fuel 22351 Kg (average).
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 315475
+            maxAmount = 315475
+        }
+
+        //  EPC-E oxidizer 150648 Kg (average).
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 132030
+            maxAmount = 132030
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 115 Wh.
+    //  Supports the EPC-E for the initial duration of the flight (approximately 9 minutes).
+    //  Assumes that the electricity consumption of the EPC-E avionics is 200 W.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 415
+        maxAmount = 415
+    }
+}
+
+//  ==================================================
+//  Ariane 5 P241A EAP (Étages d’Accélération à Poudre) nose cone.
+
+//  Dimensions: 3.07 m x 4.5 m
+//  Gross Mass: 2100 Kg
+//  ==================================================
+
+@PART[RSBnoseconeArianeVSRB]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Ariane V P241A EAP Nose Cone
+    @manufacturer = MT Aerospace
+    @description = The nose cone for the Ariane 5 P241A EAP. Contains separation motors to help prevent recontact after booster separation.
+
+    @mass = 2.025
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 280
+        @maxThrust = 280
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 220
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 42.7
+        basemass = -1
+
+        //  HTPB/AP propellant mixture 75.6 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 42.7
+            maxAmount = 42.7
+        }
+    }
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
* Add RO support for the Real Scale Boosters Ariane 5.

This requires the RSB engine changes (https://github.com/KSP-RO/RealismOverhaul/pull/1008) for the SRM, the HM-7 and the Vulcain engine and, optionally, the HM-7 engine config update (https://github.com/KSP-RO/RealismOverhaul/pull/1006) for the ullage and ignition simulations.