### PR TITLE
RN fix reaction wheels

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
@@ -28,6 +28,17 @@
 			@rate = 0.1
 		}
 	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.015
+		@YawTorque = 0.015
+		@RollTorque = 0.0075
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.025
+		}
+	}
 	@MODULE[ModuleRCS]
 	{
 		%name = ModuleRCS
@@ -157,6 +168,17 @@
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.0092
+		}
+	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.015
+		@YawTorque = 0.015
+		@RollTorque = 0.0075
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.025
 		}
 	}
 	@MODULE[ModuleRCS]
@@ -299,6 +321,17 @@
 			@rate = 0.1
 		}
 	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.0075
+		@YawTorque = 0.0075
+		@RollTorque = 0.00325
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.0125
+		}
+	}
 	@MODULE[ModuleRCS]
 	{
 		%name = ModuleRCS
@@ -430,6 +463,17 @@
 			@rate = 0.08
 		}
 	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.015
+		@YawTorque = 0.015
+		@RollTorque = 0.0075
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.025
+		}
+	}
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 0.645
@@ -540,6 +584,17 @@
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.085
+		}
+	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.0075
+		@YawTorque = 0.0075
+		@RollTorque = 0.00325
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.0125
 		}
 	}
 	@MODULE[ModuleEngines*]
@@ -663,6 +718,9 @@
 	{
 	}
 	!RESOURCE[ElectricCharge]
+	{
+	}
+	!MODULE[ModuleReactionWheel]
 	{
 	}
 	!MODULE[ModuleCommand] {}
@@ -836,6 +894,17 @@
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.015
+		}
+	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.0075
+		@YawTorque = 0.0075
+		@RollTorque = 0.00325
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.0125
 		}
 	}
 	@MODULE[ModuleRCS]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
@@ -318,6 +318,17 @@ MODULE
 			rate = 0.021
 		}
 	}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 0.0075
+		@YawTorque = 0.0075
+		@RollTorque = 0.00325
+		
+		@RESOURCE[ElectricCharge]
+		{ 
+			@rate = 0.0125
+		}
+	}
 	@MODULE[ModuleRCS]
 	{
 		%name = ModuleRCS
@@ -604,7 +615,7 @@ MODULE
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	!RESOURCE[ModuleReactionWheel]
+	!MODULE[ModuleReactionWheel]
 	{
 	}
 	!RESOURCE[ElectricCharge]


### PR DESCRIPTION
-Fix RW for probes that either don't have them, or don't use the
insanely high stock values.