### PR TITLE
Verniers for RD-107/8 in SSTU

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
@@ -42,3 +42,15 @@
 		!origMass = 0
 	}
 }
+// Subtract thrust from engine with verniers defined.
+@PART[*]:HAS[#useVerniers[True]]:AFTER[RealismOverhaulEngines] {
+	@MODULE[ModuleEngineConfigs]
+    {
+		@CONFIG,*
+		{
+			@maxThrust -= #$../../vernierThrust$
+			@minThrust -= #$../../vernierThrust$
+			gimbalRange = 0 //For engines that may have a main gimbal defined.
+		}
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -14,6 +14,7 @@
 //  Used by:
 //      SXT
 //      Ven Stock Revamp
+//		SSTU
 //  ==================================================
 
 @PART[*]:HAS[#engineType[RD108-118]]:FOR[RealismOverhaulEngines]
@@ -40,9 +41,9 @@
     MODULE
     {
         name = ModuleEngineConfigs
-        type = ModuleEngines
-        origMass = 1.278
-        configuration = RD-108_8D75
+		type = ModuleEngines
+		origMass = 1.278
+        configuration = RD-108_8D75PS //FIXME: missing RD-108_8D75 ???
         modded = false
 
         CONFIG

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU-RD-10X.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU-RD-10X.cfg
@@ -1,23 +1,31 @@
 @PART[SSTU-SC-ENG-RD-107A]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	vernierThrust = 70 //2 verniers, 35 kn each.
+	useVerniers = True
 	%engineType = RD107-117
 	@mass = 1.090
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*],0
 	{
-		@minThrust = 1040
-		@maxThrust = 1040
+		@minThrust = 972.3 //FIXME: very strange glitch, on these particular engines the thrust values here get shown on the engineconfig GUI, rather then the values in ModuleEngineConfigs
+		@maxThrust = 972.3
 		@heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.745
+			@ratio = 0.3531
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.255
+			@ratio = 0.6274
+		}
+		PROPELLANT
+		{
+			name = HTP
+			ignoreForIsp = True
+			ratio = 0.0195
 		}
 		@atmosphereCurve
 		{
@@ -25,20 +33,29 @@
 			@key,1 = 1 256
 		}
 	}
+	
+	//Verniers
 	@MODULE[ModuleEngines*],1
 	{
-		@minThrust = 40
-		@maxThrust = 40
+		@minThrust = 70
+		@maxThrust = 70
 		@heatProduction = 10
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.745
+			@ratio = 0.3531
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.255
+			@ratio = 0.6274
+		}
+		PROPELLANT
+		{
+			name = HTP
+			ratio = 0.0195
+			ignoreForIsp = True
+			DrawGauge = False
 		}
 		@atmosphereCurve
 		{
@@ -51,7 +68,9 @@
 {
     @MODULE[ModuleGimbal]
     {
-        %gimbalRange = 15
+        %gimbalRange = 35 // FIXME: no source on this value, could be wildly off
+        %useGimbalResponceSpeed = True
+        %@gimbalResponseSpeed = 16 //FIXME: seems to have no effect
     }
 }
 
@@ -69,12 +88,18 @@
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.745
+			@ratio = 0.3531
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.255
+			@ratio = 0.6274
+		}
+		PROPELLANT
+		{
+			name = HTP
+			ignoreForIsp = True
+			ratio = 0.0195
 		}
 		@atmosphereCurve
 		{
@@ -87,23 +112,33 @@
 @PART[SSTU-SC-ENG-RD-108A]:NEEDS[SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	
+	vernierThrust = 140 //4 verniers
+	useVerniers = True
 	%engineType = RD108-118
 	@mass = 1.075
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*],0
 	{
-		@minThrust = 1010
-		@maxThrust = 1010
+		@minThrust = 918.3 //FIXME: same as RD-107A
+		@maxThrust = 918.3
 		@heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.745
+			@ratio = 0.3531
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.255
+			@ratio = 0.6274
+		}
+		PROPELLANT
+		{
+			%name = HTP
+			%ratio = 0.0195
+			%ignoreForIsp = True
+			%DrawGauge = False
 		}
 		@atmosphereCurve
 		{
@@ -113,18 +148,25 @@
 	}
 	@MODULE[ModuleEngines*],1
 	{
-		@minThrust = 80
-		@maxThrust = 80
+		@minThrust = 140
+		@maxThrust = 140
 		@heatProduction = 10
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
-			@ratio = 0.745
+			@ratio = 0.3531
+			DrawGauge = False
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.255
+			@ratio = 0.6274
+		}	
+		PROPELLANT
+		{
+			%name = HTP
+			%ignoreForIsp = True
+			%ratio = 0.0195
 		}
 		@atmosphereCurve
 		{
@@ -137,6 +179,13 @@
 {
     @MODULE[ModuleGimbal]
     {
-        %gimbalRange = 15
+        %gimbalRange = 35        
+        %useGimbalResponceSpeed = True
+        %@gimbalResponseSpeed = 16 //FIXME: seems to have no effect
     }
+    @MODULE[ModuleEngineConfigs]
+    {
+		@engineID = SSTU-RD-108
+		isMaster = true
+	}
 }


### PR DESCRIPTION
fixed mix ratios and propellants.
create a system to support an engine having optional verniers with keeping thrust constant for the engine/config as a whole.

There are a few unresolved glitches with the RD-107/8 in SSTU still:

- verniers don't seem to respect gimbal response speed
- the ModuleEngineConfigs GUI shows engine stats from the wrong source(ModuleEngines*), until the engine config is changed(only a gui issue, correct stats load ingame)

Also, the gimbalrange i gave for verniers is a guess, anyone have a source on that?
