### PR TITLE
Improved gimbal response speed for AJ10-Early

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -240,7 +240,7 @@
 	{
 		@gimbalRange = 4.25
 		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 8
+		%gimbalResponseSpeed = 16
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-37]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]


### PR DESCRIPTION
Are you tired of your Able stage wobbling back and forth like a drunk sailor when under Mechjeb control? Because I am.

With this bump Mechjeb can control the engine like a boss, as is tradition.