### PR TITLE
RO SXT Utility updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -844,6 +844,58 @@
 }
 
 //  ==================================================
+//  PPD-SM400 service module.
+
+//  Dimensions: 3.1 m x 2.4 m
+//  Inert Mass: 6000 Kg
+//  ==================================================
+
+@PART[LSVCM3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL,0
+    {
+        %scale = 1.2, 1.2, 1.2
+    }
+
+    @MODEL,1
+    {
+        %scale = 1.2, 1.2, 1.2
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+    !rimFalloff = NULL
+
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Utility
+    @title = PPD-SM400 Service Module
+    @manufacturer = Generic
+    @description = An innovative multi-purpose design. Allows the storage of multiple and various resources to suit most mission parameters easily accessible by the crew.
+
+    @mass = 6.0
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    @skinMaxTemp = 873.15
+    %fuelCrossFeed = True
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 8000
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
 //  PPD-SM1600 service module.
 
 //  Dimensions: 3.1 m x 2.4 m
@@ -882,6 +934,7 @@
     @breakingTorque = 250
     @maxTemp = 773.15
     @skinMaxTemp = 873.15
+    %fuelCrossFeed = True
 
     @MODULE[ModuleFuelTanks]
     {
@@ -929,6 +982,7 @@
     @breakingTorque = 250
     @maxTemp = 773.15
     @skinMaxTemp = 873.15
+    %fuelCrossFeed = True
 
     @MODULE[ModuleFuelTanks]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -842,3 +842,97 @@
     
     @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.
 }
+
+//  ==================================================
+//  PPD-SM1600 service module.
+
+//  Dimensions: 3.1 m x 2.4 m
+//  Inert Mass: 6000 Kg
+//  ==================================================
+
+@PART[LFUELM3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL,0
+    {
+        %scale = 1.2, 1.2, 1.2
+    }
+
+    @MODEL,1
+    {
+        %scale = 1.2, 1.2, 1.2
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+    !rimFalloff = NULL
+
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Utility
+    @title = PPD-SM1600 Service Module
+    @manufacturer = Generic
+    @description = An innovative multi-purpose design. Allows the storage of multiple and various resources to suit most mission parameters.
+
+    @mass = 6.0
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    @skinMaxTemp = 873.15
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 8000
+        %basemass = -1
+    }
+}
+
+//  ==================================================
+//  PPD-SM555 service module.
+
+//  Dimensions: 3.1 m x 0.8 m
+//  Inert Mass: 2000 Kg
+//  ==================================================
+
+@PART[LSmallFuelMod]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL,0
+    {
+        %scale = 1.2, 1.2, 1.2
+    }
+
+    @MODEL,1
+    {
+        %scale = 1.2, 1.2, 1.2
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+    !rimFalloff = NULL
+
+    @node_stack_top = 0.0, 0.42, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.42, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Utility
+    @title = PPD-SM555 Service Module
+    @manufacturer = Generic
+    @description = A smaller version of the PPD-SM1600. Can hold approximately one third of the resources.
+
+    @mass = 2.0
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    @skinMaxTemp = 873.15
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 3000
+        %basemass = -1
+    }
+}


### PR DESCRIPTION
* Add RO support for the space station service module tanks. Compatible with the PPD-4 and PPD-6 Crew Cabins.