### PR TITLE
SSTU Command Pod Fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_A_BPC]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-BPC]:FOR[RealismOverhaul]
 {
 	%category = Engine
 	%RSSROConfig = True
@@ -20,7 +20,7 @@
 		@maxAmount *= 6.4
 	}
 }
-@PART[SSTU_ShipCore_A_CM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-CM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,0
@@ -263,7 +263,7 @@
 	{
 	}
 }
-@PART[SSTU_ShipCore_A_CM]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-CM]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
 	MODULE
 	{
@@ -283,7 +283,7 @@
 	}
 }
 
-@PART[SSTU_ShipCore_A_SM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-B-SM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-B-BPC]:FOR[RealismOverhaul] 
+@PART[SSTU-SC-C-BPC]:FOR[RealismOverhaul] 
 {
 	%category = Engine
 	%RSSROConfig = True
@@ -21,7 +21,7 @@
 	}
 }
 
-@PART[SSTU-SC-B-CM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-C-CM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,*
@@ -260,7 +260,7 @@
 		impassablenodes = bottom
 	}
 }
-@PART[SSTU-SC-B-SM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-C-SM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS_Upper_Stages.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SLS_Upper_Stages.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-B-ICPS]:FOR[RealismOverhaul]
+@PART[SSTU-SC-C-ICPS]:FOR[RealismOverhaul]
 {
 	@MODEL,*
 	{
@@ -156,7 +156,7 @@
 		}
 	}
 }
-@PART[SSTU-SC-B-HUS]:FOR[RealismOverhaul]
+@PART[SSTU-SC-C-HUS]:FOR[RealismOverhaul]
 {
 	@MODEL,*
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Soyuz.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-C-BPC]:FOR[RealismOverhaul]
+@PART[SSTU-SC-A-BPC]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,*
@@ -10,7 +10,7 @@
 	@title = Soyuz SAS (WIP)
 }
 
-@PART[SSTU-SC-C-OM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-A-OM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,0
@@ -29,7 +29,7 @@
 	@CrewCapacity = 3
 }
 
-@PART[SSTU-SC-C-DM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-A-DM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,*
@@ -50,7 +50,7 @@
 	}
 }
 
-@PART[SSTU-SC-C-SM]:FOR[RealismOverhaul]
+@PART[SSTU-SC-A-SM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODEL,*


### PR DESCRIPTION
Mod author changed part names so Orion / Apollo / Soyuz parts were mixed
up

Fixed @PART definitions in the configs and tested ingame - known functionality restored