### PR TITLE
RO Coatl Aerospace Probes+ v0.13.1 updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -29,16 +29,17 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = CA-A02 Conic Omnidirectional Antenna
+    @title = CA-A02 Helical Omnidirectional Antenna
     @manufacturer = Generic
-    @description = A low gain helical omnidirectional antenna for short range high bandwidth communications.
+    @description = A low gain omnidirectional antenna for short range, high bandwidth communications.
 
     @mass = 0.003
     @crashTolerance = 8
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @bulkheadProfiles = srf
+    @tags ^= :$: communications
 }
 
 //  ==================================================
@@ -49,6 +50,8 @@
 
 @PART[antenna_cone]:FOR[RealismOverhaul]
 {
+    @description ^= :$: Effective range 75 Mm, maximum data rate 3.8 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -67,6 +70,8 @@
         Mode0OmniRange = 0
         Mode1OmniRange = 750000
         EnergyCost = 0.005
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
         TRANSMITTER
         {
@@ -80,8 +85,8 @@
 //  ==================================================
 //  Ground plane telemetry antenna.
 
-//  Dimensions: 0.04 m x 0.35 m
-//  Inert Mass: 1 Kg
+//  Dimensions: 0.04 m x 1.75 m (extended)
+//  Inert Mass: 3 Kg
 //  ==================================================
 
 @PART[antenna_tv]:FOR[RealismOverhaul]
@@ -101,14 +106,14 @@
 
     @title = CA-A01 Ground Plane Antenna
     @manufacturer = Generic
-    @description = A simple omnidirectional antenna for telemetry purposes. Activated by default.
+    @description = A simple omnidirectional antenna for telemetry purposes.
 
-    @mass = 0.001
+    @mass = 0.003
     @crashTolerance = 10
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
-    %tags = antenna communications omnidirectional transmitter
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @tags ^= :$: communications
 
     !MODULE[DMModuleScienceAnimateGeneric]{}
 }
@@ -121,6 +126,8 @@
 
 @PART[antenna_tv]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Effective range 10 Mm, maximum data rate 6.1 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -135,22 +142,25 @@
     MODULE
     {
         name = ModuleRTAntenna
-        IsRTActive = True
-        Mode0OmniRange = 100000
+        IsRTActive = False
+        Mode0OmniRange = 0
         Mode1OmniRange = 100000
         EnergyCost = 0.005
+        MaxQ = 6000
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 10.24
+            PacketSize = 6.144
             PacketResourceCost = 0.005
         }
     }
 }
 
 //  ==================================================
-//  Whip communications antenna.
+//  Whip omnidirectional antenna.
 
 //  Dimensions: 0.075 m x 0.7 m 
 //  Inert Mass: 3 Kg
@@ -178,19 +188,21 @@
     @mass = 0.003
     @crashTolerance = 8
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
-    %tags = antenna communications omnidirectional transmitter
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @tags ^= :$: communications
 }
 
 //  ==================================================
-//  Whip communications antenna.
+//  Whip omnidirectional antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[antenna_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Effective range 150 Mm, maximum data rate 1 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -209,6 +221,8 @@
         Mode0OmniRange = 0
         Mode1OmniRange = 1500000
         EnergyCost = 0.005
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
         TRANSMITTER
         {
@@ -220,7 +234,7 @@
 }
 
 //  ==================================================
-//  Dish communications antenna.
+//  Folding parabolic antenna.
 
 //  Dimensions: 1.1 m x 0.15 m (retracted)
 //  Inert Mass: 22 Kg
@@ -246,8 +260,9 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @tags ^= :$: communications parabolic
 
     @MODULE[ModuleAnimateGeneric]
     {
@@ -258,13 +273,15 @@
 }
 
 //  ==================================================
-//  Dish communications antenna.
+//  Folding parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[dish_deploy_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Effective range 1.75 Gm, maximum data rate 2.5 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -281,9 +298,9 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 25000000
+        Mode1DishRange = 3500000
         EnergyCost = 0.035
-        DishAngle = 40.0
+        DishAngle = 10.0
         MaxQ = 6000
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -298,7 +315,7 @@
 }
 
 //  ==================================================
-//  Voyager dish antenna.
+//  Voyager 1 & 2 parabolic antenna.
 
 //  Dimensions: 3.66 m x 1.45 m
 //  Inert Mass: 53 Kg
@@ -320,29 +337,31 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
-    @title = Voyager Antenna
+    @title = Voyager 1 & 2 Parabolic Antenna
     @manufacturer = Ford Aerospace and Communications Corp.
-    @description = The main dish antenna of the Voyager spacecraft.
+    @description = The main parabolic telecommunications antenna of the Voyager spacecraft.
 
     @mass = 0.053
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %bulkheadProfiles = srf, size1
-    %tags = antenna communications dish transmitter voyager
+    @tags ^= :$: communications parabolic voyager
 }
 
 //  ==================================================
-//  Voyager antenna dish.
+//  Voyager 1 & 2 parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[dish_L]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Effective range 30 Tm, maximum data rate 0.2 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -359,21 +378,23 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 2.5e13
+        Mode1DishRange = 5.5e12
         EnergyCost = 0.02415
-        DishAngle = 0.5
+        DishAngle = 0.6
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.512
+            PacketSize = 0.256
             PacketResourceCost = 0.0236
         }
     }
 }
 
 //  ==================================================
-//  Pioneer 10/11 dish antenna.
+//  Pioneer 10 & 11 parabolic antenna.
 
 //  Dimensions: 2.77 m x 1 m
 //  Inert Mass: 40 Kg
@@ -394,29 +415,31 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
-    @title = Pioneer 10/11 Antenna
+    @title = Pioneer 10 & 11 Parabolic Antenna
     @manufacturer = TRW
-    @description = The main dish antenna of the Pioneer spacecraft.
+    @description = The main parabolic telecommunications antenna of the Pioneer spacecraft.
 
     @mass = 0.04
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %bulkheadProfiles = srf, size1
-    %tags = antenna communications dish pioneer transmitter
+    @tags ^= :$: communications parabolic pioneer
 }
 
 //  ==================================================
-//  Pioneer 10/11 dish antenna.
+//  Pioneer 10 & 11 parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[dish_M]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Effective range 15 Tm, maximum data rate 0.4 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -433,9 +456,11 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 1.2e13
+        Mode1DishRange = 1.75e12
         EnergyCost = 0.016
-        DishAngle = 0.5
+        DishAngle = 3.0
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
         TRANSMITTER
         {
@@ -447,7 +472,7 @@
 }
 
 //  ==================================================
-//  Ulysses dish antenna.
+//  Ulysses parabolic antenna.
 
 //  Dimensions: 1.65 m x 1.2 m
 //  Inert Mass: 25 Kg
@@ -468,29 +493,31 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
-    @title = Ulysses Antenna
+    @title = Ulysses Parabolic Antenna
     @manufacturer = Astrium GmbH
-    @description = The main dish antenna of the Ulysses spacecraft.
+    @description = The main parabolic telecommunications antenna of the Ulysses spacecraft.
 
     @mass = 0.025
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %bulkheadProfiles = srf, size1
-    %tags = antenna communications dish transmitter ulysses
+    @tags ^= :$: communications parabolic ulysses
 }
 
 //  ==================================================
-//  Ulysses dish antenna.
+//  Ulysses parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[dish_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Effective range 1 Tm, maximum data rate 1 Mbit/sec.
+
     !MODULE[ModuleDataTransmitter]{}
 
     !MODULE[ModuleSPU*]{}
@@ -507,9 +534,11 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 2e9
+        Mode1DishRange = 8.75e9
         EnergyCost = 0.02
         DishAngle = 2.0
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
         TRANSMITTER
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -280,7 +280,7 @@
 
 @PART[dish_deploy_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 1.75 Gm, maximum data rate 2.5 Mbit/sec.
+    @description ^= :$: Effective range 1.75 Gm, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
 
     !MODULE[ModuleDataTransmitter]{}
 
@@ -360,7 +360,7 @@
 
 @PART[dish_L]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 30 Tm, maximum data rate 0.2 Mbit/sec.
+    @description ^= :$: Effective range 30 Tm, maximum data rate 0.2 Mbit/sec, gain 48 dBi.
 
     !MODULE[ModuleDataTransmitter]{}
 
@@ -438,7 +438,7 @@
 
 @PART[dish_M]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 15 Tm, maximum data rate 0.4 Mbit/sec.
+    @description ^= :$: Effective range 15 Tm, maximum data rate 0.4 Mbit/sec, gain 34 dBi.
 
     !MODULE[ModuleDataTransmitter]{}
 
@@ -458,7 +458,7 @@
         Mode0DishRange = 0
         Mode1DishRange = 1.75e12
         EnergyCost = 0.016
-        DishAngle = 3.0
+        DishAngle = 3.5
         DeployFxModules = 0
         ProgressFxModules = 1
 
@@ -516,7 +516,7 @@
 
 @PART[dish_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 1 Tm, maximum data rate 1 Mbit/sec.
+    @description ^= :$: Effective range 1 Tm, maximum data rate 1 Mbit/sec, gain 41 dBi.
 
     !MODULE[ModuleDataTransmitter]{}
 
@@ -536,7 +536,7 @@
         Mode0DishRange = 0
         Mode1DishRange = 8.75e9
         EnergyCost = 0.02
-        DishAngle = 2.0
+        DishAngle = 1.45
         DeployFxModules = 0
         ProgressFxModules = 1
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -117,6 +117,8 @@
 {
     !MODULE[ModuleSPU*]{}
 
+    !MODULE[ModuleRTAntenna*]{}
+
     MODULE
     {
         name = ModuleSPU
@@ -217,6 +219,8 @@
 {
     !MODULE[ModuleSPU*]{}
 
+    !MODULE[ModuleRTAntenna*]{}
+
     MODULE
     {
         name = ModuleSPU
@@ -314,6 +318,8 @@
 @PART[quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
     !MODULE[ModuleSPU*]{}
+
+    !MODULE[ModuleRTAntenna*]{}
 
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -36,11 +36,11 @@
 
     @mass = 0.1
     @crashTolerance = 10
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     !explosionPotential = NULL
     %bulkheadProfiles = size0
-    %tags = bus probe satellite science
+    @tags = command control (core gyro probe react sas satellite space stab steer avionics bus satellite
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = False
@@ -126,7 +126,7 @@
 }
 
 //  ==================================================
-//  Voyager spacecraft bus.
+//  Voyager 1 & 2 spacecraft bus.
 
 //  Dimensions: 1.78 m x 0.8 m
 //  Gross Mass: 535 Kg
@@ -155,11 +155,11 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     !explosionPotential = NULL
     @bulkheadProfiles = size1
-    %tags = avionics control core jpl probe voyager
+    @tags = okto command control (core gyro probe react sas satellite space stab steer avionics control jpl voyager
 
     //  Average electricity consumption post - launch (no instruments active yet).
 
@@ -210,7 +210,7 @@
 }
 
 //  ==================================================
-//  Voyager spacecraft bus.
+//  Voyager 1 & 2 spacecraft bus.
 
 //  Remote Tech compatibility.
 //  ==================================================
@@ -228,10 +228,13 @@
 }
 
 //  ==================================================
-//  Pioneer 10/11 spacecraft bus.
+//  Pioneer 10 & 11 spacecraft bus.
 
 //  Dimensions: 1.45 m x 0.6 m
 //  Gross Mass: 140 Kg
+
+//  Inert mass does not include the mass of the Pioneer
+//  Science Package (15 Kg).
 //  ==================================================
 
 @PART[quetzal]:FOR[RealismOverhaul]
@@ -253,15 +256,15 @@
     @manufacturer = TRW
     @description = Avionics and control unit for the Pioneer deep space probes.
 
-    @mass = 0.1
+    @mass = 0.09
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     !explosionPotential = NULL
     @bulkheadProfiles = size1
-    %tags = avionics control core pioneer probe trw
+    @tags = command control hex (core gyro probe sas satellite space stab steer avionics pioneer trw
 
     //  Average electricity consumption post - launch (no instruments active yet).
 
@@ -310,7 +313,7 @@
 }
 
 //  ==================================================
-//  Pioneer 10/11 spacecraft bus.
+//  Pioneer 10 & 11 spacecraft bus.
 
 //  Remote Tech compatibility.
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -487,7 +487,7 @@
 //  ==================================================
 //  Mars Odyssey solar array.
 
-//  Dimensions: 1.5 m x 5.7 m
+//  Dimensions: 1.5 m x 5.7 m (extended)
 //  Inert Mass: 35 Kg
 //  ==================================================
 
@@ -505,7 +505,7 @@
 
     @title = Mars Odyssey Solar Array
     @manufacturer = Generic
-    @description = A very efficient Gallium Arsenide (GaAs) photovoltaic array with an eccentric pivot point to minimize its stowed footprint.
+    @description = A very efficient Gallium Arsenide (GaAs) photovoltaic array with an eccentric pivot point to minimize it's stowed footprint.
 
     @mass = 0.035
     @crashTolerance = 10
@@ -518,5 +518,42 @@
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 1.5
+    }
+}
+
+//  ==================================================
+//  CA-E200B Solar Array.
+
+//  Dimensions: 5.6 m x 1.25 m (extended)
+//  Inert Mass: 40 Kg
+//  ==================================================
+
+@PART[sp_odyssey_b]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.0, 3.0, 3.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-E200B 1x2 Solar Array
+    @manufacturer = Generic
+    @description = An alternate photovoltaic system with vastly improved clearance, based on our award-winning E200 Series.
+
+    @mass = 0.04
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 1.88
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -1,7 +1,15 @@
 //  ==================================================
 //  Sources:
 
-//  Pioneer Odyssey (Chapter 4): http://history.nasa.gov/SP-349/ch4.htm
+//  Stardust NExT SRC:                          http://stardust.jpl.nasa.gov/mission/capsule.html
+//  Stardust launch press kit:                  http://www2.jpl.nasa.gov/files/misc/stardust.pdf
+//  Cassini Cosmic Dust Analyzer:               http://lasp.colorado.edu/~horanyi/graduate_seminar/Dust_Analyzer.pdf
+//  2001 Mars Odyssey instruments:              http://mars.jpl.nasa.gov/odyssey/mission/instruments
+//  MAVEN IUVS instrument:                      http://lasp.colorado.edu/home/maven/files/2014/10/MAVEN_IUVS.pdf
+//  Cassini RPWS:                               http://lasp.colorado.edu/~horanyi/graduate_seminar/RPWS.pdf
+//  Voyager Backgrounder:                       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
+//  MRO HiRISE instrument test and calibration: http://marsoweb.nas.nasa.gov/HiRISE/papers/other/IAF_2004_Bergstrom_revH.pdf
+//  Pioneer 10/11 Odyssey (Chapter 4):          http://history.nasa.gov/SP-349/ch4.htm
 
 //  ==================================================
 //  Accelerometer.
@@ -16,13 +24,13 @@
 
     @title = CA-SC103 Accelerometer
     @manufacturer = Generic
-    @description = The SC103 has sensitive sensors that can detect seismic vibrations and vehicle acceleration.
+    @description = The SC103 has sensitive sensors that can detect seismic vibrations and vehicle accelerations.
 
     @mass = 0.001
     @crashTolerance = 8
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
-    %tags = accelerometer experiment research science seismic sensor
+    @tags ^= :$: seismic
 }
 
 //  ==================================================
@@ -44,7 +52,107 @@
     @crashTolerance = 8
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
-    %tags = atmospheric experiment pressure science sensor
+    @tags ^= :$: atmospheric pressure
+}
+
+//  ==================================================
+//  Dust Particle Collector.
+
+//  Dimensions: - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_DUSTC]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.5, 2.5, 2.5
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-DUST-C Dust Sample Collector
+    @manufacturer = Generic
+    @description = The DUST-C array features an aerogel - coated collector for trapping the dust particles to return them to Earth for analysis. After exposure the array will be stowed inside the Sample Return Capsule (SRC).
+
+    @mass = 0.017
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: capsule container return sample
+}
+
+//  ==================================================
+//  Cosmic Dust Counter.
+
+//  Dimensions: 0.5 m x 0.6 m
+//  Inert Mass: 17 Kg
+//  ==================================================
+
+@PART[ca_DUSTX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.05, 2.05, 2.05
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-DUST-X Cosmic Dust Counter
+    @manufacturer = Generic
+    @description = The DUST-X is an instrument that collects dust particles and provides information about their size, speed and direction.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: counter dust
+}
+
+//  ==================================================
+//  Electrostatic Analyzer.
+
+//  Dimensions: 0.11 m x 0.65 m
+//  Inert Mass: 5 Kg
+//  ==================================================
+
+@PART[ca_ELIX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-ELIX Electrostatic & Ionization Experiment
+    @manufacturer = Generic
+    @description = The ELIX is an electrostatic analyzer for analyzing the synthesis of charged particles. By employing electric and magnetic fields ELIX concentrates and separates the different particles by their mass and charge, allowing for very precise measurements of plasma density, velocity and distribution.
+
+    @mass = 0.005
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @bulkheadProfiles = srf
+    @tags ^= :$: analyzer particle plasma
 }
 
 //  ==================================================
@@ -69,7 +177,237 @@
     @crashTolerance = 8
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
-    %tags = experiment gravity gradiometer research science sensor
+    @tags ^= :$: gradiometer sensor
+}
+
+//  ==================================================
+//  Gamma Ray Spectrometer.
+
+//  Dimensions: 6.2 m x - m (extended)
+//  Inert Mass: 30 Kg
+//  ==================================================
+
+@PART[ca_GRS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.125, 2.125, 2.125
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-SCGRS Gamma Ray Spectrometer
+    @manufacturer = Generic
+    @description = The Gamma Ray Spectrometer measures the gamma ray energy generated from the planetary surfaces when these are bombarded by cosmic rays. By measuring the gamma ray energy we can determine the elemental synthesis and concentration of the soil.
+
+    @mass = 0.03
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: cosmic element synthesis
+}
+
+//  ==================================================
+//  Infrared Spectrometer.
+
+//  Dimensions: 0.5 m x 0.4 m
+//  Inert Mass: 11 Kg
+//  ==================================================
+
+@PART[ca_KLIR]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.5, 1.5, 1.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-THEMIS Infrared Spectrometer
+    @manufacturer = Generic
+    @description = The THEMIS (Thermal Emission Imaging System) is used to measure the thermal emissions of the planetary bodies, calculate the surface temperature or even map small details of surface features. The spectrometer can also measure the wavelength of IR emissions to detect certain minerals in the soil.
+
+    @mass = 0.011
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @tags ^= :$: imaging soil surface temperature themis
+
+    !MODULE[ModuleResourceScanner]{}
+}
+
+//  ==================================================
+//  Ultraviolet Spectrometer.
+
+//  Dimensions: - m (extended)
+//  Inert Mass: 27 Kg
+//  ==================================================
+
+@PART[ca_LUV]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.25, 1.25, 1.25
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-IUVS Imaging Ultraviolet Spectrometer
+    @manufacturer = Generic
+    @description = IUVS (Imaging Ultraviolet Spectrometer) images the lower part of the UV spectrum. By doing so it can measure the global characteristics of the upper atmospheric and ionospheric layers, providing information about the synthesis, the morphology and the interactions between the solar wind and the atmosphere.
+
+    @mass = 0.027
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: iuvs maven uv ultraviolet spectrometer
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = Deploy IUVS
+        @endEventGUIName = Retract IUVS
+        @actionGUIName = Toggle IUVS
+    }
+}
+
+//  ==================================================
+//  Radio and Plasma Wave Science.
+
+//  Dimensions: 0.6 m x 10 m (extended)
+//  Inert Mass: 38 Kg
+//  ==================================================
+
+@PART[ca_RPWS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.45, 2.45, 2.45
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-RPWS Radio and Plasma Wave Science
+    @manufacturer = Generic
+    @description = The Radio and Plasma Wave Science (RPWS) uses sensitive wideband electric/magnetic monopole and dipole antennae to receive low frequency radio transmissions caused by trapped charged particles (cyclotron waves), electrostatic discharges and whistlers (lighting) and thermal plasma. All these sources can be used to analyze the spectrum and type of the plasma, the electron density and distribution of the magnetospheres and the various lighting effects on the lower atmospheric layers.
+
+    @mass = 0.038
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: cassini
+}
+
+//  ==================================================
+//  Voyager 1 & 2 Science Boom.
+
+//  Dimensions: 2.5 m x 0.5 m (extended)
+//  Inert Mass: 103 Kg
+//  ==================================================
+
+@PART[ca_sciBoom]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Voyager Science Boom
+    @manufacturer = Generic
+    @description = The science boom of the Voyager deep space probe. The boom mounts Narrow and Wide field cameras for orbital survey images, as well as an Infrared and an Ultraviolet spectrometer. NOTE: Deploy the boom to keep experiments away from electromagnetic interference and radiation.
+
+    @mass = 0.103
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @bulkheadProfiles = srf
+    @tags ^= :$: voyager
+}
+
+//  ==================================================
+//  Solar Wind Analyzer.
+
+//  Dimensions: 0.16 m x 0.22 m
+//  Inert Mass: 3 Kg
+//  ==================================================
+
+@PART[ca_SWIS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-SWIA Solar Wind Analyzer
+    @manufacturer = Generic
+    @description = The Solar Wind Analyzer (SWIA) instrument is designed specifically to detect and measure solar wind electron/ion velocity and density.
+
+    @mass = 0.003
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: analyzer electron ion maven
+}
+
+//  ==================================================
+//  Optical Telescope.
+
+//  Dimensions: 0.6 m
+//  Inert Mass: 65 Kg
+//  ==================================================
+
+@PART[ca_telescope_a]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.0, 2.0, 2.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-HiRISE Telescope
+    @manufacturer = Generic
+    @description = The High Resolution Imaging Science Experiment (HiRISE) is a Cassegrain - type visible spectrum telescope and one of the biggest to ever fly in a deep space probe. With it's high resolution capability it can acquire high definition color surface images.
+
+    @mass = 0.065
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    @tags ^= :$: hirise mro
 }
 
 //  ==================================================
@@ -88,35 +426,35 @@
 
     @title = CA-SC100 Infrared Radiometer
     @manufacturer = Generic
-    @description = The SC100 radiometer measures the infrared radiant flux, providing information about the atmospheric and/or the surface temperature.
+    @description = The SC100 radiometer measures the infrared radiant flux, providing information about the atmospheric and/or the surface soil temperature.
 
     @mass = 0.001
     @crashTolerance = 8
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
-    %tags = experiment infrared heat radiometer science sensor temperature thermometer
+    @tags ^= :$: flux infrared radiometer soil surface thermometer
 }
 
 //  ==================================================
-//  Magnetometer.
+//  Pioneer 10 & 11 Triaxial Helium Vector Magnetometer.
 
 //  Dimensions: 0.7 m x 6.6 m (extended)
 //  Inert Mass: 5 Kg
 //  ==================================================
 
-@PART[ca_magneto]:FOR[RealismOverhaul]
+@PART[ca_magneto2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
     @MODEL
     {
-        %scale = 1.5, 1.5, 1.5
+        %scale = 2.15, 2.15, 2.15
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = Triaxial Helium Magnetometer
+    @title = Triaxial Helium Vector Magnetometer
     @manufacturer = Generic
     @description = The magnetometer instruments are used to determine the magnitude and direction of planetary magnetic fields The long boom separates these instruments from any interference caused by magnetic elements in the probe.
 
@@ -124,7 +462,7 @@
     @crashTolerance = 8
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
-    %tags = experiment magnetic research science sensor
+    @tags ^= :$: pioneer sensor triaxial
 
     !MODULE[ModuleResourceScanner]{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -3,6 +3,9 @@
 
 //  Stardust NExT SRC:                          http://stardust.jpl.nasa.gov/mission/capsule.html
 //  Stardust launch press kit:                  http://www2.jpl.nasa.gov/files/misc/stardust.pdf
+//  Aerodynamics of Stardust SRC:               http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040105538.pdf
+//  Genesis SRC Subsystem:                      http://genesismission.jpl.nasa.gov/gm2/spacecraft/sample.html
+//  Genesis SRC Overview:                       https://solarsystem.nasa.gov/docs/6.8_Willcockson.pdf
 //  Cassini Cosmic Dust Analyzer:               http://lasp.colorado.edu/~horanyi/graduate_seminar/Dust_Analyzer.pdf
 //  2001 Mars Odyssey instruments:              http://mars.jpl.nasa.gov/odyssey/mission/instruments
 //  MAVEN IUVS instrument:                      http://lasp.colorado.edu/home/maven/files/2014/10/MAVEN_IUVS.pdf
@@ -28,8 +31,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @tags ^= :$: seismic
 }
 
@@ -50,16 +53,16 @@
 
     @mass = 0.001
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @tags ^= :$: atmospheric pressure
 }
 
 //  ==================================================
 //  Dust Particle Collector.
 
-//  Dimensions: - m
-//  Inert Mass: - Kg
+//  Dimensions: 1.15 m x 0.51 m
+//  Inert Mass: 150 Kg
 //  ==================================================
 
 @PART[ca_DUSTC]:FOR[RealismOverhaul]
@@ -68,7 +71,7 @@
 
     @MODEL
     {
-        %scale = 2.5, 2.5, 2.5
+        %scale = 5.75, 5.75, 5.75
     }
 
     %scale = 1.0
@@ -76,14 +79,14 @@
 
     @title = CA-DUST-C Dust Sample Collector
     @manufacturer = Generic
-    @description = The DUST-C array features an aerogel - coated collector for trapping the dust particles to return them to Earth for analysis. After exposure the array will be stowed inside the Sample Return Capsule (SRC).
+    @description = The DUST-C array features an aerogel - coated collector for trapping the dust particles to return them to Earth for analysis. NOTE: heat shield and parachutes are not included.
 
-    @mass = 0.017
+    @mass = 0.15
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: capsule container return sample
 }
@@ -115,8 +118,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: counter dust
 }
@@ -148,8 +151,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: analyzer particle plasma
@@ -175,15 +178,15 @@
 
     @mass = 0.001
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @tags ^= :$: gradiometer sensor
 }
 
 //  ==================================================
 //  Gamma Ray Spectrometer.
 
-//  Dimensions: 6.2 m x - m (extended)
+//  Dimensions: 6.2 m x 0.45 m (extended)
 //  Inert Mass: 30 Kg
 //  ==================================================
 
@@ -207,8 +210,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: cosmic element synthesis
 }
@@ -240,8 +243,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @tags ^= :$: imaging soil surface temperature themis
 
     !MODULE[ModuleResourceScanner]{}
@@ -250,7 +253,7 @@
 //  ==================================================
 //  Ultraviolet Spectrometer.
 
-//  Dimensions: - m (extended)
+//  Dimensions: 0.5 m x 1.45 m (extended)
 //  Inert Mass: 27 Kg
 //  ==================================================
 
@@ -274,8 +277,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: iuvs maven uv ultraviolet spectrometer
 
@@ -314,8 +317,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: cassini
 }
@@ -342,8 +345,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: voyager
@@ -371,8 +374,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: analyzer electron ion maven
 }
@@ -404,8 +407,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: hirise mro
 }
@@ -430,8 +433,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @tags ^= :$: flux infrared radiometer soil surface thermometer
 }
 
@@ -460,8 +463,8 @@
 
     @mass = 0.005
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @tags ^= :$: pioneer sensor triaxial
 
     !MODULE[ModuleResourceScanner]{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -1,0 +1,50 @@
+//  ==================================================
+//  Pioneer 10 & 11 Science Package.
+
+//  Dimensions: - m
+//  Gross Mass: - Kg
+//  ==================================================
+
+@PART[ca_ESM]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @category = Science
+    @title = Pioneer 10/11 Science Package
+    @manufacturer = Generic
+    @description = The ESM provides the necessary utilities for long-range expeditions. It features additional batteries, reaction wheels, thermal control, and a monopropellant bottle.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
+    @tags = ca coatl cooling louvre pack pioneer science thermal
+
+    !MODULE[ModuleReactionWheel]{}
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 50
+        @overcoolFactor = 1.0
+        @isCoreRadiator = True
+        @maxLinksAway = 2
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.025
+        }
+    }
+
+    !RESOURCE,*{}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -1,8 +1,8 @@
 //  ==================================================
 //  Pioneer 10 & 11 Science Package.
 
-//  Dimensions: - m
-//  Gross Mass: - Kg
+//  Dimensions: 1.25 m x 0.6 m
+//  Gross Mass: 10 Kg
 //  ==================================================
 
 @PART[ca_ESM]:FOR[RealismOverhaul]
@@ -20,29 +20,29 @@
     @category = Science
     @title = Pioneer 10/11 Science Package
     @manufacturer = Generic
-    @description = The ESM provides the necessary utilities for long-range expeditions. It features additional batteries, reaction wheels, thermal control, and a monopropellant bottle.
+    @description = An integrated science package designed for the Pioneer 10 & 11 deep space probes.
 
-    @mass = 1.0
+    @mass = 0.01
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = True
-    @tags = ca coatl cooling louvre pack pioneer science thermal
+    @tags ^= :$: pioneer science
 
     !MODULE[ModuleReactionWheel]{}
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 50
+        @maxEnergyTransfer = 2.0
         @overcoolFactor = 1.0
         @isCoreRadiator = True
         @maxLinksAway = 2
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.025
+            @rate = 0.12
         }
     }
 


### PR DESCRIPTION
* Fix the temperature (part & skin) stats of all parts.
* Fix the telemetry antenna stats.
* Add RT - specific descriptions (range & gain).
* Rework the ranges of the generic antennae.
* The Pioneer, Voyager and Ulysses antennae now have the historically correct stats.
* Decrease the inert mass of the Pioneer bus to balance it for the Science Package.
* Use the historically accurate power usage for the Pioneer temperature control system.

NOTE: The Pioneer Science Package does not currently include any scientific instruments, these must be done by RP-0.