### PR TITLE
VSR Engine updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -22,7 +22,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	@title = Separation Motor (small)
+	@title = Separation Motor (Small)
 	@manufacturer = Generic
 	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others. Smaller and less advanced than the radial separation motor.
 	@mass = 0.008
@@ -72,9 +72,13 @@
 			}
 		}
 	}
-	
+
 	// TestFlight ( TESTFLIGHT ) config is with the stock sep.
 }
+
+//  ==================================================
+//  Baby Sergeant SRM.
+//  ==================================================
 
 +PART[SnubOtron]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp,!RftS,!RealFuels_StockEngines]
 {
@@ -95,7 +99,7 @@
 		scale = 0.24384, 2.5, 0.24384
 		position = 0.0, 0.05625, 0.0
 	}
-	
+
 	MODEL
 	{
 		model = RealismOverhaul/emptyengine
@@ -106,12 +110,17 @@
 	%node_stack_bottom = 0.0, -0.69, 0.0, 0.0, -1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.0762, 0.0, 0.0, 1.0, 1
 	@attachRules = 1,1,1,1,0
-	
-	@title = Baby Sergeant Rocket Motor
-	%manufacturer = Thiokol
-	@description = Small solid kick motor used on as the Jupiter-C's (and later Juno I and II's) upper stages, in clusters of 11, 3, and finally one attached to the payload. Very low performance.
-	@mass = 0.00567
-	@maxTemp = 1973.15
+
+    @mass = 0.00567
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    @tags = booster explo motor rocket solid srb thruster ullage (ven (vsr
+
+    %engineType = BabySergeant
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 8
@@ -120,18 +129,16 @@
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
 		@thrustVectorTransformName = newThrustTransform
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 235
 			@key,1 = 1 214
 		}
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleFuelTanks]
-	{
-	}
+
+	!MODULE[ModuleFuelTanks],*{}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -139,63 +146,22 @@
 		basemass = -1
 		type = PSPC
 	}
-	!MODULE[ModuleEngineConfigs]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		configuration = BabySergeant
-		modded = false
-		CONFIG
-		{
-			name = BabySergeant
-			maxThrust = 8
-			heatProduction = 10
-			PROPELLANT
-			{
-				name = PSPC
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 235
-				key = 1 214
-			}
-		}
-	}
-	
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[BabySergeant]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+
+//  ==================================================
+//  Baby Sergeant SRM.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[ROBabySergeant]:FOR[RealismOverhaul]
 {
-	TESTFLIGHT
-	{
-		name = BabySergeant
-		ratedBurnTime = 6
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.995
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.9985 // because failchance is 10x during the first 5 seconds of burn, this needs to be 10x as relaible as you'd think.
-		reliabilityDataRateMultiplier = 1.5
-		
-		isSolid = True
-	}
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = JPL-532A
+    }
 }
-@PART[FASAExplorerSgt3]:BEFORE[zTestFlight]
-{
-	@TESTFLIGHT
-	{
-		clusterMultiplier = 3
-	}
-}
-@PART[FASAExplorerSgt11]:BEFORE[zTestFlight]
-{
-	@TESTFLIGHT
-	{
-		clusterMultiplier = 11
-	}
-}
+
 @PART[LVT15]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
@@ -235,21 +201,21 @@
 	%rescaleFactor = 1.0
 	%scale = 1.0
 	%node_stack_bottom = 0, -1.656, 0, 0, -1, 0, 1
-	
+
 	// make radially attachable
 	@attachRules = 1,1,1,0,0
 	%node_attach = 0
 	@node_attach = #$node_stack_top$
-	
+
 	@mass = 0.87
 	@maxTemp = 1973.15
 	!emissiveConstant = DEL
-	
+
 	// remove LV-T15 stuff
 	!MODULE[ModuleAblator] {}
 	!RESOURCE[Ablator] {}
 	!MODULE[ModuleHeatShield] {}
-	
+
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 469.7
@@ -298,7 +264,7 @@
 	@node_stack_bottom = 0.0, -8.240668, 0.0, 0.0, -2.0, 0.0, 2
 	@node_stack_top = 0.0, 14.0348321, 0.0, 0.0, 2.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.524, 0.0, 0.0, 2.0
-	
+
 	@mass = 33.6
 	@maxTemp = 1973.15
 	@MODULE[ModuleEngines*]
@@ -315,7 +281,7 @@
 	!RESOURCE[SolidFuel]
 	{
 	}
-	
+
 	engineType = UA1205
 }
 
@@ -323,7 +289,7 @@
 @PART[LargeOMS]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	@MODEL
 	{
 		scale = 1.15, 1.15, 1.15
@@ -379,14 +345,16 @@
 	@node_attach = 0.0, 0.0, -0.395, 0.0, 0.0, 1.0, 1
 	%node_stack_top = 0.0, 3.20144, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -3.05592, 0.0, 0.0, -1.0, 0.0, 0
-	
+
 	@attachRules = 1,1,1,1,0
-	
+
+    @category = Engine
+
 	engineType = Castor-2
 }
 
 //  ==================================================
-//  Castor 4
+//  Castor 4 SRM.
 
 //  Dimensions: 1.02 m x 9.08 m
 //  Gross Mass: 10534 Kg
@@ -410,9 +378,6 @@
     @node_attach = 0.0, 0.0, -0.3, 0.0, 0.0, 1.0
 
     @category = Engine
-    @title = Castor IV
-    @manufacturer = Thiokol
-    @description = The Castor IV is an improvement over the Castor 2 SRM, featuring an increased propellant loadout and thrust. Used as a strap-on booster on the Delta 3000 launch vehicle family and as the main core booster for the Athena H. Burn time approximately 58 seconds.
 
     @mass = 1.27
     @crashTolerance = 10
@@ -466,7 +431,7 @@
             maxAmount = 5227.96
         }
     }
-	
+
     !RESOURCE,*{}
 }
 
@@ -492,26 +457,26 @@
 	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 
 	@mass = 0.132
-	
+
 	// make radially attachable
 	@attachRules = 1,1,1,0,0
 	%node_attach = 0
 	@node_attach = #$node_stack_top$
-	
+
 	@mass = 0.132
 	@maxTemp = 1973.15
 	!emissiveConstant = DEL
-	
+
 	// remove LV-T15 stuff
 	!MODULE[ModuleAblator] {}
 	!RESOURCE[Ablator] {}
 	!MODULE[ModuleHeatShield] {}
-	
+
 	@MODULE[ModuleEngines*]
 	{
 		@useEngineResponseTime = False
 	}
-	
+
 	MODULE
 	{
 		name = ModuleGimbal
@@ -546,7 +511,7 @@
 	%node_stack_top = 0.0, 0.432996, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_top2 = 0.0, 0.65, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.756502, 0.0, 0.0, -1.0, 0.0, 2
-	
+
 	%attachRules = 1,0,1,0,0
 	%mass = 0.415
 	%maxTemp = 2000
@@ -582,7 +547,7 @@
        jettisonedObjectMass = 0.1
        jettisonForce = 0
        jettisonDirection = 0 0 1
-	
+
 	}
 }
 
@@ -599,7 +564,7 @@
 	%node_stack_top    = 0.0,  0.0, 0.0, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -3.5568, 0.0, 0.0, -1.0, 0.0, 4
 	%category = Propulsion
-	
+
 	%attachRules = 1,0,1,1,0
 	%mass = 4.5 //Guess (TWR 120)
 	%maxTemp = 1973.15
@@ -670,7 +635,7 @@
     @node_stack_top = 0.0, 1.738, 0.0, 0.0, 1.0, 0.0, 2
 
     @category = Engine
-    
+
     @mass = 1.278
     @maxTemp = 1024.15
     %skinMaxTemp = 1773.15


### PR DESCRIPTION
* Convert the Baby Sergeant part config to use the global engine
configuration.
* Remove some TestFlight - specific parts (now included with the global
engine config & the FASA Explorer configs).
* Remove some reduntant fields from the Castor 4 SRM.
* Normalize the suffix of the separation motor.
* Trim trailing spaces.

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1426/files?w=1)