### PR TITLE
RO Squad Engines updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  RD-253
+//  RD-253 (booster engine).
 //  ==================================================
 
 +PART[engineLargeSkipper]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -21,11 +21,6 @@
 		scale = 1.82, 1.82, 1.82
 	}
 
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
-	}
-
     %scale = 1.0
 	@rescaleFactor = 1.0
 
@@ -33,11 +28,10 @@
 	@node_stack_bottom = 0.0, -3.74, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.02, 0.0, 0.0, 1.0, 0.0, 2
 
-	%attachRules = 1,1,1,1,0
-
 	%mass = 1.28
-	%maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = RD253
     %engineTypeMult = 1
@@ -46,6 +40,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 1635
 		@maxThrust = 1635
 		@heatProduction = 100
@@ -68,12 +63,24 @@
 			@key,1 = 1 285
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  RL10
+//  RD-253 (booster engine).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[RO-RD-253]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@MODEL
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
+	}
+}
+
+//  ==================================================
+//  RL10 (vacuum engine).
 //  ==================================================
 
 @PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -89,10 +96,6 @@
 		model = Squad/Parts/Engine/liquidEngineSkipper/model
 		scale = 0.8415, 0.8415, 0.8415
 	}
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
-	}
 
     %scale = 1.0
 	@rescaleFactor = 1.0
@@ -100,12 +103,11 @@
 	@node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.725, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
-	
-	%attachRules = 1,1,1,1,0
 
 	%mass = 0.167
-	%maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = RL10
     %engineTypeMult = 1
@@ -114,6 +116,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 65.6
 		%minThrust = 65.6
 		%heatProduction = 100
@@ -136,12 +139,24 @@
 			@ratio = 0.237
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  NSTAR
+//  RL10 (vacuum engine).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@MODEL
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
+	}
+}
+
+//  ==================================================
+//  NSTAR (ion engine).
 //  ==================================================
 
 @PART[ionEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -167,8 +182,9 @@
 	@category = Engine
 
 	@mass = 0.0495
-	@maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @crashTolerance = 10
+	@maxTemp = 673.15
+    %skinMaxTemp = 673.15
 
     %engineType = NSTAR
     %engineTypeMult = 1
@@ -177,6 +193,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 0.000019
 		@maxThrust = 0.000092
 		@heatProduction = 0	
@@ -208,12 +225,10 @@
 			rate = -2.3
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  LR105
+//  LR105 (sustainer engine).
 //  ==================================================
 
 @PART[liquidEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -236,11 +251,10 @@
 	%node_stack_top = 0.0, 1.44, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.375, 0.0, 0.0, -1.0, 0.0, 2
 
-	@attachRules = 1,0,1,0,0
-
 	@mass = 0.46 // I think 844kg was for the engine + tank.
-	@maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = LR105
     %engineTypeMult = 1
@@ -249,6 +263,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@maxThrust = 366.1
 		@minThrust = 366.1
 		@heatProduction = 100
@@ -272,16 +287,17 @@
 		}
 	}
 
+    //  Placeholder gimbal module.
+
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
-		gimbalRange = 3
 	}
 }
 
 //  ==================================================
-//  LR79
+//  LR79 (booster engine).
 //  ==================================================
 
 @PART[liquidEngine1-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -304,11 +320,10 @@
 	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
-	@attachRules = 1,0,1,0,0
-
 	@mass = 0.907
-	@maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = LR79
     %engineTypeMult = 1
@@ -317,6 +332,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 947
 		%minThrust = 947
 		%heatProduction = 100
@@ -339,21 +355,10 @@
 			@ratio = 0.6158
 		}
 	}
-
-    !MODULE[TweakScale]{}
-	
-	@MODULE[ModuleGimbal]
-	{
-		!gimbalRange = DEL // just in case
-		%gimbalTransformName = thrustTransform
-		%gimbalRange = 10
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
 }
 
 //  ==================================================
-//  H-1/RS-27
+//  H-1/RS-27 (booster engine).
 //  ==================================================
 
 +PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -382,8 +387,9 @@
     @node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 0.907
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = H1
     %engineTypeMult = 1
@@ -392,6 +398,7 @@
 
     @MODULE[ModuleEngines*]
     {
+        @name = ModuleEnginesRF
         @maxThrust = 947
         @minThrust = 947
         @heatProduction = 100
@@ -414,21 +421,10 @@
             @key,1 = 1 255
         }
     }
-	
-	@MODULE[ModuleGimbal]
-	{
-		!gimbalRange = DEL // just in case
-		%gimbalTransformName = thrustTransform
-		%gimbalRange = 10
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  LR89
+//  LR89 (booster engine).
 //  ==================================================
 
 +PART[liquidEngine1-2]:BEFORE[RealismOverhaul]
@@ -456,11 +452,10 @@
 	@node_stack_top = 0.0, 0.735, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.235, 0.0, 0.0, -1.0, 0.0, 2
 
-	@attachRules = 1,0,1,0,0
-
 	@mass = 0.72
-	@maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = LR89
     %engineTypeMult = 1
@@ -469,6 +464,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 758.7
 		%minThrust = 758.7
 		%heatProduction = 100
@@ -491,21 +487,10 @@
 			@ratio = 0.618
 		}
 	}
-	
-	@MODULE[ModuleGimbal]
-	{
-		!gimbalRange = DEL // just in case
-		%gimbalTransformName = thrustTransform
-		%gimbalRange = 10
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  S1.5400/11D33, RD-58
+//  S1.5400/11D33, RD-58 (vacuum engine).
 //  ==================================================
 
 @PART[liquidEngine2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -525,15 +510,14 @@
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
-	@node_stack_top = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_top = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.315, 0.0, 0.0, -1.0, 0.0, 1
-	%node_attach = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 1
-
-	@attachRules = 1,1,1,0,0
+	%node_attach = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0
 
 	@mass = 0.15
-	@maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = RD58
     %engineTypeMult = 1
@@ -542,31 +526,33 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 63.7
 		%minThrust = 63.7
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 338.6
 			@key,1 = 1 100
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
 			@ratio = 0.359
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.641
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  RD-0210
+//  RD-0210 (booster engine).
 //  ==================================================
 
 +PART[liquidEngine2-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -594,11 +580,10 @@
 	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
 
-	%attachRules = 1,0,1,0,0
-
 	%mass = 0.566
-	%maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = RD0210
     %engineTypeMult = 1
@@ -607,6 +592,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 582.1
 		@maxThrust = 582.1
 		@heatProduction = 100
@@ -630,12 +616,10 @@
 			@key,1 = 1 225
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  LMDE
+//  LMDE (vacuum engine).
 //  ==================================================
 
 @PART[liquidEngine2-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -658,11 +642,10 @@
 	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
 
-	%attachRules = 1,0,1,0,0
-
 	%mass = 0.135
-	%maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = LMDE
     %engineTypeMult = 1
@@ -671,6 +654,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%minThrust = 4.67
 		%maxThrust = 43.9
 		%heatProduction = 100
@@ -696,7 +680,7 @@
 }
 
 //  ==================================================
-//  RD-0105/0109
+//  RD-0105/0109 (vacuum engine).
 //  ==================================================
 
 @PART[liquidEngine3]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -713,22 +697,16 @@
 		scale = 2.0, 2.0, 2.0
 	}
 
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909B
-	}
-
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
 	%node_stack_top = 0.0, 0.46, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 2
 
-	%attachRules = 1,0,1,0,0
-
 	%mass = 0.125
-	%maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = RD0105
     %engineTypeMult = 1
@@ -737,6 +715,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%minThrust = 49.4
 		%maxThrust = 49.4
 		%heatProduction = 100
@@ -759,12 +738,24 @@
 			@key,1 = 1 100
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
 //  ==================================================
-//  LMAE
+//  RD-0105/0109 (vacuum engine).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[liquidEngine3]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@MODEL
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909
+	}
+}
+
+//  ==================================================
+//  LMAE (vacuum engine).
 //  ==================================================
 
 @PART[liquidEngineMini]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -787,11 +778,10 @@
 	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.605, 0.0, 0.0, -1.0, 0.0, 2
 
-	%attachRules = 1,0,1,0,0
-
 	%mass = 0.095
-	%maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
     %engineType = LMAE
     %engineTypeMult = 1
@@ -800,6 +790,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 15.57
 		%minThrust = 15.57
 		%heatProduction = 100
@@ -822,93 +813,142 @@
 			@ratio = 0.4983
 		}
 	}
-
-    !MODULE[TweakScale]{}
 }
 
-// Surveyor RD-339 vernier engine.
+//  ==================================================
+//  TD-339 (vernier engine).
+//  ==================================================
+
 +PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = RO-SurveyorVernier
 }
+
 @PART[RO-SurveyorVernier]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	@MODEL:NEEDS[VenStockRevamp]
+
+	@mass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+	%engineType = TD339
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 0.134
+        @maxThrust = 0.463
+        @heatProduction = 100
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+            @ratio = 0.516
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = MON10
+            @ratio = 0.484
+        }
+
+        @atmosphereCurve
+        {
+            @key = 0 287
+            @key = 1 100
+        }
+    }
+}
+
+//  ==================================================
+//  TD-339 (vernier engine).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[RO-SurveyorVernier]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@MODEL
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
 	}
-	
-	@mass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
-	@maxTemp = 1973.15
-	!MODULE[ModuleEngineConfigs] {}
-	@MODULE[ModuleEngines*]
-	{
-		!IGNITOR_RESOURCE,* {}
-	}
-	
-	engineType = TD339
-	
-	!useRcsConfig = DEL
-	!useRcsCostMult = DEL
-	!useRcsMass = DEL
+
+    !node_stack_top2 = NULL
+
+    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
-// Not using engineType, this engine is virtually RCS.
+//  ==================================================
+//  Generic 1 kN thruster.
+
+//  Not using engineType, this engine is virtually
+//  an RCS thruster.
+//  ==================================================
+
 @PART[microEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
-	}
-	
+
 	%title = 1kN Thruster
 	%manufacturer = Generic
 	%description = Thruster for orbital maneuvers, similar to ones used in the Galileo probe.
-	%attachRules = 1,1,1,0,0
+
 	%mass = 0.015
-	%maxTemp = 1973.15
-	!MODULE[ModuleJettison],*:NEEDS[VenStockRevamp] {} // no tankbutss in LV-1B model
-	!node_stack_top1 = DEL // no tankbutts in model, no need for extra node.
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+	%useRcsConfig = RCSBlock4x
+	%useRcsCostMult = 0.25
+	%useRcsMass = True
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 1.618
 		%minThrust = 1.618
 		%heatProduction = 17.5
+		%ullage = False
+		%pressureFed = True
+        %ignitions = -1
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 321
 			@key,1 = 1 112
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = MMH
 			@ratio = 0.504
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
 			@ratio = 0.496
 		}
-		ullage = False
-		pressureFed = True
+
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
 			amount = 0.01
 		}
 	}
-	useRcsConfig = RCSBlock4x
-	useRcsCostMult = 0.25
-	useRcsMass = True
 }
+
+//  ==================================================
+//  Generic 1 kN thruster.
+
+//  TestFlight compatibility.
+//  ==================================================
+
 @PART[microEngine]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -924,6 +964,7 @@
 		reliabilityDataRateMultiplier = 0.1
 		techTransfer = NitrousOxide,HTP,Hydrazine,Cavea-B,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
 	}
+
 	TESTFLIGHT
 	{
 		name = MonopropellantRCS
@@ -937,6 +978,7 @@
 		reliabilityDataRateMultiplier = 0.1
 		techTransfer = Helium,Nitrogen,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
 	}
+
 	TESTFLIGHT
 	{
 		name = BipropellantRCS
@@ -952,34 +994,69 @@
 	}
 }
 
-// AJ10-137 Apollo SPS
-+PART[microEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+//  ==================================================
+//  Generic 1 kN thruster.
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[microEngine]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@MODEL
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
+	}
+
+    !node_stack_top2 = NULL
+
+    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
+}
+
+//  ==================================================
+//  AJ10-137 (Apollo SPS).
+//  ==================================================
+
++PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = ROAJ10-137
+}
+
+@PART[ROAJ10-137]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DEL
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-1/model
 		scale = 17.5, 17.5, 17.5
 		position = 0.0, 2.0, 0.0
 	}
+
 	%node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 4
 	%node_attach = 0.0, 0.016, 0.01, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -2.93, 0.0, 0.0, -1.0, 0.0, 3
-	%attachRules = 1,1,1,0,0
-	@mass = 0.650
-	@maxTemp = 1973.15
-	!MODULE[ModuleEngineConfigs] {}
+
+	@mass = 0.65
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = AJ10_137
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 97.86
 		@maxThrust = 97.86
 		@heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Aerozine50
@@ -995,113 +1072,127 @@
 			@key,0 = 0 314
 			@key,1 = 1 150
 		}
-		!IGNITOR_RESOURCE,* {}
 	}
-	engineType = AJ10_137
-	// have to add a gimbal module to thid part.
+
+    //  Placeholder gimbal module.
+
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
-		gimbalRange = 4.5
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
 	}
-	!useRcsConfig = DEL
-	!useRcsCostMult = DEL
-	!useRcsMass = DEL
 }
 
-@PART[ROAJ10-137]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+//  ==================================================
+//  AJ10-137 (Apollo SPS).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[ROAJ10-137]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	@MODEL
 	{
-		%model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
-		%scale = 17.35, 9.0, 17.35
-		%position = 0.0, 0.1, 0.0
+		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
+		@scale = 17.35, 9.0, 17.35
+		@position = 0.0, 0.1, 0.0
 	}
+
 	%node_stack_top = 0.0, 0.001, 0.0, 0.0, 1.0, 0.0, 4
+    !node_stack_top2 = NULL
 	%node_attach = 0.0, 0.0, 0.001, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -2.123, 0.0, 0.0, -1.0, 0.0, 3
-	
+
 	@MODULE[ModuleGimbal]
-	{
-		%gimbalTransformName = Gimbal
-	}
+    {
+        @gimbalTransformName = Gimbal
+    }
+
+    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
-// Aerobee / WAC sustainer
-+PART[microEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+//  ==================================================
+//  Aerobee / WAC sustainer.
+//  ==================================================
+
++PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = ROAerobeeSustainer
+}
+
+@PART[ROAerobeeSustainer]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DEL
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-1/model
 		scale = 0.8, 0.64, 0.8
 		position = 0.0, 0.096, 0.0
 	}
+
 	%node_stack_top = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
 	%node_attach = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_bottom = 0.0, -0.08432, 0.0, 0.0, -1.0, 0.0, 0
-	
-	%attachRules = 1,1,1,0,0
+	%node_stack_bottom = 0.0, -0.084, 0.0, 0.0, -1.0, 0.0, 0
+
 	// FIXME section
 	%mass = 0.008 // total guess
 	// ALSO: Mass ratio of propellants are total guesses.
 	// In fact, it's 65:35 Aniline:Furfuryl Alc. Presume mass ratio for RFNA:that is same as IWFNA:UDMH for Able?
 	// And Isps of Aerobee engines, too. Hard to find docs.
-	%maxTemp = 1273.15
-	!fx_exhaustFlame_white_tiny = 0.0, -0.2816985, 0.0, 0.0, 1.0, 0.0, running
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
-	!sound_vent_medium = engage
-	!sound_rocket_mini = running
-	!sound_vent_soft = disengage
-	!sound_explosion_low = flameout
-	// stolen from 24-77
+    %engineType = Aerobee
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 6.7
 		%minThrust = 6.7
 		%heatProduction = 40
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 230
 			@key,1 = 1 184
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Aniline
 			@ratio = 0.326832
 		}
+
 		PROPELLANT
 		{
 			name = Furfuryl
 			ratio = 0.081708
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = IRFNA-III
 			@ratio = 0.59146
 		}
-
-		!IGNITOR_RESOURCE,* {}
 	}
-	!MODULE[ModuleEngineConfigs] {}
-	
-	engineType = Aerobee
-	
-	!useRcsConfig = DEL
-	!useRcsCostMult = DEL
-	!useRcsMass = DEL
 }
 
-@PART[ROAerobeeSustainer]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+//  ==================================================
+//  Aerobee / WAC sustainer.
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[ROAerobeeSustainer]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	@MODEL
 	{
@@ -1109,54 +1200,77 @@
 		%scale = 0.2125, 0.17, 0.2125
 		%position = 0.0, 0.1, 0.0
 	}
+
 	%node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    !node_stack_top2 = NULL
 	%node_attach = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_bottom = 0.0, -0.11091152, 0.0, 0.0, -1.0, 0.0, 0
+	%node_stack_bottom = 0.0, -0.111, 0.0, 0.0, -1.0, 0.0, 0
+
+    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
-// Nuclear Thermal NERVA 1 engine
+//  ==================================================
+//  NERVA 1 (Nuclear Thermal Rocket engine).
+//  ==================================================
+
 @PART[nuclearEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-N/model
-		scale = 1.04, 1.122206, 1.04
+		scale = 2.95, 2.86, 2.95
 	}
-	@scale = 1.122206
-	%rescaleFactor = 2.94
-	@node_stack_top = 0.0, 1.40383, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.731957, 0.0, 0.0, -1.0, 0.0, 1
+
+	@scale = 1.0
+	%rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 4.05, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -5.0, 0.0, 0.0, -1.0, 0.0, 3
 	
 	@mass = 8.5
-	@maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = NERVA
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 111
 		@maxThrust = 333
 		@heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
 			@ratio = 1.0
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = EnrichedUranium
 			@ratio = 0.00000000001
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 925
 			@key,1 = 1 380
 		}
 	}
-	engineType = NERVA
+
+    //  Placeholder gimbal module.
+
 	MODULE
 	{
 		name = ModuleGimbal
@@ -1164,228 +1278,262 @@
 	}
 }
 
-// Radial AJ10-190 OMS engine.
+//  ==================================================
+//  AJ10-190 (radial).
+//  ==================================================
+
 @PART[omsEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
+
 	@MODEL
 	{
 		%scale = 11.0, 11.0, 11.0
-		%position = 0, 0, 0
-		%rotation = 38, 0, 0
+		%position = 0.0, 0.0, 0.0
+		%rotation = 380., 0.0, 0.0
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
 	
 	@mass = 0.118
-	@maxTemp = 1973.15
-	@PhysicsSignificance = 0
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = AJ10_190
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 26.7
 		@maxThrust = 26.7
 		@heatProduction = 17.5
+
 		@PROPELLANT[MonoPropellant]
 		{
 			@name = MMH
 			@ratio = 0.504
 		}
+
 		PROPELLANT
 		{
 			name = NTO
 			ratio = 0.496
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 316
 			@key,1 = 1 100
 		}
-		ullage = False
-		pressureFed = True
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.3
-		}
 	}
-	engineType = AJ10_190
 }
 
-@PART[omsEngine]:FOR[RealismOverhaul]:AFTER[RealismOverhaulEngines]
+//  ==================================================
+//  AJ10-190 (radial).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[omsEngine]:AFTER[RealismOverhaulEngines]
 {
 	@title = AJ10-190 [Radial]
 	
-	!MODULE[ModuleGimbal]
-	{
-	}
+	!MODULE[ModuleGimbal],*{}
 }
 
-//	LR101 Atlas, Thor/Delta Vernier
+//  ==================================================
+//  LR101 (Atlas, Thor/Delta vernier).
+//  ==================================================
+
 @PART[radialEngineMini]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
 
-	%attachRules = 0,1,0,0,0
 	%mass = 0.024
-	%maxTemp = 1973.15
-	!fx_exhaustFlame_white_tiny = 0.0, -0.075, -0.3, 0.0, 1.0, 0.0, running
-	!sound_vent_medium = engage
-	!sound_rocket_mini = running
-	!sound_vent_soft = disengage
-	!sound_explosion_low = flameout
-	// cribbed from 24-77
-	EFFECTS
-	{
-	  power
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_rocket_mini
-		  volume = 0.0 0 0 0
-		  volume = 0.01 0 0 0
-		  volume = 1.0 1.0
-		  pitch = 0.0 0.8
-		  pitch = 1.0 1.0
-		  loop = true
-		}
-		PREFAB_PARTICLE
-		{
-		  prefabName = fx_exhaustFlame_yellow_tiny_Z
-		  transformName = thrustTransform
-		  emission = 0.0 0 0 0
-		  emission = 0.01 0 0 0
-		  emission = 1.0 1.0
-		  speed = 0.0 0.8
-		  speed = 1.0 1.0
-		}
-	  }
-	  engage
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_vent_medium
-		  loop = false
-		}
-	  }
-	  disengage
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_vent_soft
-		  loop = false
-		}
-	  }
-	}
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = LR101
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
 		%maxThrust = 4.523
 		%minThrust = 4.523
 		%heatProduction = 10
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 243
 			@key,1 = 1 207
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
 			@ratio = 0.382
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.618
 		}
 	}
-	engineType = LR101
 }
 
-// RD-855
+//  ==================================================
+//  RD-855 (vernier engine).
+//  ==================================================
+
 @PART[radialLiquidEngine1-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
 	
-	%attachRules = 1,1,1,0,0
 	%mass = 0.12
-	%maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = RD855
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		%maxThrust = 83
 		%minThrust = 83
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 292
 			@key,1 = 1 254
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = UDMH
 			@ratio = 0.482
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
 			@ratio = 0.518
 		}
 	}
-	engineType = RD855
 }
+
+//  ==================================================
+//  RAPIER.
+//  ==================================================
+
 @PART[RAPIER]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
+
+    @description = The dual-mode active-cooling RAPIER hypersonic engine which burns Methane. SFC 2.0 lb/lbf/hr, O/F in rocket mode 2.8 to 1.
+
+    @maxTemp = 873.15
+    @crashTolerance = 10
+    %skinMaxTemp = 973.15
+
+    @MODULE[ModuleEnginesAJEJet]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdMethane
+        }
+    }
+
+	@MODULE[ModuleEngines*]:HAS[~engineID[AirBreathing]]
 	{
+		@name = ModuleEnginesRF
+		@minThrust = 150
+		@maxThrust = 250
+		@heatProduction = 100
+		%ullage = False
+        %pressureFed = False
+
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdMethane
+			@ratio = 0.49
+		}
+
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.51
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 360
+			@key,1 = 1 300
+		}
 	}
 }
+
+//  ==================================================
+//  Separation motor (large).
+//  ==================================================
+
 @PART[sepMotor1]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/solidBoosterSep/model
 		scale = 2.2, 1.58, 2.2
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	@title = Separation Motor
+
+	@title = Separation Motor (Large)
 	@manufacturer = Generic
 	@description = Small solid motor use to help separate one stage from another. Best used with others.
+
 	@mass = 0.044
-	@maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
+        @minThrust = 98
 		@maxThrust = 98
 		@heatProduction = 17.5
 		%exhaustDamage = False
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 250
 			@key,1 = 0 220
 		}
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -1393,23 +1541,27 @@
 		type = PSPC
 		basemass = -1
 	}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = SolidFuel
 		modded = false
+
 		CONFIG
 		{
 			name = SolidFuel
 			maxThrust = 98
 			heatProduction = 17.5
+
 			PROPELLANT
 			{
 				name = PSPC
-				ratio = 1
+				ratio = 1.0
 				DrawGauge = True
 			}
+
 			atmosphereCurve
 			{
 				key = 0 250
@@ -1417,7 +1569,16 @@
 			}
 		}
 	}
+
+    !RESOURCE,*{}
 }
+
+//  ==================================================
+//  Separation motor (large & small).
+
+//  TestFlight compatibility.
+//  ==================================================
+
 @PART[sepMotor1|SnubOtron]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -1435,89 +1596,100 @@
 	}
 }
 
-//	RD-856 vernier
+//  ==================================================
+//	RD-856 (vernier engine).
+//  ==================================================
+
 @PART[smallRadialEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
 	
-	%attachRules = 1,1,1,0,0
 	%mass = 0.027
-	%maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = RD856
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
-		%maxThrust = 13
-		%minThrust = 13
+        @name = ModuleEnginesRF
+		@maxThrust = 13
+		@minThrust = 13
 		%heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 280
 			@key,1 = 1 84
 		}
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = UDMH
 			@ratio = 0.482
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
 			@ratio = 0.518
 		}
 	}
-
-	engineType = RD856
 }
 
-//	Castor 30XL
+//  ==================================================
+//  Castor 30XL.
+//  ==================================================
+
 @PART[solidBooster]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/solidBoosterRT-10/model
 		scale = 2.3368, 2.632887, 2.3368
 	}
-	@MODEL:NEEDS[VenStockRevamp]
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/RT5
-		@scale = 2.3368, 4.4402956655, 2.3368
-		%position = 0, 0.2577835324, 0
-	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
+
 	@node_stack_bottom = 0.0, -3.294453, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 2.699947, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
 	
-	@attachRules = 1,1,1,1,0
 	@mass = 2.3
-	@maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = Castor-30XL
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 0
+        @name = ModuleEnginesRF
+		@minThrust = 715
 		@maxThrust = 715
 		@heatProduction = 100
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 303
 			@key,1 = 0 100
 		}
 	}
-	@MODULE[ModuleEngines*]:NEEDS[VenStockRevamp]
-	{
-		@thrustVectorTransformName = thrustTransform
-	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -1525,63 +1697,104 @@
 		type = HTPB
 		basemass = -1
 	}
-	MODULE:NEEDS[!VenStockRevamp]
+
+    //  Placeholder gimbal module.
+
+	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
-		gimalRange = 3.5
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
 	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalTransformName = thrustTransform
-	}
-	engineType = Castor-30XL
+
+    !RESOURCE,*{}
 }
 
-//	Castor 120
+//  ==================================================
+//  Castor 30XL.
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[solidBooster]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+	@MODEL
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/RT5
+		@scale = 2.3368, 4.4402956655, 2.3368
+	}
+
+    @node_stack_top = 0.0, 2.45, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -3.95, 0.0, 0.0, -1.0, 0.0, 2
+
+	@MODULE[ModuleEngines*]
+	{
+		@thrustVectorTransformName = thrustTransform
+	}
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalTransformName = thrustTransform
+    }
+}
+
+//  ==================================================
+//	Castor 120.
+//  ==================================================
+
 @PART[solidBooster1-1]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL,* {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/solidBoosterBACC/model
 		scale = 1.88976, 1.148061, 1.88976
 	}
+
 	%rescaleFactor = 1.0
-	@node_stack_bottom = 0.0, -4.494219107637, 0.0, 0.0, -1.0, 0.0, 2
-	@node_stack_top = 0.0, 4.522782865317, 0.0, 0.0, 1.0, 0.0, 2
+
+	@node_stack_bottom = 0.0, -4.74, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 4.47, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1811, 0.0, 0.0, 1.0
 	
-	@attachRules = 1,1,1,1,0
 	@mass = 4.35
-	@maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+	%engineType = Castor-120
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
+        @minThrust = 1970
 		@maxThrust = 1970
 		@heatProduction = 100
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 280
 			@key,1 = 0 253
 		}
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+
+    //  Placeholder gimbal module.
+
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
 	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -1589,47 +1802,65 @@
 		type = HTPB
 		basemass = -1
 	}
-	%engineType = Castor-120
+
+    !RESOURCE,*{}
 }
 
-// J-2T
+//  ==================================================
+//  J-2T (aerospike engine).
+//  ==================================================
+
 @PART[toroidalAerospike]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DELETE
-	!MODEL {}
+
+	!MODEL,*{}
+
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineAerospike/AeroSpike
 		scale = 2.5, 1.667, 2.5
 		position = 0.0, 0.1, 0.0
 	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
+
 	@node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 2
+
 	@mass = 1.4
-	@maxTemp = 1973.15
-	
-	@attachRules = 1,0,1,0,0
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+	%engineType = J2T
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 889.3
 		@maxThrust = 889.3
 		@heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
 			@ratio = 0.745
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.255
 		}
+
 		!atmosphereCurve {}
+
 		atmosphereCurve
 		{
 			key = 0 435 0 -355.588
@@ -1639,18 +1870,22 @@
 			key = 40 0.0001 -2.319966 0
 		}
 	}
-	engineType = J2T
 }
+
+//  ==================================================
+//  Conformal RCS Thruster.
+//  ==================================================
+
 @PART[vernierEngine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	@mass = 0.01
+
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
-	
+
+    @crashTolerance = 10
 	@skinMaxTemp = 2500
 	@maxTemp = 1500
 	
@@ -1663,17 +1898,17 @@
 		@name = ModuleRCS
 		@thrusterPower = 0.275
 		!resourceName = DELETE
+
 		PROPELLANT
 		{
 			ratio = 1.0
 			name = Hydrazine
 		}
-		!PROPELLANT[LiquidFuel]
-		{
-		}
-		!PROPELLANT[Oxidizer]
-		{
-		}
+
+		!PROPELLANT[LiquidFuel]{}
+
+		!PROPELLANT[Oxidizer]{}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 254
@@ -1681,6 +1916,12 @@
 		}
 	}
 }
+
+//  ==================================================
+//  Conformal RCS Thruster.
+
+//  Realism Overhaul/Real Fuels compatibility.
+//  ==================================================
 
 @PART[vernierEngine]:AFTER[RO-RCS]
 {
@@ -1690,10 +1931,12 @@
 		{
 			@IspSL = 0.953
 		}
+
 		@CONFIG[UDMH+NTO]
 		{
 			@IspSL = 0.95
 		}
+
 		@CONFIG[Aerozine50+NTO]
 		{
 			@IspSL = 0.963
@@ -1701,66 +1944,146 @@
 	}
 }
 
-// BACC clone, now Altair (X-248)
-+PART[solidBooster1-1]:AFTER[RealismOverhaul]
+//  ==================================================
+//  Altair (X-248).
+//  ==================================================
+
++PART[solidBooster1-1]:BEFORE[RealismOverhaul]
 {
 	@name = RO-X-248
-	@MODEL
+}
+
+@PART[RO-X-248]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    !MODEL,*{}
+
+	MODEL
 	{
-		@scale = 0.34544, 0.256, 0.34544
+        model = Squad/Parts/Engine/solidBoosterBACC/model
+		scale = 0.34544, 0.256, 0.34544
 	}
+
 	@node_stack_bottom = 0.0, -1.055, 0.0, 0.0, -1.0, 0.0, 0
-	@node_stack_top = 0.0, 1.00352, 0.0, 0.0, 1.0, 0.0, 0
-	@node_attach = 0.0, 0.0, -0.2193544, 0.0, 0.0, 1.0, 0
+	@node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0
+	@node_attach = 0.0, 0.0, -0.22, 0.0, 0.0, 1.0, 0
 	
 	@mass = 0.03
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+	%engineType = Altair
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
+        @minThrust = 12.4
 		@maxThrust = 12.4
 		@heatProduction = 100
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = PSPC
+        }
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 256
 			@key,1 = 0 233
 		}
 	}
-	@MODULE[ModuleFuelTanks]
+
+	MODULE
 	{
-		@volume = 119.5403
-		@type = PSPC
+        name = ModuleFuelTanks
+		type = PSPC
+		volume = 119.5403
+        basemass = -1
+
+        TANK
+        {
+            name = PSPC
+            amount = 119.5403
+            maxAmount = 119.5403
+        }
 	}
-	%engineType = Altair
-	// Effects
-	!fx_exhaustFlame_yellow = 0.0, -3.5, 0.0, 0.0, 1.0, 0.0, running
-	!fx_exhaustSparks_yellow = 0.0, -3.5, 0.0, 0.0, 1.0, 0.0, running
-	!fx_smokeTrail_medium = 0.0, -4, 0.0, 0.0, 1.0, 0.0, running
-	fx_exhaustFlame_yellow_tiny = 0.0, -0.17, 0.163, 0.0, 1.0, 0.0, running
+
+    !RESOURCE,*{}
 }
-+PART[solidBooster_sm]:AFTER[RealismOverhaul]
+
+//  ==================================================
+//  Altair (X-248).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[RO-X-248]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    @MODEL
+    {
+        @model = VenStockRevamp/Squad/Parts/Propulsion/BACC
+        @scale = 0.34544, 0.256, 0.34544
+	}
+}
+
+//  ==================================================
+//  Altair-II (X-258).
+//  ==================================================
+
++PART[solidBooster_sm]:BEFORE[RealismOverhaul]
 {
 	@name = RO-X-258
-	@MODEL
+}
+
+@PART[RO-X-258]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    !MODEL,*{}
+
+	MODEL
 	{
-		@scale = 0.64, 1.875, 0.64
+        model = Squad/Parts/Engine/solidBoosterRT-5/SRB_RT5
+		scale = 0.64, 1.875, 0.64
 	}
-	!MODULE[TweakScale]
-	{
-	}
+
 	%rescaleFactor = 1.0
 	%scale = 1.0
-	@node_stack_bottom = 0.0, -1.5, 0.0, 0.0, -1.0, 0.0, 0
-	@node_stack_top = 0.0, 1.03125, 0.0, 0.0, 1.0, 0.0, 0
-	@node_attach = 0.0, 0.0, -0.4, 0.0, 0.0, 1.0, 0
-	
+
+	@node_stack_bottom = 0.0, -1.5, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 1.03125, 0.0, 0.0, 1.0, 0.0, 1
+	@node_attach = 0.0, 0.0, -0.4, 0.0, 0.0, 1.0
+
 	@mass = 0.037
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+	%engineType = Altair-II
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
+        @minThrust = 22.3
 		@maxThrust = 22.3
 		@heatProduction = 100
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 266
@@ -1768,159 +2091,108 @@
 		}
 	}
 	
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 136.8
-		@type = PSPC
-	}
-	%engineType = Altair-II
-	// Effects
-	!fx_exhaustFlame_yellow = 0.0, -3.5, 0.0, 0.0, 1.0, 0.0, running
-	!fx_exhaustSparks_yellow = 0.0, -3.5, 0.0, 0.0, 1.0, 0.0, running
-	!fx_smokeTrail_medium = 0.0, -4, 0.0, 0.0, 1.0, 0.0, running
-	%fx_exhaustFlame_yellow_tiny = 0.0, -0.17, 0.163, 0.0, 1.0, 0.0, running
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = PSPC
+        volume = 136.8
+        basemass = -1
+
+        TANK
+        {
+            name = PSPC
+            amount = 136.8
+            maxAmount = 136.8
+        }
+    }
+
+    !RESOURCE,*{}
 }
 
-//KVD1 / CE 7.5 engine
-+PART[liquidEngine3]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+//  ==================================================
+//  Altair-II (X-258).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[RO-X-258]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    @MODEL
+	{
+        @model = VenStockRevamp/Squad/Parts/Propulsion/BACC
+        @scale = 0.4718, 0.3125, 0.4718
+	}
+
+	@node_stack_top = 0.0, 1.215, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.295, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 0.0, -0.28, 0.0, 0.0, 1.0
+}
+
+//  ==================================================
+//  KVD1/CE 7.5 (vacuum engine).
+//  ==================================================
+
++PART[liquidEngine3]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = RO_KVD1
+}
+
+@PART[RO_KVD1]:FOR[RealismOverhaul]
+{
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	!mesh = DEL
-	MODEL:NEEDS[!VenStockRevamp]
+
+    !MODEL,*{}
+
+	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-909/model
 		scale = 2.8, 4.0, 2.8
 	}
-	@MODEL,0:NEEDS[VenStockRevamp]
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909B
-		%scale = 2.8, 4.0, 2.8
-	}
+
 	MODEL
 	{
 		model = RealismOverhaul/Models/KVDvernStock
 		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
-		scale = 1, 1, 1
-		position = 0, -1.15, -0.585
-		rotation = 16.5, 0, 0
+		scale = 1.0, 1.0, 1.0
+		position = 0.0, -1.6, -0.58
+		rotation = 12.0, 0.0, 0.0
 	}
+
 	MODEL
 	{
 		model = RealismOverhaul/Models/KVDvernStock
 		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
-		scale = 1, 1, 1
-		position = 0, -1.15, 0.585
-		rotation = 16.5, 180, 0
+		scale = 1.0, 1.0, 1.0
+		position = 0.0, -1.6, 0.58
+		rotation = 12.0, 180, 0.0
 	}
-	@MODEL,1:NEEDS[VenStockRevamp]		//Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0
-	{
-		@model = RealismOverhaul/Models/KVDvernVSR
-		!texture = DELETE
-		texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
-		texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
-	}
-	@MODEL,2:NEEDS[VenStockRevamp]
-	{
-		@model = RealismOverhaul/Models/KVDvernVSR
-		!texture = DELETE
-		texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
-		texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
-	}
+
 	MODEL
 	{
 		model = Squad/Parts/Structural/strutOcto/model
-		scale = 3, 4.5, 3
-		position = 0, 0.35, 0
-		rotation = 0, 22.5, 0
+		scale = 3.0, 4.5, 3.0
+		position = 0.0, 0.35, 0.0
+		rotation = 0.0, 22.5, 0.0
 	}
 
 	@scale = 1.0
 	%rescaleFactor = 1.0
+
 	%node_stack_top = 0.0, 0.9, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -1.513004, 0.0, 0.0, -1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -1.513, 0.0, 0.0, -1.0, 0.0, 2
 	
-	%attachRules = 1,1,1,1,0
 	%mass = 0.282
-	%maxTemp = 1973.15
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
 
-	!engineType = KVD1 //FIXME temp delete
+	%engineType = KVD1
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
 
-	!fx_exhaustFlame_blue_small = DELETE
-	!fx_exhaustLight_blue = DELETE
-	!fx_smokeTrail_light = DELETE
-
-
-	!sound_vent_medium = DELETE
-	!sound_rocket_hard = DELETE
-	!sound_vent_soft = DELETE
-	!sound_explosion_low = DELETE
-
-	EFFECTS
-	{
-	  running
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_rocket_spurts
-		  volume = 0.0 0.0 0 0
-		  volume = 0.01 0 0 0
-		  volume = 0.5 0.25
-		  volume = 1.0 1.0
-		  pitch = 0.0 1.3
-		  pitch = 1.0 1.6
-		  loop = true
-		}
-		PREFAB_PARTICLE
-		{
-		  prefabName = fx_exhaustFlame_blue_small
-		  transformName = thrustTransform
-		  emission = 0.0 0.0
-		  emission = 0.01 0 0 0
-		  emission = 0.01 0.0
-		  emission = 1.0 1.0
-		  speed = 0.0 0.8
-		  speed = 1.0 1.0
-		}
-		PREFAB_PARTICLE
-		{
-		  prefabName = fx_exhaustFlame_white_tiny
-		  transformName = vern01Transform
-		  emission = 0.0 0.0
-		  emission = 0.01 0 0 0
-		  emission = 0.01 0.0
-		  emission = 1.0 1.0
-		  speed = 0.0 0.8
-		  speed = 1.0 1.0
-		}
-	  }
-	  engage
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_vent_medium
-		  loop = false
-		}
-	  }
-	  disengage
-	  {
-		AUDIO
-		{
-		  channel = Ship
-		  clip = sound_vent_soft
-		  loop = false
-		}
-	  }
-	}
-
-	//density LH2 = 0.00007085
-	//density LOX = 0.001141
-	//density rat LH2:LOX = 0.06209465381244522348816827344435
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
@@ -1929,23 +2201,26 @@
 		@minThrust = 71.6
 		@maxThrust = 71.6
 		@heatProduction = 100
-		PROPELLANT[LiquidFuel]
+
+		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
 			@ratio = 0.72856
 		}
-		PROPELLANT[Oxidizer]
+
+		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.27144
 		}
-		atmosphereCurve
+
+		@atmosphereCurve
 		{
 			@key,0 = 0 461
 			@key,1 = 1 150
 		}
-		!IGNITOR_RESOURCE,* {}
 	}
+
 	MODULE
 	{
 		name = ModuleEnginesRF
@@ -1956,105 +2231,276 @@
 		heatProduction = 0
 		exhaustDamage = False
 		ignitionThreshold = 0.1
+
 		PROPELLANT
 		{
 			name = LqdHydrogen
 			ratio = 0.72856
 		}
+
 		PROPELLANT[Oxidizer]
 		{
 			name = LqdOxygen
 			ratio = 0.27144
 		}
+
 		atmosphereCurve
 		{
 			key,0 = 0 452
 			key,1 = 1 150
 		}
-		ullage = True
-		ignitions = 5
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.01
-		}
 	}
-	// The Verniers.
+
+	// Verniers gimbal setup.
+
 	@MODULE[ModuleGimbal]
 	{
-        
 		@gimbalTransformName = vern01Transform
-        	%gimbalRange = 15
-		%gimbalRangeXP = 1
-		%gimbalRangeXN = 1
+        !gimbalRange = NULL
+		%gimbalRangeXP = 5
+		%gimbalRangeXN = 5
 		%gimbalRangeYP = 15
 		%gimbalRangeYN = 15
 		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
 	}
-	@MODULE[ModuleGimbal]:NEEDS[VenStockRevamp]
-	{
-        	@gimbalTransformName = Nozzle
-	}
-	
-	!MODULE[ModuleEngineConfigs]
-	{
-	}
-	engineType = KVD1
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		type = ModuleEnginesFX
+		type = ModuleEnginesRF
 		configuration = KVD-1-Verniers
 		engineID = vernier
 		isMaster = false
 		modded = false
+
 		CONFIG
 		{
 			name = KVD-1-Verniers
 			minThrust = 4
 			maxThrust = 4
 			heatProduction = 0
+            ullage = True
+            pressureFed = False
+            ignitions = 5
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.01
+            }
+
 			PROPELLANT
 			{
 				name = LqdHydrogen
 				ratio = 0.72856
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.27144
 			}
+
 			atmosphereCurve
 			{
-				key = 0 452.0
-				key = 1 150.0
+				key = 0 452
+				key = 1 150
 			}
 		}
 	}
 }
+
+//  ==================================================
+//  KVD1/CE 7.5 (vacuum engine).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[RO_KVD1]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    @MODEL,0
+	{
+        @model = VenStockRevamp/Squad/Parts/Propulsion/LV909
+        @scale = 2.8, 4.0, 2.8
+    }
+
+    //  Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0.
+
+    @MODEL,1		
+    {
+        @model = RealismOverhaul/Models/KVDvernVSR
+        !texture = DELETE
+        texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
+        texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
+    }
+
+    @MODEL,2
+    {
+        @model = RealismOverhaul/Models/KVDvernVSR
+        !texture = DELETE
+        texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
+        texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
+    }
+}
+
+//  ==================================================
+//  Star 37.
+//  ==================================================
+
++PART[solidBooster_sm]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+    @name = RO-STAR-37
+}
+
+@PART[RO-STAR-37]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 0.9347, 1.174, 0.9347
+    }
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.65, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 1
+	@node_attach = 0.0, 0.0, -0.45, 0.0, 0.0, 1.0
+
+    @mass = 0.081
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = Star-37
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 54.8
+        @maxThrust = 54.8
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 289.8
+            @key,1 = 1 200
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleGimbal
+        gimbalTransformName = thrustTransform
+        gimbalRange = 3.5
+        useGimbalResponseSpeed = True
+        gimbalResponseSpeed = 16
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 602.25
+        basemass = -1
+
+        TANK
+        {
+            name = HTPB
+            amount = 602.25
+            maxAmount = 602.25
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Star 37.
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[RO-STAR-37]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    @MODEL
+    {
+        @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
+        @scale = 0.9347, 1.174, 0.9347
+    }
+}
+
+//  ==================================================
+//  Star 48B.
+//  ==================================================
+
 @PART[solidBooster_sm]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
+
+    @MODEL
 	{
+		@scale = 1.25, 1.25, 1.25
 	}
-	@MODEL
-	{
-		@scale = 1.25, 1.35466667, 1.25
-	}
+
 	%scale = 1.0
 	%rescaleFactor = 1.0
-	@node_stack_bottom = 0.0, -1.0838, 0.0, 0.0, -1.0, 0.0, 1
-	@node_stack_top = 0.0, 0.7451125, 0.0, 0.0, 1.0, 0.0, 1
-	@node_attach = 0.0, 0.0, -0.625, 0.0, 0.0, 1.0, 1
-	@maxTemp = 1973.15
-	!RESOURCE[SolidFuel] {}
+
+	@node_stack_bottom = 0.0, -1.11, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.695, 0.0, 0.0, 1.0, 0.0, 1
+	@node_attach = 0.0, 0.0, -0.625, 0.0, 0.0, 1.0
+
+    @mass = 0.117
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = Star-48B
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 78.0
+        @maxThrust = 78.0
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 292.1
+            @key,1 = 1 200
+        }
+    }
+
+    //  Placeholder gimbal module.
+
 	MODULE
 	{
 		name = ModuleGimbal
-		gimbalTransformName = thrustTransform // unless there's a better transform?
+		gimbalTransformName = thrustTransform
 	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -2062,91 +2508,97 @@
 		type = HTPB
 		basemass = -1
 	}
-	%engineType = Star-48B
+
+    !RESOURCE,*{}
 }
 
-// RAPIER config, ported from old AJE
-@PART[RAPIER]:FOR[RealismOverhaul]
+//  ==================================================
+//  Star 48B.
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[solidBooster_sm]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
-	@description = The dual-mode active-cooling RAPIER hypersonic engine which burns Methane. SFC 2.0 lb/lbf/hr, O/F in rocket mode 2.8 to 1.
-	@MODULE[ModuleEnginesAJEJet]
-	{
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdMethane
-		}
-	}
-	@MODULE[ModuleEngines*]:HAS[~engineID[AirBreathing]]
-	{
-		@name = ModuleEnginesRF
-		@minThrust = 150
-		@maxThrust = 250
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdMethane
-			@ratio = 0.49
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.51
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 360
-			@key,1 = 1 300
-		}
-		%ullage = False
-	}
+    @MODEL
+    {
+        @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
+        @scale = 1.25, 1.25, 1.25  
+    }
 }
 
-// Vector
-@PART[SSME]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines] // RS-25D/E
+//  ==================================================
+//  RS-25D/E (SSME).
+//  ==================================================
+
+@PART[SSME]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
 
-    MODEL:NEEDS[!VenStockRevamp]
+    !mesh = NULL
+
+    !MODEL,*{}
+
+    MODEL
     {
         model = Squad/Parts/Engine/liquidEngineSSME/SSME
         scale = 1.915, 2.225, 1.915
     }
 
-    @MODEL:NEEDS[VenStockRevamp]
-    {
-        @scale = 2.5, 2.78, 2.5
-    }
-
     %scale = 1.0
     @rescaleFactor = 1.0
-    @node_stack_bottom:NEEDS[!VenStockRevamp] = 0.0, -3.475, 0.0, 0.0, -1.0, 0.0, 2
-    @node_stack_bottom:NEEDS[VenStockRevamp] = 0.0, -4.075, 0.0, 0.0, -1.0, 0.0, 2
+
+    @node_stack_bottom = 0.0, -3.475, 0.0, 0.0, -1.0, 0.0, 2
+
 	@mass = 3.527
-	@maxTemp = 1800
+    @crashTolerance = 10
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+
+    %engineType = SSME
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
+        @name = ModuleEnginesRF
 		@minThrust = 1400
 		@maxThrust = 2280
 		@heatProduction = 100
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = LqdHydrogen
 			@ratio = 0.728
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.272
 		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 452
 			@key,1 = 1 366
 		}
-		!IGNITOR_RESOURCE,* {}
 	}
-	engineType = SSME
+}
+
+//  ==================================================
+//  RS-25 (SSME).
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[SSME]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    @MODEL
+    {
+        @scale = 2.5, 2.78, 2.5
+    }
+
+    @node_stack_bottom = 0.0, -4.075, 0.0, 0.0, -1.0, 0.0, 2
 }


### PR DESCRIPTION
* Separate the VSR passes from the main RO configs for better clarity.
* Make sure that ant new parts (+PART) are created before any RO changes are applied to the source part (@PART).
* Remove redundant attachment rules (taken care by the global RO patches).
* Decrease the crash tolerances and the maximum temperatures. Engines now can be destroyed when deorbited.
* Start to move the "ModuleEnginesRF" from the RealPlume pass to the main RO pass.
* Remove some redundant modules (taken care by the global engine configs).
* Remove leftover IGNITOR{} blocks (taken care by the global engine configs).
* Remove some VSR "tankbutt" nodes (not applicable unfortunately for all the engines).
* Comment each patch for easier search/identification.
* Remove some old engine FX configs (taken care by RealPlume).
* Fix some model removals (!MODEL).
* Replace the Altair - II model with the same model as Altair.
* Merge the two RAPIER patches into one.
* Fix the KVD-1 and the RD-0105/0109 models.
* Fix the KVD-1 verniers (ullage, ignitions, gimballing).
* Fix the attachment node sizes and placements of some parts.
* Simplify RESOURCE removal from any parts that require it.
* Add a STAR 37 SRM.
* Fix the size of the STAR 48B SRM.

NOTE 1: Due to an issue with RealPlume the KVD-1 main engine plume will not appear.
NOTE 2: The NSTAR ion engine still uses the old workaround for setting the ElectricCharge consumption. This will be fixed in a future update.