### PR TITLE
SXT PPD-8 Lander Can

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -436,3 +436,150 @@
 		maxAmount = 225
 	}
 }
+
+//  ==================================================
+//  PPD-8 Lander Can.
+
+//  Dimensions: 4 m x 2.1 m
+//  Gross Mass: 3120 Kg
+//  ==================================================
+
+@PART[SXTLander]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL,0
+    {
+        @scale = 1.6, 1.6, 1.6
+    }
+
+    @MODEL,1
+    {
+        %scale = 1.6, 1.6, 1.6
+        @position = 0.0, 0.314, 0.0
+    }
+
+    @MODEL,2
+    {
+        %scale = 1.6, 1.6, 1.6
+        @position = 0.0, -0.314, 0.0
+    }
+
+    @node_stack_top = 0.0, 1.035, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.035, 0.0, 0.0, -1.0, 0.0 , 3
+
+    @manufacturer = Generic
+    @description = While similar to the Mk2 Lander Can internally, the PPD-8 offers a ruggedized casing and improved crash resistance, plus handy EVA hand grips. It can also be controlled remotely.
+
+    @mass = 2.75
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    @skinMaxTemp = 873.15
+    %bulkheadProfiles = size3
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.2
+        }
+    }
+
+    !MODULE[ModuleReactionWheel]{}
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 5.0
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1000
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 43200
+            maxAmount = 43200
+        }
+
+        TANK
+        {
+            name = Food
+            amount = 245.7
+            maxAmount = 245.7
+        }
+
+        TANK
+        {
+            name = Water
+            amount = 162.4
+            maxAmount = 162.4
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 24872.34
+            maxAmount = 24872.34
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 22.34
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 206.8
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 860
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 67.5
+            maxAmount = 67.5
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  PPD-8 Lander Can.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[SXTLander:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a crew of 2 for 21 days.:
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        conversionRate = 2.0
+        inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -570,7 +570,7 @@
 //  TAC Life Support compatibility.
 //  ==================================================
 
-@PART[SXTLander:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+@PART[SXTLander]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
     @description ^= :$: Supports a crew of 2 for 21 days.:
 


### PR DESCRIPTION
* Add RO support for the PPD-8 lander can. Stats similar to the Mk2 Lander Can.