### PR TITLE
CST-100 pack updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
@@ -2,7 +2,7 @@
 //  CST-100 main heat shield.
 
 //  Dimensions: 4.65 m x 0.9 m
-//  Gross Mass: 930 kg
+//  Gross Mass: 1200 kg
 //  ==================================================
 
 @PART[CST-100?Heat?Shield]:FOR[RealismOverhaul]
@@ -13,7 +13,7 @@
 
     MODEL
     {
-        model = CST-100/Parts/heatShield/model
+        model = CST-100/Parts/cstHeatShield/model
         scale = 1.24, 1.24, 1.24
     }
 
@@ -25,12 +25,12 @@
 
     @title = CST-100 Heat Shield
     @manufacturer = Boeing Co.
-    @description =  The main heat shield for CST-100 command module.
+    @description = The heat shield for CST-100 "Starliner" command module.
 
-    @mass = 0.13
+    @mass = 0.23
     @crashTolerance = 12
-    @maxTemp = 873.15
-    %skinMaxTemp = 3773.15
+    @maxTemp = 2473.15
+    %skinMaxTemp = 3673.15
     %stageOffset = 1
     %chilStageOffset = 1
     %stagingIcon = DECOUPLER_HOR
@@ -43,18 +43,27 @@
 
     @MODULE[ModuleAblator]
     {
-        @lossExp = -8000
-        @lossConst = 0.06
-        @pyrolysisLossFactor = 26000
+        @outputResource = CharredAblator
+        @outputMult = 1.0
+        @lossExp = -6000
+        @lossConst = 0.13
+        @pyrolysisLossFactor = 6000
         %charMin = 0
         %charMax = 1
     }
 
     @RESOURCE[Ablator]
     {
-        @amount = 800
-        @maxAmount = 800
-    }	
+        @amount = 970
+        @maxAmount = 970
+    }
+
+    RESOURCE
+    {
+        name = CharredAblator
+        amount = 0
+        maxAmount = 970
+    }
 }
 
 //  ==================================================
@@ -79,11 +88,11 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.05, 0.0, 0.0, -1.0, 0.0, 1
 
     @title = CST-100 Nose Cone
     @manufacturer = Boeing Co.
-    @description = A protective nose cone for the CST-100 NASA Docking System.
+    @description = A protective nose cone for the CST-100 "Starliner" NASA Docking System.
 
     @mass = 0.07
     @crashTolerance = 14

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -2,9 +2,11 @@
 //  CST-100 command module.
 
 //  Dimensions: 4.65 m x 2.6 m
-//  Gross Mass: 4500 Kg
+//  Gross Mass: 4610 Kg
 
-//  Source 1: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  Sources:
+
+//  Boeing CST-100 Commercial Crew Transportation System: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
 //  ==================================================
 
 @PART[CST-100?capsule]:FOR[RealismOverhaul]
@@ -28,9 +30,9 @@
 
     @title = CST-100 Command Module
     @manufacturer = Boeing Co.
-    @description = The CST-100 command module is designed to be reusable for up to 10 times.
+    @description = The command module of the CST-100 "Starliner" Commercial Crew Transportation System (COTS). Designed to be reusable for up to 10 times.
 
-    @mass = 4.3
+    @mass = 4.4
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
@@ -45,7 +47,7 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 0.725
+            rate = 1.0
         }
     }
 
@@ -99,19 +101,19 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 350
+        volume = 510
         basemass = -1
 
-        //  Electricity 45 kWh.
+        //  Batteries 550 Wh.
 
         TANK
         {
             name = ElectricCharge
-            amount = 45000
-            maxAmount = 45000
+            amount = 2000
+            maxAmount = 2000
         }
 
-        //  Hydrazine 150 Kg.
+        //  ACS propellant 150 Kg.
 
         TANK
         {
@@ -120,7 +122,7 @@
             maxAmount = 150
         }
 
-        //  Helium 4 Kg.
+        //  ACS pressurization 4 Kg.
 
         TANK
         {
@@ -128,80 +130,8 @@
             amount = 22500
             maxAmount = 22500
         }
-    }
 
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  CST-100 command module.
-
-//  Connected Living Space compatibility.
-//  ==================================================
-
-@PART[CST-100?capsule]:HAS[!MODULE[ModuleConnectedLivingSpace]]:AFTER[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
-{
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        impassablenodes = bottom
-    }
-}
-
-//  ==================================================
-//  CST-100 command module.
-
-//  Remote Tech compatibility.
-//  ==================================================
-
-@PART[CST-100?capsule]:AFTER[RealismOverhaul]:NEEDS[RemoteTech]
-{
-    @MODULE[ModuleCommand]
-    {
-        @RESOURCE[ElectricCharge]
-        {
-            @rate = 0.71
-        }
-    }
-
-    MODULE
-    {
-        name = ModuleSPU
-    }
-
-    MODULE
-    {
-        name = ModuleRTAntenna
-        IsRTActive = False
-        Mode0OmniRange = 0
-        Mode1OmniRange = 1000000
-        EnergyCost = 0.015
-        DeployFxModules = 0
-        ProgressFxModules = 1
-
-        TRANSMITTER
-        {
-            PacketInterval = 0.2
-            PacketSize = 0.47
-            PacketResourceCost = 0.05
-        }
-    }
-}
-
-//  ==================================================
-//  CST-100 command module.
-
-//  TAC Life Support compatibility.
-//  ==================================================
-
-@PART[CST-100?capsule]:AFTER[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-    @description ^= :$: Supports a crew of 7 for 2 days.:
-
-    @MODULE[ModuleFuelTanks]
-    {
-        @volume = 510
+        //  Crew supplies.
 
         TANK
         {
@@ -250,6 +180,83 @@
             name = LithiumHydroxide
             amount = 5.18
             maxAmount = 10.4
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  Connected Living Space compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
+{
+    MODULE
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = bottom
+    }
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.015
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 800000
+        EnergyCost = 0.015
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 0.2
+            PacketSize = 0.47
+            PacketResourceCost = 0.05
+        }
+    }
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a crew of 7 for 2 days.:
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.01
         }
     }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -1,14 +1,13 @@
 //  ==================================================
-//  RS-88 quad engine block
+//  CST-100 RS-88 quad engine block
 
 //  Dimensions: 0.65 m x 0.7 m
 //  Gross Mass: 1000 Kg
 
 //  Sources:
 
-//  http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
-//  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
-//  http://astronautix.com/engines/rs88.htm
+//  RS-88 Pad Abort Demonstrator Thrust Chamber Assembly: http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
+//  Astronautix - RS-88:                                  http://astronautix.com/engines/rs88.htm
 //  ==================================================
 
 @PART[RS88]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -47,6 +46,7 @@
 
     @MODULE[ModuleEngines*]
     {
+        @name = ModuleEnginesRF
         @minThrust = 907.2
         @maxThrust = 907.2
         @heatProduction = 100
@@ -72,13 +72,20 @@
 }
 
 //  ==================================================
-//  RS-88 quad engine block
+//  CST-100 RS-88 quad engine block
 
-//  Custom engine configuration.
+//  Engine configuration.
 //  ==================================================
 
 @PART[RS88]:AFTER[RealismOverhaulEngines]
 {
     @title = CST-100 LAE
     @description = Four of these engines are used by the CST-100 "Starliner" spacecraft for launch aborts and orbital maneuvering.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = LAE
+
+        !CONFIG,*:HAS[~name[LAE]]{}
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
@@ -2,12 +2,12 @@
 //  CST-100 service module.
 
 //  Dimensions: 5.4 m x 2.5 m
-//  Gross Mass: 7340 Kg
+//  Gross Mass: 6220 Kg
 
 //  Sources:
 
-//  http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
-//  http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  Design Considerations for a Commercial Crew Transportation System: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//  Boeing CST-100 Commercial Crew Transportation System:              http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
 //  ==================================================
 
 @PART[CST-100?Service?Module]:FOR[RealismOverhaul]
@@ -31,9 +31,9 @@
 
     @title = CST-100 Service Module
     @manufacturer = Boeing Co.
-    @description = The service module for the CST-100 spacecraft.
+    @description = The service module for the CST-100 "Starliner" spacecraft.
 
-    @mass = 4.7
+    @mass = 3.9
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -86,19 +86,19 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 2100
+        volume = 2180
         basemass = -1
 
-        //  Electricity 12.5 kWh
+        //  Electricity 37.5 kWh
 
         TANK
         {
             name = ElectricCharge
-            amount = 45000
-            maxAmount = 45000
+            amount = 135000
+            maxAmount = 135000
         }
 
-        //  Water 200 Kg.
+        //  Cooling & life support water 200 Kg.
 
         TANK
         {
@@ -125,7 +125,7 @@
             maxAmount = 875
         }
 
-        //  RS-88 & ACS pressurization ~3.2 Kg.
+        //  ACS pressurization ~3.2 Kg.
 
         TANK
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
@@ -67,7 +67,7 @@
 
     @title = CST-100 4M Adapter
     @manufacturer = Boeing Co.
-    @description = A structural adapter to connect the service module of the CST-100 to 4.65m parts.
+    @description = A structural adapter to connect the service module of the CST-100 to 4.65 meter parts.
 
     @mass = 0.09
     @crashTolerance = 14
@@ -109,7 +109,7 @@
 
     @title = CST-100 3M Adapter
     @manufacturer = Boeing Co.
-    @description = A structural adapter to connect the service module of the CST-100 to 3.75m parts.
+    @description = A structural adapter to connect the service module of the CST-100 to 3.75 meter parts.
 
     @mass = 0.1
     @crashTolerance = 14

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
@@ -8,7 +8,7 @@
 //  CST-100 parachute pack.
 
 //  Dimensions: 2.7 m x 0.65 m
-//  Gross Mass: 280 Kg
+//  Gross Mass: 250 Kg
 //  ==================================================
 
 @PART[cstparachute]:FOR[RealismOverhaul]
@@ -31,9 +31,9 @@
 
     @title = CST-100 Parachute Pack
     @manufacturer = Boeing Co.
-    @description = The parachute pack for the CST-100 command module.
+    @description = The parachute pack for the CST-100 "Starliner" command module.
 
-    @mass = 0.28
+    @mass = 0.3
     %crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -47,7 +47,7 @@
     @MODULE[ModuleParachute]
     {
         @deployAltitude = 1000
-        @chuteMaxTemp = 400
+        @chuteMaxTemp = 423.15
     }
 
     MODULE
@@ -69,11 +69,13 @@
 //  Real Chute compatibility.
 //  ==================================================
 
-@PART[cstparachute]:AFTER[RealismOverhaul]:NEEDS[RealChute]
+@PART[cstparachute]:FOR[RealismOverhaul]:NEEDS[RealChute]
 {
     !sound_parachute_open = NULL
 
     @category = none
+
+    @mass = 0.1
 
     !MODULE[ModuleParachute]{}
 
@@ -222,14 +224,14 @@
 
     MODEL
     {
-        model = CST-100/Parts/nds/NDS1/ndsport3
-        scale = 1.295, 1.295, 1.295
+        model = CST-100/Parts/nds/NDS3/ndsport3
+        scale = 0.69, 0.69, 0.69
     }
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.336, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_top = 0.0, 0.215, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
@@ -271,7 +273,7 @@
 // Connected Living Space compatibility.
 //  ==================================================
 
-@PART[ndsport1|ndsport3]:HAS[!MODULE[ModuleConnectedLivingSpace]]:AFTER[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
+@PART[ndsport1|ndsport3]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
     {
@@ -361,7 +363,7 @@
 // Connected Living Space compatibility.
 //  ==================================================
 
-@PART[idaONE]:HAS[!MODULE[ModuleConnectedLivingSpace]]:AFTER[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
+@PART[idaONE]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
     {


### PR DESCRIPTION
* Fix a wrong model file path for the heat shield model.
* Update heat shield stats to be compatible with the new changes of the reentry heating system (comparable to the LEO - rated 5 meter heat shield).
* Fix the attachment node position of the NDS protective nose cone.
* Increase a bit the dry mass of the command module.
* Increase a bit the electricity consumption of the command module to be in line with the required keep - alive requierements.
* Decreased the amount of electricity carried by the command module (the service module is always required).
* Decrease a bit the range of the RemoteTech antenna.
* Include all life support resources within the command module so not to have any mass disparencies if the user does not have TACLS installed.
* Keep the electricity consumption of the command module to a fixed value if the user has not installed RemoteTech and/or TACLS.
* Remove the original RS-88 engine configuration (Ethanol & LOX) from the available engine configurations.
* Decrease the dry mass of the service module and increase the carried battery storage (the built - in solar array should barely keep it operational for approximately 60 hours while in autonomous mode).
* Fix the excessive mass of the parachute pack if RealChute is installed.
* Fix the scaling of the active NDS port (model was probably replaced) and it's attachment node.

NOTE 1: The nose cone still has issues with it's collider (nothing we can do on our end).