### PR TITLE
RSB 0.13 updates [RealPlume]

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBathenaOAM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBathenaOAM.cfg
@@ -1,18 +1,18 @@
 //  ==================================================
-//  PS4 plume configuration.
+//  OAM plume configuration.
 //  ==================================================
 
-@PART[RSBtankPSLVps4]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBathenaOAM]:FPR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-Upper
-        transformName = fxTransform
+        transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.25
-        fixedScale = 0.75
+        localPosition = 0.0, 0.0, 0.05
+        fixedScale = 0.125
         energy = 0.75
-        speed = 1.0
+        speed = 1.25
     }
 
     @MODULE[ModuleEngines*]
@@ -31,10 +31,10 @@
 }
 
 //  ==================================================
-//  PS4 flare configuration.
+//  OAM flare configuration.
 //  ==================================================
 
-@PART[RSBtankPSLVps4]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+@PART[RSBathenaOAM]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
@@ -42,8 +42,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.25
-                @fixedScale = 0.55
+                @localPosition = 0.0, 0.0, 0.36
+                @fixedScale = 0.1
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta2srm.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta2srm.cfg
@@ -62,8 +62,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -0.9
-                @fixedScale = 0.4
+                @localPosition = 0.0, 0.0, -1.0
+                @fixedScale = 0.425
             }
         }
     }
@@ -82,7 +82,6 @@
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
                 @localPosition = 0.0, 0.0, -1.5
-                @fixedScale = 1.0
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srm.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srm.cfg
@@ -43,7 +43,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, -0.25
+                @localPosition = 0.0, 0.0, -0.3
                 @fixedScale = 0.7
             }
         }
@@ -62,8 +62,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -0.9
-                @fixedScale = 0.4
+                @localPosition = 0.0, 0.0, -1.0
+                @fixedScale = 0.425
             }
         }
     }
@@ -82,7 +82,6 @@
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
                 @localPosition = 0.0, 0.0, -1.4
-                @fixedScale = 1.0
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srmG.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srmG.cfg
@@ -43,7 +43,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, -0.25
+                @localPosition = 0.0, 0.0, -0.3
                 @fixedScale = 0.7
             }
         }
@@ -62,8 +62,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.2, -0.9
-                @fixedScale = 0.4
+                @localPosition = 0.0, 0.2, -1.0
+                @fixedScale = 0.425
             }
         }
     }
@@ -83,7 +83,6 @@
             {
                 @localRotation = 10.0, 0.0, 0.0
                 @localPosition = 0.0, 0.0, -1.4
-                @fixedScale = 1.0
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdeltaIVsrm.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdeltaIVsrm.cfg
@@ -43,7 +43,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, -0.2
+                @localPosition = 0.0, 0.0, -0.3
                 @fixedScale = 0.85
             }
         }
@@ -62,8 +62,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -1.1
-                @fixedScale = 0.4
+                @localPosition = 0.0, 0.0, -1.0
+                @fixedScale = 0.425
             }
         }
     }
@@ -82,7 +82,6 @@
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
                 @localPosition = 0.0, 0.0, -1.25
-                @fixedScale = 0.8
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAJ10-118K.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAJ10-118K.cfg
@@ -19,7 +19,7 @@
     {
         %powerEffectName = Hypergolic-OMS-White
         !runningEffectName = NULL
-		!fxOffset = NULL
+        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAJ10-118K.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAJ10-118K.cfg
@@ -1,0 +1,51 @@
+//  ==================================================
+//  AJ10-118F/K engine plume configuration.
+//  ==================================================
+
+@PART[RSBengineAJ10-118K]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 1.25
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        !runningEffectName = NULL
+		!fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}
+
+//  ==================================================
+//  AJ10-118F/K engine flare configuration.
+//  ==================================================
+
+@PART[RSBengineAJ10-118K]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-OMS-White
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.25
+                @fixedScale = 0.65
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAresSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAresSRB.cfg
@@ -9,11 +9,10 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        flarePosition = 0.0, 0.0, 0.0
-        plumePosition = 0.0, 0.0, 0.0
-        fixedScale = 1.25
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 2.0
         energy = 1.0
-        speed = 1.0
+        speed = 1.25
     }
 
     @MODULE[ModuleEngines*]
@@ -44,8 +43,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, -0.5
-                @fixedScale = 3.0
+                @localPosition = 0.0, 0.0, -0.75
+                @fixedScale = 2.75
             }
         }
     }
@@ -63,8 +62,26 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -2.0
+                @localPosition = 0.0, 0.0, -1.25
                 @fixedScale = 1.0
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  Five segment RSRM slag configuration.
+//  ==================================================
+
+@PART[RSBengineAresSRB]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Solid-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[slag]
+            {
+                @localPosition = 0.0, 0.0, -0.75
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineArianeVSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineArianeVSRB.cfg
@@ -9,7 +9,7 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.7
+        localPosition = 0.0, 0.0, 0.5
         fixedScale = 2.0
         energy = 0.8
         speed = 1.75
@@ -43,8 +43,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.3
-                @fixedScale = 2.4
+                @localPosition = 0.0, 0.0, -0.2
+                @fixedScale = 2.3
             }
         }
     }
@@ -62,7 +62,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, 0.0
+                @localPosition = 0.0, 0.0, -0.5
                 @fixedScale = 1.0
             }
         }
@@ -81,8 +81,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
-                @localPosition = 0.0, 0.0, -2.5
-                @fixedScale = 2.4
+                @localPosition = 0.0, 0.0, -0.75
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAtlasSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAtlasSRB.cfg
@@ -9,8 +9,8 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.1
-        fixedScale = 1.25
+        localPosition = 0.0, 0.0, 0.05
+        fixedScale = 1.0
         energy = 1.0
         speed = 1.25
     }
@@ -32,37 +32,56 @@
 }
 
 //  ==================================================
-//  AJ-60A engine flare configuration.
+//  AJ-60A flare configuration.
 //  ==================================================
 
 @PART[RSBengineAtlasSRB]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Solid-Lower
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, -0.2
+                @localPosition = 0.0, 0.0, -0.45
+                @fixedScale = 0.75
             }
         }
     }
 }
 
 //  ==================================================
-//  AJ-60A engine smoke configuration.
+//  AJ-60A smoke configuration.
 //  ==================================================
 
 @PART[RSBengineAtlasSRB]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {
-        @Kerolox-Lower
+        @Solid-Lower
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -1.1
-                @fixedScale = 0.4
+                @localPosition = 0.0, 0.0, -1.0
+                @fixedScale = 0.5
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  AJ-60A slag configuration.
+//  ==================================================
+
+@PART[RSBengineAtlasSRB]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Solid-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[slag]
+            {
+                @localPosition = 0.0, 0.0, -1.5
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor120.cfg
@@ -10,7 +10,7 @@
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
         localPosition = 0.0, 0.0, 0.6
-        fixedScale = 0.8
+        fixedScale = 1.15
         energy = 1.1
         speed = 1.5
     }
@@ -43,8 +43,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.25
-                @fixedScale = 1.25
+                @localPosition = 0.0, 0.0, 0.0
+                @fixedScale = 1.1
             }
         }
     }
@@ -62,7 +62,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -0.25
+                @localPosition = 0.0, 0.0, 0.0
                 @fixedScale = 0.6
             }
         }
@@ -81,8 +81,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
-                @localPosition = 0.0, 0.0, -0.75
-                @fixedScale = 1.0
+                @localPosition = 0.0, 0.0, -1.0
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor30.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor30.cfg
@@ -1,0 +1,51 @@
+//  ==================================================
+//  Castor 30 plume configuration.
+//  ==================================================
+
+@PART[RSBengineCastor30]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Solid-Vacuum
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.6
+        fixedScale = 1.5
+        energy = 1.25
+        speed = 1.25
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Vacuum
+		!runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEnginesConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Vacuum
+        }
+    }
+}
+
+//  ==================================================
+//  Castor 30 flare configuration.
+//  ==================================================
+
+@PART[RSBengineCastor30]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Solid-Vacuum
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.6
+                @fixedScale = 1.0
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVps1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVps1.cfg
@@ -9,7 +9,7 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -0.1
         fixedScale = 1.5
         energy = 1.25
         speed = 1.25
@@ -43,7 +43,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, -0.75
+                @localPosition = 0.0, 0.0, -0.8
                 @fixedScale = 1.75
             }
         }
@@ -81,8 +81,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
-                @localPosition = 0.0, 0.0, -2.0
-                @fixedScale = 1.25
+                @localPosition = 0.0, 0.0, -1.5
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb10m.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb10m.cfg
@@ -9,7 +9,7 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -0.1
         fixedScale = 0.5
         energy = 1.0
         speed = 1.5
@@ -62,7 +62,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -1.0
+                @localPosition = 0.0, 0.0, -1.2
                 @fixedScale = 0.25
             }
         }
@@ -81,8 +81,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
-                @localPosition = 0.0, 0.0, -1.0
-                @fixedScale = 0.5
+                @localPosition = 0.0, 0.0, -1.25
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb13m.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb13m.cfg
@@ -9,7 +9,7 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -0.1
         fixedScale = 0.5
         energy = 1.0
         speed = 1.5
@@ -62,7 +62,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -1.0
+                @localPosition = 0.0, 0.0, -1.2
                 @fixedScale = 0.25
             }
         }
@@ -82,7 +82,6 @@
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
                 @localPosition = 0.0, 0.0, -1.25
-                @fixedScale = 0.25
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineSTSSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineSTSSRB.cfg
@@ -9,7 +9,7 @@
         name = Solid-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.75
+        localPosition = 0.0, 0.0, 0.7
         fixedScale = 2.5
         energy = 1.25
         speed = 1.25
@@ -43,7 +43,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.0
+                @localPosition = 0.0, 0.0, -0.5
                 @fixedScale = 2.75
             }
         }
@@ -81,8 +81,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[slag]
             {
-                @localPosition = 0.0, 0.0, -2.5
-                @fixedScale = 2.5
+                @localPosition = 0.0, 0.0, -0.75
             }
         }
     }


### PR DESCRIPTION
* Add plume configs for the Athena OAM and the Castor 30 SRM.
* Update the plumes of all parts that use either the "Solid-Lower" or the
"Hyperglic-Upper" templates (RealPlume v10.5.1 compatibility).