### PR TITLE
Fix plume config and typo for HM-7B (KW Rocketry Pack)

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineWildcatXR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineWildcatXR.cfg
@@ -1,4 +1,4 @@
-@PART[KW3mengineWildcarXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL10
+@PART[KW3mengineWildcatXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // HM-7(B)
 {
 	@MODULE[ModuleEngines*]
 	{


### PR DESCRIPTION
- engine plume was not being displayed as config had a typo and thus did not reference the correct part
- updated description for the WildcatXR as it is used for the HM-7 model

**tested and confirmed working on latest RO version**