### PR TITLE
CMES Aero updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
@@ -1,509 +1,565 @@
-//	==================================================
-//	Removed extra parts.
-//	==================================================
-
-	!PART[XKzProcFairingBaseRing8]:FOR[RealismOverhaul]{}
-
-	!PART[XKzProcFairingBaseRing8TALUS]:FOR[RealismOverhaul]{}
-
-	!PART[XKW2mNoseConeXl]:FOR[RealismOverhaul]{}
-
-//	==================================================
-//	Inflatable heat shield (small).
-
-//	Dimensions: 10.000 x 2.500 m
-//	Gross Mass: 2815.00 Kg
-//	==================================================
-
-	@PART[XPC_InflateHeatshield31X]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.725, 1.725, 1.725
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  0.215, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -0.780, 0.000, 0.000, -1.000, 0.000, 3
-
-		%fx_gasBurst_white = 0.000, 0.000, 0.000, 0.000, 1.000, 0.000, decouple
-
-		%sound_vent_large = decouple
-
-		!TechRequired,* = NULL
-		!entryCost,*    = NULL
-		!cost,*		    = NULL
-		%TechRequired 	= heavyAerodynamics
-		%entryCost 		= 7500
-		%cost 			= 1250
-		@category 		= Aero
-		@title 			= HIAD [10 m]
-		@manufacturer 	= NASA
-		@description 	= The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
-
-		@mass		   	  = 2.8150
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%skinMaxTemp 	  = 2500
-		%emissiveConstant = 0.950
-		@CoMOffset		  = 0.000, -1.500, 0.000
-		@CoLOffset		  = 0.000, -6.000, 0.000
-		@CoDOffset		  = 0.000,  1.500, 0.000
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 5.000
-		}
-
-		@MODULE[ModuleAnimateGeneric]
-		{
-			@isOneShot		    = false
-			@startEventGUIName  = Inflate Heat Shield
-			%endEventGUIName    = Deflate Heat Shield
-			%actionGUIName	    = Toggle Heat Shield
-			%allowManualControl = true
-		}
-
-		!MODULE[ModuleAnimation2Value],*{}
-
-		!MODULE[ModuleEnviroSensor]{}
-
-		!MODULE[ModuleHeatShield]{}
-
-		!MODULE[ModuleAeroReentry]{}
-
-		!RESOURCE[LeadBallast]{}
-	}
-
-//	==================================================
-//	Inflatable heat shield (medium).
-
-//	Dimensions: 15.000 x 3.800 m
-//	Gross Mass: 5125.00 Kg
-//	==================================================
-
-	@PART[XPC_InflateHeatshieldLX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
-
-		@MODEL
-		{
-			@scale	  = 2.625, 2.625, 2.625
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  0.408, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -1.185, 0.000, 0.000, -1.000, 0.000, 3
-
-		%fx_gasBurst_white = 0.000, 0.000, 0.000, 0.000, 1.000, 0.000, decouple
-
-		%sound_vent_large = decouple
-
-		!TechRequired,* = NULL
-		!entryCost,*    = NULL
-		!cost,*		    = NULL
-		%TechRequired   = heavyAerodynamics
-		%entryCost	    = 7500
-		%cost		    = 1250
-		@category	    = Aero
-		@title		  	= HIAD [15 m]
-        @manufacturer 	= NASA
-        @description  	= The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
-
-		@mass			  = 5.1250
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%skinMaxTemp 	  = 2500
-		%emissiveConstant = 0.950
-		@CoMOffset		  = 0.000, -1.500, 0.000
-		@CoLOffset		  = 0.000, -6.000, 0.000
-		@CoDOffset		  = 0.000,  1.500, 0.000
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 5.000
-		}
-
-		@MODULE[ModuleAnimateGeneric]
-		{
-			@isOneShot		    = false
-			@startEventGUIName  = Inflate Heat Shield
-			%endEventGUIName    = Deflate Heat Shield
-			%actionGUIName	    = Toggle Heat Shield
-			%allowManualControl = true
-		}
-
-		!MODULE[ModuleAnimation2Value],*{}
-
-		!MODULE[ModuleEnviroSensor]{}
-
-		!MODULE[ModuleHeatShield]{}
-
-		!MODULE[ModuleAeroReentry]{}
-
-		!RESOURCE[LeadBallast]{}
-	}
-
-//	==================================================
-//	Inflatable heat shield (large).
-
-//	Dimensions: 20.000 x 5.000 m
-//	Gross Mass: 6628.00 Kg
-//	==================================================
-
-	@PART[PC_InflateHeatshieldLxx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 3.450, 3.450, 3.450
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top    = 0.000,  0.543, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -1.550, 0.000, 0.000, -1.000, 0.000, 3
-
-		%fx_gasBurst_white = 0.000, 0.000, 0.000, 0.000, 1.000, 0.000, decouple
-
-		%sound_vent_large = decouple
-
-		@category	  = Aero
-		@title		  = HIAD [20 m]
-		@manufacturer = NASA
-		@description  = The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
-
-		@mass			  = 6.6280
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%skinMaxTemp 	  = 2500
-		%emissiveConstant = 0.950
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = DECOUPLER_HOR
-		@CoMOffset		  = 0.000, -1.500, 0.000
-		@CoLOffset		  = 0.000, -6.000, 0.000
-		@CoDOffset		  = 0.000,  1.500, 0.000
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 5.000
-		}
-
-		@MODULE[ModuleAnimateGeneric]
-		{
-			@isOneShot		    = false
-			@startEventGUIName  = Inflate Heat Shield
-			%endEventGUIName    = Deflate Heat Shield
-			%actionGUIName	    = Toggle Heat Shield
-			%allowManualControl = true
-		}
-
-		!MODULE[ModuleAnimation2Value],*{}
-
-		!MODULE[ModuleEnviroSensor]{}
-
-		!MODULE[ModuleHeatShield]{}
-
-		!MODULE[ModuleAeroReentry]{}
-
-		!RESOURCE[LeadBallast]{}
-	}
-
-//	==================================================
-//	Payload fairing base ring (procedural).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[XKzProcFairingBaseRing3_75]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.000, 1.000, 1.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		@node_stack_bottom	  = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 1
-		@node_stack_top		  = 0.000, 0.200, 0.000, 0.000,  1.000, 0.000, 1
-		@node_stack_connect01 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-		@node_stack_connect02 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-		@node_stack_connect03 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-		@node_stack_connect04 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-
-		@title		  = Payload Fairing - Base (Type IA) [Procedural]
-		@manufacturer = NASA
-        %description  = Procedural payload fairing base. Payload decoupling system not included.
-
-		@mass		    	= 0.100
-		@breakingForce  	= 250
-		@breakingTorque	 	= 250
-		!explosionPotential = NULL
-		!CrewCapacity 		= NULL
-		%bulkheadProfiles   = size1
-
-		!MODULE[ModuleCommand]{}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		!MODULE[ModuleSAS]{}
-
-		!MODULE[MechJebCore]{}
-
-		@MODULE[ProceduralFairingBase]
-		{
-			@baseSize	   = 1.150
-			@sideThickness = 0.150
-			@verticalStep  = 0.100
-			@extraRadius   = 0.600
-		}
-
-		MODULE
-		{
-			name			  = KzNodeNumberTweaker
-			nodePrefix		  = connect
-			maxNumber		  = 4
-			numNodes		  = 2
-			radius			  = 0.625
-			shouldResizeNodes = False
-		}
-
-		MODULE
-		{
-			name			 	   = KzFairingBaseResizer
-			size			 	   = 3.000
-			costPerTonne	 	   = 1000
-			specificMass		   = 0.0064, 0.0130, 0.0098, 0.000
-			specificBreakingForce  = 500
-			specificBreakingTorque = 500
-			diameterStepLarge	   = 1.000
-			diameterStepSmall	   = 0.100
-			dragAreaScale		   = 1.500
-		}
-	}
-
-//	==================================================
-//	Ares Standard payload fairing (procedural).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[xKosmos_URM_Fairing_Conic_Salt]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		!mesh	 	   = NULL
-		%scale		   = 1.000
-		%rescaleFactor = 1.000
-
-		@title		  = Payload Fairing - Ares Standard [Procedural]
-		@manufacturer = NASA
-		@description  = Protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
-
-		@maxTemp = 2273.15
-
-		@MODULE[ProceduralFairingSide]
-		{
-			@density				= 0.0260
-			@specificBreakingForce  = 500
-			@specificBreakingTorque = 500
-		}
-	}
-
-//	==================================================
-//	Ares Aeroshell payload fairing (procedural).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[xMLSBALLISTICX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		!mesh	 	   = NULL
-		%scale		   = 1.000
-		%rescaleFactor = 1.000
-
-		@title		  = Payload Fairing - Ares Aeroshell [Procedural]
-		@manufacturer = NASA
-		@description  = Protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight. Doubles as a heat shield for reentry.
-
-		@crashTolerance = 8
-		@breakingForce  = 200
-		@breakingTorque = 200
-		@maxTemp	    = 3200
-		%emissiveConstant  = 0.850
-
-		@MODULE[ProceduralFairingSide]
-		{
-			@density				= 0.0260
-			@specificBreakingForce  = 500
-			@specificBreakingTorque = 500
-		}
-	}
-
-//	==================================================
-//	SLS payload fairing (procedural).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[xKosmos_URM_Fairing_Parabolic_Stalt]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		!mesh	 	   = NULL
-		%scale		   = 1.000
-		%rescaleFactor = 1.000
-
-		@title		  = Payload Fairing - SLS [Procedural]
-		@manufacturer = NASA
-		@description  = Protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
-
-		@crashTolerance = 8
-		@breakingForce  = 200
-		@breakingTorque = 200
-		@maxTemp 		= 2273.15
-
-		@MODULE[ProceduralFairingSide]
-		{
-			@density				= 0.0260
-			@specificBreakingForce  = 500
-			@specificBreakingTorque = 500
-		}
-	}
-
-//	==================================================
-//	Delta IV payload fairing (procedural).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[xEMLVFX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		!mesh	 	   = NULL
-		%scale		   = 1.000
-		%rescaleFactor = 1.000
-
-		@title		  = Payload Fairing - Delta IV [Procedural]
-		@manufacturer = RUAG Space
-		@description  = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
-
-		@maxTemp = 2273.15
-
-		@MODULE[ProceduralFairingSide]
-		{
-			@density				= 0.0510
-			@specificBreakingForce  = 500
-			@specificBreakingTorque = 500
-		}
-	}
-
-//	==================================================
-//	Vulcan payload fairing (procedural).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[xEMLVKosmos_URM_Fairing_Conic_Salt]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		!mesh	 	   = NULL
-		%scale		   = 1.000
-		%rescaleFactor = 1.000
-
-		@title		  = Payload Fairing - Vulcan [Procedural]
-		@manufacturer = RUAG Space
-		@description  = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
-
-		@maxTemp = 2273.15
-
-		@MODULE[ProceduralFairingSide]
-		{
-			@density				= 0.0485
-			@specificBreakingForce  = 500
-			@specificBreakingTorque = 500
-		}
-	}
-
-//	==================================================
-//	RSRM aerodynamic nose cone.
-
-//	Dimensions: 3.770 x 5.200 m
-//	Gross Mass: 1435.00 Kg
-//	==================================================
-
-	@PART[XKW2mNoseConeX]:FOR[RealismOverhaul]
-	{
-		@module		 = Part
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.885, 2.750, 1.885
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-
-		@title 		  = RSRM Nose Cone
-		@manufacturer = NASA
-		@description  = An aerodynamic nosecone for large solid rocket motors. Recovery parachutes not included.
-
-		@mass			  = 1.4350
-		@crashTolerance   = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = false
-		%bulkheadProfiles = size2
-	}
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
+
+!PART[XDragon2NoseCone2X]:FOR[RealismOverhaul]{}
+
+!PART[xEMLVKosmos_URM_Fairing_Conic_SaltWV2]:FOR[RealismOverhaul]{}
+
+!PART[xEMLVKosmos_URM_Fairing_Conic_Salt8mx]:FOR[RealismOverhaul]{}
+
+!PART[XKzProcFairingBaseRing8]:FOR[RealismOverhaul]{}
+
+!PART[XKzProcFairingBaseRing8TALUS]:FOR[RealismOverhaul]{}
+
+!PART[XKzProcFairingBaseRing3_75X]:FOR[RealismOverhaul]{}
+
+!PART[XKzProcFairingBaseRing843ABNNX]:FOR[RealismOverhaul]{}
+
+!PART[XKW2mNoseConeXl]:FOR[RealismOverhaul]{}
+
+!PART[x8MOPFXXX168A]:FOR[RealismOverhaul]{}
+
+//  ==================================================
+//  Inflatable heat shield (10 meters).
+
+//  Dimensions: 10 m x 2.5 m
+//  Gross Mass: 2800 Kg
+//  ==================================================
+
+@PART[XPC_InflateHeatshield31X]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.725, 1.725, 1.725
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.215, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -0.78, 0.0, 0.0, -1.0, 0.0, 10
+    @attachRules = 1,0,1,1,0
+
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_vent_large = decouple
+
+    @category = Aero
+    @title = HIAD (10 m)
+    @manufacturer = NASA
+    @description = The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
+
+    @mass = 2.8
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 2773.15
+    %skinMassPerArea = 4
+    %emissiveConstant = 0.95
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size5, size10
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @isOneShot = False
+        @startEventGUIName = Inflate Heat Shield
+        %endEventGUIName = Deflate Heat Shield
+        %actionGUIName = Toggle Heat Shield
+        %allowManualControl = True
+        %allowAnimationWhileShielded = False
+    }
+
+    !MODULE[ModuleAnimation2Value],*{}
+
+    !MODULE[ModuleEnviroSensor],*{}
+
+    !MODULE[ModuleHeatShield],*{}
+
+    !MODULE[ModuleAeroReentry],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Inflatable heat shield (15 meters).
+
+//  Dimensions: 15 m x 3.8 m
+//  Gross Mass: 5200 Kg
+//  ==================================================
+
+@PART[XPC_InflateHeatshieldLX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 2.625, 2.625, 2.625
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.408, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -1.185, 0.0, 0.0, -1.0, 0.0, 10
+    @attachRules = 1,0,1,1,0
+
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_vent_large = decouple
+
+    @category = Aero
+    @title = HIAD (15 m)
+    @manufacturer = NASA
+    @description = The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
+
+    @mass = 5.2
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 2773.15
+    %skinMassPerArea = 4
+    %emissiveConstant = 0.95
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size5, size10
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @isOneShot = False
+        @startEventGUIName = Inflate Heat Shield
+        %endEventGUIName = Deflate Heat Shield
+        %actionGUIName = Toggle Heat Shield
+        %allowManualControl = True
+        %allowAnimationWhileShielded = False
+    }
+
+    !MODULE[ModuleAnimation2Value],*{}
+
+    !MODULE[ModuleEnviroSensor],*{}
+
+    !MODULE[ModuleHeatShield],*{}
+
+    !MODULE[ModuleAeroReentry],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Inflatable heat shield (20 meters).
+
+//  Dimensions: 20 m x 5 m
+//  Gross Mass: 6700 Kg
+//  ==================================================
+
+@PART[PC_InflateHeatshieldLxx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 3.45, 3.45, 3.45
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.543, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -1.55, 0.0, 0.0, -1.0, 0.0, 10
+    @attachRules = 1,0,1,1,0
+
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_vent_large = decouple
+
+    @category = Aero
+    @title = HIAD (20 m)
+    @manufacturer = NASA
+    @description = The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
+
+    @mass = 6.7
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 2773.15
+    %skinMassPerArea = 4
+    %emissiveConstant = 0.95
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size5, size10
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @isOneShot = False
+        @startEventGUIName = Inflate Heat Shield
+        %endEventGUIName = Deflate Heat Shield
+        %actionGUIName = Toggle Heat Shield
+        %allowManualControl = True
+        %allowAnimationWhileShielded = False
+    }
+
+    !MODULE[ModuleAnimation2Value],*{}
+
+    !MODULE[ModuleEnviroSensor],*{}
+
+    !MODULE[ModuleHeatShield],*{}
+
+    !MODULE[ModuleAeroReentry],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  NDS protective aerodynamic nose cone.
+
+//  Dimensions: 1.8 m x 0.5 m
+//  Gross Mass: 40 Kg
+//  ==================================================
+
+@PART[XDragon2NoseConeX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 0.7, 0.25, 0.7
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.16, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = NDS Protective Nose Cone
+    @manufacturer = Generic
+    @description = An aerodynamic nose cone for the NASA Docking System.
+
+    @mass = 0.04
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    !stagingIcon = NULL
+    !stageOffset = NULL
+    !childStageOffset = NULL
+
+    !MODULE[ModuleDecouple],*{}
+}
+
+//  ==================================================
+//  Ares Standard payload fairing (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[xKosmos_URM_Fairing_Conic_Salt]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @title = Payload Fairing - Ares Standard [Procedural]
+    @manufacturer = RUAG Space
+    @description = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
+
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @breakingForce = 250
+    @breakingTorque = 250
+    @crashTolerance = 14
+}
+
+//  ==================================================
+//  Ares Aeroshell payload fairing (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[xMLSBALLISTICX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @title = Payload Fairing - Ares Aeroshell [Procedural]
+    @manufacturer = RUAG Space
+    @description = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight. Doubles as a heat shield for reentry.
+
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 2773.15
+    %skinMassPerArea = 4
+    %emissiveConstant = 0.95
+}
+
+//  ==================================================
+//  SLS payload fairing (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[xKosmos_URM_Fairing_Parabolic_Stalt]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @title = Payload Fairing - SLS [Procedural]
+    @manufacturer = RUAG Space
+    @description = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
+
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  Delta IV payload fairing (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[xEMLVFX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @title = Payload Fairing - Delta IV [Procedural]
+    @manufacturer = RUAG Space
+    @description = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
+
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  Vulcan payload fairing (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[xEMLVKosmos_URM_Fairing_Conic_Salt]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @title = Payload Fairing - Vulcan [Procedural]
+    @manufacturer = RUAG Space
+    @description = A composite fairing that protects the payload from aerodynamic forces and heating during the launch and ascent phases of the flight.
+
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+}
+
+//  ==================================================
+//  Interstage fairing base ring (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[XKzProcFairingBaseRing3_75]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_top = 0.0, 0.2, 0.0, 0.0,  1.0, 0.0, 1
+    %node_stack_top1 = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+
+    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_vent_large = decouple
+
+    @title = Interstage Fairing - Base [Procedural]
+    @manufacturer = NASA
+    %description = A procedural interstage fairing base for creating interstages. Includes a decoupler.
+
+    @mass = 0
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    !explosionPotential = NULL
+    !CrewCapacity = NULL
+    %bulkheadProfiles = size1, size2
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    MODULE
+    {
+        name = ProceduralFairingAdapter
+        baseSize = 3.0
+        topSize = 3.0
+        height = 2.0
+        diameterStepLarge = 1.0
+        diameterStepSmall = 0.1
+        costPerTonne = 100
+        specificMass = 0.0064, 0.013, 0.0098, 0.0
+        specificBreakingForce = 500
+        specificBreakingTorque = 500
+        dragAreaScale = 1.5
+    }
+
+    @MODULE[ProceduralFairingBase]
+    {
+        @baseSize = 1.15
+        @sideThickness = 0.05
+        @verticalStep = 0.1
+        @extraRadius = 0
+    }
+
+    MODULE
+    {
+        name = KzNodeNumberTweaker
+        nodePrefix = connect
+        maxNumber = 4
+        numNodes = 2
+        radius = 0.625
+        shouldResizeNodes = False
+    }
+
+    MODULE
+    {
+        name = ModuleDecouple
+        ejectionForce = 0
+        explosiveNodeID = top1
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseShielding
+    }
+}
+
+//  ==================================================
+//  RSRM aerodynamic nose cone.
+
+//  Dimensions: 3.77 x 5.2 m
+//  Gross Mass: 1400 Kg
+//  ==================================================
+
+@PART[XKW2mNoseConeX]:FOR[RealismOverhaul]
+{
+    @module = Part
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.885, 2.75, 1.885
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+
+    @title = RSRM Nose Cone
+    @manufacturer = NASA
+    @description = An aerodynamic nosecone for large solid rocket motors. Recovery parachutes not included.
+
+    @mass = 1.4
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @fuelCrossFeed = False
+    %bulkheadProfiles = size3
+}
+
+//  ==================================================
+//  Interstage fairing (procedural).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+@PART[xOPFPROCEDURALX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = Interstage Fairing [Procedural]
+    @manufacturer = Generic
+    @description = A structural procedural fairing for creating interstages or protective covers. Lacks a decoupler.
+
+    @mass = 0
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @crashTolerance = 14
+    !stagingIcon = NULL
+    !stageOffset = NULL
+    !childStageOffset = NULL
+
+    !MODULE[ProceduralFairingDecoupler],*{}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
@@ -31,8 +31,6 @@
 {
     %RSSROConfig = True
 
-    !mesh = NULL
-
     @MODEL
     {
         @scale = 1.725, 1.725, 1.725
@@ -104,8 +102,6 @@
 {
     %RSSROConfig = True
 
-    !mesh = NULL
-
     @MODEL
     {
         @scale = 2.625, 2.625, 2.625
@@ -176,8 +172,6 @@
 @PART[PC_InflateHeatshieldLxx]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
-    !mesh = NULL
 
     @MODEL
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
@@ -24,7 +24,7 @@
 //  Inflatable heat shield (10 meters).
 
 //  Dimensions: 10 m x 2.5 m
-//  Gross Mass: 2800 Kg
+//  Inert Mass: 2800 Kg
 //  ==================================================
 
 @PART[XPC_InflateHeatshield31X]:FOR[RealismOverhaul]
@@ -95,7 +95,7 @@
 //  Inflatable heat shield (15 meters).
 
 //  Dimensions: 15 m x 3.8 m
-//  Gross Mass: 5200 Kg
+//  Inert Mass: 5200 Kg
 //  ==================================================
 
 @PART[XPC_InflateHeatshieldLX]:FOR[RealismOverhaul]
@@ -166,7 +166,7 @@
 //  Inflatable heat shield (20 meters).
 
 //  Dimensions: 20 m x 5 m
-//  Gross Mass: 6700 Kg
+//  Inert Mass: 6700 Kg
 //  ==================================================
 
 @PART[PC_InflateHeatshieldLxx]:FOR[RealismOverhaul]
@@ -237,7 +237,7 @@
 //  NDS protective aerodynamic nose cone.
 
 //  Dimensions: 1.8 m x 0.5 m
-//  Gross Mass: 40 Kg
+//  Inert Mass: 40 Kg
 //  ==================================================
 
 @PART[XDragon2NoseConeX]:FOR[RealismOverhaul]
@@ -277,7 +277,7 @@
 //  Ares Standard payload fairing (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[xKosmos_URM_Fairing_Conic_Salt]:FOR[RealismOverhaul]
@@ -302,7 +302,7 @@
 //  Ares Aeroshell payload fairing (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[xMLSBALLISTICX]:FOR[RealismOverhaul]
@@ -329,7 +329,7 @@
 //  SLS payload fairing (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[xKosmos_URM_Fairing_Parabolic_Stalt]:FOR[RealismOverhaul]
@@ -354,7 +354,7 @@
 //  Delta IV payload fairing (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[xEMLVFX]:FOR[RealismOverhaul]
@@ -379,7 +379,7 @@
 //  Vulcan payload fairing (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[xEMLVKosmos_URM_Fairing_Conic_Salt]:FOR[RealismOverhaul]
@@ -404,7 +404,7 @@
 //  Interstage fairing base ring (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[XKzProcFairingBaseRing3_75]:FOR[RealismOverhaul]
@@ -499,7 +499,7 @@
 //  RSRM aerodynamic nose cone.
 
 //  Dimensions: 3.77 x 5.2 m
-//  Gross Mass: 1400 Kg
+//  Inert Mass: 1400 Kg
 //  ==================================================
 
 @PART[XKW2mNoseConeX]:FOR[RealismOverhaul]
@@ -535,7 +535,7 @@
 //  Interstage fairing (procedural).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
 @PART[xOPFPROCEDURALX]:FOR[RealismOverhaul]


### PR DESCRIPTION
This will be part of a complete overhaul of the Chaka Monkey Exploration Systems (CMES) that is in a dire need of (re)making it's RO configs (i have learned a lot since my last attempt).

The previous configs were scrapped and new ones were developed since a) many parts were added/modified and b) the configs had some issues with tabbing, false spacing and arithmetic accuracy.

Also, @NathanKell, @SirKeplan @stratochief66 is it possible to rename the folder from "CMES-WIP" to just "CMES"? I am not sure of how git handles the renaming of files/folders.

Changelog:
- Add RO compatibility for the NDS protective cover, the PF interstage adapter and the PF interstage fairing side.
- Round the mass of the HIADs
- Zero the ejection force of the HIADs.
- Update the part titles and descriptions.
- Make the RESOURCE removal a bit more bulletproof.
- Remove the density modifiers from the PF sides (now taken care by RO itself).
- Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1360/files?w=1)
