### PR TITLE
Correct the dish ranges from raidernick probes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
@@ -96,12 +96,13 @@ MODULE
 	}
 	MODULE
 	{
+	//Copied the stats from the Reflectron KR-7
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 1E+13
+		Mode1DishRange = 75e6
 		MaxQ = 6000
-		EnergyCost = 0.008
-		DishAngle = 4
+		EnergyCost = 0.05
+		DishAngle = 25
 		TRANSMITTER
 		{
 			PacketInterval = 0.3

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
@@ -90,10 +90,10 @@ MODULE
 	{
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 1E+13
+		Mode1DishRange = 1E+12
 		MaxQ = 6000
-		EnergyCost = 0.008
-		DishAngle = 4
+		EnergyCost = 0.24
+		DishAngle = 1
 		TRANSMITTER
 		{
 			PacketInterval = 0.3
@@ -379,12 +379,13 @@ MODULE
 	}
 	MODULE
 	{
+	//Copied from RTGigaDish1
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 1E+13
+		Mode1DishRange = 1E+12
 		MaxQ = 6000
-		EnergyCost = 0.008
-		DishAngle = 4
+		EnergyCost = 0.08
+		DishAngle = 0.2
 		TRANSMITTER
 		{
 			PacketInterval = 0.3

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
@@ -166,12 +166,13 @@
 	}
 	MODULE
 	{
+	//copied from the Reflectron GX-128 stats
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 1E+13
+		Mode1DishRange = 1E+12
 		MaxQ = 6000
-		EnergyCost = 0.02
-		DishAngle = 4
+		EnergyCost = 0.08
+		DishAngle = 0.2
 		DeployFxModules = 0
 		TRANSMITTER
 		{
@@ -182,9 +183,10 @@
 	}
 	MODULE
 	{
+	//Also reduced from the omni, which looked exagerated on 70Gm
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
-		Mode1OmniRange = 70000000000
+		Mode1OmniRange = 700000000
 		MaxQ = 6000
 		EnergyCost = 0.005
 		DeployFxModules = 0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
@@ -421,10 +421,12 @@ MODULE
 	}
 	MODULE
 	{
+	//I copyied the stats from the Asteroid day dish (HG-55) as the function
+	//looks similar
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 90000000000
-		EnergyCost = 0.008
+		Mode1DishRange = 1000000000
+		EnergyCost = 0.07
 		MaxQ = 6000
 		DishAngle = 5
 		TRANSMITTER
@@ -546,10 +548,10 @@ MODULE
 	{
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
-		Mode1DishRange = 1E+13
+		Mode1DishRange = 20e9
 		MaxQ = 6000
-		EnergyCost = 0.008
-		DishAngle = 4
+		EnergyCost = 0.16
+		DishAngle = 3.3
 		TRANSMITTER
 		{
 			PacketInterval = 0.3


### PR DESCRIPTION
I could not find accurate independent information, so I copied from similar antennas - either the ones specified for the same missions, or ones with similar functions.