### PR TITLE
RO Squad Utility Updates/Fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -32,7 +32,7 @@
 
 @PART[HighGainAntenna]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
-    %rescaleFactor = 0.5
+    %rescaleFactor = 1.0
 }
 
 @PART[commDish]:FOR[RealismOverhaul] //Comm-88, 2.4m folding dish 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -2,11 +2,12 @@
 {
 	%RSSROConfig = True
 	@mass = 0.025 //supposedly mariner-like
-	@description = Mariner-style extendable high-gain antenna. Effective range ~340Gm, suitable for missions to Venus and (with some care) Mars. Comparatively low bandwidth, on par with standard omnis.
+	@description = Mariner-style extendable high-gain antenna, suitable for missions to Venus and (with some care) Mars. Comparatively low bandwidth, on par with standard omnidirectional antennae.
 }
 @PART[HighGainAntenna]:AFTER[RemoteTech]
 {
-	%rescaleFactor = 0.5  //doesn't work! WHY?
+    @description ^=:$: Effective range ~340Gm, power consumption 70 Watts.
+
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
@@ -22,6 +23,18 @@
 		}
 	}
 }
+
+//  ==================================================
+//  Communotron HG-55.
+
+//  Ven Stock Revamp compatibility.
+//  ==================================================
+
+@PART[HighGainAntenna]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    %rescaleFactor = 0.5
+}
+
 @PART[commDish]:FOR[RealismOverhaul] //Comm-88, 2.4m folding dish 
 {
 	%RSSROConfig = True
@@ -31,6 +44,8 @@
 }
 @PART[commDish]:AFTER[RemoteTech]
 {
+    @description ^=:$: Effective range ~1.5 Tm, power consumption 50 Watts.
+
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
@@ -67,7 +82,7 @@
 			@PacketResourceCost = 0.05
 		}
 	}
-	%description = The DTS-M1 is a fully deployable communications and data transmission system. It has been designed to have a minimal form factor when stowed. Wide angle and reasonable bandwidth among the inner planets. Effective range 580Gm.
+	%description = The DTS-M1 is a fully deployable communications and data transmission system. It has been designed to have a minimal form factor when stowed. Wide angle and reasonable bandwidth among the inner planets. Effective range ~580Gm, power consumption 50 Watts.
 }
 @PART[longAntenna]:FOR[RealismOverhaul] //Comm-16
 {
@@ -88,7 +103,7 @@
 			@PacketResourceCost = 0.0075
 		}
 	}
-	%description = A powerful omni antenna, fully adequate for early lunar probes. If you wonder how a 4Mm antenna can reach the Moon, check the Realism Overhaul FAQ.
+	%description = A powerful omni antenna, fully adequate for early lunar probes. If you wonder how a 4Mm antenna can reach the Moon, check the Realism Overhaul FAQ. Effective range 400 Mm, power consumption 1.5 Watts.
 }
 @PART[radialDecoupler1-2]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
* Add RT range and power descriptions for all antennae.
* Fix the size of the Communotron HG-55.

NOTE: the power consumption entry is a temporary measure until RT implements the stock value display system.