### PR TITLE
RO Procedural Fairings update

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_MainSailor.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_MainSailor.cfg
@@ -1,0 +1,143 @@
+//  ==================================================
+//  Conic fairing (black).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairingConicBlk]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Egg fairing (black).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairingEggBlk]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Soyuz fairing (black).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairing001BK]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Conic fairing (Gamma).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairingConicGamma]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Egg fairing (Gamma).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairingEggGamma]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Soyuz fairing (Gamma).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairing001]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Conic fairing (white).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairingConicWht]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Egg fairing (white).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairingEggWht]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}
+
+//  ==================================================
+//  Soyuz fairing (white).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[MainSailorFairing001]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @crashTolerance = 10
+    @maxTemp = 873.15
+    %skinMaxTemp = 3273.15
+}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_MainSailor.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_MainSailor.cfg
@@ -9,6 +9,8 @@
 {
     %RSSROConfig = True
 
+    @title = Payload Fairing - Conic (Black) [Procedural]
+
     @crashTolerance = 10
     @maxTemp = 873.15
     %skinMaxTemp = 3273.15
@@ -24,6 +26,8 @@
 @PART[MainSailorFairingEggBlk]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @title = Payload Fairing - Egg-Shaped (Black) [Procedural]
 
     @crashTolerance = 10
     @maxTemp = 873.15
@@ -41,6 +45,8 @@
 {
     %RSSROConfig = True
 
+    @title = Payload Fairing - Soyuz (Black) [Procedural]
+
     @crashTolerance = 10
     @maxTemp = 873.15
     %skinMaxTemp = 3273.15
@@ -56,6 +62,8 @@
 @PART[MainSailorFairingConicGamma]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @title = Payload Fairing - Conic (Gamma) [Procedural]
 
     @crashTolerance = 10
     @maxTemp = 873.15
@@ -73,6 +81,8 @@
 {
     %RSSROConfig = True
 
+    @title = Payload Fairing - Egg-Shaped (Gamma) [Procedural]
+
     @crashTolerance = 10
     @maxTemp = 873.15
     %skinMaxTemp = 3273.15
@@ -88,6 +98,8 @@
 @PART[MainSailorFairing001]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @title = Payload Fairing - Soyuz (Gamma) [Procedural]
 
     @crashTolerance = 10
     @maxTemp = 873.15
@@ -105,6 +117,8 @@
 {
     %RSSROConfig = True
 
+    @title = Payload Fairing - Conic (White) [Procedural]
+
     @crashTolerance = 10
     @maxTemp = 873.15
     %skinMaxTemp = 3273.15
@@ -121,6 +135,8 @@
 {
     %RSSROConfig = True
 
+    @title = Payload Fairing - Egg-Shaped (White) [Procedural]
+
     @crashTolerance = 10
     @maxTemp = 873.15
     %skinMaxTemp = 3273.15
@@ -136,6 +152,8 @@
 @PART[MainSailorFairing001]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @title = Payload Fairing - Soyuz (White) [Procedural]
 
     @crashTolerance = 10
     @maxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_blackheart-PP-PF.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_blackheart-PP-PF.cfg
@@ -201,12 +201,12 @@
 //	Gross Mass: N/A
 //	==================================================
 
-	@PART[KzProcFairingAtlas]:FOR[RealismOverhaul]
-	{
-		@title = Payload Fairing - Atlas [Procedural]
+@PART[KzProcFairingAtlas]:FOR[RealismOverhaul]
+{
+	@title = Payload Fairing - Atlas [Procedural]
 
     @mass = 0
-	}
+}
 
 //	==================================================
 //	Long March payload fairing (procedural).
@@ -215,12 +215,12 @@
 //	Gross Mass: N/A
 //	==================================================
 
-	@PART[KzProcFairingChina]:FOR[RealismOverhaul]
-	{
-		@title = Payload Fairing - Long March [Procedural]
+@PART[KzProcFairingChina]:FOR[RealismOverhaul]
+{
+	@title = Payload Fairing - Long March [Procedural]
 
     @mass = 0
-	}
+}
 
 //	==================================================
 //	Cone Egg payload fairing (procedural).
@@ -229,12 +229,12 @@
 //	Gross Mass: N/A
 //	==================================================
 
-	@PART[KzProcFairingConegg]:FOR[RealismOverhaul]
-	{
-		@title = Payload Fairing - Cone-Egg [Procedural]
+@PART[KzProcFairingConegg]:FOR[RealismOverhaul]
+{
+	@title = Payload Fairing - Cone-Egg [Procedural]
 
     @mass = 0
-	}
+}
 
 //	==================================================
 //	Jupiter payload fairing (procedural).
@@ -243,12 +243,12 @@
 //	Gross Mass: N/A
 //	==================================================
 
-	@PART[KzProcFairingJupiter]:FOR[RealismOverhaul]
-	{
-		@title = Payload Fairing - Jupiter [Procedural]
+@PART[KzProcFairingJupiter]:FOR[RealismOverhaul]
+{
+	@title = Payload Fairing - Jupiter [Procedural]
 
     @mass = 0
-	}
+}
 
 //	==================================================
 //	Titan payload fairing (procedural).
@@ -257,9 +257,9 @@
 //	Gross Mass: N/A
 //	==================================================
 
-	@PART[KzProcFairingTitan]:FOR[RealismOverhaul]
-	{
-		@title = Payload Fairing - Titan [Procedural]
+@PART[KzProcFairingTitan]:FOR[RealismOverhaul]
+{
+	@title = Payload Fairing - Titan [Procedural]
 
     @mass = 0
-	}
+}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_blackheart-PP-PF.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_blackheart-PP-PF.cfg
@@ -194,68 +194,68 @@
 	@node_stack_connect = 0, 0.5, 0, 0, -1, 0, 0
 }
 
-//	==================================================
-//	Atlas payload fairing (procedural).
+//  ==================================================
+//  Atlas payload fairing (procedural).
 
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
 
 @PART[KzProcFairingAtlas]:FOR[RealismOverhaul]
 {
-	@title = Payload Fairing - Atlas [Procedural]
+    @title = Payload Fairing - Atlas [Procedural]
 
     @mass = 0
 }
 
-//	==================================================
-//	Long March payload fairing (procedural).
+//  ==================================================
+//  Long March payload fairing (procedural).
 
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
 
 @PART[KzProcFairingChina]:FOR[RealismOverhaul]
 {
-	@title = Payload Fairing - Long March [Procedural]
+    @title = Payload Fairing - Long March [Procedural]
 
     @mass = 0
 }
 
-//	==================================================
-//	Cone Egg payload fairing (procedural).
+//  ==================================================
+//  Cone Egg payload fairing (procedural).
 
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
 
 @PART[KzProcFairingConegg]:FOR[RealismOverhaul]
 {
-	@title = Payload Fairing - Cone-Egg [Procedural]
+    @title = Payload Fairing - Cone-Egg [Procedural]
 
     @mass = 0
 }
 
-//	==================================================
-//	Jupiter payload fairing (procedural).
+//  ==================================================
+//  Jupiter payload fairing (procedural).
 
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
 
 @PART[KzProcFairingJupiter]:FOR[RealismOverhaul]
 {
-	@title = Payload Fairing - Jupiter [Procedural]
+    @title = Payload Fairing - Jupiter [Procedural]
 
     @mass = 0
 }
 
-//	==================================================
-//	Titan payload fairing (procedural).
+//  ==================================================
+//  Titan payload fairing (procedural).
 
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
 
 @PART[KzProcFairingTitan]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_blackheart-PP-PF.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_blackheart-PP-PF.cfg
@@ -204,6 +204,8 @@
 	@PART[KzProcFairingAtlas]:FOR[RealismOverhaul]
 	{
 		@title = Payload Fairing - Atlas [Procedural]
+
+    @mass = 0
 	}
 
 //	==================================================
@@ -216,6 +218,8 @@
 	@PART[KzProcFairingChina]:FOR[RealismOverhaul]
 	{
 		@title = Payload Fairing - Long March [Procedural]
+
+    @mass = 0
 	}
 
 //	==================================================
@@ -228,6 +232,8 @@
 	@PART[KzProcFairingConegg]:FOR[RealismOverhaul]
 	{
 		@title = Payload Fairing - Cone-Egg [Procedural]
+
+    @mass = 0
 	}
 
 //	==================================================
@@ -240,6 +246,8 @@
 	@PART[KzProcFairingJupiter]:FOR[RealismOverhaul]
 	{
 		@title = Payload Fairing - Jupiter [Procedural]
+
+    @mass = 0
 	}
 
 //	==================================================
@@ -252,4 +260,6 @@
 	@PART[KzProcFairingTitan]:FOR[RealismOverhaul]
 	{
 		@title = Payload Fairing - Titan [Procedural]
+
+    @mass = 0
 	}


### PR DESCRIPTION
* Add RO support for the MainSailor procedural fairing sides.
* Fix a mass problem with the BlackHeart procedural fairing sides (their mass would increase indefinitely).

NOTE: The white version of the Soyuz fairing has the same part module name as the Gamma version and so It will not appear in game. I have notified MainSailor for it.