### PR TITLE
Update early NK engines values

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -6,6 +6,7 @@
 // https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
 // http://www.lpre.de/sntk/NK-33/index.htm
 // http://history.nasa.gov/SP-4408pt1.pdf
+// http://lpre.de/resources/articles/AIAA-1998-3361.pdf - good on data
 // FIXME: ignitions may need looking into.
 
 @PART[*]:HAS[#engineType[NK33]]:FOR[RealismOverhaulEngines]
@@ -23,8 +24,8 @@
 		CONFIG
 		{
 			name = NK-15
-			maxThrust = 1605
-			minThrust = 772
+			maxThrust = 1681 // 378,000 Ibf 
+			minThrust = 841
 			heatProduction = 100
 			massMult = 1.020458
 			PROPELLANT
@@ -60,8 +61,8 @@
 		CONFIG
 		{
 			name = NK-15-Original-NoGimbal
-			maxThrust = 1544
-			minThrust = 772
+			maxThrust = 1681
+			minThrust = 841
 			heatProduction = 100
 			massMult = 1.020458
 			gimbalRange = 0
@@ -101,7 +102,7 @@
 			maxThrust = 1766 //105% rated thrust
 			minThrust = 841
 			heatProduction = 100
-			massMult = 1
+			massMult = 1.1937 //1.459t, mass value from AJ26-59
 			PROPELLANT
 			{
 				name = Kerosene
@@ -188,7 +189,7 @@
 		}
 		CONFIG
 		{
-			name = AJ26-62
+			name = AJ26-62 //NK-33 modifed for the Antares-100 series
 			maxThrust = 1815
 			minThrust = 941.92		
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -21,8 +21,8 @@
 		CONFIG
 		{
 			name = NK-15V
-			maxThrust = 1648
-			minThrust = 824
+			maxThrust = 1755
+			minThrust = 877.5
 			heatProduction = 100
 			massMult = 0.963467
 			PROPELLANT
@@ -35,9 +35,10 @@
 			{
 				name = LqdOxygen
 				ratio = 0.64426
-			}atmosphereCurve
+			}
+			atmosphereCurve
 			{
-				key = 0 331
+				key = 0 345
 				key = 1 248
 			}
 			
@@ -57,8 +58,8 @@
 		CONFIG
 		{
 			name = NK-15V-Original-NoGimbal
-			maxThrust = 1648
-			minThrust = 824
+			maxThrust = 1755
+			minThrust = 877.5
 			heatProduction = 100
 			massMult = 0.963467
 			gimbalRange = 0
@@ -75,7 +76,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 331
+				key = 0 345
 				key = 1 248
 			}
 			

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -4,8 +4,7 @@
 // http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm (more reliable)
 // https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
 // http://www.lpre.de/sntk/NK-33/index.htm
-// Per discussion with SirKeplan, the existing NK-15V stats don't make sense.
-// We've computed something reaosnable from RPA Lite. Assume ~11.5-12MPa chamber pressure, establish NK-15 stats, up AR.
+// Assume NK-15V has same performance stats as NK-43(as stated in multiple sources) when no other references are found.
 @PART[*]:HAS[#engineType[NK43]]:FOR[RealismOverhaulEngines]
 {
 	%title = NK-15V/43
@@ -38,8 +37,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 345
-				key = 1 248
+				key = 0 346
+				key = 1 260
 			}
 			
 			ullage = True
@@ -76,8 +75,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 345
-				key = 1 248
+				key = 0 346
+				key = 1 260
 			}
 			
 			ullage = True
@@ -113,7 +112,7 @@
 			atmosphereCurve
 			{
 				key = 0 346
-				key = 1 246
+				key = 1 260 //calc with RPA
 			}
 			
 			ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
@@ -8,6 +8,7 @@
 //  Sources:
 //	http://www.astronautix.com/engines/nk9.htm
 //	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm
+//	http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf
 
 //  Used by:
 //      Bobcat
@@ -29,7 +30,7 @@
 		CONFIG
 		{
 			name = NK-9
-			maxThrust = 421 // sources differ. Nautix says 441kN for the engine, but 421kN for the GR-1's stage. b14643 claims only 373kN. Also it claims only SL Isp of 259, not 280. We'll use it for Isp.
+			maxThrust = 421 // sources differ. Nautix says 441kN for the engine, but 421kN for the GR-1's stage. lpre.de also says 421 kn, so go with this
 			minThrust = 421
 			heatProduction = 205
 			PROPELLANT
@@ -46,7 +47,7 @@
 			atmosphereCurve
 			{
 				key = 0 328
-				key = 1 259
+				key = 1 286.5	//calculated from sl and vac thrust
 			}
 			massMult = 1.0
 			

--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -66,8 +66,8 @@
 		{
 			name = NK-19
 			description = NK-9V rerated for N1 use.
-			maxThrust = 451.1 // b14643
-			minThrust = 451.1
+			maxThrust = 400
+			minThrust = 240
 			heatProduction = 205
 			PROPELLANT
 			{
@@ -82,7 +82,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 345
+				key = 0 353 //assuming same as NK-31
 				key = 1 240 // astronautix, GR-1 entry
 			}
 			massMult = 0.9 // I...guess?


### PR DESCRIPTION
Update early NK engines values, NK-9/NK-9V still sketchy, but are ateast consistent now.

http://lpre.de/resources/articles/AIAA-1998-3361.pdf
http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf

figures on astronautix are generally close to these, though sometimes astronautix disagrees with itself.

