### PR TITLE
Fix M55 gimbal and thrust transforms under VSR

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
@@ -46,11 +46,13 @@
 	@MODULE[ModuleGimbal]
 	{
 		%gimbalRange = 2.0
+		%gimbalTransformName:NEEDS[VenStockRevamp] = Nozzle
 	}
-	@MODULE[ModuleEngines]
+	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 876
 		@heatProduction = 100
+		@thrustVectorTransformName:NEEDS[VenStockRevamp] = thrust
 		@atmosphereCurve
 		{
 			@key,0 = 0 262

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/M55.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/M55.cfg
@@ -3,7 +3,8 @@
     PLUME
     {
         name = Solid-Lower
-        transformName = thrustTransform
+        transformName:NEEDS[!VenStockRevamp] = thrustTransform
+        transformName:NEEDS[VenStockRevamp] = thrust
         localRotation = 0,0,0
         flarePosition = 0,0,0
         plumePosition = 0,0,-0.1


### PR DESCRIPTION
Now has individual gimbal and thrust transforms for each of the 4
nozzles so that roll control can be achieved and effects actually come
from each nozzle.  Plume might need adjustment.