### PR TITLE
VSR Cryo tanks renaming

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_FuelTank.cfg
@@ -232,6 +232,7 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 8
 
     @category = FuelTank
+    @title = CryoX Nose Propellant Tank
 
     @mass = 5.16
     @bulkheadProfiles = size8
@@ -270,6 +271,7 @@
     @node_attach = 4.2, 0.0, 0.0, 1.0, 0.0, 0.0
 
     @category = FuelTank
+    @title = CryoX XXL Propellant Tank
 
     @mass = 28.4
     @bulkheadProfiles = size8, srf
@@ -308,6 +310,7 @@
     @node_attach = 4.2, 0.0, 0.0, 1.0, 0.0, 0.0
 
     @category = FuelTank
+    @title = CryoX XL Propellant Tank
 
     @mass = 14.9
     @bulkheadProfiles = size8, srf
@@ -346,6 +349,7 @@
     @node_attach = 4.2, 0.0, 0.0, 1.0, 0.0, 0.0
 
     @category = FuelTank
+    @title = CryoX L Propellant Tank
 
     @mass = 7.5
     @bulkheadProfiles = size8, srf
@@ -382,6 +386,7 @@
     @node_stack_top = 0.0, -0.1, 0.0, 0.0, 1.0, 0.0, 8
 
     @category = FuelTank
+    @title = CryoX Butt Propellant Tank
 
     @mass = 2.6
     @bulkheadProfiles = size8


### PR DESCRIPTION
* They are now generic "propellant" tanks instead of just "fuel" tanks.