### PR TITLE
Update RO_DeadlyReEntry.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -7,7 +7,7 @@
 	@crewGPower = 5
 	@crewGWarn = 200000000
 	@crewGLimit = 300000000
-	@crewGKillChance = 0.75 // Maybe decrease this?
+	@crewGKillChance = 0.01 // 1% chance per physics frame
 }
 
 // Fix DRE bugs, remove from wings

--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -1,3 +1,15 @@
+// RO Custom g-force settings.
+// These will peg max durations for 6g at 12 minute and 10g at 1 minute.
+@REENTRY_EFFECTS[Default]:AFTER[DeadlyReentry]
+{
+	@crewGMin = 5
+	@crewGClamp = 40
+	@crewGPower = 5
+	@crewGWarn = 200000000
+	@crewGLimit = 300000000
+	@crewGKillChance = 0.75 // Maybe decrease this?
+}
+
 // Fix DRE bugs, remove from wings
 @PART[*]:HAS[@MODULE[WingManipulator]]:BEFORE[RealismOverhaul]
 {


### PR DESCRIPTION
This will bring g-force tolerances closer to real world data. (except that crewGKillChance maybe should be brought down if we don't want these limits to be hard limits for life/death)