### PR TITLE
Update RealismOverhaul_Global_Config.cfg

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -132,25 +132,21 @@
 
 // ******** DRE ********
 // DRE don't change temps
-@PART[*]:HAS[#RSSROConfig[*],!MODULE[ModuleAeroReentry],!MODULE[ModuleHeatShield]]:NEEDS[DeadlyReentry]:FINAL
+@PART[*]:HAS[#RSSROConfig[*],@MODULE[ModuleAeroReentry]]:NEEDS[DeadlyReentry]:FINAL
+{
+	@MODULE[ModuleAeroReentry]
+	{
+		%leaveTemp = True
+	}
+}
+
+@PART[*]:HAS[#RSSROConfig[*],!MODULE[ModuleAeroReentry]]:NEEDS[DeadlyReentry]:FINAL
 {
 	MODULE
 	{
 		name = ModuleAeroReentry
 		skinHeatConductivity = 0.001
 		leaveTemp = True
-	}
-}
-
-@PART[*]:HAS[#RSSROConfig[*]]:FINAL
-{
-	@MODULE[ModuleAeroReentry]
-	{
-		%leaveTemp = True
-	}
-	@MODULE[ModuleHeatShield]
-	{
-		%leaveTemp = True
 	}
 }
 


### PR DESCRIPTION
Fixed issue where leaveTemp inserted into ModuleHeatShield (which does nothing) and fails to create ModuleAeroReentry (with leaveTemp in it) in parts that are heat shields.