### PR TITLE
Gimbals for Puff & Aerospike (Shuttle OMS and J-2T).

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -30,9 +30,9 @@
 
     @MODULE[ModuleGimbal],*
     {
-        @gimbalRange = 6.0
-        %useGimbalResponseSpeed = True
-        %gimbalResponseSpeed = 16
+        gimbalRange = 6.0
+        useGimbalResponseSpeed = True
+        gimbalResponseSpeed = 16
     }
 
     MODULE

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -1,10 +1,20 @@
 // J-2T Aerospike engine
 // Squad, RLA
+// http://www.alternatewars.com/BBOW/Space_Engines/ADP_Vol_I_JAN-1968.pdf
+// p. 40: Gimbal +-7deg; Rate 30deg/sec; Accel 30rad/sec^2
+// 20% min throttle; "Excursions from extreme to extreme in thrust or mixture ratio within 5 seconds."
+
 @PART[*]:HAS[#engineType[J2T]]:FOR[RealismOverhaulEngines]
 {
 	@title = J-2T-200/250K
 	@manufacturer = Rocketdyne
 	@description = Aerospike. Using proven technology from the J-2 and introducing an aerospike nozzle to the developing J-2S machinery. Diameter: [2.5 m].
+	@MODULE[ModuleGimbal],*
+	{
+		gimbalRange = 7.0
+		useGimbalResponseSpeed = True
+		gimbalResponseSpeed = 16
+	}
 	
 	MODULE
 	{
@@ -17,7 +27,7 @@
 		{
 			name = J-2T-200K
 			maxThrust = 889.3
-			minThrust = 889.3
+			minThrust = 177.8
 			PROPELLANT
 			{
 				name = LqdHydrogen

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1365,19 +1365,23 @@
 		%position = 0.0, 0.0, 0.0
 		%rotation = 380., 0.0, 0.0
 	}
-
+	MODULE  //new, has been stripped at creation (below)
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+	}
 	@scale = 1.0
 	%rescaleFactor = 1.0
 	
 	@mass = 0.118
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = AJ10_190
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = AJ10_190
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
@@ -1940,14 +1944,20 @@
 	@node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 2
 
 	@mass = 1.4
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	%engineType = J2T
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
+
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+	}
 
 	@MODULE[ModuleEngines*]
 	{


### PR DESCRIPTION
Both have no gimbals in stock, needed a MODULE stanza.
Gimbal range added for J-2T (+source);
OMS already had a range it set, but it went unused until now.

New attempt at https://github.com/KSP-RO/RealismOverhaul/pull/1367

source for J2:  http://www.alternatewars.com/BBOW/Space_Engines/ADP_Vol_I_JAN-1968.pdf, p. 40 (PDF pagination)
The document doesn't call it J2T, but by all appearances that's the engine it's about.
