### PR TITLE
RO Coatl Aerospace ProbesPlus 0.14.2

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -235,7 +235,7 @@
 }
 
 //  ==================================================
-//  Folding parabolic antenna.
+//  Medium folding parabolic antenna.
 
 //  Dimensions: 1.1 m x 0.15 m (retracted)
 //  Inert Mass: 22 Kg
@@ -264,17 +264,10 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     @tags ^= :$: communications parabolic
-
-    @MODULE[ModuleAnimateGeneric]
-    {
-        @startEventGUIName = Extend Antenna
-        @endEventGUIName = Retract Antenna
-        @actionGUIName = Toggle Antenna
-    }
 }
 
 //  ==================================================
-//  Folding parabolic antenna.
+//  Medium folding parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
@@ -282,6 +275,8 @@
 @PART[dish_deploy_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
     @description ^= :$: Effective range 1.75 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
+
+    !MODULE[ModuleDeployableAntenna],*{}
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -311,6 +306,87 @@
             PacketInterval = 1.0
             PacketSize = 2.56
             PacketResourceCost = 0.75
+        }
+    }
+}
+
+//  ==================================================
+//  Small folding parabolic antenna.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 37 Kg
+//  ==================================================
+
+@PART[dish_deploy_S2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    //@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+    //@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = CA-AD1-R Folding Dish Antenna
+    @manufacturer = Generic
+    @description = A medium gain directional antenna for short range, high bandwidth communications.
+
+    @mass = 0.037
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    !impactTolerance = NULL
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @bulkheadProfiles = size0, srf
+    @tags ^= :$: communications parabolic
+}
+
+//  ==================================================
+//  Small folding parabolic antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[dish_deploy_S2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Effective range X Mm, power consumption 18 Watts, maximum data rate 4.8 Mbit/sec, gain W dBi.
+
+    !MODULE[ModuleDeployableAntenna],*{}
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0DishRange = 0
+        Mode1DishRange = 100000
+        EnergyCost = 0.018
+        DishAngle = 25.0
+        MaxQ = 6000
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 4.80
+            PacketResourceCost = 0.005
         }
     }
 }
@@ -430,10 +506,11 @@
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic pioneer
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.0044
         !resourceName = NULL
+        !fxOffset = NULL
 
         PROPELLANT
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -238,7 +238,7 @@
 //  Medium folding parabolic antenna.
 
 //  Dimensions: 1.1 m x 0.15 m (retracted)
-//  Inert Mass: 22 Kg
+//  Inert Mass: 20 Kg
 //  ==================================================
 
 @PART[dish_deploy_S]:FOR[RealismOverhaul]
@@ -256,7 +256,7 @@
     @title = CA-A10 Folding Dish Antenna
     @manufacturer = Generic
 
-    @mass = 0.022
+    @mass = 0.02
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
@@ -314,7 +314,7 @@
 //  Small folding parabolic antenna.
 
 //  Dimensions: - m x - m
-//  Inert Mass: 37 Kg
+//  Inert Mass: 35 Kg
 //  ==================================================
 
 @PART[dish_deploy_S2]:FOR[RealismOverhaul]
@@ -329,14 +329,11 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    //@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
-    //@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
-
     @title = CA-AD1-R Folding Dish Antenna
     @manufacturer = Generic
     @description = A medium gain directional antenna for short range, high bandwidth communications.
 
-    @mass = 0.037
+    @mass = 0.035
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
@@ -355,7 +352,7 @@
 
 @PART[dish_deploy_S2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range X Mm, power consumption 18 Watts, maximum data rate 4.8 Mbit/sec, gain W dBi.
+    @description ^= :$: Effective range 1.25 Gm, power consumption 18 Watts, maximum data rate 4.8 Mbit/sec, gain 38 dBi.
 
     !MODULE[ModuleDeployableAntenna],*{}
 
@@ -375,9 +372,9 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 100000
+        Mode1DishRange = 250000
         EnergyCost = 0.018
-        DishAngle = 25.0
+        DishAngle = 28.0
         MaxQ = 6000
         DeployFxModules = 0
         ProgressFxModules = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -313,7 +313,7 @@
 //  ==================================================
 //  Small folding parabolic antenna.
 
-//  Dimensions: - m x - m
+//  Dimensions: 0.8 m x 0.14 m
 //  Inert Mass: 35 Kg
 //  ==================================================
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -60,6 +60,7 @@
     @MODULE[ModuleSAS]
     {
         @SASServiceLevel = 3
+        %standalone = True
     }
 
     @MODULE[ModuleReactionWheel]
@@ -111,6 +112,8 @@
             maxAmount = 540
         }
     }
+
+    !MODULE[ModuleDataTransmitter],*{}
 
     !MODULE[ModuleSPU*],*{}
 
@@ -172,11 +175,12 @@
         }
     }
 
-    !MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleReactionWheel],*{}
 
     @MODULE[ModuleSAS]
     {
         %SASServiceLevel = 2
+        %standalone = True
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -208,6 +212,8 @@
             maxAmount = 104
         }
     }
+
+    !MODULE[ModuleDataTransmitter],*{}
 
     !MODULE[ModuleSPU*],*{}
 
@@ -272,11 +278,12 @@
         }
     }
 
-    !MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleReactionWheel],*{}
 
     @MODULE[ModuleSAS]
     {
-        %SASServiceLevel = 2
+        @SASServiceLevel = 2
+        %standalone = True
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -306,6 +313,8 @@
             maxAmount = 36
         }
     }
+
+    !MODULE[ModuleDataTransmitter],*{}
 
     !MODULE[ModuleSPU*],*{}
 
@@ -371,7 +380,7 @@
         }
     }
 
-    @MODULE[ModuleRCS*]
+    @MODULE[ModuleRCS]
     {
         @thrusterPower = 0.0255
         !resourceName = NULL
@@ -401,6 +410,11 @@
         }
     }
 
+    @MODULE[ModuleSAS]
+    {
+        %standalone = True
+    }
+
     !MODULE[ModuleFuelTanks],*{}
 
     MODULE
@@ -419,6 +433,8 @@
             maxAmount = 5760
         }
     }
+
+    !MODULE[ModuleDataTransmitter],*{}
 
     !MODULE[ModuleSPU*],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -23,12 +23,12 @@
     @description = This reaction wheel assembly combines three RW4 high performance reaction wheels for larger spacecraft that require precision attitude control.
 
     @mass = 0.012
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
-    %tags = assembly attitude control reaction RW wheel
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -61,16 +61,16 @@
     @rescaleFactor = 1.0
 
     @title = RW-2A Radial Reaction Wheel Assembly
-    manufacturer = Blue Canyon Tech
-    description = This reaction wheel assembly combines two RW4 high performance reaction wheels for medium size spacecraft that require precision attitude control.
+    @manufacturer = Blue Canyon Tech
+    @description = This reaction wheel assembly combines two RW4 high performance reaction wheels for medium size spacecraft that require precision attitude control.
 
     @mass = 0.006
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
-    %tags = assembly attitude control reaction RW wheel
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -104,12 +104,12 @@
     @description = High performance reaction wheels for precision spacecraft attitude control.
 
     @mass = 0.0025
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
-    %tags = attitude control reaction RW wheel
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -143,12 +143,12 @@
     @description = High performance reaction wheels for precision spacecraft attitude control.
 
     @mass = 0.0016
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
-    %tags = attitude control reaction RW wheel
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -179,21 +179,18 @@
     @description = An integrated computer system utilizing two star trackers and ring laser gyroscopes (RLG) to provide attitude control information to the spacecraft.
 
     @mass = 0.001
-    @crashTolerance = 10
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    %tags = attitude control
 
-    @MODULE[ModuleSAS]
-    {
-        %standalone = True
-    }
+    //  Avionics batteries 15 Wh.
+    //  Generic power source & sink.
 
     @RESOURCE[ElectricCharge]
     {
-        @amount = 10
-        @maxAmount = 10
+        @amount = 54
+        @maxAmount = 54
     }
 }
 
@@ -213,16 +210,10 @@
     @description = A highly sensitive star tracker. By measuring the angle between different stars and comparing them with the stored database it provides attitude control information to the spacecraft.
 
     @mass = 0.001
-    @crashTolerance = 10
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    %tags = attitude control
-
-    @MODULE[ModuleSAS]
-    {
-        %standalone = True
-    }
 }
 
 //  ==================================================
@@ -254,6 +245,8 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @tags ^= :$: attitude block thruster
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
@@ -307,6 +300,8 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @tags ^= :$: attitude block thruster
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
@@ -366,6 +361,8 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @tags ^= :$: attitude block thruster
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
@@ -419,6 +416,8 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @tags ^= :$: attitude block thruster
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = True
@@ -471,6 +470,8 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @tags ^= :$: attitude block thruster
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = True
@@ -516,7 +517,7 @@
 
     @title = CA-RST RCS Thruster Block
     @manufacturer = Generic
-    @description = This compact thruster block can fire a single nozzle as a directional RCS or all three as an engine.
+    @description = This compact thruster block uses a single nozzle as a directional RCS or all three as a throttleable rocket engine.
 
     @mass = 0.015
     @crashTolerance = 10
@@ -524,9 +525,11 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
+    @tags ^= :$: attitude block thruster
 
     %useRcsConfig = RCSBlockDouble
     %useRcsMass = True
@@ -554,7 +557,7 @@
     {
         @name = ModuleEnginesRF
         @exhaustDamage = True
-        @minThrust = 1.618
+        @minThrust = 0.485
         @maxThrust = 1.618
         @heatProduction = 100
         %ullage = False

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -28,7 +28,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    %tags ^= :$: assembly RW wheel
+    @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -70,7 +70,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    %tags ^= :$: assembly RW wheel
+    @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -109,7 +109,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    %tags ^= :$: assembly RW wheel
+    @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -148,7 +148,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    %tags ^= :$: assembly RW wheel
+    @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
     {
@@ -572,8 +572,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 321
-            @key,1 = 1 112
+            @key,0 = 0 254
+            @key,1 = 1 82.08
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -48,7 +48,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
     %fuelCrossFeed = False
-    @tags ^= :$: battery
+    @tags ^= :$: battery storage
 
     @RESOURCE[ElectricCharge]
     {
@@ -79,7 +79,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
     %fuelCrossFeed = False
-    @tags ^= :$: battery
+    @tags ^= :$: battery storage
 
     @RESOURCE[ElectricCharge]
     {
@@ -110,7 +110,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
     %fuelCrossFeed = False
-    @tags ^= :$: battery
+    @tags ^= :$: battery storage
 
     @RESOURCE[ElectricCharge]
     {
@@ -150,10 +150,10 @@
     @description = The SNAP-19 radioisotope thermoelectric generator as found on the Pioneer spacecraft. Developed by the Atomic Energy Commission (AEC).
 
     @mass = 0.028
-    @crashTolerance = 10
+    @crashTolerance = 16
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 1773.15
+    @maxTemp = 1273.15
     %skinMaxTemp = 1773.15
     %fuelCrossFeed = False
     @tags ^= :$: pioneer snap
@@ -205,8 +205,10 @@
     @MODULE[ModuleCoreHeat]
     {
         @CoreTempGoal = 520
-        @CoreShutdownTemp = 900
+        @CoreShutdownTemp = 800
     }
+
+    !RESOURCE,*{}
 
     RESOURCE
     {
@@ -247,16 +249,17 @@
 
     @node_stack_magneto = 0.0, 0.293, -0.06, 0.0, 0.5, 0.0, 0
     @node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, -90.0
+    @attachRules = 0,1,0,0,0
 
     @title = Voyager MHW-RTG
     @manufacturer = Department Of Energy [DOE]
     @description = The Multihundred-Watt radioisotope thermoelectric generator (MHW-RTG) as found on the Voyager spacecraft.
 
     @mass = 0.107
-    @crashTolerance = 10
+    @crashTolerance = 16
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 1773.15
+    @maxTemp = 1273.15
     %skinMaxTemp = 1773.15
     %fuelCrossFeed = False
     @tags ^= :$: multihundred thermoelectric voyager
@@ -305,15 +308,17 @@
         }
     }
 
-    !MODULE[ModuleEnviroSensor]{}
+    !MODULE[ModuleEnviroSensor],*{}
 
-    !MODULE[ModuleScienceExperiment]{}
+    !MODULE[ModuleScienceExperiment],*{}
 
     @MODULE[ModuleCoreHeat]
     {
         @CoreTempGoal = 520
-        @CoreShutdownTemp = 900
+        @CoreShutdownTemp = 800
     }
+
+    !RESOURCE,*{}
 
     RESOURCE
     {
@@ -361,14 +366,14 @@
     @description = The General-Purpose Heat Source radioisotope thermoelectric generator as found on the Ulysses and the New Horizons spacecrafts.
 
     @mass = 0.0483
-    @crashTolerance = 10
+    @crashTolerance = 16
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 1773.15
+    @maxTemp = 1273.15
     %skinMaxTemp = 1773.15
     %CoMOffset = -2.0, 0.0, 0.0
     %fuelCrossFeed = False
-    @tags ^= :$: general horizons ne ulysses
+    @tags ^= :$: general horizons ulysses
 
     !MODULE[ModuleGenerator],*{}
 
@@ -408,8 +413,10 @@
     @MODULE[ModuleCoreHeat]
     {
         @CoreTempGoal = 520
-        @CoreShutdownTemp = 900
+        @CoreShutdownTemp = 800
     }
+
+    !RESOURCE,*{}
 
     RESOURCE
     {
@@ -463,6 +470,8 @@
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.4
+
+        !UPGRADES,*{}
     }
 }
 
@@ -503,6 +512,8 @@
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.74
+
+        !UPGRADES,*{}
     }
 }
 
@@ -540,6 +551,8 @@
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.25
+
+        !UPGRADES,*{}
     }
 }
 
@@ -574,11 +587,23 @@
     %fuelCrossFeed = False
     @tags ^= :$: mariner panel photovoltaic
 
-    !MODULE[ModuleReactionWheel],*{}
+    @MODULE[ModuleReactionWheel]
+    {
+        @PitchTorque = 0.00025
+        @YawTorque = 0
+        @RollTorque = 0
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.0025
+        }
+    }
 
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.21
+
+        !UPGRADES,*{}
     }
 }
 
@@ -619,6 +644,8 @@
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.85
+
+        !UPGRADES,*{}
     }
 }
 
@@ -649,14 +676,16 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: mars odyssey panel photovoltaic
 
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 1.5
+
+        !UPGRADES,*{}
     }
 }
 
@@ -686,13 +715,15 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: panel photovoltaic
 
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 1.88
+
+        !UPGRADES,*{}
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -3,6 +3,7 @@
 
 //  Aerojet Rocketdyne bipropellant motors data sheet: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
 //  Alternate Wars - Aerojet General Space Engines:    http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN: http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
 //  Russian Space Web - Fregat upper stage:            http://www.russianspaceweb.com/fregat.html
 //  NPO Lavochkin - Fregat upper stage:                http://www.laspace.ru/rus/fregat_construction.php
 //  KB KhIMMASH - S5.92 engine:                        http://kbhmisaeva.ru/main.php?id=53
@@ -97,8 +98,8 @@
     @node_stack_bottom = 0.0, -0.525, 0.0, 0.0, -1.0, 0.0, 1
 
     @title = R-40 Series
-    @manufacturer = Aerojet Rocketdyne
-    @description = A bipropellant rocket motor burning either MMH and MON3 (R-40A/B and R-42) or Hydrazine and MON3 (R-42DM). Used for orbital insertion or as a kick motor.
+    @manufacturer = Marquardt & Aerojet Rocketdyne
+    @description = A bipropellant rocket motor burning either MMH and MON3 (R-40A/B and R-42) or Hydrazine and MON3 (R-42DM). Used for attitude control, orbital insertion or as an apogee motor.
 
     @mass = 0.012
     @crashTolerance = 10
@@ -107,7 +108,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = size1
-    @tags ^= :$: apogee insertion motor
+    @tags ^= :$: aerojet attitude apogee insertion marquardt motor rocketdyne
 
     @MODULE[ModuleEngines*]
     {
@@ -159,7 +160,7 @@
             maxThrust = 4.0
             heatProduction = 100
             massMult = 1.0
-            description = Low efficiency, high thrust.
+            description = Attitude control thruster developed for the Space Shuttle.
 
             ullage = False
             pressureFed = True
@@ -199,7 +200,7 @@
             maxThrust = 4.0
             heatProduction = 100
             massMult = 1.0
-            description = NTO variant of the baseline R-40A/B.
+            description = NTO variant of the baseline R-40A/B thruster.
 
             ullage = False
             pressureFed = True
@@ -239,7 +240,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 0.7916
-            description = Low thrust with improved steady - state firing performance.
+            description = Improved steady - state firing performance.
 
             ullage = False
             pressureFed = True
@@ -279,7 +280,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 0.7916
-            description = NTO variant of the baseline R-42.
+            description = NTO variant of the baseline R-42 thruster.
 
             ullage = False
             pressureFed = True
@@ -319,7 +320,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 1.0416
-            description = Low thrust, high efficiency.
+            description = Low thrust, high efficiency apogee motor.
 
             ullage = False
             pressureFed = True
@@ -359,7 +360,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 1.0416
-            description = NTO variant of the baseline R-42DM.
+            description = NTO variant of the baseline R-42DM thruster.
 
             ullage = False
             pressureFed = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -3,11 +3,73 @@
 
 //  Aerojet Rocketdyne bipropellant motors data sheet: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
 //  Alternate Wars - Aerojet General Space Engines:    http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN: http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
 //  Russian Space Web - Fregat upper stage:            http://www.russianspaceweb.com/fregat.html
 //  NPO Lavochkin - Fregat upper stage:                http://www.laspace.ru/rus/fregat_construction.php
 //  KB KhIMMASH - S5.92 engine:                        http://kbhmisaeva.ru/main.php?id=53
 //  DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY:    http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
+
+//  ==================================================
+//  Jib rocket engine.
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_jib]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    //@node_stack_bottom = 0.0, -0.079, 0.0, 0.0, -1.0, 0.0, 0
+    //@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+    //@node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
+
+    @title = CA-MV04 "Jib" MonoPropellant Engine
+    @manufacturer = Generic
+    @description = Despite the maritime legacy of its name, we're pretty sure we've seen sails push a craft with more "oomph." Despite the fact, this internally mounted engine has found its uses for light craft. It can also be surface-mounted for design flexibility
+
+    @mass = 1.0
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @tags ^= :$: mariner mono propuls rocket vacuum
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        //thrustVectorTransformName = Thrust_transform
+        @minThrust = 0
+        @maxThrust = 5
+        @heatProduction = 100
+        //fxOffset = 0, 0, 0.45
+        @EngineType = LiquidFuel
+
+        @PROPELLANT[MonoPropellant]
+        {
+            @name = Hydrazine
+            @ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 243
+            @key,1 = 1 82
+        }
+
+        !UPGRADES,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+}
 
 //  ==================================================
 //  R-40 series bipropellant rocket engine.
@@ -35,8 +97,8 @@
     @node_stack_bottom = 0.0, -0.525, 0.0, 0.0, -1.0, 0.0, 1
 
     @title = R-40 Series
-    @manufacturer = Marquardt & Aerojet Rocketdyne
-    @description = A bipropellant rocket motor burning either MMH and MON3 (R-40A/B and R-42) or Hydrazine and MON3 (R-42DM). Used for attitude control, orbital insertion or as an apogee motor.
+    @manufacturer = Aerojet Rocketdyne
+    @description = A bipropellant rocket motor burning either MMH and MON3 (R-40A/B and R-42) or Hydrazine and MON3 (R-42DM). Used for orbital insertion or as a kick motor.
 
     @mass = 0.012
     @crashTolerance = 10
@@ -45,7 +107,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = size1
-    @tags ^= :$: aerojet attitude apogee insertion marquardt motor rocketdyne
+    @tags ^= :$: apogee insertion motor
 
     @MODULE[ModuleEngines*]
     {
@@ -75,6 +137,8 @@
             @key,0 = 0 293
             @key,1 = 1 150
         }
+
+        !UPGRADES,*{}
     }
 
     !MODULE[ModuleGimbal],*{}
@@ -95,7 +159,7 @@
             maxThrust = 4.0
             heatProduction = 100
             massMult = 1.0
-            description = Attitude control thruster developed for the Space Shuttle.
+            description = Low efficiency, high thrust.
 
             ullage = False
             pressureFed = True
@@ -135,7 +199,7 @@
             maxThrust = 4.0
             heatProduction = 100
             massMult = 1.0
-            description = NTO variant of the baseline R-40A/B thruster.
+            description = NTO variant of the baseline R-40A/B.
 
             ullage = False
             pressureFed = True
@@ -175,7 +239,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 0.7916
-            description = Improved steady - state firing performance.
+            description = Low thrust with improved steady - state firing performance.
 
             ullage = False
             pressureFed = True
@@ -215,7 +279,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 0.7916
-            description = NTO variant of the baseline R-42 thruster.
+            description = NTO variant of the baseline R-42.
 
             ullage = False
             pressureFed = True
@@ -255,7 +319,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 1.0416
-            description = Low thrust, high efficiency apogee motor.
+            description = Low thrust, high efficiency.
 
             ullage = False
             pressureFed = True
@@ -295,7 +359,7 @@
             maxThrust = 0.89
             heatProduction = 100
             massMult = 1.0416
-            description = NTO variant of the baseline R-42DM thruster.
+            description = NTO variant of the baseline R-42DM.
 
             ullage = False
             pressureFed = True
@@ -414,6 +478,8 @@
             @key,0 = 0 326
             @key,1 = 1 150
         }
+
+        !UPGRADES,*{}
     }
 
     @MODULE[ModuleGimbal]
@@ -573,7 +639,7 @@
 
     @title = CA-LT80 Propellant Tank (Pressurized)
     @manufacturer = Generic
-    @description = A generic inline propellant tank for use on medium - sized spacecraft.
+    @description = A generic inline high pressure propellant tank for use on medium - sized spacecraft.
 
     @mass = 0.045
     @crashTolerance = 14
@@ -586,7 +652,7 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    //  Max fill ratio at 90%.
+    //  Max fill ratio set at 90%.
 
     MODULE
     {
@@ -623,7 +689,7 @@
 
     @title = CA-MT170 Propellant Tank (Pressurized)
     @manufacturer = Generic
-    @description = A generic inline propellant tank for use on medium - sized spacecraft.
+    @description = A generic inline high pressure propellant tank for use on medium - sized spacecraft.
 
     @mass = 0.065
     @crashTolerance = 14
@@ -636,7 +702,7 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    //  Max fill ratio at 95%.
+    //  Max fill ratio set at 95%.
 
     MODULE
     {
@@ -669,7 +735,7 @@
 
     @title = CA-MT10 Propellant Tank (Pressurized)
     @manufacturer = Generic
-    @description = A generic, radially attached, propellant tank for use on upper stages or small - sized spacecraft.
+    @description = A generic radially attached high pressure propellant tank for use on upper stages or small - sized spacecraft.
 
     @mass = 0.003
     @crashTolerance = 14
@@ -681,7 +747,7 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    //  Max fill ratio at 90%.
+    //  Max fill ratio set at 90%.
 
     MODULE
     {
@@ -760,6 +826,8 @@
             @key,0 = 0 321
             @key,1 = 1 150
         }
+
+        !UPGRADES,*{}
     }
 
     !MODULE[ModuleGimbal],*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -10,10 +10,10 @@
 //  DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY:    http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
 
 //  ==================================================
-//  Jib rocket engine.
+//  Generic 0.5 kN mono/bipropellant rocket engine.
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.29 m x 0.25 m
+//  Inert Mass: 8 Kg
 //  ==================================================
 
 @PART[ca_jib]:FOR[RealismOverhaul]
@@ -28,31 +28,42 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    //@node_stack_bottom = 0.0, -0.079, 0.0, 0.0, -1.0, 0.0, 0
-    //@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
-    //@node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
-
-    @title = CA-MV04 "Jib" MonoPropellant Engine
+    @title = Generic 0.5 kN Thruster
     @manufacturer = Generic
-    @description = Despite the maritime legacy of its name, we're pretty sure we've seen sails push a craft with more "oomph." Despite the fact, this internally mounted engine has found its uses for light craft. It can also be surface-mounted for design flexibility
+    @description = A generic mono/bipropellant rocket motor. Can be configured within a great range of propellants.
 
-    @mass = 1.0
+    @mass = 0.008
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
-    @tags ^= :$: mariner mono propuls rocket vacuum
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @tags ^= :$: bipropellant motor
+
+    %useRcsConfig = RCSBlockDouble
+    %useRcsCostMult = 0.25
+    %useRcsMass = True
 
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
-        //thrustVectorTransformName = Thrust_transform
-        @minThrust = 0
-        @maxThrust = 5
-        @heatProduction = 100
-        //fxOffset = 0, 0, 0.45
+        @minThrust = 0.55
+        @maxThrust = 0.55
+        @heatProduction = 17.5
         @EngineType = LiquidFuel
+        %ullage = False
+        %pressureFed = True
+        %ignitions = -1
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 0.0075
+        }
 
         @PROPELLANT[MonoPropellant]
         {
@@ -62,8 +73,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 243
-            @key,1 = 1 82
+            @key,0 = 0 254
+            @key,1 = 1 82.08
         }
 
         !UPGRADES,*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -115,7 +115,7 @@
     @description = The DUST-X is an instrument that collects dust particles and provides information about their size, speed and direction.
 
     @mass = 1.0
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -148,7 +148,7 @@
     @description = The ELIX is an electrostatic analyzer for analyzing the synthesis of charged particles. By employing electric and magnetic fields ELIX concentrates and separates the different particles by their mass and charge, allowing for very precise measurements of plasma density, velocity and distribution.
 
     @mass = 0.005
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -207,7 +207,7 @@
     @description = The Gamma Ray Spectrometer measures the gamma ray energy generated from the planetary surfaces when these are bombarded by cosmic rays. By measuring the gamma ray energy we can determine the elemental synthesis and concentration of the soil.
 
     @mass = 0.03
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -240,7 +240,7 @@
     @description = The THEMIS (Thermal Emission Imaging System) is used to measure the thermal emissions of the planetary bodies, calculate the surface temperature or even map small details of surface features. The spectrometer can also measure the wavelength of IR emissions to detect certain minerals in the soil.
 
     @mass = 0.011
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -274,7 +274,7 @@
     @description = IUVS (Imaging Ultraviolet Spectrometer) images the lower part of the UV spectrum. By doing so it can measure the global characteristics of the upper atmospheric and ionospheric layers, providing information about the synthesis, the morphology and the interactions between the solar wind and the atmosphere.
 
     @mass = 0.027
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -314,7 +314,7 @@
     @description = The Radio and Plasma Wave Science (RPWS) uses sensitive wideband electric/magnetic monopole and dipole antennae to receive low frequency radio transmissions caused by trapped charged particles (cyclotron waves), electrostatic discharges and whistlers (lighting) and thermal plasma. All these sources can be used to analyze the spectrum and type of the plasma, the electron density and distribution of the magnetospheres and the various lighting effects on the lower atmospheric layers.
 
     @mass = 0.038
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -342,7 +342,7 @@
     @description = The science boom of the Voyager deep space probe. The boom mounts Narrow and Wide field cameras for orbital survey images, as well as an Infrared and an Ultraviolet spectrometer. NOTE: Deploy the boom to keep experiments away from electromagnetic interference and radiation.
 
     @mass = 0.103
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -371,7 +371,7 @@
     @description = The Solar Wind Analyzer (SWIA) instrument is designed specifically to detect and measure solar wind electron/ion velocity and density.
 
     @mass = 0.003
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
@@ -404,7 +404,7 @@
     @description = The High Resolution Imaging Science Experiment (HiRISE) is a Cassegrain - type visible spectrum telescope and one of the biggest to ever fly in a deep space probe. With it's high resolution capability it can acquire high definition color surface images.
 
     @mass = 0.065
-    @crashTolerance = 10
+    @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -1,0 +1,137 @@
+//  ==================================================
+//  Sources:
+
+//  ==================================================
+//  Thermal control system (small).
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_louver_s]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-TCL4 Thermal Control Louver
+    @manufacturer = Generic
+    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This is the standard size system.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @radiatorHeadroom = 0.6129
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 12500
+        @overcoolFactor = 0.6129
+        @isCoreRadiator = True
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.005
+        }
+    }
+}
+
+//  ==================================================
+//  Thermal control system (medium).
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_louver_s2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-TCL4-B Thermal Control Louver
+    @manufacturer = Generic
+    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This is an alternate, longer version of the TCL4.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @radiatorHeadroom = 0.6129
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 25000
+        @overcoolFactor = 0.6129
+        @isCoreRadiator = True
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.0075
+        }
+    }
+}
+
+//  ==================================================
+//  Thermal control system (large).
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_louver_m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-TCL8 Thermal Control Louver
+    @manufacturer = Generic
+    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This system has double the height and performance of the TCL4-B for better cooling.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @radiatorHeadroom = 0.6129
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 50000
+        @overcoolFactor = 0.6129
+        @isCoreRadiator = True
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.015
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -1,11 +1,13 @@
 //  ==================================================
 //  Sources:
 
+//  Spacecraft Thermal Control Handbook (Chapter 9): http://matthewwturner.com/uah/IPT2008_summer/baselines/LOW%20Files/Thermal/Spacecraft%20Thermal%20Control%20Handbook/09.pdf
+
 //  ==================================================
 //  Thermal control system (small).
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.45 m x 0.4 m
+//  Inert Mass: 1 Kg
 //  ==================================================
 
 @PART[ca_louver_s]:FOR[RealismOverhaul]
@@ -22,9 +24,9 @@
 
     @title = CA-TCL4 Thermal Control Louver
     @manufacturer = Generic
-    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This is the standard size system.
+    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This is the standard size system with a rated heat rejection capability of 40 Watts.
 
-    @mass = 1.0
+    @mass = 0.001
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -35,13 +37,14 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 12500
+        @maxEnergyTransfer = 2.0
         @overcoolFactor = 0.6129
         @isCoreRadiator = True
+        %parentCoolingOnly = True
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.005
+            @rate = 0.0035
         }
     }
 }
@@ -49,8 +52,8 @@
 //  ==================================================
 //  Thermal control system (medium).
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.3 m x 0.725 m
+//  Inert Mass: 1.25 Kg
 //  ==================================================
 
 @PART[ca_louver_s2]:FOR[RealismOverhaul]
@@ -67,9 +70,9 @@
 
     @title = CA-TCL4-B Thermal Control Louver
     @manufacturer = Generic
-    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This is an alternate, longer version of the TCL4.
+    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This is an alternate, longer version of the TCL4, with a rated heat rejection capability of 50 Watts.
 
-    @mass = 1.0
+    @mass = 0.00125
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -80,13 +83,14 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 25000
+        @maxEnergyTransfer = 2.5
         @overcoolFactor = 0.6129
         @isCoreRadiator = True
+        %parentCoolingOnly = True
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.0075
+            @rate = 0.00375
         }
     }
 }
@@ -94,8 +98,8 @@
 //  ==================================================
 //  Thermal control system (large).
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.5 m x 0.725 m
+//  Inert Mass: 2 Kg
 //  ==================================================
 
 @PART[ca_louver_m]:FOR[RealismOverhaul]
@@ -112,9 +116,9 @@
 
     @title = CA-TCL8 Thermal Control Louver
     @manufacturer = Generic
-    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This system has double the height and performance of the TCL4-B for better cooling.
+    @description = Thermal Control Louvers are heat control systems that can expel heat by exposing cooling fins and a radiator. Toggle the vents open to release heat from the spacecraft. This system has double the height and performance of the TCL4-B for better cooling. Rated heat rejection capability 100 Watts.
 
-    @mass = 1.0
+    @mass = 0.002
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -125,13 +129,14 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 50000
+        @maxEnergyTransfer = 5.0
         @overcoolFactor = 0.6129
         @isCoreRadiator = True
+        %parentCoolingOnly = True
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.015
+            @rate = 0.0075
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -20,7 +20,7 @@
     @category = Science
     @title = Pioneer 10/11 Science Package
     @manufacturer = Generic
-    @description = An integrated science package designed for the Pioneer 10 & 11 deep space probes.
+    @description = An integrated science package originally designed for the Pioneer 10 & 11 deep space probes. Includes a thermal control system.
 
     @mass = 0.01
     @crashTolerance = 10
@@ -29,14 +29,15 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = True
+    @radiatorHeadroom = 0.6129
     @tags ^= :$: pioneer science
 
     !MODULE[ModuleReactionWheel],*{}
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 2.0
-        @overcoolFactor = 1.0
+        @maxEnergyTransfer = 12500
+        @overcoolFactor = 0.6129
         @isCoreRadiator = True
         @maxLinksAway = 2
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -20,7 +20,7 @@
     @category = Science
     @title = Pioneer 10/11 Science Package
     @manufacturer = Generic
-    @description = An integrated science package originally designed for the Pioneer 10 & 11 deep space probes. Includes a thermal control system.
+    @description = An integrated science package originally designed for the Pioneer 10 & 11 deep space probes. Includes a thermal control system with a thermal rejection capability of 50 Watts.
 
     @mass = 0.01
     @crashTolerance = 10
@@ -36,14 +36,14 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 12500
+        @maxEnergyTransfer = 2.5
         @overcoolFactor = 0.6129
         @isCoreRadiator = True
         @maxLinksAway = 2
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.12
+            @rate = 0.004
         }
     }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
@@ -15,11 +15,11 @@
         fixedScale = 1.0
         energy = 0.75
         speed = 1.0
-		emissionMult = 0.5
-		plumePosition = 0.0, 0.0, 0.13
-		plumeScale = 0.4
-		flarePosition = 0.0, 0.0, 0.0
-		flareScale = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, 0.13
+        plumeScale = 0.4
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -54,11 +54,11 @@
         fixedScale = 1.0
         energy = 1.25
         speed = 1.0
-		emissionMult = 0.5
-		plumePosition = 0.0, 0.0, 0.575
-		plumeScale = 0.5
-		flarePosition = 0.0, 0.0, 0.0
-		flareScale = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, 0.575
+        plumeScale = 0.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -93,11 +93,11 @@
         fixedScale = 1.0
         energy = 1.25
         speed = 1.0
-		emissionMult = 0.5
-		plumePosition = 0.0, 0.0, 0.4
-		plumeScale = 1.0
-		flarePosition = 0.0, 0.0, 0.0
-		flareScale = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, 0.4
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -133,11 +133,11 @@
         fixedScale = 1.0
         energy = 1.25
         speed = 1.0
-		emissionMult = 0.5
-		plumePosition = 0.0, 0.0, 0.45
-		plumeScale = 0.5
-		flarePosition = 0.0, 0.0, 0.0
-		flareScale = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, 0.45
+        plumeScale = 0.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
@@ -1,4 +1,15 @@
 //  ==================================================
+//  Cleanup.
+//  ==================================================
+
+@PART[ca_rst|ca_jib|ca_lahar|ca_linkor|ca_trident]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+    !EFFECTS,*{}
+
+    !PLUME,*{}
+}
+
+//  ==================================================
 //  CA-RST generic engine & RCS thruster port
 //  combination.
 
@@ -16,15 +27,30 @@
         energy = 0.75
         speed = 1.0
         emissionMult = 0.5
-        plumePosition = 0.0, 0.0, 0.13
+        plumePosition = 0.0, 0.0, 0.14
         plumeScale = 0.4
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
     }
 
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = Thrust_transform
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 0.25
+        flarePosition = 0.0, 0.0, -0.075
+        flareScale = 0.125
+    }
+
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Hypergolic-OMS-Red
+        %powerEffectName = Hypergolic-OMS-White
         !runningEffectName = NULL
         !fxOffset = NULL
     }
@@ -32,6 +58,125 @@
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}
+
+//  ==================================================
+//  CA-RST generic engine & RCS thruster port
+//  combination.
+
+//  Plume configuration.
+//  ==================================================
+
+@PART[ca_rst]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[MMH+NTO]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[MMH+MON3]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[UDMH+NTO]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[Cavea-B]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+//  ==================================================
+//  Generic 0.5 kN mono/bipropellant rocket engine.
+
+//  Plume setup.
+//  ==================================================
+
+@PART[ca_jib]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-Red
+        transformName = Thrust_transform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 1.0
+        plumePosition = 0.0, 0.0, 0.35
+        plumeScale = 0.35
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+    }
+
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = Thrust_transform
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, 0.05
+        plumeScale = 0.125
+        flarePosition = 0.0, 0.0, -0.45
+        flareScale = 0.075
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}
+
+//  ==================================================
+//  Generic 0.5 kN mono/bipropellant rocket engine.
+
+//  Plume configuration.
+//  ==================================================
+
+@PART[ca_jib]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[MMH+NTO]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[MMH+MON3]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[UDMH+NTO]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
+        @CONFIG[Cavea-B]
         {
             %powerEffectName = Hypergolic-OMS-Red
         }


### PR DESCRIPTION
* Add RO configs for the new parts:
    * Small folding dish (local high speed communications)
    * Generic 0.5 kN engine (similar to the stock 1 kN thruster)
    * Thermal control systems (small, medium & large)
* Remove a deprecated ModuleAnimateGeneric{} module from the medium size folding dish.
*  Patch all ModuleRCS{} modules for future compatibility with the new ModuleRCSFX{} module.
* Fix the tags of the reaction wheel assemblies.
* Make the radial RCS + Engine combo throttleable (similar to the TD-339).
* Reenable the reaction wheel of the Mariner 4 Solar Array Wing (low torque & single - axis to simulate the solar vane).
* Normalize the crash tolerances & max temperatures of sensitive parts (instruments, solar arrays, utility) to 8 m/s and 473.15 K.
* Add separate RealPlume configs on the radial RCS + Engine combo & the generic 0.5 kN engine according to the propellant combination currently used.
* Fix some rogue tabs.

Note 1: all UPGRADES{} nodes have been removed (functionality not needed or provided by ModuleEngineConfigs).
Note 2: a RealPlume cleanup sub - patch is included due to an issue overriding
the original RealPlume configs.