### PR TITLE
Gimbals for Puff / Aerospike (Shuttle OMS / J-2T)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1962,7 +1962,7 @@
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
-		gimbalRange = 3		//FIXME, real value unknown
+		gimbalRange = 7
 		useGimbalResponseSpeed = true
 		gimbalResponseSpeed = 16
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1417,6 +1417,15 @@
 	@title = AJ10-190 [Radial]
 	
 	!MODULE[ModuleGimbal],*{}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 7
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
+	}
+
 }
 
 //  ==================================================
@@ -1948,6 +1957,15 @@
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False
+
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 3		//FIXME, real value unknown
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
+	}
 
 	@MODULE[ModuleEngines*]
 	{


### PR DESCRIPTION
Shuttle OMS should have 7 degrees IIRC.

J-2T... according to Ferram there's no reason why spikes can't gimbal. I don't know what the proper/real value would be, but certainly not zero.

ETA:  http://www.alternatewars.com/BBOW/Space_Engines/ADP_Vol_I_JAN-1968.pdf, p. 40 (PDF pagination)
The document doesn't call it J2T, but by all appearances that's the engine it's about.