### PR TITLE
RSB Atlas V additions

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -679,3 +679,37 @@
         maxAmount = 17.25
     }
 }
+
+//  ==================================================
+//  Common Centaur ACS propellant tank.
+
+//  Dimensions: 0.65 m x 0.65 m
+//  Inert Mass: 6 Kg
+//  ==================================================
+
+@PART[RSBtankSphereCentaur]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = FuelTank
+    @title = Spherical Tank (Centaur)
+    @manufacturer = Generic
+    @description = A spherical, general purpose, propellant tank.
+
+    @mass = 0.006
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 120
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
* Add RO support for the Centaur auxiliary spherical propellant tank.