### PR TITLE
Update Atlas Vernier LR101 to new stock gimbal

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -576,6 +576,10 @@
 		@gimbalRange = 35
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
+		%gimbalRangeXP = 1 // inward
+		%gimbalRangeXN = 10 // outward
+		%gimbalRangeYP = 35
+		%gimbalRangeYN = 35
 	}
 	engineType = LR101
 }


### PR DESCRIPTION
Update Atlas Vernier LR101 to new stock gimbal abilities. Tested in game, used the numbers NathanKell suggested.

The verniers will no longer point in towards the core and scorch it. Only -1 degree inward gimalling now allowed, 10 degrees outward.