### PR TITLE
Place/price later variants of RD-253

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
@@ -100,6 +100,10 @@
 				name = ElectricCharge
 				amount = 1.0
 			}
+			
+			%techRequired = stagedTL5
+			cost = 100 //FIXME costs of this and 275M are not sourced
+			entrycost = 10000
 		}
 		CONFIG
 		{
@@ -133,6 +137,13 @@
 			{
 				name = ElectricCharge
 				amount = 1.0
+			}
+			%techRequired = stagedTL6
+			cost = 300
+			entrycost = 20000
+			entryCostSubtractors
+			{
+				RD-275 = 10000
 			}
 		}
 	}


### PR DESCRIPTION
costs are more or less based on NK-33
historically the RD-275 should be TL6, but RD-253s flew in the mid 80s(mir core launch) with a similar thrust upgrade to the 275, so seems reasonable.
EDIT: #1322 