### PR TITLE
Skylab storage capacity

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -74,7 +74,7 @@
 	{
 			name = ModuleFuelTanks
 			type = ServiceModule
-			volume = 85500.0
+			volume = 25000.0
 			basemass = -1
 			TANK
 			{
@@ -85,14 +85,14 @@
 			TANK
 			{
 				name = MMH
-				amount = 92.54
-				maxAmount = 92.54
+				amount = 332.35
+				maxAmount = 332.35
 			}
 			TANK
 			{
 				name = NTO
-				amount = 112.2
-				maxAmount = 112.2
+				amount = 402.95
+				maxAmount = 402.95
 			}
 			TANK
 			{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -84,15 +84,9 @@
 			}
 			TANK
 			{
-				name = MMH
-				amount = 332.35	//see RO github #1091 for explanation of value
-				maxAmount = 332.35
-			}
-			TANK
-			{
-				name = NTO
-				amount = 402.95	//see RO github #1091 for explanation of value
-				maxAmount = 402.95
+				name = Nitrogen
+				amount = 700841.95	//see RO github #1091 for explanation of value
+				maxAmount = 700841.95
 			}
 			TANK
 			{
@@ -177,33 +171,49 @@
 		@name = ModuleRCS
 		%thrusterTransformName = RCSthruster
 		%resourceFlowMode = STACK_PRIORITY_SEARCH
-		%thrusterPower = 0.500
+		%thrusterPower = 0.441	//http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19710007043.pdf lists "45 kg at start of mission" which equates to 441N.
 		!resourceName = DELETE
 			%PROPELLANT
 			{
-				%name = MMH
-				%ratio = 0.452
+				%name = Nitrogen
+				%ratio = 1.0
 			}
-			PROPELLANT
+			@atmosphereCurve	//I Couldn't find any ISP information so I used the Surveyor probe's nitrogran rcs for these values
 			{
-				name = NTO
-				ratio = 0.548
-			}
-			@atmosphereCurve
-			{
-				@key,0 = 0 260
-				@key,1 = 1 100
+				@key,0 = 0 280
+				@key,1 = 1 35
 			}
 	}
 	
 	@MODULE[ModuleDataTransmitter]
 	{
-		@PacketInterval = 0.4
-		@PacketSize = 1
-		@PacketResourceCost = 8
+		@PacketInterval = 0.10
+		@PacketSize = 2
+		@PacketResourceCost = 4.0
 	}
 }
+@PART[skylab]:AFTER[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter] {}
 
+    %MODULE[ModuleRTAntenna] {
+        %Mode0OmniRange = 0
+        %Mode1OmniRange = 6000000
+        %MaxQ = 6000
+        %EnergyCost = 0.36
+        
+        %DeployFxModules = 0
+        
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.4
+            %PacketSize = 1
+            %PacketResourceCost = 8.0
+        }
+    }
+    
+    %MODULE[ModuleSPUPassive] {}
+}
 
 @PART[sl_left_panel,sl_right_panel]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -85,13 +85,13 @@
 			TANK
 			{
 				name = MMH
-				amount = 332.35
+				amount = 332.35	//see RO github #1091 for explanation of value
 				maxAmount = 332.35
 			}
 			TANK
 			{
 				name = NTO
-				amount = 402.95
+				amount = 402.95	//see RO github #1091 for explanation of value
 				maxAmount = 402.95
 			}
 			TANK
@@ -194,6 +194,13 @@
 				@key,0 = 0 260
 				@key,1 = 1 100
 			}
+	}
+	
+	@MODULE[ModuleDataTransmitter]
+	{
+		@PacketInterval = 0.4
+		@PacketSize = 1
+		@PacketResourceCost = 8
 	}
 }
 


### PR DESCRIPTION
In a previous PR we corrected the amount of life support that is included with Skylab to reflect what the actual Skylab included, but we didn't adjust the available storage volume.  The 85.5kL of space meant you could easily setup the Skylab with nearly 2 years worth of life support.  I'm not sure if that volume was made up or if there was some documentation to go along with it.  Barring any documentation, I've lowered the volume so that there's only about 45% additional storage capacity.

I've also altered the initial RCS fuel capacity.  According to http://pages.erau.edu/~ericksol/projects/issa/skylab.html#Skylab Systems the Skylab's "Thruster Attitude Control Subsystem" was powered by "Cold gas propellant (nitrogen)" but the Skylab we have uses MMH/NTO for it's RCS thrusters.  I'm not sure if that was done intentionally or not.  And I didn't want to mess with the existing RCS without knowing exactly why MMT/NTO was used in place of the actual Nitrogen system.  But I did want to make sure that the same quantity of fuel was available so I've adjusted the amount of MMH and NTO available to approximately match the weight of Nitrogen that would have been included.  Here's my math:

http://pages.erau.edu/~ericksol/projects/issa/skylab.html#Skylab Systems says Skylab included "22 propellant storage spheres" and that each sphere "stored [nitrogen] at 3,100psi at 100 degrees F in 4.5 cubic foot titanium spheres ".
According to http://siei.org/usefulequations.html, "A K-cylinder holds about 1 cubic foot [at STP, and]....A K-cylinder of nitrogen (at 3000 psi) holds roughly 250 scf"
Based on the above, the Skylab has 22 spheres, each holding approximately 1125 standard cubic feet (scf) of nitrogen.  That works out to 24750 scf, or 700841.95L of nitrogen.  That is roughly 876.75kg of nitrogen based on the density provided in CommonResources.cfg.
At a 45.2%/54.8% MMH/NTO ratio, 332.35MMH + 402.95NTO works out to 876.75kg.