### PR TITLE
Add CLS to Skylab docking port

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -347,6 +347,15 @@
 	}
 }
 
+@PART[FASALM_DockingConern]:AFTER[RealismOverhaul]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
 @PART[skylab-trs]:FOR[RealismOverhaul]
 {
 %RSSROConfig = True


### PR DESCRIPTION
Hopefully this doesn't conflict with #1136  I noticed that the skylab docking node doesn't have a CLS module.  This should correct that.