### PR TITLE
Added most of the remaining BDB solids

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
@@ -620,3 +620,458 @@
 		}
 	}
 }
+
+@PART[bluedog_castorSRB]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.50, 1.50, 1.50
+	}
+	%node_attach = 0.0, 0.0, -0.40, 0.0, 0.0, 1.0, 1
+	@maxTemp = 1800
+	@mass = 0.535
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1912.07
+		basemass = -1
+		type = PSPC
+	}
+	@MODULE[ModuleEngines*]
+	{
+		%maxThrust = 286
+		@atmosphereCurve
+		{
+			@key,0 = 0 247
+			@key,1 = 1 232
+		}
+	}
+	%engineType = Castor-1
+}
+
+@PART[bluedog_Titan_SRB5seg]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 1.627, 1.627
+	}
+	%node_stack_top = 0.0, 13.20, 0.0, 0.0, 1.0, 0.0, 1
+	%node_attach = 1.525, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	%engineType = UA1205
+	@mass = 33.800
+	@maxTemp = 1973.15
+	!RESOURCE[SolidFuel]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+}
+
+@PART[bluedog_Titan_SRB5segStack]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 1.627, 1.627
+	}
+	%node_stack_bottom = 0.0, -10.14, 0.0, 0.0, -1.0, 0.0, 1
+	%node_stack_top = 0.0, 13.20, 0.0, 0.0, 1.0, 0.0, 1
+	%node_attach = 1.525, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	%engineType = UA1205
+	@mass = 36.800
+	@maxTemp = 1973.15
+	!RESOURCE[SolidFuel]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	@description = Strap-on booster for Titan IIIC, IIID, IIIE, proposed for Saturn IB derivatives. Burn time 115s. This is the (never flown, but proposed) inline version with two TVC tanks. Diameter: [3.05 m].
+}
+
+@PART[bluedog_Titan_SRB7seg]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 1.627, 1.627
+	}
+	%node_stack_top = 0.0, 19.27, 0.0, 0.0, 1.0, 0.0, 1
+	%node_attach = 1.525, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	%engineType = UA1207
+	@mass = 51.230
+	@maxTemp = 1973.15
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 150560.17
+		basemass = -1
+		type = PBAN
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+}
+
+@PART[bluedog_Titan_SRB7segStack]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 1.627, 1.627
+	}
+	%node_stack_bottom = 0.0, -10.15, 0.0, 0.0, -1.0, 0.0, 1
+	%node_stack_top = 0.0, 19.27, 0.0, 0.0, 1.0, 0.0, 1
+	%node_attach = 1.525, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	%engineType = UA1207
+	@description = The UA1207 was used on the Titan IVA, which was developed to launch payloads that had been designed to fly on the Shuttle from Vandenberg. It was a 7-segment modification of the 5-segment UA1205 used on the Titan 3. Burn time 130 seconds. This is the (never flown, but proposed) inline version with 2 TVC tanks. Diameter: [3.05 m].
+	@mass = 54.230
+	@maxTemp = 1973.15
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 150560.17
+		basemass = -1
+		type = PBAN
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+}
+
+@PART[bluedog_Titan_SRB2seg]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 2.293, 1.627
+	}
+	@node_stack_top = 0.0, 5.95, 0.0, 0.0, 1.0, 0.0, 3
+	@node_attach = 1.525, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	@title = UA1204
+	%manufacturer = United Technologies
+	@description = Earliest UA120 series booster designed. Intended for Titan booster augmentation for DynaSoar. Candidate for various Saturn INT studies. Diameter: [3.05 m].
+	@mass = 30.479
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 4289.5
+		@heatProduction = 100
+		@thrustVectorTransformName = thrustTransform
+		@atmosphereCurve
+		{
+			@key,0 = 0 261
+			@key,1 = 1 238
+		}
+	}
+	@MODULE[ModuleGimbal]  //http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720007150.pdf, A Study of Performance and Cost Improvement Potential of the 120-in (3.05 m) Diameter Solid Rocket Motor, p 97
+	{
+		@gimbalTransformName = thrustTransform
+		@gimbalRange = 5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 89446.60
+		basemass = -1
+		type = PBAN
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = UA-1204
+		modded = false
+		CONFIG
+		{
+			name = UA-1204
+			maxThrust = 4289.5
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 260
+				key = 1 236
+			}
+			curveResource = PBAN
+			// guesses (note: max is above nominal * thrust_curve_max)
+			%chamberNominalTemp  = 2200
+			%maxEngineTemp = 2430
+			thrustCurve
+			{
+				key = 	0.0		0.12
+				key = 	0.01	0.18
+				key = 	0.064	0.69
+				key = 	0.1		0.7107
+				key = 	0.56	0.8615
+				key = 	0.85	1.066
+				key = 	0.9		1.08	
+				key = 	0.97	1.063
+				key = 	0.99	1.1
+				key = 	1.0		0.55
+			}
+		}
+	}
+}
+
+@PART[bluedog_Titan_SRB3seg]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.707, 1.707, 1.707
+	}
+	%node_stack_top = 0.0, 19.40, 0.0, 0.0, 1.0, 0.0, 1
+	%node_attach = 1.60, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	%engineType = SRMU
+	@mass = 36.564
+	@maxTemp = 1973.15
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 178200.55
+		type = HTPB
+		basemass = -1
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	!MODULE[ModuleEngineIgnitor]
+	{
+	}
+}
+
+@PART[bluedog_Soltan_Radial]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.693, 1.3756, 1.693
+	}
+	@node_stack_top = 0.0, 9.56, 0.0, 0.0, 1.0, 0.0, 3
+	@node_attach = 1.27, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	@title = 100-Inch SRM
+	%manufacturer = Aerojet
+	@description = 3-segment motor designed for a solid-augmented Titan II around 1961. Four test firings were made, of which two ended with the nozzle disintegrating. Burn time roughly 80 seconds. Diameter: [2.54 m].
+	@mass = 12.000
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 3330.0
+		@heatProduction = 100
+		@thrustVectorTransformName = thrustTransform
+		@atmosphereCurve
+		{
+			@key,0 = 0 260
+			@key,1 = 1 235
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalTransformName = thrustTransform
+		@gimbalRange = 2
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 58323.9
+		basemass = -1
+		type = PBAN
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 100-Inch SRM
+		modded = false
+		CONFIG
+		{
+			name = 100-Inch SRM
+			maxThrust = 3330.0
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 260
+				key = 1 235
+			}
+
+		}
+	}
+}
+
+@PART[bluedog_Soltan_Inline]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.693, 1.3756, 1.693
+	}
+	@node_stack_top = 0.0, 9.56, 0.0, 0.0, 1.0, 0.0, 3
+	@node_attach = 1.27, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	@title = 100-Inch SRM (inline)
+	%manufacturer = Aerojet
+	@description = Inline version of the 3-segment motor designed for a solid-augmented Titan II around 1961. Four test firings were made, of which two ended with the nozzle disintegrating. Burn time roughly 80 seconds. Diameter: [2.54 m].
+	@mass = 12.000
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 3330.0
+		@heatProduction = 100
+		@thrustVectorTransformName = thrustTransform
+		@atmosphereCurve
+		{
+			@key,0 = 0 260
+			@key,1 = 1 235
+		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalTransformName = thrustTransform
+		@gimbalRange = 2
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+	!RESOURCE[SolidFuel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 58323.9
+		basemass = -1
+		type = PBAN
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 100-Inch SRM
+		modded = false
+		CONFIG
+		{
+			name = 100-Inch SRM
+			maxThrust = 3330.0
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 260
+				key = 1 235
+			}
+
+		}
+	}
+}
+
+@PART[bluedog_Soltan_SRBnose]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.693, 1.693, 1.693
+	}
+	%node_stack_bottom = 0.0, -0.6772, 0.0, 0.0, -1.0, 0.0, 2
+	@title = 100-Inch SRM nosecone
+	@mass = 0.15
+	%manufacturer = Aerojet
+	@description = Nosecone and separation rocket for 100-inch solid motors. Diameter: [2.54 m].
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 90
+	}
+	@RESOURCE
+	{
+		amount = 40
+		maxAmount = 40
+	}
+}
+
+@PART[bluedog_Titan_SRBnose]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 1.627, 1.627
+	}
+	%node_stack_bottom = 0.0, -0.8135, 0.0, 0.0, -1.0, 0.0, 2
+	@title = Titan SRM nosecone
+	@mass = 0.25
+	%manufacturer = United Technologies
+	@description = Diameter: [3.05 m].
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 120
+	}
+	@RESOURCE
+	{
+		amount = 60
+		maxAmount = 60
+	}
+}
+
+@PART[bluedog_Titan_SRBseparator]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@MODEL
+	{
+		scale = 1.627, 1.627, 1.627
+	}
+	node_attach = 0.28773, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	@title = Titan SRM separation motor
+	@mass = 0.1
+	%manufacturer = United Technologies
+	@description = Lower separation motor for Titan solids.
+	@maxTemp = 1973.15
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 120
+	}
+	@RESOURCE
+	{
+		amount = 60
+		maxAmount = 60
+	}
+}


### PR DESCRIPTION
Stuff that still requires attention:
-SRM separation rockets currently use SolidFuel
-100-inch solids need thrust curves and their gimbal ranges checked
-Baby Sergeant clusters and mercury-related motors not yet included