### PR TITLE
Add RF tags to engines

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -9,225 +9,225 @@
 // Put fuel mixtures, etc. into engine tags
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethylene]]]]
 {
-	@tags ^=:$: (Ethylene:
+	@tags ^=:$: Ethylene :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AvGas]]]]
 {
-	@tags ^=:$: (AvGas plane gas spirit piston:
+	@tags ^=:$: AvGas plane spirit piston:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NitrousOxide]]]]
 {
-	@tags ^=:$: (NitrousOxide (nitrous no2 oxide ?nos:
+	@tags ^=:$: NitrousOxide no2 ?nos:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethanol75]]]]
 {
-	@tags ^=:$: (Ethanol75 alcohol:
+	@tags ^=:$: Ethanol75 alcohol:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Methanol]]]]
 {
-	@tags ^=:$: (Methanol alcohol:
+	@tags ^=:$: Methanol alcohol:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Hydyne]]]]
 {
-	@tags ^=:$: (Hydyne:
+	@tags ^=:$: Hydyne udmh unsymmetrical methyl hydrazine deta ethylene amine:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[OF2]]]]
 {
-	@tags ^=:$: (OF2 (oxygen fluor [difluor:
+	@tags ^=:$: OF2 oxygen difluor:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX30]]]]
 {
-	@tags ^=:$: (FLOX30 (fluorine (oxygen:
+	@tags ^=:$: FLOX30 fluorine oxygen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IRFNA-III]]]]
 {
-	@tags ^=:$: (IRFNA-III inhibit ?red (fuming (nitric acid rfna ?iii ?3:
+	@tags ^=:$: IRFNA-III inhibit ?red fuming nitric acid ?3:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ArgonGas]]]]
 {
-	@tags ^=:$: (ArgonGas:
+	@tags ^=:$: ArgonGas noble:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX70]]]]
 {
-	@tags ^=:$: (FLOX70 (fluorine (oxygen:
+	@tags ^=:$: FLOX70 fluorine oxygen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Furfuryl]]]]
 {
-	@tags ^=:$: (Furfuryl alcohol:
+	@tags ^=:$: Furfuryl alcohol:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka250]]]]
 {
-	@tags ^=:$: (Tonka250 (triethylamine:
+	@tags ^=:$: Tonka250 triethylamine:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AK20]]]]
 {
-	@tags ^=:$: (AK20 (nitric acid:
+	@tags ^=:$: AK20 nitric acid:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[TEATEB]]]]
 {
-	@tags ^=:$: (TEATEB ethyl alumin borane:
+	@tags ^=:$: TEATEB ethyl alumin borane:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[EnrichedUranium]]]]
 {
-	@tags ^=:$: (EnrichedUranium (uranium:
+	@tags ^=:$: EnrichedUranium :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF3]]]]
 {
-	@tags ^=:$: (ClF3 (chlorine (fluorine:
+	@tags ^=:$: ClF3 chlorine trifluori:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethane]]]]
 {
-	@tags ^=:$: (Ethane:
+	@tags ^=:$: Ethane :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON3]]]]
 {
-	@tags ^=:$: (MON3 mixed (oxides (nitrogen:
+	@tags ^=:$: MON3 mixed oxides nitrogen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON1]]]]
 {
-	@tags ^=:$: (MON1 mixed (oxides (nitrogen:
+	@tags ^=:$: MON1 mixed oxides nitrogen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[N2F4]]]]
 {
-	@tags ^=:$: (N2F4 tetra fluoro (hydrazine:
+	@tags ^=:$: N2F4 tetra fluoro hydrazine:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[PBAN]]]]
 {
-	@tags ^=:$: (PBAN (polybutadiene (acrylonitrile:
+	@tags ^=:$: PBAN polybutadiene acrylonitrile:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Aniline]]]]
 {
-	@tags ^=:$: (Aniline:
+	@tags ^=:$: Aniline :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[PSPC]]]]
 {
-	@tags ^=:$: (PSPC:
+	@tags ^=:$: PSPC :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[XenonGas]]]]
 {
-	@tags ^=:$: (XenonGas:
+	@tags ^=:$: XenonGas noble:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Hydrazine]]]]
 {
-	@tags ^=:$: (Hydrazine n2h4:
+	@tags ^=:$: Hydrazine n2h4:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdFluorine]]]]
 {
-	@tags ^=:$: (LqdFluorine liquid (fluorine:
+	@tags ^=:$: LqdFluorine liquid:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Diborane]]]]
 {
-	@tags ^=:$: (Diborane boron borane:
+	@tags ^=:$: Diborane boron:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MMH]]]]
 {
-	@tags ^=:$: (MMH mono methyl (hydrazine:
+	@tags ^=:$: MMH mono methyl hydrazine:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Aerozine50]]]]
 {
-	@tags ^=:$: (Aerozine50 (hydrazine (unsymmetrical methyl udmh:
+	@tags ^=:$: Aerozine50 hydrazine unsymmetrical methyl udmh:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON15]]]]
 {
-	@tags ^=:$: (MON15 mixed (oxides (nitrogen:
+	@tags ^=:$: MON15 mixed oxides nitrogen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF5]]]]
 {
-	@tags ^=:$: (ClF5 (chlorine (fluorine:
+	@tags ^=:$: ClF5 chlorine pentafluori:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON10]]]]
 {
-	@tags ^=:$: (MON10 mixed (oxides (nitrogen:
+	@tags ^=:$: MON10 mixed oxides nitrogen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AK27]]]]
 {
-	@tags ^=:$: (AK27 (nitric acid:
+	@tags ^=:$: AK27 nitric acid:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Syntin]]]]
 {
-	@tags ^=:$: (Syntin:
+	@tags ^=:$: Syntin hydrocarbon:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Pentaborane]]]]
 {
-	@tags ^=:$: (Pentaborane boron borane:
+	@tags ^=:$: Pentaborane boron:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NGNC]]]]
 {
-	@tags ^=:$: (NGNC:
+	@tags ^=:$: NGNC :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HTPB]]]]
 {
-	@tags ^=:$: (HTPB (hydroxyl (polybutadiene:
+	@tags ^=:$: HTPB hydroxyl terminat polybutadiene:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NTO]]]]
 {
-	@tags ^=:$: (NTO [nitro (tetroxide oxide n2o4:
+	@tags ^=:$: NTO nitro tetroxide n2o4:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Kerosene]]]]
 {
-	@tags ^=:$: (Kerosene rp-1 rp1:
+	@tags ^=:$: Kerosene rp-1 rp1 t-1 t1 rg-1 rg1 hydrocarbon:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IRFNA-IV]]]]
 {
-	@tags ^=:$: (IRFNA-IV inhibit ?red (fuming (nitric acid rfna ?iv ?4:
+	@tags ^=:$: IRFNA-IV inhibit ?red fuming nitric acid ?4:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HNIW]]]]
 {
-	@tags ^=:$: (HNIW (hexanitrohexaazaisowurtzitane nitro:
+	@tags ^=:$: HNIW hexanitrohexaazaisowurtzitane cl20 cl-20:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[UH25]]]]
 {
-	@tags ^=:$: (UH25 udmh (hydrazine:
+	@tags ^=:$: UH25 udmh hydrazine:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[UDMH]]]]
 {
-	@tags ^=:$: (UDMH (unsymmetrical methyl (hydrazine:
+	@tags ^=:$: UDMH unsymmetrical methyl hydrazine:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IWFNA]]]]
 {
-	@tags ^=:$: (IWFNA inhibit white (fuming (nitric acid wfna:
+	@tags ^=:$: IWFNA inhibit white fuming nitric acid wfna:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON25]]]]
 {
-	@tags ^=:$: (MON25 mixed (oxides (nitrogen:
+	@tags ^=:$: MON25 mixed oxides nitrogen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON20]]]]
 {
-	@tags ^=:$: (MON20 mixed (oxides (nitrogen:
+	@tags ^=:$: MON20 mixed oxides nitrogen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdOxygen]]]]
 {
-	@tags ^=:$: (LqdOxygen lox liquid (oxygen o2 (cryogenic:
+	@tags ^=:$: LqdOxygen lox liquid o2 cryo:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdMethane]]]]
 {
-	@tags ^=:$: (LqdMethane liquid ch4 (methane:
+	@tags ^=:$: LqdMethane liquid ch4:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX88]]]]
 {
-	@tags ^=:$: (FLOX88 (fluorine (oxygen:
+	@tags ^=:$: FLOX88 fluorine oxygen:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[KryptonGas]]]]
 {
-	@tags ^=:$: (KryptonGas:
+	@tags ^=:$: KryptonGas noble:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[CaveaB]]]]
 {
-	@tags ^=:$: (CaveaB:
+	@tags ^=:$: CaveaB :
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdAmmonia]]]]
 {
-	@tags ^=:$: (LqdAmmonia liquid nh3 (ammonia:
+	@tags ^=:$: LqdAmmonia liquid nh3:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdHydrogen]]]]
 {
-	@tags ^=:$: (LqdHydrogen (hydrogen liquid h2 (cryogenic:
+	@tags ^=:$: LqdHydrogen liquid h2 cryo:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HTP]]]]
 {
-	@tags ^=:$: (HTP high test (peroxide (hydrogen h2o2:
+	@tags ^=:$: HTP high test peroxide hydrogen h2o2:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka500]]]]
 {
-	@tags ^=:$: (Tonka500 (triethylamine:
+	@tags ^=:$: Tonka500 triethylamine:
 }

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -55,10 +55,6 @@
 {
 	@tags ^=:$: (Furfuryl alcohol:
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[DepletedUranium]]]]
-{
-	@tags ^=:$: (DepletedUranium:
-}
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka250]]]]
 {
 	@tags ^=:$: (Tonka250 (triethylamine:

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -231,3 +231,43 @@
 {
 	@tags ^=:$: Tonka500 triethylamine:
 }
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[ElectricPropulsion]]]]
+{
+	@tags ^=:$: ElectricPropulsion :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[LifeSupport]]]]
+{
+	@tags ^=:$: LifeSupport :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Fuselage]]]]
+{
+	@tags ^=:$: Fuselage :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Default]]]]
+{
+	@tags ^=:$: Default :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[ServiceModule]]]]
+{
+	@tags ^=:$: ServiceModule pressur insulat cryogenic electri life support:
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Balloon]]]]
+{
+	@tags ^=:$: Balloon :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[LifeSupportWaste]]]]
+{
+	@tags ^=:$: LifeSupportWaste :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[BalloonCryo]]]]
+{
+	@tags ^=:$: BalloonCryo (insulat:
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Cryogenic]]]]
+{
+	@tags ^=:$: Cryogenic (insulat:
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Structural]]]]
+{
+	@tags ^=:$: Structural :
+}

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -69,7 +69,7 @@
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[EnrichedUranium]]]]
 {
-	@tags ^=:$: (EnrichedUranium:
+	@tags ^=:$: (EnrichedUranium (uranium:
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF3]]]]
 {

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -5,3 +5,233 @@
 	%throttlingRate = 3
 	%throttlingClamp = 1.1
 }
+
+// Put fuel mixtures, etc. into engine tags
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethylene]]]]
+{
+	@tags ^=:$: (Ethylene:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AvGas]]]]
+{
+	@tags ^=:$: (AvGas plane gas spirit piston:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NitrousOxide]]]]
+{
+	@tags ^=:$: (NitrousOxide (nitrous no2 oxide ?nos:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethanol75]]]]
+{
+	@tags ^=:$: (Ethanol75 alcohol:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Methanol]]]]
+{
+	@tags ^=:$: (Methanol alcohol:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Hydyne]]]]
+{
+	@tags ^=:$: (Hydyne:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[OF2]]]]
+{
+	@tags ^=:$: (OF2 (oxygen fluor [difluor:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX30]]]]
+{
+	@tags ^=:$: (FLOX30 (fluorine (oxygen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IRFNA-III]]]]
+{
+	@tags ^=:$: (IRFNA-III inhibit ?red (fuming (nitric acid rfna ?iii ?3:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ArgonGas]]]]
+{
+	@tags ^=:$: (ArgonGas:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX70]]]]
+{
+	@tags ^=:$: (FLOX70 (fluorine (oxygen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Furfuryl]]]]
+{
+	@tags ^=:$: (Furfuryl alcohol:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[DepletedUranium]]]]
+{
+	@tags ^=:$: (DepletedUranium:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka250]]]]
+{
+	@tags ^=:$: (Tonka250 (triethylamine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AK20]]]]
+{
+	@tags ^=:$: (AK20 (nitric acid:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[TEATEB]]]]
+{
+	@tags ^=:$: (TEATEB ethyl alumin borane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[EnrichedUranium]]]]
+{
+	@tags ^=:$: (EnrichedUranium:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF3]]]]
+{
+	@tags ^=:$: (ClF3 (chlorine (fluorine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethane]]]]
+{
+	@tags ^=:$: (Ethane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON3]]]]
+{
+	@tags ^=:$: (MON3 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON1]]]]
+{
+	@tags ^=:$: (MON1 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[N2F4]]]]
+{
+	@tags ^=:$: (N2F4 tetra fluoro (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[PBAN]]]]
+{
+	@tags ^=:$: (PBAN (polybutadiene (acrylonitrile:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Aniline]]]]
+{
+	@tags ^=:$: (Aniline:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[PSPC]]]]
+{
+	@tags ^=:$: (PSPC:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[XenonGas]]]]
+{
+	@tags ^=:$: (XenonGas:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Hydrazine]]]]
+{
+	@tags ^=:$: (Hydrazine n2h4:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdFluorine]]]]
+{
+	@tags ^=:$: (LqdFluorine liquid (fluorine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Diborane]]]]
+{
+	@tags ^=:$: (Diborane boron borane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MMH]]]]
+{
+	@tags ^=:$: (MMH mono methyl (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Aerozine50]]]]
+{
+	@tags ^=:$: (Aerozine50 (hydrazine (unsymmetrical methyl udmh:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON15]]]]
+{
+	@tags ^=:$: (MON15 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF5]]]]
+{
+	@tags ^=:$: (ClF5 (chlorine (fluorine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON10]]]]
+{
+	@tags ^=:$: (MON10 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AK27]]]]
+{
+	@tags ^=:$: (AK27 (nitric acid:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Syntin]]]]
+{
+	@tags ^=:$: (Syntin:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Pentaborane]]]]
+{
+	@tags ^=:$: (Pentaborane boron borane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NGNC]]]]
+{
+	@tags ^=:$: (NGNC:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HTPB]]]]
+{
+	@tags ^=:$: (HTPB (hydroxyl (polybutadiene:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NTO]]]]
+{
+	@tags ^=:$: (NTO [nitro (tetroxide oxide n2o4:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Kerosene]]]]
+{
+	@tags ^=:$: (Kerosene rp-1 rp1:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IRFNA-IV]]]]
+{
+	@tags ^=:$: (IRFNA-IV inhibit ?red (fuming (nitric acid rfna ?iv ?4:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HNIW]]]]
+{
+	@tags ^=:$: (HNIW (hexanitrohexaazaisowurtzitane nitro:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[UH25]]]]
+{
+	@tags ^=:$: (UH25 udmh (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[UDMH]]]]
+{
+	@tags ^=:$: (UDMH (unsymmetrical methyl (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IWFNA]]]]
+{
+	@tags ^=:$: (IWFNA inhibit white (fuming (nitric acid wfna:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON25]]]]
+{
+	@tags ^=:$: (MON25 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON20]]]]
+{
+	@tags ^=:$: (MON20 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdOxygen]]]]
+{
+	@tags ^=:$: (LqdOxygen lox liquid (oxygen o2 (cryogenic:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdMethane]]]]
+{
+	@tags ^=:$: (LqdMethane liquid ch4 (methane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX88]]]]
+{
+	@tags ^=:$: (FLOX88 (fluorine (oxygen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[KryptonGas]]]]
+{
+	@tags ^=:$: (KryptonGas:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[CaveaB]]]]
+{
+	@tags ^=:$: (CaveaB:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdAmmonia]]]]
+{
+	@tags ^=:$: (LqdAmmonia liquid nh3 (ammonia:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdHydrogen]]]]
+{
+	@tags ^=:$: (LqdHydrogen (hydrogen liquid h2 (cryogenic:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HTP]]]]
+{
+	@tags ^=:$: (HTP high test (peroxide (hydrogen h2o2:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka500]]]]
+{
+	@tags ^=:$: (Tonka500 (triethylamine:
+}

--- a/Scripts/gen_RF_tags.py
+++ b/Scripts/gen_RF_tags.py
@@ -1,0 +1,94 @@
+from sys import argv
+
+filename = argv[1]
+
+tags = [
+    ('@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[',
+        {
+            'LqdOxygen' : ['lox', 'liquid', 'o2', 'cryo'],
+            'Kerosene' : ['rp-1', 'rp1', 't-1', 't1', 'rg-1', 'rg1',
+                          'hydrocarbon'],
+            'LqdHydrogen' : ['liquid', 'h2', 'cryo'],
+            'NTO' : ['nitro', 'tetroxide', 'n2o4'],
+            'UDMH' : ['unsymmetrical', 'methyl', 'hydrazine'],
+            'Hydrazine' : ['n2h4'],
+            'Aerozine50' : ['hydrazine', 'unsymmetrical', 'methyl', 'udmh'],
+            'MMH' : ['mono', 'methyl', 'hydrazine'],
+            'HTP' : ['high', 'test', 'peroxide', 'hydrogen', 'h2o2'],
+            'AvGas' : ['plane', 'spirit', 'piston'],
+            'IRFNA-III' : ['inhibit', '?red', 'fuming', 'nitric', 'acid', '?3'],
+            'NitrousOxide' : ['no2', '?nos'],
+            'Aniline' : [],
+            'Ethanol75' : ['alcohol'],
+            'LqdAmmonia' : ['liquid', 'nh3'],
+            'LqdMethane' : ['liquid', 'ch4'],
+            'ClF3' : ['chlorine', 'trifluori'],
+            'ClF5' : ['chlorine', 'pentafluori'],
+            'Diborane' : ['boron'],
+            'Pentaborane' : ['boron'],
+            'Ethane' : [],
+            'Ethylene' : [],
+            'OF2' : ['oxygen', 'difluor'],
+            'LqdFluorine' : ['liquid'],
+            'N2F4' : ['tetra', 'fluoro', 'hydrazine'],
+            'Methanol' : ['alcohol'],
+            'Furfuryl' : ['alcohol'],
+            'UH25' : ['udmh', 'hydrazine'],
+            'Tonka250' : ['triethylamine'],
+            'Tonka500' : ['triethylamine'],
+            'FLOX30' : ['fluorine', 'oxygen'],
+            'FLOX70' : ['fluorine', 'oxygen'],
+            'FLOX88' : ['fluorine', 'oxygen'],
+            'IWFNA' : ['inhibit', 'white', 'fuming', 'nitric', 'acid',
+                       'wfna'],
+            'IRFNA-IV' : ['inhibit', '?red', 'fuming', 'nitric', 'acid', '?4'],
+            'AK20' : ['nitric', 'acid'],
+            'AK27' : ['nitric', 'acid'],
+            'CaveaB' : [],
+            'MON1' : ['mixed', 'oxides', 'nitrogen'],
+            'MON3' : ['mixed', 'oxides', 'nitrogen'],
+            'MON10' : ['mixed', 'oxides', 'nitrogen'],
+            'MON15' : ['mixed', 'oxides', 'nitrogen'],
+            'MON20' : ['mixed', 'oxides', 'nitrogen'],
+            'MON25' : ['mixed', 'oxides', 'nitrogen'],
+            'ArgonGas' : ['noble'],
+            'KryptonGas' : ['noble'],
+            'Hydyne' : ['udmh', 'unsymmetrical', 'methyl', 'hydrazine', 'deta',
+                        'ethylene', 'amine'],
+            'Syntin' : ['hydrocarbon'],
+            'XenonGas' : ['noble'],
+            'EnrichedUranium' : [],
+            'TEATEB' : ['ethyl', 'alumin', 'borane'],
+            'HTPB' : ['hydroxyl', 'terminat', 'polybutadiene'],
+            'PBAN' : ['polybutadiene', 'acrylonitrile'],
+            'PSPC' : [],
+            'HNIW' : ['hexanitrohexaazaisowurtzitane', 'cl20', 'cl-20'],
+            'NGNC' : ['nitroglycerin', 'nitrocellulose']
+        }),
+    ('@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[',
+        {
+            'Balloon' : [],
+            'BalloonCryo' : ['(insulat'],
+            'Cryogenic' : ['(insulat'],
+            'Default' : [],
+            'ElectricPropulsion' : [],
+            'Fuselage' : [],
+            'LifeSupport' : [],
+            'LifeSupportWaste' : [],
+            'ServiceModule' : ['pressur', 'insulat', 'cryogenic', 'electri',
+                               'life', 'support'],
+            'Structural' : []
+        })
+]
+
+output_file = open(filename, 'w')
+output_file.truncate()
+
+for string, tag_dict in tags:
+    for k, v in tag_dict.viewitems():
+        mm_string = string + k + ']]]]'
+        new_tags = ':$: ' + k + ' ' + ' '.join(v) + ':'
+        output_file.write(mm_string)
+        output_file.write('\n{\n')
+        output_file.write('\t@tags ^=' + new_tags)
+        output_file.write('\n}\n')

--- a/Scripts/out
+++ b/Scripts/out
@@ -1,0 +1,264 @@
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethylene]]]]
+{
+	@tags ^=:$: (Ethylene :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AvGas]]]]
+{
+	@tags ^=:$: (AvGas plane gas spirit piston:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NitrousOxide]]]]
+{
+	@tags ^=:$: (NitrousOxide (nitrous no2 oxide ?nos:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethanol75]]]]
+{
+	@tags ^=:$: (Ethanol75 alcohol:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Methanol]]]]
+{
+	@tags ^=:$: (Methanol alcohol:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Hydyne]]]]
+{
+	@tags ^=:$: (Hydyne :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[OF2]]]]
+{
+	@tags ^=:$: (OF2 (oxygen fluor [difluor:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX30]]]]
+{
+	@tags ^=:$: (FLOX30 (fluorine (oxygen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IRFNA-III]]]]
+{
+	@tags ^=:$: (IRFNA-III inhibit ?red (fuming (nitric acid rfna ?iii ?3:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ArgonGas]]]]
+{
+	@tags ^=:$: (ArgonGas :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX70]]]]
+{
+	@tags ^=:$: (FLOX70 (fluorine (oxygen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Furfuryl]]]]
+{
+	@tags ^=:$: (Furfuryl alcohol:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka250]]]]
+{
+	@tags ^=:$: (Tonka250 (triethylamine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AK20]]]]
+{
+	@tags ^=:$: (AK20 (nitric acid:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[TEATEB]]]]
+{
+	@tags ^=:$: (TEATEB ethyl alumin borane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[EnrichedUranium]]]]
+{
+	@tags ^=:$: (EnrichedUranium (uranium:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF3]]]]
+{
+	@tags ^=:$: (ClF3 (chlorine (fluorine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Ethane]]]]
+{
+	@tags ^=:$: (Ethane :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON3]]]]
+{
+	@tags ^=:$: (MON3 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON1]]]]
+{
+	@tags ^=:$: (MON1 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[N2F4]]]]
+{
+	@tags ^=:$: (N2F4 tetra fluoro (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[PBAN]]]]
+{
+	@tags ^=:$: (PBAN (polybutadiene (acrylonitrile:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Aniline]]]]
+{
+	@tags ^=:$: (Aniline :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[PSPC]]]]
+{
+	@tags ^=:$: (PSPC :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[XenonGas]]]]
+{
+	@tags ^=:$: (XenonGas :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Hydrazine]]]]
+{
+	@tags ^=:$: (Hydrazine n2h4:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdFluorine]]]]
+{
+	@tags ^=:$: (LqdFluorine liquid (fluorine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Diborane]]]]
+{
+	@tags ^=:$: (Diborane boron borane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MMH]]]]
+{
+	@tags ^=:$: (MMH mono methyl (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Aerozine50]]]]
+{
+	@tags ^=:$: (Aerozine50 (hydrazine (unsymmetrical methyl udmh:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON15]]]]
+{
+	@tags ^=:$: (MON15 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[ClF5]]]]
+{
+	@tags ^=:$: (ClF5 (chlorine (fluorine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON10]]]]
+{
+	@tags ^=:$: (MON10 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[AK27]]]]
+{
+	@tags ^=:$: (AK27 (nitric acid:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Syntin]]]]
+{
+	@tags ^=:$: (Syntin :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Pentaborane]]]]
+{
+	@tags ^=:$: (Pentaborane boron borane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NGNC]]]]
+{
+	@tags ^=:$: (NGNC :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HTPB]]]]
+{
+	@tags ^=:$: (HTPB (hydroxyl (polybutadiene:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[NTO]]]]
+{
+	@tags ^=:$: (NTO [nitro (tetroxide oxide n2o4:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Kerosene]]]]
+{
+	@tags ^=:$: (Kerosene rp-1 rp1:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IRFNA-IV]]]]
+{
+	@tags ^=:$: (IRFNA-IV inhibit ?red (fuming (nitric acid rfna ?iv ?4:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HNIW]]]]
+{
+	@tags ^=:$: (HNIW (hexanitrohexaazaisowurtzitane nitro:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[UH25]]]]
+{
+	@tags ^=:$: (UH25 udmh (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[UDMH]]]]
+{
+	@tags ^=:$: (UDMH (unsymmetrical methyl (hydrazine:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[IWFNA]]]]
+{
+	@tags ^=:$: (IWFNA inhibit white (fuming (nitric acid wfna:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON25]]]]
+{
+	@tags ^=:$: (MON25 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[MON20]]]]
+{
+	@tags ^=:$: (MON20 mixed (oxides (nitrogen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdOxygen]]]]
+{
+	@tags ^=:$: (LqdOxygen lox liquid (oxygen o2 (cryogenic:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdMethane]]]]
+{
+	@tags ^=:$: (LqdMethane liquid ch4 (methane:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[FLOX88]]]]
+{
+	@tags ^=:$: (FLOX88 (fluorine (oxygen:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[KryptonGas]]]]
+{
+	@tags ^=:$: (KryptonGas :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[CaveaB]]]]
+{
+	@tags ^=:$: (CaveaB :
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdAmmonia]]]]
+{
+	@tags ^=:$: (LqdAmmonia liquid nh3 (ammonia:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[LqdHydrogen]]]]
+{
+	@tags ^=:$: (LqdHydrogen (hydrogen liquid h2 (cryogenic:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[HTP]]]]
+{
+	@tags ^=:$: (HTP high test (peroxide (hydrogen h2o2:
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[*]:HAS[@PROPELLANT[Tonka500]]]]
+{
+	@tags ^=:$: (Tonka500 (triethylamine:
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[ElectricPropulsion]]]]
+{
+	@tags ^=:$: (ElectricPropulsion :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[LifeSupport]]]]
+{
+	@tags ^=:$: (LifeSupport :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Fuselage]]]]
+{
+	@tags ^=:$: (Fuselage :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Default]]]]
+{
+	@tags ^=:$: (Default :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[ServiceModule]]]]
+{
+	@tags ^=:$: (ServiceModule :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Balloon]]]]
+{
+	@tags ^=:$: (Balloon :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[LifeSupportWaste]]]]
+{
+	@tags ^=:$: (LifeSupportWaste :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[BalloonCryo]]]]
+{
+	@tags ^=:$: (BalloonCryo :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Cryogenic]]]]
+{
+	@tags ^=:$: (Cryogenic :
+}
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]:HAS[type[Structural]]]]
+{
+	@tags ^=:$: (Structural :
+}


### PR DESCRIPTION
Should let engines be searchable by the fuel/oxidizer/monoprop they use.

This was generated using a short Python script; if that script is preferred, I can change the PR to that.

Tags definitely aren't final; certainly missing some, and still have to figure out what needs what prefixes, if any.

Info on syntax can be found [here](http://forum.kerbalspaceprogram.com/index.php?/topic/137633-syntax-for-11-part-tagging/)