### PR TITLE
SXT Airbags

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -832,11 +832,13 @@
 @PART[SXTAirbag]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    
+    @description = A set of inflatable balloon that can handle speed impact on planetary surface. These airbags are well suited for landing small landers and probe on rough terrains, when your retroburn system is not precise enough. Firts used on Russian luna landers like luna 9, airbags served well as Mars landing systems during various missions.
 }
 
 @PART[SXTAirbagSmall]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@description = Three inflatable re-purposed footballs from the last World Championship League. Can be triggered using action groups and jettisoned like landing struts.
+    
+    @description = A more advanced alternative to the Mk-10 landing system. A team of highly trained monkeys finally developped these incredibly strongs aibags, and they told us that we could use them anywhere on Solar System's planets and moons. Don't expect them to resist an over-nine-thousand meter per second impact, though.
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -822,3 +822,21 @@
 		outputResources = Oxygen, 0.0071565375, true, Waste, 0.0000027155975, true	// See RO Github #844 for explanation of values
 	}
 }
+
+//  ==================================================
+//  Airbags
+
+//  Realism Overhaul configuration.
+//  ==================================================
+
+@PART[SXTAirbag]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+}
+
+@PART[SXTAirbagSmall]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@description = Three inflatable re-purposed footballs from the last World Championship League. Can be triggered using action groups and jettisoned like landing struts.
+}


### PR DESCRIPTION
Not a lot of change here, just mark these two airbags as "RO-supported". I did not change the scale or anything because I think it's better to do it with tweakscale (on these parts).