### PR TITLE
Update RO_KOSMOS.cfg

### DIFF
--- a/GameData/RealismOverhaul/REWORK/RO_KOSMOS.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_KOSMOS.cfg
@@ -28,7 +28,8 @@
 	scale = 1.0
 	rescaleFactor = 1
 	@node_stack_top = 0, 0.549246654, 0, 0, 1, 0
-	@node_stack_bottom = 0, -0.548010141, 0, 0.0, -1.0, 0.0@mass = 0.5
+	@node_stack_bottom = 0, -0.548010141, 0, 0.0, -1.0, 0.0
+	@mass = 0.5
 	@maxTemp = 1973.15
 	@maximum_drag = 0.32
 	@title = Salyut 2/1.33m Adapter Section
@@ -88,7 +89,8 @@
 	scale = 1.0
 	rescaleFactor = 1
 	@node_stack_top = 0, 0.545836533, 0, 0, 1, 0
-	@node_stack_bottom = 0, -0.547324532, 0, 0.0, -1.0, 0.0@mass = 2
+	@node_stack_bottom = 0, -0.547324532, 0, 0.0, -1.0, 0.0
+	@mass = 2
 	@maxTemp = 1973.15
 	@maximum_drag = 0.32
 	@title = Salyut 4/2.66m Adapter Section
@@ -148,7 +150,8 @@
 	scale = 1.0
 	rescaleFactor = 1
 	@node_stack_top = 0, 0.205513942, 0, 0, 1, 0
-	@node_stack_bottom = 0, -0.205513809, 0, 0.0, -1.0, 0.0@mass = 1
+	@node_stack_bottom = 0, -0.205513809, 0, 0.0, -1.0, 0.0
+	@mass = 1
 	@maxTemp = 1973.15
 	@maximum_drag = 0.32
 	@title = Salyut 2.66/2m Adapter Section
@@ -686,7 +689,8 @@
 	scale = 1.0
 	rescaleFactor = 1
 	@node_stack_top = 0, 1.106406796, 0, 0, 1, 0
-	@node_stack_bottom = 0, -1.106700589, 0, 0.0, -1.0, 0.0@mass = 1.4
+	@node_stack_bottom = 0, -1.106700589, 0, 0.0, -1.0, 0.0
+	@mass = 1.4
 	@maxTemp = 1973.15
 	@maximum_drag = 0.32
 	@title = Kosmos Salyut Forward Transfer Compartment (2m)
@@ -747,7 +751,8 @@
 	scale = 1.0
 	rescaleFactor = 1
 	@node_stack_top = 0, 1.822599836, 0, 0, 1, 0
-	@node_stack_bottom = 0, -1.824997237, 0, 0.0, -1.0, 0.0@mass = 3.25
+	@node_stack_bottom = 0, -1.824997237, 0, 0.0, -1.0, 0.0
+	@mass = 3.25
 	@maxTemp = 1973.15
 	@maximum_drag = 0.32
 	@title = Kosmos Salyut Operations Compartment (2.66m)
@@ -819,7 +824,8 @@
 	scale = 1.0
 	rescaleFactor = 1
 	@node_stack_top = 0, 1.965079007, 0, 0, 1, 0
-	@node_stack_bottom = 0, -1.96406926, 0, 0.0, -1.0, 0.0@mass = 6
+	@node_stack_bottom = 0, -1.96406926, 0, 0.0, -1.0, 0.0
+	@mass = 6
 	@maxTemp = 1973.15
 	@maximum_drag = 0.32
 	@title = Kosmos Salyut Main Storage Compartment (4m)


### PR DESCRIPTION
Fix for @mass variable not being on a separate line for some parts. Causes several Kosmos parts not to load on startup.