### PR TITLE
CMES Pod updates/fixes (part I)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -1,20 +1,45 @@
-//	==================================================
-//	Removed extra parts.
-//	==================================================
+//  ==================================================
+//  Sources:
 
-	!PART[xALCOR_LanderCapsule2x]:FOR[RealismOverhaul]{}
+//  From Apollo LM to Altair:                              http://www.csc.caltech.edu/references/AIAA-2009-6404.pdf
+//  The NASA Docking System (NDS):                         https://web.archive.org/web/20130215180627/http://dockingstandard.nasa.gov/Meetings/TIM_%28Nov-17-2010%29/NDS_TIM_presentation.pdf
+//  Orion MPCV Quick Facts:                                https://www.nasa.gov/sites/default/files/atoms/files/fs-2014-08-004-jsc-orion_quickfacts-web.pdf
+//  Orion CEV Facts:                                       https://www.nasa.gov/pdf/306407main_orion_crew%20_expl_vehicle.pdf
+//  Project Orion Overview:                                https://www.nasa.gov/pdf/156298main_orion_handout.pdf
+//  Challenges of the Orion CM Touchdown Roll Orientation: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20080015885.pdf
+//  Aerojet Rocketdyne MR thruster series:                 http://www.asi.org/adb/04/03/09/01/rocket-research.html
+//  ECLSS (Altair, Apollo, Orion, Lunar Outpost):          http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090029327.pdf
+//  The Orion MPCV European Service Module:                http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140010527.pdf
 
-	!PART[xLERroverXBodyxX]:FOR[RealismOverhaul]{}
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
 
-	!PART[xLERDockPortSHABSSA]:FOR[RealismOverhaul]{}
+!PART[xALCOR_LanderCapsule2x]:FOR[RealismOverhaul]{}
 
-	!PART[xLERDockPortSHABSSA3xq]:FOR[RealismOverhaul]{}
+!PART[xALCOR_LanderCapsule3x]:FOR[RealismOverhaul]{}
 
-	!PART[OrionDockingPort2Xx]:FOR[RealismOverhaul]{}
+!PART[Xcupola2X]:FOR[RealismOverhaul]{}
 
-	!PART[xparachuteRadialx]:FOR[RealismOverhaul]{}
+!PART[Xcupola3X]:FOR[RealismOverhaul]{}
 
-	!PART[xparachuteRadial2x]:FOR[RealismOverhaul]{}
+!PART[xLERroverXBodyxX]:FOR[RealismOverhaul]{}
+
+!PART[xLERroverXBod32xX]:FOR[RealismOverhaul]{}
+
+!PART[xLERDockPortSHABSSA]:FOR[RealismOverhaul]{}
+
+!PART[xLERDockPortSHABSSA3xq]:FOR[RealismOverhaul]{}
+
+!PART[xLERDockPortSHABSSA3xXq]:FOR[RealismOverhaul]{}
+
+!PART[xndsport2x]:FOR[RealismOverhaul]{}
+
+!PART[xndsport3x]:FOR[RealismOverhaul]{}
+
+!PART[xndsport5x]:FOR[RealismOverhaul]{}
+
+!PART[xparachuteRadial2x]:FOR[RealismOverhaul]{}
 
 //	==================================================
 //	MSEV crew cabin.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -41,665 +41,753 @@
 
 !PART[xparachuteRadial2x]:FOR[RealismOverhaul]{}
 
-//	==================================================
-//	MSEV crew cabin.
+//  ==================================================
+//  MMSEV crew cabin.
 
-//	Realism Overhaul configuration.
+//  Dimensions: 3.6 m x 2.8 m
+//  Gross Mass: 2000 Kg
+//  ==================================================
 
-//	Dimensions: 3.600 x 2.800 m
-//	Gross Mass: 1393.00 Kg
-//	==================================================
+@PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-	@PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    !mesh = NULL
 
-		MODEL
-		{
-			model	 = CMES/Pod/ALCOR_Monkey_Rover/Part/ALCORcapsule
-			scale	 = 1.850, 1.850, 1.850
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    MODEL
+    {
+        model = CMES/Pod/ALCOR_Monkey_Rover/Part/ALCORcapsule
+        scale = 1.85, 1.85, 1.85
+    }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@node_stack_bottom = 0.000, -1.140, 0.000, 0.000, -1.000, 0.000, 2
-		@node_stack_top	   = 0.000,  1.620, 0.000, 0.000,  1.000, 0.000, 2
+    @node_stack_top = 0.0, 1.62, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.14, 0.0, 0.0, -1.0, 0.0, 3
 
-		@title		  = MSEV Crew Cabin
-		@manufacturer = NASA
-		@description  = The MSEV (Multi - Mission Space Exploration Vehicle) is a pressurized cabin exploration vehicle for either space or surface application. Features include an airlock (for both in - space and rover versions) a total travel distance of 10 kilometers (only for the rover version) and a two - crew support for 14 days or up to 4 crew for shorter periods.
+    @title = MMSEV Crew Cabin
+    @manufacturer = NASA
+    @description = The MMSEV (Multi - Mission Space Exploration Vehicle) is a pressurized cabin exploration vehicle for either space or surface application. Features an airlock and a travel endurance for up to 10 kilometers.
 
-		@mass			  = 1.1500
-		@crashTolerance	  = 12
-		@maxTemp		  = 1073.15
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@vesselType		  = Ship
-		!stagingIcon	  = NULL
-		@CrewCapacity	  = 4
-		%bulkheadProfiles = size2
+    @mass = 2.0
+    @crashTolerance = 8
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @breakingForce = 250
+    @breakingTorque = 250
+    @vesselType = Ship
+    !stagingIcon = NULL
+    @CrewCapacity = 4
+    %bulkheadProfiles = size3
 
-		@MODULE[ModuleCommand]
-		{
-			RESOURCE
-			{
-				name = ElectricCharge
-				rate = 1.500
-			}
-		}
-
-		@MODULE[ModuleSAS]
-		{
-			%SASServiceLevel = 3
-		}
-
-		MODULE[ModuleScienceContainer]
-		{
-			@storageRange = 3.000
-		}
-
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			basemass = -1
-			volume	 = 45
-
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
-		}
-
-		!MODULE[ModuleScienceLab]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		!MODULE[ModuleGenerator]{}
-
-		!MODULE[RasterPropMonitorComputer]{}
-
-		!MODULE[KASModuleContainer]{}
-
-		!MODULE[MechJebCore]{}
-	}
-
-//	==================================================
-//	MSEV crew cabin.
-
-//	Remote Tech configuration.
-//	==================================================
-
-	@PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-	{
-		MODULE
-		{
-			name = ModuleSPU
-		}
-
-		MODULE
-		{
-			IsRTActive	      = false
-			Mode0OmniRange    = 0
-			Mode1OmniRange    = 250000
-			EnergyCost	      = 0.008
-			DeployFxModules   = 0
-			ProgressFxModules = 1
-
-			TRANSMITTER
-			{
-				PacketInterval	   = 0.400
-				PacketSize		   = 0.270
-				PacketResourceCost = 0.025
-			}
-		}
-	}
-
-//	==================================================
-//	MSEV crew cabin.
-
-//	TAC Life Support configuration.
-//	==================================================
-
-	@PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-	{
-		@MODULE[ModuleFuelTanks]
-		{
-			@volume = 700
-
-			TANK
-			{
-				name	  = Food
-				amount	  = 163.78
-				maxAmount = 163.78
-			}
-
-			TANK
-			{
-				name	  = Water
-				amount	  = 108.39
-				maxAmount = 108.39
-			}
-
-			TANK
-			{
-				name	  = Oxygen
-				amount	  = 1776
-				maxAmount = 16571.52
-			}
-
-			TANK
-			{
-				name	  = CarbonDioxide
-				amount	  = 0
-				maxAmount = 512
-			}
-
-			TANK
-			{
-				name	  = Waste
-				amount	  = 0
-				maxAmount = 14.91
-			}
-
-			TANK
-			{
-				name	  = WasteWater
-				amount	  = 0
-				maxAmount = 137.9
-			}
-
-			TANK
-			{
-				name	  = LithiumHydroxide
-				amount	  = 31.5
-				maxAmount = 31.5
-			}
-		}
-
-		MODULE
-		{
-			name			= TacGenericConverter
-			converterName   = CO2 Scrubber
-			conversionRate  = 2.000
-			inputResources  = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-			outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
-		}
-	}
-
-//	==================================================
-//	Altair lunar lander Ascent Module (LDAC - 2 configuration).
-
-//	Realism Overhaul configuration.
-
-//	The engine is NOT a real AJ10-118K but a hypothetical derivative (closer to the Astris) with lower maximum thrust and using MMH instead of Aerozine 50 for fuel.
-
-//	Dimensions: 5.500 x 6.000 m
-//	Gross Mass: 10609.00 Kg
-//	Throttle Range: N/A
-//	Burn Time: 646 s
-//	O/F Ratio: 1.80
-//	==================================================
-
-	@PART[altairPod]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Pod/altairPod/altairPod
-			scale	 = 1.000, 1.000, 1.000
-			position = 0.000, 0.000, 0.000 
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, -3.800, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  2.220, 0.000, 0.000,  1.000, 0.000, 3
-
-		@title		  = Altair Ascent Module
-		@manufacturer = Boeing Co. & NASA
-		@description  = The ascent module for the Altair lunar lander. Can support a 4 crew lunar sortie for up to 7 days of active time.
-
-		@mass			  = 5.100
-		%crashTolerance   = 12
-		%breakingForce    = 250
-		%breakingTorque   = 250
-		@maxTemp		  = 1973.15
-		%fuelCrossFeed	  = true
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = LIQUID_ENGINE
-		%bulkheadProfiles = size2, size3
-		@CrewCapacity	  = 4
-
-		!INTERNAL[ALCOR_Monley_Internals]{}
-
-		@MODULE[ModuleCommand]
-		{
-			@minimumCrew = 0
-
-			RESOURCE
-			{
-				name = ElectricCharge
-				rate = 2.125
-			}
-		}
-
-		@MODULE[ModuleEngines*]
-		{
-			%maxThrust	 	= 24.50
-			%minThrust	 	= 24.50
-			%heatProduction = 100
-			%ullage			= false
-			%pressureFed	= true
-			%ignitions		= -1
-
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = MMH
-				@ratio = 0.4819
-			}
-
-			@PROPELLANT[Oxidizer]
-			{
-				@name  = NTO
-				@ratio = 0.5180
-			}
-
-			// For future reference: add a Helium requirement for tank pressurization.
-
-			//PROPELLANT
-			//{
-			//	name		 = Helium
-			//	ratio		 = 0.7548
-			//	ignoreForIsp = true
-			//}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 321.0
-				@key,1 = 1 212.5
-			}
-		}
-
-		@MODULE[ModuleGimbal]
-		{
-			@gimbalRange		 	= 7.000
-			%useGimbalResponseSpeed = true
-			%gimbalResponseSpeed 	= 16
-		}
-
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			configuration = AJ10-118K-Altair
-			modded		  = false
-
-			CONFIG
-			{
-				name	  = AJ10-118K-Altair
-				maxThrust = 24.50
-				minThrust = 24.50
-
-				PROPELLANT
-				{
-					name	  = MMH
-					ratio	  = 0.4819
-					DrawGauge = true
-				}
-
-				PROPELLANT
-				{
-					name  = NTO
-					ratio = 0.5180
-				}
-
-				atmosphereCurve
-				{
-					key = 0 321.0
-					key = 1 212.5
-				}
-			}
-		}
-
-        @MODULE[ModuleRCS]
+    @MODULE[ModuleCommand]
+    {
+        %RESOURCE
         {
-			@name		   = ModuleRCS
-			@thrusterPower = 0.207
-			!resourceName  = NULL
+            %name = ElectricCharge
+            %rate = 0.5
+        }
+    }
 
-			PROPELLANT
-			{
-				name  = MMH
-				ratio = 0.4819
-			}
+    @MODULE[ModuleSAS]
+    {
+        %SASServiceLevel = 3
+    }
 
-			PROPELLANT
-			{
-				name  = NTO
-				ratio = 0.5180
-			}
+    MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 3.0
+    }
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 319.0
-				@key,1 = 1 112.0
-			}
-		}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!MODULE[RasterPropMonitorComputer]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        basemass = -1
+        volume = 15
 
-		!MODULE[MechJebCore]{}
-	
-        !MODULE[ModuleAlternator]{}
+        //  Batteries 3.6 kWh.
 
-        !MODULE[ModuleReactionWheel]{}
+        TANK
+        {
+            name = ElectricCharge
+            amount = 12960
+            maxAmount = 12960
+        }
+    }
 
-        !MODULE[ModuleGenerator]{}
+    !MODULE[ModuleScienceLab],*{}
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			volume   = 4970
-			basemass = -1
+    !MODULE[ModuleReactionWheel],*{}
 
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
+    !MODULE[ModuleGenerator],*{}
 
-			TANK
-			{
-				name	  = MMH
-				amount	  = 2156
-				maxAmount = 2156
-			}
+    !MODULE[RasterPropMonitorComputer],*{}
 
-			TANK
-			{
-				name	  = NTO
-				amount	  = 2318
-				maxAmount = 2318
-			}
+    !MODULE[KASModuleContainer],*{}
 
-			TANK
-			{
-				name	  = Helium
-				amount	  = 70960
-				maxAmount = 70960
-			}
-		}
+    !MODULE[MechJebCore],*{}
 
-        !RESOURCE[MonoPropellant]{}
-	}
+    !MODULE[ModuleConnectedLivingSpace],*{}
 
-//	==================================================
-//	Altair lunar lander Ascent Module.
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = bottom
+        surfaceAttachmentsPassable = True
+    }
 
-//	Remote Tech configuration.
-//	==================================================
+    !RESOURCE,*{}
+}
 
-	@PART[altairPod]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-	{
-		MODULE
-		{
-			name = ModuleSPU
-		}
+//  ==================================================
+//  MMSEV crew cabin.
 
-		MODULE
-		{
-			name			  = ModuleRTAntenna
-			IsRTActive		  = false
-			Mode0OmniRange	  = 1000000
-			Mode1OmniRange	  = 1000000
-			EnergyCost		  = 0.005
-			DeployFxModules	  = 0
-			ProgressFxModules = 1
+//  Remote Tech compatibility.
+//  ==================================================
 
-			TRANSMITTER
-			{
-				PacketInterval	   = 0.200
-				PacketSize		   = 0.470
-				PacketResourceCost = 0.050
-			}
-		}
-	}
+@PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
 
-//	==================================================
-//	Altair lunar lander Ascent Module.
+    !MODULE[ModuleSPU*],*{}
 
-//	TAC Life Support configuration.
-//	==================================================
+    !MODULE[ModuleRTAntenna*],*{}
 
-	@PART[altairPod]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-	{
-		@MODULE[ModuleFuelTanks]
-		{
-			@volume = 5390
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.008
+        }
+    }
 
-			TANK
-			{
-				name	  = Food
-				amount	  = 163.8
-				maxAmount = 163.8
-			}
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
 
-			TANK
-			{
-				name	  = Water
-				amount	  = 15.5
-				maxAmount = 15.5
-			}
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 250000
+        EnergyCost = 0.008
+        DeployFxModules = 0
+        ProgressFxModules = 1
 
-			TANK
-			{
-				name	  = Oxygen
-				amount	  = 2367.5
-				maxAmount = 2367.5
-			}
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.025
+        }
+    }
+}
 
-			TANK
-			{
-				name	  = CarbonDioxide
-				amount	  = 0
-				maxAmount = 2048
-			}
+//  ==================================================
+//  MMSEV crew cabin.
 
-			TANK
-			{
-				name	  = Waste
-				amount	  = 0
-				maxAmount = 14.91
-			}
+//  TAC Life Support compatibility.
+//  ==================================================
 
-			TANK
-			{
-				name	  = WasteWater
-				amount	  = 0
-				maxAmount = 137.9
-			}
+@PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports 2 crew for 7 days or up to 4 crew for half the time.:
 
-			TANK
-			{
-				name	  = LithiumHydroxide
-				amount	  = 63
-				maxAmount = 63
-			}
-		}
+    @mass -= 0.11
 
-		MODULE
-		{
-			name		    = TacGenericConverter
-			converterName   = CO2 Scrubber
-			conversionRate  = 4.000
-			inputResources  = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-			outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
-		}
-	}
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 350
 
-//	==================================================
-//	Linear RCS thruster (low thrust).
+        TANK
+        {
+            name = Food
+            amount = 81.89
+            maxAmount = 81.89
+        }
 
-//	Dimensions: 0.100 x 0.200 m
-//	Gross Mass: 1.50 Kg
-//	O/F Ratio: N/A
-//	==================================================
+        TANK
+        {
+            name = Water
+            amount = 54.19
+            maxAmount = 54.19
+        }
 
-	@PART[B9_Control_RCS_Port_R1x]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+        TANK
+        {
+            name = Oxygen
+            amount = 8285.76
+            maxAmount = 8285.76
+        }
 
-		@MODEL
-		{
-			%scale    = 1.000, 1.000, 1.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 256
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 7.45
+        }
 
-		@node_attach = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 68.95
+        }
 
-		@title		  = R1 Linear RCS Thruster (69/111N class)
-		@manufacturer = Generic
-		@description  = A generic single RCS thruster for attitude control.
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 15.75
+            maxAmount = 15.75
+        }
+    }
 
-		@mass			  = 0.0015
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = True
-		%bulkheadProfiles = srf
-		%useRcsConfig	  = RCSBlockQuarter
-		%useRcsMass		  = true
-		%useRcsCostMult	  = 0.250
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        conversionRate = 2.0
+        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+    }
+}
 
-		@MODULE[ModuleRCS]
-		{
-			@name			  = ModuleRCS
-			@thrusterPower	  = 0.069
-			!resourceName	  = NULL
-			@resourceFlowMode = STACK_PRIORITY_SEARCH
+//  ==================================================
+//  Altair ascent module (LDAC - 2 configuration).
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 254.00
-				@key,1 = 1 82.08
-			}
-		}
-	}
+//  Dimensions: 5.5 m x 6 m
+//  Gross Mass: 10610 Kg
 
-//	==================================================
-//	Linear RCS thruster (medium thrust).
+//  This part is currently missing from CMES but we
+//  retain it's RO config for a future release.
+//  ==================================================
 
-//	Dimensions: 0.150 x 0.300 m
-//	Gross Mass: 3.00 Kg
-//	O/F Ratio: N/A
-//	==================================================
+@PART[altairPod]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
 
-	@PART[B9_Control_RCS_Port_R1X1x]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    !mesh = NULL
 
-		@MODEL
-		{
-			%scale    = 1.500, 1.500, 1.500
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    MODEL
+    {
+        model = CMES/Pod/altairPod/altairPod
+        scale = 1.0, 1.0, 1.0
+    }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    %scale = 1.0
+    @rescaleFactor = 1.0
 
-		@node_attach = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000
+    @node_stack_top = 0.0, 2.22, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -3.8, 0.0, 0.0, -1.0, 0.0, 3
 
-		@title		  = R1 Linear RCS Thruster (138/233N class)
-		@manufacturer = Generic
-		@description  = A generic single RCS thruster for attitude control.
+    @mass = 5.1
+    %crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = size2, size3
+    @CrewCapacity = 4
 
-		@mass			  = 0.003
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = True
-		%bulkheadProfiles = srf
-		%useRcsConfig	  = RCSBlockQuarter
-		%useRcsMass		  = true
-		%useRcsCostMult	  = 0.250
+    %engineType = AJ10_190
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = True
 
-		@MODULE[ModuleRCS]
-		{
-			@name			  = ModuleRCS
-			@thrusterPower	  = 0.138
-			!resourceName	  = NULL
-			@resourceFlowMode = STACK_PRIORITY_SEARCH
+    !INTERNAL[ALCORMonleyInternals]{}
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 254.00
-				@key,1 = 1 82.08
-			}
-		}
-	}
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
 
-//	==================================================
-//	Pegasus IA low profile ladder.
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.15
+        }
+    }
 
-//	Dimensions: 0.400 x 0.400 m
-//	Gross Mass: 5.00 Kg
-//	==================================================
+    @MODULE[ModuleSAS]
+    {
+        %SASServiceLevel = 3
+    }
 
-	@PART[xladder1x]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 26.7
+        @maxThrust = 26.7
+        @heatProduction = 100
+        %exhaustDamageMultiplier = 0.75
+        %ullage = False
+        %pressureFed = True
+        %ignitions = 500
 
-		MODEL
-		{
-			model	 = CMES/Pod/ladderRadial/model
-			scale	 = 1.333, 1.333, 1.333
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+            @ratio = 0.499
+        }
 
-		!mesh		   = NULL
-		%scale		   = 1.000
-		%rescaleFactor = 1.000
+        @PROPELLANT[Oxidizer]
+        {
+            @name = MON3
+            @ratio = 0.501
+            @DrawGauge = False
+        }
 
-		@node_attach = -0.060, 0.000, 0.000, 1.000, 0.000, 0.000
+        @atmosphereCurve
+        {
+            @key,0 = 0 316
+            @key,1 = 1 100
+        }
+    }
 
-		@title		  = Pegasus IA Mobility Enhancer [Low Profile]
-		@manufacturer = Generic
-		%description  = The Pegasus IA Mobility Enhancer, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
-	
-		@mass 			= 0.005
-		@crashTolerance = 12
-		%breakingForce	= 250
-		%breakingTorque = 250
-		@maxTemp		= 1073.15
-		%fuelCrossFeed  = false
-	}
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.445
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.499
+        }
+
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.501
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 300
+            @key,1 = 1 82
+        }
+    }
+
+    !MODULE[RasterPropMonitorComputer],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleAlternator],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4900
+        basemass = -1
+
+        //  Batteries 3.6 kWh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 12960
+            maxAmount = 12960
+        }
+
+        //  AMAE & ACS fuel 2015 Kg.
+
+        TANK
+        {
+            name = MMH
+            amount = 2290
+            maxAmount = 2290
+        }
+
+        //  AMAE & ACS oxidizer 3273 Kg.
+
+        TANK
+        {
+            name = MON3
+            amount = 2300
+            maxAmount = 2300
+        }
+
+        //  AMAE & ACS Helium 9 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 45900
+            maxAmount = 45900
+        }
+    }
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = bottom
+        surfaceAttachmentsPassable = True
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Altair ascent module (LDAC - 2 configuration).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[altairPod]:AFTER[RealismOverhaulEngines]
+{
+    @title = Altair Ascent Module
+    @manufacturer = Boeing Co. & NASA
+    @description = The ascent module for the Altair lunar lander.
+
+    //  AJ10-190 has 6 degrees of gimbal for pitch and 7 for yaw.
+
+    @MODULE[ModuleGimbal]
+    {
+        !gimbalRange = NULL
+        %gimbalRangeXP = 6
+        %gimbalRangeXN = 6
+        %gimbalRangeYP = 7
+        %gimbalRangeYN = 7
+    }
+}
+
+//  ==================================================
+//  Altair ascent module (LDAC - 2 configuration).
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[altairPod]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.015
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 1000000
+        Mode1OmniRange = 1000000
+        EnergyCost = 0.015
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.05
+        }
+    }
+}
+
+//  ==================================================
+//  Altair ascent module (LDAC - 2 configuration).
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[altairPod]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a 4 crew lunar sortie for up to 7 days.:
+
+    @mass -= 0.16
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 5400
+
+        TANK
+        {
+            name = Food
+            amount = 163.8
+            maxAmount = 163.8
+        }
+
+        TANK
+        {
+            name = Water
+            amount = 15.5
+            maxAmount = 15.5
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 2367.5
+            maxAmount = 2367.5
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 2048
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 14.91
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 137.9
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 63
+            maxAmount = 63
+        }
+    }
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        conversionRate = 4.0
+        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+    }
+}
+
+//  ==================================================
+//  Linear RCS thruster (low thrust).
+
+//  Dimensions: 0.1 m x 0.2 m
+//  Inert Mass: 1.5 Kg
+//  ==================================================
+
+@PART[B9_Control_RCS_Port_R1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = R1 - A Attitude Jet (69/111N class)
+    @manufacturer = Generic
+    @description = A generic, single port, RCS thruster for attitude control.
+
+    @mass = 0.0015
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @fuelCrossFeed = True
+    %bulkheadProfiles = srf
+
+    %useRcsConfig = RCSBlockQuarter
+    %useRcsMass = True
+    %useRcsCostMult = 0.25
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.069
+        !resourceName = NULL
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 254
+            @key,1 = 1 82
+        }
+    }
+}
+
+//  ==================================================
+//  Linear RCS thruster (medium thrust).
+
+//  Dimensions: 0.15 m x 0.3 m
+//  Inert Mass: 3 Kg
+//  ==================================================
+
+@PART[B9_Control_RCS_Port_R1X1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        %scale = 1.5, 1.5, 1.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = R1 - B Attitude Jet (138/233N class)
+    @manufacturer = Generic
+    @description = A generic, single port, RCS thruster for attitude control.
+
+    @mass = 0.003
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @fuelCrossFeed = True
+    %bulkheadProfiles = srf
+
+    %useRcsConfig = RCSBlockHalf
+    %useRcsMass = True
+    %useRcsCostMult = 0.25
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.138
+        !resourceName = NULL
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 254
+            @key,1 = 1 82
+        }
+    }
+}
+
+//  ==================================================
+//  Linear RCS thruster (high thrust).
+
+//  Dimensions: 0.15 m x 0.3 m
+//  Inert Mass: 12 Kg
+//  ==================================================
+
+@PART[B9_Control_RCS_Port_R1Ox]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.5, 2.5, 2.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = R1 - C Attitude Jet (550/890N class)
+    @manufacturer = Generic
+    @description = A generic, single port, RCS thruster for attitude control.
+
+    @mass = 0.012
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @fuelCrossFeed = True
+    %bulkheadProfiles = srf
+
+    %useRcsConfig = RCSBlockDouble
+    %useRcsMass = True
+    %useRcsCostMult = 0.25
+
+    @MODULE[ModuleRCS]
+    {
+        @thrusterPower = 0.55
+        !resourceName = NULL
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 254
+            @key,1 = 1 82
+        }
+    }
+}
 
 //	==================================================
 //	MSEV chassis.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -789,465 +789,471 @@
     }
 }
 
-//	==================================================
-//	MSEV chassis.
-
-//	Dimensions: 2.500 x 5.300 m
-//	Gross Mass: 400.00 Kg
-//	==================================================
-
-	@PART[xLERroverBodyx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Pod/LER_base/model
-			scale	 = 2.125, 2.000, 1.850
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  0.125, 1.170, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, -0.950, 0.000, 0.000, -1.000, 0.000, 2
-		!node_stack_1	   = NULL
-		!node_stack_2	   = NULL
-		!node_stack_3	   = NULL
-		!node_stack_4	   = NULL
-		!node_stack_5	   = NULL
-		!node_stack_6	   = NULL
-
-		@title		  = MSEV Chassis
-		@manufacturer = NASA
-		@description  = A modular structural frame for the MSEV surface exploration rover variant.
-
-		@mass			 	= 0.400
-		@crashTolerance	 	= 12
-		@breakingForce	 	= 250
-		@breakingTorque		= 250
-		@maxTemp		 	= 1073.15
-		!explosionPotential = NULL
-		%bulkheadProfiles   = size2
-		@CoMOffset			= 0.000, 0.000, -2.000
-		!CoLOffset			= NULL
-
-		!MODULE[ModuleCommand]{}
-
-		!MODULE[ModuleSAS]{}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		!MODULE[ModuleGenerator]{}
-
-		!RESOURCE[ElectricCharge]{}
-	
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Surface Docking Mechanism (SDM).
-
-//	Dimensions: 1.200 x 1.700 m
-//	Gross Mass: 350.00 Kg
-//	==================================================
-
-	@PART[xLERDockPortxs]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Pod/LER_dockport/model
-			scale	 = 1.600, 1.600, 1.600
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, -0.200, 0.000, -1.000, 0.000, 0.000, 2
-
-		@title		  = Surface Docking Mechanism (SDM)
-		%manufacturer = Boeing Co. & NASA
-		@description  = The SDM provides a safe passage for crew and cargo between surface - landed modules or exploration rovers.
-
-		@mass			  = 0.350
-		@crashTolerance   = 12
-		@breakingForce	  = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1073.12
-		%bulkheadProfiles = srf
-
-		@MODULE[ModuleDockingNode]
-		{
-			@nodeType			   = NASADockSurf
-			%acquireForce		   = 0.5
-			%acquireMinFwdDot	   = 0.8
-			%acquireminRollDot	   = -3.40282347E+38
-			%acquireRange		   = 0.25
-			%acquireTorque		   = 0.5
-			%captureMaxRvel	 	   = 0.1
-			%captureMinFwdDot 	   = 0.998
-			%captureMinRollDot 	   = -3.40282347E+38
-			%captureRange		   = 0.05
-			%minDistanceToReEngage = 0.25
-			%undockEjectionForce   = 0.1
-		}
-
-		@MODULE[ModuleAnimateGeneric]
-		{
-			@startEventGUIName = Deploy Docking Port
-			@endEventGUIName   = Retract Docking Port
-			%actionGUIName 	   = Toggle Docking Port
-		}
-	}
-
-//	==================================================
-//	Orion EFT Crew Module LES decoupler system.
-
-//	Dimensions: 2.700 x 1.000 m
-//	Gross Mass: 600.000 Kg
-//	==================================================
-
-	@PART[OrionDockingPortXx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.500, 1.350, 1.500
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top    = 0.000,  0.625, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, -0.270, 0.000, 0.000, -1.000, 0.000, 3
-
-		@title		  = Orion EFT LAS decoupler.
-		@manufacturer = Lockheed Martin
-		@description  = The Launch Abort System (LAS) explosive bolt decoupler of the Orion EFT Crew Module.
-
-		@mass			  = 0.600
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1973.15
-		@fuelCrossFeed    = false
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%emissiveConstant = 0.700
-		%bulkheadProfiles = size2, size3
-
-		MODULE
-		{
-			name		    = ModuleDecouple
-			ejectionForce   = 10.000
-			explosiveNodeID = top
-		}
-
-		!MODULE[ModuleDockingNode]{}
-
-		!MODULE[ModuleDockingNodeNamed]{}
-
-		!MODULE[ModuleCommand]{}
-
-		!MODULE[ModuleSAS]{}
-
-		!MODULE[ModuleReactionWheel]{}
-	
-		!MODULE[MechJebCore]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Orion MPCV Crew Module docking system.
-
-//	Dimensions: 2.700 x 1.000 m
-//	Gross Mass: 600.000 Kg
-//	==================================================
-
-	@PART[OrionDockingPortXWSTANDARDDOCKPORT]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.500, 1.350, 1.500
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top    = 0.000,  0.625, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, -0.270, 0.000, 0.000, -1.000, 0.000, 3
-
-		@title		  = Orion MPCV Docking System
-		@manufacturer = Lockheed Martin
-		@description  = The NASA docking system of the Orion MPCV Crew Module.
-
-		@mass			  = 0.600
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1973.15
-		@fuelCrossFeed    = False
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%emissiveConstant = 0.700
-		%bulkheadProfiles = size2, size3
-
-		@MODULE[ModuleDockingNode]
-		{
-			@nodeType			   = NASADock
-			%acquireForce		   = 0.500
-			%acquireMinFwdDot	   = 0.800
-			%acquireminRollDot	   = -3.40282347E+38
-			%acquireRange		   = 0.250
-			%acquireTorque		   = 0.500
-			%captureMaxRvel		   = 0.100
-			%captureMinFwdDot	   = 0.998
-			%captureMinRollDot 	   = -3.40282347E+38
-			%captureRange		   = 0.050
-			%minDistanceToReEngage = 0.250
-			%undockEjectionForce   = 0.100
-		}
-
-		!MODULE[ModuleCommand]{}
-
-		!MODULE[ModuleSAS],*{}
-
-		!MODULE[ModuleReactionWheel]{}
-	
-		!MODULE[MechJebCore]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Orion Crew Module (EFT & MPCV) Launch Abort System (LAS).
-
-//	Dimensions: 4.800 x 13.300 m
-//	Gross Mass: 6176.00 Kg
-//  Throttle Range: N/A
-//	Burn Time: 3 s
-//	O/F Ratio: 2.13
-//	==================================================
-
-	@PART[XOrionLES]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.530, 1.410, 1.530
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   0.000, 8.775, -0.340
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100, 0.100, 0.100
-			position =  0.000, 8.775, 0.340
-			rotation = 90.000, 0.000, 0.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 = 0.100, 0.100,   0.100
-			position = 0.340, 8.775,   0.000
-			rotation = 0.000, 0.000, -90.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100, 0.100,  0.100
-			position = -0.340, 8.775,  0.000
-			rotation =  0.000, 0.000, 90.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100,  0.100,  0.100
-			position = -0.230,  8.775, -0.230
-			rotation = -90.000, 45.000, 0.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100, 0.100,  0.100
-			position =  0.250, 8.775,  0.250
-			rotation = 90.000, 45.000, 0.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100,   0.100, 0.100
-			position = -0.225,   8.775, 0.225
-			rotation = 90.000, -45.000, 0.000
-		}
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100,   0.100,  0.100
-			position =   0.225,   8.775, -0.225
-			rotation = -90.000, -45.000,  0.000
-		}
-
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, -0.680, 0.000, 0.000, -1.000, 0.000, 3
-
-		@category 	  = Engines
-		@title		  = Orion Launch Abort System (LAS)
-		@manufacturer = Orbital ATK
-		@description  = The launch escape tower of the Orion command module. Activates in the case of an emergency and carries the crew of the Orion safely away from the launch vehicle.
-
-		@mass			  = 4.1290
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1973.15
-		%fuelCrossFeed 	  = false
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%emissiveConstant = 0.700
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleEngines]
-		{
-			@minThrust 		= 1760.00
-			@maxThrust	 	= 1760.00
-			@heatProduction = 100
-			!fxOffset 		= NULL
-			%ullage			= false
-			%pressureFed 	= false
-			%ignitions		= 1
-
-			@PROPELLANT[SolidFuel]
-			{
-				@name = HTPB
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 290.00
-				@key,1 = 1 245.00
-			}
-		}
-
-		!MODULE[ModuleDecouple]{}
-
-		MODULE
-		{
-			name				  = ModuleRCS
-			thrusterTransformName = RCSthruster
-			thrusterPower		  = 22.300
-
-			PROPELLANT
-			{
-				name  = Hydrazine
-				ratio = 1.000
-			}
-
-			atmosphereCurve
-			{
-				key = 0 254
-				key = 1 82.08
-			}
-		}
-
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			volume	 = 150
-			type	 = Fuselage
-			basemass = -1
-
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 150
-				maxAmount = 150
-			}
-		}
-
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			volume   = 1071.42
-			type	 = HTPB
-			basemass = -1
-		}
-
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			configuration = Orion-LAS
-			modded		  = false
-
-			CONFIG
-			{
-				name		   = Orion-LAS
-				minThrust 	   = 1760.00
-				maxThrust	   = 1760.00
-				heatProduction = 100
-				%ullage		   = false
-				%pressureFed   = false
-				%ignitions	   = 1
-
-				PROPELLANT
-				{
-					name	  = HTPB
-					ratio	  = 1.000
-					DrawGauge = True
-				}
-
-				atmosphereCurve
-				{
-					key = 0 290.00
-					key = 1 245.00
-				}
-			}
-		}
-
-		!RESOURCE[SolidFuel]{}
-	}
+//  ==================================================
+//  Mobile base chassis.
+
+//  Dimensions: 2.5 m x 5.3 m
+//  Inert Mass: 400 Kg
+//  ==================================================
+
+@PART[xLERroverBodyx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/LER_base/model
+        scale = 2.125, 2.125, 1.85
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_1 = NULL
+    !node_stack_2 = NULL
+    !node_stack_3 = NULL
+    !node_stack_4 = NULL
+    !node_stack_5 = NULL
+    !node_stack_6 = NULL
+
+    @title = Mobile Base Chassis
+    @manufacturer = NASA
+    @description = A modular structural frame. Can be used as a chassis for the MMSEV rover or for mobile surface habitats.
+
+    @mass = 0.4
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    !explosionPotential = NULL
+    %bulkheadProfiles = size2, size3
+    !CoMOffset = NULL
+    !CoLOffset = NULL
+
+    !MODULE,*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Surface Docking Mechanism (SDM).
+
+//  Dimensions: 1.2 m x 1.7 m
+//  Inert Mass: 350 Kg
+//  ==================================================
+
+@PART[xLERDockPortxs]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/LER_dockport/model
+        scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, -0.2, 0.0, -1.0, 0.0, 0.0
+
+    @title = Surface Docking Mechanism (SDM)
+    %manufacturer = Boeing Co.
+    @description = The SDM provides a safe pressurized passage for crew and cargo between surface - landed modules or exploration rovers.
+
+    @mass = 0.35
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    !stagingIcon = NULL
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NASADockSurf
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+    }
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = Deploy Docking Port
+        @endEventGUIName = Retract Docking Port
+        %actionGUIName = Toggle Docking Port
+        %allowAnimationWhileShielded = False
+    }
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        passableWhenSurfaceAttached = True
+    }
+}
+
+//  ==================================================
+//  Orion EFT Crew Module LES decoupling system.
+
+//  Dimensions: 2.7 m x 1 m
+//  Gross Mass: 600 Kg
+//  ==================================================
+
+@PART[OrionDockingPortXx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.575, 1.35, 1.575
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.625, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.185, 0.0, 0.0, -1.0, 0.0, 2
+
+    %fx_gasBurst_white = 0.0, 0.625, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_decoupler_fire = decouple
+
+    @title = Orion EFT LAS Decoupler
+    %manufacturer = Lockheed Martin
+    @description = The Launch Abort System (LAS) explosive bolt decoupler of the Orion EFT Crew Module.
+
+    @mass = 0.6
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @fuelCrossFeed = False
+    %stageOffset = 1
+    %childStageOffset = 1
+    %emissiveConstant = 0.7
+    @bulkheadProfiles = size2
+
+    !MODULE,*{}
+
+    MODULE
+    {
+        name = ModuleDecouple
+        ejectionForce = 0
+        explosiveNodeID = top
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Orion MPCV crew module docking system.
+
+//  Dimensions: 2.7 m x 1 m
+//  Inert Mass: 600 Kg
+//  ==================================================
+
+@PART[OrionDockingPortXWSTANDARDDOCKPORT]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.575, 1.35, 1.575
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.625, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.185, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Orion MPCV Docking System
+    %manufacturer = Lockheed Martin
+    @description = The NASA docking system for the Orion MPCV Crew Module.
+
+    @mass = 0.6
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @fuelCrossFeed = False
+    %stageOffset = 1
+    %childStageOffset = 1
+    %emissiveConstant = 0.7
+    %bulkheadProfiles = size2
+
+    !MODULE[ModuleDockingNode],*{}
+
+    MODULE
+    {
+        name = ModuleDockingNode
+        nodeType = NASADock
+        referenceAttachNode = top
+        acquireForce = 0.5
+        acquireMinFwdDot = 0.8
+        acquireminRollDot = -3.40282347E+38
+        acquireRange = 0.25
+        acquireTorque = 0.5
+        captureMaxRvel = 0.1
+        captureMinFwdDot = 0.998
+        captureMinRollDot = -3.40282347E+38
+        captureRange = 0.05
+        minDistanceToReEngage = 0.25
+        undockEjectionForce = 0.1
+        stagingEnabled = False
+    }
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+    }
+}
+
+//  ==================================================
+//  Orion Crew Module (EFT & MPCV) Launch Abort System (LAS).
+
+//  Dimensions: 4.8 m x 13.3 m
+//  Gross Mass: 6180 Kg
+//  ==================================================
+
+@PART[XOrionLES]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.58, 1.4125, 1.58
+    }
+
+    //  ACM thrusters.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.0, 8.775, -0.34
+        rotation = -90.0, 0.0,  0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.0, 8.775, 0.34
+        rotation = 90.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.34, 8.775, 0.0
+        rotation = 0.0, 0.0, -90.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -0.34, 8.775, 0.0
+        rotation = 0.0, 0.0, 90.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -0.23, 8.775, -0.23
+        rotation = -90.0, 45.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.25, 8.775, 0.25
+        rotation = 90.0, 45.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -0.225, 8.775, 0.225
+        rotation = 90.0, -45.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.225, 8.775, -0.225
+        rotation = -90.0, -45.0,  0.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Orion Launch Abort System (LAS)
+    @manufacturer = Orbital ATK
+    @description = The launch escape tower of the Orion command module. Activates in the case of an emergency and carries the crew of the Orion safely away from the launch vehicle.
+
+    @mass = 4.13
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.5
+    %fuelCrossFeed = False
+    %stageOffset = 1
+    %childStageOffset = 1
+    %emissiveConstantant = 0.7
+    %bulkheadProfiles = size2
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1760
+        @maxThrust = 1760
+        @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 290
+            @key,1 = 1 245
+        }
+    }
+
+    !MODULE[ModuleDecouple],*{}
+
+    MODULE
+    {
+        name = ModuleRCS
+        thrusterTransformName = RCSthruster
+        thrusterPower = 22.3
+
+        PROPELLANT
+        {
+            name  = Hydrazine
+            ratio = 1.0
+        }
+
+        atmosphereCurve
+        {
+            key = 0 254
+            key = 1 82
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 1071.42
+        type = HTPB
+        basemass = -1
+
+        //  HTPB/AP propellant mixture ~1900 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 1071.42
+            maxAmount = 1071.42
+        }
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = Orion-LAS
+        modded = False
+
+        CONFIG
+        {
+            name = Orion-LAS
+            minThrust = 1760
+            maxThrust = 1760
+            heatProduction = 100
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 290
+                key = 1 245
+            }
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  ACM propellant 150 Kg.
+
+    RESOURCE
+    {
+        name = Hydrazine
+        amount = 150
+        maxAmount = 150
+    }
+}
 
 //	==================================================
 //	Orion EFT Crew Module.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -790,6 +790,43 @@
 }
 
 //  ==================================================
+//  Pegasus IA low profile ladder.
+
+//  Dimensions: 0.4 m x 0.4 m
+//  Inert Mass: 5 Kg
+//  ==================================================
+
+@PART[xladder1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/ladderRadial/model
+        scale = 1.333, 1.333, 1.333
+    }
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_attach = -0.06, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @title = Pegasus IA Mobility Enhancer (Low Profile)
+    @manufacturer = Generic
+    %description = The Pegasus IA Mobility Enhancer, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
+
+    @mass = 0.005
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+}
+
+//  ==================================================
 //  Mobile base chassis.
 
 //  Dimensions: 2.5 m x 5.3 m


### PR DESCRIPTION
Updates and fixes for the CMES "Pod" parts (first pass).

Changelog:
- Decrease the standby power consumption of the MMSEV crew cabin and the Altair Ascent module.
- Improve the RT compatibility patches.
- Add compatibility for the global engine config system.
- Fix the RCS config for the R1 RCS thruster series.
- Make the Surface Docking Mechanism (SDM) non - extendable if inside a fairing.
- Orion LAS: separate the HTPB from the Hydrazine resource due to an issue with multiple ModuleFuelTanks{} definitions.
- Remove patches of non existent/moved parts (note 1).
- Add Connected Living Space support for all parts that should have it.
- Adjust some insane max temperature values.
- Adjust the maximum battery capacity carried by the crewed pods.
- Update the part titles and the descriptions.
- Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1380/files?w=1)

NOTE 1: the Altair Ascent Module has been removed from the latest CMES release due to an issue with the crew hatch. It will probably be included again in the future so it's RO config has been correctly updated.
