### PR TITLE
CMES AerojetKerbodyne updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
@@ -112,7 +112,7 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (DCSS) engine truss.
+//  Delta Cryogenic Second Stage (DCSS) equipment bay.
 
 //  Dimensions: 3.1 m x 0.8 m
 //  Inert Mass: 100 Kg
@@ -133,17 +133,96 @@
     @node_stack_top = 0.0, 0.85, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -0.335, 0.0, 0.0, -1.0, 0.0, 3
 
-    @title = Delta IV DCSS Engine Truss
+    @category = Pods
+    @title = Delta IV DCSS Equipment Bay
     @manufacturer = United Launch Alliance (ULA)
-    @description = The Delta Cryogenic Second Stage (DCSS) avionics and engine holder truss.
+    @description = The Delta Cryogenic Second Stage (DCSS) avionics and engine mounting truss.
 
     @mass = 0.1
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %bulkheadProfiles = size3
+    %vesselType = Probe
+    %CrewCapacity = 0
+
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.2
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSAS
+        SASServiceLevel = 3
+        standalone = True
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 1.4 kWh.
+    //  Can support the DCSS for flights up to 7 hours in duration.
+    //  Assumes that the electricity consumption of the DCSS avionics is 200 W.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 5040
+        maxAmount = 5040
+    }    
+}
+
+//  ==================================================
+//  Delta Cryogenic Second Stage (DCSS) equipment bay.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[BasketTrussCX]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.025
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.0075
+        }
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
@@ -1,491 +1,416 @@
-//	==================================================
-//	Removed extra parts.
-//	==================================================
+//  ==================================================
+//  Sources:
 
-	!PART[BasketTrussCX2]:FOR[RealismOverhaul]{}
+//  Delta IV Payload User's Guide:   http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//  Bipropellant Data Sheets:        https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+//  Evolution of MPCV SM Propulsion: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150000145.pdf
+//  Aerojet General Space Engines:   http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
 
-	!PART[BasketTrussCX21y]:FOR[RealismOverhaul]{}
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
 
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) 4 - meter truss.
+!PART[BasketTrussCX2]:FOR[RealismOverhaul]{}
 
-//	Dimensions: 4.000 x 1.300 m
-//	Gross Mass: 215.00 Kg
-//	==================================================
+!PART[BasketTrussCX21y]:FOR[RealismOverhaul]{}
 
-	+PART[ICPSAdapterx]:FOR[RealismOverhaul]
-	{
-		@name		 = ICPSAdapterx2
-		%RSSROConfig = true
+//  ==================================================
+//  Delta Cryogenic Second Stage (DCSS) 4 - meter truss.
 
-		@MODEL
-		{
-			@scale	  = 1.600, 1.000, 1.600
-			%position = 0.000, 0.000, 0.000 
-			%rotation = 0.000, 0.000, 0.000
-		}
+//  Dimensions: 4 m x 1.3 m
+//  Inert Mass: 220 Kg
+//  ==================================================
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
++PART[ICPSAdapterx]:FOR[RealismOverhaul]
+{
+    @name = ICPSAdapterx2
+    %RSSROConfig = True
 
-		@node_stack_bottom = 0.000, -0.615, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  0.615, 0.000, 0.000,  1.000, 0.000, 3
+    @MODEL
+    {
+        @scale = 1.6, 1.0, 1.6
+    }
 
-		@title		  = Delta IV DCSS Truss [4 Meters]
-		@manufacturer = United Launch Alliance (ULA)
-		@description  = The structural truss for the 4 - meter Delta Cryogenic Second Stage (DCSS).
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@mass			  = 0.2150
-		@crashTolerance   = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = true
-		%bulkheadProfiles = size3
+    @node_stack_bottom = 0.0, -0.615, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_top = 0.0, 0.615, 0.0, 0.0, 1.0, 0.0, 3
 
-		!MODULE[ModuleCommand]{}
+    @title = Delta IV DCSS Truss (4 Meters)
+    @manufacturer = United Launch Alliance (ULA)
+    @description = The structural support truss for the 4 meter Delta Cryogenic Second Stage (DCSS) liquid Hydrogen and liquid Oxygen propellant tanks.
 
-		!MODULE[ModuleSAS]{}
+    @mass = 0.22
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @fuelCrossFeed = True
+    !stageOffset = NULL
+    !childStageOffset = NULL
+    %bulkheadProfiles = size3
 
-		!MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleCommand],*{}
 
-		!MODULE[MechJebCore]{}
+    !MODULE[ModuleSAS],*{}
 
-		!RESOURCE[ElectricCharge]{}
+    !MODULE[ModuleReactionWheel],*{}
 
-		!RESOURCE[MonoPropellant]{}
-	}
+    !MODULE[MechJebCore],*{}
 
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) 5 - meter truss.
+    !RESOURCE,*{}
+}
 
-//	Dimensions: 5.000 x 2.600 m
-//	Gross Mass: 430.00 Kg
-//	==================================================
+//  ==================================================
+//  Delta Cryogenic Second Stage (DCSS) 5 - meter truss.
 
-	@PART[ICPSAdapterx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+//  Dimensions: 5 m x 2.6 m
+//  Inert Mass: 430 Kg
+//  ==================================================
 
-		@MODEL
-		{
-			@scale	  = 2.040, 2.000, 2.040
-			%position = 0.000, 0.000, 0.000 
-			%rotation = 0.000, 0.000, 0.000
-		}
+@PART[ICPSAdapterx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 2.04, 2.0, 2.04
+    }
 
-		@node_stack_bottom = 0.000, -1.200, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  1.200, 0.000, 0.000,  1.000, 0.000, 3
-
-		@title		  = Delta IV DCSS Truss [5 Meters]
-		@manufacturer = United Launch Alliance (ULA)
-		@description  = The structural truss for the 5 - meter Delta Cryogenic Second Stage (DCSS).
-
-		@mass			  = 0.4300
-		@crashTolerance   = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = true
-		%bulkheadProfiles = size3
-
-		!MODULE[ModuleCommand]{}
-
-		!MODULE[ModuleSAS]{}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		!MODULE[MechJebCore]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) engine truss.
-
-//	Dimensions: 3.100 x 0.800 m
-//	Gross Mass: 100.00 Kg
-//	==================================================
-
-	@PART[BasketTrussCX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 2.030, 3.100, 2.030
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  0.850, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -0.335, 0.000, 0.000, -1.000, 0.000, 3
-
-		@title		  = Delta IV DCSS Engine Truss
-		@manufacturer = United Launch Alliance (ULA)
-		@description  = The Delta Cryogenic Second Stage (DCSS) avionics and engine holder truss.
-
-		@mass			  = 0.100
-		@crashTolerance   = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
-	}
-
-//	==================================================
-//	Orion MPCV Service Module linear thruster (radial).
-
-//	Dimensions: 0.400 x 0.800 m
-//	Gross Mass: 32.00 Kg
-//	O/F Ratio: 1.70
-//	==================================================
-
-	@PART[X2009RCSX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
-
-		@MODEL
-		{
-			%scale	  = 1.785, 1.785, 1.785
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-        @node_attach = 0.000, 0.000, 0.000, 0.000, 0.000, 0.000
-    
-        @title		  = Orion MPCV Radial RCS Thruster
-        @manufacturer = Airbus SAS
-        @description  = Linear RCS thruster pod, each containing two 200 N thrusters (400 N total thrust). Originally developed for the Automatic Transfer Vehicle (ATV) resupply spacecraft with the purposes of attitude control and orbital maneuvering.
-
-		@mass			  = 0.032
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = srf
-		%useRcsConfig	  = NULL
-		%useRcsMass		  = true
-
-        @MODULE[ModuleRCS]
-		{
-			@name		   = ModuleRCS
-			@thrusterPower = 0.400
-			!resourceName  = NULL
-
-			PROPELLANT
-			{
-				name  = MMH
-				ratio = 0.469
-			}
-
-			PROPELLANT
-			{
-				name  = MON3
-				ratio = 0.531
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 270
-				@key,1 = 1 100
-			}
-		}
-
-        !MODULE[TweakScale]{}
-	}
-
-//	==================================================
-//	Orion MPCV Service Module linear thruster (inline).
-
-//	Dimensions: 0.100 x 0.400 m
-//	Gross Mass: 56.00 Kg
-//	O/F Ratio: 1.70
-//	==================================================
-
-	@PART[XESARCSX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			%scale	  = 1.785, 1.785, 1.785
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000
-
-		@title		  = Orion MPCV Inline RCS Thruster
-		@manufacturer = Aerojet Rocketdyne
-		@description  = Radiatively cooled linear RCS thruster, each containing two R-4D-11 engines. The R-4D-11 was originally designed by Marquardt for use on the Apollo Service Module, the Lunar Ascent and Descent modules and as a satellite apogee motor. Now it finds use as an Auxiliary Thruster (AT) for the Orion MPCV.
-
-		@mass			  = 0.056
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = srf
-		%useRcsConfig	  = NULL
-		%useRcsMass		  = true
-
-        @MODULE[ModuleRCS]
-		{
-			@name		   = ModuleRCS
-			@thrusterPower = 0.980
-			!resourceName  = DELETE
-
-			PROPELLANT
-			{
-				name  = MMH
-				ratio = 0.469
-			}
-
-			PROPELLANT
-			{
-				name  = MON3
-				ratio = 0.531
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 312
-				@key,1 = 1 100
-			}
-		}
-
-		!MODULE[TweakScale]{}
-	}
-
-//	==================================================
-//	Aerojet Rocketdyne AJ10-190 engine.
-
-//	Dimensions: 1.170 x 1.960 m
-//	Gross Mass: 118.00 Kg
-//	Throttle Range: N/A
-//	Burn Time: 1250 s
-//	O/F Ratio: 1.70
-//	==================================================
-
-	@PART[CHAKAOME2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 2.275, 2.150, 2.275
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  0.340, 0.000, 0.000,  1.000, 0.000, 3
-		%node_stack_bottom = 0.000, -1.540, 0.000, 0.000, -1.000, 0.000, 3
-
-		@category	  = Engine
-		@title		  = AJ10-190 [1.2 m]
-		@manufacturer = Aerojet Rocketdyne
-		@description  = Pressure - fed, radiatively cooled hypergolic engine. Derived from the AJ10-37 engine, it was used on the Space Shuttle Orbital Maneuvering System (OMS) and now it finds use as the Orion MPCV main engine.
-
-		@mass			  = 0.118
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%fuelCrossFeed	  = true
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleEngines*]
-		{
-			@minThrust	 	= 26.70
-			@maxThrust		= 26.70
-			@heatProduction	= 17.50
-			!fxOffset		= NULL
-			%ullage			= true
-			%pressureFed	= true
-
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.500
-			}
-
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = MMH
-				@ratio = 0.5084
-			}
-
-			PROPELLANT[Oxidizer]
-			{
-				@name  = MON3
-				@ratio = 0.4915
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 294.30
-				@key,1 = 1 150.00
-			}
-		}
-
-		//	Gimbal range value is the average of the pitch and yaw ranges (6 for pitch, 7 for yaw).
-
-		@MODULE[ModuleGimbal]
-		{
-			@gimbalRange		 	= 6.500
-			%useGimbalResponseSpeed = true
-			%gimbalResponseSpeed 	= 16
-		}
-
-		!MODULE[TweakScale]{}
-
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			modded		  = false
-			configuration = AJ10-190-OMS
-
-			CONFIG
-			{
-				name		   = AJ10-190-OMS
-				minThrust	   = 26.70
-				maxThrust	   = 26.70
-				heatProduction = 17.50
-
-				PROPELLANT
-				{
-					name	  = MMH
-					ratio	  = 0.504
-					DrawGauge = True
-				}
-
-				PROPELLANT
-				{
-					name  = MON3
-					ratio = 0.496
-				}
-
-				atmosphereCurve
-				{
-					key = 0 294.30
-					key = 1 100.00
-				}
-			}
-
-			CONFIG
-			{
-				name		   = AJ10-190-Orion
-				minThrust	   = 33.40
-				maxThrust	   = 33.40
-				heatProduction = 17.50
-
-				PROPELLANT
-				{
-					name	  = MMH
-					ratio	  = 0.503
-					DrawGauge = True
-				}
-
-				PROPELLANT
-				{
-					name  = MON3
-					ratio = 0.496
-				}
-
-				atmosphereCurve
-				{
-					key = 0 313.20
-					key = 1 100.00
-				}
-			}
-		}
-	}
-
-//	==================================================
-//	Orion MPCV Service Module RCS block.
-
-//	Dimensions: 0.300 x 0.300 m
-//	Gross Mass: 28.00 Kg
-//	O/F Ratio: 1.70
-//	==================================================
-
-	@PART[XRCSX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			%scale	  = 1.785, 1.785, 1.785
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 0.000, 0.000, 0.000
-
-		@title		  = Orion MPCV RCS Block
-		@manufacturer = Airbus SAS
-		@description  = Multi - port RCS block for the Orion MPCV Service Module. Each thruster is rated for up to 200 N of thrust (400 N combined for each direction).
-
-		@mass			  = 0.0280
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp	 	  = 1073.15
-		%bulkheadProfiles = srf
-		%useRcsConfig	  = NULL
-		%useRcsMass		  = true
-
-		@MODULE[ModuleRCS]
-		{
-			@name		   = ModuleRCS
-			@thrusterPower = 0.400
-			!resourceName  = NULL
-
-			PROPELLANT
-			{
-				name  = MMH
-				ratio = 0.469
-			}
-
-			PROPELLANT
-			{
-				name  = MON3
-				ratio = 0.531
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 270.00
-				@key,1 = 1 100.00
-			}
-		}
-
-		!MODULE[TweakScale]{}
-	}
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 4
+
+    @title = Delta IV DCSS Truss (5 Meters)
+    @manufacturer = United Launch Alliance (ULA)
+    @description = The structural support truss for the 5 meter Delta Cryogenic Second Stage (DCSS) liquid Hydrogen and liquid Oxygen propellant tanks.
+
+    @mass = 0.43
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @fuelCrossFeed = True
+    !stageOffset = NULL
+    !childStageOffset = NULL
+    %bulkheadProfiles = size4
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Delta Cryogenic Second Stage (DCSS) engine truss.
+
+//  Dimensions: 3.1 m x 0.8 m
+//  Inert Mass: 100 Kg
+//  ==================================================
+
+@PART[BasketTrussCX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 2.03, 3.1, 2.03
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.85, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.335, 0.0, 0.0, -1.0, 0.0, 3
+
+    @title = Delta IV DCSS Engine Truss
+    @manufacturer = United Launch Alliance (ULA)
+    @description = The Delta Cryogenic Second Stage (DCSS) avionics and engine holder truss.
+
+    @mass = 0.1
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %bulkheadProfiles = size3
+}
+
+//  ==================================================
+//  Orion MPCV Service Module linear thruster (radial).
+
+//  Dimensions: 0.4 m x 0.8 m
+//  Inert Mass: 25 Kg
+//  ==================================================
+
+@PART[X2009RCSX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.785, 1.785, 1.785
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+    @title = Orion MPCV RCS Thruster (Radial)
+    @manufacturer = Aerojet Rocketdyne
+    @description = Linear RCS thruster pod, each containing two R-1E thrusters. Originally developed for the Constellation CEV as auxiliary thrusters for orbital maneuvers and as a backup for the main engine.
+
+    @mass = 0.025
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 773.15
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.22
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.499
+        }
+
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.501
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 280
+            @key,1 = 1 100
+        }
+    }
+
+    !MODULE[TweakScale],*{}
+}
+
+//  ==================================================
+//  Orion MPCV Service Module linear thruster (inline).
+
+//  Dimensions: 0.1 m x 0.4 m
+//  Inert Mass: 16 Kg
+//  ==================================================
+
+@PART[XESARCSX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 3.85, 2.825, 3.85
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = Orion MPCV RCS Thruster (Inline)
+    @manufacturer = Aerojet Rocketdyne
+    @description = Linear RCS thruster pod, each containing two R-4D-11 thrusters. Originally designed by Marquardt for use on the Apollo Service Module, the Lunar Ascent and Descent modules and as a satellite apogee motor. Later variants were modified to support new propellant combinations and to increase the efficiency.
+
+    @mass = 0.016
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 773.15
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.98
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.499
+        }
+
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.501
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 315.5
+            @key,1 = 1 100
+        }
+    }
+
+    !MODULE[TweakScale],*{}
+}
+
+//  ==================================================
+//  Aerojet Rocketdyne AJ10-190 engine.
+
+//  Dimensions: 1.17 m x 1.96 m
+//  Inert Mass: 118 Kg
+//  ==================================================
+
+@PART[CHAKAOME2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 2.275, 2.15, 2.275
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, -0.365, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_bottom = 0.0, -1.54, 0.0, 0.0, -1.0, 0.0, 1
+
+    @category = Engine
+
+    @mass = 0.118
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 1023.15
+    %skinMaxTemp = 1773.15
+    %fuelCrossFeed = True
+    %bulkheadProfiles = size3
+
+    %engineType = AJ10_190
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 26.7
+        @maxThrust = 26.7
+        @heatProduction = 100
+        %exhaustDamageMultiplier = 0.75
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+            @ratio = 0.499
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = MON3
+            @ratio = 0.501
+            @DrawGauge = False
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 316
+            @key,1 = 1 100
+        }
+    }
+
+    !MODULE[TweakScale],*{}
+}
+
+//  ==================================================
+//  Aerojet Rocketdyne AJ10-190 engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[CHAKAOME2]:AFTER[RealismOverhaulEngines]
+{
+    //  AJ10-190 has 6 degrees of gimbal for pitch and 7 for yaw.
+
+    @MODULE[ModuleGimbal]
+    {
+        !gimbalRange = NULL
+        %gimbalRangeXP = 6
+        %gimbalRangeXN = 6
+        %gimbalRangeYP = 7
+        %gimbalRangeYN = 7
+    }
+}
+
+//  ==================================================
+//  Orion MPCV Service Module RCS block.
+
+//  Dimensions: 0.3 m x 0.3 m
+//  Inert Mass: 28 Kg
+//  ==================================================
+
+@PART[XRCSX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.785, 1.785, 1.785
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+    @title = Orion MPCV RCS Block
+    @manufacturer = Airbus Defence & Space
+    @description = Multi - port RCS block for the Orion MPCV Service Module. Each thruster is rated for up to 220 N of thrust (440 N combined for each direction).
+
+    @mass = 0.028
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 773.15
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.44
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.469
+        }
+
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.531
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 270
+            @key,1 = 1 100
+        }
+    }
+
+    !MODULE[TweakScale],*{}
+}


### PR DESCRIPTION
Continuation of the CMES updates, this time for the "AerojetKerbodyne" parts.

Changelog:
- Add sources for some of the part configs.
- Round the mass of the DCSS 4 truss adapter.
- Adjust the inert mass of Orion MPCV linear thruster blocks.
- Add Global Engine compatibility for the AJ10-190 engine.
- Make the RESOURCE removal a bit more bulletproof.
- Update the part titles and the descriptions.
- Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1361/files?w=1)
