### PR TITLE
Skylab ECLSS

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -127,7 +127,7 @@
 			{
 				name = Waste
 				amount = 0
-				maxAmount = 391.1	//170 days for 3 crew including CO2-O2 Converter
+				maxAmount = 271.4	//170 days for 3 crew
 			}
 			TANK
 			{
@@ -140,10 +140,9 @@
 	MODULE
 	{
 		name = TacGenericConverter
-		converterName = CO2-O2 Converter
+		converterName = CO2 Extractor
 		conversionRate = 6.0	// # of people - Figures based on per/person
-		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010	// See RO Github #844 for explanation of values
-		outputResources = Oxygen, 0.0071565375, true, Waste, 0.0000027155975, true	// See RO Github #844 for explanation of values
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.10	// See RO Github #844 & #1146 for explanation of values
 	}
 
 	MODULE


### PR DESCRIPTION
So back in #844 we updated the "CO2 Scrubber" on Skylab to be a CO2-O2 converter.  This was done primarily due to a video that was posted (which sadly seems to no longer be available) which implied that CO2 extracted from the air was them separated into C and O2.  This results in a nearly perfect O2 recovery system.  I always thought that was a bit odd because Skylab included over 2 tons of O2, but in the end I just figured NASA was being extra cautious.
In my career game I'm getting to the point where I'm looking at setting up ISS and planning my first mission to Mars so I've been researching more modern life support systems.  And one of the first things I noticed was that ISS currently dumps CO2 overboard.  I found that strange considering what the video about Skylab's ECLSS.  Well, after further research (http://pages.erau.edu/~ericksol/projects/futurspcrft/sp/intro.html), it seems that Skylab's molecular sieve system didn't convert the CO2 back into O2 (with waste C).  It just dumped the CO2 overboard, pretty much just like ISS currently does.
Since the CO2 is just dumped overboard, I've removed the "outputResources" and adjusted the Waste tank accordingly.  Now instead of recycling CO2 back into O2 (and basically never using any of the O2 that comes with Skylab), now all that the extractor does is remove CO2 as it's generated.  I did leave the same 105% efficiency that we previously had so we can recover from time warp inconsistencies.

I've also increased the electrical requirement for the extractor.  I can't find any documentation stating how much electricity was used to run the CO2 extractor, but I have to think it would have been more than 0.01EC/s (10 watts / hour).