### PR TITLE
RSB Delta IV additions

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
@@ -135,6 +135,52 @@
 }
 
 //  ==================================================
+//  DCSS-4 payload fairing base.
+
+//  Dimensions: 4 m x 0.8 m
+//  Inert Mass: 120 Kg
+//  ==================================================
+
+@PART[RSBfairingDeltaIV4m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = DCSS-4 Payload Fairing Base
+    @manufacturer = United Launch Alliance (ULA)
+    @description = A procedural payload fairing base designed for the 4 meter variant of the Delta Cryogenic Second Stage (DCSS).
+
+    @mass = 0.12
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  DCSS-5 payload fairing base.
+
+//  Dimensions: 5.1 m x 1.3 m
+//  Inert Mass: 300 Kg
+//  ==================================================
+
+@PART[RSBfairingDeltaIV5m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = DCSS-5 Payload Fairing Base
+    @manufacturer = United Launch Alliance (ULA)
+    @description = A procedural payload fairing base designed for the 5 meter variant of the Delta Cryogenic Second Stage (DCSS).
+
+    @mass = 0.3
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
 //  Delta IV Medium 4+ payload attach fitting
 
 //  Dimensions: 4 m x 1.1 m
@@ -654,4 +700,38 @@
         amount = 180
         maxAmount = 180
     }
+}
+
+//  ==================================================
+//  DCSS ACS propellant tank.
+
+//  Dimensions: 0.6 m x 0.6 m
+//  Inert Mass: 4.5 Kg
+//  ==================================================
+
+@PART[RSBtankSphereDeltaIV]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = FuelTank
+    @title = Spherical Tank (DCSS)
+    @manufacturer = Generic
+    @description = A spherical, general purpose, propellant tank.
+
+    @mass = 0.0045
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 90
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
 }


### PR DESCRIPTION
* Add RO support for the DCSS 4 & 5 meter procedural fairing bases
(missed them for some reason).
* Add RO support for the DCSS auxiliary spherical propellant tank.