### PR TITLE
Squad fuel tank updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_FuelTank.cfg
@@ -15,6 +15,45 @@
 		type = Structural
 	}
 }
+
+//  ==================================================
+//  C7 Brand Adapter (straight).
+//  ==================================================
+
+@PART[adapterSize2-Size1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[TweakScale]
+    {
+        @type = RealismOverhaulStackSolid
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  C7 Brand Adapter (slanted).
+//  ==================================================
+
+@PART[adapterSize2-Size1Slant]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[TweakScale]
+    {
+        @type = RealismOverhaulStackSolid
+    }
+
+    !RESOURCE,*{}
+}
+
 @PART[fuelTank3-2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -239,4 +278,23 @@
 	!RESOURCE[XenonGas]
 	{
 	}
+}
+
+//  ==================================================
+//  Xenon container (large).
+//  ==================================================
+
+@PART[xenonTankLarge]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+
+    @MODULE[TweakScale]
+    {
+        @type = RealismOverhaulStackSolid
+    }
+
+    !RESOURCE,*{}
 }


### PR DESCRIPTION
* Add RO support for the C7 Brand Adapter tanks.
* Add RO support for the large Xenon storage tank.