### PR TITLE
RO Vanguard probe core updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -50,7 +50,7 @@
 
 	@MODULE[ModuleDecouple]
 	{
-		@ejectionForce = 5.0
+		@ejectionForce = 2.5
 	}
 }
 

--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -1,36 +1,45 @@
+//  ==================================================
+//  Vanguard probe core.
+
+//  Dimensions: 0.5 m x 0.5 m
+//  Gross Mass: 10 Kg
+//  ==================================================
+
 +PART[SXTSputnik]:FIRST
 {
 	@name = RP0probeVanguardXray
 }
-@PART[RP0probeVanguardXray]:FOR[RP-0]
+
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]
 {
-	!MODULE[TweakScale]
-	{
-	}
+	!MODULE[TweakScale]{}
+
 	@MODEL
 	{
-		%scale = 0.8128, 0.8128, 0.8128
-		@position = 0 , -0.41893744 , 0 // was -0.515425
+		%scale = 0.79375, 0.79375, 0.79375
 	}
+
 	%RSSROConfig = true
-	@node_stack_bottom = 0.0, -0.41893744, 0.0, 0.0, -1.0, 0.0, 0 // was -0.515425
+
+	@node_stack_bottom = 0.0, -0.516, 0.0, 0.0, -1.0, 0.0, 0
 
 	@mass = 0.01
-	@maxTemp = 410
-	%skinMaxTemp = 450
-	@crashTolerance = 7 // same as propulsion standard.
+	@maxTemp = 473.15
+	%skinMaxTemp = 473.15
+	@crashTolerance = 8
+	%fuelCrossFeed = False
+	%CoMOffset = 0.0, -0.1125, 0.0
+
 	@title = 20in X-Ray Detector
-	@manufacturer = Naval Research Laboratory
-	@description = A small (.5m) satellite designed to study the variation in solar X-ray radiation.
-	
-	!MODULE[ModuleReactionWheel]
-	{
-	}
+	@manufacturer = Naval Research Laboratory (NRL)
+	@description = A small (0.5m) satellite designed to study the variation in solar X-ray radiation.
+
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 2851.2
 		@maxAmount = 2851.2
 	}
+
 	@MODULE[ModuleCommand]
 	{
 		@RESOURCE[ElectricCharge]
@@ -38,28 +47,45 @@
 			@rate = 0.001
 		}
 	}
+
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 5.0
+	}
 }
 
-// Have RemoteTech? Then have an SPU, with an integrated antenna
-@PART[RP0probeVanguardXray]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+//  ==================================================
+//  Vanguard probe core.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    MODULE
-    {
-        name = ModuleSPU
-    }
+	!MODULE[ModuleDataTransmitter],*{}
 
-    MODULE
-    {
-        name = ModuleRTAntennaPassive
-        TechRequired = start
+	!MODULE[ModuleSPU*],*{}
 
-        OmniRange = 200000
+	!MODULE[ModuleRTAntenna*],*{}
 
-        TRANSMITTER
-        {
-            PacketInterval = 0.4
-            PacketSize = 0.27
-            PacketResourceCost = 0.01
-        }
-    }
+	MODULE
+	{
+		name = ModuleSPU
+	}
+
+	MODULE
+	{
+		name = ModuleRTAntenna
+		IsRTActive = True
+		Mode0OmniRange = 0
+		Mode1OmniRange = 200000
+		EnergyCost = 0.005
+
+		TRANSMITTER
+		{
+			PacketInterval = 1.0
+			PacketSize = 0.384
+			PacketResourceCost = 0.005
+		}
+	}
 }


### PR DESCRIPTION
* Fix the MM name pass (it broke RP-0 checks and made craft files using it unavailable if RP-0 was not installed).
* Increase the temperature limits to account for DRE (no more heat indicators on the pad).
* Lower the ejection force of the built - in decoupler.
* Remove the stock antenna module and replace it with an active RT antenna (consumes power, unlike the old one that did not have a standby power consumption).
* Decrease the data transmittion rate from 675 kBit/s to 384 kBit/s.
* Offset the center of mass instead of the model origin.