### PR TITLE
RO CoatlAerospace ProbesPlus updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -51,9 +51,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
@@ -123,9 +123,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
@@ -193,9 +193,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
@@ -267,9 +267,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
@@ -345,9 +345,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
@@ -419,9 +419,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {
@@ -493,9 +493,9 @@
 {
     !MODULE[ModuleDataTransmitter]{}
 
-    !MODULE[ModuleSPUPassive]{}
+    !MODULE[ModuleSPU*]{}
 
-    !MODULE[ModuleRTAntenna]{}
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -108,6 +108,22 @@
 }
 
 //  ==================================================
+//  SSTL-150 satellite bus.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[barquetta]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleSPU*]{}
+
+    MODULE
+    {
+        name = ModuleSPU
+    }
+}
+
+//  ==================================================
 //  Voyager spacecraft bus.
 
 //  Dimensions: 1.78 m x 0.8 m
@@ -192,6 +208,22 @@
 }
 
 //  ==================================================
+//  Voyager spacecraft bus.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[torekka]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleSPU*]{}
+
+    MODULE
+    {
+        name = ModuleSPU
+    }
+}
+
+//  ==================================================
 //  Pioneer 10/11 spacecraft bus.
 
 //  Dimensions: 1.45 m x 0.6 m
@@ -271,4 +303,20 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Pioneer 10/11 spacecraft bus.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleSPU*]{}
+
+    MODULE
+    {
+        name = ModuleSPU
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -143,6 +143,11 @@
     %fuelCrossFeed = False
     %tags = attitude control
 
+    @MODULE[ModuleSAS]
+    {
+        %standalone = True
+    }
+
     @RESOURCE[ElectricCharge]
     {
         @amount = 10
@@ -171,4 +176,9 @@
     %skinMaxTemp = 673.15
     %fuelCrossFeed = False
     %tags = attitude control
+
+    @MODULE[ModuleSAS]
+    {
+        %standalone = True
+    }
 }


### PR DESCRIPTION
* Add missing Remote Tech support to the probe cores.
* Make the Remote Tech patching a bit more "bulletproof".
* Make the AACS and the StarTracker SAS modules standalone.