### PR TITLE
RO avionics parts updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/Parts/Avionics/Able.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Able.cfg
@@ -11,18 +11,18 @@
 	}
 	@MODEL:NEEDS[VenStockRevamp]
 	{
-		%scale = 0.331704, 1.02, 0.331704
+		%scale = 0.3265, 1.05, 0.3265
 	}
 	%rescaleFactor = 1.0
 	@node_stack_top = 0, 0.25, 0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0, -0.25, 0, 0.0, -1.0, 0.0, 1
 	@mass = 0.140 // 140kg is a fair guess: with default utilization tanks, it leads to correct
 	// Able mass with a Fuselage-type tank
-	%maxTemp = 500
-	%skinMaxTemp = 800
+	%maxTemp = 573.15
+	%skinMaxTemp = 773.15
 	@crashTolerance = 7 // same as propulsion standard.
 	@title = Able Avionics Package [0.813m]
-	@manufacturer = Honeywell // FIXME, Honeywell made the main guidance for Vanguard, but did it also do the Able guidance?
+	@manufacturer = Honeywell Aerospace // FIXME, Honeywell made the main guidance for Vanguard, but did it also do the Able guidance?
 	@description = An early avionics module capable of maintaining a pitch and roll program, used by small upper stages. Control lasts approximately a half hour. Allows full control over the vessel, up to the tonnage limit (cumulative).
 	
 	%CrewCapacity = 0

--- a/GameData/RealismOverhaul/Parts/Avionics/Agena.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Agena.cfg
@@ -14,16 +14,17 @@
 	}
 	%rescaleFactor = 1.0
 	%scale = 1.0
-	@node_stack_bottom = 0.0, -0.43733232, 0.0, 0.0, -1.0, 0.0, 1
-	@node_stack_top = 0.0, 0.43733232, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.47, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.47, 0.0, 0.0, 1.0, 0.0, 1
 	@mass = 0.228
-	%maxTemp = 500
-	%skinMaxTemp = 900
+	%maxTemp = 573.15
+	%skinMaxTemp = 773.15
 	@crashTolerance = 7 // same as propulsion standard.
 	@title = Agena Avionics Package
 	%manufacturer = Lockheed
 	@description = An early but advanced avionics module for upper stages. Carries an 11.8 kWh battery, providing control for just over 47 hr, and an omnidirectional antenna with an effective range of 1,500 km to ground stations. Capable of maintaining a pitch and roll program. Allows full control over the vessel, up to the tonnage limit (cumulative).
-	
+
+	@bulkheadProfiles = size1
 	%CrewCapacity = 0
 	%vesselType = Probe
 	

--- a/GameData/RealismOverhaul/Parts/Avionics/Centaur.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Centaur.cfg
@@ -1,0 +1,137 @@
+//  ==================================================
+//  Centaur avionics unit.
+
+//  Dimensions: 3.05 m x 0.5 m
+//  Inert Mass: 200 Kg
+//  ==================================================
+
++PART[asasmodule1-2]:FIRST:NEEDS[RealismOverhaul]
+{
+    @name = RP0probeAvionics3-05m
+
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = Squad/Parts/Command/advancedSasModuleLarge/model
+        scale = 1.22, 1.0, 1.22
+    }
+
+    @MODEL:NEEDS[VenStockRevamp]
+    {
+        %scale = 1.225, 1.05, 1.225
+    }
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_stack_top = 0, 0.25, 0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0, -0.25, 0, 0.0, -1.0, 0.0, 3
+
+    @category = Pods
+    @title = Centaur Avionics Package [3.05m]
+    @manufacturer = Honeywell Aerospace
+    @description = An avionics module for large upper stages. Rated control lasts approximately two hours.
+
+    @mass = 0.2
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 773.15
+    %rescaleCube = 1
+    %CrewCapacity = 0
+    %vesselType = Probe
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleCommand],*{}
+
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.25
+        }
+    }
+
+    !MODULE[ModuleSAS],*{}
+
+    MODULE
+    {
+        name = ModuleSAS
+        SASServiceLevel = 3
+        standalone = True
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 500 Wh.
+    //  Supports the avionics package for the rated control period (approximately 2 hours).
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 1800
+        maxAmount = 1800
+    }
+
+    @DRAG_CUBE
+    {
+        %rescaleX = 1.22
+        %rescaleY = 1.0
+        %rescaleZ = 1.22
+    }
+}
+
+//  ==================================================
+//  Centaur avionics unit.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[RP0probeAvionics3-05m]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[Module*DataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.025
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.0075
+        }
+    }
+}

--- a/GameData/RealismOverhaul/Parts/Avionics/Delta.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Delta.cfg
@@ -18,7 +18,7 @@
 	@node_stack_bottom = 0, -0.25, 0, 0.0, -1.0, 0.0, 1
 	@mass = 0.16 // slightly more than Able, more than half Agena but way cheaper.
 	@maxTemp = 573.15
-    %skinMaxTemp = 773.15
+	%skinMaxTemp = 773.15
 	@crashTolerance = 7 // same as propulsion standard.
 	@title = Delta Avionics Package [1.45m]
 	@manufacturer = Honeywell Aerospace

--- a/GameData/RealismOverhaul/Parts/Avionics/Delta.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Delta.cfg
@@ -11,18 +11,20 @@
 	}
 	@MODEL:NEEDS[VenStockRevamp]
 	{
-		%scale = 0.5916, 1.02, 0.5916
+		%scale = 0.5825, 1.05, 0.5825
 	}
 	%rescaleFactor = 1.0
 	@node_stack_top = 0, 0.25, 0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0, -0.25, 0, 0.0, -1.0, 0.0, 1
 	@mass = 0.16 // slightly more than Able, more than half Agena but way cheaper.
-	@maxTemp = 1273.15
+	@maxTemp = 573.15
+    %skinMaxTemp = 773.15
 	@crashTolerance = 7 // same as propulsion standard.
 	@title = Delta Avionics Package [1.45m]
-	@manufacturer = Honeywell // FIXME, Honeywell made the main guidance for Vanguard, but did it also do the Able guidance?
+	@manufacturer = Honeywell Aerospace
 	@description = A mid-period avionics module capable of maintaining a pitch and roll program, used by small upper stages. Control lasts approximately a half hour. Allows full control over the vessel, up to the tonnage limit (cumulative).
-	
+
+	@bulkheadProfiles = size1
 	%CrewCapacity = 0
 	%vesselType = Probe
 	
@@ -37,7 +39,7 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
-	// Battery capacity and kW rate are total wild guesses, balance so it only lasts 15 minutes.
+
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/GameData/RealismOverhaul/Parts/Avionics/GuidanceRings.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/GuidanceRings.cfg
@@ -31,12 +31,12 @@
 	%MODULE[ModuleSPU]
 	{
 	}
-	
+
 	%MODULE[ModuleRTAntennaPassive]
 	{
 		%TechRequired = start
 		%OmniRange = 50000
-		
+
 		%TRANSMITTER {
 			%PacketInterval = 0.3
 			%PacketSize = 2
@@ -76,12 +76,12 @@
 	%MODULE[ModuleSPU]
 	{
 	}
-	
+
 	%MODULE[ModuleRTAntennaPassive]
 	{
 		%TechRequired = start
 		%OmniRange = 40000
-		
+
 		%TRANSMITTER {
 			%PacketInterval = 0.3
 			%PacketSize = 2
@@ -125,12 +125,12 @@
 	%MODULE[ModuleSPU]
 	{
 	}
-	
+
 	%MODULE[ModuleRTAntennaPassive]
 	{
 		%TechRequired = start
 		%OmniRange = 20000
-		
+
 		%TRANSMITTER {
 			%PacketInterval = 0.3
 			%PacketSize = 2
@@ -178,12 +178,12 @@
 	%MODULE[ModuleSPU]
 	{
 	}
-	
+
 	%MODULE[ModuleRTAntennaPassive]
 	{
 		%TechRequired = start
 		%OmniRange = 40000
-		
+
 		%TRANSMITTER {
 			%PacketInterval = 0.3
 			%PacketSize = 2
@@ -231,12 +231,12 @@
 	%MODULE[ModuleSPU]
 	{
 	}
-	
+
 	%MODULE[ModuleRTAntennaPassive]
 	{
 		%TechRequired = start
 		%OmniRange = 80000
-		
+
 		%TRANSMITTER {
 			%PacketInterval = 0.3
 			%PacketSize = 2

--- a/GameData/RealismOverhaul/Parts/Avionics/SaturnIU.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/SaturnIU.cfg
@@ -2,30 +2,47 @@
 {
 	%RSSROConfig = true
 	@name = RP0probeAvionics66m
-	@category = Pods
-	%rescaleFactor = 2.6416
-	@node_stack_top = 0, 0.25, 0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0, -0.25, 0, 0.0, -1.0, 0.0, 3
-	
+
+	!mesh = NULL
+
+	MODEL
+	{
+		model = Squad/Parts/Command/advancedSasModuleLarge/model
+		scale = 2.64, 2.64, 2.64
+	}
+
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+        %scale = 2.6595, 2.6595, 2.6595
+	}
+
+	%scale = 1.0
+	%rescaleFactor = 1.0
+
+	@node_stack_top = 0, 0.66, 0, 0.0, 1.0, 0.0, 6
+	@node_stack_bottom = 0, -0.66, 0, 0.0, -1.0, 0.0, 6
+
 	rescaleCube = 1
 	@DRAG_CUBE
 	{
-		rescaleX = 2.6416
-		rescaleY = 2.6416
-		rescaleZ = 2.6416
+		rescaleX = 2.64
+		rescaleY = 2.64
+		rescaleZ = 2.64
 	}
-	
-	@mass = 1.996
-	%maxTemp = 500
-	%skinMaxTemp = 900
+
+	@category = Pods
+	@mass = 2.0
+	%maxTemp = 573.15
+	%skinMaxTemp = 773.15
 	@crashTolerance = 7 // same as propulsion standard.
-	@title = Saturn Instrument Unit
+	@title = Saturn IB/V Instrument Unit
 	@manufacturer = IBM
-	@description = This avionics unit was designed by IBM for the Saturn V launch vehicle. Allows full control over the vessel, up to the tonnage limit (cumulative).
-	
+	@description = This avionics unit was designed by IBM for the Saturn IB and V launch vehicles. Allows full control over the vessel, up to the tonnage limit (cumulative).
+
+	@bulkheadProfiles = size6
 	%CrewCapacity = 0
 	%vesselType = Probe
-	
+
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -40,7 +57,7 @@
 	{
 		name = ModuleCommand
 		minimumCrew = 0
-		
+
 		RESOURCE
 		{
 			name = ElectricCharge

--- a/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
@@ -2,8 +2,23 @@
 {
 	%RSSROConfig = true
 	@name = RP0probeSounding0-3m
-	@category = Pods
-	%rescaleFactor = 0.12
+
+	!mesh = NULL
+
+	MODEL
+	{
+		model = Squad/Parts/Command/advancedSasModuleLarge/model
+		scale = 0.12, 0.12, 0.12
+	}
+
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+		%scale = 0.1205, 0.1205, 0.1205
+	}
+
+	%scale = 1.0
+	%rescaleFactor = 1.0
+
 	rescaleCube = 1
 	@DRAG_CUBE
 	{
@@ -11,20 +26,24 @@
 		rescaleY = 0.12
 		rescaleZ = 0.12
 	}
-	@node_stack_top = 0, 0.25, 0, 0.0, 1.0, 0.0, 0
-	@node_stack_bottom = 0, -0.25, 0, 0.0, -1.0, 0.0, 0
+
+	@node_stack_top = 0, 0.03, 0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0, -0.03, 0, 0.0, -1.0, 0.0, 0
+
+	@category = Pods
 	@mass = 0.06
-	%maxTemp = 500
-	%skinMaxTemp = 900
+	%maxTemp = 573.15
+	%skinMaxTemp = 773.15
 	@crashTolerance = 7 // same as propulsion standard.
 	@TechRequired = start
 	@title = Sounding Rocket Telemetry Unit
 	@manufacturer = Generic
 	@description = A simple RF receiver and time-delay circuit for sounding rockets. Allows staging and for information to be reported, but no yaw/pitch/roll control.
-	
+
+	@bulkheadProfiles = size0
 	%CrewCapacity = 0
 	%vesselType = Probe
-	
+
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -38,7 +57,7 @@
 	{
 		name = ModuleCommand
 		minimumCrew = 0
-		
+
 		RESOURCE
 		{
 			name = ElectricCharge


### PR DESCRIPTION
- Add a new Centaur - class avionics ring.
- Trim the size of the Able, Agena and Delta rings so that attached
  parts will not clip them.
- Add alternate VSR models to the Saturn V IU and the Sounding Rocket
  unit.
- Adjust the size of the attachment nodes.
- Add bulkhead profiles.
- Normalize the temperatures across the parts (still too high).
- Fix the Saturn IU title & description to include the Saturn IB
  vehicle.
- Trim some leftover trailing spaces.

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1411/files?w=1)
