### PR TITLE
Updates for SSTU 0.3.29.11 - SRBs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_EnginesBasePatch.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_EnginesBasePatch.cfg
@@ -102,3 +102,8 @@
 //remove the placeholder engines
 -PART[SSTU-SC-ENG-Merlin-1B]{}
 -PART[SSTU-SC-ENG-H1]{}
+//remove original MSRB parts
+-PART[SSTU-SC-ENG-SRB-A]{}
+-PART[SSTU-SC-ENG-SRB-B]{}
+-PART[SSTU-SC-ENG-SRB-C]{}
+-PART[SSTU-SC-ENG-SRB-D]{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_MSRB_GEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_MSRB_GEM.cfg
@@ -1,0 +1,1595 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRBD1
+author = Shadowmage
+
+TechRequired = basicRocketry
+entryCost = 16000
+cost = 0
+category = Engine
+subcategory = 0
+title = GEM-40/46/60 (Modular)
+manufacturer = Orbital ATK
+description = Modular GEM booster. 1.05m for GEM-40, 1.50m for GEM-60.  Also has options for varying the length, and additional diameter scaling.
+RSSROConfig = True
+stagingIcon = SOLID_BOOSTER
+
+MODEL
+{
+	model = SSTU/Assets/EmptyProxyModel
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+node_stack_top = 0,1,0,0,1,0,2
+node_stack_bottom =  0,-1,0,0,-1,0,2
+node_attach = 1.25, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 1
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 4
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 1
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SSTU-MSRM-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SSTU-MSRM-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	minThrust = 1225
+	maxThrust = 3212
+	heatProduction = 1000
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0
+	PROPELLANT
+	{
+		name = HTPB
+	}
+	atmosphereCurve
+	{
+		key = 0 267
+		key = 1 245
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SSTU-MSRM-GimbalTransform
+	gimbalRange = 6
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 10000
+	type = HTPB
+}
+MODULE
+{
+	name = SSTUModularBooster
+	
+	// a transform of this name will be added and positioned for the main thrust transform
+	// default = empty
+	thrustTransformName = SSTU-MSRM-ThrustTransform	
+		
+	// if true, engine max thrust will scale with the SRB size
+	// default = true
+	scaleMotorThrust = true
+	
+	// the power to use for scaling of engine thrust; 3 = cubic, 2 = square
+	// default = 2
+	thrustScalePower = 3
+	
+	// if true, nozzle mass will be scaled according to the motorMassScalePower variable
+	scaleMotorMass = true
+	
+	// if scaleMotorMass = true, nozzle mass will be scaled according to this power (Mathf.pow(scale, power)*mass);
+	motorMassScalePower = 3
+	
+	// if true, resources are scaled according to booster size
+	// default = true
+	scaleResources = true
+	
+	// the power to use for scaling of resources; 3 = cubic (standard), 2 = square
+	// default = 3
+	resourceScalePower = 3
+	
+	// minimum available diameter for the booster/tank
+	// default = 0.625
+	minDiameter = 1
+	
+	// maximum available diameter for the booster/tank
+	// default = 10
+	maxDiameter = 10
+	
+	// how much the diameter is changed by the main diameter adjust button in the editor
+	// default = 0.625
+	diameterIncrement = 1
+	
+	// if true, RealFuels will be used to update the part volume and resources rather than internal methods
+	// default = false
+	useRF = true
+	
+	// this value determines how 'scale' is treated for thrust calculations, rather than using the models diameter
+	// set this to the value of your engine configs setup diameter (e.g if the real thing is 3.75m, that is what this value should be set to)
+	// default = -1 (disabled)
+	diameterForThrustScaling = 1.05
+		
+	//setup for 'defaults', differs from MFT by directly using the 'currentXX' fields, rather than a second set of fields specifically for the defaults
+	//these are all -mandatory- fields, or the part will not initialize properly
+	currentMainName = SRB-D-7
+	currentNoseName = SRB-Nosecone-2
+	currentNozzleName = Nozzle-SRB-E
+	currentDiameter = 1.05
+	
+	//fuel type info can be found in SSTU/Data/Tanks/FuelTypes.cfg
+	FUELTYPE	
+	{
+		name = Solid
+	}
+	
+	MAINMODEL
+	{
+		name = SRB-D-1
+		engineConfig = GEM401
+		volume = 16.053
+	}
+	MAINMODEL
+	{
+		name = SRB-D-2
+		engineConfig = GEM402
+		volume = 30.335
+	}
+	MAINMODEL
+	{
+		name = SRB-D-3
+		engineConfig = GEM403
+		volume = 44.617
+	}
+	MAINMODEL
+	{
+		name = SRB-D-4
+		engineConfig = GEM404
+		volume = 58.899
+	}
+	MAINMODEL
+	{
+		name = SRB-D-5
+		engineConfig = GEM405
+		volume = 73.181
+	}
+	MAINMODEL
+	{
+		name = SRB-D-6
+		engineConfig = GEM406
+		volume = 87.463
+	}
+	MAINMODEL
+	{
+		name = SRB-D-7
+		engineConfig = GEM407
+		volume = 101.745
+	}
+	MAINMODEL
+	{
+		name = SRB-D-8
+		engineConfig = GEM408
+		volume = 116.027
+	}
+	NOZZLE
+	{
+		name = Nozzle-SRB-C
+		thrustTransformName = SC-ENG-MOUNT-SRB-C-ThrustTransform
+		gimbalTransformName = SC-ENG-MOUNT-SRB-C-NOZZLE
+		gimbalAdjustRange = 10
+		gimbalFlightRange = 2
+	}
+	NOZZLE
+	{
+		name = Nozzle-SRB-E
+		thrustTransformName = SC-ENG-MOUNT-SRB-E-ThrustTransform
+		gimbalTransformName = SC-ENG-MOUNT-SRB-E-NOZZLE
+		gimbalAdjustRange = 5
+		gimbalFlightRange = 2
+	}
+	
+	NOSE
+	{
+		name = Adapter-Flat
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-1
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-2
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-3
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-4
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-5
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-6
+	}
+	NOSE
+	{
+		name = Nosecone-1
+	}
+	NOSE
+	{
+		name = Nosecone-2
+	}
+	NOSE
+	{
+		name = Nosecone-3
+	}
+	NOSE
+	{
+		name = Nosecone-4
+	}
+	NOSE
+	{
+		name = Nosecone-5
+	}
+}
+
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = GEM407
+	modded = false
+	isMaster = false
+	CONFIG
+	{
+		name = GEM401
+		maxThrust = 80.5
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}	
+	CONFIG
+	{
+		name = GEM402
+		maxThrust = 161
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}	
+	CONFIG
+	{
+		name = GEM403
+		maxThrust = 241.5
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}	
+	CONFIG
+	{
+		name = GEM404
+		maxThrust = 322
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = GEM405
+		maxThrust = 402.5
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = GEM406
+		maxThrust = 483
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = GEM407
+		maxThrust = 563
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = GEM408
+		maxThrust = 664
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = HTPB
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 279
+			key = 1 251
+		}
+		curveResource = HTPB
+		thrustCurve
+		{
+				key = 0.99597 1
+				key = 0.98568 0.989
+				key = 0.97585 0.944
+				key = 0.96596 0.95
+				key = 0.95606 0.951
+				key = 0.94613 0.954
+				key = 0.93617 0.957
+				key = 0.92616 0.961
+				key = 0.91612 0.965
+				key = 0.90603 0.969
+				key = 0.89589 0.975
+				key = 0.88572 0.977
+				key = 0.8755 0.982
+				key = 0.86525 0.984
+				key = 0.855 0.985
+				key = 0.84473 0.986
+				key = 0.83444 0.988
+				key = 0.82417 0.987
+				key = 0.8139 0.986
+				key = 0.80365 0.985
+				key = 0.7934 0.984
+				key = 0.78319 0.982
+				key = 0.77298 0.98
+				key = 0.76281 0.977
+				key = 0.75267 0.974
+				key = 0.74259 0.969
+				key = 0.73252 0.967
+				key = 0.72246 0.967
+				key = 0.71241 0.966
+				key = 0.70239 0.962
+				key = 0.6924 0.96
+				key = 0.68244 0.956
+				key = 0.67252 0.953
+				key = 0.66265 0.948
+				key = 0.65283 0.944
+				key = 0.64306 0.938
+				key = 0.63335 0.932
+				key = 0.6237 0.927
+				key = 0.61415 0.918
+				key = 0.60468 0.91
+				key = 0.59528 0.903
+				key = 0.58599 0.893
+				key = 0.57676 0.887
+				key = 0.56759 0.881
+				key = 0.55849 0.874
+				key = 0.54943 0.87
+				key = 0.54043 0.865
+				key = 0.53147 0.861
+				key = 0.52254 0.857
+				key = 0.51364 0.855
+				key = 0.5048 0.849
+				key = 0.49601 0.845
+				key = 0.48728 0.839
+				key = 0.47858 0.836
+				key = 0.46994 0.83
+				key = 0.46134 0.826
+				key = 0.45276 0.824
+				key = 0.44422 0.821
+				key = 0.43572 0.816
+				key = 0.42727 0.812
+				key = 0.41885 0.809
+				key = 0.41046 0.806
+				key = 0.40211 0.802
+				key = 0.39381 0.797
+				key = 0.38554 0.794
+				key = 0.37731 0.791
+				key = 0.3691 0.789
+				key = 0.36091 0.786
+				key = 0.35277 0.782
+				key = 0.34466 0.78
+				key = 0.33659 0.775
+				key = 0.32856 0.772
+				key = 0.32056 0.768
+				key = 0.31259 0.766
+				key = 0.30467 0.761
+				key = 0.29679 0.757
+				key = 0.28897 0.751
+				key = 0.28122 0.744
+				key = 0.27352 0.74
+				key = 0.26588 0.734
+				key = 0.25827 0.732
+				key = 0.25069 0.728
+				key = 0.24314 0.725
+				key = 0.23562 0.723
+				key = 0.22812 0.72
+				key = 0.22065 0.718
+				key = 0.21319 0.717
+				key = 0.20576 0.713
+				key = 0.19836 0.711
+				key = 0.19097 0.71
+				key = 0.18359 0.709
+				key = 0.17624 0.706
+				key = 0.16892 0.703
+				key = 0.16162 0.701
+				key = 0.15437 0.697
+				key = 0.14712 0.696
+				key = 0.13989 0.694
+				key = 0.13268 0.693
+				key = 0.1255 0.69
+				key = 0.11833 0.688
+				key = 0.1112 0.685
+				key = 0.10409 0.684
+				key = 0.09699 0.681
+				key = 0.08994 0.678
+				key = 0.08292 0.674
+				key = 0.07592 0.672
+				key = 0.06897 0.668
+				key = 0.06213 0.657
+				key = 0.05542 0.644
+				key = 0.04894 0.623
+				key = 0.04282 0.588
+				key = 0.03708 0.551
+				key = 0.03172 0.515
+				key = 0.02687 0.466
+				key = 0.02261 0.409
+				key = 0.01903 0.344
+				key = 0.01597 0.294
+				key = 0.01342 0.245
+				key = 0.0112 0.213
+				key = 0.00929 0.183
+				key = 0.00766 0.156
+				key = 0.00631 0.13
+				key = 0.00518 0.108
+				key = 0.00428 0.087
+				key = 0.00355 0.071
+				key = 0.00296 0.056
+				key = 0.00248 0.047
+				key = 0.00208 0.039
+				key = 0.00173 0.033
+				key = 0.00145 0.027
+				key = 0.00117 0.026
+				key = 0.00095 0.022
+				key = 0.00082 0.013
+				key = 0.00000 0.005
+		}
+	}
+	
+}
+
+
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_MSRB_RSRM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_MSRB_RSRM.cfg
@@ -1,0 +1,1717 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRBA
+author = Shadowmage
+
+TechRequired = basicRocketry
+entryCost = 16000
+cost = 0
+category = Engine
+subcategory = 0
+title = RSRM (Modular)
+manufacturer = Orbital ATK
+description = Modular RSRM booster.  Has options for up to 6 segements, with optional scaling of diameter
+RSSROConfig = True
+stagingIcon = SOLID_BOOSTER
+
+MODEL
+{
+	model = SSTU/Assets/EmptyProxyModel
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+node_stack_top = 0,1,0,0,1,0,2
+node_stack_bottom =  0,-1,0,0,-1,0,2
+node_attach = 1.25, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 1
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 6
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 1
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SSTU-MSRM-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SSTU-MSRM-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	heatProduction = 10
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0	
+	maxThrust = 14780
+	heatProduction = 100
+	PROPELLANT
+	{
+		name = PBAN
+		ratio = 1
+		DrawGauge = True
+	}
+	atmosphereCurve
+	{
+		key = 0 268.5
+		key = 1 243
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SSTU-MSRM-GimbalTransform
+	gimbalRange = 6
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 365486.64
+	type = PBAN
+}
+MODULE
+{
+	name = SSTUModularBooster
+	
+	// a transform of this name will be added and positioned for the main thrust transform
+	// default = empty
+	thrustTransformName = SSTU-MSRM-ThrustTransform	
+		
+	// if true, engine max thrust will scale with the SRB size
+	// default = true
+	scaleMotorThrust = true
+	
+	// the power to use for scaling of engine thrust; 3 = cubic, 2 = square
+	// default = 2
+	thrustScalePower = 3
+	
+	// if true, nozzle mass will be scaled according to the motorMassScalePower variable
+	scaleMotorMass = true
+	
+	// if scaleMotorMass = true, nozzle mass will be scaled according to this power (Mathf.pow(scale, power)*mass);
+	motorMassScalePower = 3
+	
+	// if true, resources are scaled according to booster size
+	// default = true
+	scaleResources = true
+	
+	// the power to use for scaling of resources; 3 = cubic (standard), 2 = square
+	// default = 3
+	resourceScalePower = 3
+	
+	// minimum available diameter for the booster/tank
+	// default = 0.625
+	minDiameter = 1
+	
+	// maximum available diameter for the booster/tank
+	// default = 10
+	maxDiameter = 10
+	
+	// how much the diameter is changed by the main diameter adjust button in the editor
+	// default = 0.625
+	diameterIncrement = 1
+	
+	// if true, RealFuels will be used to update the part volume and resources rather than internal methods
+	// default = false
+	useRF = true
+	
+	// this value determines how 'scale' is treated for thrust calculations, rather than using the models diameter
+	// set this to the value of your engine configs setup diameter (e.g if the real thing is 3.75m, that is what this value should be set to)
+	// default = -1 (disabled)
+	diameterForThrustScaling = 3.75
+	
+	// which tech-limit set determines the limitations for this part?	
+	techLimitSet = Default
+		
+	currentMainName = SRB-A-4
+	currentNoseName = SRB-Nosecone-1
+	currentNozzleName = Nozzle-SRB-A
+	currentDiameter = 3.75
+	
+	//fuel type info can be found in SSTU/Data/Tanks/FuelTypes.cfg
+	//not used for RO, but still needs to be defined
+	FUELTYPE	
+	{
+		name = Solid
+	}
+	
+	MAINMODEL
+	{
+		name = SRB-A-1
+		engineConfig = RSRM-1
+		volume = 29.6
+	}
+	MAINMODEL
+	{
+		name = SRB-A-2
+		engineConfig = RSRM-2
+		volume = 54.6
+	}
+	MAINMODEL
+	{
+		name = SRB-A-3
+		engineConfig = RSRM-3
+		volume = 74.4
+	}
+	MAINMODEL
+	{
+		name = SRB-A-4
+		engineConfig = RSRM
+		volume = 97.6
+	}
+	MAINMODEL
+	{
+		name = SRB-A-5
+		engineConfig = RSRMV
+		volume = 125.9
+	}
+	MAINMODEL
+	{
+		name = SRB-A-6
+		engineConfig = RSRM-6
+		volume = 150.2
+	}
+	NOZZLE
+	{
+		name = Nozzle-SRB-A
+		thrustTransformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+		gimbalTransformName = SC-ENG-MOUNT-SRB-A-NOZZLE
+		gimbalAdjustRange = 1
+		gimbalFlightRange = 6
+	}	
+	NOSE
+	{
+		name = Adapter-Flat
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-1
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-2
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-3
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-4
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-5
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-6
+	}
+	NOSE
+	{
+		name = Nosecone-1
+	}
+	NOSE
+	{
+		name = Nosecone-2
+	}
+	NOSE
+	{
+		name = Nosecone-3
+	}
+	NOSE
+	{
+		name = Nosecone-4
+	}
+	NOSE
+	{
+		name = Nosecone-5
+	}
+}
+
+
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = RSRM-4
+	modded = false
+	isMaster = false
+	CONFIG
+	{
+		name = RSRM-1
+		maxThrust = 4092
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 267
+			key = 1 235
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1.0		0.933
+			key = 	0.995	0.9333
+			key = 	0.99	0.9366
+			key = 	0.985	0.9399
+			key = 	0.98	0.9432
+			key = 	0.975	0.9474
+			key = 	0.97	0.9523
+			key = 	0.965	0.9568
+			key = 	0.96	0.9611
+			key = 	0.955	0.9673
+			key = 	0.95	0.9737
+			key = 	0.945	0.979
+			key = 	0.94	0.984
+			key = 	0.935	0.9871
+			key = 	0.93	0.9896
+			key = 	0.925	0.9896
+			key = 	0.92	0.9896
+			key = 	0.915	0.9896
+			key = 	0.91	0.9896
+			key = 	0.905	0.9896
+			key = 	0.9		0.9896
+			key = 	0.895	0.9896
+			key = 	0.89	0.9896
+			key = 	0.885	0.9896
+			key = 	0.88	0.9896
+			key = 	0.875	0.9896
+			key = 	0.87	0.9896
+			key = 	0.865	0.9896
+			key = 	0.86	0.9905
+			key = 	0.855	0.9915
+			key = 	0.85	0.9935
+			key = 	0.845	0.9955
+			key = 	0.84	0.9955
+			key = 	0.835	0.9955
+			key = 	0.83	0.9955
+			key = 	0.825	0.9947
+			key = 	0.82	0.9905
+			key = 	0.815	0.9875
+			key = 	0.81	0.9875
+			key = 	0.805	0.9895
+			key = 	0.8		0.9947
+			key = 	0.795	0.998
+			key = 	0.79	0.999
+			key = 	0.785	0.9978
+			key = 	0.78	0.9947
+			key = 	0.775	0.9922
+			key = 	0.77	0.9901
+			key = 	0.765	0.9887
+			key = 	0.76	0.9876
+			key = 	0.755	0.9848
+			key = 	0.75	0.9816
+			key = 	0.745	0.9804
+			key = 	0.74	0.9794
+			key = 	0.735	0.9794
+			key = 	0.73	0.9794
+			key = 	0.725	0.9794
+			key = 	0.72	0.9797
+			key = 	0.715	0.9808
+			key = 	0.71	0.9807
+			key = 	0.705	0.9786
+			key = 	0.7		0.977
+			key = 	0.695	0.9759
+			key = 	0.69	0.9755
+			key = 	0.685	0.9755
+			key = 	0.68	0.9755
+			key = 	0.675	0.9755
+			key = 	0.67	0.9755
+			key = 	0.665	0.9755
+			key = 	0.66	0.9755
+			key = 	0.655	0.9755
+			key = 	0.65	0.9755
+			key = 	0.645	0.9755
+			key = 	0.64	0.9755
+			key = 	0.635	0.9755
+			key = 	0.63	0.9755
+			key = 	0.625	0.975
+			key = 	0.62	0.9739
+			key = 	0.615	0.9734
+			key = 	0.61	0.9734
+			key = 	0.605	0.9734
+			key = 	0.6		0.9734
+			key = 	0.595	0.9725
+			key = 	0.59	0.9714
+			key = 	0.585	0.9713
+			key = 	0.58	0.9714
+			key = 	0.575	0.9735
+			key = 	0.57	0.9754
+			key = 	0.565	0.9765
+			key = 	0.56	0.9773
+			key = 	0.555	0.9773
+			key = 	0.55	0.976
+			key = 	0.545	0.9728
+			key = 	0.54	0.9713
+			key = 	0.535	0.9713
+			key = 	0.53	0.9713
+			key = 	0.525	0.9713
+			key = 	0.52	0.9713
+			key = 	0.515	0.9713
+			key = 	0.51	0.9713
+			key = 	0.505	0.9714
+			key = 	0.5		0.9735
+			key = 	0.495	0.9753
+			key = 	0.49	0.9753
+			key = 	0.485	0.9759
+			key = 	0.48	0.978
+			key = 	0.475	0.9805
+			key = 	0.47	0.9837
+			key = 	0.465	0.9863
+			key = 	0.46	0.9884
+			key = 	0.455	0.9899
+			key = 	0.45	0.9909
+			key = 	0.445	0.9912
+			key = 	0.44	0.9912
+			key = 	0.435	0.9928
+			key = 	0.43	0.9949
+			key = 	0.425	0.9952
+			key = 	0.42	0.9952
+			key = 	0.415	0.9952
+			key = 	0.41	0.9952
+			key = 	0.405	0.9952
+			key = 	0.4		0.9952
+			key = 	0.395	0.9952
+			key = 	0.39	0.9955
+			key = 	0.385	0.9976
+			key = 	0.38	0.9992
+			key = 	0.375	0.9992
+			key = 	0.37	0.9992
+			key = 	0.365	0.9992
+			key = 	0.36	0.9984
+			key = 	0.355	0.9963
+			key = 	0.35	0.9947
+			key = 	0.345	0.9937
+			key = 	0.34	0.9921
+			key = 	0.335	0.99
+			key = 	0.33	0.9886
+			key = 	0.325	0.9875
+			key = 	0.32	0.9896
+			key = 	0.315	0.9927
+			key = 	0.31	0.9941
+			key = 	0.305	0.9951
+			key = 	0.3		0.9942
+			key = 	0.295	0.9932
+			key = 	0.29	0.9911
+			key = 	0.285	0.9891
+			key = 	0.28	0.988
+			key = 	0.275	0.9871
+			key = 	0.27	0.9871
+			key = 	0.265	0.9859
+			key = 	0.26	0.9817
+			key = 	0.255	0.9783
+			key = 	0.25	0.9762
+			key = 	0.245	0.9732
+			key = 	0.24	0.9694
+			key = 	0.235	0.9625
+			key = 	0.23	0.9538
+			key = 	0.225	0.9468
+			key = 	0.22	0.9402
+			key = 	0.215	0.9335
+			key = 	0.21	0.9272
+			key = 	0.205	0.9227
+			key = 	0.2		0.9201
+			key = 	0.195	0.9201
+			key = 	0.19	0.9194
+			key = 	0.185	0.9183
+			key = 	0.18	0.9131
+			key = 	0.175	0.9078
+			key = 	0.17	0.9055
+			key = 	0.165	0.9025
+			key = 	0.16	0.8984
+			key = 	0.155	0.8955
+			key = 	0.15	0.8932
+			key = 	0.145	0.8931
+			key = 	0.14	0.8926
+			key = 	0.135	0.8903
+			key = 	0.13	0.8868
+			key = 	0.125	0.8821
+			key = 	0.12	0.8774
+			key = 	0.115	0.8726
+			key = 	0.11	0.8678
+			key = 	0.105	0.863
+			key = 	0.1		0.8582
+			key = 	0.095	0.8553
+			key = 	0.09	0.8531
+			key = 	0.085	0.8519
+			key = 	0.08	0.8488
+			key = 	0.075	0.8439
+			key = 	0.07	0.8406
+			key = 	0.065	0.837
+			key = 	0.06	0.832
+			key = 	0.055	0.8209
+			key = 	0.05	0.803
+			key = 	0.045	0.7546
+			key = 	0.04	0.6908
+			key = 	0.035	0.6306
+			key = 	0.03	0.5845
+			key = 	0.025	0.5245
+			key = 	0.02	0.4245
+			key = 	0.015	0.3756
+			key = 	0.01	0.3678
+			key = 	0.009	0.3549
+			key = 	0.008	0.342
+			key = 	0.007	0.3277
+			key = 	0.006	0.3062
+			key = 	0.005	0.2847
+			key = 	0.004	0.2431
+			key = 	0.003	0.183
+			key = 	0.002	0.0884
+			key = 	0.001	0.0384
+			key = 	0		0.0014
+		}
+	}	
+	CONFIG
+	{
+		name = RSRM-2
+		maxThrust = 7305
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 265
+			key = 1 234
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1.0		0.933
+			key = 	0.995	0.9333
+			key = 	0.99	0.9366
+			key = 	0.985	0.9399
+			key = 	0.98	0.9432
+			key = 	0.975	0.9474
+			key = 	0.97	0.9523
+			key = 	0.965	0.9568
+			key = 	0.96	0.9611
+			key = 	0.955	0.9673
+			key = 	0.95	0.9737
+			key = 	0.945	0.979
+			key = 	0.94	0.984
+			key = 	0.935	0.9871
+			key = 	0.93	0.9896
+			key = 	0.925	0.9896
+			key = 	0.92	0.9896
+			key = 	0.915	0.9896
+			key = 	0.91	0.9896
+			key = 	0.905	0.9896
+			key = 	0.9		0.9896
+			key = 	0.895	0.9896
+			key = 	0.89	0.9896
+			key = 	0.885	0.9896
+			key = 	0.88	0.9896
+			key = 	0.875	0.9896
+			key = 	0.87	0.9896
+			key = 	0.865	0.9896
+			key = 	0.86	0.9905
+			key = 	0.855	0.9915
+			key = 	0.85	0.9935
+			key = 	0.845	0.9955
+			key = 	0.84	0.9955
+			key = 	0.835	0.9955
+			key = 	0.83	0.9955
+			key = 	0.825	0.9947
+			key = 	0.82	0.9905
+			key = 	0.815	0.9875
+			key = 	0.81	0.9875
+			key = 	0.805	0.9895
+			key = 	0.8		0.9947
+			key = 	0.795	0.998
+			key = 	0.79	0.999
+			key = 	0.785	0.9978
+			key = 	0.78	0.9947
+			key = 	0.775	0.9922
+			key = 	0.77	0.9901
+			key = 	0.765	0.9887
+			key = 	0.76	0.9876
+			key = 	0.755	0.9848
+			key = 	0.75	0.9816
+			key = 	0.745	0.9804
+			key = 	0.74	0.9794
+			key = 	0.735	0.9794
+			key = 	0.73	0.9794
+			key = 	0.725	0.9794
+			key = 	0.72	0.9797
+			key = 	0.715	0.9808
+			key = 	0.71	0.9807
+			key = 	0.705	0.9786
+			key = 	0.7		0.977
+			key = 	0.695	0.9759
+			key = 	0.69	0.9755
+			key = 	0.685	0.9755
+			key = 	0.68	0.9755
+			key = 	0.675	0.9755
+			key = 	0.67	0.9755
+			key = 	0.665	0.9755
+			key = 	0.66	0.9755
+			key = 	0.655	0.9755
+			key = 	0.65	0.9755
+			key = 	0.645	0.9755
+			key = 	0.64	0.9755
+			key = 	0.635	0.9755
+			key = 	0.63	0.9755
+			key = 	0.625	0.975
+			key = 	0.62	0.9739
+			key = 	0.615	0.9734
+			key = 	0.61	0.9734
+			key = 	0.605	0.9734
+			key = 	0.6		0.9734
+			key = 	0.595	0.9725
+			key = 	0.59	0.9714
+			key = 	0.585	0.9713
+			key = 	0.58	0.9714
+			key = 	0.575	0.9735
+			key = 	0.57	0.9754
+			key = 	0.565	0.9765
+			key = 	0.56	0.9773
+			key = 	0.555	0.9773
+			key = 	0.55	0.976
+			key = 	0.545	0.9728
+			key = 	0.54	0.9713
+			key = 	0.535	0.9713
+			key = 	0.53	0.9713
+			key = 	0.525	0.9713
+			key = 	0.52	0.9713
+			key = 	0.515	0.9713
+			key = 	0.51	0.9713
+			key = 	0.505	0.9714
+			key = 	0.5		0.9735
+			key = 	0.495	0.9753
+			key = 	0.49	0.9753
+			key = 	0.485	0.9759
+			key = 	0.48	0.978
+			key = 	0.475	0.9805
+			key = 	0.47	0.9837
+			key = 	0.465	0.9863
+			key = 	0.46	0.9884
+			key = 	0.455	0.9899
+			key = 	0.45	0.9909
+			key = 	0.445	0.9912
+			key = 	0.44	0.9912
+			key = 	0.435	0.9928
+			key = 	0.43	0.9949
+			key = 	0.425	0.9952
+			key = 	0.42	0.9952
+			key = 	0.415	0.9952
+			key = 	0.41	0.9952
+			key = 	0.405	0.9952
+			key = 	0.4		0.9952
+			key = 	0.395	0.9952
+			key = 	0.39	0.9955
+			key = 	0.385	0.9976
+			key = 	0.38	0.9992
+			key = 	0.375	0.9992
+			key = 	0.37	0.9992
+			key = 	0.365	0.9992
+			key = 	0.36	0.9984
+			key = 	0.355	0.9963
+			key = 	0.35	0.9947
+			key = 	0.345	0.9937
+			key = 	0.34	0.9921
+			key = 	0.335	0.99
+			key = 	0.33	0.9886
+			key = 	0.325	0.9875
+			key = 	0.32	0.9896
+			key = 	0.315	0.9927
+			key = 	0.31	0.9941
+			key = 	0.305	0.9951
+			key = 	0.3		0.9942
+			key = 	0.295	0.9932
+			key = 	0.29	0.9911
+			key = 	0.285	0.9891
+			key = 	0.28	0.988
+			key = 	0.275	0.9871
+			key = 	0.27	0.9871
+			key = 	0.265	0.9859
+			key = 	0.26	0.9817
+			key = 	0.255	0.9783
+			key = 	0.25	0.9762
+			key = 	0.245	0.9732
+			key = 	0.24	0.9694
+			key = 	0.235	0.9625
+			key = 	0.23	0.9538
+			key = 	0.225	0.9468
+			key = 	0.22	0.9402
+			key = 	0.215	0.9335
+			key = 	0.21	0.9272
+			key = 	0.205	0.9227
+			key = 	0.2		0.9201
+			key = 	0.195	0.9201
+			key = 	0.19	0.9194
+			key = 	0.185	0.9183
+			key = 	0.18	0.9131
+			key = 	0.175	0.9078
+			key = 	0.17	0.9055
+			key = 	0.165	0.9025
+			key = 	0.16	0.8984
+			key = 	0.155	0.8955
+			key = 	0.15	0.8932
+			key = 	0.145	0.8931
+			key = 	0.14	0.8926
+			key = 	0.135	0.8903
+			key = 	0.13	0.8868
+			key = 	0.125	0.8821
+			key = 	0.12	0.8774
+			key = 	0.115	0.8726
+			key = 	0.11	0.8678
+			key = 	0.105	0.863
+			key = 	0.1		0.8582
+			key = 	0.095	0.8553
+			key = 	0.09	0.8531
+			key = 	0.085	0.8519
+			key = 	0.08	0.8488
+			key = 	0.075	0.8439
+			key = 	0.07	0.8406
+			key = 	0.065	0.837
+			key = 	0.06	0.832
+			key = 	0.055	0.8209
+			key = 	0.05	0.803
+			key = 	0.045	0.7546
+			key = 	0.04	0.6908
+			key = 	0.035	0.6306
+			key = 	0.03	0.5845
+			key = 	0.025	0.5245
+			key = 	0.02	0.4245
+			key = 	0.015	0.3756
+			key = 	0.01	0.3678
+			key = 	0.009	0.3549
+			key = 	0.008	0.342
+			key = 	0.007	0.3277
+			key = 	0.006	0.3062
+			key = 	0.005	0.2847
+			key = 	0.004	0.2431
+			key = 	0.003	0.183
+			key = 	0.002	0.0884
+			key = 	0.001	0.0384
+			key = 	0		0.0014
+		}
+	}	
+	CONFIG
+	{
+		name = RSRM-3
+		maxThrust = 11790
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 264.4
+			key = 1 243
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.985
+			key = 	0.995	0.98
+			key = 	0.99	0.975
+			key = 	0.985	0.97
+			key = 	0.98	0.967
+			key = 	0.975	0.964
+			key = 	0.97	0.961
+			key = 	0.965	0.96
+			key = 	0.96	0.96
+			key = 	0.955	0.961
+			key = 	0.95	0.963
+			key = 	0.945	0.965
+			key = 	0.94	0.968
+			key = 	0.935	0.971
+			key = 	0.93	0.976
+			key = 	0.925	0.984
+			key = 	0.92	0.992
+			key = 	0.915	0.997
+			key = 	0.91	0.999
+			key = 	0.905	1
+			key = 	0.9	1
+			key = 	0.895	0.9995
+			key = 	0.89	0.999
+			key = 	0.885	0.998
+			key = 	0.88	0.997
+			key = 	0.875	0.996
+			key = 	0.87	0.995
+			key = 	0.865	0.994
+			key = 	0.86	0.993
+			key = 	0.855	0.992
+			key = 	0.85	0.991
+			key = 	0.845	0.99
+			key = 	0.84	0.989
+			key = 	0.835	0.988
+			key = 	0.83	0.987
+			key = 	0.825	0.986
+			key = 	0.82	0.985
+			key = 	0.815	0.984
+			key = 	0.81	0.983
+			key = 	0.805	0.982
+			key = 	0.8	0.981
+			key = 	0.795	0.98
+			key = 	0.79	0.979
+			key = 	0.785	0.978
+			key = 	0.78	0.977
+			key = 	0.775	0.976
+			key = 	0.77	0.9745
+			key = 	0.765	0.973
+			key = 	0.76	0.9715
+			key = 	0.755	0.97
+			key = 	0.75	0.968
+			key = 	0.745	0.966
+			key = 	0.74	0.96
+			key = 	0.735	0.948
+			key = 	0.73	0.936
+			key = 	0.725	0.924
+			key = 	0.72	0.912
+			key = 	0.715	0.9
+			key = 	0.71	0.888
+			key = 	0.705	0.878
+			key = 	0.7	0.868
+			key = 	0.695	0.858
+			key = 	0.69	0.848
+			key = 	0.685	0.838
+			key = 	0.68	0.828
+			key = 	0.675	0.818
+			key = 	0.67	0.808
+			key = 	0.665	0.798
+			key = 	0.66	0.788
+			key = 	0.655	0.778
+			key = 	0.65	0.768
+			key = 	0.645	0.758
+			key = 	0.64	0.748
+			key = 	0.635	0.738
+			key = 	0.63	0.728
+			key = 	0.625	0.718
+			key = 	0.62	0.708
+			key = 	0.615	0.698
+			key = 	0.61	0.688
+			key = 	0.605	0.68
+			key = 	0.6	0.672
+			key = 	0.595	0.664
+			key = 	0.59	0.656
+			key = 	0.585	0.648
+			key = 	0.58	0.64
+			key = 	0.575	0.632
+			key = 	0.57	0.625
+			key = 	0.565	0.618
+			key = 	0.56	0.611
+			key = 	0.555	0.604
+			key = 	0.55	0.597
+			key = 	0.545	0.59
+			key = 	0.54	0.583
+			key = 	0.535	0.577
+			key = 	0.53	0.571
+			key = 	0.525	0.565
+			key = 	0.52	0.556
+			key = 	0.515	0.551
+			key = 	0.51	0.553
+			key = 	0.505	0.559
+			key = 	0.5	0.561
+			key = 	0.495	0.556
+			key = 	0.49	0.551
+			key = 	0.485	0.546
+			key = 	0.48	0.546
+			key = 	0.475	0.548
+			key = 	0.47	0.551
+			key = 	0.465	0.554
+			key = 	0.46	0.557
+			key = 	0.455	0.56
+			key = 	0.45	0.562
+			key = 	0.445	0.5635
+			key = 	0.44	0.565
+			key = 	0.435	0.5665
+			key = 	0.43	0.568
+			key = 	0.425	0.5695
+			key = 	0.42	0.571
+			key = 	0.415	0.5725
+			key = 	0.41	0.574
+			key = 	0.405	0.5755
+			key = 	0.4	0.577
+			key = 	0.395	0.5785
+			key = 	0.39	0.58
+			key = 	0.385	0.5815
+			key = 	0.38	0.583
+			key = 	0.375	0.5845
+			key = 	0.37	0.586
+			key = 	0.365	0.5875
+			key = 	0.36	0.589
+			key = 	0.355	0.5905
+			key = 	0.35	0.592
+			key = 	0.345	0.5935
+			key = 	0.34	0.595
+			key = 	0.335	0.5965
+			key = 	0.33	0.598
+			key = 	0.325	0.5995
+			key = 	0.32	0.601
+			key = 	0.315	0.6025
+			key = 	0.31	0.604
+			key = 	0.305	0.6055
+			key = 	0.3	0.607
+			key = 	0.295	0.6085
+			key = 	0.29	0.61
+			key = 	0.285	0.6115
+			key = 	0.28	0.613
+			key = 	0.275	0.6145
+			key = 	0.27	0.616
+			key = 	0.265	0.6175
+			key = 	0.26	0.619
+			key = 	0.255	0.6205
+			key = 	0.25	0.622
+			key = 	0.245	0.6235
+			key = 	0.24	0.625
+			key = 	0.235	0.625
+			key = 	0.23	0.624
+			key = 	0.225	0.622
+			key = 	0.22	0.62
+			key = 	0.215	0.618
+			key = 	0.21	0.6155
+			key = 	0.205	0.613
+			key = 	0.2	0.6105
+			key = 	0.195	0.608
+			key = 	0.19	0.6055
+			key = 	0.185	0.6015
+			key = 	0.18	0.5975
+			key = 	0.175	0.5935
+			key = 	0.17	0.5895
+			key = 	0.165	0.5855
+			key = 	0.16	0.5815
+			key = 	0.155	0.5775
+			key = 	0.15	0.5715
+			key = 	0.145	0.5655
+			key = 	0.14	0.5595
+			key = 	0.135	0.5535
+			key = 	0.13	0.5415
+			key = 	0.125	0.5295
+			key = 	0.12	0.5175
+			key = 	0.115	0.5075
+			key = 	0.11	0.4975
+			key = 	0.105	0.4895
+			key = 	0.1	0.4865
+			key = 	0.095	0.4835
+			key = 	0.09	0.4805
+			key = 	0.085	0.4775
+			key = 	0.08	0.4745
+			key = 	0.075	0.4715
+			key = 	0.07	0.4635
+			key = 	0.065	0.4535
+			key = 	0.06	0.4435
+			key = 	0.055	0.4335
+			key = 	0.05	0.4235
+			key = 	0.045	0.4135
+			key = 	0.04	0.4035
+			key = 	0.035	0.3935
+			key = 	0.03	0.3835
+			key = 	0.025	0.3735
+			key = 	0.02	0.3635
+			key = 	0.015	0.3435
+			key = 	0.01	0.3135
+			key = 	0.009	0.3005
+			key = 	0.008	0.2805
+			key = 	0.007	0.2505
+			key = 	0.006	0.2155
+			key = 	0.005	0.1755
+			key = 	0.004	0.1255
+			key = 	0.003	0.0955
+			key = 	0.002	0.0655
+			key = 	0.001	0.0305
+			key = 	0	0.0005
+		}
+	}	
+	CONFIG
+	{
+		name = RSRM
+		maxThrust = 14780
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 268.5
+			key = 1 243
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.945
+			key = 	0.995	0.945
+			key = 	0.99	0.9437
+			key = 	0.985	0.9423
+			key = 	0.98	0.942
+			key = 	0.975	0.942
+			key = 	0.97	0.9439
+			key = 	0.965	0.9467
+			key = 	0.96	0.9508
+			key = 	0.955	0.9559
+			key = 	0.95	0.9605
+			key = 	0.945	0.9642
+			key = 	0.94	0.9682
+			key = 	0.935	0.9732
+			key = 	0.93	0.9781
+			key = 	0.925	0.9795
+			key = 	0.92	0.9809
+			key = 	0.915	0.983
+			key = 	0.91	0.9853
+			key = 	0.905	0.987
+			key = 	0.9	0.9884
+			key = 	0.895	0.9892
+			key = 	0.89	0.9892
+			key = 	0.885	0.9895
+			key = 	0.88	0.9909
+			key = 	0.875	0.9923
+			key = 	0.87	0.9923
+			key = 	0.865	0.9923
+			key = 	0.86	0.993
+			key = 	0.855	0.9939
+			key = 	0.85	0.9943
+			key = 	0.845	0.9943
+			key = 	0.84	0.9943
+			key = 	0.835	0.9943
+			key = 	0.83	0.9943
+			key = 	0.825	0.9943
+			key = 	0.82	0.9943
+			key = 	0.815	0.9955
+			key = 	0.81	0.9968
+			key = 	0.805	0.9973
+			key = 	0.8	0.9973
+			key = 	0.795	0.9979
+			key = 	0.79	0.9992
+			key = 	0.785	1.0003
+			key = 	0.78	1.0003
+			key = 	0.775	1.0003
+			key = 	0.77	1.0003
+			key = 	0.765	1.0003
+			key = 	0.76	0.9968
+			key = 	0.755	0.9918
+			key = 	0.75	0.9836
+			key = 	0.745	0.972
+			key = 	0.74	0.9608
+			key = 	0.735	0.9504
+			key = 	0.73	0.9412
+			key = 	0.725	0.9364
+			key = 	0.72	0.9311
+			key = 	0.715	0.9228
+			key = 	0.71	0.915
+			key = 	0.705	0.9125
+			key = 	0.7	0.9099
+			key = 	0.695	0.9054
+			key = 	0.69	0.9009
+			key = 	0.685	0.8954
+			key = 	0.68	0.8899
+			key = 	0.675	0.8848
+			key = 	0.67	0.8798
+			key = 	0.665	0.8752
+			key = 	0.66	0.8704
+			key = 	0.655	0.8647
+			key = 	0.65	0.859
+			key = 	0.645	0.8532
+			key = 	0.64	0.8474
+			key = 	0.635	0.8415
+			key = 	0.63	0.8363
+			key = 	0.625	0.832
+			key = 	0.62	0.8277
+			key = 	0.615	0.8234
+			key = 	0.61	0.819
+			key = 	0.605	0.8146
+			key = 	0.6	0.8112
+			key = 	0.595	0.8078
+			key = 	0.59	0.8033
+			key = 	0.585	0.7983
+			key = 	0.58	0.7921
+			key = 	0.575	0.7877
+			key = 	0.57	0.7848
+			key = 	0.565	0.7792
+			key = 	0.56	0.7729
+			key = 	0.555	0.7682
+			key = 	0.55	0.7639
+			key = 	0.545	0.7604
+			key = 	0.54	0.758
+			key = 	0.535	0.7562
+			key = 	0.53	0.7533
+			key = 	0.525	0.7502
+			key = 	0.52	0.7466
+			key = 	0.515	0.7411
+			key = 	0.51	0.7344
+			key = 	0.505	0.7276
+			key = 	0.5	0.7221
+			key = 	0.495	0.719
+			key = 	0.49	0.7159
+			key = 	0.485	0.7132
+			key = 	0.48	0.7132
+			key = 	0.475	0.7132
+			key = 	0.47	0.7132
+			key = 	0.465	0.7144
+			key = 	0.46	0.7165
+			key = 	0.455	0.7202
+			key = 	0.45	0.7234
+			key = 	0.445	0.7263
+			key = 	0.44	0.7281
+			key = 	0.435	0.7299
+			key = 	0.43	0.7317
+			key = 	0.425	0.733
+			key = 	0.42	0.7347
+			key = 	0.415	0.7383
+			key = 	0.41	0.7409
+			key = 	0.405	0.7427
+			key = 	0.4	0.744
+			key = 	0.395	0.7453
+			key = 	0.39	0.7471
+			key = 	0.385	0.7489
+			key = 	0.38	0.7507
+			key = 	0.375	0.7525
+			key = 	0.37	0.7542
+			key = 	0.365	0.7554
+			key = 	0.36	0.7569
+			key = 	0.355	0.7587
+			key = 	0.35	0.7618
+			key = 	0.345	0.7651
+			key = 	0.34	0.7663
+			key = 	0.335	0.7677
+			key = 	0.33	0.7694
+			key = 	0.325	0.77
+			key = 	0.32	0.77
+			key = 	0.315	0.7716
+			key = 	0.31	0.773
+			key = 	0.305	0.773
+			key = 	0.3	0.7738
+			key = 	0.295	0.7755
+			key = 	0.29	0.776
+			key = 	0.285	0.776
+			key = 	0.28	0.776
+			key = 	0.275	0.776
+			key = 	0.27	0.776
+			key = 	0.265	0.7751
+			key = 	0.26	0.7734
+			key = 	0.255	0.7694
+			key = 	0.25	0.7648
+			key = 	0.245	0.7613
+			key = 	0.24	0.7573
+			key = 	0.235	0.7525
+			key = 	0.23	0.7477
+			key = 	0.225	0.7429
+			key = 	0.22	0.7393
+			key = 	0.215	0.734
+			key = 	0.21	0.726
+			key = 	0.205	0.7198
+			key = 	0.2	0.7146
+			key = 	0.195	0.7115
+			key = 	0.19	0.7043
+			key = 	0.185	0.694
+			key = 	0.18	0.6868
+			key = 	0.175	0.6786
+			key = 	0.17	0.6692
+			key = 	0.165	0.6651
+			key = 	0.16	0.6624
+			key = 	0.155	0.661
+			key = 	0.15	0.6569
+			key = 	0.145	0.6539
+			key = 	0.14	0.6517
+			key = 	0.135	0.6482
+			key = 	0.13	0.6406
+			key = 	0.125	0.6317
+			key = 	0.12	0.626
+			key = 	0.115	0.6202
+			key = 	0.11	0.6144
+			key = 	0.105	0.6087
+			key = 	0.1	0.6043
+			key = 	0.095	0.5987
+			key = 	0.09	0.5917
+			key = 	0.085	0.5835
+			key = 	0.08	0.5773
+			key = 	0.075	0.571
+			key = 	0.07	0.5606
+			key = 	0.065	0.5469
+			key = 	0.06	0.534
+			key = 	0.055	0.5246
+			key = 	0.05	0.5216
+			key = 	0.045	0.521
+			key = 	0.04	0.5168
+			key = 	0.035	0.5002
+			key = 	0.03	0.4681
+			key = 	0.025	0.4226
+			key = 	0.02	0.3576
+			key = 	0.015	0.2926
+			key = 	0.01	0.2226
+			key = 	0.009	0.2076
+			key = 	0.008	0.1877
+			key = 	0.007	0.1677
+			key = 	0.006	0.1477
+			key = 	0.005	0.1277
+			key = 	0.004	0.1077
+			key = 	0.003	0.0827
+			key = 	0.002	0.0427
+			key = 	0.001	0.0127
+			key = 	0	0.0007
+		}
+	}
+	CONFIG
+	{
+		name = RSRMV
+		maxThrust = 17885
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 267
+			key = 1 245
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.95
+			key = 	0.995	0.9549
+			key = 	0.99	0.9562
+			key = 	0.985	0.9562
+			key = 	0.98	0.9562
+			key = 	0.975	0.9562
+			key = 	0.97	0.9565
+			key = 	0.965	0.9574
+			key = 	0.96	0.9585
+			key = 	0.955	0.9616
+			key = 	0.95	0.9647
+			key = 	0.945	0.9682
+			key = 	0.94	0.9718
+			key = 	0.935	0.9751
+			key = 	0.93	0.9782
+			key = 	0.925	0.9811
+			key = 	0.92	0.9837
+			key = 	0.915	0.9863
+			key = 	0.91	0.9876
+			key = 	0.905	0.9889
+			key = 	0.9	0.9899
+			key = 	0.895	0.9908
+			key = 	0.89	0.9922
+			key = 	0.885	0.994
+			key = 	0.88	0.9953
+			key = 	0.875	0.9953
+			key = 	0.87	0.9953
+			key = 	0.865	0.9953
+			key = 	0.86	0.9953
+			key = 	0.855	0.9953
+			key = 	0.85	0.9953
+			key = 	0.845	0.9953
+			key = 	0.84	0.9953
+			key = 	0.835	0.9951
+			key = 	0.83	0.9942
+			key = 	0.825	0.9933
+			key = 	0.82	0.9911
+			key = 	0.815	0.9889
+			key = 	0.81	0.9856
+			key = 	0.805	0.982
+			key = 	0.8	0.9781
+			key = 	0.795	0.974
+			key = 	0.79	0.9691
+			key = 	0.785	0.963
+			key = 	0.78	0.9564
+			key = 	0.775	0.9478
+			key = 	0.77	0.9397
+			key = 	0.765	0.9349
+			key = 	0.76	0.93
+			key = 	0.755	0.9236
+			key = 	0.75	0.9172
+			key = 	0.745	0.9117
+			key = 	0.74	0.9062
+			key = 	0.735	0.9007
+			key = 	0.73	0.8952
+			key = 	0.725	0.8896
+			key = 	0.72	0.8838
+			key = 	0.715	0.876
+			key = 	0.71	0.8685
+			key = 	0.705	0.8627
+			key = 	0.7	0.8566
+			key = 	0.695	0.8496
+			key = 	0.69	0.843
+			key = 	0.685	0.837
+			key = 	0.68	0.8309
+			key = 	0.675	0.8248
+			key = 	0.67	0.8195
+			key = 	0.665	0.8144
+			key = 	0.66	0.8058
+			key = 	0.655	0.798
+			key = 	0.65	0.7928
+			key = 	0.645	0.7891
+			key = 	0.64	0.7868
+			key = 	0.635	0.78
+			key = 	0.63	0.7726
+			key = 	0.625	0.7672
+			key = 	0.62	0.7611
+			key = 	0.615	0.7543
+			key = 	0.61	0.7502
+			key = 	0.605	0.7463
+			key = 	0.6	0.7419
+			key = 	0.595	0.7388
+			key = 	0.59	0.7358
+			key = 	0.585	0.7287
+			key = 	0.58	0.7233
+			key = 	0.575	0.7194
+			key = 	0.57	0.7121
+			key = 	0.565	0.7048
+			key = 	0.56	0.6974
+			key = 	0.555	0.6926
+			key = 	0.55	0.6882
+			key = 	0.545	0.6841
+			key = 	0.54	0.6806
+			key = 	0.535	0.6785
+			key = 	0.53	0.6771
+			key = 	0.525	0.6757
+			key = 	0.52	0.6777
+			key = 	0.515	0.6808
+			key = 	0.51	0.6843
+			key = 	0.505	0.6871
+			key = 	0.5	0.6899
+			key = 	0.495	0.6927
+			key = 	0.49	0.6961
+			key = 	0.485	0.6991
+			key = 	0.48	0.702
+			key = 	0.475	0.7061
+			key = 	0.47	0.7115
+			key = 	0.465	0.7173
+			key = 	0.46	0.722
+			key = 	0.455	0.7244
+			key = 	0.45	0.7265
+			key = 	0.445	0.7318
+			key = 	0.44	0.7366
+			key = 	0.435	0.7413
+			key = 	0.43	0.7465
+			key = 	0.425	0.7505
+			key = 	0.42	0.7537
+			key = 	0.415	0.7563
+			key = 	0.41	0.7599
+			key = 	0.405	0.7644
+			key = 	0.4	0.7682
+			key = 	0.395	0.7723
+			key = 	0.39	0.7767
+			key = 	0.385	0.7796
+			key = 	0.38	0.7821
+			key = 	0.375	0.7846
+			key = 	0.37	0.7883
+			key = 	0.365	0.7926
+			key = 	0.36	0.7951
+			key = 	0.355	0.7976
+			key = 	0.35	0.8001
+			key = 	0.345	0.8041
+			key = 	0.34	0.8083
+			key = 	0.335	0.8119
+			key = 	0.33	0.8152
+			key = 	0.325	0.8182
+			key = 	0.32	0.8207
+			key = 	0.315	0.8226
+			key = 	0.31	0.8226
+			key = 	0.305	0.8233
+			key = 	0.3	0.8245
+			key = 	0.295	0.8246
+			key = 	0.29	0.8246
+			key = 	0.285	0.8246
+			key = 	0.28	0.8239
+			key = 	0.275	0.8227
+			key = 	0.27	0.8204
+			key = 	0.265	0.8173
+			key = 	0.26	0.8118
+			key = 	0.255	0.807
+			key = 	0.25	0.8027
+			key = 	0.245	0.7977
+			key = 	0.24	0.7929
+			key = 	0.235	0.7885
+			key = 	0.23	0.7831
+			key = 	0.225	0.7778
+			key = 	0.22	0.774
+			key = 	0.215	0.7689
+			key = 	0.21	0.7629
+			key = 	0.205	0.7557
+			key = 	0.2	0.7484
+			key = 	0.195	0.7412
+			key = 	0.19	0.7358
+			key = 	0.185	0.7292
+			key = 	0.18	0.7217
+			key = 	0.175	0.7141
+			key = 	0.17	0.7054
+			key = 	0.165	0.6969
+			key = 	0.16	0.6905
+			key = 	0.155	0.6827
+			key = 	0.15	0.6765
+			key = 	0.145	0.6722
+			key = 	0.14	0.6685
+			key = 	0.135	0.6665
+			key = 	0.13	0.6644
+			key = 	0.125	0.6612
+			key = 	0.12	0.6559
+			key = 	0.115	0.6512
+			key = 	0.11	0.6456
+			key = 	0.105	0.639
+			key = 	0.1	0.6343
+			key = 	0.095	0.6275
+			key = 	0.09	0.6213
+			key = 	0.085	0.616
+			key = 	0.08	0.6109
+			key = 	0.075	0.6035
+			key = 	0.07	0.596
+			key = 	0.065	0.589
+			key = 	0.06	0.5787
+			key = 	0.055	0.5673
+			key = 	0.05	0.5593
+			key = 	0.045	0.5478
+			key = 	0.04	0.5377
+			key = 	0.035	0.5235
+			key = 	0.03	0.5022
+			key = 	0.025	0.4735
+			key = 	0.02	0.4111
+			key = 	0.015	0.3361
+			key = 	0.01	0.2461
+			key = 	0.009	0.2241
+			key = 	0.008	0.2021
+			key = 	0.007	0.1855
+			key = 	0.006	0.1546
+			key = 	0.005	0.1206
+			key = 	0.004	0.0947
+			key = 	0.003	0.0668
+			key = 	0.002	0.0463
+			key = 	0.001	0.0263
+			key = 	0	0.0003
+		}
+	}
+	CONFIG
+	{
+		name = RSRM-6
+		maxThrust = 21000
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 266
+			key = 1 244
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.95
+			key = 	0.995	0.9549
+			key = 	0.99	0.9562
+			key = 	0.985	0.9562
+			key = 	0.98	0.9562
+			key = 	0.975	0.9562
+			key = 	0.97	0.9565
+			key = 	0.965	0.9574
+			key = 	0.96	0.9585
+			key = 	0.955	0.9616
+			key = 	0.95	0.9647
+			key = 	0.945	0.9682
+			key = 	0.94	0.9718
+			key = 	0.935	0.9751
+			key = 	0.93	0.9782
+			key = 	0.925	0.9811
+			key = 	0.92	0.9837
+			key = 	0.915	0.9863
+			key = 	0.91	0.9876
+			key = 	0.905	0.9889
+			key = 	0.9	0.9899
+			key = 	0.895	0.9908
+			key = 	0.89	0.9922
+			key = 	0.885	0.994
+			key = 	0.88	0.9953
+			key = 	0.875	0.9953
+			key = 	0.87	0.9953
+			key = 	0.865	0.9953
+			key = 	0.86	0.9953
+			key = 	0.855	0.9953
+			key = 	0.85	0.9953
+			key = 	0.845	0.9953
+			key = 	0.84	0.9953
+			key = 	0.835	0.9951
+			key = 	0.83	0.9942
+			key = 	0.825	0.9933
+			key = 	0.82	0.9911
+			key = 	0.815	0.9889
+			key = 	0.81	0.9856
+			key = 	0.805	0.982
+			key = 	0.8	0.9781
+			key = 	0.795	0.974
+			key = 	0.79	0.9691
+			key = 	0.785	0.963
+			key = 	0.78	0.9564
+			key = 	0.775	0.9478
+			key = 	0.77	0.9397
+			key = 	0.765	0.9349
+			key = 	0.76	0.93
+			key = 	0.755	0.9236
+			key = 	0.75	0.9172
+			key = 	0.745	0.9117
+			key = 	0.74	0.9062
+			key = 	0.735	0.9007
+			key = 	0.73	0.8952
+			key = 	0.725	0.8896
+			key = 	0.72	0.8838
+			key = 	0.715	0.876
+			key = 	0.71	0.8685
+			key = 	0.705	0.8627
+			key = 	0.7	0.8566
+			key = 	0.695	0.8496
+			key = 	0.69	0.843
+			key = 	0.685	0.837
+			key = 	0.68	0.8309
+			key = 	0.675	0.8248
+			key = 	0.67	0.8195
+			key = 	0.665	0.8144
+			key = 	0.66	0.8058
+			key = 	0.655	0.798
+			key = 	0.65	0.7928
+			key = 	0.645	0.7891
+			key = 	0.64	0.7868
+			key = 	0.635	0.78
+			key = 	0.63	0.7726
+			key = 	0.625	0.7672
+			key = 	0.62	0.7611
+			key = 	0.615	0.7543
+			key = 	0.61	0.7502
+			key = 	0.605	0.7463
+			key = 	0.6	0.7419
+			key = 	0.595	0.7388
+			key = 	0.59	0.7358
+			key = 	0.585	0.7287
+			key = 	0.58	0.7233
+			key = 	0.575	0.7194
+			key = 	0.57	0.7121
+			key = 	0.565	0.7048
+			key = 	0.56	0.6974
+			key = 	0.555	0.6926
+			key = 	0.55	0.6882
+			key = 	0.545	0.6841
+			key = 	0.54	0.6806
+			key = 	0.535	0.6785
+			key = 	0.53	0.6771
+			key = 	0.525	0.6757
+			key = 	0.52	0.6777
+			key = 	0.515	0.6808
+			key = 	0.51	0.6843
+			key = 	0.505	0.6871
+			key = 	0.5	0.6899
+			key = 	0.495	0.6927
+			key = 	0.49	0.6961
+			key = 	0.485	0.6991
+			key = 	0.48	0.702
+			key = 	0.475	0.7061
+			key = 	0.47	0.7115
+			key = 	0.465	0.7173
+			key = 	0.46	0.722
+			key = 	0.455	0.7244
+			key = 	0.45	0.7265
+			key = 	0.445	0.7318
+			key = 	0.44	0.7366
+			key = 	0.435	0.7413
+			key = 	0.43	0.7465
+			key = 	0.425	0.7505
+			key = 	0.42	0.7537
+			key = 	0.415	0.7563
+			key = 	0.41	0.7599
+			key = 	0.405	0.7644
+			key = 	0.4	0.7682
+			key = 	0.395	0.7723
+			key = 	0.39	0.7767
+			key = 	0.385	0.7796
+			key = 	0.38	0.7821
+			key = 	0.375	0.7846
+			key = 	0.37	0.7883
+			key = 	0.365	0.7926
+			key = 	0.36	0.7951
+			key = 	0.355	0.7976
+			key = 	0.35	0.8001
+			key = 	0.345	0.8041
+			key = 	0.34	0.8083
+			key = 	0.335	0.8119
+			key = 	0.33	0.8152
+			key = 	0.325	0.8182
+			key = 	0.32	0.8207
+			key = 	0.315	0.8226
+			key = 	0.31	0.8226
+			key = 	0.305	0.8233
+			key = 	0.3	0.8245
+			key = 	0.295	0.8246
+			key = 	0.29	0.8246
+			key = 	0.285	0.8246
+			key = 	0.28	0.8239
+			key = 	0.275	0.8227
+			key = 	0.27	0.8204
+			key = 	0.265	0.8173
+			key = 	0.26	0.8118
+			key = 	0.255	0.807
+			key = 	0.25	0.8027
+			key = 	0.245	0.7977
+			key = 	0.24	0.7929
+			key = 	0.235	0.7885
+			key = 	0.23	0.7831
+			key = 	0.225	0.7778
+			key = 	0.22	0.774
+			key = 	0.215	0.7689
+			key = 	0.21	0.7629
+			key = 	0.205	0.7557
+			key = 	0.2	0.7484
+			key = 	0.195	0.7412
+			key = 	0.19	0.7358
+			key = 	0.185	0.7292
+			key = 	0.18	0.7217
+			key = 	0.175	0.7141
+			key = 	0.17	0.7054
+			key = 	0.165	0.6969
+			key = 	0.16	0.6905
+			key = 	0.155	0.6827
+			key = 	0.15	0.6765
+			key = 	0.145	0.6722
+			key = 	0.14	0.6685
+			key = 	0.135	0.6665
+			key = 	0.13	0.6644
+			key = 	0.125	0.6612
+			key = 	0.12	0.6559
+			key = 	0.115	0.6512
+			key = 	0.11	0.6456
+			key = 	0.105	0.639
+			key = 	0.1	0.6343
+			key = 	0.095	0.6275
+			key = 	0.09	0.6213
+			key = 	0.085	0.616
+			key = 	0.08	0.6109
+			key = 	0.075	0.6035
+			key = 	0.07	0.596
+			key = 	0.065	0.589
+			key = 	0.06	0.5787
+			key = 	0.055	0.5673
+			key = 	0.05	0.5593
+			key = 	0.045	0.5478
+			key = 	0.04	0.5377
+			key = 	0.035	0.5235
+			key = 	0.03	0.5022
+			key = 	0.025	0.4735
+			key = 	0.02	0.4111
+			key = 	0.015	0.3361
+			key = 	0.01	0.2461
+			key = 	0.009	0.2241
+			key = 	0.008	0.2021
+			key = 	0.007	0.1855
+			key = 	0.006	0.1546
+			key = 	0.005	0.1206
+			key = 	0.004	0.0947
+			key = 	0.003	0.0668
+			key = 	0.002	0.0463
+			key = 	0.001	0.0263
+			key = 	0	0.0003
+		}
+	}
+}
+
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_MSRB_UA120.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_MSRB_UA120.cfg
@@ -1,0 +1,1613 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRBC
+author = Shadowmage
+
+TechRequired = basicRocketry
+entryCost = 16000
+cost = 0
+category = Engine
+subcategory = 0
+title = UA-120 (Modular)
+manufacturer = UA
+description = Modular UA-120 booster.  Has options to vary the number of segments, with optional diameter scaling.
+RSSROConfig = True
+stagingIcon = SOLID_BOOSTER
+
+MODEL
+{
+	model = SSTU/Assets/EmptyProxyModel
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+node_stack_top = 0,1,0,0,1,0,2
+node_stack_bottom =  0,-1,0,0,-1,0,2
+node_attach = 1.25, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 1
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 4
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 1
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SSTU-MSRM-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SSTU-MSRM-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SSTU-MSRM-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	minThrust = 1225
+	maxThrust = 3212
+	heatProduction = 10
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0
+	PROPELLANT
+	{
+		name = PBAN
+	}
+	atmosphereCurve
+	{
+		key = 0 267
+		key = 1 245
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SSTU-MSRM-GimbalTransform
+	gimbalRange = 6
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 10000
+	type = PBAN
+}
+MODULE
+{
+	name = SSTUModularBooster
+	
+	// a transform of this name will be added and positioned for the main thrust transform
+	// default = empty
+	thrustTransformName = SSTU-MSRM-ThrustTransform	
+		
+	// if true, engine max thrust will scale with the SRB size
+	// default = true
+	scaleMotorThrust = true
+	
+	// the power to use for scaling of engine thrust; 3 = cubic, 2 = square
+	// default = 2
+	thrustScalePower = 3
+	
+	// if true, nozzle mass will be scaled according to the motorMassScalePower variable
+	scaleMotorMass = true
+	
+	// if scaleMotorMass = true, nozzle mass will be scaled according to this power (Mathf.pow(scale, power)*mass);
+	motorMassScalePower = 3
+	
+	// if true, resources are scaled according to booster size
+	// default = true
+	scaleResources = true
+	
+	// the power to use for scaling of resources; 3 = cubic (standard), 2 = square
+	// default = 3
+	resourceScalePower = 3
+	
+	// minimum available diameter for the booster/tank
+	// default = 0.625
+	minDiameter = 1
+	
+	// maximum available diameter for the booster/tank
+	// default = 10
+	maxDiameter = 10
+	
+	// how much the diameter is changed by the main diameter adjust button in the editor
+	// default = 0.625
+	diameterIncrement = 1
+	
+	// if true, RealFuels will be used to update the part volume and resources rather than internal methods
+	// default = false
+	useRF = true
+	
+	// this value determines how 'scale' is treated for thrust calculations, rather than using the models diameter
+	// set this to the value of your engine configs setup diameter (e.g if the real thing is 3.75m, that is what this value should be set to)
+	// default = -1 (disabled)
+	diameterForThrustScaling = 3.05
+		
+	//setup for 'defaults', differs from MFT by directly using the 'currentXX' fields, rather than a second set of fields specifically for the defaults
+	//these are all -mandatory- fields, or the part will not initialize properly
+	currentMainName = SRB-C-5
+	currentNoseName = SRB-Nosecone-1
+	currentNozzleName = Nozzle-SRB-F
+	currentDiameter = 3.05	
+	
+	//fuel type info can be found in SSTU/Data/Tanks/FuelTypes.cfg
+	FUELTYPE	
+	{
+		name = Solid
+	}
+		
+	MAINMODEL
+	{
+		name = SRB-C-1
+		engineConfig = UA1201
+		volume = 13.840
+	}
+	MAINMODEL
+	{
+		name = SRB-C-2
+		engineConfig = UA1202
+		volume = 27.681
+	}
+	MAINMODEL
+	{
+		name = SRB-C-3
+		engineConfig = UA1203
+		volume = 41.522
+	}
+	MAINMODEL
+	{
+		name = SRB-C-4
+		engineConfig = UA1204
+		volume = 55.362
+	}
+	MAINMODEL
+	{
+		name = SRB-C-5
+		engineConfig = UA1205
+		volume = 69.203
+	}
+	MAINMODEL
+	{
+		name = SRB-C-6
+		engineConfig = UA1206
+		volume = 83.044
+	}
+	MAINMODEL
+	{
+		name = SRB-C-7
+		engineConfig = UA1207
+		volume = 96.884
+	}
+	MAINMODEL
+	{
+		name = SRB-C-8
+		engineConfig = UA1208
+		volume = 110.725
+	}
+	NOZZLE
+	{
+		name = Nozzle-SRB-F
+		thrustTransformName = SC-ENG-MOUNT-SRB-F-ThrustTransform
+		gimbalTransformName = SC-ENG-MOUNT-SRB-F-NOZZLE
+		gimbalAdjustRange = 5
+		gimbalFlightRange = 2
+	}
+	
+	NOSE
+	{
+		name = Adapter-Flat
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-1
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-2
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-3
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-4
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-5
+	}
+	NOSE
+	{
+		name = SRB-Nosecone-6
+	}
+	NOSE
+	{
+		name = Nosecone-1
+	}
+	NOSE
+	{
+		name = Nosecone-2
+	}
+	NOSE
+	{
+		name = Nosecone-3
+	}
+	NOSE
+	{
+		name = Nosecone-4
+	}
+	NOSE
+	{
+		name = Nosecone-5
+	}
+	
+	//standard tech-limits setup; need to adjust height stuff
+	TECHLIMIT
+	{
+		name = start
+		maxDiameter = 1.25
+		maxHeight = 10
+	}
+	TECHLIMIT
+	{
+		name = advRocketry
+		maxDiameter = 2.5
+		maxHeight = 15
+	}
+	TECHLIMIT
+	{
+		name = largeVolumeContainment
+		maxDiameter = 3.75
+		maxHeight = 25
+	}
+	TECHLIMIT
+	{
+		name = veryHeavyRocketry
+		maxDiameter = 10
+		maxHeight = 40
+	}
+}
+
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = UA1201
+	modded = false
+	isMaster = false
+	CONFIG
+	{
+		name = UA1201
+		maxThrust = 1016
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 255
+			key = 1 235
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}	
+	CONFIG
+	{
+		name = UA1202
+		maxThrust = 2033
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 258
+			key = 1 236
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}	
+	CONFIG
+	{
+		name = UA1203
+		maxThrust = 3049
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 260
+			key = 1 237
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}	
+	CONFIG
+	{
+		name = UA1204
+		maxThrust = 4289
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 261
+			key = 1 238
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = UA1205
+		maxThrust = 5849
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 263
+			key = 1 238
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = UA1206
+		maxThrust = 6226
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 265
+			key = 1 240
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = UA1207
+		maxThrust = 7116
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 272
+			key = 1 245
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}
+	CONFIG
+	{
+		name = UA1208
+		maxThrust = 8132
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 270
+			key = 1 248
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 0.99597 1
+			key = 0.98568 0.989
+			key = 0.97585 0.944
+			key = 0.96596 0.95
+			key = 0.95606 0.951
+			key = 0.94613 0.954
+			key = 0.93617 0.957
+			key = 0.92616 0.961
+			key = 0.91612 0.965
+			key = 0.90603 0.969
+			key = 0.89589 0.975
+			key = 0.88572 0.977
+			key = 0.8755 0.982
+			key = 0.86525 0.984
+			key = 0.855 0.985
+			key = 0.84473 0.986
+			key = 0.83444 0.988
+			key = 0.82417 0.987
+			key = 0.8139 0.986
+			key = 0.80365 0.985
+			key = 0.7934 0.984
+			key = 0.78319 0.982
+			key = 0.77298 0.98
+			key = 0.76281 0.977
+			key = 0.75267 0.974
+			key = 0.74259 0.969
+			key = 0.73252 0.967
+			key = 0.72246 0.967
+			key = 0.71241 0.966
+			key = 0.70239 0.962
+			key = 0.6924 0.96
+			key = 0.68244 0.956
+			key = 0.67252 0.953
+			key = 0.66265 0.948
+			key = 0.65283 0.944
+			key = 0.64306 0.938
+			key = 0.63335 0.932
+			key = 0.6237 0.927
+			key = 0.61415 0.918
+			key = 0.60468 0.91
+			key = 0.59528 0.903
+			key = 0.58599 0.893
+			key = 0.57676 0.887
+			key = 0.56759 0.881
+			key = 0.55849 0.874
+			key = 0.54943 0.87
+			key = 0.54043 0.865
+			key = 0.53147 0.861
+			key = 0.52254 0.857
+			key = 0.51364 0.855
+			key = 0.5048 0.849
+			key = 0.49601 0.845
+			key = 0.48728 0.839
+			key = 0.47858 0.836
+			key = 0.46994 0.83
+			key = 0.46134 0.826
+			key = 0.45276 0.824
+			key = 0.44422 0.821
+			key = 0.43572 0.816
+			key = 0.42727 0.812
+			key = 0.41885 0.809
+			key = 0.41046 0.806
+			key = 0.40211 0.802
+			key = 0.39381 0.797
+			key = 0.38554 0.794
+			key = 0.37731 0.791
+			key = 0.3691 0.789
+			key = 0.36091 0.786
+			key = 0.35277 0.782
+			key = 0.34466 0.78
+			key = 0.33659 0.775
+			key = 0.32856 0.772
+			key = 0.32056 0.768
+			key = 0.31259 0.766
+			key = 0.30467 0.761
+			key = 0.29679 0.757
+			key = 0.28897 0.751
+			key = 0.28122 0.744
+			key = 0.27352 0.74
+			key = 0.26588 0.734
+			key = 0.25827 0.732
+			key = 0.25069 0.728
+			key = 0.24314 0.725
+			key = 0.23562 0.723
+			key = 0.22812 0.72
+			key = 0.22065 0.718
+			key = 0.21319 0.717
+			key = 0.20576 0.713
+			key = 0.19836 0.711
+			key = 0.19097 0.71
+			key = 0.18359 0.709
+			key = 0.17624 0.706
+			key = 0.16892 0.703
+			key = 0.16162 0.701
+			key = 0.15437 0.697
+			key = 0.14712 0.696
+			key = 0.13989 0.694
+			key = 0.13268 0.693
+			key = 0.1255 0.69
+			key = 0.11833 0.688
+			key = 0.1112 0.685
+			key = 0.10409 0.684
+			key = 0.09699 0.681
+			key = 0.08994 0.678
+			key = 0.08292 0.674
+			key = 0.07592 0.672
+			key = 0.06897 0.668
+			key = 0.06213 0.657
+			key = 0.05542 0.644
+			key = 0.04894 0.623
+			key = 0.04282 0.588
+			key = 0.03708 0.551
+			key = 0.03172 0.515
+			key = 0.02687 0.466
+			key = 0.02261 0.409
+			key = 0.01903 0.344
+			key = 0.01597 0.294
+			key = 0.01342 0.245
+			key = 0.0112 0.213
+			key = 0.00929 0.183
+			key = 0.00766 0.156
+			key = 0.00631 0.13
+			key = 0.00518 0.108
+			key = 0.00428 0.087
+			key = 0.00355 0.071
+			key = 0.00296 0.056
+			key = 0.00248 0.047
+			key = 0.00208 0.039
+			key = 0.00173 0.033
+			key = 0.00145 0.027
+			key = 0.00117 0.026
+			key = 0.00095 0.022
+			key = 0.00082 0.013
+			key = 0.00000 0.005
+		}
+	}
+	
+}
+
+
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB2.cfg
@@ -1,0 +1,415 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRB2
+author = Shadowmage
+
+TechRequired = veryHeavyRocketry
+entryCost = 16000
+cost = 20000
+category = Engine
+subcategory = 0
+title = RSRM (2-segment)
+manufacturer = ATK
+description = Proposed 2-segment version of RSRM.
+RSSROConfig = True
+
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-A-2
+	scale = 1.484, 1.484, 1.484
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-NOSE1
+	scale = 1.484, 1.484, 1.484
+	position = 0, 9.275, 0
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-MOUNT-SRB-A
+	scale = 1.484, 1.484, 1.484
+	position = 0, -9.275, 0
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision3
+node_stack_bottom =  0,-13.77776,0,0,-1,0,2
+node_attach = 1.855, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 48.2
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 6
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 2
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	minThrust = 1225
+	maxThrust = 7305
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0
+	heatProduction = 100
+	PROPELLANT
+	{
+		name = PBAN
+	}
+	atmosphereCurve
+	{
+		key = 0 276
+		key = 1 249
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SC-ENG-MOUNT-SRB-A-NOZZLE
+	gimbalRange = 6
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}		
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 158451
+	basemass = -1
+	type = PBAN
+}
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = RSRM-2
+	modded = false
+	CONFIG
+	{
+		name = RSRM-2
+		maxThrust = 7305
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 276
+			key = 1 240
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1.0		0.933
+			key = 	0.995	0.9333
+			key = 	0.99	0.9366
+			key = 	0.985	0.9399
+			key = 	0.98	0.9432
+			key = 	0.975	0.9474
+			key = 	0.97	0.9523
+			key = 	0.965	0.9568
+			key = 	0.96	0.9611
+			key = 	0.955	0.9673
+			key = 	0.95	0.9737
+			key = 	0.945	0.979
+			key = 	0.94	0.984
+			key = 	0.935	0.9871
+			key = 	0.93	0.9896
+			key = 	0.925	0.9896
+			key = 	0.92	0.9896
+			key = 	0.915	0.9896
+			key = 	0.91	0.9896
+			key = 	0.905	0.9896
+			key = 	0.9		0.9896
+			key = 	0.895	0.9896
+			key = 	0.89	0.9896
+			key = 	0.885	0.9896
+			key = 	0.88	0.9896
+			key = 	0.875	0.9896
+			key = 	0.87	0.9896
+			key = 	0.865	0.9896
+			key = 	0.86	0.9905
+			key = 	0.855	0.9915
+			key = 	0.85	0.9935
+			key = 	0.845	0.9955
+			key = 	0.84	0.9955
+			key = 	0.835	0.9955
+			key = 	0.83	0.9955
+			key = 	0.825	0.9947
+			key = 	0.82	0.9905
+			key = 	0.815	0.9875
+			key = 	0.81	0.9875
+			key = 	0.805	0.9895
+			key = 	0.8		0.9947
+			key = 	0.795	0.998
+			key = 	0.79	0.999
+			key = 	0.785	0.9978
+			key = 	0.78	0.9947
+			key = 	0.775	0.9922
+			key = 	0.77	0.9901
+			key = 	0.765	0.9887
+			key = 	0.76	0.9876
+			key = 	0.755	0.9848
+			key = 	0.75	0.9816
+			key = 	0.745	0.9804
+			key = 	0.74	0.9794
+			key = 	0.735	0.9794
+			key = 	0.73	0.9794
+			key = 	0.725	0.9794
+			key = 	0.72	0.9797
+			key = 	0.715	0.9808
+			key = 	0.71	0.9807
+			key = 	0.705	0.9786
+			key = 	0.7		0.977
+			key = 	0.695	0.9759
+			key = 	0.69	0.9755
+			key = 	0.685	0.9755
+			key = 	0.68	0.9755
+			key = 	0.675	0.9755
+			key = 	0.67	0.9755
+			key = 	0.665	0.9755
+			key = 	0.66	0.9755
+			key = 	0.655	0.9755
+			key = 	0.65	0.9755
+			key = 	0.645	0.9755
+			key = 	0.64	0.9755
+			key = 	0.635	0.9755
+			key = 	0.63	0.9755
+			key = 	0.625	0.975
+			key = 	0.62	0.9739
+			key = 	0.615	0.9734
+			key = 	0.61	0.9734
+			key = 	0.605	0.9734
+			key = 	0.6		0.9734
+			key = 	0.595	0.9725
+			key = 	0.59	0.9714
+			key = 	0.585	0.9713
+			key = 	0.58	0.9714
+			key = 	0.575	0.9735
+			key = 	0.57	0.9754
+			key = 	0.565	0.9765
+			key = 	0.56	0.9773
+			key = 	0.555	0.9773
+			key = 	0.55	0.976
+			key = 	0.545	0.9728
+			key = 	0.54	0.9713
+			key = 	0.535	0.9713
+			key = 	0.53	0.9713
+			key = 	0.525	0.9713
+			key = 	0.52	0.9713
+			key = 	0.515	0.9713
+			key = 	0.51	0.9713
+			key = 	0.505	0.9714
+			key = 	0.5		0.9735
+			key = 	0.495	0.9753
+			key = 	0.49	0.9753
+			key = 	0.485	0.9759
+			key = 	0.48	0.978
+			key = 	0.475	0.9805
+			key = 	0.47	0.9837
+			key = 	0.465	0.9863
+			key = 	0.46	0.9884
+			key = 	0.455	0.9899
+			key = 	0.45	0.9909
+			key = 	0.445	0.9912
+			key = 	0.44	0.9912
+			key = 	0.435	0.9928
+			key = 	0.43	0.9949
+			key = 	0.425	0.9952
+			key = 	0.42	0.9952
+			key = 	0.415	0.9952
+			key = 	0.41	0.9952
+			key = 	0.405	0.9952
+			key = 	0.4		0.9952
+			key = 	0.395	0.9952
+			key = 	0.39	0.9955
+			key = 	0.385	0.9976
+			key = 	0.38	0.9992
+			key = 	0.375	0.9992
+			key = 	0.37	0.9992
+			key = 	0.365	0.9992
+			key = 	0.36	0.9984
+			key = 	0.355	0.9963
+			key = 	0.35	0.9947
+			key = 	0.345	0.9937
+			key = 	0.34	0.9921
+			key = 	0.335	0.99
+			key = 	0.33	0.9886
+			key = 	0.325	0.9875
+			key = 	0.32	0.9896
+			key = 	0.315	0.9927
+			key = 	0.31	0.9941
+			key = 	0.305	0.9951
+			key = 	0.3		0.9942
+			key = 	0.295	0.9932
+			key = 	0.29	0.9911
+			key = 	0.285	0.9891
+			key = 	0.28	0.988
+			key = 	0.275	0.9871
+			key = 	0.27	0.9871
+			key = 	0.265	0.9859
+			key = 	0.26	0.9817
+			key = 	0.255	0.9783
+			key = 	0.25	0.9762
+			key = 	0.245	0.9732
+			key = 	0.24	0.9694
+			key = 	0.235	0.9625
+			key = 	0.23	0.9538
+			key = 	0.225	0.9468
+			key = 	0.22	0.9402
+			key = 	0.215	0.9335
+			key = 	0.21	0.9272
+			key = 	0.205	0.9227
+			key = 	0.2		0.9201
+			key = 	0.195	0.9201
+			key = 	0.19	0.9194
+			key = 	0.185	0.9183
+			key = 	0.18	0.9131
+			key = 	0.175	0.9078
+			key = 	0.17	0.9055
+			key = 	0.165	0.9025
+			key = 	0.16	0.8984
+			key = 	0.155	0.8955
+			key = 	0.15	0.8932
+			key = 	0.145	0.8931
+			key = 	0.14	0.8926
+			key = 	0.135	0.8903
+			key = 	0.13	0.8868
+			key = 	0.125	0.8821
+			key = 	0.12	0.8774
+			key = 	0.115	0.8726
+			key = 	0.11	0.8678
+			key = 	0.105	0.863
+			key = 	0.1		0.8582
+			key = 	0.095	0.8553
+			key = 	0.09	0.8531
+			key = 	0.085	0.8519
+			key = 	0.08	0.8488
+			key = 	0.075	0.8439
+			key = 	0.07	0.8406
+			key = 	0.065	0.837
+			key = 	0.06	0.832
+			key = 	0.055	0.8209
+			key = 	0.05	0.803
+			key = 	0.045	0.7546
+			key = 	0.04	0.6908
+			key = 	0.035	0.6306
+			key = 	0.03	0.5845
+			key = 	0.025	0.5245
+			key = 	0.02	0.4245
+			key = 	0.015	0.3756
+			key = 	0.01	0.3678
+			key = 	0.009	0.3549
+			key = 	0.008	0.342
+			key = 	0.007	0.3277
+			key = 	0.006	0.3062
+			key = 	0.005	0.2847
+			key = 	0.004	0.2431
+			key = 	0.003	0.183
+			key = 	0.002	0.0884
+			key = 	0.001	0.0384
+			key = 	0		0.0014
+		}
+	}
+}
+
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB3.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB3.cfg
@@ -1,0 +1,415 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRB3
+author = Shadowmage
+
+TechRequired = veryHeavyRocketry
+entryCost = 16000
+cost = 20000
+category = Engine
+subcategory = 0
+title = RSRM (3-segment)
+manufacturer = ATK
+description = Proposed 3-segment version of RSRM that includes a new aft skirt and TVC system.
+RSSROConfig = True
+
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-A-3
+	scale = 1.484, 1.484, 1.484
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-NOSE1
+	scale = 1.484, 1.484, 1.484
+	position = 0, 12.985, 0
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-MOUNT-SRB-A
+	scale = 1.484, 1.484, 1.484
+	position = 0, -12.985, 0
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision3
+node_stack_bottom =  0,-17.48776,0,0,-1,0,2
+node_attach = 1.855, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 70.38
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 6
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 2
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	minThrust = 1225
+	maxThrust = 11790
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0
+	heatProduction = 100
+	PROPELLANT
+	{
+		name = PBAN
+	}
+	atmosphereCurve
+	{
+		key = 0 264.4
+		key = 1 243
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SC-ENG-MOUNT-SRB-A-NOZZLE
+	gimbalRange = 5
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}		
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 215862.37
+	basemass = -1
+	type = PBAN
+}
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = RSRM-3
+	modded = false
+	CONFIG
+	{
+		name = RSRM-3
+		maxThrust = 11790
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 264.4
+			key = 1 243
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.985
+			key = 	0.995	0.98
+			key = 	0.99	0.975
+			key = 	0.985	0.97
+			key = 	0.98	0.967
+			key = 	0.975	0.964
+			key = 	0.97	0.961
+			key = 	0.965	0.96
+			key = 	0.96	0.96
+			key = 	0.955	0.961
+			key = 	0.95	0.963
+			key = 	0.945	0.965
+			key = 	0.94	0.968
+			key = 	0.935	0.971
+			key = 	0.93	0.976
+			key = 	0.925	0.984
+			key = 	0.92	0.992
+			key = 	0.915	0.997
+			key = 	0.91	0.999
+			key = 	0.905	1
+			key = 	0.9	1
+			key = 	0.895	0.9995
+			key = 	0.89	0.999
+			key = 	0.885	0.998
+			key = 	0.88	0.997
+			key = 	0.875	0.996
+			key = 	0.87	0.995
+			key = 	0.865	0.994
+			key = 	0.86	0.993
+			key = 	0.855	0.992
+			key = 	0.85	0.991
+			key = 	0.845	0.99
+			key = 	0.84	0.989
+			key = 	0.835	0.988
+			key = 	0.83	0.987
+			key = 	0.825	0.986
+			key = 	0.82	0.985
+			key = 	0.815	0.984
+			key = 	0.81	0.983
+			key = 	0.805	0.982
+			key = 	0.8	0.981
+			key = 	0.795	0.98
+			key = 	0.79	0.979
+			key = 	0.785	0.978
+			key = 	0.78	0.977
+			key = 	0.775	0.976
+			key = 	0.77	0.9745
+			key = 	0.765	0.973
+			key = 	0.76	0.9715
+			key = 	0.755	0.97
+			key = 	0.75	0.968
+			key = 	0.745	0.966
+			key = 	0.74	0.96
+			key = 	0.735	0.948
+			key = 	0.73	0.936
+			key = 	0.725	0.924
+			key = 	0.72	0.912
+			key = 	0.715	0.9
+			key = 	0.71	0.888
+			key = 	0.705	0.878
+			key = 	0.7	0.868
+			key = 	0.695	0.858
+			key = 	0.69	0.848
+			key = 	0.685	0.838
+			key = 	0.68	0.828
+			key = 	0.675	0.818
+			key = 	0.67	0.808
+			key = 	0.665	0.798
+			key = 	0.66	0.788
+			key = 	0.655	0.778
+			key = 	0.65	0.768
+			key = 	0.645	0.758
+			key = 	0.64	0.748
+			key = 	0.635	0.738
+			key = 	0.63	0.728
+			key = 	0.625	0.718
+			key = 	0.62	0.708
+			key = 	0.615	0.698
+			key = 	0.61	0.688
+			key = 	0.605	0.68
+			key = 	0.6	0.672
+			key = 	0.595	0.664
+			key = 	0.59	0.656
+			key = 	0.585	0.648
+			key = 	0.58	0.64
+			key = 	0.575	0.632
+			key = 	0.57	0.625
+			key = 	0.565	0.618
+			key = 	0.56	0.611
+			key = 	0.555	0.604
+			key = 	0.55	0.597
+			key = 	0.545	0.59
+			key = 	0.54	0.583
+			key = 	0.535	0.577
+			key = 	0.53	0.571
+			key = 	0.525	0.565
+			key = 	0.52	0.556
+			key = 	0.515	0.551
+			key = 	0.51	0.553
+			key = 	0.505	0.559
+			key = 	0.5	0.561
+			key = 	0.495	0.556
+			key = 	0.49	0.551
+			key = 	0.485	0.546
+			key = 	0.48	0.546
+			key = 	0.475	0.548
+			key = 	0.47	0.551
+			key = 	0.465	0.554
+			key = 	0.46	0.557
+			key = 	0.455	0.56
+			key = 	0.45	0.562
+			key = 	0.445	0.5635
+			key = 	0.44	0.565
+			key = 	0.435	0.5665
+			key = 	0.43	0.568
+			key = 	0.425	0.5695
+			key = 	0.42	0.571
+			key = 	0.415	0.5725
+			key = 	0.41	0.574
+			key = 	0.405	0.5755
+			key = 	0.4	0.577
+			key = 	0.395	0.5785
+			key = 	0.39	0.58
+			key = 	0.385	0.5815
+			key = 	0.38	0.583
+			key = 	0.375	0.5845
+			key = 	0.37	0.586
+			key = 	0.365	0.5875
+			key = 	0.36	0.589
+			key = 	0.355	0.5905
+			key = 	0.35	0.592
+			key = 	0.345	0.5935
+			key = 	0.34	0.595
+			key = 	0.335	0.5965
+			key = 	0.33	0.598
+			key = 	0.325	0.5995
+			key = 	0.32	0.601
+			key = 	0.315	0.6025
+			key = 	0.31	0.604
+			key = 	0.305	0.6055
+			key = 	0.3	0.607
+			key = 	0.295	0.6085
+			key = 	0.29	0.61
+			key = 	0.285	0.6115
+			key = 	0.28	0.613
+			key = 	0.275	0.6145
+			key = 	0.27	0.616
+			key = 	0.265	0.6175
+			key = 	0.26	0.619
+			key = 	0.255	0.6205
+			key = 	0.25	0.622
+			key = 	0.245	0.6235
+			key = 	0.24	0.625
+			key = 	0.235	0.625
+			key = 	0.23	0.624
+			key = 	0.225	0.622
+			key = 	0.22	0.62
+			key = 	0.215	0.618
+			key = 	0.21	0.6155
+			key = 	0.205	0.613
+			key = 	0.2	0.6105
+			key = 	0.195	0.608
+			key = 	0.19	0.6055
+			key = 	0.185	0.6015
+			key = 	0.18	0.5975
+			key = 	0.175	0.5935
+			key = 	0.17	0.5895
+			key = 	0.165	0.5855
+			key = 	0.16	0.5815
+			key = 	0.155	0.5775
+			key = 	0.15	0.5715
+			key = 	0.145	0.5655
+			key = 	0.14	0.5595
+			key = 	0.135	0.5535
+			key = 	0.13	0.5415
+			key = 	0.125	0.5295
+			key = 	0.12	0.5175
+			key = 	0.115	0.5075
+			key = 	0.11	0.4975
+			key = 	0.105	0.4895
+			key = 	0.1	0.4865
+			key = 	0.095	0.4835
+			key = 	0.09	0.4805
+			key = 	0.085	0.4775
+			key = 	0.08	0.4745
+			key = 	0.075	0.4715
+			key = 	0.07	0.4635
+			key = 	0.065	0.4535
+			key = 	0.06	0.4435
+			key = 	0.055	0.4335
+			key = 	0.05	0.4235
+			key = 	0.045	0.4135
+			key = 	0.04	0.4035
+			key = 	0.035	0.3935
+			key = 	0.03	0.3835
+			key = 	0.025	0.3735
+			key = 	0.02	0.3635
+			key = 	0.015	0.3435
+			key = 	0.01	0.3135
+			key = 	0.009	0.3005
+			key = 	0.008	0.2805
+			key = 	0.007	0.2505
+			key = 	0.006	0.2155
+			key = 	0.005	0.1755
+			key = 	0.004	0.1255
+			key = 	0.003	0.0955
+			key = 	0.002	0.0655
+			key = 	0.001	0.0305
+			key = 	0	0.0005
+		}
+	}
+}
+
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB4.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB4.cfg
@@ -1,0 +1,415 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRB3
+author = Shadowmage
+
+TechRequired = veryHeavyRocketry
+entryCost = 16000
+cost = 20000
+category = Engine
+subcategory = 0
+title = RSRM
+manufacturer = Thiokol
+description = The Redesigned Solid Rocket Motor (RSRM) was a modification of the High-Performance Solid Rocket Motor (HPM), which failed catastrophically on STS-51L. The RSRM incorporated many safety improvements but was intended to be used only temporarily, until the introduction of the Advanced Solid Rocket Motor (ASRM). Eventually development of the ASRM was terminated and the RSRM (renamed the Reusable Solid Rocket Motor) was used on all remaining shuttle flights.
+RSSROConfig = True
+
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-A-4
+	scale = 1.484, 1.484, 1.484
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-NOSE1
+	scale = 1.484, 1.484, 1.484
+	position = 0, 16.695, 0
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-MOUNT-SRB-A
+	scale = 1.484, 1.484, 1.484
+	position = 0, -16.695, 0
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision3
+node_stack_bottom =  0,-21.19776,0,0,-1,0,2
+node_attach = 1.855, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 86.21
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 6
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 2
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	minThrust = 1225
+	maxThrust = 14780
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0
+	heatProduction = 100
+	PROPELLANT
+	{
+		name = PBAN
+	}
+	atmosphereCurve
+	{
+		key = 0 268.5
+		key = 1 243
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SC-ENG-MOUNT-SRB-A-NOZZLE
+	gimbalRange = 6
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}		
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 281853.9
+	basemass = -1
+	type = PBAN
+}
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = RSRM
+	modded = false
+	CONFIG
+	{
+		name = RSRM
+		maxThrust = 14780
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 268.5
+			key = 1 243
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.945
+			key = 	0.995	0.945
+			key = 	0.99	0.9437
+			key = 	0.985	0.9423
+			key = 	0.98	0.942
+			key = 	0.975	0.942
+			key = 	0.97	0.9439
+			key = 	0.965	0.9467
+			key = 	0.96	0.9508
+			key = 	0.955	0.9559
+			key = 	0.95	0.9605
+			key = 	0.945	0.9642
+			key = 	0.94	0.9682
+			key = 	0.935	0.9732
+			key = 	0.93	0.9781
+			key = 	0.925	0.9795
+			key = 	0.92	0.9809
+			key = 	0.915	0.983
+			key = 	0.91	0.9853
+			key = 	0.905	0.987
+			key = 	0.9	0.9884
+			key = 	0.895	0.9892
+			key = 	0.89	0.9892
+			key = 	0.885	0.9895
+			key = 	0.88	0.9909
+			key = 	0.875	0.9923
+			key = 	0.87	0.9923
+			key = 	0.865	0.9923
+			key = 	0.86	0.993
+			key = 	0.855	0.9939
+			key = 	0.85	0.9943
+			key = 	0.845	0.9943
+			key = 	0.84	0.9943
+			key = 	0.835	0.9943
+			key = 	0.83	0.9943
+			key = 	0.825	0.9943
+			key = 	0.82	0.9943
+			key = 	0.815	0.9955
+			key = 	0.81	0.9968
+			key = 	0.805	0.9973
+			key = 	0.8	0.9973
+			key = 	0.795	0.9979
+			key = 	0.79	0.9992
+			key = 	0.785	1.0003
+			key = 	0.78	1.0003
+			key = 	0.775	1.0003
+			key = 	0.77	1.0003
+			key = 	0.765	1.0003
+			key = 	0.76	0.9968
+			key = 	0.755	0.9918
+			key = 	0.75	0.9836
+			key = 	0.745	0.972
+			key = 	0.74	0.9608
+			key = 	0.735	0.9504
+			key = 	0.73	0.9412
+			key = 	0.725	0.9364
+			key = 	0.72	0.9311
+			key = 	0.715	0.9228
+			key = 	0.71	0.915
+			key = 	0.705	0.9125
+			key = 	0.7	0.9099
+			key = 	0.695	0.9054
+			key = 	0.69	0.9009
+			key = 	0.685	0.8954
+			key = 	0.68	0.8899
+			key = 	0.675	0.8848
+			key = 	0.67	0.8798
+			key = 	0.665	0.8752
+			key = 	0.66	0.8704
+			key = 	0.655	0.8647
+			key = 	0.65	0.859
+			key = 	0.645	0.8532
+			key = 	0.64	0.8474
+			key = 	0.635	0.8415
+			key = 	0.63	0.8363
+			key = 	0.625	0.832
+			key = 	0.62	0.8277
+			key = 	0.615	0.8234
+			key = 	0.61	0.819
+			key = 	0.605	0.8146
+			key = 	0.6	0.8112
+			key = 	0.595	0.8078
+			key = 	0.59	0.8033
+			key = 	0.585	0.7983
+			key = 	0.58	0.7921
+			key = 	0.575	0.7877
+			key = 	0.57	0.7848
+			key = 	0.565	0.7792
+			key = 	0.56	0.7729
+			key = 	0.555	0.7682
+			key = 	0.55	0.7639
+			key = 	0.545	0.7604
+			key = 	0.54	0.758
+			key = 	0.535	0.7562
+			key = 	0.53	0.7533
+			key = 	0.525	0.7502
+			key = 	0.52	0.7466
+			key = 	0.515	0.7411
+			key = 	0.51	0.7344
+			key = 	0.505	0.7276
+			key = 	0.5	0.7221
+			key = 	0.495	0.719
+			key = 	0.49	0.7159
+			key = 	0.485	0.7132
+			key = 	0.48	0.7132
+			key = 	0.475	0.7132
+			key = 	0.47	0.7132
+			key = 	0.465	0.7144
+			key = 	0.46	0.7165
+			key = 	0.455	0.7202
+			key = 	0.45	0.7234
+			key = 	0.445	0.7263
+			key = 	0.44	0.7281
+			key = 	0.435	0.7299
+			key = 	0.43	0.7317
+			key = 	0.425	0.733
+			key = 	0.42	0.7347
+			key = 	0.415	0.7383
+			key = 	0.41	0.7409
+			key = 	0.405	0.7427
+			key = 	0.4	0.744
+			key = 	0.395	0.7453
+			key = 	0.39	0.7471
+			key = 	0.385	0.7489
+			key = 	0.38	0.7507
+			key = 	0.375	0.7525
+			key = 	0.37	0.7542
+			key = 	0.365	0.7554
+			key = 	0.36	0.7569
+			key = 	0.355	0.7587
+			key = 	0.35	0.7618
+			key = 	0.345	0.7651
+			key = 	0.34	0.7663
+			key = 	0.335	0.7677
+			key = 	0.33	0.7694
+			key = 	0.325	0.77
+			key = 	0.32	0.77
+			key = 	0.315	0.7716
+			key = 	0.31	0.773
+			key = 	0.305	0.773
+			key = 	0.3	0.7738
+			key = 	0.295	0.7755
+			key = 	0.29	0.776
+			key = 	0.285	0.776
+			key = 	0.28	0.776
+			key = 	0.275	0.776
+			key = 	0.27	0.776
+			key = 	0.265	0.7751
+			key = 	0.26	0.7734
+			key = 	0.255	0.7694
+			key = 	0.25	0.7648
+			key = 	0.245	0.7613
+			key = 	0.24	0.7573
+			key = 	0.235	0.7525
+			key = 	0.23	0.7477
+			key = 	0.225	0.7429
+			key = 	0.22	0.7393
+			key = 	0.215	0.734
+			key = 	0.21	0.726
+			key = 	0.205	0.7198
+			key = 	0.2	0.7146
+			key = 	0.195	0.7115
+			key = 	0.19	0.7043
+			key = 	0.185	0.694
+			key = 	0.18	0.6868
+			key = 	0.175	0.6786
+			key = 	0.17	0.6692
+			key = 	0.165	0.6651
+			key = 	0.16	0.6624
+			key = 	0.155	0.661
+			key = 	0.15	0.6569
+			key = 	0.145	0.6539
+			key = 	0.14	0.6517
+			key = 	0.135	0.6482
+			key = 	0.13	0.6406
+			key = 	0.125	0.6317
+			key = 	0.12	0.626
+			key = 	0.115	0.6202
+			key = 	0.11	0.6144
+			key = 	0.105	0.6087
+			key = 	0.1	0.6043
+			key = 	0.095	0.5987
+			key = 	0.09	0.5917
+			key = 	0.085	0.5835
+			key = 	0.08	0.5773
+			key = 	0.075	0.571
+			key = 	0.07	0.5606
+			key = 	0.065	0.5469
+			key = 	0.06	0.534
+			key = 	0.055	0.5246
+			key = 	0.05	0.5216
+			key = 	0.045	0.521
+			key = 	0.04	0.5168
+			key = 	0.035	0.5002
+			key = 	0.03	0.4681
+			key = 	0.025	0.4226
+			key = 	0.02	0.3576
+			key = 	0.015	0.2926
+			key = 	0.01	0.2226
+			key = 	0.009	0.2076
+			key = 	0.008	0.1877
+			key = 	0.007	0.1677
+			key = 	0.006	0.1477
+			key = 	0.005	0.1277
+			key = 	0.004	0.1077
+			key = 	0.003	0.0827
+			key = 	0.002	0.0427
+			key = 	0.001	0.0127
+			key = 	0	0.0007
+		}
+	}
+}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB5.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RO_SRB5.cfg
@@ -1,0 +1,416 @@
+PART
+{
+module = Part
+name = SSTU-RO-ENG-SRB3
+author = Shadowmage
+
+TechRequired = veryHeavyRocketry
+entryCost = 16000
+cost = 20000
+category = Engine
+subcategory = 0
+title = RSRMV
+manufacturer = Orbital ATK
+description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as a performance and safety enhancement for the space shuttle. Adding an additonal segment to the RSRM improved the shuttle's payload capacity ISS's high-inclination orbit and made the Trans-Atlantic Abort option available immediately after booster burnout, reducing the chance of a Return to Launch Site Abort. Though work on the RSRMV for the shuttle was eventually terminated, the need of a more powerful booster for Ares I led to the motor's full-scale development. When Ares I was cancelled, the RSRMV was selected for use on the Space Launch System.
+RSSROConfig = True
+
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-A-5
+	scale = 1.484, 1.484, 1.484
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-SRB-NOSE1
+	scale = 1.484, 1.484, 1.484
+	position = 0, 20.405, 0
+}
+MODEL
+{
+	model = SSTU/Assets/SC-ENG-MOUNT-SRB-A
+	scale = 1.484, 1.484, 1.484
+	position = 0, -20.405, 0
+}
+rescaleFactor = 1
+
+// nodes/attachment 
+// node position specification- posX,posY,posZ,axisX,axisY,axisZ,size
+// attachment rules- stack, srfAttach, allowStack, allowSrfAttach, allowCollision3
+node_stack_bottom =  0,-24.90776,0,0,-1,0,2
+node_attach = 1.855, 0, 0, 1, 0, 0
+attachRules = 1,1,1,1,0
+
+mass = 97.3
+crashTolerance = 14
+maxTemp = 2000
+fuelCrossFeed = True
+breakingForce = 2000
+breakingTorque = 2000
+
+
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_rocket_spurts
+			volume = 0.0 0.0
+			volume = 0.05 0.0
+			volume = 0.075 0.25
+			volume = 0.25 0.85
+			volume = 1.0 1.25
+			pitch = 1.0
+			loop = true
+		}
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_smokeTrail_veryLarge
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.25
+			speed = 1.0 1.0
+			localOffset = 0, 0, 6
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/SRB_Large
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.75
+			emission = 1.0 0.85
+			speed = 0.0 0.35
+			speed = 1.0 0.8
+			localPosition = 0, 0, 2
+		}
+		MODEL_PARTICLE
+		{
+			modelName = Squad/FX/SRB_LargeSparks
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.05 0.0
+			emission = 0.075 0.25
+			emission = 0.25 0.85
+			emission = 1.0 1.25
+			speed = 0.0 0.5
+			speed = 1.0 1.2
+			localPosition = 0, 0, 2
+		}
+	}	
+	engage
+	{
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_large
+			volume = 1.5
+			pitch = 1.0
+			loop = false
+		}
+	}
+	flameout
+	{
+		PREFAB_PARTICLE
+		{
+			prefabName = fx_exhaustSparks_flameout_2
+			transformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+			oneShot = true
+		}
+		AUDIO
+		{
+			channel = Ship
+			clip = sound_explosion_low
+			volume = 1.0
+			pitch = 2.0
+			loop = false
+		}
+	}
+}
+
+MODULE
+{
+	name = ModuleEnginesFX
+	thrustVectorTransformName = SC-ENG-MOUNT-SRB-A-ThrustTransform
+	engineID = SC-MSRM
+	runningEffectName = running
+	exhaustDamage = True
+	throttleLocked = True
+	allowShutdown = False
+	EngineType = SolidBooster
+	ignitionThreshold = 0.1
+	minThrust = 1225
+	maxThrust = 17885
+	useEngineResponseTime = True
+	engineAccelerationSpeed = 8.0
+	heatProduction = 100
+	PROPELLANT
+	{
+		name = PBAN
+	}
+	atmosphereCurve
+	{
+		key = 0 267
+		key = 1 245
+	}
+}
+MODULE
+{
+	name = ModuleGimbal
+	gimbalTransformName = SC-ENG-MOUNT-SRB-A-NOZZLE
+	gimbalRange = 6
+	useGimbalResponseSpeed = true
+	gimbalResponseSpeed = 16
+}
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 365486.64
+	basemass = -1
+	type = PBAN
+}
+MODULE
+{
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = RSRMV
+	modded = false
+	CONFIG
+	{
+		name = RSRMV
+		maxThrust = 17885
+		heatProduction = 100
+		PROPELLANT
+		{
+			name = PBAN
+			ratio = 1
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 267
+			key = 1 245
+		}
+		curveResource = PBAN
+		thrustCurve
+		{
+			key = 	1	0.95
+			key = 	0.995	0.9549
+			key = 	0.99	0.9562
+			key = 	0.985	0.9562
+			key = 	0.98	0.9562
+			key = 	0.975	0.9562
+			key = 	0.97	0.9565
+			key = 	0.965	0.9574
+			key = 	0.96	0.9585
+			key = 	0.955	0.9616
+			key = 	0.95	0.9647
+			key = 	0.945	0.9682
+			key = 	0.94	0.9718
+			key = 	0.935	0.9751
+			key = 	0.93	0.9782
+			key = 	0.925	0.9811
+			key = 	0.92	0.9837
+			key = 	0.915	0.9863
+			key = 	0.91	0.9876
+			key = 	0.905	0.9889
+			key = 	0.9	0.9899
+			key = 	0.895	0.9908
+			key = 	0.89	0.9922
+			key = 	0.885	0.994
+			key = 	0.88	0.9953
+			key = 	0.875	0.9953
+			key = 	0.87	0.9953
+			key = 	0.865	0.9953
+			key = 	0.86	0.9953
+			key = 	0.855	0.9953
+			key = 	0.85	0.9953
+			key = 	0.845	0.9953
+			key = 	0.84	0.9953
+			key = 	0.835	0.9951
+			key = 	0.83	0.9942
+			key = 	0.825	0.9933
+			key = 	0.82	0.9911
+			key = 	0.815	0.9889
+			key = 	0.81	0.9856
+			key = 	0.805	0.982
+			key = 	0.8	0.9781
+			key = 	0.795	0.974
+			key = 	0.79	0.9691
+			key = 	0.785	0.963
+			key = 	0.78	0.9564
+			key = 	0.775	0.9478
+			key = 	0.77	0.9397
+			key = 	0.765	0.9349
+			key = 	0.76	0.93
+			key = 	0.755	0.9236
+			key = 	0.75	0.9172
+			key = 	0.745	0.9117
+			key = 	0.74	0.9062
+			key = 	0.735	0.9007
+			key = 	0.73	0.8952
+			key = 	0.725	0.8896
+			key = 	0.72	0.8838
+			key = 	0.715	0.876
+			key = 	0.71	0.8685
+			key = 	0.705	0.8627
+			key = 	0.7	0.8566
+			key = 	0.695	0.8496
+			key = 	0.69	0.843
+			key = 	0.685	0.837
+			key = 	0.68	0.8309
+			key = 	0.675	0.8248
+			key = 	0.67	0.8195
+			key = 	0.665	0.8144
+			key = 	0.66	0.8058
+			key = 	0.655	0.798
+			key = 	0.65	0.7928
+			key = 	0.645	0.7891
+			key = 	0.64	0.7868
+			key = 	0.635	0.78
+			key = 	0.63	0.7726
+			key = 	0.625	0.7672
+			key = 	0.62	0.7611
+			key = 	0.615	0.7543
+			key = 	0.61	0.7502
+			key = 	0.605	0.7463
+			key = 	0.6	0.7419
+			key = 	0.595	0.7388
+			key = 	0.59	0.7358
+			key = 	0.585	0.7287
+			key = 	0.58	0.7233
+			key = 	0.575	0.7194
+			key = 	0.57	0.7121
+			key = 	0.565	0.7048
+			key = 	0.56	0.6974
+			key = 	0.555	0.6926
+			key = 	0.55	0.6882
+			key = 	0.545	0.6841
+			key = 	0.54	0.6806
+			key = 	0.535	0.6785
+			key = 	0.53	0.6771
+			key = 	0.525	0.6757
+			key = 	0.52	0.6777
+			key = 	0.515	0.6808
+			key = 	0.51	0.6843
+			key = 	0.505	0.6871
+			key = 	0.5	0.6899
+			key = 	0.495	0.6927
+			key = 	0.49	0.6961
+			key = 	0.485	0.6991
+			key = 	0.48	0.702
+			key = 	0.475	0.7061
+			key = 	0.47	0.7115
+			key = 	0.465	0.7173
+			key = 	0.46	0.722
+			key = 	0.455	0.7244
+			key = 	0.45	0.7265
+			key = 	0.445	0.7318
+			key = 	0.44	0.7366
+			key = 	0.435	0.7413
+			key = 	0.43	0.7465
+			key = 	0.425	0.7505
+			key = 	0.42	0.7537
+			key = 	0.415	0.7563
+			key = 	0.41	0.7599
+			key = 	0.405	0.7644
+			key = 	0.4	0.7682
+			key = 	0.395	0.7723
+			key = 	0.39	0.7767
+			key = 	0.385	0.7796
+			key = 	0.38	0.7821
+			key = 	0.375	0.7846
+			key = 	0.37	0.7883
+			key = 	0.365	0.7926
+			key = 	0.36	0.7951
+			key = 	0.355	0.7976
+			key = 	0.35	0.8001
+			key = 	0.345	0.8041
+			key = 	0.34	0.8083
+			key = 	0.335	0.8119
+			key = 	0.33	0.8152
+			key = 	0.325	0.8182
+			key = 	0.32	0.8207
+			key = 	0.315	0.8226
+			key = 	0.31	0.8226
+			key = 	0.305	0.8233
+			key = 	0.3	0.8245
+			key = 	0.295	0.8246
+			key = 	0.29	0.8246
+			key = 	0.285	0.8246
+			key = 	0.28	0.8239
+			key = 	0.275	0.8227
+			key = 	0.27	0.8204
+			key = 	0.265	0.8173
+			key = 	0.26	0.8118
+			key = 	0.255	0.807
+			key = 	0.25	0.8027
+			key = 	0.245	0.7977
+			key = 	0.24	0.7929
+			key = 	0.235	0.7885
+			key = 	0.23	0.7831
+			key = 	0.225	0.7778
+			key = 	0.22	0.774
+			key = 	0.215	0.7689
+			key = 	0.21	0.7629
+			key = 	0.205	0.7557
+			key = 	0.2	0.7484
+			key = 	0.195	0.7412
+			key = 	0.19	0.7358
+			key = 	0.185	0.7292
+			key = 	0.18	0.7217
+			key = 	0.175	0.7141
+			key = 	0.17	0.7054
+			key = 	0.165	0.6969
+			key = 	0.16	0.6905
+			key = 	0.155	0.6827
+			key = 	0.15	0.6765
+			key = 	0.145	0.6722
+			key = 	0.14	0.6685
+			key = 	0.135	0.6665
+			key = 	0.13	0.6644
+			key = 	0.125	0.6612
+			key = 	0.12	0.6559
+			key = 	0.115	0.6512
+			key = 	0.11	0.6456
+			key = 	0.105	0.639
+			key = 	0.1	0.6343
+			key = 	0.095	0.6275
+			key = 	0.09	0.6213
+			key = 	0.085	0.616
+			key = 	0.08	0.6109
+			key = 	0.075	0.6035
+			key = 	0.07	0.596
+			key = 	0.065	0.589
+			key = 	0.06	0.5787
+			key = 	0.055	0.5673
+			key = 	0.05	0.5593
+			key = 	0.045	0.5478
+			key = 	0.04	0.5377
+			key = 	0.035	0.5235
+			key = 	0.03	0.5022
+			key = 	0.025	0.4735
+			key = 	0.02	0.4111
+			key = 	0.015	0.3361
+			key = 	0.01	0.2461
+			key = 	0.009	0.2241
+			key = 	0.008	0.2021
+			key = 	0.007	0.1855
+			key = 	0.006	0.1546
+			key = 	0.005	0.1206
+			key = 	0.004	0.0947
+			key = 	0.003	0.0668
+			key = 	0.002	0.0463
+			key = 	0.001	0.0263
+			key = 	0	0.0003
+		}
+	}
+}
+
+}


### PR DESCRIPTION
## Features
* Add first pass of modular SRB parts (3 variants)
  * Full part config files custom tailored for specific lines of SRB models
  * Including thrust differentiation for different lengths/segments, burn time, and thrust curves
  * RSRM (1-6 segments, with diameter scaling)
  * UA120 (1-8 segments, with diameter scaling),
  * GEM-40/46/60/xx (multiple diameters and lengths).
  * Additional body/nozzle/nosecone variants exist that are as-yet unused; more SRB model-lines may be created in the future (feel free to use these as examples)
* Disable original SSTU-MSRB parts (not configured for RO, might as well remove the configs)
* Add replacement stand-alone SRB parts as-per stratochief's request (not needed though with the modular ones working finally); feel free to remove these if they are deemed unnecessary

## Known Issues
* Thrust curves for many segments are copied from the closest available;
  * GEM uses the same curve for all lengths / diameters
  * UA120 uses the 1207 curve for all lengths / diameters
* Diameter scaling is enabled with thrust scaled for constant burn-time (cubic)
  * Might want to flip this around for square scaling for both thrust and resources
  * These are controlled by the thrustScalePower and resourceScalePower options in the MSRB module; change both to 2 to use square scaling
* Effects scaling and positioning is WIP - needs a plugin side fix that should be available soon.