### PR TITLE
SSTU Pod updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Landers.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Landers.cfg
@@ -918,20 +918,45 @@
 		}
 	}
 }
-@PART[SSTU_LanderCore_LC2-POD]:FOR[RealismOverhaul]
+@PART[SSTU-LC2-POD]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
 	!MODULE[TweakScale]
 	{
 	}
 	@mass *= 1.953125
-	@MODEL,*
+	@MODEL,0
 	{
 		%scale = 1.25,1.25,1.25
 	}
+	@MODEL,1
+	{
+		%scale = 1.25,1.25,1.25
+		%position = 0, 1.0151375, 0
+	}
+	@MODEL,2
+	{
+		%scale = 0.5175,0.5175,0.5175
+		%position = 1.0152375, 0, 1.0152375
+	}
+	@MODEL,3
+	{
+		%scale = 0.5175,0.5175,0.5175
+		%position = 1.0152375, 0, -1.0152375
+	}
+	@MODEL,4
+	{
+		%scale = 0.5175,0.5175,0.5175
+		%position = -1.0152375, 0, -1.0152375
+	}
+	@MODEL,5
+	{
+		%scale = 0.5175,0.5175,0.5175
+		%position = -1.0152375, 0, 1.0152375
+	}
 	//%rescaleFactor = 1.25
 	@node_stack_bottomEngine = 0,-0.884675,0,0,-1,0,2
-	@node_stack_top = 0,0.9526375,0,0,1,0,2
+	@node_stack_top = 0,1.1250875,0,0,1,0,2
 	@node_stack_bottom = 0,-0.9700625,0,0,-1,0,2
 	@crashTolerance = 12
 	%breakingForce = 250
@@ -939,66 +964,80 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 0.5
+		volume = 3000
 		utilizationTweakable = true
 		type = ServiceModule
+		%TANK[ElectricCharge]
+		{
+			amount = 600000
+			maxAmount = 600000
+		}
+		%TANK[MMH]
+		{
+			amount = 50.4
+			maxAmount = 50.4
+		}
+		%TANK[NTO]
+		{
+			amount = 49.6
+			maxAmount = 49.6
+		}
+		%TANK[Food]
+		{
+			amount = 82
+			maxAmount = 82
+		}
+		%TANK[Water]
+		{
+			amount = 54.2
+			maxAmount = 54.2
+		}
+		%TANK[Oxygen]
+		{
+			amount = 8300
+			maxAmount = 8300
+		}
+		%TANK[CarbonDioxide]
+		{
+			amount = 0
+			maxAmount = 1025
+		}
+		%TANK[Waste]
+		{
+			amount = 0
+			maxAmount = 60
+		}
+		%TANK[WasteWater]
+		{
+			amount = 0
+			maxAmount = 70
+		}
+		%TANK[LithiumHydroxide]
+		{
+			amount = 14.4
+			maxAmount = 14.4
+		}
 	}
-	@RESOURCE[ElectricCharge]
+	!RESOURCE[ElectricCharge]{}
+	!RESOURCE[MMH]{}
+	!RESOURCE[NTO]{}
+	!RESOURCE[Food]{}
+	!RESOURCE[Water]{}
+	!RESOURCE[Oxygen]{}
+	!RESOURCE[CarbonDioxide]{}
+	!RESOURCE[Waste]{}
+	!RESOURCE[WasteWater]{}
+	!RESOURCE[LithiumHydroxide]{}
+	MODULE:NEED[TacLifeSupport]
 	{
-		amount = 600000
-		maxAmount = 600000
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 2.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
 	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	%RESOURCE[MMH]
-	{
-		amount = 50
-		maxAmount = 50
-	}
-	%RESOURCE[NTO]
-	{
-		amount = 50
-		maxAmount = 50
-	}
-	%RESOURCE[Food]
-	{
-		amount = 22
-		maxAmount = 36.6
-	}
-	%RESOURCE[Water]
-	{
-		amount = 19.3
-		maxAmount = 19.3
-	}
-	%RESOURCE[Oxygen]
-	{
-		amount = 2220
-		maxAmount = 3700
-	}
-	%RESOURCE[CarbonDioxide]
-	{
-		amount = 0
-		maxAmount = 767
-	}
-	%RESOURCE[Waste]
-	{
-		amount = 0
-		maxAmount = 24.2
-	}
-	%RESOURCE[WasteWater]
-	{
-		amount = 0
-		maxAmount = 20
-	}
-	%RESOURCE[LithiumHydroxide]
-	{
-		amount = 3.9
-		maxAmount = 6.5
-	}
-	!MODULE[ModuleRCS]
-	{
-	}
+	!RESOURCE[MonoPropellant]{}
+	!MODULE[ModuleRCS]{}
 	MODULE
 	{
 		name = ModuleRCS
@@ -1029,148 +1068,10 @@
 			rate = 1.01
 		}
 	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!MODULE[SSTUResourceSwitch]
-	{
-	}
-	%MODULE[SSTUResourceSwitch]
-	{
-		externalControl = true
-		TANK
-		{
-			tankName = Plain
-			tankDryMass = 2.1484375
-			tankCost = 1800
-			TANKRESOURCE
-			{
-				resource = MMH
-				amount = 50 
-				fillAmount = 50
-			}
-			TANKRESOURCE
-			{
-				resource = NTO
-				amount = 50 
-				fillAmount = 50
-			}
-			TANKRESOURCE
-			{
-				resource = ElectricCharge
-				amount = 600000
-				fillAmount = 600000
-			}
-			TANKRESOURCE
-		  {
-  			resource = Food
-	  		fillAmount = 22
-  			amount = 36.6
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Water
-  			fillAmount = 19.3
-  			amount = 19.3
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Oxygen
-  			fillAmount = 2220
-  			amount = 3700
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = CarbonDioxide
-  			fillAmount = 0
-  			amount = 767
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Waste
-  			fillAmount = 0
-  			amount = 24.2
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = WasteWater
-  			fillAmount = 0
-  			amount = 20
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = LithiumHydroxide
-  			fillAmount = 3.9
-  			amount = 6.5
-  		}
-		}
-		TANK
-		{
-			tankName = Ascent Tanks
-			tankDryMass = 2.55093359375
-			tankCost = 2400
-			TANKRESOURCE
-			{
-				resource = ElectricCharge
-				amount = 600000
-				fillAmount = 600000
-			}
-			TANKRESOURCE
-			{
-				resource = MMH
-				amount = 908.3549113
-				fillAmount = 908.3549113
-			}
-			TANKRESOURCE
-			{
-				resource = NTO
-				amount = 893.91087
-				fillAmount = 893.91087
-			}
-			TANKRESOURCE
-		  {
-  			resource = Food
-	  		fillAmount = 22
-  			amount = 36.6
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Water
-  			fillAmount = 19.3
-  			amount = 19.3
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Oxygen
-  			fillAmount = 2220
-  			amount = 3700
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = CarbonDioxide
-  			fillAmount = 0
-  			amount = 767
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Waste
-  			fillAmount = 0
-  			amount = 24.2
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = WasteWater
-  			fillAmount = 0
-  			amount = 20
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = LithiumHydroxide
-  			fillAmount = 3.9
-  			amount = 6.5
-  		}
-		}
-	}
+	!MODULE[ModuleReactionWheel]{}
+	!MODULE[SSTUResourceSwitch]{}
+	!MODULE[SSTUVolumeContainer]{}
+	!MODULE[SSTUResourceBoiloff]{}
 }
 @PART[SSTU_LanderCore_LC3-POD]:FOR[RealismOverhaul]
 {
@@ -1179,13 +1080,38 @@
 	{
 	}
 	@mass *= 1.953125
-	@MODEL,*
+	@MODEL,0
 	{
 		%scale = 1.25,1.25,1.25
 	}
+	@MODEL,1
+	{
+		%scale = 1.25,1.25,1.25
+		%position = 0, 1.3049, 0
+	}
+	@MODEL,2
+	{
+		%scale = 0.7925,0.7925,0.7925
+		%position = 1.5074125, 0, 1.5074125
+	}
+	@MODEL,3
+	{
+		%scale = 0.7925,0.7925,0.7925
+		%position = 1.5074125, 0, -1.5074125
+	}
+	@MODEL,4
+	{
+		%scale = 0.7925,0.7925,0.7925
+		%position = -1.5074125, 0, -1.5074125
+	}
+	@MODEL,5
+	{
+		%scale = 0.7925,0.7925,0.7925
+		%position = -1.5074125, 0, 1.5074125
+	}
 	//%rescaleFactor = 1.25
 	@node_stack_bottomEngine = 0,-1.1592375,0,0,-1,0,2
-	@node_stack_top = 0,1.2424,0,0,1,0,2
+	@node_stack_top = 0,1.41485,0,0,1,0,2
 	@node_stack_bottom = 0,-1.244625,0,0,-1,0,2
 	@crashTolerance = 12
 	%breakingForce = 250
@@ -1193,66 +1119,80 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 0.5
+		volume = 4500
 		utilizationTweakable = true
 		type = ServiceModule
+		%TANK[ElectricCharge]
+		{
+			amount = 600000
+			maxAmount = 600000
+		}
+		%TANK[MMH]
+		{
+			amount = 50.4
+			maxAmount = 50.4
+		}
+		%TANK[NTO]
+		{
+			amount = 49.6
+			maxAmount = 49.6
+		}
+		%TANK[Food]
+		{
+			amount = 122.9
+			maxAmount = 122.9
+		}
+		%TANK[Water]
+		{
+			amount = 81.3
+			maxAmount = 81.3
+		}
+		%TANK[Oxygen]
+		{
+			amount = 12500
+			maxAmount = 12500
+		}
+		%TANK[CarbonDioxide]
+		{
+			amount = 0
+			maxAmount = 1025
+		}
+		%TANK[Waste]
+		{
+			amount = 0
+			maxAmount = 82.6
+		}
+		%TANK[WasteWater]
+		{
+			amount = 0
+			maxAmount = 103.5
+		}
+		%TANK[LithiumHydroxide]
+		{
+			amount = 21.6
+			maxAmount = 21.6
+		}
 	}
-	@RESOURCE[ElectricCharge]
+	!RESOURCE[ElectricCharge]{}
+	!RESOURCE[MMH]{}
+	!RESOURCE[NTO]{}
+	!RESOURCE[Food]{}
+	!RESOURCE[Water]{}
+	!RESOURCE[Oxygen]{}
+	!RESOURCE[CarbonDioxide]{}
+	!RESOURCE[Waste]{}
+	!RESOURCE[WasteWater]{}
+	!RESOURCE[LithiumHydroxide]{}
+	MODULE:NEED[TacLifeSupport]
 	{
-		amount = 600000
-		maxAmount = 600000
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 3.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
 	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	%RESOURCE[MMH]
-	{
-		amount = 50
-		maxAmount = 50
-	}
-	%RESOURCE[NTO]
-	{
-		amount = 50
-		maxAmount = 50
-	}
-	%RESOURCE[Food]
-	{
-		amount = 22
-		maxAmount = 36.6
-	}
-	%RESOURCE[Water]
-	{
-		amount = 19.3
-		maxAmount = 19.3
-	}
-	%RESOURCE[Oxygen]
-	{
-		amount = 2220
-		maxAmount = 3700
-	}
-	%RESOURCE[CarbonDioxide]
-	{
-		amount = 0
-		maxAmount = 767
-	}
-	%RESOURCE[Waste]
-	{
-		amount = 0
-		maxAmount = 24.2
-	}
-	%RESOURCE[WasteWater]
-	{
-		amount = 0
-		maxAmount = 20
-	}
-	%RESOURCE[LithiumHydroxide]
-	{
-		amount = 3.9
-		maxAmount = 6.5
-	}
-	!MODULE[ModuleRCS]
-	{
-	}
+	!RESOURCE[MonoPropellant]{}
+	!MODULE[ModuleRCS]{}
 	MODULE
 	{
 		name = ModuleRCS
@@ -1283,148 +1223,10 @@
 			rate = 1.01
 		}
 	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!MODULE[SSTUResourceSwitch]
-	{
-	}
-	%MODULE[SSTUResourceSwitch]
-	{
-		externalControl = true
-		TANK
-		{
-			tankName = Plain
-			tankDryMass = 4.39453125
-			tankCost = 1800
-			TANKRESOURCE
-			{
-				resource = MMH
-				amount = 50 
-				fillAmount = 50
-			}
-			TANKRESOURCE
-			{
-				resource = NTO
-				amount = 50 
-				fillAmount = 50
-			}
-			TANKRESOURCE
-			{
-				resource = ElectricCharge
-				amount = 600000
-				fillAmount = 600000
-			}
-			TANKRESOURCE
-		  {
-  			resource = Food
-	  		fillAmount = 22
-  			amount = 36.6
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Water
-  			fillAmount = 19.3
-  			amount = 19.3
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Oxygen
-  			fillAmount = 2220
-  			amount = 3700
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = CarbonDioxide
-  			fillAmount = 0
-  			amount = 767
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Waste
-  			fillAmount = 0
-  			amount = 24.2
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = WasteWater
-  			fillAmount = 0
-  			amount = 20
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = LithiumHydroxide
-  			fillAmount = 3.9
-  			amount = 6.5
-  		}
-		}
-		TANK
-		{
-			tankName = Ascent Tanks
-			tankDryMass = 5.078125
-			tankCost = 2400
-			TANKRESOURCE
-			{
-				resource = ElectricCharge
-				amount = 600000
-				fillAmount = 600000
-			}
-			TANKRESOURCE
-			{
-				resource = MMH
-				amount = 2091.164311
-				fillAmount = 2091.164311
-			}
-			TANKRESOURCE
-			{
-				resource = NTO
-				amount = 2055.975064
-				fillAmount = 2055.975064
-			}
-			TANKRESOURCE
-		  {
-  			resource = Food
-	  		fillAmount = 22
-  			amount = 36.6
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Water
-  			fillAmount = 19.3
-  			amount = 19.3
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Oxygen
-  			fillAmount = 2220
-  			amount = 3700
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = CarbonDioxide
-  			fillAmount = 0
-  			amount = 767
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Waste
-  			fillAmount = 0
-  			amount = 24.2
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = WasteWater
-  			fillAmount = 0
-  			amount = 20
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = LithiumHydroxide
-  			fillAmount = 3.9
-  			amount = 6.5
-  		}
-		}
-	}
+	!MODULE[ModuleReactionWheel]{}
+	!MODULE[SSTUResourceSwitch]{}
+	!MODULE[SSTUVolumeContainer]{}
+	!MODULE[SSTUResourceBoiloff]{}
 }
 @PART[SSTU_LanderCore_LC5-POD]:FOR[RealismOverhaul]
 {
@@ -1433,80 +1235,120 @@
 	{
 	}
 	@mass *= 1.953125
-	@MODEL,*
+	@MODEL,0
 	{
 		%scale = 1.25,1.25,1.25
 	}
+	@MODEL,1
+	{
+		%scale = 1.25,1.25,1.25
+		%position = 0, 1.5184, 0
+	}
+	@MODEL,2
+	{
+		%scale = 0.8525,0.8525,0.8525
+		%position = 2.081975, 0, 2.081975
+	}
+	@MODEL,3
+	{
+		%scale = 0.8525,0.8525,0.8525
+		%position = 2.081975, 0, -2.081975
+	}
+	@MODEL,4
+	{
+		%scale = 0.8525,0.8525,0.8525
+		%position = -2.081975, 0, -2.081975
+	}
+	@MODEL,5
+	{
+		%scale = 0.8525,0.8525,0.8525
+		%position = -2.081975, 0, 2.081975
+	}
 	//%rescaleFactor = 1.25
 	@node_stack_bottomEngine = 0,-1.673625,0,0,-1,0,2
-	@node_stack_top = 0,1.4559,0,0,1,0,2
+	@node_stack_top = 0,1.62835,0,0,1,0,2
 	@node_stack_bottom = 0,-1.7628375,0,0,-1,0,2
+	@node_stack_center = 0,-0.3,0,0,1,0,2
 	@crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 0.5
+		volume = 9000
 		utilizationTweakable = true
 		type = ServiceModule
+		%TANK[ElectricCharge]
+		{
+			amount = 600000
+			maxAmount = 600000
+		}
+		%TANK[MMH]
+		{
+			amount = 50.4
+			maxAmount = 50.4
+		}
+		%TANK[NTO]
+		{
+			amount = 49.6
+			maxAmount = 49.6
+		}
+		%TANK[Food]
+		{
+			amount = 245.7
+			maxAmount = 245.7
+		}
+		%TANK[Water]
+		{
+			amount = 162.6
+			maxAmount = 162.6
+		}
+		%TANK[Oxygen]
+		{
+			amount = 25000
+			maxAmount = 25000
+		}
+		%TANK[CarbonDioxide]
+		{
+			amount = 0
+			maxAmount = 1025
+		}
+		%TANK[Waste]
+		{
+			amount = 0
+			maxAmount = 170
+		}
+		%TANK[WasteWater]
+		{
+			amount = 0
+			maxAmount = 210
+		}
+		%TANK[LithiumHydroxide]
+		{
+			amount = 43.2
+			maxAmount = 43.2
+		}
 	}
-	@RESOURCE[ElectricCharge]
+	!RESOURCE[ElectricCharge]{}
+	!RESOURCE[MMH]{}
+	!RESOURCE[NTO]{}
+	!RESOURCE[Food]{}
+	!RESOURCE[Water]{}
+	!RESOURCE[Oxygen]{}
+	!RESOURCE[CarbonDioxide]{}
+	!RESOURCE[Waste]{}
+	!RESOURCE[WasteWater]{}
+	!RESOURCE[LithiumHydroxide]{}
+	MODULE:NEED[TacLifeSupport]
 	{
-		amount = 600000
-		maxAmount = 600000
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
 	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
-	%RESOURCE[MMH]
-	{
-		amount = 50
-		maxAmount = 50
-	}
-	%RESOURCE[NTO]
-	{
-		amount = 50
-		maxAmount = 50
-	}
-	%RESOURCE[Food]
-	{
-		amount = 22
-		maxAmount = 36.6
-	}
-	%RESOURCE[Water]
-	{
-		amount = 19.3
-		maxAmount = 19.3
-	}
-	%RESOURCE[Oxygen]
-	{
-		amount = 2220
-		maxAmount = 3700
-	}
-	%RESOURCE[CarbonDioxide]
-	{
-		amount = 0
-		maxAmount = 767
-	}
-	%RESOURCE[Waste]
-	{
-		amount = 0
-		maxAmount = 24.2
-	}
-	%RESOURCE[WasteWater]
-	{
-		amount = 0
-		maxAmount = 20
-	}
-	%RESOURCE[LithiumHydroxide]
-	{
-		amount = 3.9
-		maxAmount = 6.5
-	}
-	!MODULE[ModuleRCS]
-	{
-	}
+	!RESOURCE[MonoPropellant]{}
+	!MODULE[ModuleRCS]{}
 	MODULE
 	{
 		name = ModuleRCS
@@ -1537,148 +1379,10 @@
 			rate = 1.01
 		}
 	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!MODULE[SSTUResourceSwitch]
-	{
-	}
-	%MODULE[SSTUResourceSwitch]
-	{
-		externalControl = true
-		TANK
-		{
-			tankName = Plain
-			tankDryMass = 8.3984375
-			tankCost = 1800
-			TANKRESOURCE
-			{
-				resource = MMH
-				amount = 50 
-				fillAmount = 50
-			}
-			TANKRESOURCE
-			{
-				resource = NTO
-				amount = 50 
-				fillAmount = 50
-			}
-			TANKRESOURCE
-			{
-				resource = ElectricCharge
-				amount = 600000
-				fillAmount = 600000
-			}
-			TANKRESOURCE
-		  {
-  			resource = Food
-	  		fillAmount = 22
-  			amount = 36.6
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Water
-  			fillAmount = 19.3
-  			amount = 19.3
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Oxygen
-  			fillAmount = 2220
-  			amount = 3700
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = CarbonDioxide
-  			fillAmount = 0
-  			amount = 767
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Waste
-  			fillAmount = 0
-  			amount = 24.2
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = WasteWater
-  			fillAmount = 0
-  			amount = 20
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = LithiumHydroxide
-  			fillAmount = 3.9
-  			amount = 6.5
-  		}
-		}
-		TANK
-		{
-			tankName = Ascent Tanks
-			tankDryMass = 9.4140625
-			tankCost = 2400
-			TANKRESOURCE
-			{
-				resource = ElectricCharge
-				amount = 600000
-				fillAmount = 600000
-			}
-			TANKRESOURCE
-			{
-				resource = MMH
-				amount = 3047.021829
-				fillAmount = 3047.021829
-			}
-			TANKRESOURCE
-			{
-				resource = NTO
-				amount = 2996.589186
-				fillAmount = 2996.589186
-			}
-			TANKRESOURCE
-		  {
-  			resource = Food
-	  		fillAmount = 22
-  			amount = 36.6
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Water
-  			fillAmount = 19.3
-  			amount = 19.3
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Oxygen
-  			fillAmount = 2220
-  			amount = 3700
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = CarbonDioxide
-  			fillAmount = 0
-  			amount = 767
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = Waste
-  			fillAmount = 0
-  			amount = 24.2
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = WasteWater
-  			fillAmount = 0
-  			amount = 20
-  		}
-  		TANKRESOURCE
-  		{
-  			resource = LithiumHydroxide
-  			fillAmount = 3.9
-  			amount = 6.5
-  		}
-		}
-	}
+	!MODULE[ModuleReactionWheel]{}
+	!MODULE[SSTUResourceSwitch]{}
+	!MODULE[SSTUVolumeContainer]{}
+	!MODULE[SSTUResourceBoiloff]{}
 }
 @PART[SSTU_LanderCore_LC-DC3]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
I know most of the Lander components have been (at least temporarily) removed from SSTU due to compatibility problems with KSP 1.1, but the three pods do still exist.  I decided not to remove the missing parts from this file as I'm guessing they will eventually be returned.  All I'm doing here is updating the three lander pods so they are usable in RO.  These changes primarily adjust the size/position of the RCS thrusters, docking port and attachment points.  I've also removed the static RESOURCES and replaced the SSTUVolumeContainer with ModuleFuelTanks.  I left the SSTUModelSwitch from the base files in place though they are currently just visual changes as I don't know of any way to have ModuleFuelTanks have it's volume altered on the fly.