### PR TITLE
Sensible config prices for the H-1 family

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -56,7 +56,6 @@
 
 			techRequired = advRocketry // Saturn I Block I/II engine
 			entryCost = 33750 // there's actually a source for this one!
-			cost = 700
 
 			entryCostSubtractors
 			{
@@ -112,7 +111,7 @@
 
 			techRequired = heavyRocketry
 			entryCost = 39750
-			cost = 1000
+			cost = 300
 
 			entryCostSubtractors
 			{
@@ -166,7 +165,7 @@
 			massMult = 1.0395
 
 			techRequired = heavierRocketry
-			cost = 800
+			cost = 50
 			entryCost = 40750
 
 			entryCostSubtractors
@@ -223,7 +222,7 @@
 			massMult = 1.10425
 
 			techRequired = veryHeavyRocketry
-			cost = 850
+			cost = 75
 			entryCost = 41750
 
 			entryCostSubtractors


### PR DESCRIPTION
Based on a part cost of 750, making the costs be:
H-1     750
H-1B   1050
RS-27   800
RS-27A  825
I have no source for these prices, but they're hopefully better balanced
than the old ones.