### PR TITLE
Proton vernier stock gimbal update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Proton_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Proton_Engines.cfg
@@ -387,6 +387,11 @@
 		@pitchGimbalRange = 45.0
 		@gimbalConstrain = 45
 	}
+	@MODULE[ModuleGimbal]
+	{
+		%enableYaw = true
+		%enablePitch = true
+	}
 	MODULE
 	{
 		name = ModuleEngineConfigs


### PR DESCRIPTION
	gimbalRangeXP = 11
	gimbalRangeXN = 11
	gimbalRangeYP = 0
	gimbalRangeYN = 0

Are already in the base part config. With this change they will then be contained to the one dimensional motion, although raidernick might just add these to the base part gimbal module once he has a chance to do some 1.1 testing and tweaking as well.