### PR TITLE
Vernier Gimbal edited on LR_101_Config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -160,7 +160,7 @@
 	@MODULE[ModuleGimbal]
 	{
 		%gimbalRangeXP = 10
-		%gimbalRangeXN = 10
+		%gimbalRangeXN = 0
 		%gimbalRangeYP = 75
 		%gimbalRangeYN = 75
 		%useGimbalResponseSpeed = True

--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -159,7 +159,12 @@
 	}
 	@MODULE[ModuleGimbal]
 	{
-		%gimbalRange = 35
+		%gimbalRangeXP = 35
+		%gimbalRangeXN = 0
+		%gimbalRangeYP = 35
+		%gimbalRangeYN = 35
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR101-NA-3]]]:BEFORE[zTestFlight]

--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -159,10 +159,10 @@
 	}
 	@MODULE[ModuleGimbal]
 	{
-		%gimbalRangeXP = 35
-		%gimbalRangeXN = 0
-		%gimbalRangeYP = 35
-		%gimbalRangeYN = 35
+		%gimbalRangeXP = 10
+		%gimbalRangeXN = 10
+		%gimbalRangeYP = 75
+		%gimbalRangeYN = 75
 		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
 	}


### PR DESCRIPTION
I think verniers only need 1 axis but this is 1.5 axis i think. Check image i can still disable XP Axis. https://gyazo.com/8de6f6febf75ff3c36ce8a4f20f4fb91