### PR TITLE
RO_Engines.cfg updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_Engines.cfg
@@ -9,3 +9,12 @@
 {
     %category = Engine
 }
+
+//  ==================================================
+//  Make sure that no engine has a TweakScale module.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[TweakScale],@MODULE[ModuleEngines*]]:FOR[zzzRealismOverhaul]
+{
+    !MODULE[TweakScale]{}
+}

--- a/GameData/RealismOverhaul/RO_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_Engines.cfg
@@ -1,13 +1,10 @@
 // final added to catch engines where gimbal is added by RO
 // this method does not catch the LEM ascent engine specifically
 // ModuleCommand added to not catch MechJeb
-@PART[*]:HAS[@MODULE[ModuleGimbal],!MODULE[ModuleCommand]]:FINAL
+
+@PART[*]:HAS[@MODULE[ModuleEngines*],!MODULE[*Decouple*],@MODULE[ModuleGimbal],!MODULE[ModuleCommand]]:FOR[zzzRealismOverhaul]
 {
 	%category = Engine
-}
-@PART[*]:HAS[@MODULE[ModuleEngines*],!MODULE[*Decouple*],!MODULE[ModuleCommand]]:FINAL
-{
-    %category = Engine
 }
 
 //  ==================================================


### PR DESCRIPTION
* Remove the TweakScale module from parts that are engines. Covers the TS removals from https://github.com/KSP-RO/RealismOverhaul/pull/1270.
* Fix the engine part category assignment patch since it broke the category assignment of some RSB parts (engine + fuel tank as one part).