### PR TITLE
Rescaled IVA's for stock, Ven Stock Revamp and RPM variations.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -78,6 +78,16 @@
 		}
 	}
 }
+@INTERNAL[cupolaInternal|cupolaInternalRPM]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
 @PART[seatExternalCmd]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -163,6 +173,18 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[crewCabinInternals]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[advSasModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -453,23 +475,12 @@
 	}
 }
 
-@INTERNAL[PodCockpit]:FOR[RealismOverhaul]
+@INTERNAL[PodCockpit|PodCockpitRPM]:FOR[RealismOverhaul]
 {
 	%scaleAll = 1.722222, 1.722222, 1.722222
 	@MODULE[InternalSeat],*
 	{
 		%kerbalScale = 1.722222, 1.722222, 1.722222
-		%kerbalOffset = 0.0, 0.0, 0.0
-		%kerbalEyeOffset = 0.0, 0.0, 0.0
-	}
-}
-
-@INTERNAL[PodCockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-	%scaleAll = 1.64, 1.64, 1.64
-	@MODULE[InternalSeat],*
-	{
-		%kerbalScale = 1.64, 1.64, 1.64
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
@@ -572,6 +583,19 @@
 	@node_stack_bottom = 0.0, -0.7859536, 0.0, 0.0, -1.0, 0.0, 4
 	@node_stack_top = 0.0, 1.9568316, 0.0, 0.0, 1.0, 0.0, 2
 }
+
+@INTERNAL[PodCockpit|PodCockpitRPM]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	%scaleAll = 1.64, 1.64, 1.64
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.64, 1.64, 1.64
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+
 @PART[Mark1-2Pod]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
 {
 	@maxTemp = 800
@@ -665,6 +689,17 @@
 		conversionRate = 1.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+@INTERNAL[landerCabinSmallInternal|landerCabinSmallInternalRPM]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
 }
 @PART[mk1pod]:FOR[RealismOverhaul]
@@ -879,6 +914,17 @@
 		DescentModeCoM = 0.0, -0.1, 0.0
 	}
 }
+@INTERNAL[mk1PodCockpit|mk1PodCockpitRPM]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mk1pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
@@ -932,7 +978,7 @@
 			amount = 43200
 			maxAmount = 43200
 		}
-				TANK
+		TANK
 		{
 			name = Food
 			amount = 245.7
@@ -986,17 +1032,7 @@
 	}
 }
 
-@INTERNAL[landerCabinInternals]:BEFORE[RealismOverhaul]
-{
-	%scaleAll = 1.6, 1.6, 1.6
-	@MODULE[InternalSeat],*
-	{
-		%kerbalScale = 1.6, 1.6, 1.6
-		%kerbalOffset = 0.0, 0.0, 0.0
-		%kerbalEyeOffset = 0.0, 0.0, 0.0
-	}
-}
-@INTERNAL[landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
+@INTERNAL[landerCabinInternals|landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
 {
 	%scaleAll = 1.6, 1.6, 1.6
 	@MODULE[InternalSeat],*
@@ -1007,6 +1043,8 @@
 	}
 }
 
+// Is this an old cockpit definition?  mk3Cockpit_Shuttle appears to be the 
+// current v1.0.5 standard.
 @PART[mark3Cockpit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -1204,7 +1242,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 50
-		basemass = 0.1
+		basemass = -1
 		type = ServiceModule
 		TANK
 		{
@@ -1371,7 +1409,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 18
-		basemass = 0.05
+		basemass = -1
 		type = Fuselage
 		TANK
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -452,6 +452,29 @@
 		playAnimationOnEditorSpawn = false
 	}
 }
+
+@INTERNAL[PodCockpit]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[PodCockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	%scaleAll = 1.64, 1.64, 1.64
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.64, 1.64, 1.64
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[Mark1-2Pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
@@ -962,6 +985,28 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[landerCabinInternals]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+@INTERNAL[landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mark3Cockpit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -1,3 +1,16 @@
++INTERNAL[mk1CockpitInternal]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@name = RO-Mk1CockpitInternal-1.25
+	%RSSROConfig = True
+	%scaleAll = 1.25, 1.25, 1.25
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.25, 1.25, 1.25
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mk2_1m_Bicoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -195,16 +208,11 @@
 			rate = 0.7//200W for life support base
 		}
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+	!MODULE[ModuleReactionWheel] {}
 	!MODULE[ModuleFuelTanks] {}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -269,6 +277,18 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[mk2CockpitStandardInternals|mk2CockpitStandardInternalsRPM|MK2_CrewCab_Int]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mk2Cockpit_Standard]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -451,6 +471,7 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
 @PART[mk2DockingPort]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -722,16 +743,10 @@
 			rate = 0.5
 		}
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
 	!MODULE[ModuleFuelTanks] {}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -794,6 +809,17 @@
 		conversionRate = 4.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+@INTERNAL[MK3_Cockpit_Int|MK3_CrewCab_Int]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
 }
 @PART[mk3CrewCabin]:FOR[RealismOverhaul]
@@ -1452,7 +1478,10 @@
 	%rescaleFactor = 1
 	%scale = 1
 	@node_stack_bottom = 0.0, -0.175, 0.0, 0.0, -1.0, 0.0, 1
-	
+
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+
 	!MODULE[ModuleAnimateGeneric],0:NEEDS[VenStockRevamp] {}
 	
 	@MODULE[ModuleCommand]
@@ -1464,18 +1493,8 @@
 		}
 	}
 	
-	!MODULE[TweakScale]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!MODULE[TweakScale] {}
+	!MODULE[ModuleReactionWheel] {}
 	!MODULE[ModuleFuelTanks] {}
 	MODULE
 	{
@@ -1560,6 +1579,7 @@
 		}
 	}
 }
+
 @PART[Mark2Cockpit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -1884,6 +1904,7 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
 // Use alt VSR graphics for 1.25s if available
 @PART[Mark1Cockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
@@ -1894,6 +1915,12 @@
 	}
 	@node_stack_bottom = 0.0, -0.1858, 0.0, 0.0, -1.0, 0.0, 1
 	
+	@INTERNAL
+	{
+		@name = RO-Mk1CockpitInternal-1.25
+		%offset = 0.0, 0.2, 0.0
+	}
+
 	@MODULE[ModuleAnimateGeneric]
 	{
 		%animationName = MK1Light
@@ -1903,6 +1930,7 @@
 		@textureQuadName = flagTransform
 	}
 }
+
 
 //	==================================================
 //	MK1 Crew Cabin.


### PR DESCRIPTION
Should work for both stock (RO) and Ven's along with RPM variants.

Word of caution:  Other ships using these IVA's that aren't scaled the same way as the
aforementioned ships might not line-up properly in the IVA.  But I figure it cannot be
any worse than *not* having it scaled this way.  For example, if this IVA was scaled to
1.6, but your cockpit is scale to 1.72222 then my rescale will arguably be better than
the unscaled IVA, but slightly off.

Update:  I completed all IVA's in the RO_Squad_Command.cfg and RO_Squad_Spaceplanes.cfg files.  Command was no problem, but Spaceplanes had one IVA being re-used by two cockpits with different scaling factors.  To overcome this I cloned the IVA giving it a similar yet intuitive name with "-1.25" appended to the name so as to indicate the scaling factor and make it unique.