### PR TITLE
Titan Engine updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -3,6 +3,8 @@
 // References:
 // [1] http://crgis.ndc.nasa.gov/crgis/images/c/cd/A_Historical_Look_at_US_Launch_Vehicles_1967-Present_%281988%29.pdf
 // [2] Astronautix
+// [3] https://ia802608.us.archive.org/29/items/gemini7nasamissi00godw/gemini7nasamissi00godw.pdf
+// [4] http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
 @PART[*]:HAS[#engineType[2XLR87]]:FOR[RealismOverhaulEngines]
 {
 	%title = LR87 Booster
@@ -22,8 +24,8 @@
 		CONFIG
 		{
 			name = LR87-AJ-3
-			minThrust = 1466
-			maxThrust = 1466
+			minThrust = 1467.5
+			maxThrust = 1467.5
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -52,8 +54,8 @@
 		CONFIG
 		{
 			name = LR87-AJ-5
-			minThrust = 2193.6
-			maxThrust = 2193.6
+			minThrust = 2108.5
+			maxThrust = 2108.5
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -68,7 +70,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 297
+				key = 0 296
 				key = 1 259
 			}
 			ullage = True
@@ -86,8 +88,8 @@
 		CONFIG
 		{
 			name = LR87-AJ-7
-			minThrust = 2172.2
-			maxThrust = 2172.2
+			minThrust = 2313.1
+			maxThrust = 2313.1
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -102,7 +104,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 296
+				key = 0 299.9
 				key = 1 258
 			}
 			ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -3,6 +3,8 @@
 // FIXME: check the vernier configs for the engines that use this.
 // References:
 // [1] http://crgis.ndc.nasa.gov/crgis/images/c/cd/A_Historical_Look_at_US_Launch_Vehicles_1967-Present_%281988%29.pdf
+// [2] https://ia802608.us.archive.org/29/items/gemini7nasamissi00godw/gemini7nasamissi00godw.pdf
+// [3] http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
 //
 @PART[*]:HAS[#engineType[LR91]]:FOR[RealismOverhaulEngines]
 {
@@ -22,8 +24,8 @@
 		CONFIG
 		{
 			name = LR91-AJ-3
-			minThrust = 353.5
-			maxThrust = 353.5
+			minThrust = 355.9
+			maxThrust = 355.9
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -59,8 +61,8 @@
 		CONFIG
 		{
 			name = LR91-AJ-5
-			minThrust = 442.4
-			maxThrust = 442.4
+			minThrust = 444.8
+			maxThrust = 444.8
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -99,8 +101,8 @@
 		CONFIG
 		{
 			name = LR91-AJ-7
-			minThrust = 442.4
-			maxThrust = 442.4
+			minThrust = 453.7
+			maxThrust = 453.7
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -143,8 +145,8 @@
 		CONFIG
 		{
 			name = LR91-AJ-9
-			minThrust = 451.3
-			maxThrust = 451.3
+			minThrust = 453.7
+			maxThrust = 453.7
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -188,8 +190,8 @@
 		CONFIG
 		{
 			name = LR91-AJ-11
-			minThrust = 458.0
-			maxThrust = 458.0
+			minThrust = 460.4
+			maxThrust = 460.4
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -232,8 +234,8 @@
 		CONFIG
 		{
 			name = LR91-AJ-11A
-			minThrust = 469.8
-			maxThrust = 469.8
+			minThrust = 472.2
+			maxThrust = 472.2
 			heatProduction = 160
 			PROPELLANT
 			{


### PR DESCRIPTION
For some reason we currently have the LR87-AJ-7 and LR91-AJ-7 engines used on the Titan GLV as being weaker than the LR87-NA-5 and LR91-NA-5 engines used on the Titan II ICBM and Titan 23G (Titan II SLV).  I'm not sure where the numbers we currently use came from.  The first reference address, while full of great information, doesn't seem to have any thrust or ISP information for the Titan.  And Astronautix no longer seems to have usable data.  I was able to find a NASA Technical Document from the Gemini 7 mission which does list the thrust for both engines and those values appear to line up with what can be found on b14643.de so I'm suggesting we update.

Also, I've found in game that I can't seem to get the FASA Gemini into orbit using the values as we have them currently.  I'm always around 200-300dV shy.  But by using the numbers from b14643.de, I'm able to get into orbit with about 100-200dV to spare.