### PR TITLE
Gendered docking ports

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Orion.cfg
@@ -205,6 +205,22 @@
 	@maxTemp = 1073.15
 	@node_stack_top = 0.0, 0.4483674, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.1945558, 0.0, 0.0, -1.0, 0.0, 2
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NASADock
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1
+    }
 }
 
 @PART[Orion_Circularpanel]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Orion.cfg
@@ -209,17 +209,17 @@
     @MODULE[ModuleDockingNode]
     {
         @nodeType = NASADock
-		%acquireForce = 0.5
-		%acquireMinFwdDot = 0.8
-		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 0.25
-		%acquireTorque = 0.5
-		%captureMaxRvel = 0.1
-		%captureMinFwdDot = 0.998
-		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 0.05
-		%minDistanceToReEngage = 0.25
-		%undockEjectionForce = 0.1
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Soyuz.cfg
@@ -179,17 +179,17 @@ MODULE
         @nodeType = SSVP
         %gendered = True
         %genderedFemale = False
-		%acquireForce = 0.5
-		%acquireMinFwdDot = 0.8
-		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 0.25
-		%acquireTorque = 0.5
-		%captureMaxRvel = 0.1
-		%captureMinFwdDot = 0.998
-		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 0.05
-		%minDistanceToReEngage = 0.25
-		%undockEjectionForce = 0.1
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
     }
 }
 @PART[Soyuz_TMA_decoupler]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Soyuz.cfg
@@ -173,6 +173,24 @@ MODULE
 {
   %RSSROConfig = True
   @rescaleFactor = 1.28
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = SSVP
+        %gendered = True
+        %genderedFemale = False
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1
+    }
 }
 @PART[Soyuz_TMA_decoupler]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
@@ -1005,17 +1005,17 @@
     @MODULE[ModuleDockingNode]
     {
         @nodeType = APAS8995
-		%acquireForce = 0.5
-		%acquireMinFwdDot = 0.8
-		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 0.25
-		%acquireTorque = 0.5
-		%captureMaxRvel = 0.1
-		%captureMinFwdDot = 0.998
-		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 0.05
-		%minDistanceToReEngage = 0.25
-		%undockEjectionForce = 0.1
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
 	}
 }
 @PART[Shuttle?Manipulator]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
@@ -1001,6 +1001,22 @@
 	%RSSROConfig = True
 	@rescaleFactor = 1.55
 	@mass = 1
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = APAS8995
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1
+	}
 }
 @PART[Shuttle?Manipulator]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
@@ -190,6 +190,8 @@
     @MODULE[ModuleDockingNode]
     {
         @nodeType = NASADock
+        %gendered = True
+        %genderedFemale = True
         %acquireForce = 0.5
         %acquireMinFwdDot = 0.8
         %acquireminRollDot = -3.40282347E+38
@@ -246,6 +248,8 @@
     @MODULE[ModuleDockingNode]
     {
         @nodeType = NASADock
+        %gendered = True
+        %genderedFemale = False
         %acquireForce = 0.5
         %acquireMinFwdDot = 0.8
         %acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
@@ -28,6 +28,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = GeminiAgena
+        %gendered = True
+        %genderedFemale = True
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
@@ -103,7 +105,7 @@
 	{
 	}
 }
-// Give the FASA Agena avionics the same stats as our home-rolled veersion.
+// Give the FASA Agena avionics the same stats as our home-rolled version.
 // See KSP-RO/RP-0#124
 @PART[FASAAgenaProbe]:AFTER[RemoteTech]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -79,6 +79,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = Apollo
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -670,6 +670,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = Apollo
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -74,6 +74,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = GeminiAgena
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
@@ -114,6 +116,8 @@
 	MODULE
 	{
 		name = ModuleDockingNode
+        gendered = True
+        genderedFemale = False
 		referenceAttachNode = ArticulatedCap
 		nodeType = GeminiAgena
 		acquireForce = 0.5 // 2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
@@ -16,6 +16,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = Apollo
+        %gendered = True
+        %genderedFemale = True
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
@@ -142,6 +144,8 @@
 	{
 		name = ModuleDockingNode
 		nodeType = Apollo
+        gendered = True
+        genderedFemale = True
 		acquireForce = 0.5 // 2
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_ATV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_ATV.cfg
@@ -333,6 +333,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = SSVP
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Construction_Structures.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Construction_Structures.cfg
@@ -16,16 +16,16 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = CBM
-		%acquireForce = 0.5
-		%acquireMinFwdDot = 0.8
-		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 0.25
-		%acquireTorque = 0.5
-		%captureMaxRvel = 0.1
-		%captureMinFwdDot = 0.998
-		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 0.05
-		%minDistanceToReEngage = 0.25
-		%undockEjectionForce = 0.1
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Construction_Structures.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Construction_Structures.cfg
@@ -16,5 +16,16 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = CBM
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
@@ -273,6 +273,24 @@
 	@manufacturer = RKK Energia
 	@description = Russian docking port for the Russian modules of the International Space Station.
 	@maxTemp = 1073.15
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = SSVP
+        %gendered = True
+        %genderedFemale = True
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+    }
 }
 @PART[Mir_DockingPortCoverCap]:FOR[RealismOverhaul]
 {
@@ -292,6 +310,24 @@
 	@manufacturer = RKK Energia
 	@description = Russian docking port for Russian probes to dock to the ISS Russian Docking Port.
 	@maxTemp = 1073.15
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = SSVP
+        %gendered = True
+        %genderedFemale = False
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+    }
 }
 @PART[Mir_RCS_ThrusterBlock]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
@@ -474,6 +474,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = GeminiAgena
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -1085,6 +1085,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = SSVP
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
@@ -1125,6 +1127,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = SSVP
+        %gendered = True
+        %genderedFemale = True
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -1159,6 +1159,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = SSVP
+        %gendered = True
+        %genderedFemale = False
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38
@@ -1200,6 +1202,8 @@
 	@MODULE[ModuleDockingNode]
 	{
 		@nodeType = SSVP
+        %gendered = True
+        %genderedFemale = True
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38


### PR DESCRIPTION
Apollo (drogue - probe)
Soyuz (drogue - probe)
NDS (androgynous)
IDA (active - passive)

NOTE 1: The Common Berthing Mechanism (CBM) has an active - passive configuration but stock has no such option. We might need to clone it and make one port active and one passive.

NOTE 2: The CST-100 pack includes the International Docking Adapter (IDA) but it is configured as a NDS. This will be fixed in the near future (along with other bug fixes) to have a separate "IDA" node.