### PR TITLE
RO Squad engines RealPlume updates

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-0210.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-0210.cfg
@@ -15,6 +15,12 @@
         speed = 1.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Upper
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-0210.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-0210.cfg
@@ -1,23 +1,22 @@
-@PART[RO-RD-0210]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+//  ==================================================
+//  RD-0210 plume configuration.
+//  ==================================================
+
+@PART[RO-RD-0210]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
-        name = Hypergolic-Upper            //pre-fabbed plume you want
-        transformName = thrustTransform //which transform to attach the plume
-        localRotation = 0,0,0           //Any rotation needed
-        localPosition = 0,0,0           //Any offset needed
-        fixedScale = 2.3                  //Size adjustment to resize to engine
-        energy = 1                      //Adjust length of plume
-        speed = 2                       //Adjust speed on resize, 
-                                        //generally close to 1:1 with scale.
+        name = Hypergolic-Upper
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.75
+        fixedScale = 1.5
+        energy = 1.25
+        speed = 1.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper
@@ -38,7 +37,7 @@
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
                 @localPosition = 0.0, 0.0, 0.5
-                @fixedScale = 1.25
+                @fixedScale = 1.75
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-253.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-253.cfg
@@ -10,7 +10,7 @@
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
         localPosition = 0.0, 0.0, 0.7
-        fixedScale = 2.0
+        fixedScale = 2.75
         energy = 1.0
         speed = 2.0
         emissionMult = 0.75

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-253.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-253.cfg
@@ -1,26 +1,45 @@
-@PART[RO-RD-253]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+//  ==================================================
+//  RD-253/RD-275 plume configuration.
+//  ==================================================
+
+@PART[RO-RD-253]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
-        name = Hypergolic-Lower            //pre-fabbed plume you want
-        transformName = thrustTransform //which transform to attach the plume
-        localRotation = 0,0,0           //Any rotation needed
-        localPosition = 0,0,0           //Any offset needed
-        fixedScale = 2                  //Size adjustment to resize to engine
-        energy = 1                      //Adjust length of plume
-        speed = 2                       //Adjust speed on resize, 
-                                        //generally close to 1:1 with scale.
+        name = Hypergolic-Lower
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.7
+        fixedScale = 2.0
+        energy = 1.0
+        speed = 2.0
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Lower
         }
 	}
+}
+
+//  ==================================================
+//  RD-253/RD-275 flare configuration.
+//  ==================================================
+
+@PART[RO-RD-253]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.5
+                @fixedScale = 2.75
+            }
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-253.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-RD-253.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Lower
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-SurveyorVernier.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-SurveyorVernier.cfg
@@ -1,19 +1,22 @@
-@PART[RO-SurveyorVernier]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Generic 1kN Thruster
+//  ==================================================
+//  TD-339 Surveyor vernier plume configuration.
+//  ==================================================
+
+@PART[RO-SurveyorVernier]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.6
+        localPosition = 0,0,0.525
         fixedScale = 0.3
         energy = 1
         speed = 1.5
     }
+
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-Red
 	}
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-SurveyorVernier.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-SurveyorVernier.cfg
@@ -18,5 +18,14 @@
 	@MODULE[ModuleEngines*]
 	{
         %powerEffectName = Hypergolic-OMS-Red
+        !fxOffset = NULL
 	}
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-SurveyorVernier.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO-SurveyorVernier.cfg
@@ -9,8 +9,8 @@
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.525
-        fixedScale = 0.3
+        localPosition = 0,0,0.55
+        fixedScale = 0.25
         energy = 1
         speed = 1.5
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAJ10137.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAJ10137.cfg
@@ -8,6 +8,7 @@
 	{
 		!runningEffectName = DELETE
 		%powerEffectName = Hypergolic-Apollo-SM
+        !fxOffset = NULL
 	}
 
     PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAJ10137.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAJ10137.cfg
@@ -1,24 +1,43 @@
-@PART[ROAJ10-137]:FOR[RealPlume]:NEEDS[SmokeScreen] // AJ10-137 (Apollo SPS)
+//  ==================================================
+//  AJ10-137 (Apollo SPS) plume configuration.
+//  ==================================================
+
+@PART[ROAJ10-137]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%powerEffectName = Hypergolic-Apollo-SM
 	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-	}
+
     PLUME
     {
         name = Hypergolic-Apollo-SM
         transformName = thrustTransform
-        flarePosition = 0,0,0.75
-        flareScale = 0.9
-        plumePosition = 0,0,-0.05
-        plumeScale = 1
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -0.1
+        fixedScale = 0.7
+        energy = 1.0
         speed = 1.5
+        emissionMult = 0.5
     }
 }
 
+//  ==================================================
+//  AJ10-137 (Apollo SPS) flare configuration.
+//  ==================================================
+
+@PART[ROAJ10-137]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-Apollo-SM
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.525
+                @fixedScale = 0.7
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
@@ -1,27 +1,45 @@
+//  ==================================================
+//  Aerobee / WAC Corporal plume configuration.
+//  ==================================================
+
 @PART[ROAerobeeSustainer]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
     {
         name = Hypergolic-Lower
         transformName = thrustTransform
-        localRotation = 0,0,0
-        flarePosition = 0,0,0.75
-        plumePosition = 0,0,0
-        plumeScale = 0.18
-        flareScale = 0.15
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.1
+        fixedScale = 0.18
         energy = 0.35
-        speed = 1
+        speed = 1.0
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hypergolic-Lower
 		}
 	}
+}
+
+//  ==================================================
+//  Aerobee / WAC Corporal flare configuration.
+//  ==================================================
+
+@PART[ROAerobeeSustainer]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 1.25
+                @fixedScale = 0.2
+            }
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
@@ -37,7 +37,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 1.25
+                @localPosition = 0.0, 0.0, 1.0
                 @fixedScale = 0.2
             }
         }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Lower
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_KVD1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_KVD1.cfg
@@ -11,6 +11,7 @@
 
     @MODULE[ModuleEngines*]:HAS[#engineID[vernier]]
     {
+        %runningEffectName = Hydrolox-Red
         %powerEffectName = Hypergolic-Vernier
     }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_KVD1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_KVD1.cfg
@@ -6,23 +6,27 @@
 {
 	@MODULE[ModuleEngines*]:HAS[#engineID[mainEngine]]
 	{
-		%powerEffectName = Hydrolox-Red
+        //  Workaround for a RealPlume bug, remove as soon as it is fixed.
+
+        %runningEffectName = Hydrolox-Upper
+        !fxOffset = NULL
 	}
 
     @MODULE[ModuleEngines*]:HAS[#engineID[vernier]]
     {
-        %runningEffectName = Hydrolox-Red
         %powerEffectName = Hypergolic-Vernier
     }
 
     PLUME
     {
-        name = Hydrolox-Red
+        name = Hydrolox-Upper
         transformName = thrustTransform
-        flarePosition = 0,0,0.52
-        flareScale = 1.15
-        plumePosition = 0,0,0.34
-        plumeScale = 1.2
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.325
+        fixedScale = 1.0
+        energy = 1.5
+        speed = 1.0
+        emissionMult = 0.5
     }
 
     PLUME
@@ -35,5 +39,43 @@
         energy = 1.0
         speed = 1.0
         emissionMult = 0.75
+    }
+}
+
+//  ==================================================
+//  KVD-1/CE 7.5 plume configuration.
+//  ==================================================
+
+@PART[RO_KVD1]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[plume_grey]
+            {
+                @localPosition = 0.0, 0.0, 0.125
+                @fixedScale = 1.0
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  KVD-1/CE 7.5 flare configuration.
+//  ==================================================
+
+@PART[RO_KVD1]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.275
+                @fixedScale = 1.15
+            }
+        }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_KVD1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_KVD1.cfg
@@ -1,13 +1,19 @@
+//  ==================================================
+//  KVD-1/CE 7.5 plume configuration.
+//  ==================================================
+
 @PART[RO_KVD1]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]:HAS[#engineID[mainEngine]]
 	{
 		%powerEffectName = Hydrolox-Red
 	}
+
     @MODULE[ModuleEngines*]:HAS[#engineID[vernier]]
     {
         %powerEffectName = Hypergolic-Vernier
     }
+
     PLUME
     {
         name = Hydrolox-Red
@@ -17,17 +23,16 @@
         plumePosition = 0,0,0.34
         plumeScale = 1.2
     }
+
     PLUME
     {
         name = Hypergolic-Vernier
         transformName = vern01Transform
-        plumePosition = 0,0,0.9
-        speed = 0.7
-
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 1.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngineConfigs],*
-	{
-		%type = ModuleEnginesRF
-	}
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_STAR_37.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/RO_STAR_37.cfg
@@ -1,0 +1,51 @@
+//  ==================================================
+//  STAR 37 plume configuration.
+//  ==================================================
+
+@PART[RO-STAR-37]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Solid-Vacuum
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.5
+        fixedScale = 1.25
+        energy = 1.25
+        speed = 1.125
+        emissionMult = 0.75
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Vacuum
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEnginesConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Vacuum
+        }
+    }
+}
+
+//  ==================================================
+//  STAR 37 flare configuration.
+//  ==================================================
+
+@PART[RO-STAR-37]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Solid-Vacuum
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.25
+                @fixedScale = 0.6
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/Ks25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/Ks25.cfg
@@ -8,6 +8,7 @@
 	{
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Lower
+        !fxOffset = NULL
 	}
 
     PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/Ks25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/Ks25.cfg
@@ -1,23 +1,104 @@
-@PART[SSME]:FOR[RealPlume]:NEEDS[SmokeScreen] // SSME, from CSS config
+//  ==================================================
+//  RS-25D/E (SSME) plume configuration.
+//  ==================================================
+
+@PART[SSME]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Lower
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
 	}
 
     PLUME
     {
         name = Hydrolox-Lower
         transformName = thrustTransform
-        plumePosition = 0,0,0.394
-        plumeScale = 2.4
-        flarePosition = 0,0,0.29
-        flareScale = 2.0
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 2.4
+        energy = 1.25
+        speed = 1.5
+        emissionMult = 1.0
+    }
+}
+
+//  ==================================================
+//  RS-25D/E (SSME) plume configuration.
+//  ==================================================
+
+@PART[SSME]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[plume_grey]
+            {
+                @fixedScale = 2.4
+                @energy = 1.0
+                @speed = 1.0
+                @emissionMult = 0.5
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  RS-25D/E (SSME) plume configuration.
+//  ==================================================
+
+@PART[SSME]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[plume_red]
+            {
+                @fixedScale = 2.4
+                @energy = 1.0
+                @speed = 1.0
+                @emissionMult = 0.25
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  RS-25D/E (SSME) flare configuration.
+//  ==================================================
+
+@PART[SSME]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.25
+                @fixedScale = 2.75
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  RS-25D/E (SSME) shock cone configuration.
+//  ==================================================
+
+@PART[SSME]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[shockcone]
+            {
+                @localPosition = 0.0, 0.0, -0.85
+                @fixedScale = 2.25
+            }
+        }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/Ks25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/Ks25.cfg
@@ -77,8 +77,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.25
-                @fixedScale = 2.75
+                @localPosition = 0.0, 0.0, 0.0
+                @fixedScale = 2.6
             }
         }
     }
@@ -96,7 +96,7 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[shockcone]
             {
-                @localPosition = 0.0, 0.0, -0.85
+                @localPosition = 0.0, 0.0, -0.75
                 @fixedScale = 2.25
             }
         }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/Size3AdvancedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/Size3AdvancedEngine.cfg
@@ -1,25 +1,44 @@
-@PART[Size3AdvancedEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne F-1 [5.5m]
+//  ==================================================
+//  F-1 plume configuration.
+//  ==================================================
+
+@PART[Size3AdvancedEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Kerolox-Lower
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.7
-        fixedScale = 3.2
-        energy = 1
-        speed = 1
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 1.5
+        energy = 1.75
+        speed = 1.0
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower
 		}
 	}
+}
+
+//  ==================================================
+//  F-1 flare configuration.
+//  ==================================================
+
+@PART[Size3AdvancedEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.35
+                @fixedScale = 1.9
+            }
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/Size3AdvancedEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/Size3AdvancedEngine.cfg
@@ -15,6 +15,13 @@
         speed = 1.0
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/engineLargeSkipper.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/engineLargeSkipper.cfg
@@ -1,22 +1,23 @@
-@PART[engineLargeSkipper]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL10
+//  ==================================================
+//  RL10 plume configuration.
+//  ==================================================
+
+@PART[engineLargeSkipper]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hydrolox-Upper
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,1
+        localPosition = 0.0, 0.0, 1.75
         fixedScale = 0.8
-        energy = 1.2
-        speed = 1
+        energy = 2.5
+        speed = 1.25
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -24,3 +25,21 @@
 	}
 }
 
+//  ==================================================
+//  RL10 flare configuration.
+//  ==================================================
+
+@PART[engineLargeSkipper]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 1.15
+                @fixedScale = 1.25
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/engineLargeSkipper.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/engineLargeSkipper.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hydrolox-Upper
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine.cfg
@@ -9,8 +9,8 @@
         name = Kerolox-Lower
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.275
-        fixedScale = 1.15
+        localPosition = 0,0,0.2
+        fixedScale = 0.8
         energy = 1
         speed = 1
     }
@@ -32,12 +32,12 @@
 {
     @EFFECTS
     {
-        @Kerolox-Upper
+        @Kerolox-Lower
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
                 @localPosition = 0.0, 0.0, 0.0
-                @fixedScale = 0.95
+                @fixedScale = 0.9
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine.cfg
@@ -15,6 +15,12 @@
         speed = 1
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine.cfg
@@ -1,22 +1,22 @@
-@PART[liquidEngine]:FOR[RealPlume]:NEEDS[SmokeScreen] //Rocketdyne LR105 Series [2m]
+//  ==================================================
+//  LR105 plume configuration.
+//  ==================================================
+
+@PART[liquidEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Kerolox-Lower
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.35
+        localPosition = 0,0,0.275
         fixedScale = 1.15
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower
@@ -24,3 +24,21 @@
 	}
 }
 
+//  ==================================================
+//  LR105 flare configuration.
+//  ==================================================
+
+@PART[liquidEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.0
+                @fixedScale = 0.95
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine2.cfg
@@ -15,6 +15,12 @@
         speed = 1
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine2.cfg
@@ -1,22 +1,22 @@
-@PART[liquidEngine2]:FOR[RealPlume]:NEEDS[SmokeScreen] // S1.5400/11D33, RD-58
+//  ==================================================
+//  S1.5400/11D33, RD-58 plume configuration.
+//  ==================================================
+
+@PART[liquidEngine2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Kerolox-Upper
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.3
+        localPosition = 0,0,0.2
         fixedScale = 0.7
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Upper
@@ -24,3 +24,20 @@
 	}
 }
 
+//  ==================================================
+//  S1.5400/11D33, RD-58 flare configuration.
+//  ==================================================
+
+@PART[liquidEngine2]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.0
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine22.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine22.cfg
@@ -1,22 +1,23 @@
-@PART[liquidEngine2-2]:FOR[RealPlume]:NEEDS[SmokeScreen] //LMDE
+//  ==================================================
+//  LM Descent Engine plume configuration.
+//  ==================================================
+
+@PART[liquidEngine2-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,-0.3
-        fixedScale = 2
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.25
+        fixedScale = 2.0
         energy = 1.5
         speed = 1.5
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hypergolic-OMS-White
@@ -24,3 +25,21 @@
 	}
 }
 
+//  ==================================================
+//  LM Descent Engine flare configuration.
+//  ==================================================
+
+@PART[liquidEngine2-2]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-OMS-White
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.35
+                @fixedScale = 0.9
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine22.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine22.cfg
@@ -9,7 +9,7 @@
         name = Hypergolic-OMS-White
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.25
+        localPosition = 0.0, 0.0, 0.0
         fixedScale = 2.0
         energy = 1.5
         speed = 1.5
@@ -37,8 +37,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.35
-                @fixedScale = 0.9
+                @localPosition = 0.0, 0.0, -0.45
+                @fixedScale = 0.55
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine22.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine22.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine3.cfg
@@ -15,6 +15,12 @@
         speed = 1
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngine3.cfg
@@ -1,22 +1,22 @@
-@PART[liquidEngine3]:FOR[RealPlume]:NEEDS[SmokeScreen] // RD-0105 / 0109
+//  ==================================================
+//  RD-0105 / 0109 plume configuration.
+//  ==================================================
+
+@PART[liquidEngine3]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Kerolox-Upper
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.1
+        localPosition = 0,0,0.05
         fixedScale = 0.8
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Upper
@@ -24,3 +24,21 @@
 	}
 }
 
+//  ==================================================
+//  RD-0105 / 0109 flare configuration.
+//  ==================================================
+
+@PART[liquidEngine3]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Upper
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.1
+                @fixedScale = 0.65
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMini.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMini.cfg
@@ -1,22 +1,23 @@
-@PART[liquidEngineMini]:FOR[RealPlume]:NEEDS[SmokeScreen]	//TRW LM Ascent Engine
+//  ==================================================
+//  LM Ascent Engine plume configuration.
+//  ==================================================
+
+@PART[liquidEngineMini]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,-0.3
+        localPosition = 0.0, 0.0, -0.1
         fixedScale = 1.5
         energy = 1.5
         speed = 1.5
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hypergolic-OMS-White
@@ -24,3 +25,23 @@
 	}
 }
 
+//  ==================================================
+//  LM Ascent Engine flare configuration.
+//  ==================================================
+
+@PART[liquidEngineMini]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-OMS-White
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.85
+                @fixedScale = 1.0
+                @energy = 1.0
+                @speed = 1.0
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMini.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMini.cfg
@@ -37,10 +37,8 @@
         {
             @MODEL_MULTI_PARTICLE_PERSIST[flare]
             {
-                @localPosition = 0.0, 0.0, 0.85
-                @fixedScale = 1.0
-                @energy = 1.0
-                @speed = 1.0
+                @localPosition = 0.0, 0.0, -0.2
+                @fixedScale = 0.25
             }
         }
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMini.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMini.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
@@ -9,8 +9,8 @@
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.6
-        fixedScale = 0.3
+        localPosition = 0,0,0.55
+        fixedScale = 0.25
         energy = 1
         speed = 1.5
     }
@@ -20,8 +20,8 @@
         name = Hypergolic-OMS-White
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.0
-        fixedScale = 1.
+        localPosition = 0.0, 0.0, 0.075
+        fixedScale = 0.175
         energy = 1.0
         speed = 1.0
     }
@@ -58,6 +58,25 @@
         @CONFIG[Cavea-B]
         {
             %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+//  ==================================================
+//  Generic 1 kN thruster flare configuration.
+//  ==================================================
+
+@PART[microEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hypergolic-OMS-White
+        {
+            @MODEL_MULTI_PARTICLE_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, -0.85
+                @fixedScale = 0.05
+            }
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
@@ -1,4 +1,8 @@
-@PART[microEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Generic 1kN Thruster
+//  ==================================================
+//  Generic 1 kN thruster plume configuration.
+//  ==================================================
+
+@PART[microEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -10,10 +14,50 @@
         energy = 1
         speed = 1.5
     }
+
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 1.
+        energy = 1.0
+        speed = 1.0
+    }
+
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-Red
 	}
 }
 
+//  ==================================================
+//  Generic 1 kN thruster plume configuration.
+//  ==================================================
+
+@PART[microEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+
+        @CONFIG[MMH+NTO]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[UDMH+NTO]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[Cavea-B]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
@@ -29,6 +29,7 @@
 	@MODULE[ModuleEngines*]
 	{
         %powerEffectName = Hypergolic-OMS-Red
+        !fxOffset = NULL
 	}
 }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/nuclearEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/nuclearEngine.cfg
@@ -1,26 +1,26 @@
-@PART[nuclearEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Aerojet NERVA NRX Nuclear Engine
+//  ==================================================
+//  NERVA NRX Nuclear Thermal Engine plume configuration.
+//  ==================================================
+
+@PART[nuclearEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hydrogen-NTR
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.7
-        fixedScale = 3
-        energy = 1
-        speed = 1
+        localPosition = 0,0,0.75
+        fixedScale = 2.25
+        energy = 1.75
+        speed = 1.75
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hydrogen-NTR
 		}
 	}
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/nuclearEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/nuclearEngine.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hydrogen-NTR
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/omsEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/omsEngine.cfg
@@ -15,6 +15,12 @@
         speed = 1.0
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-Red
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/omsEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/omsEngine.cfg
@@ -1,22 +1,22 @@
-@PART[omsEngine]:FOR[RealPlume]:NEEDS[SmokeScreen] //Aerojet AJ10-190
+//  ==================================================
+//  AJ10-190 (radial) plume configuration.
+//  ==================================================
+
+@PART[omsEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.07
-        fixedScale = 2
-        energy = 1
-        speed = 1
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 2.0
+        energy = 1.5
+        speed = 1.0
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hypergolic-OMS-Red

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/radialLiquidEngine12.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/radialLiquidEngine12.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Vernier
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/radialLiquidEngine12.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/radialLiquidEngine12.cfg
@@ -1,26 +1,26 @@
-@PART[radialLiquidEngine1-2]:FOR[RealPlume]:NEEDS[SmokeScreen]	//KB Yuzhnoye RD-855
+//  ==================================================
+//  KB Yuzhnoye RD-855 plume configuration.
+//  ==================================================
+
+@PART[radialLiquidEngine1-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-Vernier
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.6
+        localPosition = 0.0, 0.0, 1.0
         fixedScale = 2
         energy = 1
         speed = 1
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hypergolic-Vernier
 		}
 	}
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/smallRadialEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/smallRadialEngine.cfg
@@ -16,6 +16,12 @@
         emissionMult = 0.75
     }
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Vernier
+        !fxOffset = NULL
+    }
+
 	@MODULE[ModuleEngineConfigs]
 	{
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/smallRadialEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/smallRadialEngine.cfg
@@ -1,26 +1,26 @@
-@PART[smallRadialEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//KB Yuzhnoye RD-856
+//  ==================================================
+//  KB Yuzhnoye RD-856 plume configuration.
+//  ==================================================
+
+@PART[smallRadialEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-Vernier
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,1
-        fixedScale = 1
-        energy = 1
-        speed = 1
+        localPosition = 0.0, 0.0, 0.75
+        fixedScale = 1.0
+        energy = 1.25
+        speed = 1.5
+        emissionMult = 0.75
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hypergolic-Vernier
 		}
 	}
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/toroidalAerospike.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/toroidalAerospike.cfg
@@ -1,4 +1,8 @@
-@PART[toroidalAerospike]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne J-2T-200/250K Aerospike
+//  ==================================================
+//  J-2T-200/250K Aerospike plume configuration.
+//  ==================================================
+
+@PART[toroidalAerospike]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -10,17 +14,12 @@
         energy = 0.7
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hydrolox-Lower
 		}
 	}
 }
-


### PR DESCRIPTION
* Fix position, size and scaling of various plumes and flares.
* Fix KVD-1/CE 7.5 plume configuration (the original plume definition has been removed from RP).
* Use different plume configurations for different propellant combinations when using the Generic 1 kN Thruster.
* Add RealPlume support for the STAR 37 SRM.

TEST: Alternate git diff ignoring whitespace changes [here](https://github.com/KSP-RO/RealismOverhaul/pull/1273/files?w=1).