### PR TITLE
Procedural Parts fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -86,8 +86,8 @@
 	%skinMaxTemp = 2500
 	@MODULE[ModuleFuelTanks]
 	{
+		@type = Structural
 		!typeAvailable,* = DEL
-		typeAvailable = Fuselage
 		typeAvailable = Structural
 	}
 }
@@ -171,7 +171,7 @@
 	%RSSROConfig = True
 	%title = Tank - Ore [Procedural]
 }
-// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internalls traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivelent and more expensive to reflect the aditional shielding etc in the part. They also have a minimum diameter of 800mm. CLS support is removed form the regular stuctural parts.
+// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internals traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivalent and more expensive to reflect the additional shielding etc in the part. They also have a minimum diameter of 2m. CLS support is removed form the regular structural parts.
 +PART[proceduralStructural]:NEEDS[ProceduralParts]:BEFORE[RealismOverhaul] // could maybe be FIRST but we want to catch any prior changes.
 {
 	@name = proceduralCrewTube
@@ -179,7 +179,7 @@
 @PART[proceduralCrewTube]:FOR[RealismOverhaul] // do our patching here.
 {
 	@title = Crew Tube [Procedural]
-	%description = Air tight pressure hull protected by a thick layer of kevlar and carbon nano fibre blankets to provide protection against micro-metorites as well as thermal insulation and limited raditation shielding. These parts provide safe and structurally intact internal spaces to allow crew to move between crewed parts. 
+	%description = Air tight pressure hull protected by a thick layer of Kevlar and carbon nanofiber blankets to provide protection against micro-meteorites as well as thermal insulation and limited radiation shielding. These parts provide safe and structurally intact internal spaces to allow crew to move between crewed parts. 
 	@cost *= 5
 	@entryCost *= 3.5
 	%TechRequired = spaceExploration

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -171,7 +171,7 @@
 	%RSSROConfig = True
 	%title = Tank - Ore [Procedural]
 }
-// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internals traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivalent and more expensive to reflect the additional shielding etc in the part. They also have a minimum diameter of 2m. CLS support is removed form the regular structural parts.
+// Extend procedural structural parts to create Procedural Crew Tubes - Parts that can be internals traversed as understood by ConnectedLivingSpace. The parts are more massive than the structural equivalent and more expensive to reflect the additional shielding etc in the part. They also have a minimum diameter of 0.8m. CLS support is removed form the regular structural parts.
 +PART[proceduralStructural]:NEEDS[ProceduralParts]:BEFORE[RealismOverhaul] // could maybe be FIRST but we want to catch any prior changes.
 {
 	@name = proceduralCrewTube


### PR DESCRIPTION
* Fix the wrong startup tank type of the shielded procedural tank.
* Remove a double tank definition from the shielded procedural tank.
* Various typo fixes.