### PR TITLE
added scaled plume to new SSTU engines, please test if ok

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/New_SSTU_LFEngines.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/New_SSTU_LFEngines.cfg
@@ -1,0 +1,142 @@
+@PART[SSTU-SC-ENG-AJ10-137]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Hypergolic-Apollo-SM
+        transformName = AJ10-137-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.6
+        plumePosition = 0,0,1.4
+        fixedScale = 1.1
+        energy = 1.5
+        speed = 1.1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Hypergolic-Apollo-SM
+	}
+}
+@PART[SSTU-SC-ENG-AJ10-190]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-Red
+        transformName = AJ10-190-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.1
+        fixedScale = 1.7
+        energy = 1.5
+        speed = 1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Hypergolic-OMS-Red
+	}
+}
+@PART[SSTU-SC-ENG-RD-107A]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = RD-107A-MainFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.4
+        plumePosition = 0,0,0.5
+        fixedScale = 0.6
+        energy = 1.5
+        speed = 1.5
+    }
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = RD-107A-VernierFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.26
+        plumePosition = 0,0,0.3
+        fixedScale = 0.26
+        energy = 0.4
+        speed = 1.2
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Lower
+		%runningEffectName = Kerolox-Upper
+	}
+}
+@PART[SSTU-SC-ENG-RD-107X]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = RD-107X-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.4
+        plumePosition = 0,0,0.5
+        fixedScale = 0.6
+        energy = 1.5
+        speed = 1.5
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Lower
+	}
+}
+@PART[SSTU-SC-ENG-RD-108A]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = RD-108A-MainFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.4
+        plumePosition = 0,0,0.5
+        fixedScale = 0.6
+        energy = 1.5
+        speed = 1.5
+    }
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = RD-108A-VernierFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.26
+        plumePosition = 0,0,0.3
+        fixedScale = 0.26
+        energy = 0.4
+        speed = 1.2
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Lower
+		%runningEffectName = Kerolox-Upper
+	}
+}
+@PART[SSTU-SC-ENG-RD-0110]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = RD-0110-MainFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.5
+        plumePosition = 0,0,1
+        fixedScale = 0.18
+        energy = 0.6
+        speed = 1
+    }
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = RD-0110-VernierFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.25
+        fixedScale = 0.6
+        energy = 0.7
+        speed = 1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Upper
+        %runningEffectName = Kerolox-Lower
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/New_SSTU_LFEngines.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/New_SSTU_LFEngines.cfg
@@ -118,10 +118,9 @@
         name = Kerolox-Upper
         transformName = RD-0110-MainFXTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.5
-        plumePosition = 0,0,1
-        fixedScale = 0.18
-        energy = 0.6
+        localPosition = 0,0,0.25
+        fixedScale = 0.6
+        energy = 0.7
         speed = 1
     }
     PLUME
@@ -129,9 +128,10 @@
         name = Kerolox-Lower
         transformName = RD-0110-VernierFXTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.25
-        fixedScale = 0.6
-        energy = 0.7
+        localPosition = 0,0,0.5
+        plumePosition = 0,0,0.1
+        fixedScale = 0.18
+        energy = 0.6
         speed = 1
     }
 	@MODULE[ModuleEngines*]
@@ -197,8 +197,8 @@
         name = Hydrolox-Upper
         transformName = RS-68-RollExhaust
         localRotation = 0, 0, 0
-        flarePosition = 0, 0.015, 0.43
-		plumePosition = 0, 0.15, 0.63
+        flarePosition = 0,0.015,0.43
+		plumePosition = 0,0,0.63
         fixedScale = 0.33
         energy = 1
         speed = 0.5

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/New_SSTU_LFEngines.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/New_SSTU_LFEngines.cfg
@@ -140,3 +140,162 @@
         %runningEffectName = Kerolox-Lower
 	}
 }
+
+@PART[SSTU-SC-ENG-RL10A-4]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = RL10A-4-ThrustTransform
+        localRotation = 0,0,0
+	   plumePosition = 0,0,1.5
+        plumeScale = 1.4
+        flarePosition = 0,0,1.5
+        flareScale = 1.4
+        energy = 1
+        speed = 1.2
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Hydrolox-Upper
+	}
+}
+@PART[SSTU-SC-ENG-RL10A-5]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = RL10A-5-ThrustTransform
+        localRotation = 0,0,0
+	   plumePosition = 0,0,1.1
+        plumeScale = 0.5
+        flarePosition = 0,0,0.92
+        flareScale = 0.5
+        energy = 1
+        speed = 1.2
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Hydrolox-Upper
+	}
+}
+@PART[SSTU-SC-ENG-RS-68]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Hydrolox-Lower
+        transformName = RS-68-MainFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2
+        plumePosition = 0, 0, 2.4
+        fixedScale = 3
+        energy = 1
+        speed = 1
+    }
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = RS-68-RollExhaust
+        localRotation = 0, 0, 0
+        flarePosition = 0, 0.015, 0.43
+		plumePosition = 0, 0.15, 0.63
+        fixedScale = 0.33
+        energy = 1
+        speed = 0.5
+    }
+	@MODULE[ModuleEngines*],0
+	{
+        %powerEffectName = Hydrolox-Lower
+        %runningEffectName = Hydrolox-Upper
+	}
+}
+@PART[SSTU-SC-ENG-Merlin-1A]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = Merlin-1A-MainFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.6
+        plumePosition = 0,0,0.7
+        fixedScale = 0.7
+        energy = 0.5
+        speed = 0.7
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Lower
+	}
+}
+@PART[SSTU-SC-ENG-Merlin-1C]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = Merlin-1C-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.96
+        plumePosition = 0,0,0.9
+        fixedScale = 0.7
+        energy = 0.75
+        speed = 1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Lower
+	}
+}
+@PART[SSTU-SC-ENG-Merlin-1CV]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = Merlin-1CV-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2.8
+        plumePosition = 0,0,2.6
+        fixedScale = 1.5
+        energy = 0.75
+        speed = 1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Upper
+	}
+}
+@PART[SSTU-SC-ENG-Merlin-1D]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = Merlin-1D-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.9
+        plumePosition = 0,0,0.85
+        fixedScale = 0.75
+        energy = 0.85
+        speed = 1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Lower
+	}
+}
+@PART[SSTU-SC-ENG-Merlin-1DV]:NEEDS[RealPlume]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = Merlin-1DV-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,2.8
+        plumePosition = 0,0,2.6
+        fixedScale = 1.5
+        energy = 0.85
+        speed = 1
+    }
+	@MODULE[ModuleEngines*]
+	{
+        %powerEffectName = Kerolox-Upper
+	}
+}


### PR DESCRIPTION
A number of new engines which had not yet RO plumes. Took stock SSTU plumes, adjusted them ingame to RO scale. 
I didn't create RealPlumes before, please check them and give me feedback if they are ok. Orientated myself on existing plumes and to some degree real videos.

For now, the file only contains AJ10-137/190, RD-107a/107x/108, and RD-0110. Gonna create the others too, but I'd like some feedback first.


Note, I'll keep this seperate form the other PR, since this is actually new stuff and not just fixed partnames.