### PR TITLE
Fix SXT J-2 engine size

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -123,7 +123,7 @@
 	engineType = Waxwing
 }
 
-// J-2
+// J-2 - http://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf for dimension reference
 // remove alternate copies
 -PART[SXTSaturnV2Engine]:FOR[RealismOverhaul] {} // 5x version
 -PART[SXTSaturnV3Enginge]:FOR[RealismOverhaul] {} // tankbutt version
@@ -135,10 +135,10 @@
 	}
 	@MODEL
 	{
-		@scale = 0.7728, 0.84, 0.7728
+		@scale = 1.053 , 1.136 , 1.053
 	}
 	@node_stack_top = 0.0, 0, 0.0, 0.0, 1.0, 0.0 , 2
-	@node_stack_bottom = 0.0, -2.5746, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -3.12, 0.0, 0.0, -1.0, 0.0, 2
 	@node_attach = 0.0, 0.12, 0.0, 0.0, 1.0, 0.0 , 2
 	
 	@mass = 1.578501


### PR DESCRIPTION
Engine was too small in size when comparing to real dimensions (http://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf)

Current state = 1.2m diameter / 2m height -> fixed to 2.1m in diameter and ~ 3.4m in length and corrected attach node