### PR TITLE
Fix node position on service bays

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -673,15 +673,8 @@
 @PART[ServiceBay_125]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
+	%rescaleFactor = 1.6
 	%scale = 1.0
-	@node_stack_top2 = 0.0, 0.4, 0.0, 0.0, -1.0, 0.0, 1
-	@node_stack_bottom2 = 0.0, -0.4, 0.0, 0, -1, 0, 1
-	@node_stack_top = 0.0, 0.48, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.48, 0.0, 0.0, -1.0, 0.0, 1
 	
 	@maxTemp = 1000
 	@title = Service Bay [2m]
@@ -694,16 +687,9 @@
 @PART[ServiceBay_250]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
+
+	%rescaleFactor = 1.6
 	%scale = 1.0
-	@node_stack_top2 = 0.0, 0.88, 0.0, 0.0, -1.0, 0.0, 1
-	@node_stack_bottom2 = 0.0, -0.88, 0.0, 0, -1, 0, 1
-	
-	@node_stack_top = 0.0, 1.04, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 2
 	
 	@maxTemp = 1000
 	@title = Service Bay [4m]


### PR DESCRIPTION
The nodes were outside the part.

the 4m bay actually looks a fraction too large for 4m, should it be scaled down a tiny amount too?