### PR TITLE
RN fix gimbals/plumes and transforms

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Dnepr.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Dnepr.cfg
@@ -159,6 +159,12 @@
 			}
 		}
 	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
+	}
 	!MODULE[ModuleAlternator]
 	{
 	}
@@ -274,6 +280,12 @@
 				key = 1 293
 			}
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
 	}
 	!MODULE[ModuleAlternator]
 	{
@@ -452,6 +464,12 @@
 				key = 1 294
 			}
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 	!MODULE[ModuleAlternator]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Proton_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Proton_Engines.cfg
@@ -113,6 +113,12 @@
 			}
 		}
 	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+	}
 	!MODULE[ModuleAlternator]
 	{
 	}
@@ -211,6 +217,12 @@
 				key = 1 225
 			}
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
 	}
 }
 
@@ -403,6 +415,12 @@
 			}
 		}
 	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
+	}
 }
 
 @PART[rn_proton_blockd_v]:FOR[RealismOverhaul]
@@ -488,6 +506,12 @@
 				key = 1 215
 			}
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_R-7_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_R-7_Engines.cfg
@@ -1000,7 +1000,12 @@
 			}
 		}
 	}
-	
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
+	}
 	!MODULE[ModuleAlternator]
 	{
 	}
@@ -2221,7 +2226,12 @@
 			}
 		}
 	}
-	
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
+	}
 	!MODULE[ModuleAlternator]
 	{
 	}
@@ -3060,11 +3070,11 @@ RESOURCE
 !MODULE[KM_Gimbal_3]
 	{ }
 
-MODULE
+@MODULE[ModuleGimbal]
 	{
- 		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 1.0
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
 	}
 
 }
@@ -3202,11 +3212,11 @@ RESOURCE
 !MODULE[KM_Gimbal_3]
 	{ }
 
-MODULE
+@MODULE[ModuleGimbal]
 	{
- 		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 1.0
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
 	}
 
 }
@@ -3344,11 +3354,11 @@ RESOURCE
 !MODULE[KM_Gimbal_3]
 	{ }
 
-MODULE
+	@MODULE[ModuleGimbal]
 	{
- 		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 1.0
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
 	}
 
 }
@@ -3447,7 +3457,12 @@ MODULE
 			}
 		}
 	}
-	
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
+	}
 	!MODULE[ModuleAlternator]
 	{
 	}
@@ -3612,7 +3627,12 @@ MODULE
 		}
 	}
 }
-
+@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+	}
 }
 
 +PART[rn_fregat1]:BEFORE[RealismOverhaul]
@@ -3771,7 +3791,12 @@ MODULE
 		}
 	}
 }
-
+@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+	}
 }
 
 +PART[rn_fregat1]:BEFORE[RealismOverhaul]
@@ -3930,7 +3955,12 @@ MODULE
 		}
 	}
 }
-
+@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+	}
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S1.5400|S1.5400A|S1.5400_Verniers|S5.92_l.n.]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
@@ -2378,6 +2378,12 @@
 			}
 		}
 	}
+	@MODULE[ModuleGimbal],*
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+	}
 }
 
 @PART[rn_x405_vernier]:FOR[RealismOverhaul]
@@ -2455,6 +2461,12 @@
 				key = 1 30.5324
 			}
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 }
 
@@ -2662,6 +2674,12 @@
 	}
 	!RESOURCE[ElectricCharge]
 	{
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 }
 
@@ -3886,6 +3904,12 @@
 			cost = -10
 			techRequired = heavyRocketry
 		}
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 }
 
@@ -6355,6 +6379,12 @@
 	}
 	!RESOURCE[ElectricCharge]
 	{
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Zenit_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Zenit_Engines.cfg
@@ -84,6 +84,12 @@
 	!RESOURCE[ElectricCharge]
 	{
 	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+	}
 }
 
 @PART[rn_zenit_rd120]:FOR[RealismOverhaul]
@@ -259,5 +265,11 @@
 	}
 	!RESOURCE[ElectricCharge]
 	{
+	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
@@ -152,6 +152,12 @@
 			///900W at launch
 		}
 	}
+	@MODULE[ModuleGimbal]
+	{
+		!responseSpeed = DELETE
+		%gimbalResponseSpeed = 25
+		%useGimbalResponseSpeed = true
+	}
 }
 
 @PART[rn_cassini]:NEEDS[RemoteTech]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/Proton/rn_proton_blockd_v.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/Proton/rn_proton_blockd_v.cfg
@@ -6,7 +6,7 @@
         transformName = thrustTransform //which transform to attach the plume
         localRotation = 0,0,0           //Any rotation needed
         localPosition = 0,0,0.22           //Any offset needed
-        fixedScale = 0.5                  //Size adjustment to resize to engine
+        fixedScale = 0.15                  //Size adjustment to resize to engine
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.

--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/R7/fregat1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/R7/fregat1.cfg
@@ -4,9 +4,10 @@
     {
         name = Hypergolic-OMS-White            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
-        localRotation = 0,0,0           //Any rotation needed
-        localPosition = 0,0,-0.9           //Any offset needed
-        fixedScale = 1.6                  //Size adjustment to resize to engine
+        flarePosition = 0,0,0.5
+        flareScale = 1.2
+        plumePosition = 0,0,0.5
+        plumeScale = 1.2
         energy = 1                      //Adjust length of plume
         speed = 1.5                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.

--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_salyut_soyuz.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_salyut_soyuz.cfg
@@ -1,11 +1,38 @@
-@PART[almaz3-5,salyut1-4,salyut6,salyut7]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[almaz3-5]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-OMS-Red            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
         localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0,0.7           //Any offset needed
+        localPosition = 0,0,0.3           //Any offset needed
+        fixedScale = 1.2                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+@PART[salyut6,salyut7]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-Red            //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0.45           //Any offset needed
         fixedScale = 1                  //Size adjustment to resize to engine
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed to fit resize, 
@@ -21,6 +48,33 @@
         @CONFIG,*   //Add the effect to every engine config
         {
             %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+@PART[salyut1-4]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-White            //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-OMS-White
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_soviet_probes.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_soviet_probes.cfg
@@ -4,9 +4,10 @@
     {
         name = Hypergolic-OMS-White            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
-        localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0,-0.7           //Any offset needed
-        fixedScale = 1                  //Size adjustment to resize to engine
+        flarePosition = 0,0,-0.2
+        flareScale = 0.65
+        plumePosition = 0,0,0
+        plumeScale = 0.65
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.
@@ -31,9 +32,10 @@
     {
         name = Hypergolic-OMS-White            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
-        localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0,-0.6           //Any offset needed
-        fixedScale = 0.2                  //Size adjustment to resize to engine
+        flarePosition = 0,0,-0.6
+        flareScale = 0.2
+        plumePosition = 0,0,0
+        plumeScale = 0.2
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.
@@ -58,9 +60,10 @@
     {
         name = Hypergolic-OMS-White            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
-        localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0,0.6           //Any offset needed
-        fixedScale = 1                  //Size adjustment to resize to engine
+        flarePosition = 0,0,0.2
+        flareScale = 1
+        plumePosition = 0,0,0.8
+        plumeScale = 1
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.


### PR DESCRIPTION
-Fix a problem with the gimbals. I had made a large number of spelling
errors in my original cfg files for the gimbals preventing them from
working correctly. This will fix the problem with older and current
version of my mods.

Future versions of my mods will include the fixes directly in the main
cfg files. But having these changes here is still a good idea.