### PR TITLE
Add reasonable solar panels to Vanguard probes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Vanguard.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Vanguard.cfg
@@ -22,6 +22,10 @@
 	{
 		@packetResourceCost = 0.001
 	}
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 0.003
+	}
 }
 @PART[vanguard-1]:NEEDS[RemoteTech]
 {
@@ -72,6 +76,10 @@
 	{
 		@packetResourceCost = 0.001
 	}
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 0.003
+	}
 }
 @PART[vanguard-2]:NEEDS[RemoteTech]
 {
@@ -121,6 +129,10 @@
 	@MODULE[ModuleDataTransmitter]
 	{
 		@packetResourceCost = 0.001
+	}
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 0.003
 	}
 }
 @PART[vanguard-3]:NEEDS[RemoteTech]


### PR DESCRIPTION
The Vaguard Probes were with extremely high energy production. I added a production of half the GRAB-1 (as per https://en.wikipedia.org/wiki/Vanguard_1#Spacecraft_design consumption from the transmitters was 15mW - still much lower than that) as a placeholder. If actual values are available, feel free to correct.