### PR TITLE
better ISP/Thrust for the B9 Sabre engine

### DIFF
--- a/GameData/RealismOverhaul/REWORK/RO_B9.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_B9.cfg
@@ -3105,9 +3105,25 @@
 @PART[B9_Engine_SABRE_Intake_M]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+
+	!mesh = DELETE
+
+	!MODEL,*{}
+
+	MODEL
+	{
+		model = B9_Aerospace/Parts/Engine_SABRE_Intake/model
+		scale = 1.52, 1.52, 1.52
+	}
+	
+	@node_stack_bottom01 = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
 	//%maxTemp = 2273.15
 	%skinMaxTemp = 2500
 	@mass = 0.4
+	@MODULE[ModuleResourceIntake]
+    	{
+        	@area = 0.0739
+    	}
 }
 @PART[B9_Engine_SABRE_S_Body]:FOR[RealismOverhaul]
 {
@@ -3195,8 +3211,23 @@
 {
 	%RSSROConfig = True
 	
+	!mesh = DELETE
+
+	!MODEL,*{}
+
+	MODEL
+	{
+		model = B9_Aerospace/Parts/Engine_SABRE_M/model
+		scale = 2, 2, 2
+	}
+	
 	@title = SABRE M
-	@mass = 8
+	@mass = 5
+	
+	@node_stack_top = 0.0, 2.5, 0.0, 0.0, 1.0, 0.0, 2
+    	@node_attach = 0.0, 1.25, 2.5, 0.0, 0.0, -1.0
+	@CoMOffset = 0.0, -1.25, 0.0
+
 	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/REWORK/RO_B9.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_B9.cfg
@@ -3182,7 +3182,7 @@
 	}
 	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
 	{
-		@minThrust = 500
+		@minThrust = 250
 		@maxThrust = 500
 	}
 	@atmosphereCurve
@@ -3218,7 +3218,7 @@
 	}
 	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
 	{
-		@minThrust = 2940
+		@minThrust = 950
 		@maxThrust = 2940
 	}
 		@atmosphereCurve

--- a/GameData/RealismOverhaul/REWORK/RO_B9.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_B9.cfg
@@ -3120,9 +3120,9 @@
 	//%maxTemp = 2273.15
 	%skinMaxTemp = 2500
 	@mass = 0.4
-	@MODULE[ModuleResourceIntake]
+	@MODULE[AJEInlet]
     	{
-        	@area = 0.0739
+        	@Area = 8.3
     	}
 }
 @PART[B9_Engine_SABRE_S_Body]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/REWORK/RO_B9.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_B9.cfg
@@ -3182,7 +3182,13 @@
 	}
 	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
 	{
+		@minThrust = 500
 		@maxThrust = 500
+	}
+	@atmosphereCurve
+	{
+		@key,0 = 0 460
+		@key,1 = 1 380
 	}
 }
 @PART[B9_Engine_SABRE_M]:FOR[RealismOverhaul]
@@ -3207,12 +3213,18 @@
 		TIT = 900
 		TAB = 3800
 		exhaustMixer = True
-		thrustUpperLimit = 1600
+		thrustUpperLimit = 1960
 		maxT3 = 2000
 	}
 	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
 	{
-		@maxThrust = 2000
+		@minThrust = 2940
+		@maxThrust = 2940
+	}
+		@atmosphereCurve
+	{
+		@key,0 = 0 460
+		@key,1 = 1 380
 	}
 
 }


### PR DESCRIPTION
Also, are the AJE parameters still okay?
Maybe we could create an engine config file for the S.A.B.R.E. too.
Sea level thrust in air breathing mode is still really low; I think there's something to change in the AJE settings (I get around 400kN whereas wikipedia and REL state "1960kN SL"). This make liftoff possible but it is incredibly hard to gain speed; my skylon stucks at mach 1.2 at 6km.