### PR TITLE
J2 restarting

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -35,11 +35,16 @@
 				key = 1 300
 			}
 			ullage = True
-			ignitions = 3
+			ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 2.0
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 			cost = 0
 		}
@@ -65,11 +70,16 @@
 				key = 1 290
 			}
 			ullage = True
-			ignitions = 3
+			ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 2.0
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 			
 			cost = 1000
@@ -83,5 +93,11 @@
 	}
 	!MODULE[ModuleAlternator]
 	{
+	}
+	RESOURCE
+	{
+		name = Helium
+		amount = 250
+		maxAmount = 250
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -35,7 +35,7 @@
 				key = 1 300
 			}
 			ullage = True
-			ignitions = 99
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -70,7 +70,7 @@
 				key = 1 290
 			}
 			ullage = True
-			ignitions = 99
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
@@ -49,7 +49,7 @@
 			}
 			
 			ullage = True
-			ignitions = 99
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
@@ -49,11 +49,16 @@
 			}
 			
 			ullage = True
-			ignitions = 8
+			ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			INGITOR_RESOURCE
+			}
+				name = Helium
+				amount = 250
 			}
 		}
 	}
@@ -68,5 +73,11 @@
 	}
 	!RESOURCE[ElectricCharge]
 	{
+	}
+	RESOURCE
+	{
+		name = Helium
+		amount = 250
+		maxAmount = 250
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -57,7 +57,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -102,7 +102,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -141,7 +141,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -57,11 +57,16 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 3 //Definately a FIXME right here
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 		CONFIG
@@ -97,11 +102,16 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 3 //was to carry three starter cartriges, http://www.astronautix.com/engines/j2s.htm
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 		CONFIG
@@ -131,11 +141,16 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 3 //Definately a FIXME right here
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 	}
@@ -150,5 +165,11 @@
 	}
 	!RESOURCE[ElectricCharge]
 	{
+	}
+	RESOURCE
+	{
+		name = Helium
+		amount = 250
+		maxAmount = 250
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -41,7 +41,7 @@
 			}
 			
 			%ullage = True
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -77,7 +77,7 @@
 			}
 			
 			%ullage = True
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -113,7 +113,7 @@
 			}
 			
 			%ullage = True
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -149,7 +149,7 @@
 			}
 			
 			%ullage = True
-			%ignitions = 99
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -41,11 +41,16 @@
 			}
 			
 			%ullage = True
-			%ignitions = 2
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 		CONFIG
@@ -72,11 +77,16 @@
 			}
 			
 			%ullage = True
-			%ignitions = 2
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 		CONFIG
@@ -103,11 +113,16 @@
 			}
 			
 			%ullage = True
-			%ignitions = 2
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 		CONFIG
@@ -134,11 +149,16 @@
 			}
 			
 			%ullage = True
-			%ignitions = 2
+			%ignitions = 99
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = Helium
+				amount = 250
 			}
 		}
 	}
@@ -150,5 +170,11 @@
 	}
 	!MODULE[ModuleAlternator]
 	{
+	}
+	RESOURCE
+	{
+		name = Helium
+		amount = 250
+		maxAmount = 250
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -212,6 +212,12 @@
 		amount = 6000
 		maxAmount = 6000
 	}
+	RESOURCE
+	{
+		name = Helium
+		amount = 0
+		maxAmount = 500
+	}
 }
 @PART[FASAApalloLFTJ2Plate]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
I know there is some complaint about handling restart capability on the J2 engine.  S-IVB-200 (used on Saturn 1B) had no restart capability.  S-IVB-500 (used on Saturn V) could be restarted up to 3 times, though it was never started more than twice.  According to the J-2 technical specifications, the built in auto-starter was effectively unlimited so the J-2 could really be started as many times as you had fuel and proper pressurization.  Maybe there is a better way to handle restarting the J-2 but this is a workable solution using the existing systems.
I've reset the "ignitions" value to 99.  For some reason I can't set "ignitions = -1" to get unlimited ignitions so I've opted for 99 since it's a high enough limit to qualify as "unlimited" for most purposes.
I've added an "IGNITOR_RESOURCE" of "Helium" which will limit the number of restarts you can have on a flight.  I set the amount of Helium required for each restart to 250L.  I came up with that figure because the S-IVB-500 included eight 3.5 cu ft (approx. 99L) "cold helium spheres" inside the LH2 tank.  That meant the S-IVB-500 included approx. 792L of Helium for fuel pressurization which was enough for up to 3 ignitions.  That means each ignition used approx. 264L.  I rounded off at 250 for ease and because I can't be sure that the Helium wasn't used for other purposes.
Finally, I've added 250L Helium to the J-2 engine itself.  This allows a single ignition version of the engine to be used as is.  No need to change existing vehicle configurations unless you need more than a single ignition.  If you need more, just add 250L/restart/engine of Helium to an existing tank.

I will add updated configs for the J-2X, J-2T and M-1 momentarily (they'll be on the same PR).

The one problem I've come across with this setup is that Default tanks can't currently hold Helium.  Only ServiceModule and Fuselage tanks currently have the ability to store Helium.  For the FASA S-IVB tank, I'm going to add a 500L Helium capacity (with current amount set to 0) so that both S-IVB-200 and S-IVB-500 versions can be modeled.  I'm wondering, though, if RealFuels should be updated so that Helium is a valid fuel for other tank types.