### PR TITLE
Fix Tantares TKS parts scale/nodes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
@@ -5,14 +5,14 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
 	%node_stack_bottom = 0.0, -1.02, 0.0, 0.0, -1.0, 0.0, 3
-	%node_stack_bottom2 = 0.0, -1.01, 0.0, 0.0, -1.0, 0.0, 3
+	%node_stack_bottom2 = 0.0, -1.01, 0.0, 0.0, 1.0, 0.0, 3
 	%node_stack_top    = 0.0,  1.02, 0.0, 0.0, 1.0, 0.0, 3
-	%node_stack_top2 = 0.0, 1.01, 0.0, 0.0, 1.0, 0.0, 3
+	%node_stack_top2 = 0.0, 1.01, 0.0, 0.0, -1.0, 0.0, 3
 	
 	%title = FGB Cargo Bay
 	%description = For transportation of large cargos.
@@ -29,11 +29,9 @@
 @PART[Alnair_Crew_A]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!mesh = dummy
-	MODEL
+	@MODEL
 	{
-		model = Tantares/Parts/TKS/Alnair_Crew_A/model
-		scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -150,7 +148,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -249,10 +247,9 @@
 {
 	%RSSROConfig = True
 	!mesh = dummy
-	MODEL
+	@MODEL
 	{
-		model = Tantares/Parts/TKS/Alnair_Crew_C/model
-		scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -348,7 +345,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -374,7 +371,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -465,7 +462,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -655,7 +652,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -678,7 +675,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -701,7 +698,7 @@
 @PART[Alnair_Mono_C]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.04
+	%rescaleFactor = 1.632
 	%scale = 0.4901
 	
 	%title = TKS Internal Fuel Storage
@@ -721,11 +718,9 @@
 @PART[Alnair_Orbital_A]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!mesh = dummy
-	MODEL
+	@MODEL
 	{
-		model = Tantares/Parts/TKS/Alnair_Orbital_A/model
-		scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -823,7 +818,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -918,7 +913,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -937,7 +932,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -1042,7 +1037,7 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		%scale = 2.04, 2.04, 2.04
+		%scale = 1.632, 1.632, 1.632
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
@@ -1059,11 +1054,11 @@
 @PART[Alnair_Structure_*]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL
-	{
-		%scale = 2.04, 2.04, 2.04
-	}
-	%rescaleFactor = 1.0
+	//@MODEL
+	//{
+	//	%scale = 1.632, 1.632, 1.632
+	//}
+	%rescaleFactor = 1.632
 	%scale = 1.0
 	@mass *= 8.489
 }


### PR DESCRIPTION
The recent Tantares (33) seems to have upscaled the TKS parts, which made them wrong size in RO.

also fixed the Nodes in the TKS structural parts which were already broken.