### PR TITLE
MMH+MON3 for RCS

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -161,6 +161,26 @@
 		}
 		CONFIG
 		{
+			name = MMH+MON3
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.499
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.501
+			}
+			IspSL = 0.362
+			IspV = 0.952
+			cost = 30
+			techRequired = flightControl
+			entryCost = 30000
+		}
+		CONFIG
+		{
 			name = UDMH+NTO
 			PROPELLANT
 			{
@@ -255,6 +275,10 @@
 			%thrusterPower = 0.114
 		}
 		@CONFIG[MMH+NTO]
+		{
+			%thrusterPower = 0.445
+		}
+		@CONFIG[MMH+MON3]
 		{
 			%thrusterPower = 0.445
 		}
@@ -420,6 +444,11 @@
 			%thrusterPower = 0.0445
 			@cost *= 0.1
 		}
+		@CONFIG[MMH+MON3]
+		{
+			%thrusterPower = 0.0445
+			@cost *= 0.1
+		}
 		@CONFIG[UDMH+NTO]
 		{
 			%thrusterPower = 0.0442
@@ -472,6 +501,11 @@
 			@cost *= 1.5
 		}
 		@CONFIG[MMH+NTO]
+		{
+			%thrusterPower = 0.6675
+			@cost *= 1.5
+		}
+		@CONFIG[MMH+MON3]
 		{
 			%thrusterPower = 0.6675
 			@cost *= 1.5
@@ -530,6 +564,11 @@
 			%thrusterPower = 1.335
 			@cost *= 3
 		}
+		@CONFIG[MMH+MON3]
+		{
+			%thrusterPower = 1.335
+			@cost *= 3
+		}
 		@CONFIG[UDMH+NTO]
 		{
 			%thrusterPower = 1.326
@@ -580,6 +619,11 @@
 			@cost *= 2
 		}
 		@CONFIG[MMH+NTO]
+		{
+			%thrusterPower = 0.89
+			@cost *= 2
+		}
+		@CONFIG[MMH+MON3]
 		{
 			%thrusterPower = 0.89
 			@cost *= 2
@@ -638,6 +682,11 @@
 			%thrusterPower = 1.78
 			@cost *= 4
 		}
+		@CONFIG[MMH+MON3]
+		{
+			%thrusterPower = 1.78
+			@cost *= 4
+		}
 		@CONFIG[UDMH+NTO]
 		{
 			%thrusterPower = 1.768
@@ -688,6 +737,11 @@
 			@cost *= 8
 		}
 		@CONFIG[MMH+NTO]
+		{
+			%thrusterPower = 3.56
+			@cost *= 8
+		}
+		@CONFIG[MMH+MON3]
 		{
 			%thrusterPower = 3.56
 			@cost *= 8


### PR DESCRIPTION
https://github.com/KSP-RO/RealismOverhaul/issues/1369

All data (ISP, thrust, cost) has been cloned from MMH+NTO under the assumption that it would be virtually identical. If anything, it should perhaps be slightly cheaper because MON3 is easier to keep.

Mixture ratio adjusted by 0.1% to match that of all currently existing main engines which happen to use MMH+MON3.