### PR TITLE
Redo Schnobs AIES Antenna patch(weight/range/power brought in line with stock/RT antennas)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Antenna.cfg
@@ -5,7 +5,7 @@
 //
 // See #194 as a possible solution.
 
-@PART[Antennacomtec1]:FINAL // CommTech - 1 // TECH LEVEL 3 // AIES
+@PART[Antennacomtec1]:FOR[RealismOverhaul] // CommTech - 1 // TECH LEVEL 3 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.020
@@ -42,7 +42,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Antennacomtec2]:FINAL // CommTech - 2 // TECH LEVEL 4 // AIES
+@PART[Antennacomtec2]:FOR[RealismOverhaul] // CommTech - 2 // TECH LEVEL 4 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.025
@@ -78,7 +78,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Antennaesc]:FINAL // CommTech ESC-EXP // TECH LEVEL 3 // AIES
+@PART[Antennaesc]:FOR[RealismOverhaul] // CommTech ESC-EXP // TECH LEVEL 3 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.005
@@ -113,7 +113,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Antennaexpatvr2]:FINAL // EXP-VR-2T // TECH LEVEL 2 // AIES
+@PART[Antennaexpatvr2]:FOR[RealismOverhaul] // EXP-VR-2T // TECH LEVEL 2 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.010
@@ -148,7 +148,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[AntennaDF2]:FINAL // CommTech DF-RD // TECH LEVEL 3 // AIES
+@PART[AntennaDF2]:FOR[RealismOverhaul] // CommTech DF-RD // TECH LEVEL 3 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.003
@@ -183,11 +183,11 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishcl1]:FINAL // CommTech CL-1 Dish // TECH LEVEL 2 // AIES
+@PART[Dishcl1]:FOR[RealismOverhaul] // CommTech CL-1 Dish // TECH LEVEL 2 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.010
-	@description = A small dish perfect for communications as far away as the Mun.
+	@description = A small dish perfect for communications as far away as the Moon.
 	!MODULE[ModuleDataTransmitter]:NEEDS[RemoteTech]
 	{
 	}
@@ -202,7 +202,7 @@
 	{
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 4e9
+		Mode1DishRange = 4e8
 		EnergyCost = 0.008
 		MaxQ = 6000
 		DishAngle = 5
@@ -220,7 +220,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishmccomu]:FINAL // CommTech CM-60 Dish // TECH LEVEL 6 // AIES
+@PART[Dishmccomu]:FOR[RealismOverhaul] // CommTech CM-60 Dish // TECH LEVEL 6 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.015
@@ -256,7 +256,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishomega2g]:FINAL // CommTech Omega-2G // TECH LEVEL 5 // AIES
+@PART[Dishomega2g]:FOR[RealismOverhaul] // CommTech Omega-2G // TECH LEVEL 5 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.055 //pretty lightweight, supposedly hightech
@@ -292,7 +292,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[Dishpcf]:FINAL // CommTech PCF-5 Dish // TECH LEVEL 4 // AIES
+@PART[Dishpcf]:FOR[RealismOverhaul] // CommTech PCF-5 Dish // TECH LEVEL 4 // AIES
 {
 	%RSSROConfig = False // too lazy to make yet another short-range dish. There's really enough.
 	@mass = 0.065
@@ -328,7 +328,7 @@
 		name = ModuleSPUPassive
 	}
 }
-@PART[dishcomlar1]:FINAL // Comlar 1 // TECH LEVEL 5 // AIES
+@PART[dishcomlar1]:FOR[RealismOverhaul] // Comlar 1 // TECH LEVEL 5 // AIES
 {
 	%RSSROConfig = True
 	@mass = 0.045 //pretty lightweight for its role


### PR DESCRIPTION
Make AIES dishes use :FOR[RealismOverhaul] instead of :FINAL
revert CommTech CL-1 Dish range to 4e8 m

Antenna all look ok in VAB