### PR TITLE
Attitude control of upper stages to use MMH/NTO

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS_Upper_Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS_Upper_Stages.cfg
@@ -24,10 +24,12 @@
 	{
 		%position = 0, -4.1841, 0
 	}
+	
 	@node_stack_bottom = 0,-5.99504,0,0,-1,0,5
 	@node_stack_top = 0,3.32604,0,0,1,0,5
 	@node_stack_top2 = 0,2.34120,0,0,1,0,5
 	@node_stack_interstage = 0,-0.58827,0,0,-1,0,2
+	
 	%RSSROConfig = True
 	@mass = 3.66 //estimate just under 5% heavier than standard 5 m DCSS
 	@title = Interim Cryogenic Propulsion Stage [5m]
@@ -36,12 +38,13 @@
 	
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}	
-
+	!RESOURCE[MonoPropellant] {}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
-		type = Default
-		volume = 94900
+		type = Cryogenic
+		volume = 95000
 		basemass = -1
 		TANK
 		{
@@ -54,6 +57,18 @@
 			name = LqdOxygen
 			amount = 20366
 			maxAmount = 20366
+		}
+		TANK
+		{
+			name = MMH
+			amount = 46.9
+			maxAmount = 46.9
+		}
+		TANK
+		{
+			name = NTO
+			amount = 56.1
+			maxAmount = 56.1
 		}
 	}
 	
@@ -155,6 +170,28 @@
 			canAdjustBottom = true
 		}
 	}
+	
+	@MODULE[ModuleRCS]
+	{
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.712
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+		@atmosphereCurve
+		{
+			key = 0 300
+			key = 1 100
+		}
+	}
 }
 @PART[SSTU-SC-B-HUS]:FOR[RealismOverhaul]
 {
@@ -205,7 +242,8 @@
 	%manufacturer = Boeing
 	@description = The Exploration Upper Stage (EUS) is being developed for SLS Block 1B and will enable large payloads to be injected on high energy trajectories to destinations throught the solar system.
 	!RESOURCE[LiquidFuel] {}
-	!RESOURCE[Oxidizer] {}	
+	!RESOURCE[Oxidizer] {}
+	!RESOURCE[MonoPropellant] {}
 
 	MODULE
 	{
@@ -224,6 +262,18 @@
 			name = LqdOxygen
 			amount = 96830.6647374
 			maxAmount = 96830.6647374
+		}
+		TANK
+		{
+			name = MMH
+			amount = 117.25
+			maxAmount = 117.25
+		}
+		TANK
+		{
+			name = NTO
+			amount = 140.25
+			maxAmount = 140.25
 		}
 	}
 	
@@ -323,6 +373,27 @@
 			topRadius = 4.2
 			bottomRadius = 4.2
 			canAdjustBottom = true
+		}
+	}
+	@MODULE[ModuleRCS]
+	{
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.712
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+		@atmosphereCurve
+		{
+			key = 0 300
+			key = 1 100
 		}
 	}
 }


### PR DESCRIPTION
Modifying the attitude control (RCS thrusters) of both the ICPS and the EUS to use a combination of MMH/NTO instead of "Monopropelant". Also, changing the tank type of the ICPS from standard to cryogenic.