### PR TITLE
CMES Pod new parts & tweaks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -202,7 +202,6 @@
 
 @PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports 2 crew for 7 days or up to 4 crew for half the time.:
 
     @mass -= 0.11
 
@@ -412,13 +411,13 @@
         PROPELLANT
         {
             name = MMH
-            ratio = 0.499
+            ratio = 0.4990
         }
 
         PROPELLANT
         {
             name = NTO
-            ratio = 0.501
+            ratio = 0.5010
         }
 
         PROPELLANT
@@ -463,7 +462,7 @@
             maxAmount = 12960
         }
 
-        //  AMAE & ACS fuel 2015 Kg.
+        //  AMAE & ACS fuel mass 2015 Kg.
 
         TANK
         {
@@ -472,7 +471,7 @@
             maxAmount = 2290
         }
 
-        //  AMAE & ACS oxidizer 3273 Kg.
+        //  AMAE & ACS oxidizer mass 3273 Kg.
 
         TANK
         {
@@ -481,7 +480,7 @@
             maxAmount = 2300
         }
 
-        //  AMAE & ACS Helium 9 Kg.
+        //  AMAE & ACS Helium pressurization gas mass 9 Kg.
 
         TANK
         {
@@ -521,10 +520,10 @@
     @MODULE[ModuleGimbal]
     {
         !gimbalRange = NULL
-        %gimbalRangeXP = 6
-        %gimbalRangeXN = 6
-        %gimbalRangeYP = 7
-        %gimbalRangeYN = 7
+        %gimbalRangeXP = 6.0
+        %gimbalRangeXN = 6.0
+        %gimbalRangeYP = 7.0
+        %gimbalRangeYN = 7.0
     }
 }
 
@@ -1114,7 +1113,7 @@
 
 @PART[XcupolaX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 1 for a single day. Air filtering unit included:
+    @description ^= :$: Supports 1 crew for a single day. Includes an air filtering unit.:
 
     @mass -= 0.005
 
@@ -1900,6 +1899,8 @@
 
     !MODULE[ModuleDecouple],*{}
 
+    !MODULE[ModuleRCS*],*{}
+
     MODULE
     {
         name = ModuleRCS
@@ -1928,7 +1929,7 @@
         type = HTPB
         basemass = -1
 
-        //  HTPB/AP propellant mixture ~1900 Kg.
+        //  HTPB/AP propellant mixture mass ~1900 Kg.
 
         TANK
         {
@@ -1974,7 +1975,7 @@
 
     !RESOURCE,*{}
 
-    //  ACM propellant 150 Kg.
+    //  ACM propellant mass ~150 Kg.
 
     RESOURCE
     {
@@ -2142,6 +2143,8 @@
 
     //  Two MR - 104G thrusters for each control axis (one main and one for backup).
 
+    !MODULE[ModuleRCS*],*{}
+
     MODULE
     {
         name = ModuleRCS
@@ -2209,7 +2212,7 @@
             maxAmount = 12960
         }
 
-        //  ACS fuel 170 Kg.
+        //  ACS propellant 170 Kg.
 
         TANK
         {
@@ -2218,7 +2221,7 @@
             maxAmount = 170
         }
 
-        // ACS Helium 0.3 Kg.
+        // ACS Helium pressurization gas mass 0.3 Kg.
 
         TANK
         {
@@ -2229,6 +2232,8 @@
     }
 
     !RESOURCE,*{}
+
+    //  AVCOAT material mass 1500 Kg.
 
     RESOURCE
     {
@@ -2382,6 +2387,8 @@
 
     !MODULE[ModuleAeroReentry],*{}
 
+    !MODULE[ModuleRCS*],*{}
+
     //  Two MR - 104G thrusters for each control axis (one main and one for backup).
 
     MODULE
@@ -2451,7 +2458,7 @@
             maxAmount = 12960
         }
 
-        //  ACS fuel 170 kg.
+        //  ACS propellant mass 170 kg.
 
         TANK
         {
@@ -2460,7 +2467,7 @@
             maxAmount = 170
         }
 
-        //  ACS Helium 0.3 Kg.
+        //  ACS Helium pressurization gas mass 0.3 Kg.
 
         TANK
         {
@@ -2480,6 +2487,8 @@
     }
 
     !RESOURCE,*{}
+
+    //  AVCOAT material mass 1500 Kg.
 
     RESOURCE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -407,7 +407,7 @@
         }
     }
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.445
         !resourceName = NULL
@@ -737,7 +737,7 @@
     %useRcsMass = True
     %useRcsCostMult = 0.25
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.069
         !resourceName = NULL
@@ -798,7 +798,7 @@
     %useRcsMass = True
     %useRcsCostMult = 0.25
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.138
         !resourceName = NULL
@@ -857,7 +857,7 @@
     %useRcsMass = True
     %useRcsCostMult = 0.25
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.55
         !resourceName = NULL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -10,6 +10,7 @@
 //  Aerojet Rocketdyne MR thruster series:                 http://www.asi.org/adb/04/03/09/01/rocket-research.html
 //  ECLSS (Altair, Apollo, Orion, Lunar Outpost):          http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090029327.pdf
 //  The Orion MPCV European Service Module:                http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140010527.pdf
+//  Constellation Program L-Ion cell storage:              https://batteryworkshop.msfc.nasa.gov/presentations/06_Adv%20Li-ion%20Cells%20Constellation_CReid.pdf
 
 //  ==================================================
 //  Removed extra parts.
@@ -73,8 +74,8 @@
 
     @mass = 2.0
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @breakingForce = 250
     @breakingTorque = 250
     @vesselType = Ship
@@ -84,10 +85,10 @@
 
     @MODULE[ModuleCommand]
     {
-        %RESOURCE
+        RESOURCE
         {
-            %name = ElectricCharge
-            %rate = 0.5
+            name = ElectricCharge
+            rate = 0.5
         }
     }
 
@@ -271,10 +272,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -344,8 +341,8 @@
     %crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
@@ -367,7 +364,7 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.15
+            rate = 1.7
         }
     }
 
@@ -657,10 +654,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -728,8 +721,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @fuelCrossFeed = True
     %bulkheadProfiles = srf
 
@@ -789,8 +782,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @fuelCrossFeed = True
     %bulkheadProfiles = srf
 
@@ -848,8 +841,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @fuelCrossFeed = True
     %bulkheadProfiles = srf
 
@@ -909,8 +902,8 @@
 
     @mass = 0.25
     @crashTolerance = 10
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @breakingForce = 250
     @breakingTorque = 250
     @bulkheadProfiles = size2
@@ -1062,8 +1055,8 @@
 
     @mass = 3.2
     @crashTolerance = 8
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @vesselType = Station
     @bulkheadProfiles = size3
 
@@ -1086,6 +1079,8 @@
         type = ServiceModule
         volume = 25
         basemass = -1
+
+        //  Batteries 6 kWh.
 
         TANK
         {
@@ -1161,10 +1156,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1233,8 +1224,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     %fuelCrossFeed = False
 }
 
@@ -1330,8 +1321,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     !stagingIcon = NULL
     %bulkheadProfiles = srf
 
@@ -1403,8 +1394,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = True
     !stagingIcon = NULL
     @bulkheadProfiles = size2, srf
@@ -1476,8 +1467,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = PARACHUTES
@@ -1685,13 +1676,13 @@
     @breakingTorque = 250
     @maxTemp = 773.15
     %skinMaxTemp = 873.15
-    @fuelCrossFeed = False
+    @fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     %emissiveConstant = 0.7
     @bulkheadProfiles = size2
 
-    !MODULE,*{}
+    !MODULE[MechJebCore],*{}
 
     MODULE
     {
@@ -1874,7 +1865,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.5
@@ -2624,10 +2615,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -790,6 +790,286 @@
 }
 
 //  ==================================================
+//  Orion parachute pack.
+
+//  Dimensions: 2.175 m x 0.5 m
+//  Gross Mass: 250 Kg
+//  ==================================================
+
+@PART[xcstparachutex]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/cstParachute/model
+        scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.21, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = Orion Parachute Pack
+    @manufacturer = Lockheed Martin
+    %description = The main parachute pack for the Orion command module.
+
+    @mass = 0.25
+    @crashTolerance = 10
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @breakingForce = 250
+    @breakingTorque = 250
+    @bulkheadProfiles = size2
+    @stageOffset = 1
+    @childStageOffset = 1
+    @stagingIcon = PARACHUTES
+
+    @MODULE[ModuleParachute]
+    {
+        @semiDeployedDrag = 25
+        @fullyDeployedDrag = 500
+        @minAirPressureToOpen = 0.04
+        @clampMinAirPressure = 0.04
+        @deployAltitude = 1000
+        @deploymentSpeed = 0.12
+        @semiDeploymentSpeed = 0.5
+        @chuteMaxTemp = 400
+    }
+
+    %MODULE
+    {
+        %name = ModuleDragModifier
+        %dragCubeName = SEMIDEPLOYED
+        %dragModifier = 15
+    }
+
+    @MODULE[ModuleDragModifier]
+    {
+        @dragModifier = 150
+    }
+}
+
+//  ==================================================
+//  Orion parachute pack.
+
+//  RealChute compatibility.
+//  ==================================================
+
+@PART[xcstparachutex]:FOR[RealismOverhaul]:NEEDS[RealChute]
+{
+    !sound_parachute_open = NULL
+
+    @category = none
+
+    !MODULE[ModuleParachute],*{}
+
+    !MODULE[RealChute*],*{}
+
+    MODULE
+    {
+        name = RealChuteModule
+        caseMass = 0.175
+        timer = 0
+        mustGoDown = True
+        spareChutes = 0
+        cutSpeed = 0.5
+        secondaryChute = False
+
+        PARACHUTE
+        {
+            material = Nylon
+            preDeployedDiameter = 3.5
+            deployedDiameter = 41.0
+            minIsPressure = False
+            minDeployment = 3500
+            deploymentAlt = 1250
+            cutAlt = 0
+            preDeploymentSpeed = 2
+            deploymentSpeed = 6
+            preDeploymentAnimation = semiDeploy
+            deploymentAnimation = fullyDeploy
+            parachuteName = canopy
+            capName = cap
+        }
+    }
+
+    EFFECTS
+    {
+        rcpredeploy
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_parachute_open
+                volume = 1
+            }
+        }
+
+        rcdeploy
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_parachute_single
+                volume = 1
+            }
+        }
+
+        rccut
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealChute/Sounds/sound_parachute_cut
+                volume = 1
+            }
+        }
+
+        rcrepack
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealChute/Sounds/sound_parachute_repack
+                volume = 1
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  Expanded Observation Module.
+
+//  Dimensions: 4.25 m x 2.5 m
+//  Gross Mass: 3200 Kg
+//  ==================================================
+
+@PART[XcupolaX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.7, 1.7, 1.7
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.428, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.68, 0.0, 0.0, -1.0, 0.0, 3
+
+    @title = Expanded Observation Module
+    @manufacturer = Thales Alenia Space
+    @description = A larger version of the observation cupola module originally deployed on the ISS.
+
+    @mass = 3.2
+    @crashTolerance = 8
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @vesselType = Station
+    @bulkheadProfiles = size3
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+
+        %RESOURCE
+        {
+            %name = ElectricCharge
+            %rate = 0.375
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 25
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 21600
+            maxAmount = 21600
+        }
+    }
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleScienceContainer],*{}
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = top
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Expanded Observation Module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[XcupolaX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a crew of 1 for a single day. Air filtering unit included:
+
+    @mass -= 0.005
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 55
+
+        TANK
+        {
+            name = Oxygen
+            amount = 592
+            maxAmount = 592
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 256
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 2.25
+            maxAmount = 2.25
+        }
+    }
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        conversionRate = 1.0
+        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
+        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+    }
+}
+
+//  ==================================================
 //  Pegasus IA low profile ladder.
 
 //  Dimensions: 0.4 m x 0.4 m
@@ -945,6 +1225,281 @@
         name = ModuleConnectedLivingSpace
         passable = True
         passableWhenSurfaceAttached = True
+    }
+}
+
+//  ==================================================
+//  NASA Docking & Berthing Mechanism (NDS).
+
+//  Dimensions: 1.725 m x 0.5 m
+//  Inert Mass: 200 Kg
+//  ==================================================
+
+@PART[xndsport1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 0.69, 0.69, 0.69
+    }
+
+    @scale = 1.0
+    !rescaleFactor,* = NULL
+    %rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.232, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.145, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+    @title = NASA Docking System
+    @manufacturer = Boeing Co.
+
+    @mass = 0.2
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
+    !stagingIcon = NULL
+    @bulkheadProfiles = size2, srf
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleCommand],*{}
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NASADock
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+        @stagingEnabled = False
+    }
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        passableWhenSurfaceAttached = True
+    }
+}
+
+//  ==================================================
+//  RSRM parachute pack.
+
+//  Dimensions: 2.5 m x 1.3 m
+//  Gross Mass: 1530 Kg
+//  ==================================================
+
+@PART[xparachuteRadialx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/Orion Parachute/model
+        scale = 2.0, 2.0, 2.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -0.1, 0.0, 0.0, -1.0, 0.0, 2
+    !node_attach = NULL
+
+    @attachRules = 1,0,1,0,0
+
+    @title = RSRM Recovery Parachute Pack
+    %manufacturer = Generic
+    %description = A parachute pack for the Reusable Solid Rocket Motors (RSRM).
+
+    @mass = 1.5
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = PARACHUTES
+    @bulkheadProfiles = size2
+
+    @MODULE[ModuleParachute]
+    {
+        @stowedDrag = 0.25
+        @semiDeployedDrag = 1
+        @fullyDeployedDrag = 500
+        @minAirPressureToOpen = 0.5
+        @clampMinAirPressure = 0.5
+        @deployAltitude = 1000
+        @deploymentSpeed = 0.05
+        @semiDeploymentSpeed = 0.5
+        %chuteMaxTemp = 400
+    }
+
+    !MODULE[ModuleTestSubject],*{}
+
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[SEMIDEPLOYED]]
+    {
+        @dragModifier = 5
+    }
+
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[DEPLOYED]]
+    {
+        @dragModifier = 50
+    }
+}
+
+//  ==================================================
+//  RSRM parachute pack.
+
+//  RealChute compatibility.
+//  ==================================================
+
+@PART[xparachuteRadialx]:FOR[RealismOverhaul]:NEEDS[RealChute]
+{
+    !sound_parachute_open = NULL
+
+    @category = none
+
+    !MODULE[ModuleParachute],*{}
+
+    !MODULE[RealChute*],*{}
+
+    MODULE
+    {
+        name = RealChuteModule
+        caseMass = 1.37
+        cutSpeed = 0.5
+        timer = 0
+        mustGoDown = True
+        deployOnGround = False
+        spareChutes = 0
+
+        PARACHUTE
+        {
+            material = Nylon
+            preDeployedDiameter = 8.0
+            deployedDiameter = 60.0
+            minIsPressure = False
+            minDeployment = 5000
+            deploymentAlt = 1500
+            cutAlt = 0
+            preDeploymentSpeed = 2
+            deploymentSpeed = 6
+            preDeploymentAnimation = semiDeployLarge
+            deploymentAnimation = fullyDeployLarge
+            parachuteName = canopy
+            capName = cap
+        }
+    }
+
+    EFFECTS
+    {
+        rcpredeploy
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_parachute_open
+                volume = 1
+            }
+        }
+
+        rcdeploy
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_parachute_single
+                volume = 1
+            }
+        }
+
+        rccut
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealChute/Sounds/sound_parachute_cut
+                volume = 1
+            }
+        }
+
+        rcrepack
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = RealChute/Sounds/sound_parachute_repack
+                volume = 1
+            }
+        }
+    }
+}
+
+//  ==================================================
+//  Orion EFT & MPCV forward heat shield.
+
+//  Dimensions: 2.9 m x 1 m
+//  Inert Mass: 400 Kg
+//  ==================================================
+
+@PART[OrionDockingPort3a49capXx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.573, 1.25, 1.573
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.475, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, 0.089, 0.0, 0.0, -1.0, 0.0, 2
+
+    @category = Structural
+    @title = Orion Forward Heat Shield
+    %manufacturer = Lockheed Martin
+    @description = The forward heat shield and docking adapter base for the Orion EFT and MPCV command modules.
+
+    @mass = 0.4
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 773.15
+    %skinMaxTemp = 873.15
+    @fuelCrossFeed = True
+    @bulkheadProfiles = size2
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -2121,10 +2121,10 @@
 
     @MODULE[ModuleCommand]
     {
-        %RESOURCE
+        RESOURCE
         {
-            %name = ElectricCharge
-            %rate = 0.85
+            name = ElectricCharge
+            rate = 0.85
         }
     }
 
@@ -2360,10 +2360,10 @@
 
     @MODULE[ModuleCommand]
     {
-        %RESOURCE
+        RESOURCE
         {
-            %name = ElectricCharge
-            %rate = 1.35
+            name = ElectricCharge
+            rate = 1.35
         }
     }
 
@@ -2495,22 +2495,6 @@
         name = Ablator
         amount = 1500
         maxAmount = 1500
-    }
-}
-
-//  ==================================================
-//  Orion Crew Module (EFT & MPCV).
-
-//  Deadly Reentry compatibility.
-//  ==================================================
-
-@PART[XOrionPodXbb31|XOrionPodX]:FOR[RealismOverhaul]:NEEDS[DeadlyReentry]
-{
-    %MODULE
-    {
-        %name = ModuleAeroReentry
-        %skinMaxTemp = 3773.15
-        %skinThicknessFactor = 0.05
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -202,6 +202,7 @@
 
 @PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
+    @description ^= :$: Supports a crew of 2 for 7 days. Maximum capacity of up to 4 crew.:
 
     @mass -= 0.11
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -66,6 +66,7 @@
     @node_stack_top = 0.0, 1.62, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -1.14, 0.0, 0.0, -1.0, 0.0, 3
 
+    @category = Pods
     @title = MMSEV Crew Cabin
     @manufacturer = NASA
     @description = The MMSEV (Multi - Mission Space Exploration Vehicle) is a pressurized cabin exploration vehicle for either space or surface application. Features an airlock and a travel endurance for up to 10 kilometers.
@@ -258,13 +259,54 @@
         }
     }
 
+    !MODULE[TacGenericConverter],*{}
+
     MODULE
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber
+        StartActionName = Start CO2 Scrubber
+        StopActionName = Stop CO2 Scrubber
         conversionRate = 2.0
-        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+        tag = Life Support
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+        SpecialistEfficiencyFactor = 0.2
+        SpecialistBonusBase = 0.05
+        ExperienceEffect = ConverterSkill
+        EfficiencyBonus = 1.0
+
+        INPUT_RESOURCE
+        {
+            ResourceName = CarbonDioxide
+            Ratio = 0.006216
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.01
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LithiumHydroxide
+            Ratio = 0.0000085683
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0032924498
+            DumpExcess = True
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Waste
+            Ratio = 0.0000257297
+            DumpExcess = False
+        }
     }
 }
 
@@ -295,6 +337,8 @@
 
     @node_stack_top = 0.0, 2.22, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -3.8, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Pods
 
     @mass = 5.1
     %crashTolerance = 8
@@ -601,13 +645,54 @@
         }
     }
 
+    !MODULE[TacGenericConverter],*{}
+
     MODULE
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber
+        StartActionName = Start CO2 Scrubber
+        StopActionName = Stop CO2 Scrubber
         conversionRate = 4.0
-        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+        tag = Life Support
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+        SpecialistEfficiencyFactor = 0.2
+        SpecialistBonusBase = 0.05
+        ExperienceEffect = ConverterSkill
+        EfficiencyBonus = 1.0
+
+        INPUT_RESOURCE
+        {
+            ResourceName = CarbonDioxide
+            Ratio = 0.006216
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.01
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LithiumHydroxide
+            Ratio = 0.0000085683
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0032924498
+            DumpExcess = True
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Waste
+            Ratio = 0.0000257297
+            DumpExcess = False
+        }
     }
 }
 
@@ -634,6 +719,7 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
+    @category = Control
     @title = R1 - A Attitude Jet (69/111N class)
     @manufacturer = Generic
     @description = A generic, single port, RCS thruster for attitude control.
@@ -694,6 +780,7 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
+    @category = Control
     @title = R1 - B Attitude Jet (138/233N class)
     @manufacturer = Generic
     @description = A generic, single port, RCS thruster for attitude control.
@@ -752,6 +839,7 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
+    @category = Control
     @title = R1 - C Attitude Jet (550/890N class)
     @manufacturer = Generic
     @description = A generic, single port, RCS thruster for attitude control.
@@ -814,6 +902,7 @@
     @node_stack_bottom = 0.0, -0.21, 0.0, 0.0, -1.0, 0.0, 2
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
+    @category = Utility
     @title = Orion Parachute Pack
     @manufacturer = Lockheed Martin
     %description = The main parachute pack for the Orion command module.
@@ -966,6 +1055,7 @@
     @node_stack_top = 0.0, 1.428, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -0.68, 0.0, 0.0, -1.0, 0.0, 3
 
+    @category = Pods
     @title = Expanded Observation Module
     @manufacturer = Thales Alenia Space
     @description = A larger version of the observation cupola module originally deployed on the ISS.
@@ -1059,13 +1149,54 @@
         }
     }
 
+    !MODULE[TacGenericConverter],*{}
+
     MODULE
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber
+        StartActionName = Start CO2 Scrubber
+        StopActionName = Stop CO2 Scrubber
         conversionRate = 1.0
-        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+        tag = Life Support
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+        SpecialistEfficiencyFactor = 0.2
+        SpecialistBonusBase = 0.05
+        ExperienceEffect = ConverterSkill
+        EfficiencyBonus = 1.0
+
+        INPUT_RESOURCE
+        {
+            ResourceName = CarbonDioxide
+            Ratio = 0.006216
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.01
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LithiumHydroxide
+            Ratio = 0.0000085683
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0032924498
+            DumpExcess = True
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Waste
+            Ratio = 0.0000257297
+            DumpExcess = False
+        }
     }
 }
 
@@ -1093,6 +1224,7 @@
 
     @node_attach = -0.06, 0.0, 0.0, 1.0, 0.0, 0.0
 
+    @category = Utility
     @title = Pegasus IA Mobility Enhancer (Low Profile)
     @manufacturer = Generic
     %description = The Pegasus IA Mobility Enhancer, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
@@ -1137,6 +1269,7 @@
     !node_stack_5 = NULL
     !node_stack_6 = NULL
 
+    @category = Structural
     @title = Mobile Base Chassis
     @manufacturer = NASA
     @description = A modular structural frame. Can be used as a chassis for the MMSEV rover or for mobile surface habitats.
@@ -1145,14 +1278,21 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
     %bulkheadProfiles = size2, size3
+    !vesselType = NULL
     !CoMOffset = NULL
     !CoLOffset = NULL
 
-    !MODULE,*{}
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleGenerator],*{}
 
     !RESOURCE,*{}
 }
@@ -1181,6 +1321,7 @@
 
     @node_attach = 0.0, -0.2, 0.0, -1.0, 0.0, 0.0
 
+    @category = Coupling
     @title = Surface Docking Mechanism (SDM)
     %manufacturer = Boeing Co.
     @description = The SDM provides a safe pressurized passage for crew and cargo between surface - landed modules or exploration rovers.
@@ -1254,6 +1395,7 @@
     @node_stack_bottom = 0.0, -0.145, 0.0, 0.0, -1.0, 0.0, 2
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
+    @category = Coupling
     @title = NASA Docking System
     @manufacturer = Boeing Co.
 
@@ -1325,6 +1467,7 @@
 
     @attachRules = 1,0,1,0,0
 
+    @category = Utility
     @title = RSRM Recovery Parachute Pack
     %manufacturer = Generic
     %description = A parachute pack for the Reusable Solid Rocket Motors (RSRM).
@@ -1531,6 +1674,7 @@
 
     %sound_decoupler_fire = decouple
 
+    @category = Coupling
     @title = Orion EFT LAS Decoupler
     %manufacturer = Lockheed Martin
     @description = The Launch Abort System (LAS) explosive bolt decoupler of the Orion EFT Crew Module.
@@ -1583,6 +1727,7 @@
     @node_stack_top = 0.0, 0.625, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, -0.185, 0.0, 0.0, -1.0, 0.0, 2
 
+    @category = Coupling
     @title = Orion MPCV Docking System
     %manufacturer = Lockheed Martin
     @description = The NASA docking system for the Orion MPCV Crew Module.
@@ -1728,8 +1873,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.5
@@ -1745,6 +1890,7 @@
         @minThrust = 1760
         @maxThrust = 1760
         @heatProduction = 100
+        %EngineType = SolidBooster
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -1870,6 +2016,7 @@
 @PART[XOrionPodXbb31]:FOR[RealismOverhaul]
 {
     @module = Part
+
     %RSSROConfig = True
 
     !mesh = NULL
@@ -1947,6 +2094,7 @@
     %node_stack_1 = 0.0, 1.045, 0.0, 0.0, 1.0, 0.0, 2
     !node_stack_2 = NULL
 
+    @category = Pods
     @title = Orion EFT Crew Module
     @manufacturer = Lockheed Martin
     @description = The Exploration Flight Test (EFT) article for the Orion MPCV.
@@ -2188,6 +2336,7 @@
     @node_stack_1 = 0.0, 1.045, 0.0, 0.0, 1.0, 0.0, 2
     !node_stack_2 = NULL
 
+    @category = Pods
     @title = Orion MPCV Crew Module
     @manufacturer = Lockheed Martin
     @description = The next generation NASA spacecraft for beyond LEO (BEO) exploration.
@@ -2479,13 +2628,54 @@
         }
     }
 
+    !MODULE[TacGenericConverter],*{}
+
     MODULE
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber
+        StartActionName = Start CO2 Scrubber
+        StopActionName = Stop CO2 Scrubber
         conversionRate = 6.0
-        inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-        outputResources = Water, 0.0032924498, True, Waste, 0.0000257297, False
+        tag = Life Support
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+        SpecialistEfficiencyFactor = 0.2
+        SpecialistBonusBase = 0.05
+        ExperienceEffect = ConverterSkill
+        EfficiencyBonus = 1.0
+
+        INPUT_RESOURCE
+        {
+            ResourceName = CarbonDioxide
+            Ratio = 0.006216
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.01
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LithiumHydroxide
+            Ratio = 0.0000085683
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0032924498
+            DumpExcess = True
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Waste
+            Ratio = 0.0000257297
+            DumpExcess = False
+        }
     }
 }
 
@@ -2514,6 +2704,7 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
+    @category = Utility
     @title = Dragon Mobility Enhancer
     @manufacturer = SpaceX
     %description = A low profile mobility enhancement system.
@@ -2522,8 +2713,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf
 }


### PR DESCRIPTION
Updates for the CMES Pod parts.

Changelog:

* Update the RCS module patching to be compatible with the new "ModuleRCSFX" module.
* Add RO configs for the following missing parts:
    * Orion main parachute pack
    * Observation cupola
    * NASA docking mechanism
    * RSRM parachute pack
    * Orion forward heat shield

[Alternate diff ignoring whitespace changes](https://github.com/KSP-RO/RealismOverhaul/pull/1453/files?w=1)