### PR TITLE
RN rcs fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_R-7_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_R-7_Engines.cfg
@@ -2316,23 +2316,6 @@ MODULE
 !MODULE[ModuleRCS]
 { }
 
-MODULE
-{
-	name = ModuleRCS
-	thrusterTransformName = RCSthruster
-	thrusterPower = 0.05
-	resourceFlowMode = STACK_PRIORITY_SEARCH
-	PROPELLANT
-	{
-	name = Nitrogen
-	ratio = 1
-	}
-	atmosphereCurve
-	{
-		key = 0 60
-		key = 1 10
-	}
-}
 
 @MODULE[ModuleEngines*]
 {
@@ -2488,24 +2471,6 @@ MODULE
 
 !MODULE[ModuleRCS]
 { }
-
-MODULE
-{
-	name = ModuleRCS
-	thrusterTransformName = RCSthruster
-	thrusterPower = 0.05
-	resourceFlowMode = STACK_PRIORITY_SEARCH
-	PROPELLANT
-	{
-	name = Nitrogen
-	ratio = 1
-	}
-	atmosphereCurve
-	{
-		key = 0 60
-		key = 1 10
-	}
-}
 
 @MODULE[ModuleEngines*]
 {
@@ -2682,24 +2647,6 @@ MODULE
 
 !MODULE[ModuleRCS]
 { }
-
-MODULE
-{
-	name = ModuleRCS
-	thrusterTransformName = RCSthruster
-	thrusterPower = 0.05
-	resourceFlowMode = STACK_PRIORITY_SEARCH
-	PROPELLANT
-	{
-	name = Nitrogen
-	ratio = 1
-	}
-	atmosphereCurve
-	{
-		key = 0 60
-		key = 1 10
-	}
-}
 
 @MODULE[ModuleEngines*]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_RCS_Tweaks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_RCS_Tweaks.cfg
@@ -1,4 +1,4 @@
-@PART[KK_ATK_Castor30A|ius_top|rn_blockl_ullage|rn_proton_blockd|rn_proton_blockd_2|rn_proton_blockd_3|rn_proton_blockd_4|rn_proton_blockd_5|rn_proton_blockd_6|rn_proton_blockd_7|ok_sa|rn_zond_sa|rn_scout_stg2|rn_scout_stg3x1_4|rn_scout_stg3x3|rn_scout_stg3|rn_junoii_ss|rn_thor_ss|rn_thor_sse|rn_thor_ss_as|rn_thor_ss_de|rn_astp_bo|rn_lok_bo|rn_lok_sa|rn_lok_tdu|ok_bo_fem|ok_bo_male|ok_pao|ok_sa|t_af_bo|t_bo|tg_bo|rn_tks|rn_tks_rcs_block|rn_tks_va_rcs|t_pao|t_pao2|rn_va_capsule|rn_zond_sa|rn_surveyor3]:HAS[@MODULE[ModuleRCS],~rcsNoStage[]]:AFTER[zzzRealismOverhaul]
+@PART[KK_ATK_Castor30A|ius_top|rn_blockl_ullage|rn_proton_blockd|rn_proton_blockd_2|rn_proton_blockd_3|rn_proton_blockd_4|rn_proton_blockd_5|rn_proton_blockd_6|rn_proton_blockd_7|ok_sa|rn_zond_sa|rn_scout_stg2|rn_scout_stg3x1_4|rn_scout_stg3x3|rn_scout_stg3|rn_junoii_ss|rn_thor_ss|rn_thor_sse|rn_thor_ss_as|rn_thor_ss_de|galileo_mb|rn_astp_bo|rn_lok_bo|rn_lok_sa|rn_lok_tdu|ok_bo_fem|ok_bo_male|ok_pao|ok_sa|t_af_bo|t_bo|tg_bo|rn_tks|rn_tks_rcs_block|rn_tks_va_rcs|t_pao|t_pao2|rn_va_capsule|rn_zond_sa|rn_surveyor3]:HAS[@MODULE[ModuleRCS],~rcsNoStage[]]:AFTER[zzzRealismOverhaul]
 {
 	@MODULE[ModuleRCS]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_RCS_Tweaks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_RCS_Tweaks.cfg
@@ -1,0 +1,9 @@
+@PART[KK_ATK_Castor30A|ius_top|rn_blockl_ullage|rn_proton_blockd|rn_proton_blockd_2|rn_proton_blockd_3|rn_proton_blockd_4|rn_proton_blockd_5|rn_proton_blockd_6|rn_proton_blockd_7|ok_sa|rn_zond_sa|rn_scout_stg2|rn_scout_stg3x1_4|rn_scout_stg3x3|rn_scout_stg3|rn_junoii_ss|rn_thor_ss|rn_thor_sse|rn_thor_ss_as|rn_thor_ss_de|rn_astp_bo|rn_lok_bo|rn_lok_sa|rn_lok_tdu|ok_bo_fem|ok_bo_male|ok_pao|ok_sa|t_af_bo|t_bo|tg_bo|rn_tks|rn_tks_rcs_block|rn_tks_va_rcs|t_pao|t_pao2|rn_va_capsule|rn_zond_sa|rn_surveyor3]:HAS[@MODULE[ModuleRCS],~rcsNoStage[]]:AFTER[zzzRealismOverhaul]
+{
+	@MODULE[ModuleRCS]
+	{
+		%stagingEnabled = False
+		%stagingToggleEnabledEditor = True
+		%rcsEnabled = True
+	}
+}


### PR DESCRIPTION
@Nathankell these are the fixes I have come up with for a few parts.

All of these parts needs RCS enabled by default because they fit a
certain criteria:
1) They have a combined solid stage/decoupler and rcs module
2) They are the first(or only) part on the rocket stack that needs rcs enabled,
so enabling it by default makes sense
3) They need RCS for ullage of a liquid stage and the rcs and liquid
engine are combined on one part

every one of these parts fits the 2nd criteria so having rcs enabled by
default should be perfectly acceptable, but that alone was not enough to accept it as part of the compromise.

I omitted a bunch of parts as I decided they need to fit at least 2 of
those options to be modified to be on by default.