### PR TITLE
Big Gemini

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -300,7 +300,7 @@
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 162
+			maxAmount = 166
 		}
 		TANK
 		{
@@ -315,7 +315,7 @@
 		converterName = CO2 Scrubber
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
-		outputResources = Waste, 0.00003847, false
+		outputResources = Waste, 0.00003932, false
 	}
 	@MODULE[ModuleRCS]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -121,8 +121,9 @@
 	@node_stack_top = 0.0, 1.058411, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.176027, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Big Gemini Passenger Compartment
-	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.
+	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This module gives the Big G a max 9-man crew capacity with additional cargo space.
 	@mass = 2.02456
+	@CrewCapacity = 7
 	CoMOffset = 0.0, -1.5, 0.0
 	!RESOURCE[MonoPropellant]
 	{
@@ -138,59 +139,59 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1400
+		volume = 2300
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
 			name = Oxygen
-			amount = 3553.2
-			maxAmount = 3553.2
+			amount = 4143
+			maxAmount = 4143
 		}
 		TANK
 		{
 			name = Food
-			amount = 491.4
-			maxAmount = 491.4
+			amount = 574
+			maxAmount = 574
 		}
 		TANK
 		{
 			name = Water
-			amount = 324.8
-			maxAmount = 324.8
-		}
-		TANK
-		{
-			name = Waste
-			amount = 0
-			maxAmount = 44.7
-		}
-		TANK
-		{
-			name = WasteWater
-			amount = 0
-			maxAmount = 413.6
+			amount = 28
+			maxAmount = 28
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 1705.1
+			maxAmount = 3581
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 386
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 483
 		}
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 63
-			maxAmount = 63
+			amount = 101
+			maxAmount = 101
 		}
 	}
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 6.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+		conversionRate = 7.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
 	}
 	// Thermo
 	!MODULE[ModuleAblator] {}
@@ -261,8 +262,9 @@
 	@node_stack_top = 0.0, 1.058411, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.176027, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Big Gemini Passenger Compartment - White
-	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.
+	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.  It has less cargo space but can support up to 12 crew, including the flight compartment.
 	@mass = 1.720876
+	@CrewCapacity = 10
 	!MODULE[ModuleRCS]
 	{
 	}
@@ -289,59 +291,59 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 838.5
+		volume = 2300
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
 			name = Oxygen
-			amount = 3553.2
-			maxAmount = 3553.2
+			amount = 5919
+			maxAmount = 5919
 		}
 		TANK
 		{
 			name = Food
-			amount = 491.4
-			maxAmount = 491.4
+			amount = 819
+			maxAmount = 819
 		}
 		TANK
 		{
 			name = Water
-			amount = 324.8
-			maxAmount = 324.8
-		}
-		TANK
-		{
-			name = Waste
-			amount = 0
-			maxAmount = 44.7
-		}
-		TANK
-		{
-			name = WasteWater
-			amount = 0
-			maxAmount = 413.6
+			amount = 39
+			maxAmount = 39
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 1705.1
+			maxAmount = 5115
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 551
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 690
 		}
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 63
-			maxAmount = 63
+			amount = 144
+			maxAmount = 144
 		}
 	}
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 3.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+		conversionRate = 10.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
 	}
 	// Thermo
 	!MODULE[ModuleAblator] {}
@@ -417,20 +419,20 @@
 	@MODEL
 	{
 		scale = 1.749404, 1.287842, 1.749404
-		position = 0.0, 1.287842, 0.0
+		position = 0.0, -1.11, 0.0
+		rotation = 180, 180, 0
 	}
 	MODEL
 	{
 		model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_UtilityPack
 		scale = 2.142506, 0.883614, 2.142506
-		rotation = 180, 0, 0
-		position = 0.0, 0.187131, 0.0
 	}
-	@node_stack_top = 0.0, -0.362477, 0.0, 0.0, 1.0, 0.0, 4
-	@node_stack_bottom = 0.0, 2.253724, 0.0, 0.0, -1.0, 0.0, 6
-	@category = Utility
+	@node_stack_top = 0.0, 0.5496, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -1.966601, 0.0, 0.0, -1.0, 0.0, 6
+	@category = Propulsion
 	@title = Big Gemini Service Module
-	@description = The service module for the Big Gemini spacecraft. Contains a docking mechanism as well.
+	@description = The service module and cargo storage for the Big Gemini spacecraft. Decouples before re-entry burn.
+	@CrewCapacity = 0
 	@mass = 7.16
 	!RESOURCE[ElectricCharge]
 	{
@@ -444,53 +446,62 @@
 	!RESOURCE[Oxidizer]
 	{
 	}
-	@MODULE[ModuleEngines*]
+	!MODULE[ModuleScienceContainer]
 	{
-		@minThrust = 0.8896444
-		@maxThrust = 0.8896444
-		@heatProduction = 10
-		@PROPELLANT[LiquidFuel]
+	}
+	!MODULE[ModuleScienceExperiment],0
+	{
+	}
+	!MODULE[ModuleScienceExperiment],1
+	{
+	}
+	!MODULE[ModuleScienceLab]
+	{
+	}
+	!MODULE[ModuleScienceConverter]
+	{
+	}
+	MODULE
+	{
+		name = ModuleRCS
+		resourceFlowMode = STACK_PRIORITY_SEARCH
+		thrusterTransformName = RCSthruster
+		thrusterPower = 0.8896444
+		fxOffset = 0, 0.1, 0.0
+		PROPELLANT
 		{
-			@name = MMH
-			@ratio = 0.554
+			name = MMH
+			ratio = 0.554
 		}
-		@PROPELLANT[Oxidizer]
+		PROPELLANT
 		{
-			@name = NTO
-			@ratio = 0.446
+			name = NTO
+			ratio = 0.446
 		}
-		@atmosphereCurve
+		atmosphereCurve
 		{
-			@key,0 = 0 273
-			@key,1 = 1 100
+			key = 0 273
+			key = 1 100
 		}
-		%ullage = True
-		%pressureFed = True
-		%ignitions = -1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.010
-		}
+
 	}
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1685.57
+		volume = 39805	// Illustration found at http://www.astronautix.com/craft/bigemini.htm shows 1310 Cu Ft available cargo space which works out to 37095.07L above and beyond the cargo space set aside for standard fuel and life support (2710).
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
 			name = LqdHydrogen
-			amount = 358.52
-			maxAmount = 358.52
+			amount = 640
+			maxAmount = 640
 		}
 		TANK
 		{
 			name = LqdOxygen
-			amount = 381.638
-			maxAmount = 381.638
+			amount = 460
+			maxAmount = 460
 		}
 		TANK
 		{
@@ -514,44 +525,14 @@
 		{
 			name = Oxygen
 			amount = 0
-			maxAmount = 50.4
+			maxAmount = 10
 		}
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = false
-		configuration = Thruster
-		CONFIG
+		TANK
 		{
-			name = Thruster
-			minThrust = 0.8896444
-			maxThrust = 0.8896444
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.554
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.446
-			}
-			atmosphereCurve
-			{
-				key = 0 273
-				key = 1 100
-			}
+			name = Water
+			amount = 452
+			maxAmount = 604
 		}
-	}
-	MODULE
-	{
-		name = TacGenericConverter
-		converterName = LOX-O2
-		conversionRate = 9.0
-		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
-		outputResources = Oxygen, 0.006883126, false
 	}
 	MODULE
 	{
@@ -559,7 +540,15 @@
 		converterName = Fuel Cell
 		conversionRate = 3.0
 		inputResources = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
-		outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
+		outputResources = Water, 0.000096685, true, ElectricCharge, 0.98, true
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = LOX-O2
+		conversionRate = 12.0
+		inputResources = LqdOxygen, 0.0000085058788, ElectricCharge, 0.025
+		outputResources = Oxygen, 0.006883126, false
 	}
 	MODULE
 	{
@@ -568,6 +557,57 @@
 		explosiveNodeID = top
 		ejectionForce = 5
 		staged = false
+	}
+}
+@PART[FASAGeminiBigGDec]:AFTER[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 2.463, 2.463, 2.463
+	}
+	@scale = 2.463
+	@mass = 0.212
+	@title = Big Gemini Decoupler
+	@MODULE[ModuleDecouple]
+	{
+		%explosiveNodeID = top
+		%isOmniDecoupler = false
+		@ejectionForce = 2
+	}
+}
+@PART[FASAGeminiBigGDockExt]:AFTER[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		@scale = 1.016, 1.016, 1.016
+	}
+	@scale = 1.016
+	@mass = 0.036
+	@title = Big Gemini Docking Ring
+	@MODULE[ModuleDockingNode]
+	{
+		@nodeType = Apollo
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}
+@PART[FASABigGeminiRetroModule|FASAGeminiBigGDock|FASAGeminiBigGDockExt]:AFTER[RealismOverhaul]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
 	}
 }
 @PART[FASAGeminiLFTBigGAdapt]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -121,7 +121,7 @@
 	@node_stack_top = 0.0, 1.058411, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.176027, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Big Gemini Passenger Compartment
-	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This module gives the Big G a max 9-man crew capacity with additional cargo space.
+	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This module gives the Big G a max 9-person crew capacity with additional cargo space.
 	@mass = 2.02456
 	@CrewCapacity = 7
 	CoMOffset = 0.0, -1.5, 0.0
@@ -262,7 +262,7 @@
 	@node_stack_top = 0.0, 1.058411, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.176027, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Big Gemini Passenger Compartment - White
-	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.  It has less cargo space but can support up to 12 crew, including the flight compartment.
+	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.  It has less cargo space but can support up to 12-person crew, including the flight compartment.
 	@mass = 1.720876
 	@CrewCapacity = 10
 	!MODULE[ModuleRCS]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -121,7 +121,7 @@
 	@node_stack_top = 0.0, 1.058411, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.176027, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Big Gemini Passenger Compartment
-	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This module gives the Big G a max 9-person crew capacity with additional cargo space.
+	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This module gives the Big G a max 9 person crew capacity with additional cargo space.
 	@mass = 2.02456
 	@CrewCapacity = 7
 	CoMOffset = 0.0, -1.5, 0.0
@@ -262,7 +262,7 @@
 	@node_stack_top = 0.0, 1.058411, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.176027, 0.0, 0.0, -1.0, 0.0, 4
 	@title = Big Gemini Passenger Compartment - White
-	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.  It has less cargo space but can support up to 12-person crew, including the flight compartment.
+	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.  It has less cargo space but can support up to 12 person crew, including the flight compartment.
 	@mass = 1.720876
 	@CrewCapacity = 10
 	!MODULE[ModuleRCS]
@@ -388,29 +388,88 @@
 	@name = FASABigGeminiRetroModule
 	@MODEL
 	{
-		@scale = 2.147468, 1.999074, 2.147468
-		@rotation = 0, 45, 0
+		@model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_UtilityPack
+		@scale = 1.9106, 0.8216, 1.9106
 	}
-	@scale = 1.999074
-	@node_stack_top = 0.0, 0.27, 0.0, 0.0, 1.0, 0.0, 4
-	@node_stack_bottom = 0.0, -0.27, 0.0, 0.0, -1.0, 0.0, 4
+	MODEL
+	{
+		model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_Mini_SRB
+		scale = 1.9106, 1.9106, 1.9106
+		position = 0.75, -0.2, 0.75
+	}
+	MODEL
+	{
+		model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_Mini_SRB
+		scale = 1.9106, 1.9106, 1.9106
+		position = 0.75, -0.2, -0.75
+	}
+	MODEL
+	{
+		model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_Mini_SRB
+		scale = 1.9106, 1.9106, 1.9106
+		position = -0.75, -0.2, 0.75
+	}
+	MODEL
+	{
+		model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_Mini_SRB
+		scale = 1.9106, 1.9106, 1.9106
+		position = -0.75, -0.2, -0.75
+	}
+	@scale = 0.8216
+	@node_stack_top = 0.0, 0.622, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -0.6, 0.0, 0.0, -1.0, 0.0, 4
+	@category = Engine
 	@title = Big Gemini Retro Module
 	@description = The Big Gemini Retro Module that contains 4x solid rockets to de-orbit Gemini. Decouples before re-entry.
 	@mass = 1.0978748
+	!MODULE[ModuleRCS]
+	{
+	}
 	@MODULE[ModuleEngines*]
 	{
-		@maxThrust = 44.48
+		@maxThrust = 22.24
 	}
-	@MODULE[ModuleFuelTanks]
+	!MODULE[ModuleFuelTanks]
 	{
-		@volume = 220.4
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		@CONFIG
+		@CONFIG[Solid]
 		{
-			@maxThrust = 44.48
+			@maxThrust = 22.24
 		}
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 820
+		type = LifeSupport
+		basemass = -1
+		TANK
+		{
+			name = Food
+			amount = 0
+			maxAmount = 0
+		}
+		TANK
+		{
+			name = Water
+			amount = 442
+			maxAmount = 594
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 49715
+			maxAmount = 49715
+		}
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 112.74
+		type = PSPC
+		basemass = -1
 	}
 }
 @PART[FASAGeminiBigGDock]:FOR[RealismOverhaul]
@@ -418,17 +477,39 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		scale = 1.749404, 1.287842, 1.749404
-		position = 0.0, -1.11, 0.0
+		scale = 1.749404, 1.5922, 1.749404
 		rotation = 180, 180, 0
 	}
 	MODEL
 	{
-		model = FASA/Gemini2/FASA_Gemini_Engine_Fuel2/Gemini_UtilityPack
-		scale = 2.142506, 0.883614, 2.142506
+		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
+		scale = 1.0, 1.0, 1.0
+		rotation = -19.0, 0.0, 0.0
+		position = 0.0, 1.125, 2.55
 	}
-	@node_stack_top = 0.0, 0.5496, 0.0, 0.0, 1.0, 0.0, 4
-	@node_stack_bottom = 0.0, -1.966601, 0.0, 0.0, -1.0, 0.0, 6
+	MODEL
+	{
+		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
+		scale = 1.0, 1.0, 1.0
+		rotation = -19.0, 90.0, 0.0
+		position = 2.55, 1.125, 0.0
+	}
+	MODEL
+	{
+		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
+		scale = 1.0, 1.0, 1.0
+		rotation = -19.0, 180.0, 0.0
+		position = 0.0, 1.125, -2.55
+	}
+	MODEL
+	{
+		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
+		scale = 1.0, 1.0, 1.0
+		rotation = -19.0, 270.0, 0.0
+		position = -2.55, 1.125, 0.0
+	}
+	@node_stack_top = 0.0, 1.6081, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -1.0079, 0.0, 0.0, -1.0, 0.0, 6
 	@category = Propulsion
 	@title = Big Gemini Service Module
 	@description = The service module and cargo storage for the Big Gemini spacecraft. Decouples before re-entry burn.
@@ -488,7 +569,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 39805	// Illustration found at http://www.astronautix.com/craft/bigemini.htm shows 1310 Cu Ft available cargo space which works out to 37095.07L above and beyond the cargo space set aside for standard fuel and life support (2710).
+		volume = 39200	// Illustration found at http://www.astronautix.com/craft/bigemini.htm shows 1310 Cu Ft available cargo space which works out to 37095.07L above and beyond the cargo space set aside for standard fuel and life support (2110).
 		type = ServiceModule
 		basemass = -1
 		TANK
@@ -530,8 +611,8 @@
 		TANK
 		{
 			name = Water
-			amount = 452
-			maxAmount = 604
+			amount = 0
+			maxAmount = 10
 		}
 	}
 	MODULE
@@ -581,9 +662,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.016, 1.016, 1.016
+		scale = 1.33, 1.3926, 1.33
 	}
-	@scale = 1.016
+	@scale = 1.3926
 	@mass = 0.036
 	@title = Big Gemini Docking Ring
 	@MODULE[ModuleDockingNode]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -320,43 +320,43 @@
 		{
 			name = Food
 			amount = 164
-			maxAmount = 164
+			maxAmount = 164	// 14 days
 		}
 		TANK
 		{
 			name = Water
-			amount = 6.6
-			maxAmount = 6.6
+			amount = 8
+			maxAmount = 8	// 1 day
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 592
-			maxAmount = 592
+			amount = 1184
+			maxAmount = 1184	// 1 day
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 512
+			maxAmount = 1023	// 1 day
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 108
+			maxAmount = 111	// 14 days
 		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 137.9
+			maxAmount = 138	// 14 days
 		}
 		TANK
 		{
 			name = LithiumHydroxide
 			amount = 29
-			maxAmount = 29
+			maxAmount = 29	// 14 days
 		}
 	}
 	MODULE
@@ -364,8 +364,8 @@
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
 		conversionRate = 2.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
-		outputResources = Waste, 0.00003847, false
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
 	}
 	
 	// Ejection
@@ -449,27 +449,6 @@
 	@title = Gemini Cabin - White
 	@description = The Gemini cabin.  Contains two astronauts.  This one is made of new lightweight material and painted white to increase efficiency for rescue operations.
 	@mass = 1.073935
-	
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 1000
-		
-		@TANK,*
-		{
-			@amount *= 2
-			@maxAmount *= 2
-		}
-		
-		@TANK[ElectricCharge]
-		{
-			@amount = 54000 // 15kWh
-			@maxAmount = 54000
-		}
-	}
-	@MODULE[TacGenericConverter]
-	{
-		@conversionRate *= 2
-	}
 }
 @PART[FASAGeminiUtilitySasRcs]:FOR[RealismOverhaul]
 {
@@ -640,20 +619,20 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 2148
+		volume = 2340
 		type = ServiceModule
 		basemass = -1
 		TANK
 		{
 			name = LqdHydrogen
-			amount = 358.5
-			maxAmount = 358.5
+			amount = 413
+			maxAmount = 413
 		}
 		TANK
 		{
 			name = LqdOxygen
-			amount = 264.7
-			maxAmount = 264.710
+			amount = 317
+			maxAmount = 317
 		}
 		TANK
 		{
@@ -670,14 +649,14 @@
 		TANK
 		{
 			name = Water
-			amount = 101.8
-			maxAmount = 101.8
+			amount = 101
+			maxAmount = 101
 		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 228.7
+			maxAmount = 315
 		}
 		TANK
 		{
@@ -698,14 +677,14 @@
 		converterName = Fuel Cell
 		conversionRate = 1.0
 		inputResources = LqdHydrogen, 0.000296379, LqdOxygen, 0.000210317
-		outputResources = WasteWater, 0.000261, true, ElectricCharge, 2.2, true
+		outputResources = WasteWater, 0.00025967179, true, ElectricCharge, 2.2, true
 	}
 	MODULE
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2
 		conversionRate = 2.0
-		inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
+		inputResources = LqdOxygen, 0.0000085058788, ElectricCharge, 0.025
 		outputResources = Oxygen, 0.006883126, false
 	}
 }


### PR DESCRIPTION
Update and setup various parts for the Big Gemini spacecraft.  Changes include:
1) Standard Big Gemini crew module crew capacity increased to 7.  This allows a 9-man Big Gemini setup (including two man cabin).
2) Rescue (White) Big Gemini crew module crew capacity increased to 10.  This allows 12-man Big Gemini setup (including two man cabin).
3) Both Big Gemini crew modules have the same tank capacity.  The white module uses all it's capacity for life support.  Since the black module allows for fewer crew, it has some extra tank space available which represents this module having some additional storage space.
4) Big Gemini Retro Module has all life support and equipment removed.  It is not setup just as the retro pack, just like the standard retro module for the normal Gemini.  I did include the ConnectedLivingSpace module, though, so that crew can pass through the retro module to make use of the rear docking port.
5) Big Gemini Service Module graphics have been realigned and oriented.  You no longer have to flip the part to set it up for use.
6) BGSM no longer includes science or crew components.
7) BGSM Storage capacity (i.e., Volume) has been increased significantly to account for the 1310 cu ft (37095.07L) of cargo space the module appears to have been capable of(see illustration at http://www.astronautix.com/graphics/b/bigcutaw.jpg)
8) BGSM includes ConnectedLivingSpace module so crew can make use or rear docking port
9) It looks like the BGSM as originally added to RO may have been intended to include built in engines but they didn't work.  I've removed those modules and added in the RCS module to allow for forward orbital translation to occur.
10) Big Gemini Docking Ring has been resized and adjusted similar to the FASAApollo_DockingDevice.  It also includes a ConnectedLivingSpace module.
11) Big Gemini Decoupler has been correctly sized for the 6.6m base.
12) I've cleaned up and balanced out the various Big Gemini life support and fuel cell modules so they properly maintain mass.