### PR TITLE
DRE heat shields category

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -789,6 +789,18 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%maxTemp = 2900
 	%emissiveConstant = 0.85 // don't want too much or too little
 }
+
+//  ==================================================
+//  Heat shield decoupler (0.625 m).
+//  ==================================================
+
+@PART[decoupler_ftr_smaller]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    @category = none
+}
+
 @PART[decoupler_ftr_small]:FOR[RealismOverhaul]
 {
 	@MODULE[TweakScale]

--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -39,6 +39,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	{
 	}
 	%RSSROConfig = True
+    @category = Aero
 	@title = Heatshield (0.625m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.004
@@ -101,6 +102,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 1
+    @category = Aero
 	@title = Heatshield (1m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.01
@@ -156,6 +158,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	{
 	}
 	%RSSROConfig = True
+    @category = Aero
 	@title = Heatshield (1.25m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.016
@@ -218,6 +221,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 1
+    @category = Aero
 	@title = Heatshield (1.5m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.0225
@@ -284,6 +288,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 2
+    @category = Aero
 	@title = Heatshield (2m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.04
@@ -350,6 +355,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 2
+    @category = Aero
 	@title = Heatshield (2.5m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.0625
@@ -416,6 +422,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 3
+    @category = Aero
 	@title = Heatshield (3m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.09
@@ -478,6 +485,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 3
+    @category = Aero
 	@title = Heatshield (3.75m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.141
@@ -540,6 +548,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 4
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 4
+    @category = Aero
 	@title = Heatshield (4m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.16
@@ -602,6 +611,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.06196643, 0.0, 0.0, 1.0, 0.0, 5
 	@node_stack_bottom = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 5
+    @category = Aero
 	@title = Heatshield (5m)
 	@description = LEO-rated heat shield. Not rated for lunar returns.
 	@mass = 0.25
@@ -667,6 +677,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	{
 		cube = Default, 1.110888,0.4409201,2.067353, 1.110888,0.4409075,2.067353, 12.55,1,0.05, 12.55,0.972568,0.05, 1.110888,0.4385583,2.067353, 1.110888,0.4432642,2.067353, 0,0.0,-8.820669E-08, 5.78,0.45,5.78
 	}
+    @category = Aero
 	@title = Heatshield (4m) - Mk 1-2 Pod
 	@description = LEO-rated heat shield for Mk1-2 and other 4m pods. Not rated for lunar returns.
 	@mass = 0.15
@@ -722,6 +733,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	!MODULE[TweakScale]
 	{
 	}
+    @category = Aero
 	@title = Heatshield (3.75m)
 	@mass = 0.14
 	@maxTemp = 1500
@@ -772,6 +784,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	{
 	}
 	%RSSROConfig = True
+    @category = Aero
 	@title = Heatshield (6.25m) - Inflatable
 	%maxTemp = 2900
 	%emissiveConstant = 0.85 // don't want too much or too little


### PR DESCRIPTION
* Move the DeadlyReentry heat shields from the "Structural" category to the "Aero" category for better organization.