### PR TITLE
RO RemoteTech updates

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_RemoteTech.cfg
@@ -1,10 +1,29 @@
-//all part descriptions assume RT root model and a DSN range of 1.14e14 meters.
-//if either changes, this file needs to be updated.
+//  ==================================================
+//  All part descriptions assume the RT root model and a
+//  DSN range of 1.14e14 meters. If either changes, the
+//  parameters of the antennae need to be updated.
+
+//  Calculating the maximum effective range can be done
+//  via the following equation:
+
+//      EffectiveRange = min(AntennaRange1, AntennaRange2) + SQRT(AntennaRange1 * AntennaRange2)
+
+//  For omnidirectional antennae the actual effective
+//  range will be clipped at 100 times the calculated
+//  effective range and for the directional at 1000 times.
+
+//  ==================================================
+//  Reflectron DP-10 omnidirectional antenna.
+//  ==================================================
+
 @PART[RTShortAntenna1]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	@mass = 0.005
 	@node_attach = 0.46, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+
+    @description ^=:$: Effective range 10 Mm, power consumption 5 Watts.
+
 	@MODULE[ModuleRTAntenna]
 	{
 		// The DP-10 is for getting off the ground, not talking
@@ -20,11 +39,16 @@
 		}
 	}
 }
-@PART[RTLongAntenna2]:AFTER[RemoteTech] //Comm-32
+
+//  ==================================================
+//  Communotron 32 omnidirectional antenna.
+//  ==================================================
+
+@PART[RTLongAntenna2]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	@mass = 0.005
-	@description = Using integrated circuits, the Communotron 32 outperforms it's smaller sibling in any conceivable way, at comparable weight and power demands. Considerable range even when retracted, always on.
+	@description = Using integrated circuits, the Communotron 32 outperforms it's smaller sibling in any conceivable way, at comparable weight and power demands. Considerable range even when retracted, always on. Effective range 1.6 Gm, power consumption 15 Watts.
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0OmniRange = 1000000
@@ -38,11 +62,19 @@
 		}
 	}
 }
+
+//  ==================================================
+//  CommTech EXP-VR-2T omnidirectional antenna.
+//  ==================================================
+
 @PART[RTLongAntenna3]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	@mass = 0.015
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+
+    @description ^=:$: Effective range 1 Gm, power consumption 20 Watts.
+
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0OmniRange = 1000000
@@ -56,14 +88,21 @@
 		}
 	}
 }
-@PART[RTShortDish2]:AFTER[RemoteTech]  //KR-7, 1.4m
+
+//  ==================================================
+//  Reflectron KR-7 parabolic antenna.
+
+//  Diameter: 1.4 m
+//  ==================================================
+
+@PART[RTShortDish2]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 0.5  //70cm
 	@mass = 0.025  //heavy!
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
-	@description = An early, small high-gain antenna. Rather wide cone and high bandwidth for Comm satellites in GEO, live video from the Moon, and similar tasks. Effective range 75Gm.
+	@description = An early, small high-gain antenna. Rather wide cone and high bandwidth for Comm satellites in GEO, live video from the Moon, and similar tasks. Effective range ~37 Gm, power consumption 50 Watts.
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
@@ -79,7 +118,14 @@
 		}
 	}
 }
-@PART[RTShortDish1]:AFTER[RemoteTech] // ?? what part is this?
+
+//  ==================================================
+//  Reflectron SS-5 parabolic antenna.
+
+//  Diameter: N/A (deprecated)
+//  ==================================================
+
+@PART[RTShortDish1]:AFTER[RemoteTech]
 {
 	%RSSROConfig = False
 	@mass = 0.110
@@ -101,7 +147,14 @@
 		}
 	}
 }
-@PART[RTLongDish2]:AFTER[RemoteTech] //KR-14, 2.8m
+
+//  ==================================================
+//  Reflectron KR-14 parabolic antenna.
+
+//  Diameter: 2.8 m
+//  ==================================================
+
+@PART[RTLongDish2]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	@title=Pioneer 10/11 Class Antenna
@@ -109,7 +162,7 @@
 	//2.75m dia, 3.3° 38dB
 	//Pioneer dry mass 230kg; incl. 4x SNAP-19 á 15.4kg & 29.6kg science (140kg left for everything else)
 	@mass = 0.080
-	@description = Dish approximating those found on Pioneer 10/11; effective range ~1500Gm (good for Jupiter and beyond), high power demands and comparatively low bandwidth.
+	@description = Dish approximating those found on Pioneer 10/11; effective range ~1500Gm (good for Jupiter and beyond), high power demands at 160 Watts and comparatively low bandwidth.
 	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	@MODULE[ModuleRTAntenna]
@@ -127,17 +180,24 @@
 		}
 	}
 }
-@PART[RTGigaDish2]:AFTER[RemoteTech] //CommTech1, 3.4m(@1.0) static
+
+//  ==================================================
+//  CommTech-1 parabolic antenna.
+
+//  Diameter: 3.4 m
+//  ==================================================
+
+@PART[RTGigaDish2]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	@title=Voyager Antenna
 	// Voyager: 3.77m, 48dB, 100x more bandwidth than pioneer10/11
 	
-	%rescaleFactor=1.1  //3.74m
+	%rescaleFactor=1.1  //3.74m, original diameter 3.4m
 	@mass = 0.100
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
-	@description = Large dish suitable for deep-space missions well past Pluto; integrated circuitry largely makes up for the weight of the wider dish. Pretty good data rate.
+	@description = Large dish suitable for deep-space missions well past Pluto; integrated circuitry largely makes up for the weight of the wider dish. Pretty good data rate. Effective range ~11 Tm, power consumption 240 Watts.
 	@MODULE[ModuleRTAntenna]
 	{
 		@Mode0DishRange = 0
@@ -153,11 +213,19 @@
 		}
 	}
 }
-@PART[RTGigaDish1]:AFTER[RemoteTech] //Gx128, 1.4/6.4m
+
+//  ==================================================
+//  Reflectron GX-128 retractable parabolic antenna.
+
+//  Diameter retracted: 1.4 m
+//  Diameter extended: 6.4 m
+//  ==================================================
+
+@PART[RTGigaDish1]:AFTER[RemoteTech]
 {
 	%RSSROConfig = True
 	@mass = 0.070
-	@description = The folding mechanism doesn't really save mass. However, the huge 6.4m dish can provide a very decent data rate at comparatively little power.
+	@description = The folding mechanism doesn't really save mass. However, the huge 6.4m dish can provide a very decent data rate at comparatively little power. Effective range ~11 Tm, power consumption 80 Watts.
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 	@MODULE[ModuleRTAntenna]
@@ -175,7 +243,15 @@
 		}
 	}
 }
-+PART[RTGigaDish1]:AFTER[RemoteTech] // Gx256, 2.2/10.5m; was final, but it will run after the above patch so who cares.
+
+//  ==================================================
+//  Reflectron GX-256 retractable parabolic antenna.
+
+//  Diameter retracted: 2.2 m
+//  Diameter extended: 10.5 m
+//  ==================================================
+
++PART[RTGigaDish1]:AFTER[RemoteTech]
 {
 	@name = RO_gx256
 	!mesh = DELETE
@@ -189,7 +265,7 @@
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	@title = Reflectron GX-256
-	@description = A massive dish, useful for high speed, long range communications, but its power usage and size make it largely unsuitable for use on interplanetary probes. It is, however, very useful as an orbital relay, or even a extra ground station.
+	@description = A massive dish, useful for high speed, long range communications, but its power usage and size make it largely unsuitable for use on interplanetary probes. It is, however, very useful as an orbital relay, or even a extra ground station. Effective range ~100 Tm, power consumption 850 Watts.
 	@mass = 0.100
 	@MODULE[ModuleRTAntenna]
 	{


### PR DESCRIPTION
* Add RT range and power descriptions for all antennae.

NOTE: the power consumption entry is a temporary measure until RT implements the stock value display system.