### PR TITLE
RN fix RT maxq problem

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -208,7 +208,7 @@
     %MODULE[ModuleRTAntenna] {
         %Mode0OmniRange = 0
         %Mode1OmniRange = 6000000
-        %MaxQ = 6000
+        !MaxQ = DELETE
         %EnergyCost = 0.36
         
         %DeployFxModules = 0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
@@ -96,7 +96,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 75e6
-		MaxQ = 6000
+		
 		EnergyCost = 0.05
 		DishAngle = 25
 		TRANSMITTER
@@ -111,7 +111,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 5000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.008
 		DeployFxModules = 0
 		TRANSMITTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
@@ -94,7 +94,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 1E+12
-		MaxQ = 6000
+		
 		EnergyCost = 0.24
 		DishAngle = 1
 		TRANSMITTER
@@ -109,7 +109,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 5000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.008
 		DeployFxModules = 0
 		TRANSMITTER
@@ -397,7 +397,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 1E+12
-		MaxQ = 6000
+		
 		EnergyCost = 0.08
 		DishAngle = 0.2
 		TRANSMITTER
@@ -412,7 +412,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 5000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.008
 		DeployFxModules = 0
 		TRANSMITTER
@@ -575,7 +575,7 @@ MODULE
 		Mode0DishRange = 0
 		Mode1DishRange = 90000000000
 		EnergyCost = 0.008
-		MaxQ = 6000
+		
 		DishAngle = 5
 		TRANSMITTER
 		{
@@ -589,7 +589,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 3000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.005
 		DeployFxModules = 0
 		TRANSMITTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
@@ -170,7 +170,7 @@
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 1E+12
-		MaxQ = 6000
+		
 		EnergyCost = 0.08
 		DishAngle = 0.2
 		DeployFxModules = 0
@@ -187,7 +187,7 @@
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 700000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.005
 		DeployFxModules = 0
 		TRANSMITTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
@@ -169,7 +169,7 @@
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 1E+12
-		MaxQ = 6000
+		
 		EnergyCost = 0.08
 		DishAngle = 0.2
 		DeployFxModules = 0
@@ -186,7 +186,7 @@
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 700000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.005
 		DeployFxModules = 0
 		TRANSMITTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Magellan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Magellan.cfg
@@ -143,7 +143,7 @@
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 1E+13
-		MaxQ = 6000
+		
 		EnergyCost = 0.02
 		DishAngle = 4
 		DeployFxModules = 0
@@ -159,7 +159,7 @@
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 70000000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.005
 		DeployFxModules = 0
 		TRANSMITTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
@@ -427,7 +427,7 @@ MODULE
 		Mode0DishRange = 0
 		Mode1DishRange = 1000000000
 		EnergyCost = 0.07
-		MaxQ = 6000
+		
 		DishAngle = 5
 		TRANSMITTER
 		{
@@ -441,7 +441,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 3000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.005
 		DeployFxModules = 0
 		TRANSMITTER
@@ -549,7 +549,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0DishRange = 0
 		Mode1DishRange = 20e9
-		MaxQ = 6000
+		
 		EnergyCost = 0.16
 		DishAngle = 3.3
 		TRANSMITTER
@@ -564,7 +564,7 @@ MODULE
 		name = ModuleRTAntenna
 		Mode0OmniRange = 500000
 		Mode1OmniRange = 5000000
-		MaxQ = 6000
+		
 		EnergyCost = 0.008
 		DeployFxModules = 0
 		TRANSMITTER


### PR DESCRIPTION
-The current values were breaking antenna off during ascent on probes
that have antenna as part of the main mesh.

This value works for when the antenna is a separate part and hidden
under a fairing, but on my parts where the antenna is part of the main
mesh, if the main body of the probe, like skylab, is exposed to the air
during launch it breaks the antennae off even though they are under the
fairing.