### PR TITLE
RD-107/108 Engines Fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -147,7 +147,7 @@
                 key = 1 256.05
             }
 			
-			cost = 200
+			cost = 100
 			techRequired = advRocketry
         }
 

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -94,9 +94,6 @@
                 key = 0 308
                 key = 1 250
             }
-			
-			cost = 100
-			techRequired = advRocketry
         }
 
         CONFIG
@@ -151,7 +148,7 @@
             }
 			
 			cost = 200
-			techRequired = heavyRocketry
+			techRequired = advRocketry
         }
 
         CONFIG

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -4,6 +4,8 @@
 //  Throttle Range: N/A
 //  Burn Time: 140 s
 //  O/F Ratio: ~2.5 (differs between different configurations)
+//  Vernier range: 45 degrees
+
 
 //  Sources:
 
@@ -13,6 +15,7 @@
 
 //  Used by:
 //      SXT
+//      SSTU
 //  ==================================================
 
 @PART[*]:HAS[#engineType[RD107-117]]:FOR[RealismOverhaulEngines]
@@ -91,7 +94,7 @@
 
             atmosphereCurve
             {
-                key = 0 308
+                key = 0 306
                 key = 1 250
             }
         }

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -80,7 +80,7 @@
             {
                 name = LqdOxygen
                 ratio = 0.6274
-                DrawGauge = True
+                DrawGauge = False
             }
 
             PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -4,6 +4,7 @@
 //  Throttle Range: N/A
 //  Burn Time: 140 s
 //  O/F Ratio: ~2.5 (differs between different configurations)
+//  Vernier range: 45 degrees
 
 //  Sources:
 
@@ -145,7 +146,7 @@
 
             atmosphereCurve
             {
-                key = 0 314.07
+                key = 0 315
                 key = 1 248.10
             }
 			

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU-RD-10X.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU-RD-10X.cfg
@@ -25,9 +25,9 @@
 {
     @MODULE[ModuleGimbal]
     {
-        %gimbalRange = 35 // FIXME: no source on this value, could be wildly off
-        %gimbalRangeYP = 35
-		%gimbalRangeYN = 35
+        %gimbalRange = 45 // http://lpre.de/energomash/RD-107/index.htm
+        %gimbalRangeYP = 45
+		%gimbalRangeYN = 45
 		%gimbalRangeXP = 0
 		%gimbalRangeXN = 0
         %useGimbalResponseSpeed = True
@@ -97,9 +97,9 @@
 {
     @MODULE[ModuleGimbal]
     {
-        %gimbalRange = 35 
-        %gimbalRangeYP = 35
-		%gimbalRangeYN = 35
+        %gimbalRange = 45 
+        %gimbalRangeYP = 45
+		%gimbalRangeYN = 45
 		%gimbalRangeXP = 0
 		%gimbalRangeXN = 0
         %useGimbalResponseSpeed = True


### PR DESCRIPTION
place RD-107_8D74K with the RD-108_8D74K(both are 1959 engines), seems these got messed up somewhere
remove cost on RD-107_8D74PS(it's first variant, so makes zero sense)