### PR TITLE
SXT AJ10-118F/K plume config

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTAJ10Adv.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTAJ10Adv.cfg
@@ -1,0 +1,46 @@
+//  ==================================================
+//  AJ10-118F/K plume configuration.
+//  ==================================================
+
+@PART[SXTAJ10Adv]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-Upper
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.3
+        fixedScale = 1.0
+        energy = 0.8
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Upper
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }    
+}
+
+//  ==================================================
+//  AJ10-118F/K flare configuration.
+//  ==================================================
+
+@PART[SXTAJ10Adv]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-Upper
+        {
+            @localPosition = 0.0, 0.0, 0.3
+            @fixedScale = 0.8
+        }
+    }
+}


### PR DESCRIPTION
* Add a missing Real Plume configuration to the advanced AJ10 variant.