### PR TITLE
Reduce the minimum diameter of the proceduralCrewTube part

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -171,7 +171,7 @@
 	%RSSROConfig = True
 	%title = Tank - Ore [Procedural]
 }
-// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internalls traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivelent and more expensive to reflect the aditional shielding etc in the part. They also have a minimum diameter of 2m. CLS support is removed form the regular stuctural parts.
+// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internalls traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivelent and more expensive to reflect the aditional shielding etc in the part. They also have a minimum diameter of 800mm. CLS support is removed form the regular stuctural parts.
 +PART[proceduralStructural]:NEEDS[ProceduralParts]:BEFORE[RealismOverhaul] // could maybe be FIRST but we want to catch any prior changes.
 {
 	@name = proceduralCrewTube
@@ -217,7 +217,7 @@
 			lengthMax = Infinity
 			volumeMax = Infinity
 		}
-		%diameterMin = 2
+		%diameterMin = 0.8
 		%lengthMin = 0.5
 	}
 	@MODULE[TankContentSwitcher]


### PR DESCRIPTION
The procedural crew tube part is very useful for creating adapters between docking ports and stations. Unfortunately most docking ports are much smaller than 2m. Reduce the minimum diameter to 800mm.

[Pressurized Mating Adapters (PMAs) specifications](https://www.nasa.gov/externalflash/ISSRG/pdfs/pma.pdf)
[APAS Development](https://en.wikipedia.org/wiki/Androgynous_Peripheral_Attach_System#Development)
[Soyuz docking probe specifications](http://www.russianspaceweb.com/docking.html)