### PR TITLE
CMES Pod updates/fixes (part II)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -1136,608 +1136,683 @@
 		!RESOURCE[SolidFuel]{}
 	}
 
-//	==================================================
-//	Orion EFT Crew Module.
-
-//	Realism Overhaul configuration.
-
-//	Dimensions: 3.300 x 5.030 m
-//	Gross Mass: 8900.000 Kg
-//	==================================================
-
-	@PART[XOrionPodXbb31]:FOR[RealismOverhaul]
-	{
-		@module		 = Part
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.500, 1.200, 1.500
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		//	Linear negative pitch thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   0.000, 0.880, -1.390
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		//	Linear positive pitch thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   0.000, 0.070, -1.950
-			rotation = -55.000, 0.000,  0.000
-		}
-
-		//	Linear negative yaw thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 = 0.100, 0.100,   0.100
-			position = 1.900, 0.040,   0.000
-			rotation = 0.000, 0.000, -55.000
-		}
-
-		//	Linear positive yaw thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100, 0.100,  0.100
-			position = -1.900, 0.040,  0.000
-			rotation =  0.000, 0.000, 55.000
-		}
-
-		//	Linear negative roll thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =  -1.450, 0.030, -1.320
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		//	Linear positive roll thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   1.450, 0.030, -1.320
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, -1.045, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  0.960, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_1	   = 0.000,  1.250, 0.000, 0.000,  1.000, 0.000, 2
-
-		@title		  = Orion EFT Crew Module
-		@manufacturer = Lockheed Martin
-		@description  = The Exploration Flight Test (EFT) article for the Orion MPCV.
-
-		@mass		      = 6.6250
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp	      = 800
-		%emissiveConstant	  = 0.850
-		@CrewCapacity     = 0
-		@vesselType		  = Probe
-		%fuelCrossFeed    = true
-		@CoMOffset 		  = 0.000, -0.670, 0.000
-		!CoLOffset 		  = NULL
-		!CoDOffset 		  = NULL
-		%bulkheadProfiles = size2, size3
-
-		!INTERNAL[ALCOR_Monley_Internals]{}
-
-		@MODULE[ModuleCommand]
-		{
-			RESOURCE
-			{
-				name = ElectricCharge
-				rate = 1.350
-			}
-		}
-
-		@MODULE[ModuleSAS]
-		{
-			%SASServiceLevel = 3
-		}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		!MODULE[ModuleScienceContainer]{}
-
-		!MODULE[ModuleScienceLab]{}
-
-		!MODULE[ModuleDataTransmitter]{}
-
-		!MODULE[MechJebCore]{}
-
-		!MODULE[ModuleGenerator]{}
-
-		!MODULE[RasterPropMonitorComputer]{}
-
-		!MODULE[ModuleAblator]{}
-
-		!MODULE[ModuleHeatShield]{}
-
-		!MODULE[ModuleAeroReentry]{}
-
-		MODULE
-		{
-			name				  = ModuleRCS
-			thrusterTransformName = RCSthruster
-			thrusterPower		  = 0.237
-
-			PROPELLANT
-			{
-				name  = Hydrazine
-				ratio = 1.000
-			}
-
-			atmosphereCurve
-			{
-				key = 0 254.00
-				key = 1 82.08
-			}
-		}
-
-		MODULE
-		{
-			name		   = CoMShifter
-			DescentModeCoM = 0.000, 0.000, -0.300
-		}
-
-		%skinMaxTemp = 3600
-		%skinMassPerArea = 4
-		MODULE
-		{
-			name = ModuleAblator
-			ablativeResource = Ablator
-			lossExp = -8000
-			lossConst = 0.06
-			pyrolysisLossFactor = 26000
-			ablationTempThresh = 500
-			reentryConductivity = 0.01
-			charMax = 1
-			charMin = 1
-		}
-
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			basemass = -1
-			type	 = ServiceModule
-			volume	 = 150
-
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
-
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 85
-				maxAmount = 85
-			}
-		}
-
-		RESOURCE
-		{
-			name	  = Ablator
-			amount	  = 1500
-			maxAmount = 1500
-		}
-
-		!RESOURCE[AblativeShielding]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Orion MPCV Crew Module.
-
-//	Realism Overhaul configuration.
-
-//	Dimensions: 3.300 x 5.030 m
-//	Gross Mass: 8900.000 Kg
-//	==================================================
-
-	@PART[XOrionPodX]:FOR[RealismOverhaul]
-	{
-		@module		 = Part
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.500, 1.200, 1.500
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		//	Linear negative pitch thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   0.000, 0.880, -1.390
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		//	Linear positive pitch thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   0.000, 0.070, -1.950
-			rotation = -55.000, 0.000,  0.000
-		}
-
-		//	Linear negative yaw thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 = 0.100, 0.100,   0.100
-			position = 1.900, 0.040,   0.000
-			rotation = 0.000, 0.000, -55.000
-		}
-
-		//	Linear positive yaw thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =  0.100, 0.100,  0.100
-			position = -1.900, 0.040,  0.000
-			rotation =  0.000, 0.000, 55.000
-		}
-
-		//	Linear negative roll thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =  -1.450, 0.030, -1.320
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		//	Linear positive roll thruster.
-
-		MODEL
-		{
-			model	 = RealismOverhaul/Models/LinearRCS
-			scale	 =   0.100, 0.100,  0.100
-			position =   1.450, 0.030, -1.320
-			rotation = -90.000, 0.000,  0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, -1.045, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  0.960, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_1	   = 0.000,  1.250, 0.000, 0.000,  1.000, 0.000, 2
-
-		@title		  = Orion MPCV Crew Module (CM)
-		@manufacturer = Lockheed Martin
-		@description  = The next - generation NASA spacecraft for beyond LEO exploration. Can support 6 crew for up to 21 days of active time.
-
-		@mass		      = 6.8310
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp	      = 800
-		%skinMaxTemp	  = 2300
-		%emissiveConstant	  = 0.850
-		@CrewCapacity     = 6
-		%fuelCrossFeed    = true
-		@CoMOffset 		  = 0.000, -0.670, 0.000
-		!CoLOffset 		  = NULL
-		!CoDOffset 		  = NULL
-		%bulkheadProfiles = size2, size3
-
-		!INTERNAL[ALCOR_Monley_Internals]{}
-
-		@MODULE[ModuleCommand]
-		{
-			RESOURCE
-			{
-				name = ElectricCharge
-				rate = 1.350
-			}
-		}
-
-		@MODULE[ModuleSAS]
-		{
-			%SASServiceLevel = 3
-		}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		@MODULE[ModuleScienceContainer]
-		{
-			@storageRange = 2.600
-		}
-
-		!MODULE[ModuleScienceLab]{}
-
-		!MODULE[ModuleDataTransmitter]{}
-
-		!MODULE[MechJebCore]{}
-
-		!MODULE[ModuleGenerator]{}
-
-		!MODULE[RasterPropMonitorComputer]{}
-
-		!MODULE[ModuleAblator]{}
-
-		!MODULE[ModuleHeatShield]{}
-
-		!MODULE[ModuleAeroReentry]{}
-
-		MODULE
-		{
-			name				  = ModuleRCS
-			thrusterTransformName = RCSthruster
-			thrusterPower		  = 0.237
-
-			PROPELLANT
-			{
-				name  = Hydrazine
-				ratio = 1.000
-			}
-
-			atmosphereCurve
-			{
-				key = 0 254.00
-				key = 1 82.08
-			}
-		}
-
-		MODULE
-		{
-			name		   = CoMShifter
-			DescentModeCoM = 0.000, 0.000, -0.300
-		}
-
-		%skinMaxTemp = 3600
-		%skinMassPerArea = 4
-		MODULE
-		{
-			name = ModuleAblator
-			ablativeResource = Ablator
-			lossExp = -8000
-			lossConst = 0.06
-			pyrolysisLossFactor = 26000
-			ablationTempThresh = 500
-			reentryConductivity = 0.01
-			charMax = 1
-			charMin = 1
-		}
-
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			basemass = -1
-			type	 = ServiceModule
-			volume	 = 130
-
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
-
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 85
-				maxAmount = 85
-			}
-		}
-
-		RESOURCE
-		{
-			name	  = Ablator
-			amount	  = 1500
-			maxAmount = 1500
-		}
-
-		!RESOURCE[AblativeShielding]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	Orion Crew Module (EFT & MPCV).
-
-//	Deadly Reentry configuration.
-//	==================================================
-
-	@PART[XOrionPodXbb31|XOrionPodX]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
-	{
-		@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
-		{
-			@name			= ModuleHeatShield
-			depletedMaxTemp = 1200
-		}
-
-		MODULE
-		{
-			name 				 = ModuleAeroReentry
-			%skinMaxTemp 		 = 2500
-			%skinThicknessFactor = 0.050
-		}
-	}
-
-//	==================================================
-//	Orion Crew Module (EFT & MPCV).
-
-//	Remote Tech configuration.
-//	==================================================
-
-	@PART[XOrionPodXbb31|XOrionPodX]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-	{
-		MODULE
-		{
-			name = ModuleSPU
-		}
-
-		MODULE
-		{
-			name			  = ModuleRTAntenna
-			IsRTActive		  = false
-			Mode0OmniRange	  = 0
-			Mode1OmniRange	  = 1000000
-			EnergyCost		  = 0.005
-			DeployFxModules	  = 0
-			ProgressFxModules = 1
-
-			TRANSMITTER
-			{
-				PacketInterval	   = 0.200
-				PacketSize		   = 0.470
-				PacketResourceCost = 0.050
-			}
-		}
-	}
-
-//	==================================================
-/	Orion Crew Module (MPCV).
-
-//	TAC Life Support configuration.
-//	==================================================
-
-	@PART[XOrionPodX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-	{
-		@MODULE[ModuleFuelTanks]
-		{
-			@volume = 1700
-
-			TANK
-			{
-				name	  = Food
-				amount	  = 737
-				maxAmount = 737
-			}
-
-			TANK
-			{
-				name	  = Water
-				amount	  = 23.22
-				maxAmount = 23.22
-			}
-
-			TANK
-			{
-				name	  = Oxygen
-				amount	  = 3550
-				maxAmount = 3550
-			}
-
-			TANK
-			{
-				name	  = CarbonDioxide
-				amount	  = 0
-				maxAmount = 1530
-			}
-
-			TANK
-			{
-				name	  = Waste
-				amount	  = 0
-				maxAmount = 67.06
-			}
-
-			TANK
-			{
-				name	  = WasteWater
-				amount	  = 0
-				maxAmount = 620.53
-			}
-
-			TANK
-			{
-				name	  = LithiumHydroxide
-				amount	  = 63
-				maxAmount = 63
-			}
-		}
-
-		MODULE
-		{
-			name		    = TacGenericConverter
-			converterName   = CO2 Scrubber
-			conversionRate  = 6.000
-			inputResources  = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-			outputResources = Water, 0.0032924498, true, Waste, 0.0000257297, false
-		}
-	}
-
-//	==================================================
-//	SpaceX Dragon V2 Crew Module ladder.
-
-//	Dimensions: 0.200 x 1.000 m
-//	Gross Mass: 12.00 Kg
-//	==================================================
-
-	@PART[xDragonLadderx]:FOR[RealismOverhaul]
-	{
-		@module		 = Part
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Pod/Parts/LazTekDragonV2Ladder/model
-			scale	 = 1.125, 1.125, 1.125
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 0.000, 0.000, -1.000
-
-		@title		  = Dragon V2 Mobility Enhancer
-		@manufacturer = SpaceX
-		%description  = A mobility enhancement system.
-
-		@mass			  = 0.0120
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%bulkheadProfiles = srf
-	}
+//  ==================================================
+//  Orion Crew Module (EFT & MPCV) Launch Abort System (LAS).
+
+//  Part configuration.
+//  ==================================================
+
+@PART[XOrionLES]:AFTER[zzzRealismOverhaul]
+{
+    @category = Utility
+}
+
+//  ==================================================
+//  Orion EFT Crew Module.
+
+//  Dimensions: 3.3 m x 5.3 m
+//  Gross Mass: 6100 Kg
+
+//  Diameter includes the CM/SM umbilical fairing.
+//  ==================================================
+
+@PART[XOrionPodXbb31]:FOR[RealismOverhaul]
+{
+    @module = Part
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.575, 1.2, 1.575
+    }
+
+    //  Linear negative pitch thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.0, 0.9, -1.475
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    //  Linear positive pitch thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.0, 0.1, -2.0
+        rotation = -90.0, 0.0, 0.0
+    }
+
+    //  Linear negative yaw thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 2.0, 0.1, 0.0
+        rotation = 0.0, 0.0, -90.0
+    }
+
+    //  Linear positive yaw thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -2.0, 0.1, 0.0
+        rotation = 0.0, 0.0, 90.0
+    }
+
+    //  Linear negative roll thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -1.55, 0.05, -1.411
+        rotation = -90.0, 0.0, 0.0
+    }
+
+    //  Linear positive roll thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 1.55, 0.05, -1.411
+        rotation = -90.0, 0.0, 0.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.96, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.045, 0.0, 0.0, -1.0, 0.0, 3
+    %node_stack_1 = 0.0, 1.045, 0.0, 0.0, 1.0, 0.0, 2
+    !node_stack_2 = NULL
+
+    @title = Orion EFT Crew Module
+    @manufacturer = Lockheed Martin
+    @description = The Exploration Flight Test (EFT) article for the Orion MPCV.
+
+    @mass = 6.1
+    !dragModelType,* = NULL
+    %dragModelType = default
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 3773.15
+    %skinMassPerArea = 4
+    %emissiveConstant = 0.85
+    @CrewCapacity = 0
+    @vesselType = Probe
+    %fuelCrossFeed = True
+    @CoMOffset = 0.0, -0.67, 0.0
+    !CoLOffset = NULL
+    !CoDOffset = NULL
+    %bulkheadProfiles = size2, size3
+
+    !INTERNAL[MK1-2_ASETInternals]{}
+
+    @MODULE[ModuleCommand]
+    {
+        %RESOURCE
+        {
+            %name = ElectricCharge
+            %rate = 0.85
+        }
+    }
+
+    @MODULE[ModuleSAS]
+    {
+        %SASServiceLevel = 3
+    }
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleScienceContainer],*{}
+
+    !MODULE[ModuleScienceLab],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[RasterPropMonitorComputer],*{}
+
+    !MODULE[ModuleHeatShield],*{}
+
+    !MODULE[ModuleAeroReentry],*{}
+
+    //  Two MR - 104G thrusters for each control axis (one main and one for backup).
+
+    MODULE
+    {
+        name = ModuleRCS
+        thrusterTransformName = RCSthruster
+        thrusterPower = 0.712
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        atmosphereCurve
+        {
+            key = 0 239
+            key = 1 228
+        }
+    }
+
+    !MODULE[CoMShifter],*{}
+
+    MODULE
+    {
+        name = CoMShifter
+        DescentModeCoM = 0.0, 0.0, -0.3
+    }
+
+    !MODULE[ModuleAblator],*{}
+
+    MODULE
+    {
+        name = ModuleAblator
+        ablativeResource = Ablator
+        lossExp = -8000
+        lossConst = 0.06
+        pyrolysisLossFactor = 26000
+        ablationTempThresh = 500
+        reentryConductivity = 0.01
+        charMin = 0
+        charMax = 1
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        basemass = -1
+        type = ServiceModule
+        volume = 230
+
+        //  Batteries 3.6 kWh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 12960
+            maxAmount = 12960
+        }
+
+        //  ACS fuel 170 Kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 170
+            maxAmount = 170
+        }
+
+        // ACS Helium 0.3 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 1700
+            maxAmount = 1700
+        }
+    }
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = Ablator
+        amount = 1500
+        maxAmount = 1500
+    }
+}
+
+//  ==================================================
+//  Orion MPCV Crew Module.
+
+//  Dimensions: 3.3 m x 5.3 m
+//  Gross Mass: 6100 Kg
+
+//  Diameter includes the CM/SM umbilical fairing.
+//  ==================================================
+
+@PART[XOrionPodX]:FOR[RealismOverhaul]
+{
+    @module = Part
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.575, 1.2, 1.575
+    }
+
+    //  Linear negative pitch thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.0, 0.9, -1.475
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    //  Linear positive pitch thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 0.0, 0.1, -2.0
+        rotation = -90.0, 0.0, 0.0
+    }
+
+    //  Linear negative yaw thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 2.0, 0.1, 0.0
+        rotation = 0.0, 0.0, -90.0
+    }
+
+    //  Linear positive yaw thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -2.0, 0.1, 0.0
+        rotation = 0.0, 0.0, 90.0
+    }
+
+    //  Linear negative roll thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = -1.55, 0.05, -1.411
+        rotation = -90.0, 0.0, 0.0
+    }
+
+    //  Linear positive roll thruster.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/LinearRCS
+        scale = 0.1, 0.1, 0.1
+        position = 1.55, 0.05, -1.411
+        rotation = -90.0, 0.0, 0.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.96, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.045, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_1 = 0.0, 1.045, 0.0, 0.0, 1.0, 0.0, 2
+    !node_stack_2 = NULL
+
+    @title = Orion MPCV Crew Module
+    @manufacturer = Lockheed Martin
+    @description = The next generation NASA spacecraft for beyond LEO (BEO) exploration.
+
+    @mass = 6.1
+    !dragModelType,* = NULL
+    %dragModelType = default
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 3773.15
+    %skinMassPerArea = 4
+    %emissiveConstant = 0.85
+    @CrewCapacity = 6
+    %fuelCrossFeed = True
+    @CoMOffset = 0.0, -0.67, 0.0
+    !CoLOffset = NULL
+    !CoDOffset = NULL
+    %bulkheadProfiles = size2, size3
+
+    @MODULE[ModuleCommand]
+    {
+        %RESOURCE
+        {
+            %name = ElectricCharge
+            %rate = 1.35
+        }
+    }
+
+    @MODULE[ModuleSAS]
+    {
+        %SASServiceLevel = 3
+    }
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    @MODULE[ModuleScienceContainer]
+    {
+        @storageRange = 2.6
+    }
+
+    !MODULE[ModuleScienceLab],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[RasterPropMonitorComputer],*{}
+
+    !MODULE[ModuleHeatShield],*{}
+
+    !MODULE[ModuleAeroReentry],*{}
+
+    //  Two MR - 104G thrusters for each control axis (one main and one for backup).
+
+    MODULE
+    {
+        name = ModuleRCS
+        thrusterTransformName = RCSthruster
+        thrusterPower = 0.712
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        atmosphereCurve
+        {
+            key = 0 239
+            key = 1 228
+        }
+    }
+
+    !MODULE[CoMShifter],*{}
+
+    MODULE
+    {
+        name = CoMShifter
+        DescentModeCoM = 0.0, 0.0, -0.3
+    }
+
+    !MODULE[ModuleAblator],*{}
+
+    MODULE
+    {
+        name = ModuleAblator
+        ablativeResource = Ablator
+        lossExp = -8000
+        lossConst = 0.06
+        pyrolysisLossFactor = 26000
+        ablationTempThresh = 500
+        reentryConductivity = 0.01
+        charMin = 0
+        charMax = 1
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        basemass = -1
+        type = ServiceModule
+        volume = 230
+
+        //  Batteries 3.6 kWh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 12960
+            maxAmount = 12960
+        }
+
+        //  ACS fuel 170 kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 170
+            maxAmount = 170
+        }
+
+        //  ACS Helium 0.3 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 1700
+            maxAmount = 1700
+        }
+    }
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = bottom
+    }
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = Ablator
+        amount = 1500
+        maxAmount = 1500
+    }
+}
+
+//  ==================================================
+//  Orion Crew Module (EFT & MPCV).
+
+//  Deadly Reentry compatibility.
+//  ==================================================
+
+@PART[XOrionPodXbb31|XOrionPodX]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
+{
+    %MODULE
+    {
+        %name = ModuleAeroReentry
+        %skinMaxTemp = 3773.15
+        %skinThicknessFactor = 0.05
+    }
+}
+
+//  ==================================================
+//  Orion Crew Module (EFT & MPCV).
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[XOrionPodXbb31|XOrionPodX]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.015
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1000000
+        EnergyCost = 0.015
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.05
+        }
+    }
+}
+
+//  ==================================================
+//  Orion Crew Module (MPCV).
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[XOrionPodX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a crew of 6 for 14 days or a crew of 4 for up to 21 days of active operations.:
+
+    @mass -= 0.26
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 1000
+
+        TANK
+        {
+            name = Food
+            amount = 491.34
+            maxAmount = 491.34
+        }
+
+        TANK
+        {
+            name = Water
+            amount = 23.2
+            maxAmount = 23.2
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 3551
+            maxAmount = 3551
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 3069
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 44.7
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 29.55
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 63.0
+            maxAmount = 63.0
+        }
+    }
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        conversionRate = 6.0
+        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+    }
+}
+
+//  ==================================================
+//  SpaceX Dragon V2 Crew Module ladder.
+
+//  Dimensions: 0.2 m x 1 m
+//  Inert Mass: 12 Kg
+//  ==================================================
+
+@PART[xDragonLadderx]:FOR[RealismOverhaul]
+{
+    @module = Part
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/Parts/LazTekDragonV2Ladder/model
+        scale = 1.125, 1.125, 1.125
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+
+    @title = Dragon Mobility Enhancer
+    @manufacturer = SpaceX
+    %description = A low profile mobility enhancement system.
+
+    @mass = 0.012
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = srf
+}


### PR DESCRIPTION
Updates and fixes for the CMES "Pod" parts (second pass).

Changelog:
- Place the Orion LAS at the correct "Utility" category.
- Fix the scale of the Orion EFT and MPCV command modules.
- Fix the thrust, Isp, position and orientation of the Orion EFT and MPCV command modules RCS thrusters (they now operate correctly).
- Decrease the electric charge requirements of the Orion EFT command module.
- Increase the amount of Hydrazine carried by the Orion EFT and MPCV command modules for reently control.
- Remove some unneeded Deadly Reentry patches (taken care by the RO global config).
- Improve the RT compatibilty patches.
- Add Connected Living Space support for all parts that should have it.
- Adjust some insane max temperature values.
- Update the part titles and the descriptions.
- Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1381/files?w=1)
