### PR TITLE
Adjust parametres for historical mercury specs

### DIFF
--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -44,7 +44,7 @@
 	// Hypersonic Convection
 	@machConvectionDensityExponent = 0.5
 	@machConvectionVelocityExponent = 3.0
-	@machConvectionFactor = 2.5
+	@machConvectionFactor = 2.9 // 2.5
 	@machTemperatureScalar = 7.5 // ~6000 at 7.3km/sec
 	@machTemperatureVelocityExponent = 0.75
 	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Mercury_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Mercury_Pod.cfg
@@ -304,9 +304,10 @@
 	{
 		name = ModuleAblator
 		ablativeResource = Ablator
-		lossExp = -6000
-		lossConst = 0.006
-		pyrolysisLossFactor = 24000
+		outputResource = CharredAblator
+		lossExp = -6000 // with -7500 half as much ablative Flux, same peak temp.
+		lossConst = 0.18 // 0.12 // 0.24 // caused more loss, higher pyroflux, same peak temp
+		pyrolysisLossFactor = 1200
 		ablationTempThresh = 400
 		reentryConductivity = 0.01
 		charMax = 1
@@ -321,6 +322,12 @@
 	{
 		name = Ablator
 		amount = 125
+		maxAmount = 125
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
 		maxAmount = 125
 	}
 }


### PR DESCRIPTION
For #1147

Experimentally derived value that provides the best fit of re-entry thermal parametres of the Mercury capsule from @NathanKell's boilerplate re-entry.