### PR TITLE
RSB 0.9.0 updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Agena.cfg
@@ -18,13 +18,13 @@
 {
     %RSSROConfig = True
 
-    @MODEL,1
+    @MODEL,0
     {
         @scale = 1.0, 1.0, 1.0
         %position = 0.0, 0.0, 0.0
     }
 
-    @MODEL,2
+    @MODEL,1
     {
         @scale = 1.25, 1.25, 1.25
         %position = 0.0, 0.5, 0.0
@@ -70,14 +70,14 @@
     }
 
     !MODULE[ModuleSPU]{}
-	
-    !MODULE[ModuleRTAntennaPassive]{}
+
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 4997
+        volume = 4994.48
         basemass = -1
 
         //  Avionics batteries 11.8 kWh.
@@ -108,13 +108,13 @@
             maxAmount = 2670
         }
 
-        //  ACS propellant 27 Kg (maximum of three tanks, each with a capacity of 36 L).
+        //  ACS propellant ~27 Kg (maximum of three tanks, each with a capacity of 36 L).
 
         TANK
         {
             name = Nitrogen
-            amount = 21710
-            maxAmount = 21710
+            amount = 21600
+            maxAmount = 21600
         }
     }
 
@@ -164,7 +164,7 @@
 //  ==================================================
 //  Agena D ACS propellant tank.
 
-//  Dimensions: 0.38 m x 0.38 m
+//  Dimensions: 0.4 m x 0.4 m
 //  Inert Mass: 1.6 Kg
 //  ==================================================
 
@@ -174,7 +174,7 @@
 
     @title = Spherical Tank (Agena)
     @manufacturer = Generic
-    @description = A spherical, general purpose, propellant tank.
+    @description = A general purpose spherical propellant tank.
 
     @mass = 0.0016
     @crashTolerance = 14

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
@@ -64,7 +64,7 @@
 
     //  Six RCS thrusters for each axis but only three active (three for redundancy).
 
-	@MODULE[ModuleRCS]
+    @MODULE[ModuleRCS]
     {
         @thrusterPower = 1.365
         !resourceName = NULL
@@ -93,7 +93,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 403000
+        volume = 402943.795
         basemass = -1
 
         //  Batteries 1.43 kWh.
@@ -133,7 +133,7 @@
             maxAmount = 13
         }
 
-        //  ACS pressurization.
+        //  ACS pressurization ~0.023 Kg.
 
         TANK
         {
@@ -142,6 +142,10 @@
             maxAmount = 130
         }
     }
+
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
 
     !RESOURCE,*{}
 }
@@ -162,21 +166,27 @@
         }
     }
 
-    @MODULE[ModuleSPU]
+    MODULE
     {
-        @IsRTCommandStation = False
-        @RTCommandMinCrew = 0
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
     }
 
-    @MODULE[ModuleRTAntennaPassive]
+    MODULE
     {
-        @name = ModuleRTAntenna
-        !TechRequired = NULL
-        !OmniRange = NULL
-        %IsRTActive = True
-        %Mode0OmniRange = 0
-        %Mode1OmniRange = 500000
-        %EnergyCost = 0.025
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.29
+            PacketResourceCost = 0.0075
+        }
     }
 }
 
@@ -232,13 +242,13 @@
     @MODULE[ModuleDecouple]
     {
         @ejectionForce = 0
-	}
+    }
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 550
+        volume = 541
         basemass = -1
 
         //  ACS fuel 515 Kg.
@@ -307,8 +317,8 @@
         {
             @key,0 = 0 208
             @key,1 = 1 85
-		}
-	}
+        }
+    }
 
     @MODULE[ModuleDecouple]
     {
@@ -319,7 +329,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 550
+        volume = 541
         basemass = -1
 
         //  ACS fuel 515 Kg.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
@@ -311,7 +311,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 46095
+        volume = 46096.16
         basemass = -1
 
         //  Avionics batteries 600 Wh.
@@ -361,6 +361,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     !RESOURCE,*{}
 }
 
@@ -380,21 +384,27 @@
         }
     }
 
-    @MODULE[ModuleSPU]
+    MODULE
     {
-        @IsRTCommandStation = False
-        @RTCommandMinCrew = 0
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
     }
-	
-    @MODULE[ModuleRTAntennaPassive]
+
+    MODULE
     {
-        @name = ModuleRTAntenna
-        !TechRequired = NULL
-        !OmniRange = NULL
-        %IsRTActive = True
-        %Mode0OmniRange = 0
-        %Mode1OmniRange = 1500000
-        %EnergyCost = 0.025
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.29
+            PacketResourceCost = 0.0075
+        }
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -398,7 +398,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 58678
+        volume = 58677.05
         basemass = -1
 
         //  Batteries 4.3 kWh.
@@ -449,6 +449,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     !RESOURCE,*{}
 }
 
@@ -468,21 +472,27 @@
         }
     }
 
-    @MODULE[ModuleSPU]
+    MODULE
     {
-        @IsRTCommandStation = False
-        @RTCommandMinCrew = 0
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
     }
-	
-    @MODULE[ModuleRTAntennaPassive]
+
+    MODULE
     {
-        @name = ModuleRTAntenna
-        !OmniRange = NULL
-        !TechRequired = NULL
-        %IsRTActive = True
-        %Mode0OmniRange = 0
-        %Mode1OmniRange = 1500000
-        %EnergyCost = 0.025
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.29
+            PacketResourceCost = 0.0075
+        }
     }
 }
 
@@ -625,17 +635,6 @@
         volume = 275182
         basemass = -1
 
-        //  Batteries 50 Wh.
-        //  Supports the CCB for the initial duration of the flight (approximately 5 minutes).
-        //  Assumes that the electricity consumption of the CBC avionics is 200 W.
-
-        TANK
-        {
-            name = ElectricCharge
-            amount = 180
-            maxAmount = 180
-        }
-
         //  CCB fuel 76367 Kg.
 
         TANK
@@ -679,6 +678,17 @@
         amount = 17.25
         maxAmount = 17.25
     }
+
+    //  Batteries 50 Wh.
+    //  Supports the CCB for the initial duration of the flight (approximately 5 minutes).
+    //  Assumes that the electricity consumption of the CBC avionics is 200 W.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 180
+        maxAmount = 180
+    }
 }
 
 //  ==================================================
@@ -694,7 +704,7 @@
 
     @title = Spherical Tank (Centaur)
     @manufacturer = Generic
-    @description = A spherical, general purpose, propellant tank.
+    @description = A general purpose spherical propellant tank.
 
     @mass = 0.006
     @crashTolerance = 14

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Carrack.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Carrack.cfg
@@ -16,7 +16,7 @@
 
     @title = Carrack LPLF
     @manufacturer = American Launch Services
-	@description = A large payload fairing for the Carrack launch vehicle family.
+    @description = A large payload fairing for the Carrack launch vehicle family.
 
     @mass = 0.83
     @crashTolerance = 16
@@ -124,6 +124,8 @@
 {
     %RSSROConfig = True
 
+    //  Roll control thrusters.
+
     MODEL
     {
         model = RealismOverhaul/Models/LinearRCS
@@ -178,7 +180,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 100
+        volume = 94.536
         basemass = -1
 
         //  Avionics batteries 10 Wh.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
@@ -402,7 +402,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 47650
+        volume = 47647.54
         basemass = -1
 
         //  Avionics batteries 1.4 kWh.
@@ -486,6 +486,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     !RESOURCE,*{}
 }
 
@@ -518,7 +522,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 58780
+        volume = 58782.54
         basemass = -1
 
         //  Avionics batteries 1.4 kWh.
@@ -602,6 +606,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     !RESOURCE,*{}
 }
 
@@ -634,7 +642,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 76568
+        volume = 76567.54
         basemass = -1
 
         //  Avionics batteries 1.4 kWh.
@@ -720,6 +728,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     !RESOURCE,*{}
 }
 
@@ -739,21 +751,27 @@
         }
     }
 
-    @MODULE[ModuleSPU]
+    MODULE
     {
-        @IsRTCommandStation = False
-        @RTCommandMinCrew = 0
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
     }
-	
-    @MODULE[ModuleRTAntennaPassive]
+
+    MODULE
     {
-        @name = ModuleRTAntenna
-        !TechRequired = NULL
-        !OmniRange = NULL
-        %IsRTActive = True
-        %Mode0OmniRange = 0
-        %Mode1OmniRange = 1500000
-        %EnergyCost = 0.025
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.29
+            PacketResourceCost = 0.0075
+        }
     }
 }
 
@@ -1001,7 +1019,7 @@
 
     @title = Spherical Tank (DCSS)
     @manufacturer = Generic
-    @description = A spherical, general purpose, propellant tank.
+    @description = A general purpose spherical propellant tank.
 
     @mass = 0.0045
     @crashTolerance = 14

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -855,7 +855,7 @@
     {
         @configuration = H-1-SaturnI
 
-        !CONFIG,*:HAS[~name[RS-27],~name[RS-27A]]{}
+        !CONFIG,*:HAS[~name[H-1-SaturnI],~name[H-1-SaturnIB]]{}
     }
 }
 
@@ -1493,7 +1493,7 @@
     {
         @configuration = RS-27
 
-        !CONFIG,*:HAS[~name[H-1-SaturnI],~name[H-1-SaturnIB]]{}
+        !CONFIG,*:HAS[~name[RS-27],~name[RS-27A]]{}
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -1,10 +1,4 @@
 //  ==================================================
-//  Remove extra parts.
-//  ==================================================
-
-!PART[RSBengineF1A]:FOR[RealismOverhaul]{}
-
-//  ==================================================
 //  P241A EAP (Étages d’Accélération à Poudre)
 
 //  Dimensions: 3.07 x 27 m
@@ -707,6 +701,55 @@
         @name = ModuleEnginesRF
         @minThrust = 7740.5
         @maxThrust = 7740.5
+        @heatProduction = 100
+        !engineAccelerationSpeed = NULL
+        !engineDecelerationSpeed = NULL
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.380
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.620
+        }
+    }
+}
+
+//  ==================================================
+//  F-1A engine (throttleable version).
+
+//  Dimensions: 3.4 m x 4.5 m
+//  Inert Mass: 8195 Kg
+//  ==================================================
+
+@PART[RSBengineF1A]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @mass = 8.195
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+
+    %engineType = F-1A_ETS
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 5513.8
+        @maxThrust = 9189.6
         @heatProduction = 100
         !engineAccelerationSpeed = NULL
         !engineDecelerationSpeed = NULL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -51,6 +51,9 @@
         @heatProduction = 100
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -146,7 +149,7 @@
             @key,0 = 0 274
             @key,1 = 1 245
         }
-    }	
+    }
 
     MODULE
     {
@@ -222,7 +225,7 @@
             @key,0 = 0 277.8
             @key,1 = 1 251
         }
-    }	
+    }
 
     MODULE
     {
@@ -316,7 +319,7 @@
             @key,0 = 0 279.8
             @key,1 = 1 251
         }
-    }	
+    }
 
     MODULE
     {
@@ -344,7 +347,7 @@
         gimbalRange = 5.0
         useGimbalResponseSpeed = True
         gimbalResponseSpeed = 16
-	}
+    }
 
     !RESOURCE,*{}
 }
@@ -981,13 +984,6 @@
             @key,1 = 1 294
         }
     }
-
-    //RESOURCE
-    //{
-    //    name = Helium
-    //    amount = 92000
-    //    maxAmount = 92000
-    //}
 }
 
 //  ==================================================
@@ -1061,8 +1057,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1447,8 +1443,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
 
     %engineType = H1
     %engineTypeMult = 1
@@ -1596,8 +1592,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1666,8 +1662,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_PSLV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_PSLV.cfg
@@ -50,7 +50,7 @@
 
     @title = PSLV Payload Fairing Base
     @manufacturer = ISRO
-	description = A 2.8 meter procedural payload fairing base designed for the PSLV stack.
+    @description = A 2.8 meter procedural payload fairing base designed for the PSLV stack.
 
     @mass = 0.22
     @crashTolerance = 14
@@ -167,7 +167,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1692
+        volume = 1691.35
         basemass = -1
 
         //  Avionics batteries 375 Wh.
@@ -231,7 +231,7 @@
             heatProduction = 100
 
             //  Ignition count just enough for a trans-Martian multi-perigee injection burn.
-            //  Estimating an O/F ratio of 2.16 (ideal MMH/NTO burn ratio).
+            //  Using an O/F ratio of 2.16 (ideal MMH/NTO burn ratio).
 
             ullage = True
             pressureFed = True
@@ -266,8 +266,8 @@
     }
 
     !MODULE[ModuleSPU]{}
-	
-    !MODULE[ModuleRTAntennaPassive]{}
+
+    !MODULE[ModuleRTAntenna*]{}
 
     !RESOURCE,*{}
 }
@@ -528,25 +528,25 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 36777
+        volume = 36326
         basemass = -1
 
-        //  Vikas fuel 15018 Kg.
+        //  Vikas fuel 14230 Kg.
 
         TANK
         {
             name = UDMH
-            amount = 18985
-            maxAmount = 18985
+            amount = 17990
+            maxAmount = 17990
         }
 
-        //  Vikas oxidizer 25681 Kg.
+        //  Vikas oxidizer 26468 Kg.
 
         TANK
         {
             name = NTO
-            amount = 17710
-            maxAmount = 17710
+            amount = 18254
+            maxAmount = 18254
         }
 
         //  ACS fuel 35 Kg.
@@ -639,6 +639,9 @@
         @minThrust = 0
         @maxThrust = 18
         @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -702,6 +705,9 @@
         @minThrust = 0
         @maxThrust = 30
         @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -807,7 +813,7 @@
             @key,0 = 0 269
             @key,1 = 1 236
         }
-    }	
+    }
 
     MODULE
     {
@@ -957,7 +963,7 @@
 
     @MODULE[ModuleEngines*]
     {
-		@name = ModuleEnginesFX
+        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 864
         @heatProduction = 100
@@ -974,7 +980,7 @@
             @key,0 = 0 262
             @key,1 = 1 236
         }
-    }	
+    }
 
     MODULE
     {
@@ -1202,7 +1208,7 @@
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 5.0
-	}
+    }
 
     MODULE
     {
@@ -1265,7 +1271,7 @@
 
     @title = Spherical Tank (PSLV)
     @manufacturer = Generic
-    @description = A spherical propellant tank.
+    @description = A general purpose spherical propellant tank.
 
     @mass = 0.0016
     @crashTolerance = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -14,6 +14,7 @@
 //  Saturn I Flight Test Evaluation:                                http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19640013313.pdf
 //  Saturn I Electrical Power and Systems Integration:              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650012954.pdf
 //  ETS Saturn IC & Multibody:                                      http://wiki.alternatehistory.com/doku.php/timelines/eyes_turned_skyward_spacecraft_and_launch_vehicle_technical_data
+//  LARGE LAUNCH VEHICLE SYSTEM FOR A MANNED LUNAR LANDING PROGRAM: http://www.pdf-archive.com/2013/04/27/ae61-0967-saturn-c-3-c-4-nova/ae61-0967-saturn-c-3-c-4-nova.pdf
 
 //  ==================================================
 //  Saturn Multibody nose cone.
@@ -28,7 +29,7 @@
 
     @title = Saturn Multibody Nose Cone
     @manufacturer = Boeing Co.
-    @description = An aerodynamic nose cone for the Saturn S-IF or S-IVC stages.
+    @description = An aerodynamic nose cone designed for the Saturn S-IF or S-IVC stages.
 
     @mass = 1.05
     @crashTolerance = 16
@@ -39,7 +40,7 @@
 }
 
 //  ==================================================
-//  Saturn small nose cone.
+//  Saturn IB nose cone.
 
 //  Dimensions: 6.6 m x 6.7 m
 //  Inert Mass: 1500 Kg
@@ -49,9 +50,9 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn Nose Cone (Small)
+    @title = Saturn IB Nose Cone
     @manufacturer = Boeing Co.
-    @description = An aerodynamic nose cone for the Saturn S-IB or S-IVB stages.
+    @description = An aerodynamic nose cone designed for the Saturn S-IB or S-IVB stages.
 
     @mass = 1.5
     @crashTolerance = 16
@@ -62,7 +63,7 @@
 }
 
 //  ==================================================
-//  Saturn large nose cone.
+//  Saturn V nose cone.
 
 //  Dimensions: 10 m x 8.3 m
 //  Inert Mass: 3100 Kg
@@ -72,9 +73,9 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn Nose Cone (Large)
+    @title = Saturn V Nose Cone
     @manufacturer = Boeing Co.
-    @description = An aerodynamic nose cone for Saturn S-IC or S-II stages.
+    @description = An aerodynamic nose cone designed for Saturn S-IC or S-II stages.
 
     @mass = 3.1
     @crashTolerance = 16
@@ -95,9 +96,9 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn Payload Fairing Base (3.9m)
+    @title = Saturn I Payload Fairing Base
     @manufacturer = Douglas Aircraft Company
-    @description = A 3.9 meter payload fairing base, designed for the Saturn S-IV stage.
+    @description = A 3.9 meter payload fairing base designed for the Saturn S-IV stage.
 
     @mass = 0.5
     @crashTolerance = 14
@@ -108,7 +109,7 @@
 }
 
 //  ==================================================
-//  Saturn V payload fairing base.
+//  Saturn V payload fairing base (6.6 meters).
 
 //  Dimensions: 6.6 m x 1.2 m
 //  Inert Mass: 1970 Kg
@@ -118,9 +119,9 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn Payload Fairing Base (6.6m)
+    @title = Saturn V Payload Fairing Base (6.6m)
     @manufacturer = Douglas Aircraft Company
-    @description = A 6.6 meter payload fairing base, designed for the Saturn S-IVB or S-IB stages.
+    @description = A 6.6 meter payload fairing base designed for the Saturn S-IVB or S-IB stages.
 
     @mass = 1.97
     @crashTolerance = 14
@@ -141,9 +142,9 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn Payload Fairing Base (10m)
+    @title = Saturn V Payload Fairing Base (10m)
     @manufacturer = North American
-    @description = A 10 meter  payload fairing base, designed for the Saturn S-II or S-IC stages.
+    @description = A 10 meter payload fairing base, designed for the Saturn S-II or S-IC stages.
 
     @mass = 6.18
     @crashTolerance = 14
@@ -192,6 +193,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     //  Avionics batteries 310 Wh.
 
     @RESOURCE[ElectricCharge]
@@ -232,6 +237,10 @@
         }
     }
 
+    !MODULE[ModuleSPU]{}
+
+    !MODULE[ModuleRTAntenna*]{}
+
     //  Avionics batteries 350 Wh.
 
     @RESOURCE[ElectricCharge]
@@ -242,7 +251,7 @@
 }
 
 //  ==================================================
-//  Saturn I/V Instrument Unit.
+//  Saturn Instrument Unit.
 
 //  Remote Tech compatibility.
 //  ==================================================
@@ -257,21 +266,27 @@
         }
     }
 
-    @MODULE[ModuleSPU]
+    MODULE
     {
-        @IsRTCommandStation = False
-        @RTCommandMinCrew = 0
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
     }
 
-    @MODULE[ModuleRTAntennaPassive]
+    MODULE
     {
-        @name = ModuleRTAntenna
-        !OmniRange = NULL
-        !TechRequired = NULL
-        %IsRTActive = True
-        %Mode0OmniRange = 0
-        %Mode1OmniRange = 1000000
-        %EnergyCost = 0.025
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1000000
+        EnergyCost = 0.025
+
+        TRANSITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.29
+            PacketResourceCost = 0.0075
+        }
     }
 }
 
@@ -292,7 +307,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IV Propellant Tank
+    @title = Saturn I S-IV Propellant Tank
     @manufacturer = Douglas Aircraft Company
 
     @mass = 4.57
@@ -347,7 +362,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IVB Propellant Tank
+    @title = Saturn IB/V S-IVB Propellant Tank
     @manufacturer = Douglas Aircraft Company
 
     @mass = 9.4
@@ -361,7 +376,7 @@
     {
         name = ModuleFuelTanks
         type = Cryogenic
-        volume = 356000
+        volume = 312280
         basemass = -1
 
         //  S-IVB fuel 16490 Kg.
@@ -397,7 +412,7 @@
 }
 
 //  ==================================================
-//  Saturn S-IVB APS unit.
+//  Saturn APS unit.
 
 //  Dimensions: 0.7 m x 1.4 m
 //  Gross Mass: 135 Kg
@@ -412,7 +427,7 @@
         @scale = 1.5, 1.5, 1.5
     }
 
-    @title = Saturn S-IVB Auxiliary Propulsion System
+    @title = Saturn Auxiliary Propulsion System (APS)
     @manufacturer = Douglas Aircraft Company
 
     @mass = 0.075
@@ -489,7 +504,7 @@
         }
     }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -504,7 +519,7 @@
     %RSSROConfig = True
 
     @category = Engine
-    @title = Saturn S-IVB Ullage Motor
+    @title = S-IVB Ullage Motor
     @manufacturer = Thiokol
 
     @crashTolerance = 12
@@ -519,6 +534,9 @@
         @minThrust = 15
         @maxThrust = 15
         @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -634,7 +652,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IB Interstage Adapter
+    @title = Saturn IB Interstage Adapter
     @manufacturer = Douglas Aircraft Company & Thiokol
     @description = The interstage adapter for the Saturn IB.
 
@@ -708,7 +726,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-II Propellant Tank
+    @title = Saturn V S-II Propellant Tank
 
     @mass = 26.9
     @crashTolerance = 12
@@ -721,7 +739,7 @@
     {
         name = ModuleFuelTanks
         type = Cryogenic
-        volume = 1349840
+        volume = 1349810
         basemass = -1
 
         //  S-II fuel 72200 Kg.
@@ -757,6 +775,67 @@
 }
 
 //  ==================================================
+//  Saturn C-8 S-II propellant tank.
+
+//  Dimensions: 10 m x 38 m
+//  Gross Mass: 756560 Kg
+//  ==================================================
+
+@PART[RSBtankSaturnSII8]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Saturn C-8 S-II Propellant Tank
+    @manufacturer = North American Aviation
+    @description = The propellant tank of the Saturn C-8 second stage. For engine restarts, eight ullage motors are recommended for this stage.
+
+    @mass = 49.24
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 2060440
+        basemass = -1
+
+        //  S-II-8 fuel 108818 Kg.
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 1535900
+            maxAmount = 1535900
+        }
+
+        //  S-II-8 oxidizer 598501 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 524540
+            maxAmount = 524540
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 350 Wh.
+    //  Supports the S-II-8 stage for the duration of it's flight.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 1260
+        maxAmount = 1260
+    }
+}
+
+//  ==================================================
 //  Saturn V S-II ullage motor.
 
 //  Dimensions: 0.4 m x 2.3 m
@@ -768,7 +847,7 @@
     %RSSROConfig = True
 
     @category = Engine
-    @title = Saturn S-II Ullage Motor
+    @title = S-II Ullage Motor
     @manufacturer = Thiokol
 
     @mass = 0.104
@@ -784,6 +863,9 @@
         @minThrust = 0
         @maxThrust = 102
         @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -831,7 +913,7 @@
     @MODEL
     {
         @scale = 1.0, 1.2, 1.0
-	}
+    }
 
     @node_stack_top = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 6
     @node_stack_bottom = 0.0, -3.0, 0.0, 0.0, -1.0, 0.0, 6
@@ -853,6 +935,77 @@
 }
 
 //  ==================================================
+//  Saturn C-8 S-IC-8/S-II-8 interstage adapter.
+
+//  Dimensions: 12.2 m x 6 m
+//  Inert Mass: 6180 Kg
+//  ==================================================
+
+@PART[RSBdecouplerSaturnSII8]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Saturn C-8 S-IC-8 Interstage Adapter
+    @manufacturer = North American Aviation
+    @description = The interstage adapter for the Saturn C-8 S-IC-8/S-II-8 stages.
+
+    @mass = 5.2
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    //  Eight 155 kN retro motors (inert 104 Kg - gross 226 Kg).
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1240
+        @maxThrust = 1240
+        @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 197
+            @key,1 = 1 177
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 551.41
+        basemass = -1
+
+        //  HTPB/AP propellant mixture 976 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 551.41
+            maxAmount = 551.41
+        }
+    }
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
 //  Saturn V S-IC propellant tank.
 
 //  Dimensions: 10 m x 38 m
@@ -863,7 +1016,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IC Propellant Tank
+    @title = Saturn V S-IC Propellant Tank
     @manufacturer = Boeing Co.
     @description = The first stage of the Saturn V. Includes explosive bolts for separation in the forward skirt.
 
@@ -880,9 +1033,13 @@
 
     @MODULE[ModuleEngines*]
     {
+        @name = ModuleEnginesRF
         @minThrust = 2697.6
         @maxThrust = 2697.6
         @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -927,7 +1084,7 @@
         }
     }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 
     //  HTPB/AP propellant mixture 152 Kg.
 
@@ -950,7 +1107,67 @@
 }
 
 //  ==================================================
-//  Saturn S-I fin (large - black).
+//  Saturn C-8 S-IC-8 propellant tank.
+
+//  Dimensions: 12.2 m x 46 m
+//  Gross Mass: 3560380 Kg
+//  ==================================================
+
+@PART[RSBtankSaturnSIC8]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @title = Saturn C-8 S-IC-8 Propellant Tank
+    @manufacturer = Real Scale Boosters
+
+    @mass = 114.28
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 3381808
+        basemass = -1
+
+        //  S-IC-8 fuel 1053852 Kg.
+
+        TANK
+        {
+            name = Kerosene
+            amount = 1285186
+            maxAmount = 1285186
+        }
+
+        //  S-IC-8 oxidizer 2392245 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 2096622
+            maxAmount = 2096622
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 150 Wh.
+    //  Supports the S-IC-8 stage for the duration of it's flight.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 540
+        maxAmount = 540
+    }
+}
+
+//  ==================================================
+//  Saturn I fin (large - black).
 
 //  Dimensions: 5.2 m x 4.5 m
 //  Inert Mass: 850 Kg
@@ -960,7 +1177,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-I Large Fin (Black)
+    @title = Saturn I Large Fin (Black)
     @manufacturer = Chrysler
     @description = Typically four fins of this type are used around the base of the Saturn S-I stage.
 
@@ -972,7 +1189,7 @@
 }
 
 //  ==================================================
-//  Saturn S-I fin (small - black).
+//  Saturn I fin (small - black).
 
 //  Dimensions: 3.5 m x 4.5 m
 //  Inert Mass: 600 Kg
@@ -982,7 +1199,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-I Stub Fin (Black)
+    @title = Saturn I Stub Fin (Black)
     @manufacturer = Chrysler
     @description = Typically four fins of this type are used around the base of the Saturn S-I stage.
 
@@ -994,7 +1211,7 @@
 }
 
 //  ==================================================
-//  Saturn S-I fin (large - white).
+//  Saturn I fin (large - white).
 
 //  Dimensions: 5.2 m x 4.5 m
 //  Inert Mass: 850 Kg
@@ -1004,7 +1221,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-I Large Fin (White)
+    @title = Saturn I Large Fin (White)
     @manufacturer = Chrysler
     @description = Typically four fins of this type are used around the base of the Saturn S-I stage.
 
@@ -1016,7 +1233,7 @@
 }
 
 //  ==================================================
-//  Saturn S-I fin (small - white).
+//  Saturn I fin (small - white).
 
 //  Dimensions: 3.5 m x 4.5 m
 //  Inert Mass: 600 Kg
@@ -1026,7 +1243,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-I Stub Fin (White)
+    @title = Saturn I Stub Fin (White)
     @manufacturer = Chrysler
     @description = Typically four fins of this type are used around the base of the Saturn S-I stage.
 
@@ -1038,7 +1255,7 @@
 }
 
 //  ==================================================
-//  Saturn S-IC fin.
+//  Saturn V fin.
 
 //  Dimensions: 4 m x 3.5 m
 //  Inert Mass: 350 Kg
@@ -1048,7 +1265,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IC Fin
+    @title = Saturn V Fin
     @manufacturer = Boeing Co.
 
     @mass = 0.35
@@ -1059,7 +1276,7 @@
 }
 
 //  ==================================================
-//  Saturn S-I interstage adapter.
+//  Saturn I interstage adapter.
 
 //  Dimensions: 5.6 m x 4.8 m
 //  Inert Mass: 2400 Kg
@@ -1069,7 +1286,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-I Interstage Adapter
+    @title = Saturn I Interstage Adapter
     @manufacturer = Douglas Aircraft Company
     @description = The interstage adapter for the Saturn I.
 
@@ -1148,7 +1365,7 @@
 }
 
 //  ==================================================
-//  Saturn S-IB fin (black).
+//  Saturn IB fin (black).
 
 //  Dimensions: 3 m x 2.5 m
 //  Mass: 200 Kg
@@ -1158,7 +1375,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IB Fin (Black)
+    @title = Saturn IB Fin (Black)
     @manufacturer = Chrysler
 
     @mass = 0.2
@@ -1169,7 +1386,7 @@
 }
 
 //  ==================================================
-//  Saturn S-IB fin (white).
+//  Saturn IB fin (white).
 
 //  Dimensions: 3 m x 2.5 m
 //  Mass: 200 Kg
@@ -1179,7 +1396,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IB Fin (White)
+    @title = Saturn IB Fin (White)
     @manufacturer = Chrysler
 
     @mass = 0.2
@@ -1200,7 +1417,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IE Propellant Tank
+    @title = Saturn IC S-IE Propellant Tank
     @manufacturer = Boeing Co.
     @description = The first stage of the fictional Saturn IC, from the Eyes Turned Skyward universe.
 
@@ -1261,7 +1478,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IF Propellant Tank
+    @title = Saturn Multibody S-IF Propellant Tank
     @manufacturer = Boeing Co.
     @description = The first stage of the fictional Saturn Multibody, from the Eyes Turned Skyward universe.
 
@@ -1322,7 +1539,7 @@
 {
     %RSSROConfig = True
 
-    @title = Saturn S-IVC Upper Stage Tank (6.6m)
+    @title = Saturn Multibody S-IVC Propellant Tank
     @manufacturer = Real Scale Boosters
     @description = The upper stage of the fictional Saturn Multibody configurations from the Eyes Turned Skyward alternate history. Typically used with a pair of J-2 engines.
 
@@ -1384,7 +1601,7 @@
     %RSSROConfig = True
 
     @manufacturer = Generic
-    @description = A generic propellant tank.
+    @description = A general purpose conical propellant tank.
 
     @mass = 2.0
     @crashTolerance = 12
@@ -1417,15 +1634,15 @@
     %RSSROConfig = True
 
     @manufacturer = Generic
-    @description = A generic propellant tank.
+    @description = A general purpose conical propellant tank.
 
-	@mass = 5.3
+    @mass = 5.3
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
-	@bulkheadProfiles = size6, size10
+    @bulkheadProfiles = size6, size10
 
     MODULE
     {
@@ -1435,7 +1652,7 @@
         basemass = -1
     }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -1450,15 +1667,15 @@
     %RSSROConfig = True
 
     @manufacturer = Generic
-    @description = A generic propellant tank.
+    @description = A general purpose conical propellant tank.
 
-	@mass = 5.8
+    @mass = 5.8
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
-	@bulkheadProfiles = size7, size10
+    @bulkheadProfiles = size7, size10
 
     MODULE
     {
@@ -1468,5 +1685,5 @@
         basemass = -1
     }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -585,6 +585,10 @@
     @manufacturer = Douglas Aircraft Company & Thiokol
     @description = The interstage adapter for the Saturn V S-II/S-IVB stages.
 
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_decoupler_fire = decouple
+
     @mass = 4.07
     @crashTolerance = 14
     @breakingForce = 250
@@ -655,6 +659,10 @@
     @title = Saturn IB Interstage Adapter
     @manufacturer = Douglas Aircraft Company & Thiokol
     @description = The interstage adapter for the Saturn IB.
+
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_decoupler_fire = decouple
 
     @mass = 2.6
     @crashTolerance = 14
@@ -949,6 +957,10 @@
     @manufacturer = North American Aviation
     @description = The interstage adapter for the Saturn C-8 S-IC-8/S-II-8 stages.
 
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_decoupler_fire = decouple
+
     @mass = 5.2
     @crashTolerance = 14
     @breakingForce = 250
@@ -1019,6 +1031,10 @@
     @title = Saturn V S-IC Propellant Tank
     @manufacturer = Boeing Co.
     @description = The first stage of the Saturn V. Includes explosive bolts for separation in the forward skirt.
+
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_decoupler_fire = decouple
 
     @mass = 86.6
     @crashTolerance = 12

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Structural.cfg
@@ -41,7 +41,7 @@
 {
     %RSSROConfig = True
 
-	@manufacturer = Generic
+    @manufacturer = Generic
 
     @mass = 0.075
     @crashTolerance = 16

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSII8.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSII8.cfg
@@ -1,15 +1,15 @@
 //  ==================================================
-//  S-IB retro motor plume configuration.
+//  S-II-8 retro motor plume configuration.
 //  ==================================================
 
-@PART[RSBdecouplerSaturnSIVB2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdecouplerSaturnSII8]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Solid-Sepmotor
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, -0.15
+        localPosition = 0.0, 0.0, -0.1
         fixedScale = 0.75
         energy = 0.75
         speed = 1.0

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSIVB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSIVB.cfg
@@ -10,8 +10,8 @@
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
         localPosition = 0.0, 0.0, -0.1
-        fixedScale = 1.0
-        energy = 1.0
+        fixedScale = 0.75
+        energy = 0.75
         speed = 1.0
     }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1A.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1A.cfg
@@ -1,0 +1,69 @@
+//  ==================================================
+//  F-1A engine plume configuration.
+//  ==================================================
+
+@PART[RSBengineF1A]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower-F1
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 1.5
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower-F1
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower-F1
+        }
+    }
+}
+
+//  ==================================================
+//  F-1A engine flare configuration.
+//  ==================================================
+
+@PART[RSBengineF1A]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower-F1
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 2.0
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  F-1A engine smoke configuration.
+//  ==================================================
+
+@PART[RSBengineF1A]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower-F1
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[smoke]
+            {
+                @localPosition = 0.0, 0.0, 2.25
+                @fixedScale = 0.75
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Update the Saturn interstage adapter retro motor plumes.
* Add RealPlume config for the Saturn C-8 interstage adapter.
* Fix a possible issue with the Agena D model configuration.
* Update the RemoteTech support to a more robust system.
* Fix the O/F propellant ratio of the PSLV second stage.
* Fix a bad engine module included with the PSOM-S12 SRM.
* Add RO support for the Saturn C-8 parts.
* Update the volumes of the propellant tanks.
* Update the Atlas CCB to include EC even if the user removes all the
tank contents.
* Normalize the max temperatures of some engines/SRMs.
* Fix various bugs.
* Fix some typos.