### PR TITLE
AIES fairings update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Structure.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Structure.cfg
@@ -1,7 +1,21 @@
-@PART[top100a1ur5]:FOR[RealismOverhaul] // AIES TOP-100 A1-RU5 Fairing
+//  ==================================================
+//  AIES TOP-100 A1-RU5 payload fairing.
+
+//  Dimensions: 1.7 m x 5 m
+//  Gross Mass: 65 Kg
+//  ==================================================
+
+@PART[top100a1ur5]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	maxTemp = 1073.15
+
+    @category = Aero
+
+    @mass = 0.065
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	MODULE
 	{
 		name = TweakScale
@@ -9,10 +23,25 @@
 		defaultScale = 1.25
 	}
 }
-@PART[top100a1ur5b]:FOR[RealismOverhaul] // AIES TOP-100 A1-RU5-B Fairing
+
+//  ==================================================
+//  AIES TOP-100 A1-RU5-B payload fairing.
+
+//  Dimensions: 1.9 m x 6 m
+//  Gross Mass: 75 Kg
+//  ==================================================
+
+@PART[top100a1ur5b]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	maxTemp = 1073.15
+
+    @category = Aero
+
+    @mass = 0.075
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	MODULE
 	{
 		name = TweakScale
@@ -20,10 +49,25 @@
 		defaultScale = 1.25
 	}
 }
-@PART[top500a1ur5]:FOR[RealismOverhaul] // AIES TOP-500 A1-RU5 Fairing
+
+//  ==================================================
+//  AIES TOP-500 A1-RU5 payload fairing.
+
+//  Dimensions: 1.75 m x 7.2 m
+//  Gross Mass: 100 Kg
+//  ==================================================
+
+@PART[top500a1ur5]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	maxTemp = 1073.15
+
+    @category = Aero
+
+    @mass = 0.1
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	MODULE
 	{
 		name = TweakScale
@@ -31,6 +75,7 @@
 		defaultScale = 1.25
 	}
 }
+
 @PART[adapterrads]:FOR[RealismOverhaul] // AIES RAD-S Adapter
 {
 	%RSSROConfig = True
@@ -213,10 +258,51 @@
 		defaultScale = 1.25
 	}
 }
-@PART[t1000v4]:FOR[RealismOverhaul] // AIES TOP-1000 V4 Fairing
+
+//  ==================================================
+//  AIES TOP-B1 payload fairing.
+
+//  Dimensions: 1.25 m x 2.7 m
+//  Gross Mass: 20 Kg
+//  ==================================================
+
+@PART[topb1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Aero
+
+    @mass = 0.02
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    MODULE
+    {
+        name = TweakScale
+        type = RealismOverhaulStackHollow
+        defaultScale = 2.5
+    }
+}
+
+//  ==================================================
+//  AIES TOP-1000 V5 payload fairing.
+
+//  Dimensions: 2.5 m x 6.7 m
+//  Gross Mass: 125 Kg
+//  ==================================================
+
+@PART[t1000v4]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	maxTemp = 1073.15
+
+    @category = Aero
+
+    @mass = 0.125
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	MODULE
 	{
 		name = TweakScale
@@ -224,10 +310,25 @@
 		defaultScale = 2.5
 	}
 }
-@PART[t1500v4]:FOR[RealismOverhaul] // AIES TOP-1500 v4 Fairing
+
+//  ==================================================
+//  AIES TOP-1500 v5 payload fairing.
+
+//  Dimensions: 2.75 m x 6 m
+//  Gross Mass: 170 Kg
+//  ==================================================
+
+@PART[t1500v4]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	maxTemp = 1073.15
+
+    @category = Aero
+
+    @mass = 0.17
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	MODULE
 	{
 		name = TweakScale
@@ -235,21 +336,25 @@
 		defaultScale = 2.5
 	}
 }
-@PART[t2000v4]:FOR[RealismOverhaul] // AIES TOP-2000 v4c Fairing
+
+//  ==================================================
+//  AIES TOP-2000 v4c payload fairing.
+
+//  Dimensions: 2.75 m x 11 m
+//  Gross Mass: 220 Kg
+//  ==================================================
+
+@PART[t2000v4]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	maxTemp = 1073.15
-	MODULE
-	{
-		name = TweakScale
-		type = RealismOverhaulStackHollow
-		defaultScale = 2.5
-	}
-}
-@PART[t3000r20c]:FOR[RealismOverhaul] // AIES TOP-3000 R20C Fairing
-{
-	%RSSROConfig = True
-	maxTemp = 1073.15
+
+    @category = Aero
+
+    @mass = 0.22
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
 	MODULE
 	{
 		name = TweakScale


### PR DESCRIPTION
* Add RO support for the TOP-B1 fairing.
* Move the fairings over to the "Aero" category.
* Remove the config for the non-existent TOP-3000 R20C fairing.
* Re-balance the mass values.