### PR TITLE
Update for VSR fixes and upcoming release (?)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -75,7 +75,7 @@
 {
 	@MODEL
 	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
+		@model = VenStockRevamp/Squad/Parts/Propulsion/Skipper
 	}
 }
 
@@ -151,7 +151,7 @@
 {
 	@MODEL
 	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/SkipperB
+		@model = VenStockRevamp/Squad/Parts/Propulsion/Skipper
 	}
 }
 


### PR DESCRIPTION
Fixed model designators for upcoming VSR release (SkipperB got deprecated, now just Skipper.mu) 
Needed for RL10 and RD253 base models