### PR TITLE
Fixed Antares AJ-26-62 thrust.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_KK_Antares.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_KK_Antares.cfg
@@ -26,7 +26,7 @@
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 1691.2
-		@maxThrust = 3260
+		@maxThrust = 3630
 		@heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
@@ -64,7 +64,7 @@
 		{
 			name = AJ-26-62
 			minThrust = 1691.2
-			maxThrust = 3260
+			maxThrust = 3630
 			heatProduction = 100
 			PROPELLANT
 			{


### PR DESCRIPTION
Current value gives <1.05 TWR with 6000 Kg Cygnus payload.
Source:
https://web.archive.org/web/20140209070336/http://www.orbital.com/NewsInfo/Publications/Antares_Brochure.pdf