### PR TITLE
Atlas engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -122,7 +122,7 @@
 			heatProduction = 10
 			massMult = 0.8
 
-			techRequired = heavyRocketry
+			techRequired = advRocketry
 			cost = -10
 			entryCost = 0
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -253,7 +253,7 @@
 				LR105-NA-5/6 = 3000
 				LR89-NA-7.2 = 2000
 			}
-			techRequired = heavyRocketry
+			techRequired = heavierRocketry
 		}
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -9,6 +9,14 @@
 
 //  http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 //  http://www.b14643.de/Spacerockets/Diverse/Atlas_MA-drive-system/index.htm
+//	https://ia800304.us.archive.org/8/items/nasa_techdoc_19670014531/19670014531.pdf
+//	https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+//	https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+//	https://ia600308.us.archive.org/14/items/nasa_techdoc_19680012465/19680012465.pdf
+//	https://ia800305.us.archive.org/18/items/nasa_techdoc_19680025782/19680025782.pdf
+//	https://ia601208.us.archive.org/8/items/NASA_NTRS_Archive_19690008977/NASA_NTRS_Archive_19690008977.pdf
+//	https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680014866.pdf
+//	https://ia601201.us.archive.org/30/items/NASA_NTRS_Archive_19700011207/NASA_NTRS_Archive_19700011207.pdf
 
 //  Used by:
 //      FASA
@@ -80,7 +88,7 @@
 		}
 		CONFIG
 		{
-			name = LR105-NA-5/6
+			name = LR105-NA-5
 			minThrust = 366.1
 			maxThrust = 366.1
 			heatProduction = 100
@@ -108,16 +116,58 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 311
-				key = 1 215
+				key = 0 313	//311
+				key = 1 217	//215
 			}
 			cost = 100
 			entryCost = 2000
 			entryCostSubtractors
 			{
-				LR89-NA-6 = 1000
+				LR89-NA-5 = 1000
 			}
 			techRequired = basicConstruction // earlier than Adv Rocketry
+		}
+		CONFIG
+		{
+			name = LR105-NA-6
+			minThrust = 373.2
+			maxThrust = 373.2
+			heatProduction = 100
+			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.382
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.618
+			}
+			atmosphereCurve
+			{
+				key = 0 313	//311
+				key = 1 217	//215
+			}
+			cost = 100
+			entryCost = 2000
+			entryCostSubtractors
+			{
+				LR105-NA-5 = 2000
+				LR89-NA-6 = 1000
+			}
+			techRequired = advRocketry
 		}
 		CONFIG
 		{
@@ -157,7 +207,7 @@
 			entryCost = 4000
 			entryCostSubtractors
 			{
-				LR105-NA-5/6 = 2000
+				LR105-NA-6 = 2000
 				LR89-NA-7.1 = 1000
 			}
 			techRequired = heavyRocketry
@@ -266,17 +316,30 @@
 		cycleReliabilityEnd = 0.967
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR105-NA-5/6]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR105-NA-5]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = LR105-NA-5/6
+		name = LR105-NA-5
 		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.92
 		ignitionReliabilityEnd = 0.985
 		cycleReliabilityStart = 0.93
 		cycleReliabilityEnd = 0.98
 		techTransfer = LR105-NA-3:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR105-NA-6]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = LR105-NA-6
+		ratedBurnTime = 350
+		ignitionReliabilityStart = 0.92
+		ignitionReliabilityEnd = 0.985
+		cycleReliabilityStart = 0.93
+		cycleReliabilityEnd = 0.98
+		techTransfer = LR105-NA-3,LR105-NA-5:50
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR105-NA-7.1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -289,7 +352,7 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.99
-		techTransfer = LR105-NA-3,LR105-NA-5/6:50
+		techTransfer = LR105-NA-3,LR105-NA-5,LR105-NA-6:50
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR105-NA-7.2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -302,7 +365,7 @@
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.995
-		techTransfer = LR105-NA-3,LR105-NA-5/6,LR105-NA-7.1:50
+		techTransfer = LR105-NA-3,LR105-NA-5,LR105-NA-6,LR105-NA-7.1:50
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-56-OSA]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -315,6 +378,6 @@
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.998
-		techTransfer = LR105-NA-5/6,LR105-NA-7.1,LR105-NA-7.2,RS-27,RS-27A:50
+		techTransfer = LR105-NA-5,LR105-NA-6,LR105-NA-7.1,LR105-NA-7.2,RS-27,RS-27A:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -253,7 +253,7 @@
 				LR105-NA-5/6 = 3000
 				LR89-NA-7.2 = 2000
 			}
-			techRequired = heavierRocketry
+			techRequired = heavyRocketry
 		}
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -209,7 +209,7 @@
 			heatProduction = 100
 			massMult = 1.414        // astronautix.com MA-5. With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
-			techRequired = heavierRocketry
+			techRequired = heavyRocketry
 			cost = 500
 			entryCost = 10000
 
@@ -262,7 +262,7 @@
 			heatProduction = 100
 			massMult = 1.414        // astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
-			techRequired = heavierRocketry
+			techRequired = heavyRocketry
 			cost = 500
 			entryCost = 10000
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -262,7 +262,7 @@
 			heatProduction = 100
 			massMult = 1.414        // astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
-			techRequired = heavyRocketry
+			techRequired = heavierRocketry
 			cost = 500
 			entryCost = 10000
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -9,6 +9,14 @@
 //      http://www.b14643.de/Spacerockets/Diverse/Atlas_MA-drive-system/index.htm
 //      http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 //      http://www.astronautix.com/engines/lr895.htm
+//		https://ia800304.us.archive.org/8/items/nasa_techdoc_19670014531/19670014531.pdf
+//		https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+//		https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+//		https://ia600308.us.archive.org/14/items/nasa_techdoc_19680012465/19680012465.pdf
+//		https://ia800305.us.archive.org/18/items/nasa_techdoc_19680025782/19680025782.pdf
+//		https://ia601208.us.archive.org/8/items/NASA_NTRS_Archive_19690008977/NASA_NTRS_Archive_19690008977.pdf
+//		https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680014866.pdf
+//		https://ia601201.us.archive.org/30/items/NASA_NTRS_Archive_19700011207/NASA_NTRS_Archive_19700011207.pdf
 
 //  Used by:
 //      FASA (FASAMercuryAtlasEngBooster)
@@ -88,10 +96,10 @@
 		CONFIG
 		{
 			name = LR89-NA-5
-			minThrust = 758.7
-			maxThrust = 758.7
+			minThrust = 831.4
+			maxThrust = 831.4
 			heatProduction = 100
-			massMult = 1.0      // astronautix.com MA-2. With a 1.61t skirt, this should result in each booster weighing 0.720t resulting in a 3.050t total weight.
+			massMult = 1.15      // https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf. With a 1.61t skirt, this should result in each booster weighing 0.828t resulting in a 3.266t total weight which includes residuals.
 
 			techRequired = basicConstruction // earlier than Adv Rocketry
 			cost = 200
@@ -99,7 +107,7 @@
 
 			entryCostSubtractors
 			{
-				LR105-NA-5/6 = 1000
+				LR105-NA-5 = 1000
 			}
 
             ullage = True
@@ -133,18 +141,18 @@
 
 			atmosphereCurve
 			{
-				key = 0 282
-				key = 1 248
+				key = 0 290	//282
+				key = 1 251	//248
 			}
 		}
 
 		CONFIG
 		{
 			name = LR89-NA-6
-			minThrust = 831.4
-			maxThrust = 831.4
+			minThrust = 846.6
+			maxThrust = 846.6
 			heatProduction = 100
-			massMult = 1.086        // astronautix.com MA-3. With a 1.61t skirt, this should result in each booster weighing 0.782t resulting in a 3.174t total weight.
+			massMult = 1.2264		// https://ia601201.us.archive.org/30/items/NASA_NTRS_Archive_19700011207/NASA_NTRS_Archive_19700011207.pdf. With a 1.61t skirt, this should result in each booster weighing 0.883t resulting in the 3.376t total weight (including residuals) of AC-13.
 
 			techRequired = advRocketry
 			cost = 300
@@ -152,7 +160,7 @@
 
 			entryCostSubtractors
 			{
-				LR105-NA-5/6 = 1000
+				LR105-NA-6 = 1000
 				LR89-NA-5 = 3000
 			}
 
@@ -201,7 +209,7 @@
 			heatProduction = 100
 			massMult = 1.414        // astronautix.com MA-5. With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
-			techRequired = advRocketry
+			techRequired = heavierRocketry
 			cost = 500
 			entryCost = 10000
 
@@ -378,7 +386,7 @@
 		cycleReliabilityEnd = 0.967
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR89-NA-6]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR89-NA-5]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -214,12 +214,12 @@
 	@node_stack_top = 0.0, 10.905, 0.0, 0.0, 1.0, 0.0, 3
 	@node_stack_bottom = 0.0, -6.095, 0.0, 0.0, -1.0, 0.0, 3
 	CoMOffset = 0, 2.0, 0
-	@title = Atlas SLV-3C Fuel Tank
-	@description = The fuel tank for the Atlas SLV-3C. Historically used with the Centaur D1 to send 1.75T to GTO.  
-	@mass = 3.098
+	@title = Atlas SLV-3C/D Fuel Tank
+	@description = The fuel tank for the Atlas SLV-3C/D. Historically used with the Centaur D1 to send 1.75T (3C) or 1.80T (3D) to GTO.  Reduce fuel by 3t to setup the earlier 3C.
+	@mass = 2.392	// Adjust mass so that empty mass of tank, decoupler, LR105-NA6 engine and 8x small seperation motors adds up to 3.534t which was dry mass (including residuals) of AC-13
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 111252.9
+		@volume = 111483.1
 		@TANK[Kerosene]
 		{
 			@amount = 35700.2
@@ -252,19 +252,20 @@
 	CoMOffset = 0, 2.0, 0
 	@title = Atlas LV-3C Fuel Tank
 	@description = The fuel tank for the Atlas LV-3C. Historically used to loft the Centaur D1 into orbit, but has many uses.
-	@mass = 2.855
+	@mass = 2.365	// Adjust mass so that empty mass of tank, decoupler, LR105-NA5 engine and 8x small seperation motors adds up to 3.507t which was dry mass (including residuals) of AC-12
+	// Volume set to match values from AC-12
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 100491.3
+		@volume = 99267.0
 		@TANK[Kerosene]
 		{
-			@amount = 31249.8
-			@maxAmount = 31249.8
+			@amount = 35788.9
+			@maxAmount = 35788.9
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 69241.5
-			@maxAmount = 69241.5
+			@amount = 75694.2
+			@maxAmount = 75694.2
 		}
 	}
 }


### PR DESCRIPTION
I was trying to launch a recreation of the Surveyor 3 which was the first US probe to use a parking orbit prior to a TLI burn.  It was launched on the Altas LV-3C - Centaur D launch vehicle.  Trouble was, no matter how I setup the vehicle, I just didn't have enough dV to make it to the moon.  So I did a bunch of research and discovered a bunch of NASA Mission Reports with more details about the Surveyor 1-7 launches than I could imagine (I've included links down below).  Two of the reports that were the most helpful includes details about the AC-12 (Surveyor III) and a second record with details for the AC-13/AC-14/AC-15 (Surveyor V-VII) launches.  So the first thing I dis was use the weights that they give (pp148-149 in AC-12 report) (pp223-224 in AC13-15 report) to as accurately recreate these vehicles as I could.  I build an Atlas LV-3C/Centaur D to within 21kg of the mass listed for the AC-12/Surveyor III launch.  And I build an Altas SLV-3C/Centaur D to within 11kg of the AC-13/Surveyor V launch.  I couldn't get any closer because the reports include some "minimum ground venting" for the Centaur which we don't really recreate in game.  But I figured 21kg and 11kg were close enough, all things considered.
Unfortunately, even with my Surveyor III setup to within 21kg of the actual rocket, I still was at least 500dV short of what was needed to actually get to the moon.  I managed to fix some of that by adjusting the mass of the fairings and centaur so that the insulation panels (which are jettisoned a couple seconds before the fairings) were included in the mass of the fairings instead of counted as part of the centaur.  What I ended up with was:
LR89 Booster and skirt (including residuals): 3.266t
LR105 Sustainer, LR101 Verniers, 8 small Separation Motors and the LV-3C tank (including residuals): 3.507t
Atlas Fuel: 112.293t
Centaur tank (including residuals): 2.114t
Fairing (including insulation panels and "ablated ice"): 1.477t
Centaur Fuel (including 91kg HTP): 13.608t
Surveyor probe: 1t
Total lift off mass: 137.266t

However, even with that adjustment, I was still at least 200dV shy of what was needed.

Next thing I noticed is that at the beginning of each of the mission reports, it gives the thrust of the engines being used.  LV-3C Had 330000 pounds (1467.913kN) boosters, 57000 pound (253.548kN) sustainer and 670 pounds (2.98kN) in each vernier.  That got me to notice that the only LR101 engines that are available in the begining have nearly 6kN but there is a LR101-NA-15 config with the correct thrust.  So I changed "techRequired = advRocketry" so that it would be available at the same time as the LR89-NA-5 and LR105-NA-5 engines.  But even with the exact timings for BECO, Fairing jettison and SECO, I still wasn't getting enough dV.
Now, the one thing that the mission reports don't include is the Isp (either s.l. or vac) for the Atlas engines.  There are one or two sources elsewhere that we have drawn that information from up until now (b14643.de, alternatewars.com and astronautix being some) but the thrust and Isp values given have never really matched up from these sources so I asked the question, what if they were wrong?
Since the mission report says the Booster Engine Cut-off occurred at T+2:22 AND the rocket was experiencing approximately 5.7g at BECO, I ran tests.  I used mechjeb ascent guidance so I could accurately rerun the launch multiple times and get basically the same results.  I used the following values:
Orbit Altitude: 16000 (so that Mechjeb wouldn't shut down the engines early)
Force Roll: climb 0 turn 0
Skip Circularization
Turn start altitude: 2km
Turn start velocity: 100m/s
Turn end altitude: 160 (I would reset this to 60 as soon as Apoapsis hit 140km)
Final flight path angle: 0
Turn shape: 35%
Then I made the launch and paused three times: Once at T+2:22, at T+3:33 and when the engines shut off because I'd run out of fuel.  At each pause, I'd note the ships current mass, current g forces and surface speed.  My first test showed that at BECO my craft weighed 34.299t, was experiencing 6.024g and was traveling 2.633km/s.  Since the mission report states that at T+2:22 the actual AC-12 mission was only experiencing approximately 5.7g, I knew I'd used up more fuel than I should have.  After some quick math, I concluded I'd used about 2.4t more fuel than the actual mission.  So I started to tweek the Isp for the LR89-NA-5 engine.  I started off just altering the sea level Isp but in the end I had to modify both to the values you see in my proposed changes.  As soon as I had made that change, my test flight resulting in: 36.627t, 5.6489g & 2.529km/s at BECO which was about as accurate as anyone can hope to recreate an actual flight.  But I was still running out of fuel at least a full second sooner than the T+237.7s in the mission report.  So, after running several more tests, I ended up slightly improving the Isp on the LR105-NA-5 engine as well.  With all these tests, my final attempt resulted in:
BECO  T+2:22  36.586t  5.6457g  2.538km/s
Fairing T+3:22  25.988t  1.4519g  3.068km/s
SECO T+3:57  20.820t  1.85g*  3.575km/s

From there, I was able to finish circulization to a 152km x 163km orbit using the Centaur.  And still had about 3130dV remaining which is just about enough to cover the Hohmann transfer.
*approx since I had to pause a split second before SECO to actually get that reading.

Once the LV-3C was done, I did the same thing for AC-13/Surveyor V using an Atlas SLV-3C.  I set the mass of the different sections as follows:
LR89 Booster and skirt (including residuals): 3.377t
LR105 Sustainer, LR101 Verniers, 8 small Separation Motors and the LV-3C tank (including residuals): 3.533t
Atlas Fuel: 121.815t
Centaur tank (including residuals): 2.210t
Fairing (including insulation panels and "ablated ice"): 1.518t
Centaur Fuel (including 72kg HTP): 13.496t
Surveyor probe: 1t
Total lift off mass: 146.950t

I ran test flights using the exact same ascent guidance as I'd used for the LV-3C flights.  In the end I didn't need to make any Isp changes to the LR89-NA-6 but I did alter it's thrust to match the 336000 pounds (1494.602kN) referenced in the mission report.  I also separated the LR105-NA-6 into it's own config so I could give it the 58000 pound (257.996kN) thrust listed in the report with the same Isp rating as I'd come up with for the LR105-NA-5.  I know 1000 pounds of thrust at sea level is not a huge difference but it allowed my final test flight to match the specifics from the mission report with 3200dV remaining in the Centaur for TLI.

I know in the end I don't have any documentation that clearly states what the Isp of the LR89 and LR105 engines actually should be.  But the values included in this PR allowed me to accurately recreate the AC-12 and AC-13 launches which I could not do using the Isp values we currently have in place.

https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680014866.pdf
https://ia800304.us.archive.org/8/items/nasa_techdoc_19670014531/19670014531.pdf
https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19690000964.pdf
https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
https://ia600308.us.archive.org/14/items/nasa_techdoc_19680012465/19680012465.pdf
https://ia601201.us.archive.org/30/items/NASA_NTRS_Archive_19700011207/NASA_NTRS_Archive_19700011207.pdf
https://ia800305.us.archive.org/18/items/nasa_techdoc_19680025782/19680025782.pdf
https://ia601208.us.archive.org/8/items/NASA_NTRS_Archive_19690008977/NASA_NTRS_Archive_19690008977.pdf

Nearly forgot to mention, I also changed the "techRequired" for the LR89-NA-7.1 so that it lines up with the LR105-NA-7.1.