### PR TITLE
RCS 1/10

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -35,6 +35,11 @@
     needsRcsConfig = True
 }
 
+@PART[*]:HAS[#useRcsConfig[RCSBlockTenth]]:FOR[RO-RCS]
+{
+    needsRcsConfig = True
+}
+
 @PART[*]:HAS[#useRcsConfig[RCSBlock15x]]:FOR[RO-RCS]
 {
     needsRcsConfig = True
@@ -374,6 +379,61 @@
 		{
 			%thrusterPower = 0.10625
 			@cost *= 0.25
+		}
+	}
+}
+
+// Tenth block
+@PART[*]:HAS[#useRcsConfig[RCSBlockTenth]]:FOR[RO-RCS]
+{
+        !useRcsConfig = DELETE
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG[HTP]
+		{
+			%thrusterPower = 0.0255
+			@cost *= 0.1
+		}
+		@CONFIG[Hydrazine]
+		{
+			%thrusterPower = 0.0275
+			@cost *= 0.1
+		}
+		@CONFIG[NitrousOxide]
+		{
+			%thrusterPower = 0.0236
+			@cost *= 0.1
+		}
+		@CONFIG[Helium]
+		{
+			%thrusterPower = 0.0072
+			@cost *= 0.1
+		}
+		@CONFIG[Nitrogen]
+		{
+			%thrusterPower = 0.0114
+			@cost *= 0.1
+		}
+		@CONFIG[MMH+NTO]
+		{
+			%thrusterPower = 0.0445
+			@cost *= 0.1
+		}
+		@CONFIG[UDMH+NTO]
+		{
+			%thrusterPower = 0.0442
+			@cost *= 0.1
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%thrusterPower = 0.0455
+			@cost *= 0.1
+		}
+		@CONFIG[Cavea-B]
+		{
+			%thrusterPower = 0.0425
+			@cost *= 0.1
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_RCS.cfg
@@ -7,7 +7,7 @@
 	{
 	}
 	@mass = 0.02
-	@title = RCS Quad, Extensible (138/223N class)
+	@title = RCS Quad, Extensible (138/223 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad on an extensible boom. Use this for attitude control or translation/ullage for small stages and spacecraft.
 	@MODULE[ModuleRCS]
@@ -40,7 +40,7 @@
 	{
 	}
 	@mass = 0.021
-	@title = RCS Thruster 3x (1.24/2kN class)
+	@title = RCS Thruster 3x (1.24/2 kN class)
 	@manufacturer = Generic
 	@description = A generic RCS thruster array. Use this for attitude control or translation/ullage for very large stages. Note that the thrust per nozzle is only one-third the thrust class; three nozzles fire in the same direction giving the class rating.
 	@MODULE[ModuleRCS]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -322,6 +322,30 @@
 		@configuration = Nitrogen
 	}
 }
++PART[linearRcs]:AFTER[RealismOverhaul]
+{
+	@name = RO_linearRcs_tenth
+	!mesh = DEL
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Utility/linearRCS/model
+		scale = 0.5, 0.5, 0.5
+	}
+	%rescaleFactor = 1.0
+	@title = Attitude Jet (28/45N class)
+	@manufacturer = Generic
+	@description = These small thrusters are for upper stage or very small probe orientation.
+	@mass = 0.0006
+	%useRcsConfig = RCSBlockTenth
+	%useRcsMass = True
+	%useRcsCostMult = 0.1
+	@MODULE[ModuleRCS*]
+	{
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.069
+	}
+}
 @PART[parachuteSingle]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -498,6 +522,32 @@
 	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.06875
+	}
+}
++PART[RCSBlock]:AFTER[RealismOverhaul]
+{
+	@name = SquadRCSBlockTenth
+	!mesh = DELETE
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Utility/rcsBlockRV-105/model
+		scale = 0.22, 0.22, 0.22
+	}
+	@scale = 0.125
+	%rescaleFactor = 1.0
+	@node_attach = 0.045212, -0.00105571, -0.00059382, 1.0, 0.0, 0.0
+	@TechRequired = stability
+	@entryCost = 1450
+	@title = RCS Quad (28/45 N class)
+	@manufacturer = Generic
+	@description = A generic RCS quad. Use this for attitude control or translation/ullage for very small stages and spacecraft.
+	@mass = 0.0028
+	%useRcsConfig = RCSBlockTenth
+	%useRcsMass = True
+	@MODULE[ModuleRCS*]
+	{
+		@thrusterPower = 0.0275
 	}
 }
 @PART[roverBody]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -236,7 +236,7 @@
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
 	%useRcsCostMult = 0.25
-	@title = RCS Thruster (550/890N class)
+	@title = RCS Thruster (550/890 N class)
 	@manufacturer = Generic
 	@description = A generic single RCS thruster. Use this for attitude control or translation/ullage for large stages.
 	@MODULE[ModuleRCS]
@@ -267,7 +267,7 @@
 		scale = 1.0, 1.0, 1.0
 	}
 	%rescaleFactor = 1.0
-	@title = Attitude Jet (138/223N class)
+	@title = Attitude Jet (138/223 N class)
 	@manufacturer = Generic
 	@description = These small thrusters are for upper stage or medium probe orientation.
 	@mass = 0.003
@@ -302,7 +302,7 @@
 		scale = 0.7, 0.7, 0.7
 	}
 	%rescaleFactor = 1.0
-	@title = Attitude Jet (69/111N class)
+	@title = Attitude Jet (69/111 N class)
 	@manufacturer = Generic
 	@description = These small thrusters are for upper stage or small probe orientation.
 	@mass = 0.0015
@@ -333,7 +333,7 @@
 		scale = 0.5, 0.5, 0.5
 	}
 	%rescaleFactor = 1.0
-	@title = Attitude Jet (28/45N class)
+	@title = Attitude Jet (28/45 N class)
 	@manufacturer = Generic
 	@description = These small thrusters are for upper stage or very small probe orientation.
 	@mass = 0.0006
@@ -452,7 +452,7 @@
 	@mass = 0.028
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
-	@title = RCS Quad (275/445N class)
+	@title = RCS Quad (275/445 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
 	@MODULE[ModuleRCS]
@@ -487,7 +487,7 @@
 	@node_attach = 0.045212, -0.00105571, -0.00059382, 1.0, 0.0, 0.0
 	@TechRequired = stability
 	@entryCost = 1450
-	@title = RCS Quad (138/223N class)
+	@title = RCS Quad (138/223 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for small stages and spacecraft.
 	@mass = 0.014
@@ -513,7 +513,7 @@
 	@node_attach = 0.045212, -0.00105571, -0.00059382, 1.0, 0.0, 0.0
 	@TechRequired = stability
 	@entryCost = 3400
-	@title = RCS Quad (69/111N class)
+	@title = RCS Quad (69/111 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for rather small spacecraft or kick stages.
 	@mass = 0.007

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RCS.cfg
@@ -9,7 +9,7 @@
 	{
 		%scale = 1.4, 1.4, 1.4
 	}
-	@title = RCS Quad (550/890N class)
+	@title = RCS Quad (550/890 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for large stages and spacecraft. Note that the thrust per nozzle is only half the thrust class, but two nozzles fire in each direction.
 	@mass = 0.052
@@ -48,7 +48,7 @@
 	@mass = 0.028
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
-	@title = RCS Quad, 45deg (275/445N class)
+	@title = RCS Quad, 45deg (275/445 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad with 45degree side-thruster orientation. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
 	@MODULE[ModuleRCS]
@@ -85,7 +85,7 @@
 	@mass = 0.05
 	%useRcsConfig = RCSBlockHalf
 	
-	@title = Inline RCS block (138/223N class)
+	@title = Inline RCS block (138/223 N class)
 	@manufacturer = Generic
 	@description = A generic inline RCS block. Use this for orientation on small capsules and probes.
 	@MODULE[ModuleRCS]


### PR DESCRIPTION
Add 1/10-size RCS thrusters (linear and quad) for tiny satellites/stages.