### PR TITLE
Update NK-19 to be similar to the NK-9V rather than NK-39.

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -68,7 +68,7 @@
 		{
 			name = NK-21
 			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
-			maxThrust = 400 // b14643
+			maxThrust = 400 // b14643.de
 			minThrust = 240 // assume 60% throttle.
 			heatProduction = 205
 			// 2.5 O/F mass ratio (b14643.de)
@@ -106,8 +106,8 @@
 		{
 			name = NK-19
 			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
-			maxThrust = 400
-			minThrust = 240
+			maxThrust = 451.1 // b14643.de
+			minThrust = 260
 			heatProduction = 205
 			massMult = 1 // I...guess?
 			// 2.5 O/F mass ratio (b14643.de)
@@ -124,7 +124,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 353 //assuming same as NK-31
+				key = 0 345 // b14643.de
 				key = 1 240 // astronautix, GR-1 entry
 			}
 
@@ -143,8 +143,8 @@
 		{
 			name = NK-39
 			description = Improved for N1F Block V. No gimbal, differential throttle.
-			maxThrust = 400
-			minThrust = 240 //FIXME guessing 60% min throttle
+			maxThrust = 400 // b14643.de
+			minThrust = 240 // assume 60% throttle.
 			heatProduction = 205
 			massMult = 1.09375 // 700kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
 			// 2.6 O/F mass ratio (b14643.de)
@@ -180,7 +180,7 @@
 		{
 			name = NK-31
 			description = Improved for N1F Block G. Relightable. Gimbal, throttle.
-			maxThrust = 402 // b14643
+			maxThrust = 402 // b14643.de
 			minThrust = 240 // assume some level of throttle, engine design was capable, and LH2 replacement engine for this stage had throttle.
 			heatProduction = 205
 			massMult = 1.128125 // 722kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
@@ -284,6 +284,6 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
-		techTransfer = NK-9V,NK-9,NK-19,NK-21,NK-39:50
+		techTransfer = NK-9,NK-9V,NK-19,NK-21,NK-39:50
 	}
 }


### PR DESCRIPTION
The NK-19 was changed as part of: https://github.com/KSP-RO/RealismOverhaul/commit/26f1c285a8d4c64b1bb53af8aec5a6c0f313c772

I've spent some time researching and isn't any evidence to suggest that the NK-19 is anything but a more reliable NK-9V, so the thrust dropping drastically doesn't make sense and I can't find a reference to it's thrust being any different than the NK-9V. Though, there are sources that suggest that both of them have lower thrust. I also haven't found any information suggesting that it throttled at all or that it had a burn time of 450 as opposed to 443.
