### PR TITLE
FASA Explorer updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Explorer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Explorer.cfg
@@ -60,6 +60,11 @@
 		}
 	}
 }
+
+//  ==================================================
+//  Baby Sergeant SRM.
+//  ==================================================
+
 @PART[FASAExplorerSgt]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -72,12 +77,12 @@
 	@node_stack_bottom = 0.0, -0.3206, 0.0, 0.0, -1.0, 0.0, 0
 	!node_attach = DELETE
 	%category = Engine
-	@title = Baby Sergeant Solid Kick Motor
-	%manufacturer = Thiokol
-	@description = Final stage in Sergeant Cluster (used in Juno I and Juno II launchers). Attached directly to the satellite. Has higher specific impulse than the 3x and 11x clusters from using JPL-532A fuel rather than T17-E2. Attach 3x decoupler to the bottom of this.
+
 	@attachRules = 1,1,1,1,1
+
 	@mass = 0.00567
 	@maxTemp = 1973.15
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 8
@@ -85,19 +90,19 @@
 		%throttleLocked = True
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 235
 			@key,1 = 1 214
 		}
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+
 	@MODULE[ModuleJettison]
 	{
 		@jettisonedObjectMass = 0.0005
 	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -105,31 +110,27 @@
 		basemass = -1
 		type = PSPC
 	}
-	MODULE
+}
+
+//  ==================================================
+//  Baby Sergeant SRM.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[FASAExplorerSgt]:FOR[RealismOverhaul]
+{
+	@MODULE[ModuleEngineConfigs]
 	{
-		name = ModuleEngineConfigs
-		configuration = BabySergeant
-		modded = false
-		CONFIG
-		{
-			name = BabySergeant
-			maxThrust = 8
-			heatProduction = 10
-			PROPELLANT
-			{
-				name = PSPC
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 235
-				key = 1 214
-			}
-		}
+		@configuration = JPL-532A
 	}
 }
-@PART[FASAExplorerSgt3Dec]:FOR[RealismOverhaul]
+
+//  ==================================================
+//  Baby Sergeant x3 cluster decoupler.
+//  ==================================================
+
+@PART[FASAExplorerSgt3Dec]:AFTER[RealismOverhaulEngines]
 {
 	%RSSROConfig = True
 	@MODEL
@@ -150,6 +151,11 @@
 		@ejectionForce = 1
 	}
 }
+
+//  ==================================================
+//  Baby Sergeant SRM (x3 cluster).
+//  ==================================================
+
 @PART[FASAExplorerSgt3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -162,11 +168,10 @@
 	@node_stack_bottom = 0.0, -0.244, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_connect1 = 0.0, 0.301, 0.0 , 0.0, -1.0, 0.0, 0
 	%category = Engine
-	@title = Baby Sergeant 3x Solid Kick Motor Cluster
-	%manufacturer = Thiokol
-	@description = Middle cluster in Sergeant Cluster used on Juno I and II launch vehicles and on the Jupiter-C test rocket. Uses T17-E2 fuel mixutre, with lower performance than the JPL-532A fuel in the final stage. Attaches below 3x decoupler. Attach 11x decoupler below this.
+
 	@mass = 0.020
 	@maxTemp = 1973.15
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 24
@@ -174,15 +179,14 @@
 		%throttleLocked = True
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 220
 			@key,1 = 1 200
 		}
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -190,29 +194,43 @@
 		basemass = -1
 		type = PSPC
 	}
-	MODULE
+}
+
+//  ==================================================
+//  Baby Sergeant SRM (x3 cluster).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[FASAExplorerSgt3]:FOR[RealismOverhaulEngines]
+{
+	@title = Baby Sergeant 3x Solid Kick Motor Cluster
+	@description = Middle cluster in Sergeant Cluster used on Juno I and II launch vehicles and on the Jupiter-C test rocket. Uses the high performance variant (JPL-532A). Attaches below 3x decoupler. Attach 11x decoupler below this.
+
+	@MODULE[ModuleEngineConfigs]
 	{
-		name = ModuleEngineConfigs
-		configuration = BabySergeant
-		modded = false
-		CONFIG
-		{
-			name = BabySergeant
-			maxThrust = 24
-			PROPELLANT
-			{
-				name = PSPC
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 220
-				key = 1 200
-			}
-		}
+		@configuration = JPL-532A
 	}
 }
+
+//  ==================================================
+//  Baby Sergeant SRM (x3 cluster).
+
+//  TestFlight configuration.
+//  ==================================================
+
+@PART[FASAExplorerSgt3]:BEFORE[zTestFlight]
+{
+	@TESTFLIGHT
+	{
+		clusterMultiplier = 3
+	}
+}
+
+//  ==================================================
+//  Baby Sergeant x11 cluster decoupler.
+//  ==================================================
+
 @PART[FASAExplorerSgt11Dec]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -233,6 +251,11 @@
 		@ejectionForce = 1
 	}
 }
+
+//  ==================================================
+//  Baby Sergeant SRM (x11 cluster).
+//  ==================================================
+
 @PART[FASAExplorerSgt11]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -242,10 +265,9 @@
 	}
 	@scale = 1.186
 	%category = Engine
-	@title = Baby Sergeant 11x Solid Kick Motor Cluster
-	%manufacturer = Thiokol
-	@description = First stage in the Sergeant Cluster used on Juno I and II launch vehicles and on the Jupiter-C test rocket. Uses T17-E2 fuel mixutre, with lower performance than the JPL-532A fuel in the final stage. Attaches to the Baby Sergeant 11x decoupler.
+
 	@mass = 0.075
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 73.4
@@ -253,15 +275,14 @@
 		%throttleLocked = True
 		@useEngineResponseTime = True
 		!engineAccelerationSpeed = DELETE
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 220
 			@key,1 = 1 200
 		}
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -269,29 +290,39 @@
 		basemass = -1
 		type = PSPC
 	}
-	MODULE
+}
+
+//  ==================================================
+//  Baby Sergeant SRM (x11 cluster).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[FASAExplorerSgt11]:FOR[RealismOverhaulEngines]
+{
+	@title = Baby Sergeant 11x Solid Kick Motor Cluster
+	@description = First stage in the Sergeant Cluster used on Juno I and II launch vehicles and on the Jupiter-C test rocket. Uses T17-E2 fuel mixture, with lower performance than the JPL-532A fuel in the third and fourth stages. Attaches to the Baby Sergeant 11x decoupler.
+
+	@MODULE[ModuleEngineConfigs]
 	{
-		name = ModuleEngineConfigs
-		configuration = BabySergeant
-		modded = false
-		CONFIG
-		{
-			name = BabySergeant
-			maxThrust = 73.4
-			PROPELLANT
-			{
-				name = PSPC
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 220
-				key = 1 200
-			}
-		}
+		@configuration = T17-E2
 	}
 }
+
+//  ==================================================
+//  Baby Sergeant SRM (x11 cluster).
+
+//  TestFlight configuration.
+//  ==================================================
+
+@PART[FASAExplorerSgt11]:BEFORE[zTestFlight]
+{
+	@TESTFLIGHT
+	{
+		clusterMultiplier = 11
+	}
+}
+
 @PART[FASAExplorerNosecone]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
* Update the Baby Sergeant SRM (and clusters) to use the new global
engine config.
* Add some TestFlight configs for the clusters (carried over from
RO_VSR_Engines).