### PR TITLE
Update RO_UniversalStorage.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/UniversalStorage/RO_UniversalStorage.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/UniversalStorage/RO_UniversalStorage.cfg
@@ -152,7 +152,7 @@
 		 @RecipeOutputs = Hydrogen, 0.0292072266, True, Oxygen, 0.013766253, False
 	}
 }
-@PART[US_1R330_Wedge_Hydrogen]:FOR[RealismOverhaul]:FINAL
+@PART[US_1R330_Wedge_Hydrogen]:FOR[zzzAfterUniversalStorage]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -227,7 +227,7 @@
 		}
 	}
 }
-@PART[US_1R210_Wedge_Liquidfuel]:FOR[RealismOverhaul]:FINAL
+@PART[US_1R210_Wedge_Liquidfuel]:FOR[zzzAfterUniversalStorage]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -249,7 +249,7 @@
 		%volume = 33
 	}
 }
-@PART[US_1R220_Wedge_Monoprop]:FOR[RealismOverhaul]:FINAL
+@PART[US_1R220_Wedge_Monoprop]:FOR[zzzAfterUniversalStorage]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/UniversalStorage/RO_UniversalStorage.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/UniversalStorage/RO_UniversalStorage.cfg
@@ -1,15 +1,15 @@
-@TANK_DEFINITION[ServiceModule]:FINAL
-{
-	TANK
-	{
-		name = Hydrogen
-		utilization = 200 // 200atm
-		mass = 0.0003 // 0.3kg/l
-		amount = 0.0
-		maxAmount = 0.0
-		note = (pressurized)
-	}
-}
+// @TANK_DEFINITION[ServiceModule]:FINAL
+// {
+	// TANK
+	// {
+		// name = Hydrogen
+		// utilization = 200 // 200atm
+		// mass = 0.0003 // 0.3kg/l
+		// amount = 0.0
+		// maxAmount = 0.0
+		// note = (pressurized)
+	// }
+// }
 @PART[US_1C10_Wedge_Quadcore]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -152,7 +152,7 @@
 		 @RecipeOutputs = Hydrogen, 0.0292072266, True, Oxygen, 0.013766253, False
 	}
 }
-@PART[US_1R330_Wedge_Hydrogen]:FOR[RealismOverhaul]
+@PART[US_1R330_Wedge_Hydrogen]:FOR[RealismOverhaul]:FINAL
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -163,12 +163,12 @@
 	!RESOURCE[Hydrogen]
 	{
 	}
-	MODULE
+	%MODULE[ModuleFuelTanks]
 	{
-		name = ModuleFuelTanks
+		%name = ModuleFuelTanks
 		basemass = -1
-		type = ServiceModule
-		volume = 18
+		%type = ServiceModule
+		%volume = 18
 		TANK
 		{
 			name = LqdHydrogen
@@ -227,7 +227,7 @@
 		}
 	}
 }
-@PART[US_1R210_Wedge_Liquidfuel]:FOR[RealismOverhaul]
+@PART[US_1R210_Wedge_Liquidfuel]:FOR[RealismOverhaul]:FINAL
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -241,15 +241,15 @@
 	!RESOURCE[Oxidizer]
 	{
 	}
-	MODULE
+	%MODULE[ModuleFuelTanks]
 	{
-		name = ModuleFuelTanks
+		%name = ModuleFuelTanks
 		basemass = -1
-		type = Default
-		volume = 33
+		%type = Default
+		%volume = 33
 	}
 }
-@PART[US_1R220_Wedge_Monoprop]:FOR[RealismOverhaul]
+@PART[US_1R220_Wedge_Monoprop]:FOR[RealismOverhaul]:FINAL
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -261,12 +261,12 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	MODULE
+	%MODULE[ModuleFuelTanks]
 	{
-		name = ModuleFuelTanks
-		basemass = -1
+		%name = ModuleFuelTanks
+		%basemass = -1
 		type = ServiceModule
-		volume = 18
+		%volume = 18
 	}
 }
 @PART[US_1M110_Wedge_ScienceBay]:FOR[RealismOverhaul]


### PR DESCRIPTION
since UniversalStorage has patch for RealFuels, we better do this :FINAL and keep an eye on for later if the patch will be deleted.

TANK_DEFINITION can be off since RealFuels define Hydrogen