### PR TITLE
Rescaled FASA IVA's for RO - Attempt #3

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -233,15 +233,9 @@
 		name = CoMShifter
 		DescentModeCoM = 0, 0, -0.192
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+	!MODULE[ModuleReactionWheel] {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -370,6 +364,17 @@
 		maxAmount = 848
 	}
 }
+@INTERNAL[FASA_Apollo_CM_Int]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.59, 1.59, 1.59
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.59, 1.59, 1.59
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[FASAApollo_CM]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -682,12 +682,12 @@
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 0.25 // 0.5
+		%acquireRange = 8.25	// Because of the animation, we need acquire and capture range to include the length of the extended docking node
 		%acquireTorque = 0.5 // 2.0
 		%captureMaxRvel = 0.1 // 0.3
 		%captureMinFwdDot = 0.998
 		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 0.05 // 0.06
+		%captureRange = 8.00	// Because of the animation, we need acquire and capture range to include the length of the extended docking node
 		%minDistanceToReEngage = 0.25 // 1.0
 		%undockEjectionForce = 0.1 // 10
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -429,7 +429,7 @@
 	@node_stack_bottom = 0.0, -0.6, 0.0, 0.0, -1.0, 0.0, 4
 	@category = Engine
 	@title = Big Gemini Retro Module
-	@description = The Big Gemini Retro Module that contains 4x solid rockets to de-orbit Gemini. Decouples before re-entry.
+	@description = The Big Gemini Retro Module that contains 4x solid rockets to de-orbit Big Gemini. Decouples before re-entry.  Provides approximately 106dV for re-entry burn.
 	@mass = 1.0978748
 	!MODULE[ModuleRCS]
 	{
@@ -476,7 +476,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 112.74
+		volume = 165.4
 		type = PSPC
 		basemass = -1
 	}
@@ -493,29 +493,29 @@
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -19.0, 0.0, 0.0
-		position = 0.0, 1.125, 2.55
+		rotation = -8.987, 0.0, 0.0
+		position = 0.0, 1.1095, 2.535
 	}
 	MODEL
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -19.0, 90.0, 0.0
-		position = 2.55, 1.125, 0.0
+		rotation = -8.987, 90.0, 0.0
+		position = 2.535, 1.1095, 0.0
 	}
 	MODEL
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -19.0, 180.0, 0.0
-		position = 0.0, 1.125, -2.55
+		rotation = -8.987, 180.0, 0.0
+		position = 0.0, 1.1095, -2.535
 	}
 	MODEL
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -19.0, 270.0, 0.0
-		position = -2.55, 1.125, 0.0
+		rotation = -8.987, 270.0, 0.0
+		position = -2.535, 1.1095, 0.0
 	}
 	@node_stack_top = 0.0, 1.6081, 0.0, 0.0, 1.0, 0.0, 4
 	@node_stack_bottom = 0.0, -1.0079, 0.0, 0.0, -1.0, 0.0, 6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -125,12 +125,8 @@
 	@mass = 2.02456
 	@CrewCapacity = 7
 	CoMOffset = 0.0, -1.5, 0.0
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	!MODULE[ModuleDecouple]
-	{
-	}
+	!RESOURCE[MonoPropellant] {}
+	!MODULE[ModuleDecouple] {}
 	MODULE
 	{
 		name = CoMShifter
@@ -241,6 +237,19 @@
 		}
 	}
 }
+
+@INTERNAL[GeminiBigGInt]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.219, 1.057354, 1.219
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.219, 1.057354, 1.219
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+
 @PART[FASAGeminiBigG]:AFTER[RealismOverhaul]:NEEDS[DeadlyReentry]
 {
 	@maxTemp = 900
@@ -420,7 +429,7 @@
 	@node_stack_bottom = 0.0, -0.6, 0.0, 0.0, -1.0, 0.0, 4
 	@category = Engine
 	@title = Big Gemini Retro Module
-	@description = The Big Gemini Retro Module that contains 4x solid rockets to de-orbit Big Gemini. Decouples before re-entry.  Provides approximately 106dV for re-entry burn.
+	@description = The Big Gemini Retro Module that contains 4x solid rockets to de-orbit Gemini. Decouples before re-entry.
 	@mass = 1.0978748
 	!MODULE[ModuleRCS]
 	{
@@ -467,7 +476,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 165.4
+		volume = 112.74
 		type = PSPC
 		basemass = -1
 	}
@@ -484,29 +493,29 @@
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -8.987, 0.0, 0.0
-		position = 0.0, 1.1095, 2.535
+		rotation = -19.0, 0.0, 0.0
+		position = 0.0, 1.125, 2.55
 	}
 	MODEL
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -8.987, 90.0, 0.0
-		position = 2.535, 1.1095, 0.0
+		rotation = -19.0, 90.0, 0.0
+		position = 2.55, 1.125, 0.0
 	}
 	MODEL
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -8.987, 180.0, 0.0
-		position = 0.0, 1.1095, -2.535
+		rotation = -19.0, 180.0, 0.0
+		position = 0.0, 1.125, -2.55
 	}
 	MODEL
 	{
 		model = FASA/Apollo/ApolloCSM/Apollo_SM_RCS
 		scale = 1.0, 1.0, 1.0
-		rotation = -8.987, 270.0, 0.0
-		position = -2.535, 1.1095, 0.0
+		rotation = -19.0, 270.0, 0.0
+		position = -2.55, 1.125, 0.0
 	}
 	@node_stack_top = 0.0, 1.6081, 0.0, 0.0, 1.0, 0.0, 4
 	@node_stack_bottom = 0.0, -1.0079, 0.0, 0.0, -1.0, 0.0, 6
@@ -673,12 +682,12 @@
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 8.25	// Because of the animation, we need acquire and capture range to include the length of the extended docking node
+		%acquireRange = 0.25 // 0.5
 		%acquireTorque = 0.5 // 2.0
 		%captureMaxRvel = 0.1 // 0.3
 		%captureMinFwdDot = 0.998
 		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 8.00	// Because of the animation, we need acquire and capture range to include the length of the extended docking node
+		%captureRange = 0.05 // 0.06
 		%minDistanceToReEngage = 0.25 // 1.0
 		%undockEjectionForce = 0.1 // 10
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -283,18 +283,10 @@
 			rate = 2.09
 		}
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	!MODULE[ModuleGenerator]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleReactionWheel] {}
 	@MODULE[ModuleLight]
 	{
 		@resourceAmount = .05
@@ -422,6 +414,18 @@
 		maxAmount = 144
 	}
 }
+
+@INTERNAL[FASAGeminiInt2]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.219, 1.194, 1.219
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.219, 1.194, 1.219
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[FASAGeminiPod2|FASAGeminiPod2White]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
@@ -463,7 +467,7 @@
 	@node_stack_bottom = 0.0, -0.27, 0.0, 0.0, -1.0, 0.0, 2
 	%fuelCrossFeed = False
 	@title = Gemini Adapter Retrograde Section
-	@description = The Gemini Adapter Retrograde Section. Contains the retrograde engines to de-orbit Gemini. Also houses RCS for translation up/down/left/right/aft. Modelled with the 2 backwards firing thrusters as well. RCS O/F Ratio 1.3:1.  Provides approximately 106dV for re-entry burn.
+	@description = The Gemini Adapter Retrograde Section. Contains the retrograde engines to de-orbit Gemini. Also houses RCS for translation up/down/left/right/aft. Modelled with the 2 backwards firing thrusters as well. RCS O/F Ratio 1.3:1.
 	@mass = 0.491
 	@maxTemp = 1973.15
 	@stagingIcon = SOLID_BOOSTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -467,7 +467,7 @@
 	@node_stack_bottom = 0.0, -0.27, 0.0, 0.0, -1.0, 0.0, 2
 	%fuelCrossFeed = False
 	@title = Gemini Adapter Retrograde Section
-	@description = The Gemini Adapter Retrograde Section. Contains the retrograde engines to de-orbit Gemini. Also houses RCS for translation up/down/left/right/aft. Modelled with the 2 backwards firing thrusters as well. RCS O/F Ratio 1.3:1.
+	@description = The Gemini Adapter Retrograde Section. Contains the retrograde engines to de-orbit Gemini. Also houses RCS for translation up/down/left/right/aft. Modelled with the 2 backwards firing thrusters as well. RCS O/F Ratio 1.3:1.  Provides approximately 106dV for re-entry burn.
 	@mass = 0.491
 	@maxTemp = 1973.15
 	@stagingIcon = SOLID_BOOSTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
@@ -123,21 +123,11 @@
 			rate = 1.01
 		}
 	}
-	!RESOURCE[LiquidFuel]
-	{
-	}
-	!RESOURCE[Oxidizer]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	!MODULE[ModuleGenerator]
-	{
-	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+	!MODULE[ModuleGenerator] {}
 	MODULE
 	{
 		name = ModuleDockingNode
@@ -252,6 +242,18 @@
 		}
 	}
 }
+@INTERNAL[FASAAscentStageInterior]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.818, 1.818, 1.818
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.818, 1.818, 1.818
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+
 @PART[FASALM_AscentStage]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
@@ -26,7 +26,7 @@
 
 	@title = Gemini Lightweight Lander
 	@description = Gemini Lander Pod. Contains one astronaut.
-	// @mass = 0.3  //  This seems kinda light?!?!?!
+	@mass = 0.3
 
 	!MODULE[ModuleReactionWheel] {}
 	@MODULE[ModuleCommand]
@@ -144,31 +144,40 @@
 @PART[FASA_Gemini_Lander_Legs]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
-		model = FASA/Gemini2/FASA_Gemini_Lander_Legs/model
-		scale = 1.75, 1.75, 1.75
+		%scale = 1.6, 1.6, 1.6
 	}
-	@rescaleFactor = 1.0
-	@scale = 1.75
-	@node_stack_top = 0.0, 0.019342, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.322179, 0.0, 0.0, -1.0, 0.0, 0
+
+	ns0 = #$node_stack_top[0]$
+	ns1 = #$node_stack_top[1]$
+	ns2 = #$node_stack_top[2]$
+	@ns0 *= 1.6
+	@ns1 *= 1.6
+	@ns2 *= 1.6
+	nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+	@node_stack_top = #$nsnew$
+
+	@ns0 = #$node_stack_bottom[0]$
+	@ns1 = #$node_stack_bottom[1]$
+	@ns2 = #$node_stack_bottom[2]$
+	@ns0 *= 1.6
+	@ns1 *= 1.6
+	@ns2 *= 1.6
+	@nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+	@node_stack_bottom = #$nsnew$
+
 	@title = Gemini Lander Legs
 	@description = Lander legs for the Gemini one man lander
 	@mass = 0.5
-	!RESOURCE[LiquidFuel]
-	{
-	}
-	!RESOURCE[Oxidizer]
-	{
-	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 135
 		type = ServiceModule
-		basemass = -1
+		basemass = 0.1
 	}
 }
 @PART[FASA_Gemini_Lander_Eng]:FOR[RealismOverhaul]
@@ -180,10 +189,25 @@
 		model = FASA/Gemini2/FASA_Gemini_Lander_Eng/model
 		scale = 1.75, 1.75, 1.75
 	}
-	@rescaleFactor = 1.0
-	@scale = 1.75
-	@node_stack_top = 0.0, -0.322179, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_bottom = 0.0, -0.4876914, 0.0, 0.0, -1.0, 0.0, 0
+
+	ns0 = #$node_stack_top[0]$
+	ns1 = #$node_stack_top[1]$
+	ns2 = #$node_stack_top[2]$
+	@ns0 *= 1.75
+	@ns1 *= 1.75
+	@ns2 *= 1.75
+	nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+	@node_stack_top = #$nsnew$
+
+	@ns0 = #$node_stack_bottom[0]$
+	@ns1 = #$node_stack_bottom[1]$
+	@ns2 = #$node_stack_bottom[2]$
+	@ns0 *= 1.75
+	@ns1 *= 1.75
+	@ns2 *= 1.75
+	@nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+	@node_stack_bottom = #$nsnew$
+
 	@title = FASA Advanced Gemini Lander Engine
 	@description = The main engine for the Gemini Lander.
 	@mass = .072
@@ -217,9 +241,7 @@
 			amount = 0.005
 		}
 	}
-	!MODULE[ModuleGimbal]
-	{
-	}
+	!MODULE[ModuleGimbal] {}
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -256,11 +278,31 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		scale = 1.219, 1.219, 1.219
+		%scale = 1.219, 1.219, 1.219
 	}
-	@scale = 1.219
+
+	// The original FASA node_stack definitions have six fields
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -1.6, 0.0, 0.0, -1.0, 0.0, 3
+
+	ns0 = #$node_stack_top[0]$
+	ns1 = #$node_stack_top[1]$
+	ns2 = #$node_stack_top[2]$
+	@ns0 *= 1.219
+	@ns1 *= 1.219
+	@ns2 *= 1.219
+	nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+	@node_stack_top = #$nsnew$
+
+	@ns0 = #$node_stack_bottom[0]$
+	@ns1 = #$node_stack_bottom[1]$
+	@ns2 = #$node_stack_bottom[2]$
+	@ns0 *= 1.219
+	@ns1 *= 1.219
+	@ns2 *= 1.219
+	@nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+	@node_stack_bottom = #$nsnew$
+
 	@title = FASA Advanced Gemini Descent Pack
 	@description = This pack contains an engine and more fuel for a Gemini based lander. Attach this as a descent stage to the Gemini for landings.
 	@mass = 0.75
@@ -270,15 +312,9 @@
 		@ejectionForce = 10
 		@staged = false
 	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	!RESOURCE[LiquidFuel]
-	{
-	}
-	!RESOURCE[Oxidizer]
-	{
-	}
+	!RESOURCE[MonoPropellant] {}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 1.7792888
@@ -400,13 +436,49 @@
 @PART[FASA_Gemini_Lander_Leg_Part]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
-		model = FASA/Gemini2/FASA_Gemini_Lander_Leg_Part/model
-		scale = 1.524, 1.524, 1.524
+		%scale = 1.6, 1.6, 1.6
 	}
 	@title = FASA Advanced Gemini Lander Leg
 	@description = Lander leg for the Gemini one man lander.
 	@mass = 0.1
+}
+
+@PART[FASA_Gemini_Lander_LFT]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		%scale = 1.6, 1.6, 1.6
+	}
+
+	ns0 = #$node_stack_top[0]$
+	ns1 = #$node_stack_top[1]$
+	ns2 = #$node_stack_top[2]$
+	@ns0 *= 1.6
+	@ns1 *= 1.6
+	@ns2 *= 1.6
+	nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+	@node_stack_top = #$nsnew$
+
+	@ns0 = #$node_stack_bottom[0]$
+	@ns1 = #$node_stack_bottom[1]$
+	@ns2 = #$node_stack_bottom[2]$
+	@ns0 *= 1.6
+	@ns1 *= 1.6
+	@ns2 *= 1.6
+	@nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+	@node_stack_bottom = #$nsnew$
+
+	@title = FASA Advanced Gemini Lander LFT
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 135
+		type = ServiceModule
+		basemass = 0.1
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
@@ -1,23 +1,34 @@
 @PART[FASA_Gemini_Lander_Pod]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@module = Part
-	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
-		model = FASA/Gemini2/FASA_Gemini_Lander_Pod/model
-		scale = 2.05, 2.05, 2.05
+		%scale = 1.6, 1.6, 1.6
 	}
-	@rescaleFactor = 1.0
-	@scale = 2.05
-	@node_stack_top = 0.0, 0.476798, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_bottom = 0.0, -0.328407, 0.0, 0.0, -1.0, 0.0, 1
+
+	ns0 = #$node_stack_top[0]$
+	ns1 = #$node_stack_top[1]$
+	ns2 = #$node_stack_top[2]$
+	@ns0 *= 1.6
+	@ns1 *= 1.6
+	@ns2 *= 1.6
+	nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_top[3]$,$node_stack_top[4]$,$node_stack_top[5]$,$node_stack_top[6]$
+	@node_stack_top = #$nsnew$
+
+	@ns0 = #$node_stack_bottom[0]$
+	@ns1 = #$node_stack_bottom[1]$
+	@ns2 = #$node_stack_bottom[2]$
+	@ns0 *= 1.6
+	@ns1 *= 1.6
+	@ns2 *= 1.6
+	@nsnew = #$ns0$,$ns1$,$ns2$,$node_stack_bottom[3]$,$node_stack_bottom[4]$,$node_stack_bottom[5]$,$node_stack_bottom[6]$
+	@node_stack_bottom = #$nsnew$
+
 	@title = Gemini Lightweight Lander
 	@description = Gemini Lander Pod. Contains one astronaut.
-	@mass = 0.3
-	!MODULE[ModuleReactionWheel]
-	{
-	}
+	// @mass = 0.3  //  This seems kinda light?!?!?!
+
+	!MODULE[ModuleReactionWheel] {}
 	@MODULE[ModuleCommand]
 	{
 		RESOURCE
@@ -26,12 +37,8 @@
 			rate = 0.45//200W for life support base
 		}
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
 	@MODULE[ModuleLight]
 	{
 		@resourceAmount = .05
@@ -95,11 +102,23 @@
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
-		conversionRate = 2.0	// # of people - Figures based on per/person
+		conversionRate = 1.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[FASAGeminiLanderInt]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[FASA_Gemini_Lander_Pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
@@ -1,6 +1,7 @@
 @PART[FASA_Gemini_Lander_Pod]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@module = Part
 	@MODEL
 	{
 		%scale = 1.6, 1.6, 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Mercury_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Mercury_Pod.cfg
@@ -21,12 +21,8 @@
 			@key,1 = 1 210
 		}
 	}
-	!MODULE[ModuleGimbal]
-	{
-	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+	!MODULE[ModuleGimbal] {}
+	!RESOURCE[SolidFuel] {}
 	%MODULE[ModuleDecouple]
 	{
 		%name = ModuleDecouple
@@ -66,7 +62,10 @@
 		}
 	}
 }
-@PART[FASAMercruyCap2]:FOR[RealismOverhaul]
+
+// Yes, Mercury is spelled incorrectly in the original FASA file.  Added 
+// correct spelling in case someone ever fixes upstream FASA name.
+@PART[FASAMercruyCap2|FASAMercuryCap2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -324,6 +323,18 @@
 		maxAmount = 125
 	}
 }
+
+@INTERNAL[FASAMercuryInt]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.514, 1.526, 1.514
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.514, 1.526, 1.514
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[FASAMercuryPod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -1242,7 +1242,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 50
-		basemass = -1
+		basemass = 0.1
 		type = ServiceModule
 		TANK
 		{
@@ -1409,7 +1409,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 18
-		basemass = -1
+		basemass = 0.05
 		type = Fuselage
 		TANK
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -78,6 +78,16 @@
 		}
 	}
 }
+@INTERNAL[cupolaInternal|cupolaInternalRPM]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
 @PART[seatExternalCmd]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -163,6 +173,18 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[crewCabinInternals]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[advSasModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -453,23 +475,12 @@
 	}
 }
 
-@INTERNAL[PodCockpit]:FOR[RealismOverhaul]
+@INTERNAL[PodCockpit|PodCockpitRPM]:FOR[RealismOverhaul]
 {
 	%scaleAll = 1.722222, 1.722222, 1.722222
 	@MODULE[InternalSeat],*
 	{
 		%kerbalScale = 1.722222, 1.722222, 1.722222
-		%kerbalOffset = 0.0, 0.0, 0.0
-		%kerbalEyeOffset = 0.0, 0.0, 0.0
-	}
-}
-
-@INTERNAL[PodCockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-	%scaleAll = 1.64, 1.64, 1.64
-	@MODULE[InternalSeat],*
-	{
-		%kerbalScale = 1.64, 1.64, 1.64
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
@@ -572,6 +583,19 @@
 	@node_stack_bottom = 0.0, -0.7859536, 0.0, 0.0, -1.0, 0.0, 4
 	@node_stack_top = 0.0, 1.9568316, 0.0, 0.0, 1.0, 0.0, 2
 }
+
+@INTERNAL[PodCockpit|PodCockpitRPM]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	%scaleAll = 1.64, 1.64, 1.64
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.64, 1.64, 1.64
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+
 @PART[Mark1-2Pod]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
 {
 	@maxTemp = 800
@@ -665,6 +689,17 @@
 		conversionRate = 1.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+@INTERNAL[landerCabinSmallInternal|landerCabinSmallInternalRPM]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
 }
 @PART[mk1pod]:FOR[RealismOverhaul]
@@ -879,6 +914,17 @@
 		DescentModeCoM = 0.0, -0.1, 0.0
 	}
 }
+@INTERNAL[mk1PodCockpit|mk1PodCockpitRPM]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mk1pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
@@ -932,7 +978,7 @@
 			amount = 43200
 			maxAmount = 43200
 		}
-				TANK
+		TANK
 		{
 			name = Food
 			amount = 245.7
@@ -986,17 +1032,7 @@
 	}
 }
 
-@INTERNAL[landerCabinInternals]:BEFORE[RealismOverhaul]
-{
-	%scaleAll = 1.6, 1.6, 1.6
-	@MODULE[InternalSeat],*
-	{
-		%kerbalScale = 1.6, 1.6, 1.6
-		%kerbalOffset = 0.0, 0.0, 0.0
-		%kerbalEyeOffset = 0.0, 0.0, 0.0
-	}
-}
-@INTERNAL[landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
+@INTERNAL[landerCabinInternals|landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
 {
 	%scaleAll = 1.6, 1.6, 1.6
 	@MODULE[InternalSeat],*
@@ -1007,6 +1043,8 @@
 	}
 }
 
+// Is this an old cockpit definition?  mk3Cockpit_Shuttle appears to be the 
+// current v1.0.5 standard.
 @PART[mark3Cockpit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -1204,7 +1242,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 50
-		basemass = 0.1
+		basemass = -1
 		type = ServiceModule
 		TANK
 		{
@@ -1371,7 +1409,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 18
-		basemass = 0.05
+		basemass = -1
 		type = Fuselage
 		TANK
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -452,6 +452,29 @@
 		playAnimationOnEditorSpawn = false
 	}
 }
+
+@INTERNAL[PodCockpit]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[PodCockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	%scaleAll = 1.64, 1.64, 1.64
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.64, 1.64, 1.64
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[Mark1-2Pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
@@ -962,6 +985,28 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[landerCabinInternals]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+@INTERNAL[landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
+{
+	%scaleAll = 1.6, 1.6, 1.6
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mark3Cockpit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -1,3 +1,16 @@
++INTERNAL[mk1CockpitInternal]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@name = RO-Mk1CockpitInternal-1.25
+	%RSSROConfig = True
+	%scaleAll = 1.25, 1.25, 1.25
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.25, 1.25, 1.25
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mk2_1m_Bicoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -195,16 +208,11 @@
 			rate = 0.7//200W for life support base
 		}
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+	!MODULE[ModuleReactionWheel] {}
 	!MODULE[ModuleFuelTanks] {}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -269,6 +277,18 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
+@INTERNAL[mk2CockpitStandardInternals|mk2CockpitStandardInternalsRPM|MK2_CrewCab_Int]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
 @PART[mk2Cockpit_Standard]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -451,6 +471,7 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
 @PART[mk2DockingPort]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -722,16 +743,10 @@
 			rate = 0.5
 		}
 	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
 	!MODULE[ModuleFuelTanks] {}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -794,6 +809,17 @@
 		conversionRate = 4.0	// # of people - Figures based on per/person
 		inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
+	}
+}
+
+@INTERNAL[MK3_Cockpit_Int|MK3_CrewCab_Int]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
 }
 @PART[mk3CrewCabin]:FOR[RealismOverhaul]
@@ -1452,7 +1478,10 @@
 	%rescaleFactor = 1
 	%scale = 1
 	@node_stack_bottom = 0.0, -0.175, 0.0, 0.0, -1.0, 0.0, 1
-	
+
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[MonoPropellant] {}
+
 	!MODULE[ModuleAnimateGeneric],0:NEEDS[VenStockRevamp] {}
 	
 	@MODULE[ModuleCommand]
@@ -1464,18 +1493,8 @@
 		}
 	}
 	
-	!MODULE[TweakScale]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+	!MODULE[TweakScale] {}
+	!MODULE[ModuleReactionWheel] {}
 	!MODULE[ModuleFuelTanks] {}
 	MODULE
 	{
@@ -1560,6 +1579,7 @@
 		}
 	}
 }
+
 @PART[Mark2Cockpit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -1884,6 +1904,7 @@
 		outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
 	}
 }
+
 // Use alt VSR graphics for 1.25s if available
 @PART[Mark1Cockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
@@ -1894,6 +1915,12 @@
 	}
 	@node_stack_bottom = 0.0, -0.1858, 0.0, 0.0, -1.0, 0.0, 1
 	
+	@INTERNAL
+	{
+		@name = RO-Mk1CockpitInternal-1.25
+		%offset = 0.0, 0.2, 0.0
+	}
+
 	@MODULE[ModuleAnimateGeneric]
 	{
 		%animationName = MK1Light
@@ -1903,6 +1930,7 @@
 		@textureQuadName = flagTransform
 	}
 }
+
 
 //	==================================================
 //	MK1 Crew Cabin.


### PR DESCRIPTION
- Rescaled FASA IVA's to match external model sizes.
- Gemini Lander Pod external model wasn't resizing due to a bug, fixed.
- Fixed Lander Pod RO resize value was too large, scaled to 1.6.
- Resized other Gemini Lander parts to match new pod size.
- Added FASA_Gemini_Lander_LFT fuel tank to RO.
- Patched FASA Lander Pod to be 'Part' instead of 'CommandPod' to comply with RO standards.

**Those reading this, please feel free to change specs so they are more RO-like (weight, thrust, etc).  My focus was on the look and feel, not sure if the technical aspects are realistic though.