### PR TITLE
VSR VA pod updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
@@ -1,15 +1,13 @@
 //  ==================================================
 //  TKS VA command module.
 
-//  Realism Overhaul configuration.
+//  Dimensions: 2.79 m x 1.8 m
+//  Gross Mass: 3800 Kg
 
-//  The specified height includes the RCS and parachute
-//  modules (not included).
+//  Sources:
 
-//  Dimensions: 2.79 m x 3.64 m
-//  Gross Mass: 4250.0 Kg
-
-//  Source 1: http://www.russianspaceweb.com/tks.html
+//  http://www.russianspaceweb.com/tks.html
+//  http://www.svengrahn.pp.se/histind/Almprog/tksalm.htm
 //  ==================================================
 
 @PART[MK2VApod]:FOR[RealismOverhaul]
@@ -33,7 +31,7 @@
     @manufacturer = OKB-52 [Chelomei]
     @description = The VA command module is part of the TKS/FGB spacecraft. It can be attached either to the FGB module of the TKS, to the front section of the Almaz station or to both. In the latter case, the station could be launched manned with the crew riding to orbit inside the VA capsule. The crew would be able to exit and enter the VA capsule in orbit via a hatch in the heat shield located at the bottom of the craft. Supports two crew for one day. Center of mass can be offset to allow lifting reentry (toggle Descent Mode).
 
-    @mass = 3.977
+    @mass = 3.23
     @crashTolerance = 7
     %breakingForce = 250
     %breakingTorque = 250
@@ -85,7 +83,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 45
+        volume = 160
         basemass = -1
 
         TANK
@@ -94,74 +92,6 @@
             amount = 43200
             maxAmount = 43200
         }
-    }
-
-    !MODULE[ModuleReactionWheel]{}
-
-    %RESOURCE
-    {
-        %name = Ablator
-        %amount = 250
-        %maxAmount = 250
-    }
-}
-
-//  ==================================================
-//  TKS VA command module.
-
-//  Deadly Reentry configuration.
-//  ==================================================
-
-@PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
-{
-    @MODULE[ModuleAblator]
-    {
-        @name = ModuleHeatShield
-        %depletedMaxTemp = 1200
-    }
-}
-
-//  ==================================================
-//  TKS VA command module.
-
-//  Remote Tech configuration.
-//  ==================================================
-
-@PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-{
-    MODULE
-    {
-        name = ModuleSPU
-        isRTCommandStation = False
-        RTCommandMinCrew = 3
-    }
-
-    MODULE
-    {
-        name = ModuleRTAntennaPassive
-        TechRequired = start
-        OmniRange = 1000000
-
-        TRANSMITTER
-        {
-            PacketInterval = 0.4
-            PacketSize = 0.27
-            PacketResourceCost = 0.025
-        }
-    }
-}
-
-//  ==================================================
-//  TKS VA command module.
-
-//  TAC Life Support configuration.
-//  ==================================================
-
-@PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-    @MODULE[ModuleFuelTanks]
-    {
-        @volume = 175
 
         TANK
         {
@@ -213,6 +143,81 @@
         }
     }
 
+    !MODULE[ModuleReactionWheel]{}
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = Ablator
+        amount = 250
+        maxAmount = 250
+    }
+}
+
+//  ==================================================
+//  TKS VA command module.
+
+//  Deadly Reentry configuration.
+//  ==================================================
+
+@PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
+{
+    @MODULE[ModuleAblator]
+    {
+        @name = ModuleHeatShield
+        %depletedMaxTemp = 1200
+    }
+}
+
+//  ==================================================
+//  TKS VA command module.
+
+//  Remote Tech configuration.
+//  ==================================================
+
+@PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.225
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        isRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.4
+            PacketSize = 0.27
+            PacketResourceCost = 0.025
+        }
+    }
+}
+
+//  ==================================================
+//  TKS VA command module.
+
+//  TAC Life Support configuration.
+//  ==================================================
+
+@PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
     MODULE
     {
         name = TacGenericConverter


### PR DESCRIPTION
* Fix the inert mass of the pod (was too high).
* Move the TACLS resources into the base RO config in order to have a
constant pod mass.
* Replace the passive RT antenna module with an active one (default:
ON).

NOTE: mass may be still a bit off (the VA pod normally includes deorbit & retro SRMs, along with a ACS module for reentry control - these mass values are not well documented).