### PR TITLE
VSR Cryo tank series

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
@@ -209,3 +209,189 @@
 
 	!RESOURCE[Oxidizer]{}
 }
+
+//  ==================================================
+//  CryoX NoseCone propellant tank.
+
+//  Dimensions: 8.4 m x 10.1 m
+//  Inert Mass: 5160 Kg
+//  ==================================================
+
+@PART[CryoXnoseCone]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.36, 3.36, 3.36
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 8
+
+    @category = FuelTank
+
+    @mass = 5.16
+    @bulkheadProfiles = size8
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 282000
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CryoX XXL propellant tank.
+
+//  Dimensions: 8.4 m x 31.2 m
+//  Inert Mass: 28400 Kg
+//  ==================================================
+
+@PART[CryoXBig]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.36, 3.36, 3.36
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 14.5, 0.0, 0.0, 1.0, 0.0, 8
+    @node_stack_bottom = 0.0, -17.2, 0.0, 0.0, -1.0, 0.0, 8
+    @node_attach = 4.2, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+
+    @mass = 28.4
+    @bulkheadProfiles = size8, srf
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 1557000
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CryoX XL propellant tank.
+
+//  Dimensions: 8.4 m x 16.8 m
+//  Inert Mass: 14900 Kg
+//  ==================================================
+
+@PART[CryoXmed]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.36, 3.36, 3.36
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 8.7, 0.0, 0.0, 1.0, 0.0, 8
+    @node_stack_bottom = 0.0, -8.7, 0.0, 0.0, -1.0, 0.0, 8
+    @node_attach = 4.2, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+
+    @mass = 14.9
+    @bulkheadProfiles = size8, srf
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 818500
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CryoX L propellant tank.
+
+//  Dimensions: 8.4 m x 8.4 m
+//  Inert Mass: 7500 Kg
+//  ==================================================
+
+@PART[CryoXsmall]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.36, 3.36, 3.36
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 4.2, 0.0, 0.0, 1.0, 0.0, 8
+    @node_stack_bottom = 0.0, -4.2, 0.0, 0.0, -1.0, 0.0, 8
+    @node_attach = 4.2, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+
+    @mass = 7.5
+    @bulkheadProfiles = size8, srf
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 409000
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CryoX Butt propellant tank.
+
+//  Dimensions: 8.4 m x 5 m
+//  Inert Mass: 2600 Kg
+//  ==================================================
+
+@PART[CryoXendButt]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.36, 3.36, 3.36
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, -0.1, 0.0, 0.0, 1.0, 0.0, 8
+
+    @category = FuelTank
+
+    @mass = 2.6
+    @bulkheadProfiles = size8
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 141000
+    }
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
* Add RO support for the Ven Stock Revamp Cryo propellant tanks. Utilization value around 88% (similar to the STS ET and the SLS core stage).