### PR TITLE
Add EngineConfigs cleanup pass

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
@@ -1,9 +1,14 @@
-// take the engineTypeCost field and apply that to cost, mass and minthrust/maxthrust
-@PART[*]:HAS[#engineTypeMult[*],~minActiveEngines[*]]:FINAL
+//  ==================================================
+//  Take the engineTypeCost field and apply that to
+//  cost, mass and minthrust/maxthrust.
+//  ==================================================
+
+@PART[*]:HAS[#engineTypeMult[*],~minActiveEngines[*]]:AFTER[RealismOverhaulEngines]
 {
 	@MODULE[ModuleEngineConfigs]
 	{
 		@origMass *= #$../engineTypeMult$
+
 		@CONFIG,*
 		{
 			@cost *= #$../../engineTypeMult$
@@ -12,12 +17,18 @@
 		}
 	}
 }
-// same as above, but have minThrust based on less engines if variable is set.
-@PART[*]:HAS[#engineTypeMult[*],#minActiveEngines[*]]:FINAL
+
+//  ==================================================
+//  Same as above, but have minThrust based on less
+//  engines if variable is set.
+//  ==================================================
+
+@PART[*]:HAS[#engineTypeMult[*],#minActiveEngines[*]]:AFTER[RealismOverhaulEngines]
 {
     @MODULE[ModuleEngineConfigs]
     {
         @origMass *= #$../engineTypeMult$
+
         @CONFIG,*
         {
             @cost *= #$../../engineTypeMult$
@@ -26,7 +37,12 @@
         }
     }
 }
-// for engines with effectively extra dead/structural mass
+
+//  ==================================================
+//  For engines with effectively extra dead/structural
+//  mass.
+//  ==================================================
+
 @PART[*]:HAS[#massOffset[*]]:AFTER[RealismOverhaulEngines]
 {
 	@MODULE[ModuleEngineConfigs]
@@ -34,7 +50,12 @@
 		@origMass += #$../massOffset$
 	}
 }
-// deletes origmass if ignoreMass field is found, use to avoid the engine changing the mass of a part.
+
+//  ==================================================
+//  Deletes origmass if ignoreMass field is found, use
+//  it to avoid the engine changing the mass of a part.
+//  ==================================================
+
 @PART[*]:HAS[#ignoreMass[true]]:AFTER[RealismOverhaulEngines]
 {
 	@MODULE[ModuleEngineConfigs]
@@ -42,8 +63,13 @@
 		!origMass = 0
 	}
 }
-// Subtract thrust from engine with verniers defined.
-@PART[*]:HAS[#useVerniers[True]]:AFTER[RealismOverhaulEngines] {
+
+//  ==================================================
+//  Subtract thrust from engines with verniers defined.
+//  ==================================================
+
+@PART[*]:HAS[#useVerniers[True]]:AFTER[RealismOverhaulEngines]
+{
 	@MODULE[ModuleEngineConfigs]
     {
 		@CONFIG,*
@@ -52,4 +78,18 @@
 			@minThrust -= #$../../vernierThrust$
 		}
     }
+}
+
+//  ==================================================
+//  Config cleanup.
+//  ==================================================
+
+@PART[*]:HAS[#engineType[*]]:AFTER[RealismOverhaulEngines]
+{
+    !engineType = NULL
+    !engineTypeMult = NULL
+    !minActiveEngines = NULL
+    !useVerniers = NULL
+    !massOffset = NULL
+    !ignoreMass = NULL
 }


### PR DESCRIPTION
* Patching now occurs at the same level for all sub - patches (no difference in the final output).
* Clean temporary Engine Configs vars (avoid KSP log error spamming).