### PR TITLE
SLA/IU Collider workarounds

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -18,16 +18,16 @@
 	@mass = 0.2845
 	@MODULE[ModuleDecouple]
 	{
-		@ejectionForce = 0.001
+		@ejectionForce = 0.2
 	}
 	@MODULE[ModuleEngines*]
 	{
-		@maxThrust = 0.01
+		@maxThrust = 0.3
 	}
 	@RESOURCE[SolidFuel]
 	{
-		@amount = .003
-		@maxAmount = .003
+		@amount = .10
+		@maxAmount = .10
 	}
 }
 +PART[FASAStrFairing3m4x]:AFTER[RealismOverhaul] // probably a better way to do it than to overwrite a random part

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -38,31 +38,32 @@
 	}
 	!MODEL,0{}
 	!MODEL,1{}
+	//Both https://en.wikipedia.org/wiki/Apollo_(spacecraft) and http://www.apollosaturn.com/asnr/SLA.htm list the length of the SLA as 7 feet which would be 2.1336m
 	MODEL
 	{
 		model = FASA/Gemini2/FASA_Gemini_LR91_Pack/FairingWall3m
-		scale = 1.761, 0.69, 1.761
-		position = 0.0, 1.492, 0.0
+		scale = 1.761, 0.7112, 1.761
+		position = 0.0, 1.0668, 0.0
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = FASA/Gemini2/FASA_Gemini_LR91_Pack/FairingWall3m
-		scale = 1.761, 0.69, 1.761
-		position = 0.0, 1.492, 0.0
+		scale = 1.761, 0.7112, 1.761
+		position = 0.0, 1.0668, 0.0
 		rotation = 0, 180, 0
 	}
-	%node_stack_top = 0.0, 6.081, 0.0, 0.0, 1.0, 0.0, 4
-	%node_stack_bottom = 0.0, 0.457, 0.0, 0.0, -1.0, 0.0, 6
-	%node_stack_fairing1 = 0.0, 2.527, 3.302, 0.0, 1.0, 0.0, 1
-	%node_stack_fairing2 = 0.0, 2.527, -3.302, 0.0, 1.0, 0.0, 1
-	%node_stack_fairing3 = 3.302, 2.527, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_fairing4 = -3.302, 2.527, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_connect1 = 0.0, -0.10, 0.0, 0.0, 1.0, 0.0, 3
+	%node_stack_top = 0.0, 5.6986, 0.0, 0.0, 1.0, 0.0, 4
+	%node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+	%node_stack_fairing1 = 0.0, 2.1336, 3.302, 0.0, 1.0, 0.0, 1
+	%node_stack_fairing2 = 0.0, 2.1336, -3.302, 0.0, 1.0, 0.0, 1
+	%node_stack_fairing3 = 3.302, 2.1336, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_fairing4 = -3.302, 2.1336, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_connect1 = 0.0, -0.4514, 0.0, 0.0, 1.0, 0.0, 3
 	@category = Structural
 	%stackSymmetry = 3
 	@title = Spacecraft Lunar Module Adapter - Base
-	@description = This part is the Spacecraft Lunar Module Adapter base used to cover the Lunar Module during ascent.
+	@description = This part is the Spacecraft Lunar Module Adapter base used to cover the Lunar Module during ascent.  It is fitted with two separate decouplers.  One separates the CSM through staging.  The other separates the LEM manually.  No extra decoupler is needed.
 	@stagingIcon = DECOUPLER_VERT
 	@mass = 0.651
 	%fuelCrossFeed = False
@@ -71,12 +72,73 @@
 		@ejectionForce = 1
 		@explosiveNodeID = top
 	}
+	MODULE
+	{
+		name = ModuleDecouple
+		ejectionForce = 1
+		explosiveNodeID = connect1
+		stagingEnabled = False
+	}
 	!MODULE[ModuleEngines]
 	{
 	}
 	!RESOURCE[SolidFuel]
 	{
 	}
+}
++PART[FASASaturnSLA]:AFTER[RealismOverhaul]
+{
+	@name = FASASaturnSLA_med
+	@MODEL,0
+	{
+		@scale = 1.761, 0.8667, 1.761
+		@position = 0.0, 1.3, 0.0
+	}
+	@MODEL,1
+	{
+		@scale = 1.761, 0.8667, 1.761
+		@position = 0.0, 1.3, 0.0
+	}
+	@node_stack_top = 0.0, 6.165, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_fairing1 = 0.0, 2.6, 3.302, 0.0, 1.0, 0.0, 1
+	@node_stack_fairing2 = 0.0, 2.6, -3.302, 0.0, 1.0, 0.0, 1
+	@node_stack_fairing3 = 3.302, 2.6, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_fairing4 = -3.302, 2.6, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_connect1 = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 3
+	@title = Spacecraft Lunar Module Adapter - Med Base
+	@description = This part is the Spacecraft Lunar Module Adapter base used to cover the Lunar Module during ascent.  It is fitted with two separate decouplers.  One separates the CSM through staging.  The other separates the LEM manually.  No extra decoupler is needed.  This is a slightly longer (2.6m) version to partially negate the collider issue with the LEM and IU while still maintaining the same basic height of the SLA.
+
+	%TechRequired = advConstruction
+	%cost = 150
+	%entryCost = 3000
+}
++PART[FASASaturnSLA]:AFTER[RealismOverhaul]
+{
+	@name = FASASaturnSLA_long
+	@MODEL,0
+	{
+		@scale = 1.761, 1.0, 1.761
+		@position = 0.0, 1.5, 0.0
+	}
+	@MODEL,1
+	{
+		@scale = 1.761, 1.0, 1.761
+		@position = 0.0, 1.5, 0.0
+	}
+	@node_stack_top = 0.0, 6.565, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_fairing1 = 0.0, 3.0, 3.302, 0.0, 1.0, 0.0, 1
+	@node_stack_fairing2 = 0.0, 3.0, -3.302, 0.0, 1.0, 0.0, 1
+	@node_stack_fairing3 = 3.302, 3.0, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_fairing4 = -3.302, 3.0, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_connect1 = 0.0, 0.415, 0.0, 0.0, 1.0, 0.0, 3
+	@title = Spacecraft Lunar Module Adapter - Long Base
+	@description = This part is the Spacecraft Lunar Module Adapter base used to cover the Lunar Module during ascent.  It is fitted with two separate decouplers.  One separates the CSM through staging.  The other separates the LEM manually.  No extra decoupler is needed.  This is a longer (3m) version to negate the collider issue with the LEM and IU.
+
+	%TechRequired = advConstruction
+	%cost = 150
+	%entryCost = 3000
 }
 @PART[FASAApolloIU]:FOR[RealismOverhaul]
 {
@@ -86,8 +148,8 @@
 		scale = 1.761, 2.285, 1.761
 	}
 	@scale = 2.285
-	@node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 6
-	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 6
+	@node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 3
 	@title = Saturn Instrument Unit
 	@description = The Saturn Instrument Unit provides command and control for the final stages of the Saturn IB/V series vehicles. Could be used with any other 260" launch vehicles.
 	@mass = 1.933664

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -26,8 +26,8 @@
 	}
 	@RESOURCE[SolidFuel]
 	{
-		@amount = .10
-		@maxAmount = .10
+		@amount = 0.10
+		@maxAmount = 0.10
 	}
 }
 +PART[FASAStrFairing3m4x]:AFTER[RealismOverhaul] // probably a better way to do it than to overwrite a random part


### PR DESCRIPTION
Based on numerous tests I've run, I'm 99.9% sure that the collider problem is on the IU texture itself.  I tried creating a single part that was made up of the two "FairingWall3m" of the standards SLA and the "Apollo_IU".  But when the LEM separates from the SLA, it is still picking up phantom momentum as it's "pushed" out of a texture. We definitely someone that can look at the collider on the texture itself and fix it.  But in the mean time I've got an update to the standard SLA so you no longer need a separate decoupler for the LEM.  Those changes include:
1) I found some documentation that puts the SLA at "7-foot long" which works out to 2.1336m.  The existing part is 2.07m.  This doesn't seem like much, but every mm reduces the amount of phantom momentum when the LEM separates.  So I've corrected the height of the basic SLA to be 2.1336m long.
2) I've slightly adjusted the fairing, top and bottom attachment points to account for the tiny increase in size and also to remove any clipping the fairing may have with the CSM.
3) I've raised the LEM attachment point to account for no longer needing an extra decoupler.

I've also added two new interim parts.  The first is a 2.6m long SLA.  It's not drastically larger than the standard part (about +22%) but does cut the phantom momentum by about half.  And there is no phantom momentum if you build your own LM so nothing is below the descent engine.
The second is a 3m long SLA.  It's large enough that the normal LM doesn't hang below it resulting in no phantom momentum upon LEM separation.

I also reduced the size of the attachment points on the SLA and IU so it's easier to find and place everything.