### PR TITLE
CMES Electrical updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -43,6 +43,7 @@
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
     @attachRules = 0,1,0,1,0
 
+    @category = Communication
     @title = Communotron 64
     @manufacturer = Generic
     @description = Medium range omnidirectional antenna.
@@ -121,6 +122,7 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
+    @category = Thermal
     @title = Retractable Radiator Array
     @manufacturer = Generic
     @description = A retractable radiator panel. Maximum thermal power dissipation 2.75 kW.
@@ -378,6 +380,7 @@
 
     @node_attach = -0.2, 0.0, 0.0, 1.0, 0.0, 0.0
 
+    @category = Electrical
     @title = TKS - A Expanded Solar Array
     @manufacturer = Generic
     @description = High power retractable solar array for demanding payloads. 42 m2.
@@ -423,6 +426,7 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
+    @category = Electrical
     @title = Orion MPCV Solar Array Wing (SAW)
     @manufacturer = Airbus Defence & Space
     @description = Derived from the solar arrays of the (now defunct) Automatic Transfer Vehicle (ATV) resupply spacecraft. Conversion efficiency has been improved from 11% to 16% and it is now able to supply up to 2.75 kW of electrical power. 14.25 m2.
@@ -468,6 +472,7 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
+    @category = Electrical
     @title = HAB - ST6 Solar Array
     @manufacturer = Generic
     @description = Level 6 static solar array. 4.5 m2.
@@ -511,6 +516,7 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
+    @category = Utility
     @title = N1 Utility Light
     @manufacturer = Generic
     @description = A light source optimized for the rigors of space.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -106,7 +106,7 @@
 //  Accepted a thermal dissipation factor of 225 W/m2.
 
 //  Dimensions: 1.7 m x 7.2 m
-//  Inert Mass: 175 Kg
+//  Inert Mass: 600 Kg
 //  ==================================================
 
 @PART[XORIGKosmos_Salyut_Solar_Array2X]:FOR[RealismOverhaul]
@@ -125,7 +125,7 @@
     @manufacturer = Generic
     @description = A retractable radiator panel. Maximum thermal power dissipation 2.75 kW.
 
-    @mass = 0.175
+    @mass = 0.6
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
@@ -214,7 +214,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1600
+        volume = 1200
         basemass = -1
     }
 
@@ -282,7 +282,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1000
+        volume = 720
         basemass = -1
     }
 
@@ -349,7 +349,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1000
+        volume = 720
         basemass = -1
     }
 
@@ -360,7 +360,7 @@
 //  Expanded solar array.
 
 //  Dimensions: 15 m x 2.8 m
-//  Inert Mass: 590 Kg
+//  Inert Mass: 400 Kg
 //  ==================================================
 
 @PART[xchakaKosmos_TKS_Solar_Arrayx]:FOR[RealismOverhaul]
@@ -382,7 +382,7 @@
     @manufacturer = Generic
     @description = High power retractable solar array for demanding payloads. 42 m2.
 
-    @mass = 0.59
+    @mass = 0.4
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
@@ -395,7 +395,7 @@
 
     @MODULE[ModuleDeployableSolarPanel]
     {
-        @chargeRate = 9.45
+        @chargeRate = 7.5
 
         !powerCurve{}
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -1,420 +1,531 @@
-//	==================================================
-//	Removed extra parts.
-//	==================================================
-
-	!PART[XLLLCommPole2X]:FOR[RealismOverhaul]{}
-
-	!PART[XATVpanel2X]:FOR[RealismOverhaul]{}
-
-	!PART[xB9_Utility_Light_N1_Large_Whitex]:FOR[RealismOverhaul]{}
-
-	!PART[XB9_Utility_Light_N2_RedX]:FOR[RealismOverhaul]{}
-
-	!PART[XB9_Utility_Light_N2_RedXl]:FOR[RealismOverhaul]{}
-
-//	==================================================
-//	Fixed omnidirectional antenna.
-
-//	Realism Overhaul configuration.
-
-//	Dimensions: 0.400 x 4.900 m
-//	Gross Mass: 60.00 Kg
-//	==================================================
-
-	@PART[xLLLCommPolex]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			%scale    = 1.333, 1.333, 1.333
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000
-		@attachRules = 0,1,0,1,0
-
-		@title		  = Communotron 64
-		@manufacturer = Generic
-		@description  = Medium range omnidirectional antenna. Can be used for lunar communications.
-
-		@mass			  = 0.060
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%bulkheadProfiles = srf
-
-		!MODULE[ModuleDataTransmitter]{}		
-	}
-
-//	==================================================
-//	Fixed omnidirectional antenna.
-
-//	Remote Tech configuration.
-//	==================================================
-
-	@PART[xLLLCommPolex]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-	{
-		MODULE
-		{
-			name		  	  = ModuleRTAntenna
-			Mode0OmniRange	  = 0
-			Mode1OmniRange	  = 16000000
-			EnergyCost	  	  = 0.010
-			MaxQ		   	  = 6000
-			DeployFxModules   = 0
-			ProgressFxModules = 1
-
-			TRANSMITTER
-			{
-				PacketInterval	   = 0.400
-				PacketSize		   = 0.760
-				PacketResourceCost = 0.004
-			}
-		}
-	}
-
-//	==================================================
-//	Retractable Radiator Array (small).
-
-//	Dimensions: 1.100 x 6.300 m
-//	Gross Mass: 115 Kg	(14 Kg/m2)
-//	Dissipation: 1559.25 W	(225 W/m2)
-//	==================================================
-
-	@PART[XORIGKosmos_Salyut_Solar_Array2X]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.215, 1.215, 1.215
-			@position = 0.000, 0.000, 0.000
-			@rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@title		  = Retractable Radiator Array - Type A
-		@manufacturer = Generic
-		@description  = A retractable radiator panel. Maximum thermal power dissipation 1.5 kW.
-
-		@mass			  = 0.1150
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = srf
-
-		!MODULE[ModuleDeployableSolarPanel]{}
-
-		MODULE
-		{
-			name		 		 = ModuleDeployableRadiator
-			animationName		 = deploy
-			retractable			 = true
-			pivotName			 = sun_pivot
-			raycastTransformName = sunCatcher
-			windResistance		 = 5
-			trackingSpeed		 = 0.100
-		}
-
-		MODULE
-		{
-			name			  = ModuleActiveRadiator
-			maxEnergyTransfer = 1559.25
-		}
-	}
-
-//	==================================================
-//	TKS/FGB/ROS Primary Propellant Tank (with radiators).
-
-//	Dimensions: 1.200 x 4.000 m
-//	Gross Mass: 243.40 Kg
-//	==================================================
-
-	@PART[xKosmos_TKS_RCS_Tankx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.440, 1.200, 1.440
-			@position = 0.000, 0.000, 0.000
-			@rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@attachRules = 0,1,0,1,0
-
-		@category	  = FuelTank
-		@title		  = ROS Primary Propellant Tank
-		@manufacturer = Roscosmos
-		@description  = The main propellant tank for the Russian Orbital Segment (ROS).
-
-		@mass		 		 = 0.2434
-		%breakingForce		 = 250
-		%breakingTorque		 = 250
-		@maxTemp			 = 1073.15
-		%emissiveConstant	 = 0.900
-		%heatConductivity	 = 0.750	
-		%thermalMassModifier = 5.000
-		%radiatorHeadroom	 = 0.500
-		%bulkheadProfiles	 = srf
-
-        MODULE
-		{
-			name   = ModuleFuelTanks
-			volume = 1600
-			type   = ServiceModule
-		}
-
-        !RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	TKS/FGB/ROS Secondary Propellant Tank (with radiators).
-
-//	Dimensions: 1.200 x 2.400 m
-//	Gross Mass: 83.35 Kg
-//	==================================================
-
-	@PART[XSMALL?Kosmos_TKS_RCS_TankX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.440, 0.725, 1.440
-			@position = 0.000, 0.000, 0.000
-			@rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@attachRules = 0,1,0,1,0
-
-		@category	  = FuelTank
-        @title		  = ROS Secondary Propellant Tank
-        @manufacturer = Roscosmos
-        @description  = The secondary propellant tank for the Russian Orbital Segment (ROS).
-
-		@mass		 		 = 0.0833
-		%breakingForce		 = 250
-		%breakingTorque		 = 250
-		@maxTemp			 = 1073.15
-		%emissiveConstant	 = 0.900
-		%heatConductivity	 = 0.750	
-		%thermalMassModifier = 5.000
-		%radiatorHeadroom	 = 0.500
-		%bulkheadProfiles	 = srf
-
-        MODULE
-		{
-			name   = ModuleFuelTanks
-			volume = 1000
-			type   = ServiceModule
-		}
-
-        !RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	TKS/FGB/ROS Auxiliary Propellant Tank (without radiators).
-
-//	Dimensions: 1.200 x 2.400 m
-//	Gross Mass: 63.19 Kg
-//	==================================================
-
-	@PART[XSMALL?Kosmos_TKS_RCS_TankXxxf]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@model	  = CMES/Electrical/Kosmos_TKS_RCS_Tank2/model_Radless
-			@scale	  = 1.440, 0.725, 1.440
-			@position = 0.000, 0.000, 0.000
-			@rotation = 0.000, 0.000, 0.000
-		}
-
-   		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@attachRules = 0,1,0,1,0
-
-		@category	  = FuelTank
-        @title		  = ROS Auxiliary Propellant Tank
-        @manufacturer = Roscosmos
-        @description  = The auxiliary propellant tank for the Russian Orbital Segment (ROS).
-
-		@mass		 		 = 0.0632
-		%breakingForce		 = 250
-		%breakingTorque		 = 250
-		@maxTemp			 = 1073.15
-		%emissiveConstant	 = 0.900
-		%heatConductivity	 = 0.750	
-		%thermalMassModifier = 5.000
-		%radiatorHeadroom	 = 0.500
-		%bulkheadProfiles	 = srf
-
-        MODULE
-		{
-			name   = ModuleFuelTanks
-			volume = 1000
-			type   = ServiceModule
-		}
-
-        !RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Orion Service Module solar array.
-
-//	Dimensions: 1.900 x 7.890 m
-//	Gross Mass: 17.50 Kg
-//	Power Production: 2750.00 W
-//	Conversion Efficiency: 16.54% (226.15 W/m2)
-//	==================================================
-
-	@PART[XATVpanel]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Electrical/LIONHEAD-CHAKA-ATV-PANEL/model
-			scale	 = 1.125, 1.125, 1.850
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@title		  = Orion MPCV Solar Array
-		@manufacturer = Airbus Defence & Space
-		@description  = Derived from the solar arrays of the (now defunct) Automatic Transfer Vehicle (ATV) resupply spacecraft. Conversion efficiency has been improved from 11% to 16%, supplying up to 2750 W of electric power.
-
-		@mass			 	 = 0.0175
-		@crashTolerance  	 = 8
-		%breakingForce   	 = 250
-		%breakingTorque  	 = 250
-		@maxTemp	     	 = 1073.15
-		%fuelCrossFeed   	 = false
-		%bulkheadProfiles 	 = srf
-		%thermalMassModifier = 2.000
-		%emissiveConstant	 = 0.950
-		%heatConductivity	 = 0.040
-
-		@MODULE[ModuleDeployableSolarPanel]
-		{
-			@chargeRate = 2.750
-
-			!powerCurve{}
-		}
-	}
-
-//	==================================================
-//	Habitation module solar array (level 6).
-
-//	Dimensions: 1.500 x 2.000 m
-//	Gross Mass: 9.22 Kg
-//	Power Production: 990.00 W
-//	Conversion Efficiency: 16% (220 W/m2)
-//	==================================================
-
-	@PART[solarPanels6]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
-
-		@MODEL
-		{
-			@scale	  = 4.285, 4.165, 1.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-    
-        @title		  = ST6 Solar Array
-        @manufacturer = Generic
-        @description  = Static Level 6 solar array (4.5 m2).
-
-		@mass				 = 0.0092
-		@crashTolerance		 = 12
-		%breakingForce 		 = 250
-		%breakingTorque		 = 250
-		@maxTemp	    	 = 1073.15
-		%thermalMassModifier = 2.000
-		%emissiveConstant	 = 0.950
-		%heatConductivity	 = 0.040
-
-		@MODULE[ModuleDeployableSolarPanel]
-		{
-			@chargeRate = 0.9900
-
-			!powerCurve{}
-		}
-	}
-
-//	==================================================
-//	Omnidirectional light.
-
-//	Dimensions: 0.400 x 0.100 m
-//	Gross Mass: 1.80 Kg
-//	Power Requirements: 22.00 W
-//	==================================================
-
-	@PART[XB9_Utility_Light_N1_WhiteX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			%scale	  = 4.000, 4.000, 4.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000
-
-		@title		  = N1 Omnidirectional Light
-		@manufacturer = Generic
-		@description  = A light source, optimized for the rigors of space.
-
-		@mass			  = 0.0018
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%bulkheadProfiles = srf
-
-		@MODULE[ModuleLight]
-		{
-			@resourceAmount = 0.022
-		}
-	}
+//  ==================================================
+//  Sources:
+
+//  The MPCV European Service Module: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140008543.pdf
+
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
+
+!PART[XLLLCommPole2X]:FOR[RealismOverhaul]{}
+
+!PART[XATVpanel2X]:FOR[RealismOverhaul]{}
+
+!PART[XATVpanel3X]:FOR[RealismOverhaul]{}
+
+!PART[solarPanels7X]:FOR[RealismOverhaul]{}
+
+!PART[xB9_Utility_Light_N1_Large_Whitex]:FOR[RealismOverhaul]{}
+
+!PART[XB9_Utility_Light_N2_RedX]:FOR[RealismOverhaul]{}
+
+!PART[XB9_Utility_Light_N2_RedXl]:FOR[RealismOverhaul]{}
+
+//  ==================================================
+//  Fixed omnidirectional antenna.
+
+//  Dimensions: 0.4 m x 4.9 m
+//  Inert Mass: 15 Kg
+//  ==================================================
+
+@PART[xLLLCommPolex]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.333, 1.333, 1.333
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+    @attachRules = 0,1,0,1,0
+
+    @title = Communotron 64
+    @manufacturer = Generic
+    @description = Medium range omnidirectional antenna.
+
+    @mass = 0.015
+    @crashTolerance = 8
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = srf
+}
+
+//  ==================================================
+//  Fixed omnidirectional antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[xLLLCommPolex]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Effective range 2.5 Gm, power consumption 30 Watts, maximum data rate 2 Mbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        Mode0OmniRange = 0
+        Mode1OmniRange = 25000000
+        EnergyCost = 0.03
+        MaxQ = 6000
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 2.048
+            PacketResourceCost = 0.005
+        }
+    }
+}
+
+//  ==================================================
+//  Retractable Radiator Array (small).
+
+//  Accepted a mass factor of 14 Kg/m2.
+//  Accepted a thermal dissipation factor of 225 W/m2.
+
+//  Dimensions: 1.7 m x 7.2 m
+//  Inert Mass: 175 Kg
+//  ==================================================
+
+@PART[XORIGKosmos_Salyut_Solar_Array2X]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.333, 1.333, 1.333
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Retractable Radiator Array
+    @manufacturer = Generic
+    @description = A retractable radiator panel. Maximum thermal power dissipation 2.75 kW.
+
+    @mass = 0.175
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %emissiveConstant = 0.90
+    %heatConductivity = 0.001
+    %skinInternalConductionMult = 2000
+    %radiatorHeadroom = 0.27                    //  Thanks to NathanKell & stratochief66 for the radiator parameters.
+    %thermalMassModifier = 2.5
+    %bulkheadProfiles = srf
+
+    !MODULE[ModuleDeployableSolarPanel],*{}
+
+    !MODULE[ModuleDeployableRadiator],*{}
+
+    MODULE
+    {
+        name = ModuleDeployableRadiator
+        animationName = deploy
+        retractable = True
+        pivotName = sun_pivot
+        raycastTransformName = sunCatcher
+        windResistance = 5
+        trackingSpeed = 0.1
+        sunAlignmentOffset = 0
+    }
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 50000
+        %overcoolFactor = 0.0186367             //  Can keep the MTV propellant tank contents in liquid form.
+        %isCoreRadiator = True
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 2.2
+        }
+    }
+}
+
+//  ==================================================
+//  TKS/FGB/ROS Primary Propellant Tank (with radiators).
+
+//  Dimensions: 1.2 m x 4 m
+//  Inert Mass: 85 Kg
+//  ==================================================
+
+@PART[xKosmos_TKS_RCS_Tankx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.44, 1.2, 1.44
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @attachRules = 0,1,0,1,0
+
+    @category = FuelTank
+    @title = ROS - 01R Radial Propellant Tank (large)
+    @manufacturer = RKK Energiya
+    @description = A radially attachable general purpose propellant tank. Includes radiators for heat dissipation.
+
+    @mass = 0.085
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %emissiveConstant = 0.9
+    %heatConductivity = 0.75
+    %thermalMassModifier = 5.0
+    %radiatorHeadroom = 0.27
+    %bulkheadProfiles = srf
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1600
+        basemass = -1
+    }
+
+    !MODULE[ModuleActiveRadiator],*{}
+
+    MODULE
+    {
+        name = ModuleActiveRadiator
+        maxEnergyTransfer = 35
+        overcoolFactor = 53.6575
+        isCoreRadiator = True
+        maxLinksAway = 2
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.05
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TKS/FGB/ROS Secondary Propellant Tank (with radiators).
+
+//  Dimensions: 1.2 m x 2.4 m
+//  Inert Mass: 65 Kg
+//  ==================================================
+
+@PART[XSMALL?Kosmos_TKS_RCS_TankX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.44, 0.725, 1.44
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @attachRules = 0,1,0,1,0
+
+    @category = FuelTank
+    @title = ROS - 02R Radial Propellant Tank (medium)
+    @manufacturer = RKK Energiya
+    @description = A radially attachable general purpose propellant tank. Includes radiators for heat dissipation.
+
+    @mass = 0.065
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %emissiveConstant = 0.9
+    %heatConductivity = 0.75
+    %thermalMassModifier = 5.0
+    %radiatorHeadroom = 0.27
+    %bulkheadProfiles = srf
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1000
+        basemass = -1
+    }
+
+    !MODULE[ModuleActiveRadiator],*{}
+
+    MODULE
+    {
+        name = ModuleActiveRadiator
+        maxEnergyTransfer = 21.5
+        overcoolFactor = 53.6575
+        isCoreRadiator = True
+        maxLinksAway = 2
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.025
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TKS/FGB/ROS Auxiliary Propellant Tank (without radiators).
+
+//  Dimensions: 1.2 m x 2.4 m
+//  Inert Mass: 40 Kg
+//  ==================================================
+
+@PART[XSMALL?Kosmos_TKS_RCS_TankXxxf]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @model = CMES/Electrical/Kosmos_TKS_RCS_Tank2/model_Radless
+        @scale = 1.44, 0.725, 1.44
+        !position = NULL
+        !rotation = NULL
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @attachRules = 0,1,0,1,0
+
+    @category = FuelTank
+    @title = ROS - 03 Radial Propellant Tank (small)
+    @manufacturer = RKK Energiya
+    @description = A radially attachable general purpose propellant tank.
+
+    @mass = 0.065
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    %bulkheadProfiles = srf
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1000
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Expanded solar array.
+
+//  Dimensions: 15 m x 2.8 m
+//  Inert Mass: 590 Kg
+//  ==================================================
+
+@PART[xchakaKosmos_TKS_Solar_Arrayx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 3.0, 1.2, 1.2
+        !position = NULL
+        !rotation = NULL
+    }
+
+    @node_attach = -0.2, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @title = TKS - A Expanded Solar Array
+    @manufacturer = Generic
+    @description = High power retractable solar array for demanding payloads. 42 m2.
+
+    @mass = 0.59
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %thermalMassModifier = 2.0
+    %emissiveConstant = 0.95
+    %heatConductivity = 0.04
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 9.45
+
+        !powerCurve{}
+    }
+}
+
+//  ==================================================
+//  Orion Service Module solar array.
+
+//  Dimensions: 1.9 m x 7.5 m
+//  Inert Mass: 18 Kg
+//  ==================================================
+
+@PART[XATVpanel]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Electrical/LIONHEAD-CHAKA-ATV-PANEL/model
+        scale = 1.045, 1.25, 1.945
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Orion MPCV Solar Array Wing (SAW)
+    @manufacturer = Airbus Defence & Space
+    @description = Derived from the solar arrays of the (now defunct) Automatic Transfer Vehicle (ATV) resupply spacecraft. Conversion efficiency has been improved from 11% to 16% and it is now able to supply up to 2.75 kW of electrical power. 14.25 m2.
+
+    @mass = 0.018
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = false
+    %bulkheadProfiles = srf
+    %thermalMassModifier = 2.0
+    %emissiveConstant = 0.95
+    %heatConductivity = 0.04
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 2.75
+
+        !powerCurve{}
+    }
+}
+
+//  ==================================================
+//  Habitation module solar array (level 6).
+
+//  Dimensions: 1.5 m x 2 m
+//  Inert Mass: 9 Kg
+//  ==================================================
+
+@PART[solarPanels6]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 4.285, 4.165, 4.125
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = HAB - ST6 Solar Array
+    @manufacturer = Generic
+    @description = Level 6 static solar array. 4.5 m2.
+
+    @mass = 0.009
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %thermalMassModifier = 2.0
+    %emissiveConstant = 0.95
+    %heatConductivity = 0.04
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 1.0
+
+        !powerCurve{}
+    }
+}
+
+//  ==================================================
+//  Omnidirectional light.
+
+//  Dimensions: 0.4 m x 0.1 m
+//  Inert Mass: 1.8 Kg
+//  ==================================================
+
+@PART[XB9_Utility_Light_N1_WhiteX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 4.0, 4.0, 4.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = N1 Utility Light
+    @manufacturer = Generic
+    @description = A light source optimized for the rigors of space.
+
+    @mass = 0.0018
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleLight]
+    {
+        @resourceAmount = 0.022
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -52,8 +52,8 @@
     @crashTolerance = 8
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf
 }
@@ -341,8 +341,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %bulkheadProfiles = srf
 
     !MODULE[ModuleFuelTanks],*{}
@@ -389,8 +389,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %thermalMassModifier = 2.0
     %emissiveConstant = 0.95
     %heatConductivity = 0.04
@@ -435,8 +435,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = false
     %bulkheadProfiles = srf
     %thermalMassModifier = 2.0
@@ -481,8 +481,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %thermalMassModifier = 2.0
     %emissiveConstant = 0.95
     %heatConductivity = 0.04
@@ -525,8 +525,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf
 


### PR DESCRIPTION
Updates and fixes for the CMES "Electrical" parts.

Changelog:
- Increase a bit the range of the Communotron 64 omni antenna (better than the Communotron 32).
- Improve the RT compatibilty patch for the Communotron 64.
- Adjust the inert mass of the Communotron 64.
- Update the active radiator module parameters of the foldable radiator (can keep cryogenic propellants liquid now).
- Add active radiator modules to the radial propellant tanks (that include them).
- Add RO support for the large foldable solar array.
- Round the inert mass of the Orion MPCV solar array.
- Round the power generation of the (surface mounted) static solar array.
- Adjust some insane max temperature values.
- Update the part titles and the descriptions.
- Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1362/files?w=1)
