### PR TITLE
RO DECQ's SLS+Orion

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/Dummy
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/Dummy
@@ -1,1 +1,0 @@
-Dunny file

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/Dummy
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/Dummy
@@ -1,0 +1,1 @@
+Dunny file

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
@@ -2,84 +2,12 @@
 {
 	%RSSROConfig = True
 	
-	@title = SLS's core stage
-	@manufacturer = Rocketdyne
-	@description = SLS's core stage with 4 RS-25D/E
-	
 	@rescaleFactor = 1
 	
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = RS-25D
-		origMass = 26.73
-		modded = false
-		CONFIG
-		{
-			name = RS-25D
-			description = Recycled Shuttle's engines used in SLS till NASA won't run out of them. Max 109% thrust.
-			minThrust = 5912.4
-			maxThrust = 9096
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7276
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2724
-			}
-			atmosphereCurve
-			{
-				key = 0 452.3
-				key = 1 363
-			}
-			
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-		}
-		CONFIG
-		{
-			name = RS-25E 
-			description = SSMEs optimized in thrust and costs for a single launch. Max 111% thrust.
-			minThrust = 5964.4
-			maxThrust = 9279.6
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7276
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2724
-			}
-			atmosphereCurve
-			{
-				key = 0 450.8
-				key = 1 363
-			}
-			
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 1
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-		}
-	}
+	engineType = SSME
+	engineTypeMult = 4
+	ignoreMass = true
+	
 	!MODULE[ModuleAlternator]
 	{
 	}
@@ -95,31 +23,117 @@
 }
 @PART[SLS_RS_25]:AFTER[RealismOverhaul]
 {
+	@title = SLS' core stage
+	@manufacturer = Rocketdyne
+	@description = SLS's core stage with 4 RS-25D/E
+	
+	@MODULE[ModuleEngineConfigs]
+    	{
+        	@configuration = RS-25D/E
+
+        	!CONFIG,*:HAS[~name[RS-25A],~name[RS-25C]]{}
+    	}
+	
 	@mass = 26.73
 }
 
-@PART[SLS_UPPERSTAGE_RL_10]:FOR[RealismOverhaul]
+@PART[SLS_UPPERSTAGE_RL_10]:NEEDS[RealismOverhaul]
 {
-	%RSSROConfig = True
-	
-	@rescaleFactor = 1
-	%engineType = RL10
-}
-
-@PART[SLS_UPPERSTAGE_RL_10]:AFTER[RealismOverhaulEngines]
-{
-	%RSSROConfig = True
-	
 	@title = RL10B-2 Engine
 	@manufacturer = Aerojet Rocketdyne
-
-    @MODULE[ModuleEngineConfigs]
-    {
-        @configuration = RL10B-2
-
-        //!CONFIG,*:HAS[~name[RL10B-2],~name[RL10C-1]]{}
-    }
+	
 	@mass = 0.277
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = RL10B-2
+		
+		CONFIG
+		{
+			name = RL10B-2
+			description = Initial RL10 configuration which will be used in the EUS
+			minThrust = 110.1
+			maxThrust = 110.1
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7325
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2675 //5.88
+			}
+			atmosphereCurve
+			{
+				key = 0 465.5
+				key = 1 235
+			}
+			massMult = 1.659
+			
+			%ullage = True
+			%ignitions = 15
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+			%cost = 2000
+			%entrycost = 80000
+			%entryCostSubtractors
+			{
+				RL10A-4 = 45000
+			}
+			%techRequired = hydroloxTL7
+		}
+		CONFIG
+		{
+			name = RL10C-2
+			description = Human rated version of the RL-10C-1
+			minThrust = 110.11
+			maxThrust = 110.11
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7325
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2675 //5.88
+			}
+			atmosphereCurve
+			{
+				key = 0 462
+				key = 1 235
+			}
+			massMult = 1.659
+			
+			%ullage = True
+			%ignitions = 15
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+			%cost = 1700
+			%entrycost = 82000
+			%entryCostSubtractors
+			{
+				RL10A-4 = 45000
+			}
+			%techRequired = hydroloxTL7
+		}
+	}
+	
+	@rescaleFactor = 1
 }
 
 //here we can rely on RO data which is quite accurate.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
@@ -1,0 +1,348 @@
+@PART[SLS_RS_25]:NEEDS[RealismOverhaul]
+{
+	@title = SLS's core stage
+	@manufacturer = Rocketdyne
+	@description = SLS's core stage with 4 RS-25D/E
+	
+	@rescaleFactor = 1
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RS-25D
+		origMass = 26.73
+		modded = false
+		CONFIG
+		{
+			name = RS-25D
+			description = Recycled Shuttle's engines used in SLS till NASA won't run out of them. Max 109% thrust.
+			minThrust = 5912.4
+			maxThrust = 9096
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7276
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2724
+			}
+			atmosphereCurve
+			{
+				key = 0 452.3
+				key = 1 363
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = RS-25E 
+			description = SSMEs optimized in thrust and costs for a single launch. Max 111% thrust.
+			minThrust = 5964.4
+			maxThrust = 9279.6
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7276
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2724
+			}
+			atmosphereCurve
+			{
+				key = 0 450.8
+				key = 1 363
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+	}
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 8.5
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[SLS_UPPERSTAGE_RL_10]:NEEDS[RealismOverhaul]
+{
+	@title = RL10B-2 Engine
+	@manufacturer = Aerojet Rocketdyne
+	
+	@mass = 0.277
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = RL10B-2
+		
+		CONFIG
+		{
+			name = RL10B-2
+			description = Initial RL10 configuration which will be used in the EUS
+			minThrust = 110.1
+			maxThrust = 110.1
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7325
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2675 //5.88
+			}
+			atmosphereCurve
+			{
+				key = 0 465.5
+				key = 1 235
+			}
+			massMult = 1.659
+			
+			%ullage = True
+			%ignitions = 15
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+			%cost = 2000
+			%entrycost = 80000
+			%entryCostSubtractors
+			{
+				RL10A-4 = 45000
+			}
+			%techRequired = hydroloxTL7
+		}
+		CONFIG
+		{
+			name = RL10C-2
+			description = Currently under development, it sucks compared to RL10B-2 and we have no idea why did they're even considering it.
+			minThrust = 110.11
+			maxThrust = 110.11
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7325
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2675 //5.88
+			}
+			atmosphereCurve
+			{
+				key = 0 462
+				key = 1 235
+			}
+			massMult = 1.659
+			
+			%ullage = True
+			%ignitions = 15
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+			%cost = 1700
+			%entrycost = 82000
+			%entryCostSubtractors
+			{
+				RL10A-4 = 45000
+			}
+			%techRequired = hydroloxTL7
+		}
+	}
+	
+	@rescaleFactor = 1
+}
+
+//here we can rely on RO data which is quite accurate.
+@PART[SSRB]:NEEDS[RealismOverhaul]
+{
+	@scale = 1
+	
+	@mass = 91.147
+	
+	@MODEL
+	{
+		@scale = 1,1,1
+	}
+	
+	!RESOURCE[SolidFuel]{}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 356304.13
+		basemass = -1
+		type = PBAN
+	}
+	
+	%engineType = RSRMV
+	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 7.0 //FIXME: source is A1Ch1
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+@PART[AJ_10_190]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+
+	%engineType = AJ10_190
+}
+
+@PART[J2X]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+
+	%engineType = J2X
+}
+
+@PART[EAS_ORION]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	//http://www.braeunig.us/space/specs/orion.htm
+	//Propellant mass: 2.599
+	//Final mass: 5,044 kg 
+	//Launch mass: 7,643 kg
+	
+	//5.044 of final mass MINUS 0.151 t of RCS Hydrazine = 4.893
+	@mass = 4.893
+	
+	!RESOURCE[SolidFuel]{}
+	
+	@MODULE[ModuleEngines]
+		{
+			@minThrust 		= 1760.00
+			@maxThrust	 	= 1760.00
+			@heatProduction = 100
+			!fxOffset 		= NULL
+			%ullage			= false
+			%pressureFed 	= false
+			%ignitions		= 1
+
+			@PROPELLANT[SolidFuel]
+			{
+				@name = HTPB
+			}
+
+			@atmosphereCurve
+			{
+				@key,0 = 0 290.00
+				@key,1 = 1 245.00
+			}
+		}
+	
+	MODULE
+	{
+		name				  = ModuleRCS
+		thrusterTransformName = RCSthruster
+		thrusterPower		  = 22.300
+
+		PROPELLANT
+		{
+			name  = Hydrazine
+			ratio = 1.000
+		}
+
+		atmosphereCurve
+		{
+			key = 0 254
+				key = 1 82.08
+		}
+	}
+
+	MODULE
+	{
+		name	 = ModuleFuelTanks
+		volume	 = 150
+		type	 = Fuselage
+		basemass = -1
+
+		TANK
+		{
+			name	  = Hydrazine
+			amount	  = 150
+			maxAmount = 150
+		}
+	}
+
+	MODULE
+	{
+		name	 = ModuleFuelTanks
+		volume   = 1468.68
+		type	 = HTPB
+		basemass = -1
+	}
+
+	MODULE
+	{
+		name		  = ModuleEngineConfigs
+		type		  = ModuleEngines
+		configuration = Orion-LAS
+		modded		  = false
+
+		CONFIG
+		{
+			name		   = Orion-LAS
+			//400000 pounds = 1779.28KN
+			minThrust 	   = 1779.28	
+			maxThrust	   = 1779.28
+			heatProduction = 100
+			%ullage		   = false
+			%pressureFed   = false
+			%ignitions	   = 1
+
+			PROPELLANT
+			{
+				name	  = HTPB
+				ratio	  = 1.000
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 290.00
+				key = 1 245.00
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
@@ -21,119 +21,41 @@
 		%gimbalResponseSpeed = 16
 	}
 }
-@PART[SLS_RS_25]:AFTER[RealismOverhaul]
+@PART[SLS_RS_25]:AFTER[RealismOverhaulEngines]
 {
 	@title = SLS' core stage
 	@manufacturer = Rocketdyne
 	@description = SLS's core stage with 4 RS-25D/E
 	
 	@MODULE[ModuleEngineConfigs]
-    	{
-        	@configuration = RS-25D/E
+    {
+        @configuration = RS-25D/E
 
-        	!CONFIG,*:HAS[~name[RS-25A],~name[RS-25C]]{}
-    	}
+        !CONFIG,*:HAS[~name[RS-25D/E]]{}
+    }
 	
 	@mass = 26.73
 }
 
-@PART[SLS_UPPERSTAGE_RL_10]:NEEDS[RealismOverhaul]
+@PART[SLS_UPPERSTAGE_RL_10]:FOR[RealismOverhaul]
 {
-	@title = RL10B-2 Engine
-	@manufacturer = Aerojet Rocketdyne
-	
-	@mass = 0.277
-	
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = false
-		configuration = RL10B-2
-		
-		CONFIG
-		{
-			name = RL10B-2
-			description = Initial RL10 configuration which will be used in the EUS
-			minThrust = 110.1
-			maxThrust = 110.1
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7325
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2675 //5.88
-			}
-			atmosphereCurve
-			{
-				key = 0 465.5
-				key = 1 235
-			}
-			massMult = 1.659
-			
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
-			{
-				%name = ElectricCharge
-				%amount = 0.5
-			}
-			%cost = 2000
-			%entrycost = 80000
-			%entryCostSubtractors
-			{
-				RL10A-4 = 45000
-			}
-			%techRequired = hydroloxTL7
-		}
-		CONFIG
-		{
-			name = RL10C-2
-			description = Human rated version of the RL-10C-1
-			minThrust = 110.11
-			maxThrust = 110.11
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7325
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2675 //5.88
-			}
-			atmosphereCurve
-			{
-				key = 0 462
-				key = 1 235
-			}
-			massMult = 1.659
-			
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
-			{
-				%name = ElectricCharge
-				%amount = 0.5
-			}
-			%cost = 1700
-			%entrycost = 82000
-			%entryCostSubtractors
-			{
-				RL10A-4 = 45000
-			}
-			%techRequired = hydroloxTL7
-		}
-	}
+	%RSSROConfig = True
 	
 	@rescaleFactor = 1
+	%engineType = RL10
+}
+@PART[SLS_UPPERSTAGE_RL_10]:AFTER[RealismOverhaulEngines]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RL10B-2
+
+        !CONFIG,*:HAS[~name[RL10B-2],~name[RL10C-1]]{}
+    }
+	@mass = 0.277
+	
+	@title = RL10B-2 Engine
+	@manufacturer = Aerojet Rocketdyne
 }
 
 //here we can rely on RO data which is quite accurate.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ENGINES.cfg
@@ -1,5 +1,7 @@
-@PART[SLS_RS_25]:NEEDS[RealismOverhaul]
+@PART[SLS_RS_25]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@title = SLS's core stage
 	@manufacturer = Rocketdyne
 	@description = SLS's core stage with 4 RS-25D/E
@@ -91,109 +93,40 @@
 		%gimbalResponseSpeed = 16
 	}
 }
-
-@PART[SLS_UPPERSTAGE_RL_10]:NEEDS[RealismOverhaul]
+@PART[SLS_RS_25]:AFTER[RealismOverhaul]
 {
-	@title = RL10B-2 Engine
-	@manufacturer = Aerojet Rocketdyne
-	
-	@mass = 0.277
-	
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = false
-		configuration = RL10B-2
-		
-		CONFIG
-		{
-			name = RL10B-2
-			description = Initial RL10 configuration which will be used in the EUS
-			minThrust = 110.1
-			maxThrust = 110.1
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7325
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2675 //5.88
-			}
-			atmosphereCurve
-			{
-				key = 0 465.5
-				key = 1 235
-			}
-			massMult = 1.659
-			
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
-			{
-				%name = ElectricCharge
-				%amount = 0.5
-			}
-			%cost = 2000
-			%entrycost = 80000
-			%entryCostSubtractors
-			{
-				RL10A-4 = 45000
-			}
-			%techRequired = hydroloxTL7
-		}
-		CONFIG
-		{
-			name = RL10C-2
-			description = Currently under development, it sucks compared to RL10B-2 and we have no idea why did they're even considering it.
-			minThrust = 110.11
-			maxThrust = 110.11
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7325
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2675 //5.88
-			}
-			atmosphereCurve
-			{
-				key = 0 462
-				key = 1 235
-			}
-			massMult = 1.659
-			
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
-			{
-				%name = ElectricCharge
-				%amount = 0.5
-			}
-			%cost = 1700
-			%entrycost = 82000
-			%entryCostSubtractors
-			{
-				RL10A-4 = 45000
-			}
-			%techRequired = hydroloxTL7
-		}
-	}
+	@mass = 26.73
+}
+
+@PART[SLS_UPPERSTAGE_RL_10]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
 	
 	@rescaleFactor = 1
+	%engineType = RL10
+}
+
+@PART[SLS_UPPERSTAGE_RL_10]:AFTER[RealismOverhaulEngines]
+{
+	%RSSROConfig = True
+	
+	@title = RL10B-2 Engine
+	@manufacturer = Aerojet Rocketdyne
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RL10B-2
+
+        //!CONFIG,*:HAS[~name[RL10B-2],~name[RL10C-1]]{}
+    }
+	@mass = 0.277
 }
 
 //here we can rely on RO data which is quite accurate.
-@PART[SSRB]:NEEDS[RealismOverhaul]
+@PART[SSRB]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@scale = 1
 	
 	@mass = 91.147
@@ -222,22 +155,32 @@
 	}
 }
 
-@PART[AJ_10_190]:NEEDS[RealismOverhaul]
+@PART[AJ_10_190]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 
 	%engineType = AJ10_190
 }
-
-@PART[J2X]:NEEDS[RealismOverhaul]
+@PART[AJ_10_190]:AFTER[RealismOverhaul]
 {
+	@mass = 0.125
+}
+
+@PART[J2X]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 
 	%engineType = J2X
 }
 
-@PART[EAS_ORION]:NEEDS[RealismOverhaul]
+@PART[EAS_ORION]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	//http://www.braeunig.us/space/specs/orion.htm
 	//Propellant mass: 2.599

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_FAIRINGS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_FAIRINGS.cfg
@@ -1,5 +1,7 @@
-@PART[ESMP9]:NEEDS[RealismOverhaul]
+@PART[ESMP9]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//http://www.braeunig.us/space/specs/orion.htm
@@ -7,8 +9,10 @@
 	@mass = 0.449
 }
 
-@PART[ESMP11]:NEEDS[RealismOverhaul]
+@PART[ESMP11]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//http://www.braeunig.us/space/specs/orion.htm
@@ -16,8 +20,10 @@
 	@mass = 0.449
 }
 
-@PART[ESMP12]:NEEDS[RealismOverhaul]
+@PART[ESMP12]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//http://www.braeunig.us/space/specs/orion.htm
@@ -25,8 +31,10 @@
 	@mass = 0.449
 }
 
-@PART[FAIRING_TOP_STAGE3]:NEEDS[RealismOverhaul]
+@PART[FAIRING_TOP_STAGE3]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//in theory it substitutes the interstage of block A which is 5t,
@@ -37,30 +45,38 @@
 	@node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
 }
 
-@PART[FAIRING_UPPER_STAGE]:NEEDS[RealismOverhaul]
+@PART[FAIRING_UPPER_STAGE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	//no data for fairings, so let's just multiply the original for 1.67
 	@mass = 1.035
 	@rescaleFactor = 1
 }
 
-@PART[FAIRING]:NEEDS[RealismOverhaul]
+@PART[FAIRING]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@mass = 1.67
 	@rescaleFactor = 1
 	
 	@node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
 }
 
-@PART[LVSA_FAIRING]:NEEDS[RealismOverhaul]
+@PART[LVSA_FAIRING]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@description = NOTE: MODEL IS UNALIGNED WITH THE BASE. USE SLS ICPS PAYLOAD FAIRING INSTEAD
 	@mass = 1.069
 	@rescaleFactor = 1
 }
 
-@PART[FAIRING_INTERSTAGE]:NEEDS[RealismOverhaul]
+@PART[FAIRING_INTERSTAGE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@mass = 1
 	@rescaleFactor = 1
 	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_FAIRINGS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_FAIRINGS.cfg
@@ -1,0 +1,68 @@
+@PART[ESMP9]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//http://www.braeunig.us/space/specs/orion.htm
+	//1.383 t / 3 fairings =  0.461t. minus 0.07 t of solid fuel:
+	@mass = 0.449
+}
+
+@PART[ESMP11]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//http://www.braeunig.us/space/specs/orion.htm
+	//1.383 t / 3 fairings =  0.461t. minus 0.07 t of solid fuel:
+	@mass = 0.449
+}
+
+@PART[ESMP12]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//http://www.braeunig.us/space/specs/orion.htm
+	//1.383 t / 3 fairings =  0.461t. minus 0.07 t of solid fuel:
+	@mass = 0.449
+}
+
+@PART[FAIRING_TOP_STAGE3]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//in theory it substitutes the interstage of block A which is 5t,
+	//so 2*2.5T = 5t of fairings for block IB/II
+	//subtract 0.075 of solid fuel and we get:
+	@mass = 2.425
+	
+	@node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
+}
+
+@PART[FAIRING_UPPER_STAGE]:NEEDS[RealismOverhaul]
+{
+	//no data for fairings, so let's just multiply the original for 1.67
+	@mass = 1.035
+	@rescaleFactor = 1
+}
+
+@PART[FAIRING]:NEEDS[RealismOverhaul]
+{
+	@mass = 1.67
+	@rescaleFactor = 1
+	
+	@node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
+}
+
+@PART[LVSA_FAIRING]:NEEDS[RealismOverhaul]
+{
+	@description = NOTE: MODEL IS UNALIGNED WITH THE BASE. USE SLS ICPS PAYLOAD FAIRING INSTEAD
+	@mass = 1.069
+	@rescaleFactor = 1
+}
+
+@PART[FAIRING_INTERSTAGE]:NEEDS[RealismOverhaul]
+{
+	@mass = 1
+	@rescaleFactor = 1
+	
+	@node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
@@ -1,0 +1,573 @@
+@PART[ORION_SERV_MODULE]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = ESA, Airbus
+	
+	//total service module mass = 6.185. Subtract 0.125t of Aj 10 engine, 0.4 ton of solar arrays (4x0.1) 
+	//0.6 t of RCS AND 0.24t of monopropellant to remove if you happen to fix RCS/SPS backup: 
+	@mass = 4.82
+	
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+	
+	RESOURCE[LiquidFuel]{}
+	RESOURCE[Oxidizer]{}
+	!MODULE[ModuleReactionWheel] {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 9840
+		basemass = -1
+		
+		TANK
+		{
+			name = Oxygen
+			amount = 71500
+			maxAmount = 71500
+		}
+		TANK
+		{
+			name = Water
+			amount = 470
+			maxAmount = 470
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 65
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 600
+		}
+		
+		TANK
+		{
+			name = MMH
+			amount = 4018.17
+			maxAmount = 4018.17
+		}
+		TANK
+		{
+			name = MON3
+			amount = 4031.3
+			maxAmount = 4031.3
+		}
+		
+		//mass = 0.240t please remove and increase the service module mass of 0.240t
+		//if you happen to know how the heck to make the RCS work with MMH/MON3 
+		TANK
+		{
+			name = MonoPropellant
+			amount = 300
+			maxAmount = 300
+		}
+	}
+	
+	@MODULE[ModuleRCS]
+	{
+		//8x490N thruster per axis = 
+		@thrusterPower = 3.92
+		
+		//resourceFlowMode = STACK_PRIORITY_SEARCH
+		
+		//EDIT: for some reason both RCS and sps backup works only with mono propellant. if you happen to solve it, please remove the comment.
+		//PROPELLANT
+		//{
+			//name = MON3
+            //ratio = 0.5010
+		//}
+		//PROPELLANT
+		//{
+			//name = MMH
+            //ratio = 0.4990
+		//}
+		
+		atmosphereCurve
+		{
+			key = 0 266
+			key = 1 190
+		}
+	}
+}
+
+@PART[ORION_COMMAND_MODULE_SILVER]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = NASA, Lockheed Martin
+
+	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS
+	@mass = 7.133
+	
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+	
+	@CrewCapacity = 6
+	
+	!RESOURCE[MonoPropellant] {}
+	!RESOURCE[ElectricCharge] {}
+	!MODULE[ModuleReactionWheel]{}
+	
+	//it's 0.06t(60kg) of contingency on the orion craft itself, ergo water and oxygen.
+	//the rest is CO2 scrubbers, wastes, food and lithium.
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 1349
+		basemass = -1
+		TANK
+		{
+			name = Oxygen
+			amount = 3557
+			maxAmount = 3557
+		}
+		TANK
+		{
+			name = Water
+			amount = 23.1
+			maxAmount = 23.1
+		}
+		TANK
+		{
+			name = Food
+			amount = 750
+			maxAmount= 750
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 27000
+			maxAmount = 27000
+		}
+		
+		TANK
+		{
+			//0.00001189 lithium per sec x 3600 sec in 1 hour x 24 hours x 21 days = +- 18 units
+			name = LithiumHydroxide
+			amount = 18		
+			maxAmount = 18
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 3.2
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 62440
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 30
+		}
+		
+		//then, it's 0.167t of RCS Propellant.
+		TANK
+		{
+			name = Hydrazine
+			amount = 168
+			maxAmount = 168
+		}
+	}
+	
+	//RCS source: http://ir.aerojetrocketdyne.com/releaseDetail.cfm?releaseid=742943
+	@MODULE[ModuleRCS]
+	{
+		//3x711kn  per each side = 2.133 KN
+		@thrusterPower = 2.133
+		
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 1
+		}
+		
+		@atmosphereCurve
+		{
+			key = 0 239
+			key = 1 190
+		}
+	}
+	
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
+	}
+}
+
+@PART[BOTTOM_SHIELD]:NEEDS[RealismOverhaul]
+{
+	//plus 0.6 tons of ablator its 1360.777 or 4000 pounds
+	//source: https://www.nasa.gov/sites/default/files/atoms/files/orionheatshield.pdf
+	@mass = 0.76
+
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+	@manufacturer = Lockheed Martin
+	
+	maxTemp = 2400
+	%skinMaxTemp = 3600
+	
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 0.75
+		lossExp = -40000
+		lossConst = 15000
+		pyrolysisLossFactor = 40000
+		ablationTempThresh = 500
+		reentryConductivity = 0.01
+		//reentryConductivity = 0.12
+		//@reentryConductivity = #$../heatConductivity$ // if it exists, use it
+	}
+	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+	{
+		@name = ModuleHeatShield
+		depletedMaxTemp = 4800	//2650C
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
+		maxAmount = 600
+	}
+}
+
+@PART[ORION_Parachute]:NEEDS[RealismOverhaul]
+{
+	//3x400 pounds plus wielding is approximately 0.452 tons.
+	//removing realchute mass:
+	//@mass = 0.452
+	@mass = 0.3498
+	
+	@manufacturer = NASA
+	
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+	
+	maximum_drag = 0.3
+	!sound_parachute_open
+	!sound_parachute_single
+
+	!MODULE[ModuleParachute]{}
+
+	MODULE
+	{
+		name = RealChuteModule
+		//caseMass = 0.04
+		caseMass = 0.3498
+		timer = 2
+		mustGoDown = false
+		spareChutes = 1
+		cutSpeed = 0.25
+		
+		PARACHUTE
+		{
+			material = Nylon
+			preDeployedDiameter = 8
+			deployedDiameter = 48
+			minIsPressure = false
+			minDeployment = 2500
+			deploymentAlt = 900
+			cutAlt = -1
+			preDeploymentSpeed = 1
+			deploymentSpeed = 2
+			preDeploymentAnimation = SEMI
+			deploymentAnimation = FULL
+			parachuteName = CANOPY
+			capName = parashute
+		}
+	}
+
+	EFFECTS
+	{	rcpredeploy
+		{	AUDIO
+			{	channel = Ship
+				clip = sound_parachute_open
+				volume = 1
+			}
+		}
+		rcdeploy
+		{
+			AUDIO
+			{	channel = Ship
+				clip = sound_parachute_single
+				volume = 1
+			}
+		}
+		rccut
+		{	AUDIO
+			{	channel = Ship
+				clip = RealChute/Sounds/sound_parachute_cut
+				volume = 1
+			}
+		}
+		rcrepack
+		{	AUDIO
+			{	channel = Ship
+				clip = RealChute/Sounds/sound_parachute_repack
+				volume = 1
+			}
+		}
+	}
+}
+
+@PART[ORION_TOP_SHIELD]:NEEDS[RealChute]:FOR[SLS]
+{
+	@manufacturer = NASA
+	@description = Orion main docking port, drogue parachute and main parachute shield. This one is equipped with a silver coating for thermal protection. NOTE: drogue works only with all the planets aligned (ergo never)
+
+	//nose and chute are 860 kg. since the chute is 452 kg there are left only:
+	//@mass = 0.408 //removed for realchute support
+	@mass = 0.4016
+	
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+
+	maximum_drag = 0.3
+	!sound_parachute_open
+	!sound_parachute_single
+
+	!MODULE[ModuleParachute]{}
+
+	MODULE
+	{
+		name = RealChuteModule
+		caseMass = 0.4016
+		timer = 1.2
+		mustGoDown = false
+		spareChutes = 1
+		cutSpeed = 0.25
+		
+		PARACHUTE
+		{
+			material = Nylon
+			preDeployedDiameter = 2
+			deployedDiameter = 12
+			minIsPressure = false
+			minDeployment = 6000
+			deploymentAlt = 3000
+			cutAlt = -1
+			preDeploymentSpeed = 1
+			deploymentSpeed = 2
+			preDeploymentAnimation = SEMI
+			deploymentAnimation = FULL
+			parachuteName = CANOPY
+			capName = parashute
+		}
+	}
+
+	EFFECTS
+	{	rcpredeploy
+		{	AUDIO
+			{	channel = Ship
+				clip = sound_parachute_open
+				volume = 1
+			}
+		}
+		rcdeploy
+		{
+			AUDIO
+			{	channel = Ship
+				clip = sound_parachute_single
+				volume = 1
+			}
+		}
+		rccut
+		{	AUDIO
+			{	channel = Ship
+				clip = RealChute/Sounds/sound_parachute_cut
+				volume = 1
+			}
+		}
+		rcrepack
+		{	AUDIO
+			{	channel = Ship
+				clip = RealChute/Sounds/sound_parachute_repack
+				volume = 1
+			}
+		}
+	}
+}
+
+@PART[ORION_TOP_SHIELD_SILVER]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = NASA
+	@description = Orion main docking port, drogue parachute and main parachute shield. This one is equipped with a silver coating for thermal protection. NOTE: drogue works only with all the planets aligned (ergo never)
+
+	//nose and chute are 860 kg. since the chute is 452 kg there are left only:
+	//@mass = 0.408 //removed for realchute support
+	@mass = 0.408
+	
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+
+	maximum_drag = 0.3
+	!sound_parachute_open
+	!sound_parachute_single
+
+	!MODULE[ModuleParachute]{}
+
+	MODULE
+	{
+		name = RealChuteModule
+		caseMass = 0.4016
+		timer = 1.2
+		mustGoDown = false
+		spareChutes = 1
+		cutSpeed = 0.25
+		
+		PARACHUTE
+		{
+			material = Nylon
+			preDeployedDiameter = 2
+			deployedDiameter = 12
+			minIsPressure = false
+			minDeployment = 6000
+			deploymentAlt = 3000
+			cutAlt = -1
+			preDeploymentSpeed = 1
+			deploymentSpeed = 2
+			preDeploymentAnimation = SEMI
+			deploymentAnimation = FULL
+			parachuteName = CANOPY
+			capName = parashute
+		}
+	}
+
+	EFFECTS
+	{	rcpredeploy
+		{	AUDIO
+			{	channel = Ship
+				clip = sound_parachute_open
+				volume = 1
+			}
+		}
+		rcdeploy
+		{
+			AUDIO
+			{	channel = Ship
+				clip = sound_parachute_single
+				volume = 1
+			}
+		}
+		rccut
+		{	AUDIO
+			{	channel = Ship
+				clip = RealChute/Sounds/sound_parachute_cut
+				volume = 1
+			}
+		}
+		rcrepack
+		{	AUDIO
+			{	channel = Ship
+				clip = RealChute/Sounds/sound_parachute_repack
+				volume = 1
+			}
+		}
+	}
+}
+
+@PART[ORION_SOLAR_PANEL]:NEEDS[RealismOverhaul]
+{
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	
+	@scale = 1
+	
+	//this is a total work of guessing
+	@mass = 0.1
+	
+	@manufacturer = Airbus
+	
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		animationName = SOLAR
+		resourceName = ElectricCharge
+		raycastTransformName = sunPivot
+		chargeRate = 1.64
+		retractable = false
+	}
+}
+
+//RCS source: http://image.slidesharecdn.com/hatfieldskip-120725121936-phpapp01/95/hatfield-skip-29-728.jpg?cb=1343218871 (OLD)
+//http://www.esa.int/Our_Activities/Human_Spaceflight/Orion/Propulsion
+@PART[ORION_RCS]:NEEDS[RealismOverhaul]
+{
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	
+	@scale = 1
+	
+	//this is a total work of guessing
+	@mass = 0.15
+	
+	@manufacturer = NASA
+	
+	@MODULE[ModuleRCS]
+	{
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		
+		//2x220N thruster per axis
+		@thrusterPower = 0.440
+		!resourceName = DELETE
+
+		//no data is known for mixture ratio for the  so i'll keep them the same.
+		//ISP for the SPS backup should be 50s lower than the OMS so i'll lower the RCS to other 20s
+		//EDIT: for some reason both RCS and sps backup works only with mono propellant. if you happen to solve it, please remove the comment.
+		//PROPELLANT
+		//{
+			//name = MON3
+            //ratio = 0.5010
+		//}
+		//PROPELLANT
+		//{
+			//name = MMH
+            //ratio = 0.4990
+		//}
+		
+		atmosphereCurve
+		{
+			key = 0 246
+			key = 1 190
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
@@ -1,10 +1,12 @@
-@PART[ORION_SERV_MODULE]:NEEDS[RealismOverhaul]
+@PART[ORION_SERV_MODULE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = ESA, Airbus
 	
-	//total service module mass = 6.185. Subtract 0.125t of Aj 10 engine, 0.4 ton of solar arrays (4x0.1) 
-	//0.6 t of RCS AND 0.24t of monopropellant to remove if you happen to fix RCS/SPS backup: 
-	@mass = 4.82
+	//total service module mass = 6.185. Subtract 0.125t of Aj 10 engine, 0.4 ton of solar arrays (4x0.1) + 0.6 t of RCS
+	//and 0.567 of other stuff:
+	@mass = 4.493
 	
 	@MODEL
 	{
@@ -12,9 +14,11 @@
 	}
 	@scale = 1
 	
-	RESOURCE[LiquidFuel]{}
-	RESOURCE[Oxidizer]{}
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
 	!MODULE[ModuleReactionWheel] {}
+	
+	%fuelCrossFeed = True
 
 	MODULE
 	{
@@ -35,18 +39,6 @@
 			amount = 470
 			maxAmount = 470
 		}
-		TANK
-		{
-			name = Waste
-			amount = 0
-			maxAmount = 65
-		}
-		TANK
-		{
-			name = WasteWater
-			amount = 0
-			maxAmount = 600
-		}
 		
 		TANK
 		{
@@ -60,35 +52,26 @@
 			amount = 4031.3
 			maxAmount = 4031.3
 		}
-		
-		//mass = 0.240t please remove and increase the service module mass of 0.240t
-		//if you happen to know how the heck to make the RCS work with MMH/MON3 
-		TANK
-		{
-			name = MonoPropellant
-			amount = 300
-			maxAmount = 300
-		}
 	}
 	
-	@MODULE[ModuleRCS]
+	MODULE[ModuleRCS]
 	{
 		//8x490N thruster per axis = 
 		@thrusterPower = 3.92
 		
-		//resourceFlowMode = STACK_PRIORITY_SEARCH
+		resourceFlowMode = STACK_PRIORITY_SEARCH
 		
 		//EDIT: for some reason both RCS and sps backup works only with mono propellant. if you happen to solve it, please remove the comment.
-		//PROPELLANT
-		//{
-			//name = MON3
-            //ratio = 0.5010
-		//}
-		//PROPELLANT
-		//{
-			//name = MMH
-            //ratio = 0.4990
-		//}
+		PROPELLANT
+		{
+			name = MON3
+            ratio = 0.5010
+		}
+		PROPELLANT
+		{
+			name = MMH
+            ratio = 0.4990
+		}
 		
 		atmosphereCurve
 		{
@@ -98,13 +81,15 @@
 	}
 }
 
-@PART[ORION_COMMAND_MODULE_SILVER]:NEEDS[RealismOverhaul]
+@PART[ORION_COMMAND_MODULE_SILVER]:FOR[RealismOverhaul]
 {
-	@name = Orion Command Module
+	%RSSROConfig = True
+	
 	@manufacturer = NASA, Lockheed Martin
 
 	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS
-	@mass = 7.133
+	//@mass = 7.133
+	@mass = 7.180
 	
 	@MODEL
 	{
@@ -124,7 +109,7 @@
 	{
 		name = ModuleFuelTanks
 		type = ServiceModule
-		volume = 1349
+		volume = 2520
 		basemass = -1
 		TANK
 		{
@@ -162,7 +147,7 @@
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 3.2
+			maxAmount = 67.2
 		}
 		TANK
 		{
@@ -174,7 +159,7 @@
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 30
+			maxAmount = 600
 		}
 		
 		//then, it's 0.167t of RCS Propellant.
@@ -215,14 +200,17 @@
 	}
 }
 
-@PART[ORION_COMMAND_MODULE]:NEEDS[RealismOverhaul]
+@PART[ORION_COMMAND_MODULE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@name = Orion Command Module (EFT-1)
-	@manufacturer = NASA, Lockheed Martin
 	@description = Tiled version of the Orion Command Module used on the EFT-1 test flight.
+	@manufacturer = NASA, Lockheed Martin
 
-	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS
-	@mass = 7.133
+	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS and 0.047 of other stuff:
+	//@mass = 7.133
+	@mass = 7.180
 	
 	@MODEL
 	{
@@ -242,7 +230,7 @@
 	{
 		name = ModuleFuelTanks
 		type = ServiceModule
-		volume = 1349
+		volume = 2520
 		basemass = -1
 		TANK
 		{
@@ -280,7 +268,7 @@
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 3.2
+			maxAmount = 67.2
 		}
 		TANK
 		{
@@ -292,7 +280,7 @@
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 30
+			maxAmount = 600
 		}
 		
 		//then, it's 0.167t of RCS Propellant.
@@ -333,8 +321,10 @@
 	}
 }
 
-@PART[BOTTOM_SHIELD]:NEEDS[RealismOverhaul]
+@PART[BOTTOM_SHIELD]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	//plus 0.6 tons of ablator its 1360.777 or 4000 pounds
 	//source: https://www.nasa.gov/sites/default/files/atoms/files/orionheatshield.pdf
 	@mass = 0.76
@@ -376,8 +366,10 @@
 	}
 }
 
-@PART[ORION_Parachute]:NEEDS[RealismOverhaul]
+@PART[ORION_Parachute]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	//3x400 pounds plus wielding is approximately 0.452 tons.
 	//removing realchute mass:
 	//@mass = 0.452
@@ -458,8 +450,10 @@
 	}
 }
 
-@PART[ORION_TOP_SHIELD]:NEEDS[RealChute]:FOR[SLS]
+@PART[ORION_TOP_SHIELD]:FOR[RealChute]:FOR[SLS]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = NASA
 	@description = Orion main docking port, drogue parachute and main parachute shield. This one is equipped with a silver coating for thermal protection. NOTE: drogue works only with all the planets aligned (ergo never)
 
@@ -539,8 +533,10 @@
 	}
 }
 
-@PART[ORION_TOP_SHIELD_SILVER]:NEEDS[RealismOverhaul]
+@PART[ORION_TOP_SHIELD_SILVER]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = NASA
 	@description = Orion main docking port, drogue parachute and main parachute shield. This one is equipped with a silver coating for thermal protection. NOTE: drogue works only with all the planets aligned (ergo never)
 
@@ -620,8 +616,10 @@
 	}
 }
 
-@PART[ORION_SOLAR_PANEL]:NEEDS[RealismOverhaul]
+@PART[ORION_SOLAR_PANEL]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@MODEL
 	{
 		@scale = 1, 1, 1
@@ -647,8 +645,10 @@
 
 //RCS source: http://image.slidesharecdn.com/hatfieldskip-120725121936-phpapp01/95/hatfield-skip-29-728.jpg?cb=1343218871 (OLD)
 //http://www.esa.int/Our_Activities/Human_Spaceflight/Orion/Propulsion
-@PART[ORION_RCS]:NEEDS[RealismOverhaul]
+@PART[ORION_RCS]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@MODEL
 	{
 		@scale = 1, 1, 1
@@ -661,6 +661,8 @@
 	
 	@manufacturer = NASA
 	
+	%fuelCrossFeed = True
+	
 	@MODULE[ModuleRCS]
 	{
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -672,16 +674,17 @@
 		//no data is known for mixture ratio for the  so i'll keep them the same.
 		//ISP for the SPS backup should be 50s lower than the OMS so i'll lower the RCS to other 20s
 		//EDIT: for some reason both RCS and sps backup works only with mono propellant. if you happen to solve it, please remove the comment.
-		//PROPELLANT
-		//{
-			//name = MON3
-            //ratio = 0.5010
-		//}
-		//PROPELLANT
-		//{
-			//name = MMH
-            //ratio = 0.4990
-		//}
+		//EDIT 2: now it works!
+		PROPELLANT
+		{
+			name = MON3
+            ratio = 0.5010
+		}
+		PROPELLANT
+		{
+			name = MMH
+            ratio = 0.4990
+		}
 		
 		atmosphereCurve
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
@@ -100,7 +100,126 @@
 
 @PART[ORION_COMMAND_MODULE_SILVER]:NEEDS[RealismOverhaul]
 {
+	@name = Orion Command Module
 	@manufacturer = NASA, Lockheed Martin
+
+	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS
+	@mass = 7.133
+	
+	@MODEL
+	{
+		@scale = 1, 1, 1
+	}
+	@scale = 1
+	
+	@CrewCapacity = 6
+	
+	!RESOURCE[MonoPropellant] {}
+	!RESOURCE[ElectricCharge] {}
+	!MODULE[ModuleReactionWheel]{}
+	
+	//it's 0.06t(60kg) of contingency on the orion craft itself, ergo water and oxygen.
+	//the rest is CO2 scrubbers, wastes, food and lithium.
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 1349
+		basemass = -1
+		TANK
+		{
+			name = Oxygen
+			amount = 3557
+			maxAmount = 3557
+		}
+		TANK
+		{
+			name = Water
+			amount = 23.1
+			maxAmount = 23.1
+		}
+		TANK
+		{
+			name = Food
+			amount = 750
+			maxAmount= 750
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 27000
+			maxAmount = 27000
+		}
+		
+		TANK
+		{
+			//0.00001189 lithium per sec x 3600 sec in 1 hour x 24 hours x 21 days = +- 18 units
+			name = LithiumHydroxide
+			amount = 18		
+			maxAmount = 18
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 3.2
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 62440
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 30
+		}
+		
+		//then, it's 0.167t of RCS Propellant.
+		TANK
+		{
+			name = Hydrazine
+			amount = 168
+			maxAmount = 168
+		}
+	}
+	
+	//RCS source: http://ir.aerojetrocketdyne.com/releaseDetail.cfm?releaseid=742943
+	@MODULE[ModuleRCS]
+	{
+		//3x711kn  per each side = 2.133 KN
+		@thrusterPower = 2.133
+		
+		PROPELLANT
+		{
+			name = Hydrazine
+			ratio = 1
+		}
+		
+		@atmosphereCurve
+		{
+			key = 0 239
+			key = 1 190
+		}
+	}
+	
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		conversionRate = 6.0	// # of people - Figures based on per/person
+		inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
+		outputResources = Waste, 0.00003932, false
+	}
+}
+
+@PART[ORION_COMMAND_MODULE]:NEEDS[RealismOverhaul]
+{
+	@name = Orion Command Module (EFT-1)
+	@manufacturer = NASA, Lockheed Martin
+	@description = Tiled version of the Orion Command Module used on the EFT-1 test flight.
 
 	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS
 	@mass = 7.133

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_STRUCT.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_STRUCT.cfg
@@ -1,5 +1,7 @@
-@PART[SSRB_TOP_CAP]:NEEDS[RealismOverhaul]
+@PART[SSRB_TOP_CAP]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
 	@mass = 4.15
 	
@@ -41,8 +43,10 @@
 	}
 }
 
-@PART[SSRB_TOP_CAP2]:NEEDS[RealismOverhaul]
+@PART[SSRB_TOP_CAP2]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
 	@mass = 4.15
 	
@@ -84,8 +88,10 @@
 	}
 }
 
-@PART[SSRB_BOTTOM_CAP]:NEEDS[RealismOverhaul]
+@PART[SSRB_BOTTOM_CAP]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
 	@mass = 4.15
 	
@@ -127,8 +133,10 @@
 	}
 }
 
-@PART[SSRB_BOTTOM_CAP2]:NEEDS[RealismOverhaul]
+@PART[SSRB_BOTTOM_CAP2]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
 	@mass = 4.15
 	
@@ -170,8 +178,10 @@
 	}
 }
 
-@PART[SSRB_decoupler]:NEEDS[RealismOverhaul]
+@PART[SSRB_decoupler]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
 	
 	@rescaleFactor = 1
@@ -182,40 +192,50 @@
 	}
 }
 
-@PART[LVSA]:NEEDS[RealismOverhaul]
+@PART[LVSA]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Boeing
 	@mass = 5
 	
 	@rescaleFactor = 1
 }
 
-@PART[DECOUPLER_ORION]:NEEDS[RealismOverhaul]
+@PART[DECOUPLER_ORION]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//http://www.braeunig.us/space/specs/orion.htm
 	@mass = 0.51
 }
 
-@PART[DECOUPLER_ORION2_UPPER_STAGE]:NEEDS[RealismOverhaul]
+@PART[DECOUPLER_ORION2_UPPER_STAGE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//http://www.braeunig.us/space/specs/orion.htm
 	@mass = 0.51
 }
 
-@PART[DEC_ORION_STAGE3]:NEEDS[RealismOverhaul]
+@PART[DEC_ORION_STAGE3]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//http://www.braeunig.us/space/specs/orion.htm
 	@mass = 0.51
 }
 
-@PART[INTERSTAGE]:NEEDS[RealismOverhaul]
+@PART[INTERSTAGE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	
 	//5t - 0.105t of solid fuel = 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_STRUCT.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_STRUCT.cfg
@@ -1,0 +1,228 @@
+@PART[SSRB_TOP_CAP]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
+	@mass = 4.15
+	
+	@rescaleFactor = 1
+	
+	!RESOURCE[SolidFuel]{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 139
+		basemass = -1
+		type = PBAN
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs	
+		modded = false
+		CONFIG
+		{
+			name = SRB_TOP_CAP
+			minThrust = 329
+			maxThrust = 329
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 150
+				key = 1 140
+				key = 6 0.001
+			}
+		}
+	}
+}
+
+@PART[SSRB_TOP_CAP2]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
+	@mass = 4.15
+	
+	@rescaleFactor = 1
+	
+	!RESOURCE[SolidFuel]{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 139
+		basemass = -1
+		type = PBAN
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs	
+		modded = false
+		CONFIG
+		{
+			name = SRB_TOP_CAP
+			minThrust = 329
+			maxThrust = 329
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 150
+				key = 1 140
+				key = 6 0.001
+			}
+		}
+	}
+}
+
+@PART[SSRB_BOTTOM_CAP]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
+	@mass = 4.15
+	
+	@rescaleFactor = 1
+	
+	!RESOURCE[SolidFuel]{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 130
+		basemass = -1
+		type = PBAN
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs	
+		modded = false
+		CONFIG
+		{
+			name = SRB_TOP_CAP
+			minThrust = 158
+			maxThrust = 158
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 150
+				key = 1 140
+				key = 6 0.001
+			}
+		}
+	}
+}
+
+@PART[SSRB_BOTTOM_CAP2]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
+	@mass = 4.15
+	
+	@rescaleFactor = 1
+	
+	!RESOURCE[SolidFuel]{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 130
+		basemass = -1
+		type = PBAN
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs	
+		modded = false
+		CONFIG
+		{
+			name = SRB_TOP_CAP
+			minThrust = 158
+			maxThrust = 158
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = PBAN
+				ratio = 1.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 150
+				key = 1 140
+				key = 6 0.001
+			}
+		}
+	}
+}
+
+@PART[SSRB_decoupler]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Orbital ATK (ex Thiokol The Space Lobbyist)
+	
+	@rescaleFactor = 1
+	
+	@MODULE[ModuleAnchoredDecoupler]
+	{
+		@ejectionForce = 800
+	}
+}
+
+@PART[LVSA]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Boeing
+	@mass = 5
+	
+	@rescaleFactor = 1
+}
+
+@PART[DECOUPLER_ORION]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//http://www.braeunig.us/space/specs/orion.htm
+	@mass = 0.51
+}
+
+@PART[DECOUPLER_ORION2_UPPER_STAGE]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//http://www.braeunig.us/space/specs/orion.htm
+	@mass = 0.51
+}
+
+@PART[DEC_ORION_STAGE3]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//http://www.braeunig.us/space/specs/orion.htm
+	@mass = 0.51
+}
+
+@PART[INTERSTAGE]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	
+	//5t - 0.105t of solid fuel = 
+	@mass = 4.89
+	
+	@MODULE[ModuleEnginesFX]
+	{
+		@maxThrust = 352
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_TANKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_TANKS.cfg
@@ -1,0 +1,154 @@
+@PART[SLS_STAGECORE]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	@manufacturer = Boeing
+	
+	@mass = 85.270
+	
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Cryogenic
+		volume = 2704000
+		basemass = -1
+		
+		TANK
+		{
+			name = LqdOxygen
+			amount = 736291.752
+			maxAmount = 736291.752
+		}
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 1966688.248
+			maxAmount = 1966688.248
+		}
+	}
+}
+
+@PART[SLS_UPPERSTAGE]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	@manufacturer = Boeing, ULA
+	
+	@mass = 3.765
+	
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Cryogenic
+		volume = 27040
+		basemass = -1
+		
+		
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 55082.71
+			maxAmount = 55082.71
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 20115.53
+			maxAmount = 20115.53
+		}
+	}
+}
+
+@PART[SLS_UPPERSTAGE_RL10_4X]:NEEDS[RealismOverhaul]
+{
+	@rescaleFactor = 1
+	@manufacturer = Boeing, ULA
+	
+	//you also have to consider the mass of 4xRL10. 0.280t added to make the initial mass equal to 308000lb or 139.706T
+	@mass = 12.779
+	
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
+	!RESOURCE[MonoPropellant]{}
+	
+	@node_stack_top = -0.0, 6.717458, -0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, 1.582581, -0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_F1 = -4.155649, 6.717458, -0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_F2 = 4.155649, 6.717458, -0.0, 0.0, 1.0, 0.0, 2
+	
+	RESOURCE
+	{
+		name = Hydrazine
+		amount = 631
+		maxAmount = 631
+	}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Cryogenic
+		volume = 350482
+		basemass = -1
+		
+		
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 256706
+			maxAmount = 256706
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 93775.38
+			maxAmount = 93775.38
+		}
+	}
+	
+	@MODULE[ModuleRCS]
+	{
+		@resourceName = Hydrazine
+	}
+}
+
+@PART[SLS_STAGECORE_J2X]:NEEDS[RealismOverhaul]
+{
+	@manufacturer = Unknown
+	@description = Only decent part of the whole SLS since it uses J-2X. Too bad NASA mothballed it in favour of the more expensive and crappier EUS.
+	
+	@rescaleFactor = 1
+	
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
+	
+	@node_stack_1 = 4.163486, 7.737436, -0.0, 0.0, 1.0, 0.0, 2	
+	@node_stack_2 = -4.163486, 7.737436, -0.0, 0.0, 1.0, 0.0, 2	
+	
+	//DELETE, based on EUS
+	@mass = 12.779
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = Cryogenic
+		volume = 350482
+		basemass = -1
+		
+		
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 256706
+			maxAmount = 256706
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 93775.38
+			maxAmount = 93775.38
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_TANKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_TANKS.cfg
@@ -1,5 +1,7 @@
-@PART[SLS_STAGECORE]:NEEDS[RealismOverhaul]
+@PART[SLS_STAGECORE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	@manufacturer = Boeing
 	
@@ -30,8 +32,10 @@
 	}
 }
 
-@PART[SLS_UPPERSTAGE]:NEEDS[RealismOverhaul]
+@PART[SLS_UPPERSTAGE]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	@manufacturer = Boeing, ULA
 	
@@ -63,8 +67,10 @@
 	}
 }
 
-@PART[SLS_UPPERSTAGE_RL10_4X]:NEEDS[RealismOverhaul]
+@PART[SLS_UPPERSTAGE_RL10_4X]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@rescaleFactor = 1
 	@manufacturer = Boeing, ULA
 	
@@ -115,8 +121,10 @@
 	}
 }
 
-@PART[SLS_STAGECORE_J2X]:NEEDS[RealismOverhaul]
+@PART[SLS_STAGECORE_J2X]:FOR[RealismOverhaul]
 {
+	%RSSROConfig = True
+	
 	@manufacturer = Unknown
 	@description = Only decent part of the whole SLS since it uses J-2X. Too bad NASA mothballed it in favour of the more expensive and crappier EUS.
 	


### PR DESCRIPTION
RO configs for DECQ's awesomely detailed SLS+Orion craft.
Masses and Delta V are accurate with a precision of a couple of kilos/meters per second.
TAC support guarantees life for 6 kerbals for 21 days just like the real pod. CO2 scrubber included.

DISCLAIMER:
This is a very unlucky mod since apparently DECQ accidentally losed all of his files and so he can't fix it. There are a couple of errors I couldn't manage to fix (or better: WIP i don't have the experience to fix but they don't stop the mod to work). If you happen to know how to fix them, please do it since it's a really beautiful mod. in particular:

0)(not really an issue): the EDS has the same masses and specs of the EUS stage, simply because NASA scrapped it before releasing any important data. Tested it with a block II version of the SLS (RO pyrios) and, strange enough, it managed to send without any problem 150 tons into LEO as it was supposed to.
1)The service module RCS simply didn't work with MMH/MON3 like it was supposed to, so i had to let it work with MonoPropellant.
2)The SPS backup stopped working entirely in RO for some reason
3)There is no RCS on the ICPS and the EDS since they lacked of RCS ports (the exploration upper stage does however and that's the really important stage)
4)The hatch is obstructed, so no EVA. Couldn't find any way to fix it.
5)The chute sometimes works, sometimes it causes the craft to spin terribly and it causes really bad stuff (i took it from another user who contribuited to the mod, anyway)
6)mechjeb won't show delta v statistics for some reason. I can guarantee however that they are the right ones.
7)the j-2x are too long, so when stacked above the core stage they collides with it. BUT this doesn't cause any issue excluding a weird glitch at staging with no explosion/bad consequences. This could be solved by making a stretched interstage (don't have the experience to do so)/just use procedural parts
