### PR TITLE
Added missing modules to FASA Thor/Delta avionics rings

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -976,7 +976,49 @@ PART
 	breakingForce = 200
 	breakingTorque = 200
 	vesselType = Probe
+	MODULE
+	{
+		name = ModuleCommand
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.3 // Using value from 1m Early ring for now.  Guidance needed
+		}
+	}
+	RESOURCE[ElectricCharge]
+	{
+		name = ElectricCharge // Again using values from 1m early ring
+		amount = 108 // 6 minutes
+		maxAmount = 108
+	}
+	MODULE
+	{
+		name = ModuleSAS
+		SASServiceLevel = 0
+	}
 }
+
+
+
+@PART[FASADeltaAv0]:AFTER[RemoteTech]
+{
+	%MODULE[ModuleSPU]
+	{
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]
+	{
+		%TechRequired = start
+		%OmniRange = 40000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.1
+		}
+	}
+}
+
 
 +PART[FASADeltaAv0]:BEFORE[RP-0]
 {
@@ -991,6 +1033,26 @@ PART
 	@mass = 0.2
 }
 
+@PART[FASADeltaAv1]:AFTER[RemoteTech]
+{
+	%MODULE[ModuleSPU]
+	{
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]
+	{
+		%TechRequired = start
+		%OmniRange = 40000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.1
+		}
+	}
+}
+
+
 +PART[FASADeltaAv0]:BEFORE[RP-0]
 {
 	@name = FASADeltaAv2
@@ -1002,6 +1064,25 @@ PART
 	@title = Delta Avionics Unit
 	@description = Avionics unit for the Extended Long Tank Thor and Extra Extended Long Tank Thor rocket stages. Delta I and Delta II.
 	@mass = 0.2
+}
+
+@PART[FASADeltaAv2]:AFTER[RemoteTech]
+{
+	%MODULE[ModuleSPU]
+	{
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]
+	{
+		%TechRequired = start
+		%OmniRange = 40000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.1
+		}
+	}
 }
 
 +PART[FASADeltaAv0]:BEFORE[RP-0]
@@ -1017,6 +1098,25 @@ PART
 	@mass = 0.2
 }
 
+@PART[FASADeltaAv3]:AFTER[RemoteTech]
+{
+	%MODULE[ModuleSPU]
+	{
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]
+	{
+		%TechRequired = start
+		%OmniRange = 40000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.1
+		}
+	}
+}
+
 +PART[FASADeltaAv0]:BEFORE[RP-0]
 {
 	@name = FASADeltaAv4
@@ -1028,4 +1128,23 @@ PART
 	@title = DCSS-5 Avionics Unit
 	@description = Integrated avionics unit for 5m Delta Cryogenic Second Stage and Delta IV-M/IV-HLV launch vehicle.
 	@mass = 0.2
+}
+
+@PART[FASADeltaAv4]:AFTER[RemoteTech]
+{
+	%MODULE[ModuleSPU]
+	{
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]
+	{
+		%TechRequired = start
+		%OmniRange = 40000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 0.1
+		}
+	}
 }


### PR DESCRIPTION
I noticed in my play through that these these were bereft of many of the modules present on all the other rings.  They just had avionics and that was it.

For now I just copied the values from `GuidanceEarly1m` which is a lower tech ring, but seemed the most comparable.  Or maybe not, but it was a start.  If anything the values would be more at the "disadvantaged" side of the slider than they should be, so they felt safe to add in.  They will probably need to be tweaked upwards, but this is better than not having them at all.