### PR TITLE
Fixed RemoteTech for RN-Skylab

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -307,6 +307,13 @@
 {
     !RESOURCE[ElectricCharge] {}  // Let's pretend this is a battery-less computer!  Batteries are stored in the Skylab.
 
+    @MODULE[ModuleCommand]
+    {
+       %RESOURCE[ElectricCharge] {
+           %rate = 0.18
+       }
+    }
+
     %MODULE[ModuleSPU] {
 	%IsRTCommandStation = true
 	%RTCommandMinCrew = 3
@@ -314,8 +321,7 @@
 
     %MODULE[ModuleRTAntennaPassive] {
         %TechRequired = unmannedTech
-        %OmniRange = 3000
-        %EnergyCost = 0.05
+        %OmniRange = 300000
         
         %TRANSMITTER {
             %PacketInterval = 0.3

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -202,7 +202,7 @@
 		@PacketResourceCost = 4.0
 	}
 }
-@PART[skylab]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+@PART[skylab]:AFTER[RemoteTech]
 {
     !MODULE[ModuleDataTransmitter] {}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -31,7 +31,6 @@
 
 	@MODULE[ModuleCommand]
 	{
-		@minimumCrew = 1
 
 		@RESOURCE[ElectricCharge]
 		{
@@ -206,21 +205,6 @@
 @PART[skylab]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     !MODULE[ModuleDataTransmitter] {}
-    !MODULE[FSanimateGeneric],0 {}   // It would seem that RemoteTech wasn't intended to work with the Firespitter animation module.  Kept getting an 'index error' when testing from orbit using Kerbal Construction Time.
-
-    MODULE
-    {
-       name = ModuleAnimateGeneric  // Replaced the Firespitter animation module with Squad's stock animation for RemoteTech compatibility.  Looks just as good, didn't notice any difference in antenna animation quality or sequences.
-       animationName = Deploy
-       isOneShot = false
-
-       startEventGUIName = Deploy Antennae
-       endEventGUIName = Retract Antennae
-       // toggleActionName = Toggle Antennae
-       actionGUIName = Toggle Antennae
-       allowAnimationWhileShielded = False
-       allowManualControl = false
-    }
 
     %MODULE[ModuleRTAntenna] {
         %Mode0OmniRange = 0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -31,7 +31,7 @@
 
 	@MODULE[ModuleCommand]
 	{
-		@minimumCrew = 0
+		@minimumCrew = 1
 
 		@RESOURCE[ElectricCharge]
 		{
@@ -203,9 +203,24 @@
 		@PacketResourceCost = 4.0
 	}
 }
-@PART[skylab]:NEEDS[RemoteTech]
+@PART[skylab]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     !MODULE[ModuleDataTransmitter] {}
+    !MODULE[FSanimateGeneric],0 {}   // It would seem that RemoteTech wasn't intended to work with the Firespitter animation module.  Kept getting an 'index error' when testing from orbit using Kerbal Construction Time.
+
+    MODULE
+    {
+       name = ModuleAnimateGeneric  // Replaced the Firespitter animation module with Squad's stock animation for RemoteTech compatibility.  Looks just as good, didn't notice any difference in antenna animation quality or sequences.
+       animationName = Deploy
+       isOneShot = false
+
+       startEventGUIName = Deploy Antennae
+       endEventGUIName = Retract Antennae
+       // toggleActionName = Toggle Antennae
+       actionGUIName = Toggle Antennae
+       allowAnimationWhileShielded = False
+       allowManualControl = false
+    }
 
     %MODULE[ModuleRTAntenna] {
         %Mode0OmniRange = 0
@@ -287,6 +302,27 @@
 	
 	@scale = 1.00
 	@rescaleFactor = 1
+}
+@PART[skylab_asas]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+{
+    !RESOURCE[ElectricCharge] {}  // Let's pretend this is a battery-less computer!  Batteries are stored in the Skylab.
+
+    %MODULE[ModuleSPU] {
+	%IsRTCommandStation = true
+	%RTCommandMinCrew = 3
+    }
+
+    %MODULE[ModuleRTAntennaPassive] {
+        %TechRequired = unmannedTech
+        %OmniRange = 3000
+        %EnergyCost = 0.05
+        
+        %TRANSMITTER {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
 }
 
 @PART[skylab_trs_docking]:FOR[RealismOverhaul]


### PR DESCRIPTION
Fixing the RemoteTech RO patch for Skylab in an earlier PR was good, but it exposed a different bug.  RemoteTech was (apparently) designed to work with Squad's ModuleAnimateGeneric.  Skylab was designed with the Firespitter equivalent animation modules back in 2014 when Firespitter probably had features the stock module didn't (perhaps).

This patch converts the antennae animation (and just the antennae animation, no other animations) to use ModuleAnimateGeneric so RemoteTech can conveniently avoid this bug.  Current generation (v1.05) ModuleAnimateGeneric looks beautiful with the Skylab antennae animation.  Perhaps v1.05 introduced features similar to Firespitter?  I did not test any of the other animations so there may or may not be a purpose for the Firespitter anim module still.

Added RemoteTech configs to the Skylab ASAS so it functions just like every other probe in RO including a small electric penalty.  Also enabled the ASAS to act as a probe control station when 3 crew members are present (since Skylab crews were typically 3-persons).

Skylab now requires a minimum of one crew member to operate, or an attached ASAS within communications range.

