### PR TITLE
RCS TestFlight configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -53,12 +53,14 @@
     needsRcsConfig = True
 }
 
-// Now our parts are all flagged, add the initial config.
+//  ==================================================
+//  Now our parts are all flagged, add the initial config.
+//  ==================================================
 
 @PART[*]:HAS[#needsRcsConfig[True]]:FOR[RO-RCS]
 {
-
 	!needsRcsConfig = DELETE
+    %useRCSTestFlightConfig = True
 
 	MODULE
 	{
@@ -235,7 +237,11 @@
 		}
 	}
 }
-// Apply mass if useRcsMass is true.
+
+//  ==================================================
+//  Apply mass if useRcsMass is true.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[*],useRcsMass[True]]:FOR[RO-RCS]
 {
 	@MODULE[ModuleEngineConfigs]
@@ -245,12 +251,15 @@
 	!useRcsMass = DELETE
 }
 
-// Apply thrust
+//  ==================================================
+//  Apply thrust
 
-// Full block
+//  Full block
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlock]]:FOR[RO-RCS]
 {
-        !useRcsConfig = DELETE
+    !useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -300,7 +309,7 @@
 // Half block
 @PART[*]:HAS[#useRcsConfig[RCSBlockHalf]]:FOR[RO-RCS]
 {
-        !useRcsConfig = DELETE
+    !useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -355,7 +364,7 @@
 // Quarter block.
 @PART[*]:HAS[#useRcsConfig[RCSBlockQuarter]]:FOR[RO-RCS]
 {
-        !useRcsConfig = DELETE
+    !useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -410,7 +419,7 @@
 // Tenth block
 @PART[*]:HAS[#useRcsConfig[RCSBlockTenth]]:FOR[RO-RCS]
 {
-        !useRcsConfig = DELETE
+    !useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -471,7 +480,7 @@
 // based upon the prices found in RO_SXT_RCS.
 @PART[*]:HAS[#useRcsConfig[RCSBlock15x]]:FOR[RO-RCS]
 {
-        !useRcsConfig = DELETE
+    !useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -774,6 +783,7 @@
 		}
 	}
 }
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS*]],!MODULE[ModuleRCS*]]:AFTER[RO-RCS]
 {
 	@MODULE[ModuleEngineConfigs]
@@ -787,12 +797,74 @@
 		}
 	}
 }
+
+//  ==================================================
+//  Generic RCS thrusters/engines.
+
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[#useRCSTestFlightConfig[True],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    !useRCSTestFlightConfig = NULL
+
+	TESTFLIGHT
+	{
+		name = ColdGasRCS
+		mainConfiguration = engineConfig = Helium,engineConfig = Nitrogen:ColdGasRCS
+		ratedBurnTime = 1200
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.999
+		reliabilityDataRateMultiplier = 0.1
+		techTransfer = NitrousOxide,HTP,Hydrazine,Cavea-B,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
+	}
+
+	TESTFLIGHT
+	{
+		name = MonopropellantRCS
+		mainConfiguration = engineConfig = NitrousOxide,engineConfig = HTP,engineConfig = Hydrazine,engineConfig = Cavea-B:MonopropellantRCS
+		ratedBurnTime = 1200
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.999
+		reliabilityDataRateMultiplier = 0.1
+		techTransfer = Helium,Nitrogen,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
+	}
+
+	TESTFLIGHT
+	{
+		name = BipropellantRCS
+		mainConfiguration = engineConfig = MMH+NTO,engineConfig = MMH+MON3,engineConfig = UDMH+NTO,engineConfig = Aerozine50+NTO:BipropellantRCS
+		ratedBurnTime = 1200
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.999
+		reliabilityDataRateMultiplier = 0.1
+		techTransfer = Helium,Nitrogen,NitrousOxide,HTP,Hydrazine,Cavea-B:50
+	}
+}
+
+//  ==================================================
+//  Cleanup.
+//  ==================================================
+
 @PART[*]:HAS[useRcsCostMult[*]]:AFTER[RO-RCS]
 {
 	!useRcsCostMult = DEL
 }
-// We should have removed our useRcsConfig by now. If not, we've
-// got a typo in the config name somewhere. Make that obvious.
+
+//  ==================================================
+//  We should have removed our useRcsConfig by now. If not, we've
+//  got a typo in the config name somewhere. Make that obvious.
+//  ==================================================
+
 @PART[*]:HAS[useRcsConfig]:AFTER[RO-RCS]
 {
     !useRcsConfig = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -1,14 +1,16 @@
-// Rather than copy/pasting the same config all over the place, we instead
-// just find all the RCS parts with the same initial thrusterPower, and
-// expand their configs here.
+//  ==================================================
+//  Rather than copy/pasting the same config all over the place, we instead
+//  just find all the RCS parts with the same initial thrusterPower, and
+//  expand their configs here.
 
-// If we see something that uses `useRcsConfig` then we start by
-// adding an EnginesConfig module for it.
+//  If we see something that uses `useRcsConfig` then we start by
+//  adding an EnginesConfig module for it.
 
-// However, I can't for the life of me figure out how to test if a part
-// has *any* useRcsConfig string, so we're doing to do a little dance
-// to get the initial configs in. We really should have code generating
-// this.
+//  However, I can't for the life of me figure out how to test if a part
+//  has *any* useRcsConfig string, so we're doing to do a little dance
+//  to get the initial configs in. We really should have code generating
+//  this.
+//  ==================================================
 
 @PART[*]:HAS[#useRcsConfig[RCSBlockTriple]]:FOR[RO-RCS]
 {
@@ -60,7 +62,7 @@
 @PART[*]:HAS[#needsRcsConfig[True]]:FOR[RO-RCS]
 {
 	!needsRcsConfig = DELETE
-    %useRCSTestFlightConfig = True
+	%useRCSTestFlightConfig = True
 
 	MODULE
 	{
@@ -73,6 +75,7 @@
 		engineType = L
 		configuration = Hydrazine
 		modded = false
+
 		CONFIG
 		{
 			name = HTP
@@ -87,6 +90,7 @@
 			entryCost = 7500
 			techRequired = stability
 		}
+
 		CONFIG
 		{
 			name = Hydrazine
@@ -101,6 +105,7 @@
 			entryCost = 10000
 			techRequired = stability
 		}
+
 		CONFIG
 		{
 			name = NitrousOxide
@@ -115,6 +120,7 @@
 			entryCost = 5000
 			techRequired = basicRocketry
 		}
+
 		CONFIG
 		{
 			name = Helium
@@ -129,6 +135,7 @@
 			entryCost = 5000
 			techRequired = engineering101
 		}
+
 		CONFIG
 		{
 			name = Nitrogen
@@ -141,6 +148,7 @@
 			IspSL = 0.1001462
 			IspV = 0.195
 		}
+
 		CONFIG
 		{
 			name = MMH+NTO
@@ -161,6 +169,7 @@
 			techRequired = flightControl
 			entryCost = 30000
 		}
+
 		CONFIG
 		{
 			name = MMH+MON3
@@ -181,6 +190,7 @@
 			techRequired = flightControl
 			entryCost = 30000
 		}
+
 		CONFIG
 		{
 			name = UDMH+NTO
@@ -201,6 +211,7 @@
 			entryCost = 25000
 			techRequired = flightControl
 		}
+
 		CONFIG
 		{
 			name = Aerozine50+NTO
@@ -221,6 +232,7 @@
 			entryCost = 30000
 			techRequired = flightControl
 		}
+
 		CONFIG
 		{
 			name = Cavea-B
@@ -248,18 +260,17 @@
 	{
 		%origMass = #$../mass$
 	}
-	!useRcsMass = DELETE
 }
 
 //  ==================================================
-//  Apply thrust
+//  Apply thrust.
 
-//  Full block
+//  Full block.
 //  ==================================================
 
 @PART[*]:HAS[#useRcsConfig[RCSBlock]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -306,10 +317,13 @@
 	}
 }
 
-// Half block
+//  ==================================================
+//  Half block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlockHalf]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -361,10 +375,13 @@
 	}
 }
 
-// Quarter block.
+//  ==================================================
+//  Quarter block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlockQuarter]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -416,10 +433,13 @@
 	}
 }
 
-// Tenth block
+//  ==================================================
+//  Tenth block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlockTenth]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -476,11 +496,14 @@
 	}
 }
 
-// 1.5x block. 20% more expensive than a regular block,
-// based upon the prices found in RO_SXT_RCS.
+//  ==================================================
+//  1.5x block. 20% more expensive than a regular block,
+//  based upon the prices found in RO_SXT_RCS.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlock15x]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -537,9 +560,13 @@
 	}
 }
 
+//  ==================================================
+//  Triple block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlockTriple]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -596,9 +623,13 @@
 	}
 }
 
+//  ==================================================
+//  Double block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlockDouble]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -655,9 +686,13 @@
 	}
 }
 
+//  ==================================================
+//  Quad block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlock4x]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -714,9 +749,13 @@
 	}
 }
 
+//  ==================================================
+//  Octa block.
+//  ==================================================
+
 @PART[*]:HAS[#useRcsConfig[RCSBlock8x]]:FOR[RO-RCS]
 {
-    !useRcsConfig = DELETE
+	!useRcsConfig = DELETE
 
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -773,6 +812,11 @@
 	}
 }
 
+//  ==================================================
+//  Price the blocks according to the RCS multiplier
+//  (if there is one defined).
+//  ==================================================
+
 @PART[*]:HAS[useRcsCostMult[*]]:AFTER[RO-RCS]
 {
 	@MODULE[ModuleEngineConfigs]
@@ -784,11 +828,16 @@
 	}
 }
 
+//  ==================================================
+//  Apply the min and max thrust levels.
+//  ==================================================
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS*]],!MODULE[ModuleRCS*]]:AFTER[RO-RCS]
 {
 	@MODULE[ModuleEngineConfigs]
 	{
 		@type = ModuleEngines
+
 		@CONFIG,*
 		{
 			%maxThrust = #$thrusterPower$
@@ -806,7 +855,7 @@
 
 @PART[*]:HAS[#useRCSTestFlightConfig[True],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-    !useRCSTestFlightConfig = NULL
+	!useRCSTestFlightConfig = NULL
 
 	TESTFLIGHT
 	{
@@ -860,14 +909,19 @@
 	!useRcsCostMult = DEL
 }
 
+@PART[*]:HAS[#useRcsMass[*]]:AFTER[RO-RCS]
+{
+	!useRcsMass = DEL
+}
+
 //  ==================================================
 //  We should have removed our useRcsConfig by now. If not, we've
 //  got a typo in the config name somewhere. Make that obvious.
 //  ==================================================
 
-@PART[*]:HAS[#useRcsConfig]:AFTER[RO-RCS]
+@PART[*]:HAS[#useRcsConfig[*]]:AFTER[RO-RCS]
 {
-    !useRcsConfig = DELETE
-    @title ^=:$: (Misconfigured RO RCS):
-    @description ^=:$: (This part refers to an RO RCS config that is not defined, and may not work correctly.):
+	!useRcsConfig = DELETE
+	@title ^=:$: (Misconfigured RO RCS):
+	@description ^=:$: (This part refers to an RO RCS config that is not defined, and may not work correctly.):
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -855,7 +855,7 @@
 //  Cleanup.
 //  ==================================================
 
-@PART[*]:HAS[useRcsCostMult[*]]:AFTER[RO-RCS]
+@PART[*]:HAS[#useRcsCostMult[*]]:AFTER[RO-RCS]
 {
 	!useRcsCostMult = DEL
 }
@@ -865,7 +865,7 @@
 //  got a typo in the config name somewhere. Make that obvious.
 //  ==================================================
 
-@PART[*]:HAS[useRcsConfig]:AFTER[RO-RCS]
+@PART[*]:HAS[#useRcsConfig]:AFTER[RO-RCS]
 {
     !useRcsConfig = DELETE
     @title ^=:$: (Misconfigured RO RCS):

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1017,57 +1017,6 @@
 //  ==================================================
 //  Generic 1 kN thruster.
 
-//  TestFlight compatibility.
-//  ==================================================
-
-@PART[microEngine]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
-{
-	TESTFLIGHT
-	{
-		name = ColdGasRCS
-		mainConfiguration = engineConfig = Helium,engineConfig = Nitrogen:ColdGasRCS
-		ratedBurnTime = 1200
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.999
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.999
-		reliabilityDataRateMultiplier = 0.1
-		techTransfer = NitrousOxide,HTP,Hydrazine,Cavea-B,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
-	}
-
-	TESTFLIGHT
-	{
-		name = MonopropellantRCS
-		mainConfiguration = engineConfig = NitrousOxide,engineConfig = HTP,engineConfig = Hydrazine,engineConfig = Cavea-B:MonopropellantRCS
-		ratedBurnTime = 1200
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.999
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.999
-		reliabilityDataRateMultiplier = 0.1
-		techTransfer = Helium,Nitrogen,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
-	}
-
-	TESTFLIGHT
-	{
-		name = BipropellantRCS
-		mainConfiguration = engineConfig = MMH+NTO,engineConfig = UDMH+NTO,engineConfig = Aerozine50+NTO:BipropellantRCS
-		ratedBurnTime = 1200
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.999
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.999
-		reliabilityDataRateMultiplier = 0.1
-		techTransfer = Helium,Nitrogen,NitrousOxide,HTP,Hydrazine,Cavea-B:50
-	}
-}
-
-//  ==================================================
-//  Generic 1 kN thruster.
-
 //  Ven Stock Revamp compatibility.
 //  ==================================================
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -198,7 +198,7 @@
         @name = ModuleEnginesRF
 		@minThrust = 0.000019
 		@maxThrust = 0.000092
-		@heatProduction = 0	
+		@heatProduction = 0
 
 		!PROPELLANT[ElectricCharge]
 		{
@@ -357,7 +357,7 @@
 			@ratio = 0.6158
 		}
 	}
-	
+
 	@MODULE[ModuleGimbal]
 	{
 		!gimbalRange = DEL // just in case
@@ -387,11 +387,11 @@
 
 	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
-	
+
 	@title = E1
 	%manufacturer = Rocketdyne
     %description = Backup Proposal for the first stage engine on the Titan 1 ICBM, and proposed first stage engine on the Saturn 1 but ultimately never flown. Diameter: [2.14 m].
-	
+
 	@mass = 1.264
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -401,7 +401,7 @@
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False
-	
+
 	@MODULE[ModuleGimbal]
 	{
 		!gimbalRange = DEL // just in case
@@ -1252,7 +1252,7 @@
 
 	@node_stack_top = 0.0, 4.05, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -5.0, 0.0, 0.0, -1.0, 0.0, 3
-	
+
 	@mass = 8.5
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -1321,7 +1321,7 @@
 	}
 	@scale = 1.0
 	%rescaleFactor = 1.0
-	
+
 	@mass = 0.118
 	@crashTolerance = 10
 	@maxTemp = 873.15
@@ -1422,7 +1422,7 @@
 @PART[radialLiquidEngine1-2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	%mass = 0.12
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -1628,7 +1628,7 @@
 		@CONFIG[SolidFuel]
 		{
 			@maxThrust *= 4
-			
+
 		}
 	}
 }
@@ -1651,7 +1651,7 @@
 		cycleReliabilityStart = 0.99
 		cycleReliabilityEnd = 0.9999 // because fail in first 5s is 10x, bump this up higher than expected.
 		reliabilityDataRateMultiplier = 0.1 // we already start reliable, so don't get data too fast
-		
+
 		isSolid = True
 	}
 }
@@ -1663,7 +1663,7 @@
 @PART[smallRadialEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	%mass = 0.027
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -1725,7 +1725,7 @@
 	@node_stack_bottom = 0.0, -3.294453, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 2.699947, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
-	
+
 	@mass = 2.3
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -1820,7 +1820,7 @@
 	@node_stack_bottom = 0.0, -4.74, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 4.47, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1811, 0.0, 0.0, 1.0
-	
+
 	@mass = 4.35
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -1954,11 +1954,11 @@
     @crashTolerance = 10
 	%skinMaxTemp = 2500
 	@maxTemp = 1500
-	
+
 	@title = Conformal RCS Thruster (275/445 N class)
 	@manufacturer = Generic
 	@description = A generic conformal RCS thruster. Use this for attitude control or translation/ullage for spaceplanes. LEO-rated heat shielding.
-	
+
 	@MODULE[ModuleRCS]
 	{
 		@name = ModuleRCS
@@ -2036,7 +2036,7 @@
 	@node_stack_bottom = 0.0, -1.055, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.22, 0.0, 0.0, 1.0, 0
-	
+
 	@mass = 0.03
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -2156,7 +2156,7 @@
 			@key,1 = 0 242
 		}
 	}
-	
+
     MODULE
     {
         name = ModuleFuelTanks
@@ -2248,7 +2248,7 @@
 
 	%node_stack_top = 0.0, 0.9, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.513, 0.0, 0.0, -1.0, 0.0, 2
-	
+
 	%mass = 0.282
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -2393,7 +2393,7 @@
 
     //  Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0.
 
-    @MODEL,1		
+    @MODEL,1
     {
         @model = RealismOverhaul/Models/KVDvernVSR
         !texture = DELETE
@@ -2589,7 +2589,7 @@
     @MODEL
     {
         @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
-        @scale = 1.25, 1.25, 1.25  
+        @scale = 1.25, 1.25, 1.25
     }
 }
 


### PR DESCRIPTION
(Re)Uses the TF configs of the stock 1 kN Generic Thruster (operates like an RCS thruster) so operational burn times might need some tweaking for the actual RCS thrusters.

All RCS & engines that use the global RCS config are automagically supported.

Also supported is the new MMH/MON3 propellant combo.

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1416/files?w=1)