### PR TITLE
Filter Extensions updates

### DIFF
--- a/GameData/RealismOverhaul/Filter_Extensions_Configs/non_WIP_RO_FE_config.cfg
+++ b/GameData/RealismOverhaul/Filter_Extensions_Configs/non_WIP_RO_FE_config.cfg
@@ -1,36 +1,22 @@
-CATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Filter by Function
-	type = stock
-	value = replace
+//  ==================================================
+//  Add the new Realism Overhaul categories:
+//  *   WIP-RO for the parts that are not 100% compatible.
+//  *   NON-RO for the parts that are not configured yet.
+//  ==================================================
 
-    
-	SUBCATEGORIES
-	{
-		list = 0,Pods
-		list = 1,Fuel Tanks
-		list = 2,Engines
-		list = 3,Command and Control
-		list = 4,Structural
-		list = 5,Aerodynamics
-		list = 6,Utility
-		list = 7,Science
-        list = 8,WIP-RO
-        list = 9,non-RO
-	}
-}
-@CATEGORY[Filter?by?Function]:NEEDS[000_FilterExtensionsConfigs]:FINAL
+@CATEGORY[Filter?by?Function]:NEEDS[000_FilterExtensionsConfigs]:FOR[RealismOverhaul]
 {
     @SUBCATEGORIES
     {
-        list,19 = 19,WIP-RO
-        list,20 = 20,non-RO
+        list,8 = 8,WIP-RO
+        list,9 = 9,non-RO
     }
 }
-@FilterSettings:NEEDS[FilterExtensions]:FINAL
-{
-	@setAdvanced = False
-}
+
+//  ==================================================
+//  Create the WIP-RO category.
+//  ==================================================
+
 SUBCATEGORY
 {
 	name = WIP-RO
@@ -45,129 +31,22 @@ SUBCATEGORY
 		}
 	}
 }
+
+//  ==================================================
+//  Create the NON-RO category.
+//  ==================================================
+
 SUBCATEGORY
 {
 	name = non-RO
 	icon = R&D_node_icon_nuclearpropulsion
-	
+
 	FILTER
 	{
 		CHECK
 		{
 			type = title
 			value = non RO
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Pods
-	icon = stockIcon_pods
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Pods
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Fuel Tanks
-	icon = stockIcon_fueltank
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Fuel Tanks
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Engines
-	icon = stockIcon_engine
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Engines
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Command and Control
-	icon = stockIcon_cmdctrl
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Command and Control
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Structural
-	icon = stockIcon_structural
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Structural
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Aerodynamics
-	icon = stockIcon_aerodynamics
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Aerodynamics
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Utility
-	icon = stockIcon_utility
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Utility
-		}
-	}
-}
-SUBCATEGORY:NEEDS[!000_FilterExtensionsConfigs]
-{
-	name = Science
-	icon = stockIcon_science
-
-	FILTER
-	{
-		CHECK
-		{
-			type = category
-			value = Science
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -195,6 +195,7 @@
 @PART[*]:HAS[~RSSROConfig[]]:FINAL
 {
     %category:NEEDS[FilterExtensions] = 9
+    %category:NEEDS[NoNonRO] = -1
 	@title ^=:^:non RO - :
 	@description ^=:$: (PART NOT SUPPORTED BY RO):
 }
@@ -202,6 +203,7 @@
 @PART[*]:HAS[#RSSROConfig[False]]:FINAL
 {
     %category:NEEDS[FilterExtensions] = 8
+    %category:NEEDS[NoNonRO] = -1
 	@title ^=:^:WIP RO - :
 	@description ^=:$: (PART IN PROGRESS, MAY NOT WORK):
 }


### PR DESCRIPTION
* Simplify the Filter Extensions compatibility patch (compatible with the actual WIP and non-RO categories).
* Add the ability to remove WIP and NON RO parts from the part list (can
still be accessed via the Advanced Search option): just create a folder named "NoNonRO" inside the GameData folder.

NOTE: The FE patch was originally part of an older PR so that RO could separate the parts correctly (RO - compatible, WIP-RO and non-RO) but it was forgotten due to a merge conflict: https://github.com/KSP-RO/RealismOverhaul/pull/809/commits/9ba72e3a416011ca5174ded5a615753e15ac4f57