### PR TITLE
RSB Engines additions

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -109,7 +109,7 @@
     @description = The GEM-60 is a graphite composite epoxy solid rocket motor used by the Delta IV for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC).
 
     @mass = 3.08
-    @crashTolerance = 10
+    @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 1023.15
@@ -195,7 +195,7 @@
     @description = A graphite epoxy composite solid rocket motor used by the Atlas V 400 and 500 series for thrust augmentation.
 
     @mass = 3.55
-    @crashTolerance = 10
+    @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 1023.15
@@ -306,13 +306,81 @@
         volume = 365485
         basemass = -1
 
-        //  PBAN/APCP propellant mixture mass 647640 Kg.
+        //  PBAN/AP propellant mixture mass 647640 Kg.
 
         TANK
         {
             name = PBAN
             amount = 365485
             maxAmount = 365485
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Castor 120 solid rocket motor.
+
+//  Dimensions: 2.36 m x 9.02 m
+//  Gross Mass: 53070 Kg
+
+//  Sources:
+
+//  https://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
+//  ==================================================
+
+@PART[RSBengineCastor120]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Engine
+    @title = Castor 120
+    @manufacturer = Orbital ATK 
+    @description = The Castor 120 is a fairly wide-purpose solid rocket motor, functioning as first and upper stages for a variety of launch vehicles, or as strap-ons.
+
+    @mass = 4.12
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %stageOffset = 1
+    %childStageOffset = 1
+
+    %engineType = Castor-120
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 0
+        @maxThrust = 1957.2
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 27655
+        basemass = -1
+
+        //  HPTB/AP mixture 48950 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 27655
+            maxAmount = 27655
         }
     }
 
@@ -1097,7 +1165,7 @@
     @description = This is the Space Shuttle's Four-Segment SRB. These Solid Rocket Boosters provided most of the lift-off thrust to get the Space Shuttle moving. Mostly recoverable and refurbished for future flights. A similar SRB would have been used in the DIRECT Jupiter program, if it had ever come to fruition.
 
     @mass = 65.77
-    @crashTolerance = 10
+    @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 1023.15
@@ -1212,6 +1280,60 @@
         {
             @key,0 = 0 429
             @key,1 = 1 310
+        }
+    }
+}
+
+//  ==================================================
+//  XLR81 engine.
+
+//  Dimensions: 0.9 m x 1.4 m
+//  Inert Mass: 134 Kg
+
+//  Sources:
+
+//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
+//  ==================================================
+
+@PART[RSBengineXLR81]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @mass = 0.134
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+
+    %engineType = Agena
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 67
+        @maxThrust = 67
+        @heatProduction = 100
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4511
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = IRFNA-III
+            @ratio = 0.5489
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 276
+            @key,1 = 1 100
         }
     }
 }


### PR DESCRIPTION
* Add RO support for the Castor 120 SRM and the XLR81.
* Normalize crash tolerances between SRMs and liquid engines.