### PR TITLE
AJ10 Advanced engine config updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -1,7 +1,32 @@
-// AJ10
-// SXT
+//  ==================================================
+//  AJ10 advanced series global engine configuration.
+
+//  Inert Mass: 100 Kg
+//  Throttle Range: N/A
+//  Burn Time: 500 s
+//  O/F Ratio: 1.85 (average value)
+
+//  Sources:
+
+//  Purdue Engineering - AJ10-118K:           https://engineering.purdue.edu/~propulsi/propulsion/rockets/liquids/aj10-118k.html
+//  Aerojet General Space Engines:            http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  Encyclopedia Astronautica - AJ10-118K:    http://www.astronautix.com/engines/aj10118k.htm
+//  Aerojet Rocketdyne - AJ10-118K:           https://www.rocket.com/delta-ii-stage-2-engine
+//  Norbert Brügge - US Space Rocket Engines: http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Spaceflight 101 - Delta II 7920:          http://spaceflight101.com/spacerockets/delta-ii-7920/
+
+//  Used by:
+
+//  Real Scale Boosters
+//  SXT
+//  ==================================================
+
 @PART[*]:HAS[#engineType[AJ10_Adv]]:FOR[RealismOverhaulEngines]
 {
+    %title = AJ10 Series [Advanced]
+    %manufacturer = Aerojet Rocketdyne
+    %description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents advanced era AJ10s with a nozzle extension and restart capability. Used on Transtage as AJ10-138; similar models but back with the -118 designation were used on the Delta F and Delta K upper stages.
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -9,89 +34,116 @@
 		configuration = AJ10-138
 		modded = false
 		origMass = 0.1
+
+        // Delta-F (Delta I) upper stage configuration.
+
 		CONFIG
 		{
-			name = AJ10-118F	// Delta F 2nd stage
+			name = AJ10-118F
 			minThrust = 42.3
 			maxThrust = 42.3
 			heatProduction = 100
+
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.502
+				ratio = 0.4654
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.498
+				ratio = 0.5346
+                DrawGauge = False
 			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 0
-			!IGNITOR_RESOURCE,* {}
+
+			ullage = True
+			pressureFed = True
+			ignitions = 0
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.2
 			}
+
 			atmosphereCurve
 			{
 				key = 0 315
 				key = 1 215
 			}
+
 			massMult = 1.0
 			techRequired = heavierRocketry
 			cost = 50
 			entryCost = 5000
 		}
+
+        // Delta-K (Delta II) upper stage configuration.
+
 		CONFIG
 		{
-			name = AJ10-118K	// Delta K 2nd stage
+			name = AJ10-118K
 			minThrust = 43.7
 			maxThrust = 43.7
 			heatProduction = 100
+
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.502
+				ratio = 0.4654
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.498
+				ratio = 0.5346
+                DrawGauge = False
 			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 0
-			!IGNITOR_RESOURCE,* {}
+
+			ullage = True
+			pressureFed = True
+			ignitions = 0
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.2
 			}
+
 			atmosphereCurve
 			{
 				key = 0 319.2
 				key = 1 215
 			}
+
 			massMult = 1.0
 			techRequired = veryHeavyRocketry
 			cost = 100
 			entryCost = 15000
+
 			entryCostSubtractors
 			{
 				AJ10-118F = 5000
 			}
 		}
 	}
+
 	@MODULE[ModuleGimbal]
 	{
 		@gimbalRange = 4.25
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 8
 	}
-	
-	engineType = AJ10_138 // add on the Transtage config
+
+    !MODULE[ModuleAlternator]{}
+
+    !RESOURCE,*{}
+
+    // The 118F and 118K engine variants have a lot in common with the
+    // Titan Transtage 138 variant (but they are not exactly the same).
+
+	%engineType = AJ10_138
 }


### PR DESCRIPTION
* Add general engine information and sources.
* Fix incorrect O/F ratios (was 1.6 but the 118F and K configurations used 1.8 to 1.9).
* Remove the alternator module and it's electric charge storage.