### PR TITLE
Soviet Engines Pack Size Corrections

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -1,7 +1,7 @@
 @PART[NK33_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.5625
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.589812, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
@@ -38,7 +38,7 @@
 @PART[NK43_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.5625
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.711397, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
@@ -75,7 +75,7 @@
 @PART[RD0120_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.4773
 	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
@@ -112,7 +112,7 @@
 @PART[RD0124_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.6641
 	%node_stack_top = 0.0, 0.790815, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.785566, 0, 0.0, -1.0, 0.0, 2
 	%category = Propulsion
@@ -149,7 +149,7 @@
 @PART[RD0146_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.5625
 	%node_stack_top = 0.0, 0.7816036, 0, 0.0, 1.0, 0.0, 1
 	%node_stack_bottom = 0.0, -1.882533, 0, 0.0, -1.0, 0.0, 1
 	!node_attach = DELETE
@@ -227,7 +227,7 @@
 @PART[RD180_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.5625
 	%node_stack_top = 0.0, 2.11619, 0, 0.0, 1.0, 0.0, 3
 	%node_stack_bottom = 0.0, -1.642843, 0, 0.0, -1.0, 0.0, 3
 	!node_attach = DELETE
@@ -264,7 +264,7 @@
 @PART[RD191_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.5625
 	%node_stack_top = 0.0, 2.124936, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.840061, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
@@ -16,7 +16,7 @@
     %sound_explosion_low = flameout
 
 	%RSSROConfig = True
-	%rescaleFactor = 1.364
+	%rescaleFactor = 2.13125
 	%node_stack_top = 0.0, 2.60529, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -2.420039, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
@@ -113,7 +113,7 @@
 	@name = NK9
 
 	%RSSROConfig = True
-	%rescaleFactor = 0.5
+	%rescaleFactor = 1.40625
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_bottom = 0.0, -1.589812, 0.0, 0.0, -1.0, 0.0, 1
 	!node_attach = DELETE
@@ -136,7 +136,7 @@
 	@name = NK9V
 
 	%RSSROConfig = True
-	%rescaleFactor = 0.5
+	%rescaleFactor = 1.40625
 	%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_bottom = 0.0, -2.711397, 0.0, 0.0, -1.0, 0.0, 1
 	!node_attach = DELETE
@@ -159,7 +159,7 @@
 	@name = RD0110
 	
 	%RSSROConfig = True
-	%rescaleFactor = 1.0
+	%rescaleFactor = 1.6641
 	%node_stack_top = 0.0, 0.790815, 0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.785566, 0, 0.0, -1.0, 0.0, 2
 	%category = Propulsion


### PR DESCRIPTION
- brought Soyuz Upper Stage engines inline with 2.66m of diameter (shrouds alignment)
- RD170 seemed to be at the same size as before (unchanged, checked with other models ingame)
- other engines are now inline with their part descriptin (diameters)

- Somthing I couldn't fix - AT LEAST FOR ME - RD180 doesn't show up ingame, didn't before size change aswell. 