### PR TITLE
Add RO support for the Tantares Castor_Nerva as the NERVA I.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares.cfg
@@ -88,6 +88,26 @@
 
 //###### Castor/Misc ######
 
+//	Nerva I
+//	looks a lot like this: http://www.aerospaceprojectsreview.com/blog/wp-content/uploads/2012/07/nervachart.jpg
+@PART[Castor_Nerva]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2.4553333333333334
+	
+	node_stack_top = 0.0, 2.0075, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom = 0.0, -2.0075, 0.0, 0.0, -1.0, 0.0, 2
+	engineType = NERVA
+	@maxTemp = 1973.15
+
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+	}
+}
+
+
 @PART[Castor_Engine_A]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/nerva_1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/nerva_1.cfg
@@ -1,11 +1,11 @@
-@PART[nuclearEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Aerojet NERVA NRX Nuclear Engine
+@PART[Castor_Nerva]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Aerojet NERVA I Nuclear Engine
 {
     PLUME
     {
         name = Hydrogen-NTR
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.7
+        localPosition = 0,0,-0.1
         fixedScale = 3
         energy = 1
         speed = 1


### PR DESCRIPTION
includes adding plume, and scaling the stock NERVA plume.

This engine model is quite a good match for the NERVA, looks a lot like [this picture](http://www.aerospaceprojectsreview.com/blog/wp-content/uploads/2012/07/nervachart.jpg)