### PR TITLE
Fix VSR RD-253/275 model dimensions

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -68,7 +68,9 @@
 //  ==================================================
 //  RD-253 (booster engine).
 
-//  Ven Stock Revamp compatibility.
+//  Ven Stock Revamp compatibility
+//  Diameter changed to match sources of 1.5m in diameter and 3m in length
+//  http://www.russianspaceweb.com/rd253.html
 //  ==================================================
 
 @PART[RO-RD-253]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
@@ -77,6 +79,8 @@
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/Skipper
 	}
+	
+	@rescaleFactor = 0.577 
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -18,7 +18,7 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineSkipper/model
-		scale = 1.82, 1.82, 1.82
+		scale = 1.238, 1.238, 1.238
 	}
 
     %scale = 1.0
@@ -79,8 +79,6 @@
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/Skipper
 	}
-	
-	@rescaleFactor = 0.577 
 }
 
 //  ==================================================


### PR DESCRIPTION
- Current RD-253/275 model was too large in contrast to real engines sizes
- rescaled to match real life dimensions

(current diameter is 2.6m in contrast to 1.5m and 3m in length // http://www.russianspaceweb.com/rd253.html )
