### PR TITLE
Update Centaur tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
@@ -157,7 +157,7 @@
 	@title = Centaur A/B/C/D/D1
 	@description = Tank and thrust structure for the Centaur A/B/C/D/D1 models. Add two RL10A series engines to complete the stage.
 	@attachRules = 1,0,1,1,0
-	@mass = 1.125	// From Astronautix, based on the Centaur I or Centaur D-1B.  Add leadbalast to duplicate older versions of this model Centaur
+	@mass = 1.003	// From Astronautix, based on the Centaur I or Centaur D-1B.  1.7t total weight comes from 2x RL-10A-3-3A engines (0.274), 4x Centaur RCS thrusters (0.024), 4x 138N attitude jets (0.012), and payload fairing base (0.387).  Add leadbalast to duplicate older versions of this model Centaur
 	!RESOURCE[LiquidFuel]
 	{
 	}
@@ -166,10 +166,39 @@
 	}
 	MODULE
 	{
-		name = ModuleFuelTanks
-		volume = 42511.0
+		name = ModuleFuelTanks	//tank size taken from http://www.alternatewars.com/BBOW/Boosters/Centaur/Centaur.htm for Centaur D-1A
+		volume = 46544.62	//46467.91 + 76.71 HTP
 		type = Balloon
 		basemass = -1
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 35820.81
+			maxAmount = 35820.81
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 10647.1
+			maxAmount = 10647.1
+		}
+		TANK	//Tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf.  Older, 242lb version using HTP.
+		{
+			name = HTP
+			amount = 76.71
+			maxAmount = 76.71
+		}
+	}
+}
++PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
+{
+	@name = FASAGeminiLFTCentarCSM_D1T
+	@title = Centaur D-1T
+	@description = Tank and thrust structure for the Centaur D1T models. Used on the Titan III-E. Add one or two RL10A series engines to complete the stage.
+	@mass = 1.934	// from Astronautix Titan 3E.  2.631 total weight comes from 2x RL-10A-3-3 engines (0.274), 4x Centaur RCS thrusters (0.024), 4x 138N attitude jets (0.012), and payload fairing base (0.387).
+	@MODULE[ModuleFuelTanks]
+	{
+		@type = BalloonCryo	//Titan version of the Centaur D-1 included radiation shielding specifically meant to increase the stages life by cutting the boil off rate to less than 2%/day.  http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
 	}
 }
 +PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
@@ -186,33 +215,28 @@
 	@node_stack_bottom2 = -0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	@node_stack_bottom3 = 0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	@title = Centaur D2
-	@description = Tank and thrust structure for the Centaur D2 models. Used on the Atlas II and IIIA. Add one or two RL10A series engines to complete the stage.
-	@mass = 1.6555	// from Astronautix.  b14643.de shows same weight for all D2 models even though engine type/weight changes.
+	@description = Tank and thrust structure for the Centaur II and IIAS models. Used on the Atlas II and IIIA. Add one or two RL10A series engines to complete the stage.
+	@mass = 1.356	// from Astronautix, Atlas II.  2.053t total weight comes from 2x RL-10A-3-3A engines (0.274), 4x Centaur RCS thrusters (0.024), 4x 138N attitude jets (0.012), and payload fairing base (0.387)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 49317.5
+		@volume = 53122.4	//tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
+		@TANK[LqdHydrogen]
+		{
+			@amount = 40011.7
+			@maxAmount = 40011.7
+		}
+		@TANK[LqdOxygen]
+		{
+			@amount = 13110.7
+			@maxAmount = 13110.7
+		}
+		!TANK[HTP]{}
 	}
-}
-+PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
-{
-	@name = FASAGeminiLFTCentarCSM_D3
-	@MODEL,1
+	RESOURCE	//Hydrazine tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
 	{
-		@model = Squad/Parts/FuelTank/fuelTankJumbo-64/model
-		@scale = 1.219, 1.16725, 1.219
-		@position = 0.0, 2.37719, 0.0
-	}
-	@node_stack_top = 0.0, 6.754375, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, -4.9256, 0.0, 0.0, -1.0, 0.0, 3
-	@node_stack_bottom1 = 0.0, -2.6095, 0.0, 0, -1, 0, 1
-	@node_stack_bottom2 = -0.660698, -3.04834, 0.0, 0, -1, 0, 1
-	@node_stack_bottom3 = 0.660698, -3.04834, 0.0, 0, -1, 0, 1
-	@title = Centaur D3
-	@description = Tank and thrust structure for the Centaur D3 models. Used on the Atlas IIIB. Add one or two RL10A series engines to complete the stage.  Includes integrated avionics for the full Atlas III launch vehicle.
-	@mass = 1.494	// from Astronautix.  b14643.de shows same weight for SEC and DEC versions.
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 62000
+		name = Hydrazine
+		amount = 144.57
+		maxAmount = 144.57
 	}
 }
 +PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
@@ -230,12 +254,30 @@
 	@node_stack_bottom2 = -0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	@node_stack_bottom3 = 0.660698, -3.04834, 0.0, 0, -1, 0, 1
 	%TechRequired = hydroloxTL7
-	@title = Centaur D5
-	@description = Tank and thrust structure for the Centaur D5 used on the Atlas V. Add one or two RL10A series engines to complete the stage.  Includes integrated avionics for the full Atlas V launch vehicle.
-	@mass = 1.557	// from Astronautix for the sack of consistency
-	@MODULE[ModuleFuelTanks]
+	@title = Centaur D3
+	@description = Tank and thrust structure for the Centaur III used on the Atlas V. Add one or two RL10A series engines to complete the stage.  Includes integrated avionics for the full Atlas V launch vehicle.
+	@mass = 1.436	// from Astronautix, Atlas V.  2.026t total weight comes from 1x RL-10A-4-1/2 engines (0.167), 4x Centaur RCS thrusters (0.024), 4x 138N attitude jets (0.012), and payload fairing base (0.387)
+	@MODULE[ModuleFuelTanks],0
 	{
-		@volume = 60678.3
+		@volume = 64449.14	//tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
+		@type = BalloonCryo	//increased shielding reduces boil off to just over 1%/day.  http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
+		@TANK[LqdHydrogen]
+		{
+			@amount = 48308.54
+			@maxAmount = 48308.54
+		}
+		@TANK[LqdOxygen]
+		{
+			@amount = 16140.6
+			@maxAmount = 16140.6
+		}
+		!TANK[HTP]{}
+	}
+	RESOURCE	//Hydrazine tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
+	{
+		name = Hydrazine
+		amount = 144.57
+		maxAmount = 144.57
 	}
 }
 +PART[FASAGeminiLFTCentar]:AFTER[RealismOverhaul]
@@ -259,10 +301,28 @@
 	%TechRequired = hydroloxTL4
 	@title = Centaur T
 	@description = 4.32m Tank and thrust structure for the Centaur T used on the Titan IV. Add a single RL10A series engines to complete the stage.
-	@mass = 1.825	// from Astronautix for the sack of consistency
-	@MODULE[ModuleFuelTanks]
+	@mass = 1.575	// from Astronautix, Titan 4.  2.775t total weight comes from 2x RL-10A-3-3A engines (0.274), 4x Centaur RCS thrusters (0.024), 4x 138N attitude jets (0.012), and payload fairing base (0.890)
+	@MODULE[ModuleFuelTanks],0
 	{
-		@volume = 63000
+		@volume = 69885.96	//tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
+		@type = BalloonCryo	//increased shielding reduces boil off to just over 1%/day.  http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
+		@TANK[LqdHydrogen]
+		{
+			@amount = 53547.16
+			@maxAmount = 53547.16
+		}
+		@TANK[LqdOxygen]
+		{
+			@amount = 16338.8
+			@maxAmount = 16338.8
+		}
+		!TANK[HTP]{}
+	}
+	RESOURCE	//Hydrazine tank size taken from http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
+	{
+		name = Hydrazine
+		amount = 144.57
+		maxAmount = 144.57
 	}
 }
 +PART[FASA_Gemini_RCS_Thrusters]:AFTER[RealismOverhaul]


### PR DESCRIPTION
We previously changed the default Centaur tank from type=ServiceModule to type=Balloon which makes sense as the Centaur was based on the same balloon tank concept as Atlas.  Plus most early Centaur tanks (those used on Atlas) had basically no insulation so high boil off rates.  However, both versions of Centaur used on the Titan (Centaur D-1T and Centaur T) were intended for longer duration flights and therefore included insulation to reduce boil off.  And the latest Centaur III (used on Atlas IIIB/V) included the same kind of insulation for the same reasons.  I've therefore added a new definition specifically for the D-1T, and set the D-1T, D3 and T tanks to all have type=BalloonCryo.  Technically the D3 and T versions should have about half the boil off of the D-1T (1%/day vs just under 2%/day) but I don't know if we currently have the ability to control boil off to that degree.

I also made a number of weight changes.  Unlike in previous updates, this time I specifically aimed for matching the dry weights of the tanks.  And in all cases, I'm including the weight of the payload fairing base, plus rcs thrusters and engines in the weight.  I've included a note on the mass line indicating exactly what I included to come up with the indicated weight and exactly what each extra parts weight was.

This PR is removing the old FASAGeminiLFTCentarCSM_D3.  Previously I had been under the impression that the Atlas IIIB flew a different model Centaur. But after much research and reading, I've come to find that the "Centaur III" (also known as the "Common Centaur") was flown on both the Atlas IIIB and Atlas V.  So there's no reason to include a separate Centaur tank specifically for the Atlas IIIB.

During my research, I discovered that while modern versions of the Centaur use a Hydrazine based RCS system, the original Centaur used a Hydrogen Peroxide based RCS system.  For the Centaur D1 and D-1T tanks, I've added 242 pounds (76.71 L) worth of HTP to the basic Balloon tank.  For the D2, D3 and T models I couldn't include Hydrazine in the existing ModuleFuelTanks because Hydrazine can't go in Balloon or BalloonCryo tanks.  I've therefore added a 320 pound (144.57 L) Hydrazine RESOURCE to these tanks.  Unfortunately that means players can only decrease the amount available (versus completely removing or altering the tank) but it's the best solution I have right now.  If there is a way to add a second ModuleFuelTank module to a part, that would work better but the tests I ran showed the two modules interacting with each other.

For all five of the Centaur tanks, I've been able to track down LOX and LH2 tank capacity information.  I've therefore reset the fuel tanks max volume, and included default LOX and LH2 tanks to match the documentation I've found.  The only concern I've come across is I can't seem to match up the tank capacities found in one set of documents, with the Gross Mass/Burn Times found in another set of documents.  It seems in all cases, the Gross Mass/Burn Times I'm finding assume that less than full tanks are launched.  Once in game, however, if you manually reduce the available fuel to match the documented burn times, the gross mass is within 200kg which I'm thinking is about as accurate as we can get.

Mass and burn time data was pulled off astronautix.com.  Pages for Titan 4, Titan 3E, Atlas V, Atlas IIIB, Atlas IIIA, Atlas IIAS, Atlas II, Atlas I, Atlas Centaur SLV-3D and Atlas Centaur LV-3C.
Other documentation comes from the following:
http://www.ulalaunch.com/uploads/docs/Published_Papers/Extended_Duration/AtlasCentaurExtensibilitytoLongDurationInSpaceApplications20056738.pdf
http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
http://history.nasa.gov/SP-4230.pdf
http://www.alternatewars.com/BBOW/Boosters/Centaur/Centaur.htm
http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/HistoryoftheTitanCentaurLaunchVehicle.pdf
http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf