### PR TITLE
1.1 Heatshield updates for FASA

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -105,7 +105,7 @@
 	@title = Apollo Command Module Forward Heat Shield
 	@description = This heat shield protects the earth landing (recovery) system components and everything else in the forward compartment.
 	@mass = 0.0766
-	%skinMaxTemp = 3200
+	%skinMaxTemp = 3800
 	%maxTemp = 2000
 	%emissiveConstant = 0.50
 	@MODULE[ModuleDecouple]
@@ -350,9 +350,9 @@
 	{
 		name = ModuleAblator
 		ablativeResource = Ablator
-		lossExp = -8000
-		lossConst = 0.06
-		pyrolysisLossFactor = 26000
+		lossExp = -7000
+		lossConst = 0.085
+		pyrolysisLossFactor = 70000
 		ablationTempThresh = 500
 		reentryConductivity = 0.01
 		charMax = 1
@@ -367,6 +367,12 @@
 	{
 		name = Ablator
 		amount = 848
+		maxAmount = 848
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
 		maxAmount = 848
 	}
 }
@@ -454,9 +460,9 @@
 	{
 		name = ModuleAblator
 		ablativeResource = Ablator
-		lossExp = -8000
-		lossConst = 0.06
-		pyrolysisLossFactor = 26000
+		lossExp = -7000
+		lossConst = 0.085
+		pyrolysisLossFactor = 70000
 		ablationTempThresh = 500
 		reentryConductivity = 0.01
 		charMax = 1
@@ -471,6 +477,12 @@
 	{
 		name = Ablator
 		amount = 848
+		maxAmount = 848
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
 		maxAmount = 848
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -402,9 +402,9 @@
 	{
 		name = ModuleAblator
 		ablativeResource = Ablator
-		lossExp = -8000
-		lossConst = 0.09
-		pyrolysisLossFactor = 26000
+		lossExp = -8600
+		lossConst = 0.214
+		pyrolysisLossFactor = 75000
 		ablationTempThresh = 500
 		reentryConductivity = 0.01
 		charMax = 1


### PR DESCRIPTION
Updating thermal parametres for FASA Apollo capsule w/built in shield. Pasted same values to the stand alone shield, in case anybody uses it.

FASA Apollo Chutes currently has a glitch that causes it to superheat during re-entry. Temp bandaid until someone smart can figure and fix that.

Leaves a narrow (~2.5km) window of re-entry for the Gemini at 11km/s (fast lunar return), so again barely lunar rated as usual.

If you slow the capsule down a bit before re-entry or use a slower return, still a good lunar return capsule.

https://www.youtube.com/watch?v=fWz0UxuZBZg