### PR TITLE
CMES Structural updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -13,46 +13,83 @@
 //  NTRS - Energy Storage Workshop:                       https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110009972.pdf
 //  NTRS - Constellation Program Li-Ion cell storage:     https://batteryworkshop.msfc.nasa.gov/presentations/06_Adv%20Li-ion%20Cells%20Constellation_CReid.pdf
 
-
 //  ==================================================
 //  Removed extra parts.
 //  ==================================================
 
-    !PART[xradialDecoupler]:FOR[RealismOverhaul]{}
+!PART[XAltair2descent2stageDUNAX]:FOR[RealismOverhaul]{}
 
-    !PART[XlpAltairDockingPortX]:FOR[RealismOverhaul]{}
+!PART[XAltair2descent2stageDUNA9X]:FOR[RealismOverhaul]{}
 
-    !PART[XlpAltairDockingPort442X]:FOR[RealismOverhaul]{}
+!PART[nosMonkeyExplorerUtilityALTAIR]:FOR[RealismOverhaul]{}
 
-    !PART[XlpAltairDockingPortdX]:FOR[RealismOverhaul]{}
+!PART[nosMonkeyExplorerUtil19843548491ityALTAIRXXX]:FOR[RealismOverhaul]{}
 
-    !PART[XAltairDock444ingPortX]:FOR[RealismOverhaul]{}
+!PART[nosMonkeyExplorerUtilityALTAIRXXX]:FOR[RealismOverhaul]{}
 
-    !PART[nosMonkeyExplorerUtilityALTAIR]:FOR[RealismOverhaul]{}
+!PART[XwheelMed2X]:FOR[RealismOverhaul]{}
 
-    !PART[XIACBM1ee25m]:FOR[RealismOverhaul]{}
+!PART[XwheelMed3X]:FOR[RealismOverhaul]{}
 
-    !PART[XKosmos_Strut_Connector2X]:FOR[RealismOverhaul]{}
+!PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
 
-    !PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
+!PART[xKosmos_Balka_1_Tunnel1222x]:FOR[RealismOverhaul]{}
 
-    !PART[XTALUSXX3]:FOR[RealismOverhaul]{}
+!PART[xKosmos_Balka_1_Tunnel12SSAx]:FOR[RealismOverhaul]{}
 
-    !PART[XXB3IUShroudXLOWERRXV]:FOR[RealismOverhaul]{}
+!PART[XKosmos_Strut_Connector2X]:FOR[RealismOverhaul]{}
 
-    !PART[XKW5mDecouplerShroudX2242ab]FOR[RealismOverhaul]{}
+!PART[XTALUSXX3]:FOR[RealismOverhaul]{}
 
-    !PART[CHAKAradialDecouplerXX]:FOR[RealismOverhaul]{}
+!PART[X84NEWTALUSXX2cx]:FOR[RealismOverhaul]{}
 
-    !PART[chakaradialDecoupler1-2XXX]:FOR[RealismOverhaul]{}
+!PART[XTALUSXXXLS2A3]:FOR[RealismOverhaul]{}
 
-    !PART[XSDHI_2.5_ServiceModuleFairing211]:FOR[RealismOverhaul]{}
+!PART[XXB3IUShroudXLOWERRXV]:FOR[RealismOverhaul]{}
 
-    !PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]{}
+!PART[PAYLOADADAPTER22gaOPXB]:FOR[RealismOverhaul]{}
 
-    !PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
+!PART[PAYLOADADAPTER2OPSFFXX]:FOR[RealismOverhaul]{}
 
-    !PART[SLS_CM_FairingAdapterk2fa]:FOR[RealismOverhaul]{}
+!PART[XKW5mDecouplerShroudX2242ab]FOR[RealismOverhaul]{}
+
+!PART[XKW5mDecouplerShroudXMERLIN224]FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack4m]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack8m]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack85M?HS]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack5mXDELTAK2VC3]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack5mXDELTAK2V]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack5mXDELTAK]:FOR[RealismOverhaul]{}
+
+!PART[CHAKAradialDecouplerXX]:FOR[RealismOverhaul]{}
+
+!PART[chakaradialDecoupler1-2XXX]:FOR[RealismOverhaul]{}
+
+!PART[XKWFlatadapter77N]:FOR[RealismOverhaul]{}
+
+!PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]{}
+
+!PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
+
+!PART[SLS_CM_FairingAdapter2xce3]:FOR[RealismOverhaul]{}
+
+!PART[SLS_CM_stackDecouplerx302hjsans]:FOR[RealismOverhaul]{}
+
+!PART[SLS_CM_stackDecouplerx302hjns]:FOR[RealismOverhaul]{}
+
+!PART[Xtrusslrg_argonXsmalldccdCxx]:FOR[RealismOverhaul]{}
+
+!PART[Xtrusslrg_argonXsmalldccd2ggaCxx]:FOR[RealismOverhaul]{}
+
+!PART[Xtrusslrg_argonXsmalldccd2ggaC2HAxx]:FOR[RealismOverhaul]{}
+
+!PART[Xtrusslrg_argonXsmalldccd343gC]:FOR[RealismOverhaul]{}
 
 //  ==================================================
 //  Altair lunar lander Descent Module.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -2101,82 +2101,96 @@
 //  ==================================================
 //  Payload attach fitting (procedural).
 
-//  Modeled after the Delta IV Payload Attach Fitting (PAF).
+//  Modeled after the Delta IV Payload Attach Fittings (PAF).
 
 //  Dimensions: N/A
-//  Gross Mass: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
-    @PART[SLS_CM_FairingAdapter2]:FOR[RealismOverhaul]
+@PART[PAYLOADADAPTER2OPSX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 0.165, 0.060, 0.165
-            %position = 0.000, 0.215, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000, 0.385, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-
-        @category     = Aero
-        @title        = Payload Fairing - Base (PAF) [Procedural]
-        @manufacturer = Generic
-        %description  = Structural base for mounting side fairings and your payload. Decoupler sold separately. Flat raised surface can be used for mounting additional hardware as required.
-
-        @mass             = 0.1000
-        @crashTolerance   = 12
-        %breakingForce    = 250
-        %breakingTorque   = 250
-        @maxTemp          = 1073.15
-        @fuelCrossFeed    = true
-        %stagingIcon      = DECOUPLER_HOR
-        %bulkheadProfiles = size1
-
-        !MODULE[ModuleDecouple]{}
-
-        MODULE
-        {
-            name          = ProceduralFairingBase
-            baseSize      = 1.150
-            sideThickness = 0.050
-            verticalStep  = 0.100
-        }
-
-        MODULE
-        {
-            name              = KzNodeNumberTweaker
-            nodePrefix        = connect
-            maxNumber         = 4
-            numNodes          = 2
-            radius            = 0.625
-            shouldResizeNodes = false
-        }
-
-        MODULE
-        {
-            name                   = KzFairingBaseResizer
-            size                   = 3.000
-            costPerTonne           = 1000
-            specificMass           = 0.006, 0.013, 0.009, 0.000
-            specificBreakingForce  = 500
-            specificBreakingTorque = 500
-            diameterStepLarge      = 1.000
-            diameterStepSmall      = 0.100
-            dragAreaScale          = 1.500
-        }
-
-        MODULE
-        {
-            name = KzFairingBaseShielding
-        }
+        @scale = 0.165, 0.05, 0.165
+        %position = 0.0, 0.185, 0.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.315, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    %node_stack_connect01 = 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+
+    @fx_gasBurst_white = 0.0, 2.78, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Payload
+    @title = Payload Attach Fitting - Base [Procedural]
+    @manufacturer = Boeing Co.
+    %description = A generic payload attach fitting for mounting side fairings and payloads. Flat and raised surface that can be used for mounting additional hardware as required.
+
+    @mass = 0.1
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 453.15
+    !fuelCrossFeed,* = NULL
+    %fuelCrossFeed = True
+    !explosionPotential = NULL
+    %stagingIcon = DECOUPLER_HOR
+    @bulkheadProfiles = size0, size1
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+
+    MODULE
+    {
+        name = ProceduralFairingBase
+        baseSize = 1.8
+        sideThickness = 0.1
+        verticalStep = 0.1
+    }
+
+    MODULE
+    {
+        name = KzNodeNumberTweaker
+        nodePrefix = connect
+        maxNumber = 4
+        numNodes = 2
+        radius = 0.9
+        shouldResizeNodes = False
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseResizer
+        size = 2.0
+        diameterStepLarge = 1.0
+        diameterStepSmall = 0.1
+        costPerTonne = 1000
+        specificMass = 0.006, 0.013, 0.009, 0.0
+        specificBreakingForce = 250
+        specificBreakingTorque = 250
+        diameterStepLarge = 1.0
+        diameterStepSmall = 0.1
+        dragAreaScale = 1.5
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseShielding
+    }
+}
 
 @PART[SLS_CM_stackDecouplerx]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1465,47 +1465,52 @@
 }
 
 //  ==================================================
-//  Orion Service Module fairing.
+//  Orion MPCV service module fairing.
 
-//  Dimensions: 2.500 x 4.000 m
-//  Gross Mass: 330.00 Kg
+//  Dimensions: 2.5 m x 4 m
+//  Inert Mass: 690 Kg
 //  ==================================================
 
-    @PART[XSDHI_2.5_ServiceModuleFairing]:FOR[RealismOverhaul]
+@PART[XSDHI_2.5_ServiceModuleFairing211]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Structural/SDHI-CHAKA-FAIRING/model
-            scale    = 2.472, 2.675, 2.472
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_bottom = -0.350, 0.450, 0.000, 0.000, -1.000, 0.000, 2
-
-        @title        = Orion SM Fairing
-        @manufacturer = NASA
-        @description  = Fairing for the Orion service module.
-
-        @mass             = 0.3300
-        @crashTolerance   = 12
-        %breakingForce    = 250
-        %breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = false
-        %bulkheadProfiles = size2
-
-        @MODULE[ModuleAnchoredDecoupler]
-        {
-            @ejectionForce = 120.000
-        }
+        @scale = 2.605, 3.0, 2.605
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 2
+
+    %fx_gasBurst_white = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Payload
+    @title = Orion Service Module Fairing
+    @manufacturer = Lockheed Martin
+    %description = A protective fairing for the Orion service module.
+
+    @mass = 0.69
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+
+    @MODULE[ModuleAnimatedAnchoredDecoupler]
+    {
+        @ejectionForce = 250
+    }
+
+    @MODULE[ModuleCargoBay]
+    {
+        @lookupRadius = 2.625
+        @lookupCenter = 2.625, 0.0, 0.0
+    }
+}
 
 @PART[XXSDHI_2.5_ServiceModuleAdapter]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -479,43 +479,43 @@
 //  ==================================================
 //  MSEV rover wheel.
 
-//  Dimensions: 1.600 x 1.500 m
-//  Gross Mass: 200.00 Kg
+//  Dimensions: 1.6 m x 1.5 m
+//  Inert Mass: 200 Kg
 //  ==================================================
 
-    @PART[XwheelMedX]:FOR[RealismOverhaul]
+@PART[XwheelMedX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = True
-
-        MODEL
-        {
-            model    = CMES/Structural/CHAKA WHEEL/model
-            scale    = 1.333, 1.333, 1.333
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
-
-        @title        = MSEV Rover Wheel
-        @manufacturer = NASA
-        @description  = Rover wheel for the NASA surface exploration vehicles.
-
-        @mass             = 0.200
-        %fuelCrossFeed    = false
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleWheel]
-        {
-            @impactTolerance         = 300
-            @overSpeedDamage         = 60
-            @resourceConsumptionRate = 0.001
-        }
+        model = CMES/Structural/CHAKA-WHEEL/model
+        scale = 1.333, 1.333, 1.333
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @category = Ground
+    @title = MSEV Rover Wheel
+    @manufacturer = Boeing Co.
+    @description = Rover wheel for the surface exploration vehicles and mobile habitation modules.
+
+    @mass = 0.2
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = size2
+
+    //@MODULE[ModuleWheel]
+    //{
+    //    @impactTolerance = 30
+    //    @overSpeedDamage = 60
+    //    @resourceConsumptionRate = 0.001
+    //}
+}
 
 //  ==================================================
 //  Altair II lander Descent Module.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -2270,28 +2270,43 @@
 //  Strut connector (high strength).
 
 //  Dimensions: N/A
-//  Gross Mass: 56.00 Kg
+//  Inert Mass: 30 Kg
 //  ==================================================
 
-    @PART[SUPERSTRUTCONNECTOR]:FOR[RealismOverhaul]
+@PART[SUPERSTRUTCONNECTOR]:FOR[RealismOverhaul]
+{
+    @module = CompoundPart
+
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = EAS-16 Strut Connector
+    @manufacturer = Generic
+    @description = A high strength structural connector.
+
+    @mass = 0.03
+    @dragModelType = SPHERICAL
+    @minimumDrag = 0.02
+    @maximumDrag = 0.02
+    @crashTolerance 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @maxLength = 50
+    %bulkheadProfiles = srf
+
+    @MODULE[CModuleStrut]
     {
-        %RSSROConfig = True
-
-        @title        = EAS-16 Strut Connector
-        @manufacturer = Generic
-        @description  = A high strength structural connector.
-
-        @mass           = 0.0560
-        @breakingForce  = 250
-        @breakingTorque = 250
-        @maxLength      = 25
-
-        @MODULE[CModuleStrut]
-        {
-            @linearStrength  = 600
-            @angularStrength = 600
-        }
+        @linearStrength = 600
+        @angularStrength = 600
     }
+
+    %DRAG_CUBE
+    {
+        %none = True
+    }
+}
 
 @PART[Xtrusslrg_argonXsmall]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1421,47 +1421,48 @@
 }
 
 //  ==================================================
-//  Ares V & SLS Block I/IB/II RSRM decoupler.
+//  TT-70L radial decoupler.
 
-//  Dimensions: 0.900 x 3.500 m
-//  Gross Mass: 325.00 Kg
+//  Dimensions: 0.9 m x 3.5 m
+//  Inert Mass: 325 Kg
 //  ==================================================
 
-    @PART[chakaradialDecoupler1-2]:FOR[RealismOverhaul]
+@PART[chakaradialDecoupler1-2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Structural/radialDecoupler1-2/model
-            scale    = 1.000, 2.000, 1.000
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
-
-        @title        = TT-70L Radial Decoupler
-        @manufacturer = Generic
-        @description  = Explosive bolt decoupler for large sized side mounted boosters.
-
-        @mass             = 0.3250
-        @crashTolerance   = 12
-        %breakingForce    = 250
-        %breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = false
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleAnchoredDecoupler]
-        {
-            @ejectionForce = 500.000
-        }
+        model = CMES/Structural/radialDecoupler1-2/model
+        scale = 1.0, 2.0, 1.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = Coupling
+    @title = TT-70L Radial Decoupler
+    @manufacturer = Generic
+    @description = Explosive cord decoupler for side mounted boosters.
+
+    @mass = 0.325
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 500
+    }
+}
 
 //  ==================================================
 //  Orion Service Module fairing.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -518,86 +518,109 @@
 }
 
 //  ==================================================
-//  Altair II lander Descent Module.
+//  Pegasus descent module.
 
-//  Dimensions: 8.300 x 4.200 m
-//  Gross Mass: 35000.00 Kg
-//  Volume: 18000.00 L
+//  Dimensions: 8.3 m x 4.2 m
+//  Gross Mass: 32300 Kg
 //  ==================================================
 
-    @PART[nosMonkeyExplorerUtilityHAB]:FOR[RealismOverhaul]
+@PART[nosMonkeyExplorerUtilityHAB]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Structural/ChakaNOSLander/model
-            scale    = 0.950, 0.950, 0.950
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  1.525, 0.000, 0.000,  1.000, 0.000, 3
-        %node_stack_middle = 0.000, -1.525, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -2.625, 0.000, 0.000, -1.000, 0.000, 3
-
-        @category     = Engine
-        @title        = Altair II Descent Module
-        @manufacturer = Boeing Co. & NASA
-        @description  = The Altair II Descent Module is designed to carry and land very heavy crew or cargo components on planetary surfaces.
-
-        @mass             = 12.000
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = true
-        @bulkheadProfiles = size3
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = ServiceModule
-            volume   = 18000
-            basemass = -1
-
-            TANK
-            {
-                name      = ElectricCharge
-                amount    = 43200
-                maxAmount = 43200
-            }
-
-            TANK
-            {
-                name      = Hydrazine
-                amount    = 200
-                maxAmount = 200
-            }
-
-            TANK
-            {
-                name      = MMH
-                amount    = 8687
-                maxAmount = 8687
-            }
-
-            TANK
-            {
-                name      = NTO
-                amount    = 8549
-                maxAmount = 8549
-            }
-        }
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
+        model = CMES/Structural/ChakaNOSLander/model
+        scale = 0.95, 0.95, 0.95
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.525, 0.0, 0.0, 1.0, 0.0, 5
+    %node_stack_middle = 0.0, -1.525, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -2.625, 0.0, 0.0, -1.0, 0.0, 5
+
+    @category = FuelTank
+    @title = Pegasus Descent Module
+    @manufacturer = Boeing Co.
+    @description = The Pegasus Descent Module is designed to carry heavy crew or cargo components on planetary surfaces. The radial attachment of the engines and the distance from the surface allows for safe propulsive landings.
+
+    @mass = 12.0
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = True
+    @bulkheadProfiles = size3, size5
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 26500
+        basemass = -1
+
+        //  Avionics batteries 20 kWh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 72000
+            maxAmount = 72000
+        }
+
+        //  Pegasus fuel mass 6710 Kg.
+
+        TANK
+        {
+            name = MMH
+            amount = 7625
+            maxAmount = 7625
+        }
+
+        //  Pegasus oxidizer mass 10875 Kg.
+
+        TANK
+        {
+            name = NTO
+            amount = 7515
+            maxAmount = 7515
+        }
+    }
+
+    MODULE:NEEDS[KIS]
+    {
+        name = ModuleKISInventory
+        maxVolume = 28000
+        externalAccess = True
+        internalAccess = True
+        slotsX = 6
+        slotsY = 4
+        slotSize = 50
+        itemIconResolution = 128
+        selfIconResolution = 128
+        openSndPath = KIS/Sounds/containerOpen
+        closeSndPath = KIS/Sounds/containerClose
+        defaultMoveSndPath = KIS/Sounds/itemMove
+        helmetOnSndPath = KIS/Sounds/helmetOn
+        helmetOffSndPath = KIS/Sounds/helmetOff
+    }
+
+    MODULE:NEEDS[KIS]
+    {
+        name = ModuleKISItem
+        volumeOverride = 29000
+        editorItemsCategory = False
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Altair Ascent Module decoupler.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -909,44 +909,50 @@
 }
 
 //  ==================================================
-//  Habitat module structural adapter (small).
+//  Habitation module structural adapter (small).
 
-//  Dimensions: 4.300 x 0.300 m
-//  Gross Mass: 165.00 Kg
+//  Dimensions: 3.75 x 0.3 m
+//  Inert Mass: 100 Kg
 //  ==================================================
 
-    @PART[XKWFlatadapter3x2]:FOR[RealismOverhaul]
+@PART[XKWFlatadapter991ax2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
     {
-        %RSSROConfig = True
-
-        @MODEL
-        {
-            @scale    = 0.960, 0.500, 0.960
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        %rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000, 0.330, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-
-        @category     = Structural
-        @title        = Habitat Adapter [Small]
-        @manufacturer = NASA
-        @description  = A flat structural adapter.
-
-        @mass             = 0.1650
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        !stageOffset      = NULL
-        !childStageOffset = NULL
-        %bulkheadProfiles = size3
+        @scale = 0.8333, 0.5, 0.8333
     }
+
+    @scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.265, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Structural
+    @title = HAB - 37 Adapter
+    @manufacturer = Generic
+    @description = A flat 3.75 meter structural adapter.
+
+    @mass = 0.1
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !stageOffset = NULL
+    !childStageOffset = NULL
+    %bulkheadProfiles = size3
+
+    !MODULE[ConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+    }
+}
 
 //  ==================================================
 //  Habitat module structural adapter (large).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -31,6 +31,8 @@
 
 !PART[XwheelMed3X]:FOR[RealismOverhaul]{}
 
+!PART[XKKLEG2X]:FOR[RealismOverhaul]{}
+
 !PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
 
 !PART[xKosmos_Balka_1_Tunnel1222x]:FOR[RealismOverhaul]{}
@@ -51,9 +53,11 @@
 
 !PART[PAYLOADADAPTER2OPSFFXX]:FOR[RealismOverhaul]{}
 
-!PART[XKW5mDecouplerShroudX2242ab]FOR[RealismOverhaul]{}
+!PART[XKW5mDecouplerShroudX2242ab]:FOR[RealismOverhaul]{}
 
-!PART[XKW5mDecouplerShroudXMERLIN224]FOR[RealismOverhaul]{}
+!PART[XKW5mDecouplerShroudXMERLIN224]:FOR[RealismOverhaul]{}
+
+!PART[XtelescopicLadderBay2X]:FOR[RealismOverhaul]{}
 
 !PART[XNPdecouplerstack4m]:FOR[RealismOverhaul]{}
 
@@ -78,6 +82,10 @@
 !PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_FairingAdapter2xce3]:FOR[RealismOverhaul]{}
+
+!PART[SLS_CM_FairingAdapter96]:FOR[RealismOverhaul]{}
+
+!PART[SLS_CM_FairingAdapterBLOCK1B96EUS]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_stackDecouplerx302hjsans]:FOR[RealismOverhaul]{}
 
@@ -164,7 +172,7 @@
         @PROPELLANT[LiquidFuel]
         {
             @name = LqdHydrogen
-       	    @ratio = 0.7352
+            @ratio = 0.7352
         }
 
         @PROPELLANT[Oxidizer]
@@ -509,12 +517,60 @@
     %fuelCrossFeed = False
     %bulkheadProfiles = size2
 
-    //@MODULE[ModuleWheel]
-    //{
-    //    @impactTolerance = 30
-    //    @overSpeedDamage = 60
-    //    @resourceConsumptionRate = 0.001
-    //}
+    @MODULE[ModuleWheelBase]
+    {
+        @radius = 0.773
+        @center = 0.0, 0.0, 0.0
+        @mass = 0.2
+        @groundHeightOffset = 0
+    }
+
+    @MODULE[ModuleWheelSuspension]
+    {
+        @suspensionDistance = 0.167
+        @targetPosition = 0.667
+        @springRatio = 7.0
+        @damperRatio = 1.0
+    }
+
+    @MODULE[ModuleWheelSteering]
+    {
+        @steeringResponse = 2
+    }
+
+    @MODULE[ModuleWheelMotor]
+    {
+        @wheelSpeedMax = 8.5
+        @driveResponse = 2.0
+        @idleDrain = 0.05
+
+        !torqueCurve{}
+
+        torqueCurve
+        {
+            key = 0.0 2.0 0.0 0.0
+            key = 2.1 1.5 0.0 0.0
+            key = 4.3 0.5 0.0 0.0
+            key = 8.5 0.0 0.0 0.0
+        }
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.5
+        }
+    }
+
+    @MODULE[ModuleWheelBrakes]
+    {
+        @maxBrakeTorque = 3.0
+        @brakeResponse = 1.0
+    }
+
+    @MODULE[ModuleWheelDamage]
+    {
+        @stressTolerance = 500
+        @impactTolerance = 125
+    }
 }
 
 //  ==================================================
@@ -1110,6 +1166,8 @@
     @module = CompoundPart
 
     %RSSROConfig = True
+
+    @mesh = Strut_Connector.mu
 
     @category = Structural
     @title = Universal Structural Connector
@@ -1820,6 +1878,16 @@
     {
         name = KzFairingBaseShielding
     }
+
+    MODULE
+    {
+        name = ModuleToggleCrossfeed
+        crossfeedStatus = False
+        toggleEditor = True
+        toggleFlight = True
+        enableText = Enable Cross Feed
+        disableText = Disable Cross Feed
+    }
 }
 
 +PART[SDHIICPSADAPTER]:FOR[RealismOverhaul]
@@ -2049,6 +2117,16 @@
     {
         name = KzFairingBaseShielding
     }
+
+    MODULE
+    {
+        name = ModuleToggleCrossfeed
+        crossfeedStatus = False
+        toggleEditor = True
+        toggleFlight = True
+        enableText = Enable Cross Feed
+        disableText = Disable Cross Feed
+    }
 }
 
 //  ==================================================
@@ -2189,6 +2267,16 @@
     MODULE
     {
         name = KzFairingBaseShielding
+    }
+
+    MODULE
+    {
+        name = ModuleToggleCrossfeed
+        crossfeedStatus = False
+        toggleEditor = True
+        toggleFlight = True
+        enableText = Enable Cross Feed
+        disableText = Disable Cross Feed
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -955,44 +955,52 @@
 }
 
 //  ==================================================
-//  Habitat module structural adapter (large).
+//  Habitation module structural adapter (large).
 
-//  Dimensions: 6.500 x 0.650 m
-//  Gross Mass: 760.00 Kg
+//  Dimensions: 7.5 m x 0.6 m
+//  Inert Mass: 700 Kg
 //  ==================================================
 
-    @PART[xKWFlatadapter3x2SHIExxLD]:FOR[RealismOverhaul]
+@PART[xKWFlatadapter3x2SHIExxLD]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 1.450, 1.000, 1.450
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000, 0.655, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-
-        @category     = Structural
-        @title        = Habitat Adapter [Large]
-        @manufacturer = NASA
-        @description  = A flat structural adapter.
-
-        @mass             = 0.7600
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        !stageOffset      = NULL
-        !childStageOffset = NULL
-        %bulkheadProfiles = size3
+        @scale = 1.6667, 1.0, 1.6667
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.655, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 5
+
+    @category = Structural
+    @title = HAB - 75 Adapter
+    @manufacturer = Generic
+    @description = A flat 7.5 meter structural adapter.
+
+    @mass = 0.7
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !stageOffset = NULL
+    !childStageOffset = NULL
+    %bulkheadProfiles = size5
+
+    !MODULE[ConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+    }
+}
 
 @PART[LANDERADAPTER]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1,2028 +1,2028 @@
-//	==================================================
-//	Removed extra parts.
-//	==================================================
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
 
-	!PART[xradialDecoupler]:FOR[RealismOverhaul]{}
+    !PART[xradialDecoupler]:FOR[RealismOverhaul]{}
 
-	!PART[XlpAltairDockingPortX]:FOR[RealismOverhaul]{}
+    !PART[XlpAltairDockingPortX]:FOR[RealismOverhaul]{}
 
-	!PART[XlpAltairDockingPort442X]:FOR[RealismOverhaul]{}
+    !PART[XlpAltairDockingPort442X]:FOR[RealismOverhaul]{}
 
-	!PART[XlpAltairDockingPortdX]:FOR[RealismOverhaul]{}
+    !PART[XlpAltairDockingPortdX]:FOR[RealismOverhaul]{}
 
-	!PART[XAltairDock444ingPortX]:FOR[RealismOverhaul]{}
+    !PART[XAltairDock444ingPortX]:FOR[RealismOverhaul]{}
 
-	!PART[nosMonkeyExplorerUtilityALTAIR]:FOR[RealismOverhaul]{}
+    !PART[nosMonkeyExplorerUtilityALTAIR]:FOR[RealismOverhaul]{}
 
-	!PART[XIACBM1ee25m]:FOR[RealismOverhaul]{}
+    !PART[XIACBM1ee25m]:FOR[RealismOverhaul]{}
 
-	!PART[XKosmos_Strut_Connector2X]:FOR[RealismOverhaul]{}
+    !PART[XKosmos_Strut_Connector2X]:FOR[RealismOverhaul]{}
 
-	!PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
+    !PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
 
-	!PART[XTALUSXX3]:FOR[RealismOverhaul]{}
+    !PART[XTALUSXX3]:FOR[RealismOverhaul]{}
 
-	!PART[XXB3IUShroudXLOWERRXV]:FOR[RealismOverhaul]{}
+    !PART[XXB3IUShroudXLOWERRXV]:FOR[RealismOverhaul]{}
 
-	!PART[XKW5mDecouplerShroudX2242ab]FOR[RealismOverhaul]{}
+    !PART[XKW5mDecouplerShroudX2242ab]FOR[RealismOverhaul]{}
 
-	!PART[CHAKAradialDecouplerXX]:FOR[RealismOverhaul]{}
+    !PART[CHAKAradialDecouplerXX]:FOR[RealismOverhaul]{}
 
-	!PART[chakaradialDecoupler1-2XXX]:FOR[RealismOverhaul]{}
+    !PART[chakaradialDecoupler1-2XXX]:FOR[RealismOverhaul]{}
 
-	!PART[XSDHI_2.5_ServiceModuleFairing211]:FOR[RealismOverhaul]{}
+    !PART[XSDHI_2.5_ServiceModuleFairing211]:FOR[RealismOverhaul]{}
 
-	!PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]{}
+    !PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]{}
 
-	!PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
+    !PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
 
-	!PART[SLS_CM_FairingAdapterk2fa]:FOR[RealismOverhaul]{}
+    !PART[SLS_CM_FairingAdapterk2fa]:FOR[RealismOverhaul]{}
 
-//	==================================================
-//	Altair lunar lander Descent Module.
+//  ==================================================
+//  Altair lunar lander Descent Module.
 
-//	Dimensions: 7.800 x 6.200 m (stowed)
-//	Gross Mass: 35055.00 Kg
-//	Throttle Range: 12.5% to 100%
-//	Burn Time: 1104 s
-//	O/F Ratio: 5.84
-//	==================================================
+//  Dimensions: 7.800 x 6.200 m (stowed)
+//  Gross Mass: 35055.00 Kg
+//  Throttle Range: 12.5% to 100%
+//  Burn Time: 1104 s
+//  O/F Ratio: 5.84
+//  ==================================================
 
-	@PART[XAltair2descent2stageX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True	
+    @PART[XAltair2descent2stageX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = True
 
-		MODEL
-		{
-			model	 = CMES/Structural/Altair_descent_stage/model
-			scale	 = 1.750, 1.750, 1.750
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+        MODEL
+        {
+            model    = CMES/Structural/Altair_descent_stage/model
+            scale    = 1.750, 1.750, 1.750
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@node_stack_top	   = 0.000, -1.000, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -3.350, 0.000, 0.000, -1.000, 0.000, 3
-    
-        @title		  = Altair Descent Module
-		%manufacturer = Boeing Co. & NASA
-		@description  = Altair (or Lunar Surface Access Module - LSAM) was a Constellation program asset designed for Moon landings. The descent module would be used to decelerate into a lunar orbit, undock from Orion and then land on the surface. Payload includes either a crewed outpost or cargo.
+        @node_stack_top    = 0.000, -1.000, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, -3.350, 0.000, 0.000, -1.000, 0.000, 3
 
-		@mass			  = 11.2810
-		%crashTolerance   = 12
-		%breakingForce    = 250
-		%breakingTorque   = 250
-		%maxTemp		  = 1973.15
-		%fuelCrossFeed	  = true
-		%bulkheadProfiles = size3
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = LIQUID_ENGINE
-    
-		!MODULE[ModuleSAS]{}
+        @title        = Altair Descent Module
+        %manufacturer = Boeing Co. & NASA
+        @description  = Altair (or Lunar Surface Access Module - LSAM) was a Constellation program asset designed for Moon landings. The descent module would be used to decelerate into a lunar orbit, undock from Orion and then land on the surface. Payload includes either a crewed outpost or cargo.
 
-		!MODULE[ModuleReactionWheel]{}
-    
-		!MODULE[ModuleGenerator]{}
+        @mass             = 11.2810
+        %crashTolerance   = 12
+        %breakingForce    = 250
+        %breakingTorque   = 250
+        %maxTemp          = 1973.15
+        %fuelCrossFeed    = true
+        %bulkheadProfiles = size3
+        %stageOffset      = 1
+        %childStageOffset = 1
+        %stagingIcon      = LIQUID_ENGINE
 
-		!MODULE[ModuleDecouple]{}
+        !MODULE[ModuleSAS]{}
+
+        !MODULE[ModuleReactionWheel]{}
+
+        !MODULE[ModuleGenerator]{}
+
+        !MODULE[ModuleDecouple]{}
 
         @MODULE[ModuleEngines*]
-		{
-			@minThrust	 	= 21.34
-			@maxThrust	 	= 266.80
-			@heatProduction = 100
-			%ullage		    = true
-			%ignitions	    = 9
-			%pressureFed	= false
-
-			IGNITOR_RESOURCE
-			{
-				name   = ElectricCharge
-				amount = 0.500
-			}
-
-			IGNITOR_RESOURCE
-			{
-				name   = LqdHydrogen
-				amount = 0.7338
-			}
-
-			IGNITOR_RESOURCE
-			{
-				name   = LqdOxygen
-				amount = 0.2661
-			}
-
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = LqdHydrogen
-				@ratio = 0.7338
-			}
-
-			@PROPELLANT[Oxidizer]
-			{
-				@name  = LqdOxygen
-				@ratio = 0.2661
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 460.00
-				@key,1 = 1 100.00
-			}
-		}
-
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			configuration = CECE
-			modded		  = false
-
-			CONFIG
-			{
-				name		   = CECE
-				minThrust	   = 21.34
-				maxThrust	   = 266.80
-				heatProduction = 100
-
-				PROPELLANT
-				{
-					name  = LqdHydrogen
-					ratio = 0.7338
-				}
-
-				PROPELLANT
-				{
-					name  = LqdOxygen
-					ratio = 0.2661
-				}
-
-				atmosphereCurve
-				{
-					key = 0 460.00
-					key = 1 100.00
-				}
-
-			}
-		}
-
-		@MODULE[ModuleGimbal]
-		{
-			@gimbalRange			= 4.000
-			%useGimbalResponseSpeed = true
-			%gimbalResponseSpeed 	= 16
-		}
-
-		@MODULE[ModuleRCS]
-		{
-			@name		   = ModuleRCS
-			@thrusterPower = 0.250
-			!resourceName  = NULL
-
-			PROPELLANT
-			{
-				ratio = 1.000
-				name  = Hydrazine
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 254.00
-				@key,1 = 1 82.08
-			}
-		}
-
-		MODULE
-		{
-			name  	 = ModuleFuelTanks
-			type  	 = ServiceModule
-			volume 	 = 65900
-			basemass = -1
-
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
-
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 48079
-				maxAmount = 48079
-			}
-
-			TANK
-			{
-				name	  = LqdOxygen
-				amount	  = 17435
-				maxAmount = 17435
-			}
-
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 150
-				maxAmount = 150
-			}
-
-			TANK
-			{
-				name	  = Water
-				amount	  = 0
-				maxAmount = 90
-			}
-		}
-
-		MODULE
-		{
-			name		    = TacGenericConverter
-			converterName   = Fuel Cell
-			conversionRate  = 3.000
-			inputResources  = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
-			outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
-		}
-
-		!RESOURCE[LiquidFuel]{}
-
-		!RESOURCE[Oxidizer]{}
-    
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
-
-//	==================================================
-//	NASA Docking & Berthing Mechanism (NDS).
-
-//	Dimensions: 1.225 x 0.500 m
-//	Gross Mass: 200.00 Kg
-//	==================================================
-
-	@PART[XAltairDockingPortX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/Altair_dockport/model
-			scale	 = 1.490, 1.450, 1.490
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh	 	   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  0.275, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, -0.020, 0.000, 0.000, -1.000, 0.000, 2
-
-		@title		  = NASA Docking System (NDS)
-		@manufacturer = Boeing Co. & NASA
-		@description  = The NDS is an androgynous spacecraft docking and berthing mechanism, developed for the Orion MPCV and the Commercial Crew vehicles.
-
-		@mass			  = 0.200
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp	 	  = 1073.15
-		%fuelCrossFeed	  = true
-		%bulkheadProfiles = srf, size2
-
-		@MODULE[ModuleDockingNode]
-		{
-			@nodeType			   = NASADock
-			%acquireForce		   = 0.5
-			%acquireMinFwdDot	   = 0.8
-			%acquireminRollDot	   = -3.40282347E+38
-			%acquireRange		   = 0.25
-			%acquireTorque		   = 0.5
-			%captureMaxRvel	 	   = 0.1
-			%captureMinFwdDot 	   = 0.998
-			%captureMinRollDot 	   = -3.40282347E+38
-			%captureRange		   = 0.05
-			%minDistanceToReEngage = 0.25
-			%undockEjectionForce   = 0.1
-		}
-
-		!MODULE[ModuleCommand]{}
-
-		!MODULE[MechJebCore]{}
-	}
-
-//	==================================================
-//	MSEV rover wheel.
-
-//	Dimensions: 1.600 x 1.500 m
-//	Gross Mass: 200.00 Kg
-//	==================================================
-
-	@PART[XwheelMedX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
-
-		MODEL
-		{
-			model	 = CMES/Structural/CHAKA WHEEL/model
-			scale	 = 1.333, 1.333, 1.333
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
-    
-        @title		  = MSEV Rover Wheel
-		@manufacturer = NASA
-		@description  = Rover wheel for the NASA surface exploration vehicles.
-
-		@mass			  = 0.200
-		%fuelCrossFeed	  = false
-		%bulkheadProfiles = srf
-
-		@MODULE[ModuleWheel]
-		{
-			@impactTolerance		 = 300
-			@overSpeedDamage		 = 60
-			@resourceConsumptionRate = 0.001
-		}
-	}
-
-//	==================================================
-//	Altair II lander Descent Module.
-
-//	Dimensions: 8.300 x 4.200 m
-//	Gross Mass: 35000.00 Kg
-//	Volume: 18000.00 L
-//	==================================================
-
-	@PART[nosMonkeyExplorerUtilityHAB]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/ChakaNOSLander/model
-			scale	 = 0.950, 0.950, 0.950
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  1.525, 0.000, 0.000,  1.000, 0.000, 3
-		%node_stack_middle = 0.000, -1.525, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -2.625, 0.000, 0.000, -1.000, 0.000, 3
-
-		@category	  = Engine
-		@title		  = Altair II Descent Module
-		@manufacturer = Boeing Co. & NASA
-		@description  = The Altair II Descent Module is designed to carry and land very heavy crew or cargo components on planetary surfaces.
-
-		@mass			  = 12.000
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = true
-		@bulkheadProfiles = size3
-
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			volume	 = 18000
-			basemass = -1
-
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
-
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 200
-				maxAmount = 200
-			}
-
-			TANK
-			{
-				name	  = MMH
-				amount	  = 8687
-				maxAmount = 8687
-			}
-
-			TANK
-			{
-				name	  = NTO
-				amount	  = 8549
-				maxAmount = 8549
-			}
-		}
-
-		!RESOURCE[LiquidFuel]{}
-
-		!RESOURCE[Oxidizer]{}
-	}
-
-//	==================================================
-//	Altair Ascent Module decoupler.
-
-//	Dimensions: 2.500 x ? m
-//	Gross Mass: 470.00 Kg
-//	==================================================
-
-	@PART[LXNPdecouplerstack4dragonm]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/Dragon Backshell/model
-			scale	 = 0.500, 0.500, 0.500
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		!scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, -0.065, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  0.065, 0.000, 0.000,  1.000, 0.000, 3
-
-		%fx_gasBurst_white = 0.000, 1.000, 0.000, 0.000, 1.000, 0.000, decouple
-
-		@title		  = Altair Ascent Module Decoupler
-		@manufacturer = NASA
-		%description  = Explosive bolt decoupler for the Altair lunar lander.
-
-		@mass			  = 0.4700
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 250.000
-		}
-	}
-
-//	==================================================
-//	Common Berthing Mechanism (CBM).
-
-//	Dimensions: 1.700 x 1.700 m
-//	Gross Mass: 250.00 Kg
-//	==================================================
-
-	@PART[XIACBM1.25m]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 2.225, 1.500, 2.225
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000, 0.285, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 2
-
-		@title		  = Common Berthing Mechanism (CBM)
-		@manufacturer = Boeing Co. & NASA
-		@description  = A berthing mechanism used from the ISS modules (non Russian), the Multipurpose Logistics Modules (MPLM) and the resupply vehicles. Features integrated illumination units and can be configured as either an active or passive CBM.
-
-		@mass			  = 0.2500
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = true
-		%bulkheadProfiles = size2
-
-		@MODULE[ModuleDockingNode]
-		{
-			@nodeType			   = CBM
-			%acquireForce		   = 0.500
-			%acquireMinFwdDot	   = 0.800
-			%acquireminRollDot	   = -3.40282347E+38
-			%acquireRange	 	   = 0.250
-			%acquireTorque	 	   = 0.500
-			%captureMaxRvel	 	   = 0.100
-			%captureMinFwdDot 	   = 0.998
-			%captureMinRollDot	   = -3.40282347E+38
-			%captureRange		   = 0.050
-			%minDistanceToReEngage = 0.250
-			%undockEjectionForce   = 0.100
-		}
-
-		@MODULE[ModuleLight]
-		{
-			@resourceAmount = 0.005
-		}
-	}
-
-//	==================================================
-//	Delta IV interstage adapter.
-
-//	Because the current RL10-B-2 has not an extensible nozzle, we cheat the length of the adapter to be 8.5 meters from the original 7.5 meters.
-
-//	Dimensions: 5.000 x 7.500 m
-//	Gross Mass: 2460.00 Kg
-//	==================================================
-
-	@PART[XKW5mDecouplerShroudX224]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.666, 4.455, 1.666
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000, 0.250, 0.000, 0.000,  1.000, 0.000, 3
-
-		@category	  = Structural
-		@title		  = Interstage - Delta IV
-		@manufacturer = Orbital ATK
-		%description  = The structural adapter and explosive cord decoupler for the Delta Cryogenic Second Stage (DCSS).
-
-		@mass			  = 2.4600
-		@crashTolerance	  = 12
-		@maxTemp		  = 1073.15
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 25.000
-		}
-	}
+        {
+            @minThrust      = 21.34
+            @maxThrust      = 266.80
+            @heatProduction = 100
+            %ullage         = true
+            %ignitions      = 9
+            %pressureFed    = false
+
+            IGNITOR_RESOURCE
+            {
+                name   = ElectricCharge
+                amount = 0.500
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name   = LqdHydrogen
+                amount = 0.7338
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name   = LqdOxygen
+                amount = 0.2661
+            }
+
+            @PROPELLANT[LiquidFuel]
+            {
+                @name  = LqdHydrogen
+                @ratio = 0.7338
+            }
+
+            @PROPELLANT[Oxidizer]
+            {
+                @name  = LqdOxygen
+                @ratio = 0.2661
+            }
+
+            @atmosphereCurve
+            {
+                @key,0 = 0 460.00
+                @key,1 = 1 100.00
+            }
+        }
+
+        MODULE
+        {
+            name          = ModuleEngineConfigs
+            type          = ModuleEngines
+            configuration = CECE
+            modded        = false
+
+            CONFIG
+            {
+                name           = CECE
+                minThrust      = 21.34
+                maxThrust      = 266.80
+                heatProduction = 100
+
+                PROPELLANT
+                {
+                    name  = LqdHydrogen
+                    ratio = 0.7338
+                }
+
+                PROPELLANT
+                {
+                    name  = LqdOxygen
+                    ratio = 0.2661
+                }
+
+                atmosphereCurve
+                {
+                    key = 0 460.00
+                    key = 1 100.00
+                }
+
+            }
+        }
+
+        @MODULE[ModuleGimbal]
+        {
+            @gimbalRange            = 4.000
+            %useGimbalResponseSpeed = true
+            %gimbalResponseSpeed    = 16
+        }
+
+        @MODULE[ModuleRCS]
+        {
+            @name          = ModuleRCS
+            @thrusterPower = 0.250
+            !resourceName  = NULL
+
+            PROPELLANT
+            {
+                ratio = 1.000
+                name  = Hydrazine
+            }
+
+            @atmosphereCurve
+            {
+                @key,0 = 0 254.00
+                @key,1 = 1 82.08
+            }
+        }
+
+        MODULE
+        {
+            name     = ModuleFuelTanks
+            type     = ServiceModule
+            volume   = 65900
+            basemass = -1
+
+            TANK
+            {
+                name      = ElectricCharge
+                amount    = 43200
+                maxAmount = 43200
+            }
+
+            TANK
+            {
+                name      = LqdHydrogen
+                amount    = 48079
+                maxAmount = 48079
+            }
+
+            TANK
+            {
+                name      = LqdOxygen
+                amount    = 17435
+                maxAmount = 17435
+            }
+
+            TANK
+            {
+                name      = Hydrazine
+                amount    = 150
+                maxAmount = 150
+            }
+
+            TANK
+            {
+                name      = Water
+                amount    = 0
+                maxAmount = 90
+            }
+        }
+
+        MODULE
+        {
+            name            = TacGenericConverter
+            converterName   = Fuel Cell
+            conversionRate  = 3.000
+            inputResources  = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
+            outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
+        }
+
+        !RESOURCE[LiquidFuel]{}
+
+        !RESOURCE[Oxidizer]{}
+
+        !RESOURCE[ElectricCharge]{}
+
+        !RESOURCE[MonoPropellant]{}
+    }
+
+//  ==================================================
+//  NASA Docking & Berthing Mechanism (NDS).
+
+//  Dimensions: 1.225 x 0.500 m
+//  Gross Mass: 200.00 Kg
+//  ==================================================
+
+    @PART[XAltairDockingPortX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/Altair_dockport/model
+            scale    = 1.490, 1.450, 1.490
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_top    = 0.000,  0.275, 0.000, 0.000,  1.000, 0.000, 2
+        @node_stack_bottom = 0.000, -0.020, 0.000, 0.000, -1.000, 0.000, 2
+
+        @title        = NASA Docking System (NDS)
+        @manufacturer = Boeing Co. & NASA
+        @description  = The NDS is an androgynous spacecraft docking and berthing mechanism, developed for the Orion MPCV and the Commercial Crew vehicles.
+
+        @mass             = 0.200
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = true
+        %bulkheadProfiles = srf, size2
+
+        @MODULE[ModuleDockingNode]
+        {
+            @nodeType              = NASADock
+            %acquireForce          = 0.5
+            %acquireMinFwdDot      = 0.8
+            %acquireminRollDot     = -3.40282347E+38
+            %acquireRange          = 0.25
+            %acquireTorque         = 0.5
+            %captureMaxRvel        = 0.1
+            %captureMinFwdDot      = 0.998
+            %captureMinRollDot     = -3.40282347E+38
+            %captureRange          = 0.05
+            %minDistanceToReEngage = 0.25
+            %undockEjectionForce   = 0.1
+        }
+
+        !MODULE[ModuleCommand]{}
+
+        !MODULE[MechJebCore]{}
+    }
+
+//  ==================================================
+//  MSEV rover wheel.
+
+//  Dimensions: 1.600 x 1.500 m
+//  Gross Mass: 200.00 Kg
+//  ==================================================
+
+    @PART[XwheelMedX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = True
+
+        MODEL
+        {
+            model    = CMES/Structural/CHAKA WHEEL/model
+            scale    = 1.333, 1.333, 1.333
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
+
+        @title        = MSEV Rover Wheel
+        @manufacturer = NASA
+        @description  = Rover wheel for the NASA surface exploration vehicles.
+
+        @mass             = 0.200
+        %fuelCrossFeed    = false
+        %bulkheadProfiles = srf
+
+        @MODULE[ModuleWheel]
+        {
+            @impactTolerance         = 300
+            @overSpeedDamage         = 60
+            @resourceConsumptionRate = 0.001
+        }
+    }
+
+//  ==================================================
+//  Altair II lander Descent Module.
+
+//  Dimensions: 8.300 x 4.200 m
+//  Gross Mass: 35000.00 Kg
+//  Volume: 18000.00 L
+//  ==================================================
+
+    @PART[nosMonkeyExplorerUtilityHAB]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/ChakaNOSLander/model
+            scale    = 0.950, 0.950, 0.950
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_top    = 0.000,  1.525, 0.000, 0.000,  1.000, 0.000, 3
+        %node_stack_middle = 0.000, -1.525, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, -2.625, 0.000, 0.000, -1.000, 0.000, 3
+
+        @category     = Engine
+        @title        = Altair II Descent Module
+        @manufacturer = Boeing Co. & NASA
+        @description  = The Altair II Descent Module is designed to carry and land very heavy crew or cargo components on planetary surfaces.
+
+        @mass             = 12.000
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = true
+        @bulkheadProfiles = size3
+
+        MODULE
+        {
+            name     = ModuleFuelTanks
+            type     = ServiceModule
+            volume   = 18000
+            basemass = -1
+
+            TANK
+            {
+                name      = ElectricCharge
+                amount    = 43200
+                maxAmount = 43200
+            }
+
+            TANK
+            {
+                name      = Hydrazine
+                amount    = 200
+                maxAmount = 200
+            }
+
+            TANK
+            {
+                name      = MMH
+                amount    = 8687
+                maxAmount = 8687
+            }
+
+            TANK
+            {
+                name      = NTO
+                amount    = 8549
+                maxAmount = 8549
+            }
+        }
+
+        !RESOURCE[LiquidFuel]{}
+
+        !RESOURCE[Oxidizer]{}
+    }
+
+//  ==================================================
+//  Altair Ascent Module decoupler.
+
+//  Dimensions: 2.500 x ? m
+//  Gross Mass: 470.00 Kg
+//  ==================================================
+
+    @PART[LXNPdecouplerstack4dragonm]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/Dragon Backshell/model
+            scale    = 0.500, 0.500, 0.500
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        !scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_bottom = 0.000, -0.065, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000,  0.065, 0.000, 0.000,  1.000, 0.000, 3
+
+        %fx_gasBurst_white = 0.000, 1.000, 0.000, 0.000, 1.000, 0.000, decouple
+
+        @title        = Altair Ascent Module Decoupler
+        @manufacturer = NASA
+        %description  = Explosive bolt decoupler for the Altair lunar lander.
+
+        @mass             = 0.4700
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size3
+
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 250.000
+        }
+    }
+
+//  ==================================================
+//  Common Berthing Mechanism (CBM).
+
+//  Dimensions: 1.700 x 1.700 m
+//  Gross Mass: 250.00 Kg
+//  ==================================================
+
+    @PART[XIACBM1.25m]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @MODEL
+        {
+            @scale    = 2.225, 1.500, 2.225
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_top    = 0.000, 0.285, 0.000, 0.000,  1.000, 0.000, 2
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 2
+
+        @title        = Common Berthing Mechanism (CBM)
+        @manufacturer = Boeing Co. & NASA
+        @description  = A berthing mechanism used from the ISS modules (non Russian), the Multipurpose Logistics Modules (MPLM) and the resupply vehicles. Features integrated illumination units and can be configured as either an active or passive CBM.
+
+        @mass             = 0.2500
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = true
+        %bulkheadProfiles = size2
+
+        @MODULE[ModuleDockingNode]
+        {
+            @nodeType              = CBM
+            %acquireForce          = 0.500
+            %acquireMinFwdDot      = 0.800
+            %acquireminRollDot     = -3.40282347E+38
+            %acquireRange          = 0.250
+            %acquireTorque         = 0.500
+            %captureMaxRvel        = 0.100
+            %captureMinFwdDot      = 0.998
+            %captureMinRollDot     = -3.40282347E+38
+            %captureRange          = 0.050
+            %minDistanceToReEngage = 0.250
+            %undockEjectionForce   = 0.100
+        }
+
+        @MODULE[ModuleLight]
+        {
+            @resourceAmount = 0.005
+        }
+    }
+
+//  ==================================================
+//  Delta IV interstage adapter.
+
+//  Because the current RL10-B-2 has not an extensible nozzle, we cheat the length of the adapter to be 8.5 meters from the original 7.5 meters.
+
+//  Dimensions: 5.000 x 7.500 m
+//  Gross Mass: 2460.00 Kg
+//  ==================================================
+
+    @PART[XKW5mDecouplerShroudX224]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @MODEL
+        {
+            @scale    = 1.666, 4.455, 1.666
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000, 0.250, 0.000, 0.000,  1.000, 0.000, 3
+
+        @category     = Structural
+        @title        = Interstage - Delta IV
+        @manufacturer = Orbital ATK
+        %description  = The structural adapter and explosive cord decoupler for the Delta Cryogenic Second Stage (DCSS).
+
+        @mass             = 2.4600
+        @crashTolerance   = 12
+        @maxTemp          = 1073.15
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size3
+
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 25.000
+        }
+    }
 
 @PART[XXB3IUShroudXSMALLERX]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 1.626667, 2.05333, 1.626667
-	}
-	@scale = 1
-	@rescaleFactor = 1
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 1.626667, 2.05333, 1.626667
+    }
+    @scale = 1
+    @rescaleFactor = 1
 
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 6.66667, 0.0, 0.0, 1.0, 0.0, 3
-    
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 6.66667, 0.0, 0.0, 1.0, 0.0, 3
+
     @title = DELTA IV 5M DCSS Interstage
-	@manufacturer = United Launch Alliance
-	@description = Interstage for the 5 meter variant of the DCSS
+    @manufacturer = United Launch Alliance
+    @description = Interstage for the 5 meter variant of the DCSS
 }
 @PART[XXB3.75DecouplerShroudXSMALLERX]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 1.626667, 1.86667, 1.626667
-	}
-	@scale = 1
-	@rescaleFactor = 1
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 1.626667, 1.86667, 1.626667
+    }
+    @scale = 1
+    @rescaleFactor = 1
 
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 0.65333, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 0.65333, 0.0, 0.0, 1.0, 0.0, 3
 }
 @PART[XXEB3IUShroudXXLERXXTX]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 1.626667, 2.361333, 1.626667
-	}
-	@scale = 1
-	@rescaleFactor = 1
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 1.626667, 2.361333, 1.626667
+    }
+    @scale = 1
+    @rescaleFactor = 1
 
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 7.8, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 7.8, 0.0, 0.0, 1.0, 0.0, 3
 }
 @PART[XTALUS8.4MSHROUDSLIGHTLYSMALLERwwwmunar]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 2.81333, 1.86667, 2.81333
-	}
-	@scale = 1
-	@rescaleFactor = 1
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 2.81333, 1.86667, 2.81333
+    }
+    @scale = 1
+    @rescaleFactor = 1
 
-	@node_stack_bottom = 0.0, 0.326667, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 1.06667, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.326667, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 1.06667, 0.0, 0.0, 1.0, 0.0, 3
 }
 @PART[X8.4MSHROUDSLIGHTLYSMALLERWWW]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 2.81333, 2.5333, 2.81333
-	}
-	@scale = 1
-	@rescaleFactor = 1
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 2.81333, 2.5333, 2.81333
+    }
+    @scale = 1
+    @rescaleFactor = 1
 
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 1.7333, 0.0, 0.0, 1.0, 0.0, 3
-    
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 1.7333, 0.0, 0.0, 1.0, 0.0, 3
+
     @title = ARES EDS Interstage
-	@manufacturer = NASA
-	@description = Interstage for the ARES Earth Departure Stage.
-	
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	!MODULE[ModuleSAS]
-	{
-	}
+    @manufacturer = NASA
+    @description = Interstage for the ARES Earth Departure Stage.
+
+    !MODULE[ModuleReactionWheel]
+    {
+    }
+    !MODULE[ModuleSAS]
+    {
+    }
 }
 
-//	==================================================
-//	Space Launch System (SLS) interstage adapter.
+//  ==================================================
+//  Space Launch System (SLS) interstage adapter.
 
-//	Dimensions: 8.384 x 13.750 m
-//	Gross Mass: 5216.40 Kg
-//	==================================================
+//  Dimensions: 8.384 x 13.750 m
+//  Gross Mass: 5216.40 Kg
+//  ==================================================
 
-	@PART[X84NEWTALUSXX2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    @PART[X84NEWTALUSXX2]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
 
-		@MODEL
-		{
-			@scale	  = 2.800, 7.255, 2.800
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+        @MODEL
+        {
+            @scale    = 2.800, 7.255, 2.800
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000, 0.500, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000, 0.500, 0.000, 0.000,  1.000, 0.000, 3
 
-		%fx_gasBurst_white = 0.000, 0.500, 0.000, 0.000, 1.000, 0.000, decouple
+        %fx_gasBurst_white = 0.000, 0.500, 0.000, 0.000, 1.000, 0.000, decouple
 
-		%sound_decoupler_fire = decouple
+        %sound_decoupler_fire = decouple
 
-		@category	  = Structural
-		@title		  = Interstage - SLS
-		@manufacturer = NASA
-		%description  = The structural adapter and explosive cord decoupler for the SLS Exploration Upper Stage (EUS).
+        @category     = Structural
+        @title        = Interstage - SLS
+        @manufacturer = NASA
+        %description  = The structural adapter and explosive cord decoupler for the SLS Exploration Upper Stage (EUS).
 
-		@mass			  = 5.2164
-		@crashTolerance	  = 12
-		@maxTemp		  = 1073.15
-		@breakingForce	  = 250
-		@breakingTorque   = 250
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
+        @mass             = 5.2164
+        @crashTolerance   = 12
+        @maxTemp          = 1073.15
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size3
 
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 1.500
-		}
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 1.500
+        }
 
-		!MODULE[ModuleReactionWheel]{}
+        !MODULE[ModuleReactionWheel]{}
 
-		!MODULE[ModuleSAS]{}
-	}
+        !MODULE[ModuleSAS]{}
+    }
 
-//	==================================================
-//	Habitat module structural adapter (small).
+//  ==================================================
+//  Habitat module structural adapter (small).
 
-//	Dimensions: 4.300 x 0.300 m
-//	Gross Mass: 165.00 Kg
-//	==================================================
+//  Dimensions: 4.300 x 0.300 m
+//  Gross Mass: 165.00 Kg
+//  ==================================================
 
-	@PART[XKWFlatadapter3x2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
+    @PART[XKWFlatadapter3x2]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 0.960, 0.500, 0.960
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+        @MODEL
+        {
+            @scale    = 0.960, 0.500, 0.960
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		%rescaleFactor = 1.000
+        !mesh          = NULL
+        @scale         = 1.000
+        %rescaleFactor = 1.000
 
-		@node_stack_top	   = 0.000, 0.330, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000, 0.330, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
 
-		@category	  = Structural
-		@title		  = Habitat Adapter [Small]
-		@manufacturer = NASA
-		@description  = A flat structural adapter.
+        @category     = Structural
+        @title        = Habitat Adapter [Small]
+        @manufacturer = NASA
+        @description  = A flat structural adapter.
 
-		@mass			  = 0.1650
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		!stageOffset	  = NULL
-		!childStageOffset = NULL
-		%bulkheadProfiles = size3
-	}
+        @mass             = 0.1650
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        !stageOffset      = NULL
+        !childStageOffset = NULL
+        %bulkheadProfiles = size3
+    }
 
-//	==================================================
-//	Habitat module structural adapter (large).
+//  ==================================================
+//  Habitat module structural adapter (large).
 
-//	Dimensions: 6.500 x 0.650 m
-//	Gross Mass: 760.00 Kg
-//	==================================================
+//  Dimensions: 6.500 x 0.650 m
+//  Gross Mass: 760.00 Kg
+//  ==================================================
 
-	@PART[xKWFlatadapter3x2SHIExxLD]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    @PART[xKWFlatadapter3x2SHIExxLD]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
 
-		@MODEL
-		{
-			@scale	  = 1.450, 1.000, 1.450
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+        @MODEL
+        {
+            @scale    = 1.450, 1.000, 1.450
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@node_stack_top	   = 0.000, 0.655, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000, 0.655, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
 
-		@category	  = Structural
-		@title		  = Habitat Adapter [Large]
-		@manufacturer = NASA
-		@description  = A flat structural adapter.
+        @category     = Structural
+        @title        = Habitat Adapter [Large]
+        @manufacturer = NASA
+        @description  = A flat structural adapter.
 
-		@mass			  = 0.7600
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		!stageOffset	  = NULL
-		!childStageOffset = NULL
-		%bulkheadProfiles = size3
-	}
+        @mass             = 0.7600
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        !stageOffset      = NULL
+        !childStageOffset = NULL
+        %bulkheadProfiles = size3
+    }
 
 @PART[LANDERADAPTER]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 1.123105, 0.94577, 1.123105
-	}
-	@scale = 1.0
-	@rescaleFactor = 1.0
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 1.123105, 0.94577, 1.123105
+    }
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-	@node_stack_bottom = 0.0, 1.205867, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 0.266, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 1.205867, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 0.266, 0.0, 0.0, 1.0, 0.0, 3
 }
 
 @PART[X1NP_decoupler_stack_4.1m]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/NOVA - CHAKA DECOUPLER/model
-		texture = NOVA Dark, CMES/Structural/NOVA - CHAKA DECOUPLER/model000
-		scale = 0.5944648, 0.5944648, 0.5944648
-	}
-	@scale = 1
-	@rescaleFactor = 1.0
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/NOVA - CHAKA DECOUPLER/model
+        texture = NOVA Dark, CMES/Structural/NOVA - CHAKA DECOUPLER/model000
+        scale = 0.5944648, 0.5944648, 0.5944648
+    }
+    @scale = 1
+    @rescaleFactor = 1.0
 
-	@node_stack_bottom = 0.0, -0.074308, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 0.074308, 0.0, 0.0, 1.0, 0.0, 3
-	%title = CMES Nova Decoupler
-	%mass = 3.0
-	MODULE
-	{
-		name = TweakScale
-		type = RODecoupler
-		defaultScale = 3.0
-	}
+    @node_stack_bottom = 0.0, -0.074308, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 0.074308, 0.0, 0.0, 1.0, 0.0, 3
+    %title = CMES Nova Decoupler
+    %mass = 3.0
+    MODULE
+    {
+        name = TweakScale
+        type = RODecoupler
+        defaultScale = 3.0
+    }
 }
 
-//	==================================================
-//	Exploration Station crew tunnel.
-
-//	Dimensions: 3.000 x 5.000 m
-//	Gross Mass: 2597.00 Kg
-//	==================================================
-
-	@PART[xKosmos_Balka_1_Tunnelx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale    = 3.000, 1.650, 3.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	   = 0.000,  2.304, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -2.304, 0.000, 0.000, -1.000, 0.000, 3
-
-		@title		  = Exploration Station Crew Tunnel
-		@manufacturer = Boeing Co.
-		@description  = A structural tunnel for crew transfer for linking living quarters.
-
-		@mass			  = 2.5970
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = true
-		!CrewCapacity	  = NULL
-		!vesselType		  = NULL
-		!stackSymmetry	  = NULL
-		%bulkheadProfiles = size3
-
-		!INTERNAL[xorbitalOrbInternals]{}
-	}
-
-//	==================================================
-//	Universal structural connector.
-
-//	Dimensions: N/A
-//	Gross Mass: 56.00 Kg
-//	==================================================
-
-	@PART[XKosmos_Strut_ConnectorX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@mesh		   = Strut_Connector.mu
-		@scale		   = 0.100
-		@rescaleFactor = 3.000
-		!specPower	   = NULL
-		!rimFalloff	   = NULL
-		!alphaCutoff   = NULL
-		@iconCenter	   = -4.690, 2.650, 0.000
-
-		@title		  = Universal Structural Connector
-		@manufacturer = Generic
-		@description  = General structural re-enforcement for space exploration vehicles.
-
-		@mass			 	= 0.0560
-		@crashTolerance	 	= 12
-		@breakingForce	 	= 250
-		@breakingTorque	 	= 250
-		@maxTemp		 	= 1973.15
-		%fuelCrossFeed	 	= false
-		!explosionPotential = NULL
-		@maxLength		    = 25
-		%bulkheadProfiles   = srf
-
-		@MODULE[CModuleStrut]
-		{
-			@linearStrength  = 1000
-			@angularStrength = 1000
-		}
-	}
-
-//	==================================================
-//	Structural docking ring.
-
-//	Dimensions: 10.000 x 0.600 m
-//	Gross Mass: 830.00 Kg
-//	==================================================
-
-	@PART[XKW3mDockingRingX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 3.325, 0.750, 3.325
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_dockingNode = 0.000,  0.000, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom		= 0.000, -0.750, 0.000, 0.000, -1.000, 0.000, 3
-
-		@title		  = LCBM
-		@manufacturer = Boeing Co.
-		%description  = The Large Common Berthing Mechanism (LCBM) is a docking system designed for heavy payloads.
-
-		@mass			  = 0.8300
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDockingNode]
-		{
-			@nodeType			   = LCBM
-			%acquireForce		   = 0.500
-			%acquireMinFwdDot	   = 0.800
-			%acquireminRollDot	   = -3.40282347E+38
-			%acquireRange	 	   = 0.250
-			%acquireTorque	 	   = 0.500
-			%captureMaxRvel	 	   = 0.100
-			%captureMinFwdDot 	   = 0.998
-			%captureMinRollDot	   = -3.40282347E+38
-			%captureRange		   = 0.050
-			%minDistanceToReEngage = 0.250
-			%undockEjectionForce   = 0.100
-		}
-	}
-
-//	==================================================
-//	Ares V interstage adapter.
-
-//	Dimensions: 8.384 x 10.300 m
-//	Gross Mass: 8090.00 Kg
-//	==================================================
-
-	@PART[X84NEWTALUSXX2cx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 2.800, 5.275, 2.800
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000, 0.500, 0.000, 0.000,  1.000, 0.000, 3
-
-		@category	  = Structural
-		@title	  	  = Interstage - Ares V
-		@manufacturer = NASA
-		%description  = The structural adapter and explosive cord decoupler for the Ares V Earth Departure Stage (EDS).
-
-		@mass			  = 8.0900
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 1.500
-		}
-
-		!MODULE[ModuleReactionWheel]{}
-
-		!MODULE[ModuleSAS]{}
-	}
-
-//	==================================================
-//	Payload fairing base ring (low profile).
-
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
-
-	@PART[XNPfairings41mplate]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/NP_Fairings_4.1m_Plate/model
-			scale	 = 0.200, 0.100, 0.200
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	  	  = 0.000, 0.025, 0.000, 0.000,  1.000, 0.000, 1
-		@node_stack_bottom	  = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 1
-		%node_stack_connect01 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-		%node_stack_connect02 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-		%node_stack_connect03 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-		%node_stack_connect04 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
-
-		@category	  = Aero
-		@title		  = Payload Fairing - Base (Type IB) [Procedural]
-		%manufacturer = NASA
-		%description  = Procedural, low profile, payload fairing base. Payload decoupling system not included.
-
-		@mass			  = 0.1000
-		@crashTolerance	  = 12
-		@maxTemp		  = 1073.15
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		!stageOffset	  = NULL
-		!childStageOffset = NULL
-		%bulkheadProfiles = size1
-
-		MODULE
-		{
-			name		  = ProceduralFairingBase
-			baseSize	  = 1.150
-			sideThickness = 0.050
-			verticalStep  = 0.100
-		}
-
-		MODULE
-		{
-			name			  = KzNodeNumberTweaker
-			nodePrefix		  = connect
-			maxNumber		  = 4
-			numNodes		  = 2
-			radius			  = 0.625
-			shouldResizeNodes = False
-		}
-
-		MODULE
-		{
-			name				   = KzFairingBaseResizer
-			size				   = 3.000
-			costPerTonne		   = 1000
-			specificMass		   = 0.0064, 0.0130, 0.0098, 0.000
-			specificBreakingForce  = 500
-			specificBreakingTorque = 500
-			diameterStepLarge	   = 1.000
-			diameterStepSmall	   = 0.100
-			dragAreaScale		   = 1.500
-		}
-
-		MODULE
-		{
-			name = KzFairingBaseShielding
-		}
-	}
-
-//	==================================================
-//	Orion MPCV structural adapter.
-
-//	Dimensions: 5.000 x 1.520 m
-//	Gross Mass: 432.00 Kg
-//	==================================================
-
-	@PART[XFASAApolloStrJ2StrJ23m5mDecX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		@MODEL
-		{
-			@scale	  = 1.000, 0.505, 1.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_stack_top	  	 =  0.000, -0.500, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom	 =  0.000, -0.750, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_connect1 =  2.870,  1.700, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_connect2 = -2.870,  1.700, 0.000, 0.000,  1.000, 0.000, 2
-
-		@title		  = Orion MPCV Adapter
-		%manufacturer = NASA
-		%description  = Structural adapter for the Orion MPCV and the Service Module protection panels.
-
-		@mass			  = 0.4320
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size2, size3
-
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 250.000
-		}
-	}
-
-//	==================================================
-//	Delta IV GEM - 60 decoupler.
-
-//	Dimensions: 0.400 x 2.300 m
-//	Gross Mass: 250.00 Kg
-//	==================================================
-
-	@PART[CHAKAradialDecoupler]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/radialDecoupler/model
-			scale	 = 1.000, 2.000, 1.000
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.016, 0.000, 0.000, 1.000, 0.000, 0.000
-
-		@title		  = TT-38L Radial Decoupler
-		@manufacturer = Generic
-		@description  = Explosive bolt decoupler for medium sized side mounted boosters.
-
-		@mass			  = 0.2500
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%bulkheadProfiles = srf
-
-		@MODULE[ModuleAnchoredDecoupler]
-		{
-			@ejectionForce = 250.000
-		}
-	}
-
-//	==================================================
-//	Ares V & SLS Block I/IB/II RSRM decoupler.
-
-//	Dimensions: 0.900 x 3.500 m
-//	Gross Mass: 325.00 Kg
-//	==================================================
-
-	@PART[chakaradialDecoupler1-2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/radialDecoupler1-2/model
-			scale	 = 1.000, 2.000, 1.000
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-
-		@node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
-
-		@title		  = TT-70L Radial Decoupler
-		@manufacturer = Generic
-		@description  = Explosive bolt decoupler for large sized side mounted boosters.
-
-		@mass			  = 0.3250
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%bulkheadProfiles = srf
-
-		@MODULE[ModuleAnchoredDecoupler]
-		{
-			@ejectionForce = 500.000
-		}
-	}
-
-//	==================================================
-//	Orion Service Module fairing.
-
-//	Dimensions: 2.500 x 4.000 m
-//	Gross Mass: 330.00 Kg
-//	==================================================
-
-	@PART[XSDHI_2.5_ServiceModuleFairing]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
-
-		MODEL
-		{
-			model	 = CMES/Structural/SDHI-CHAKA-FAIRING/model
-			scale	 = 2.472, 2.675, 2.472
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
-
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-	
-		@node_stack_bottom = -0.350, 0.450, 0.000, 0.000, -1.000, 0.000, 2
-
-		@title 		  = Orion SM Fairing
-		@manufacturer = NASA
-		@description  = Fairing for the Orion service module.
-
-		@mass			  = 0.3300
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%fuelCrossFeed	  = false
-		%bulkheadProfiles = size2
-
-		@MODULE[ModuleAnchoredDecoupler]
-		{
-			@ejectionForce = 120.000
-		}
-	}
+//  ==================================================
+//  Exploration Station crew tunnel.
+
+//  Dimensions: 3.000 x 5.000 m
+//  Gross Mass: 2597.00 Kg
+//  ==================================================
+
+    @PART[xKosmos_Balka_1_Tunnelx]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @MODEL
+        {
+            @scale    = 3.000, 1.650, 3.000
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_top    = 0.000,  2.304, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, -2.304, 0.000, 0.000, -1.000, 0.000, 3
+
+        @title        = Exploration Station Crew Tunnel
+        @manufacturer = Boeing Co.
+        @description  = A structural tunnel for crew transfer for linking living quarters.
+
+        @mass             = 2.5970
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = true
+        !CrewCapacity     = NULL
+        !vesselType       = NULL
+        !stackSymmetry    = NULL
+        %bulkheadProfiles = size3
+
+        !INTERNAL[xorbitalOrbInternals]{}
+    }
+
+//  ==================================================
+//  Universal structural connector.
+
+//  Dimensions: N/A
+//  Gross Mass: 56.00 Kg
+//  ==================================================
+
+    @PART[XKosmos_Strut_ConnectorX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @mesh          = Strut_Connector.mu
+        @scale         = 0.100
+        @rescaleFactor = 3.000
+        !specPower     = NULL
+        !rimFalloff    = NULL
+        !alphaCutoff   = NULL
+        @iconCenter    = -4.690, 2.650, 0.000
+
+        @title        = Universal Structural Connector
+        @manufacturer = Generic
+        @description  = General structural re-enforcement for space exploration vehicles.
+
+        @mass               = 0.0560
+        @crashTolerance     = 12
+        @breakingForce      = 250
+        @breakingTorque     = 250
+        @maxTemp            = 1973.15
+        %fuelCrossFeed      = false
+        !explosionPotential = NULL
+        @maxLength          = 25
+        %bulkheadProfiles   = srf
+
+        @MODULE[CModuleStrut]
+        {
+            @linearStrength  = 1000
+            @angularStrength = 1000
+        }
+    }
+
+//  ==================================================
+//  Structural docking ring.
+
+//  Dimensions: 10.000 x 0.600 m
+//  Gross Mass: 830.00 Kg
+//  ==================================================
+
+    @PART[XKW3mDockingRingX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @MODEL
+        {
+            @scale    = 3.325, 0.750, 3.325
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_dockingNode = 0.000,  0.000, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom      = 0.000, -0.750, 0.000, 0.000, -1.000, 0.000, 3
+
+        @title        = LCBM
+        @manufacturer = Boeing Co.
+        %description  = The Large Common Berthing Mechanism (LCBM) is a docking system designed for heavy payloads.
+
+        @mass             = 0.8300
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %bulkheadProfiles = size3
+
+        @MODULE[ModuleDockingNode]
+        {
+            @nodeType              = LCBM
+            %acquireForce          = 0.500
+            %acquireMinFwdDot      = 0.800
+            %acquireminRollDot     = -3.40282347E+38
+            %acquireRange          = 0.250
+            %acquireTorque         = 0.500
+            %captureMaxRvel        = 0.100
+            %captureMinFwdDot      = 0.998
+            %captureMinRollDot     = -3.40282347E+38
+            %captureRange          = 0.050
+            %minDistanceToReEngage = 0.250
+            %undockEjectionForce   = 0.100
+        }
+    }
+
+//  ==================================================
+//  Ares V interstage adapter.
+
+//  Dimensions: 8.384 x 10.300 m
+//  Gross Mass: 8090.00 Kg
+//  ==================================================
+
+    @PART[X84NEWTALUSXX2cx]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @MODEL
+        {
+            @scale    = 2.800, 5.275, 2.800
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000, 0.500, 0.000, 0.000,  1.000, 0.000, 3
+
+        @category     = Structural
+        @title        = Interstage - Ares V
+        @manufacturer = NASA
+        %description  = The structural adapter and explosive cord decoupler for the Ares V Earth Departure Stage (EDS).
+
+        @mass             = 8.0900
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size3
+
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 1.500
+        }
+
+        !MODULE[ModuleReactionWheel]{}
+
+        !MODULE[ModuleSAS]{}
+    }
+
+//  ==================================================
+//  Payload fairing base ring (low profile).
+
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
+
+    @PART[XNPfairings41mplate]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/NP_Fairings_4.1m_Plate/model
+            scale    = 0.200, 0.100, 0.200
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_top       = 0.000, 0.025, 0.000, 0.000,  1.000, 0.000, 1
+        @node_stack_bottom    = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 1
+        %node_stack_connect01 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
+        %node_stack_connect02 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
+        %node_stack_connect03 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
+        %node_stack_connect04 = 0.500, 0.100, 0.000, 0.000,  1.000, 0.000, 0
+
+        @category     = Aero
+        @title        = Payload Fairing - Base (Type IB) [Procedural]
+        %manufacturer = NASA
+        %description  = Procedural, low profile, payload fairing base. Payload decoupling system not included.
+
+        @mass             = 0.1000
+        @crashTolerance   = 12
+        @maxTemp          = 1073.15
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        !stageOffset      = NULL
+        !childStageOffset = NULL
+        %bulkheadProfiles = size1
+
+        MODULE
+        {
+            name          = ProceduralFairingBase
+            baseSize      = 1.150
+            sideThickness = 0.050
+            verticalStep  = 0.100
+        }
+
+        MODULE
+        {
+            name              = KzNodeNumberTweaker
+            nodePrefix        = connect
+            maxNumber         = 4
+            numNodes          = 2
+            radius            = 0.625
+            shouldResizeNodes = False
+        }
+
+        MODULE
+        {
+            name                   = KzFairingBaseResizer
+            size                   = 3.000
+            costPerTonne           = 1000
+            specificMass           = 0.0064, 0.0130, 0.0098, 0.000
+            specificBreakingForce  = 500
+            specificBreakingTorque = 500
+            diameterStepLarge      = 1.000
+            diameterStepSmall      = 0.100
+            dragAreaScale          = 1.500
+        }
+
+        MODULE
+        {
+            name = KzFairingBaseShielding
+        }
+    }
+
+//  ==================================================
+//  Orion MPCV structural adapter.
+
+//  Dimensions: 5.000 x 1.520 m
+//  Gross Mass: 432.00 Kg
+//  ==================================================
+
+    @PART[XFASAApolloStrJ2StrJ23m5mDecX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        @MODEL
+        {
+            @scale    = 1.000, 0.505, 1.000
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_top      =  0.000, -0.500, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom   =  0.000, -0.750, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_connect1 =  2.870,  1.700, 0.000, 0.000,  1.000, 0.000, 2
+        @node_stack_connect2 = -2.870,  1.700, 0.000, 0.000,  1.000, 0.000, 2
+
+        @title        = Orion MPCV Adapter
+        %manufacturer = NASA
+        %description  = Structural adapter for the Orion MPCV and the Service Module protection panels.
+
+        @mass             = 0.4320
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = false
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size2, size3
+
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 250.000
+        }
+    }
+
+//  ==================================================
+//  Delta IV GEM - 60 decoupler.
+
+//  Dimensions: 0.400 x 2.300 m
+//  Gross Mass: 250.00 Kg
+//  ==================================================
+
+    @PART[CHAKAradialDecoupler]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/radialDecoupler/model
+            scale    = 1.000, 2.000, 1.000
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_attach = 0.016, 0.000, 0.000, 1.000, 0.000, 0.000
+
+        @title        = TT-38L Radial Decoupler
+        @manufacturer = Generic
+        @description  = Explosive bolt decoupler for medium sized side mounted boosters.
+
+        @mass             = 0.2500
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = false
+        %stageOffset      = 1
+        %childStageOffset = 1
+        %bulkheadProfiles = srf
+
+        @MODULE[ModuleAnchoredDecoupler]
+        {
+            @ejectionForce = 250.000
+        }
+    }
+
+//  ==================================================
+//  Ares V & SLS Block I/IB/II RSRM decoupler.
+
+//  Dimensions: 0.900 x 3.500 m
+//  Gross Mass: 325.00 Kg
+//  ==================================================
+
+    @PART[chakaradialDecoupler1-2]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/radialDecoupler1-2/model
+            scale    = 1.000, 2.000, 1.000
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_attach = 0.000, 0.000, 0.000, 1.000, 0.000, 0.000
+
+        @title        = TT-70L Radial Decoupler
+        @manufacturer = Generic
+        @description  = Explosive bolt decoupler for large sized side mounted boosters.
+
+        @mass             = 0.3250
+        @crashTolerance   = 12
+        %breakingForce    = 250
+        %breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = false
+        %bulkheadProfiles = srf
+
+        @MODULE[ModuleAnchoredDecoupler]
+        {
+            @ejectionForce = 500.000
+        }
+    }
+
+//  ==================================================
+//  Orion Service Module fairing.
+
+//  Dimensions: 2.500 x 4.000 m
+//  Gross Mass: 330.00 Kg
+//  ==================================================
+
+    @PART[XSDHI_2.5_ServiceModuleFairing]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
+
+        MODEL
+        {
+            model    = CMES/Structural/SDHI-CHAKA-FAIRING/model
+            scale    = 2.472, 2.675, 2.472
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
+
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
+
+        @node_stack_bottom = -0.350, 0.450, 0.000, 0.000, -1.000, 0.000, 2
+
+        @title        = Orion SM Fairing
+        @manufacturer = NASA
+        @description  = Fairing for the Orion service module.
+
+        @mass             = 0.3300
+        @crashTolerance   = 12
+        %breakingForce    = 250
+        %breakingTorque   = 250
+        @maxTemp          = 1073.15
+        %fuelCrossFeed    = false
+        %bulkheadProfiles = size2
+
+        @MODULE[ModuleAnchoredDecoupler]
+        {
+            @ejectionForce = 120.000
+        }
+    }
 
 @PART[XXSDHI_2.5_ServiceModuleAdapter]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI - CHAKA ADAPTER/model
-		scale = 2.600533333, 2.600533333, 2.600533333
-	}
-	@scale = 1
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 0.39008, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_connect1 = 3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_connect2 = -3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
-    
-            
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI - CHAKA ADAPTER/model
+        scale = 2.600533333, 2.600533333, 2.600533333
+    }
+    @scale = 1
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.39008, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_connect1 = 3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect2 = -3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
+
+
     @title = Orion Spacecraft Decoupler
-	@manufacturer = NASA
-	@description = Fairing mount and decoupler for the Orion spacecraft.
+    @manufacturer = NASA
+    @description = Fairing mount and decoupler for the Orion spacecraft.
 }
 +PART[XXSDHI_2.5_ServiceModuleAdapter]:FOR[RealismOverhaul]
 {
-	%name = ORION_ServiceModuleAdapter_PFairing
-	%RSSROConfig = True	
+    %name = ORION_ServiceModuleAdapter_PFairing
+    %RSSROConfig = True
 
-	@MODEL
-	{
-		@scale = 0.525, 0.525, 0.525
-	}
-	%scale = 1
-	%rescaleFactor = 1.0
-	!node_stack_connect1 = DELETE
-	!node_stack_connect2 = DELETE
+    @MODEL
+    {
+        @scale = 0.525, 0.525, 0.525
+    }
+    %scale = 1
+    %rescaleFactor = 1.0
+    !node_stack_connect1 = DELETE
+    !node_stack_connect2 = DELETE
 
-	%node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
-	%node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
+    %node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 
-	%stackSymmetry = 7
-	%title = Orion SM Fairing Base
-	%mass = 0.1
+    %stackSymmetry = 7
+    %title = Orion SM Fairing Base
+    %mass = 0.1
 
-	%breakingForce = 2000
-	%breakingTorque = 2000
+    %breakingForce = 2000
+    %breakingTorque = 2000
 
-	MODULE
-	{
-	  name = ProceduralFairingBase
-	  baseSize=3.0
-	  sideThickness=0.05
-	  verticalStep=0.1
-	  extraRadius = 0.1
-	}
+    MODULE
+    {
+      name = ProceduralFairingBase
+      baseSize=3.0
+      sideThickness=0.05
+      verticalStep=0.1
+      extraRadius = 0.1
+    }
 
-	MODULE
-	{
-	  name = KzNodeNumberTweaker
-	  nodePrefix = connect
-	  maxNumber = 8
-	  numNodes = 2
-	  radius = 0.625
-	  shouldResizeNodes = False
-	}
+    MODULE
+    {
+      name = KzNodeNumberTweaker
+      nodePrefix = connect
+      maxNumber = 8
+      numNodes = 2
+      radius = 0.625
+      shouldResizeNodes = False
+    }
 
-	MODULE
-	{
-	  name = KzFairingBaseResizer
-	  size = 3.0
-	  costPerTonne=1000
-	  specificMass=0.0070, 0.0260, 0.0100, 0
-	  specificBreakingForce  = 1280
-	  diameterStepLarge = 1.0
-	  diameterStepSmall = 0.1
-	}
+    MODULE
+    {
+      name = KzFairingBaseResizer
+      size = 3.0
+      costPerTonne=1000
+      specificMass=0.0070, 0.0260, 0.0100, 0
+      specificBreakingForce  = 1280
+      diameterStepLarge = 1.0
+      diameterStepSmall = 0.1
+    }
 }
 +PART[XXSDHI_2.5_ServiceModuleAdapter]:FOR[RealismOverhaul]
 {
-	%name = ORION_ServiceModuleAdapter_PInterstage
-	%RSSROConfig = True	
+    %name = ORION_ServiceModuleAdapter_PInterstage
+    %RSSROConfig = True
 
-	@MODEL
-	{
-		@scale = 0.525, 0.525, 0.525
-	}
-	%scale = 1
-	%rescaleFactor = 1.0
-	!node_stack_connect1 = DELETE
-	!node_stack_connect2 = DELETE
+    @MODEL
+    {
+        @scale = 0.525, 0.525, 0.525
+    }
+    %scale = 1
+    %rescaleFactor = 1.0
+    !node_stack_connect1 = DELETE
+    !node_stack_connect2 = DELETE
 
-	%node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
-	%node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_top1   = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
+    %node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_top1   = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 2
+    %node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 
-	%stackSymmetry = 7
-	%title = Orion SM Interstage Base
-	%mass = 0.1
+    %stackSymmetry = 7
+    %title = Orion SM Interstage Base
+    %mass = 0.1
 
-	%breakingForce = 2000
-	%breakingTorque = 2000
+    %breakingForce = 2000
+    %breakingTorque = 2000
 
-	MODULE
-	{
-	  name = ProceduralFairingAdapter
-	  baseSize=3.0
-	  topSize =3.0
-	  height=2
-	  costPerTonne=1000
-	  specificMass=0.0064, 0.0130, 0.0098, 0
-	  specificBreakingForce =6050
-	  specificBreakingTorque=6050
-	}
+    MODULE
+    {
+      name = ProceduralFairingAdapter
+      baseSize=3.0
+      topSize =3.0
+      height=2
+      costPerTonne=1000
+      specificMass=0.0064, 0.0130, 0.0098, 0
+      specificBreakingForce =6050
+      specificBreakingTorque=6050
+    }
 
-	MODULE
-	{
-	  name = ProceduralFairingBase
-	  baseSize=3.0
-	  sideThickness=0.05
-	  verticalStep=0.1
-	  fuelCrossFeed=false
-	}
+    MODULE
+    {
+      name = ProceduralFairingBase
+      baseSize=3.0
+      sideThickness=0.05
+      verticalStep=0.1
+      fuelCrossFeed=false
+    }
 
-	MODULE
-	{
-	  name = KzNodeNumberTweaker
-	  nodePrefix = connect
-	  maxNumber = 8
-	  numNodes = 4
-	  radius = 0.625
-	  shouldResizeNodes = False
-	}
+    MODULE
+    {
+      name = KzNodeNumberTweaker
+      nodePrefix = connect
+      maxNumber = 8
+      numNodes = 4
+      radius = 0.625
+      shouldResizeNodes = False
+    }
 
-	MODULE
-	{
-	  name = ModuleDecouple
-	  ejectionForce = 0
-	  explosiveNodeID = top1
-	}
+    MODULE
+    {
+      name = ModuleDecouple
+      ejectionForce = 0
+      explosiveNodeID = top1
+    }
 }
 @PART[SDHIICPSADAPTER2]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI-IUS-ADAPTER/model
-		scale = 2.26666, 2.26666, 2.26666
-	}
-	@scale = 1
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 1.36, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_connect1 = 3.4, 3.842, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_connect2 = -3.4, 3.842, 0.0, 0.0, 1.0, 0.0, 0
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 2.26666, 2.26666, 2.26666
+    }
+    @scale = 1
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.36, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_connect1 = 3.4, 3.842, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect2 = -3.4, 3.842, 0.0, 0.0, 1.0, 0.0, 0
 }
 @PART[SDHIICPSADAPTER]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI-IUS-ADAPTER/model
-		scale = 2.29333, 2.29333, 2.29333
-	}
-	@scale = 1
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 1.421867, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_connect1 = 3.44, 3.8872, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_connect2 = -3.44, 3.8872, 0.0, 0.0, 1.0, 0.0, 0
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 2.29333, 2.29333, 2.29333
+    }
+    @scale = 1
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.421867, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_connect1 = 3.44, 3.8872, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect2 = -3.44, 3.8872, 0.0, 0.0, 1.0, 0.0, 0
 }
 @PART[XXSDHI_2.5_ServiXXce4ModuleAdapter]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI-IUS-ADAPTER/model
-		scale = 2.600533, 2.600533, 2.600533
-	}
-	@scale = 1
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 0.39008, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_connect1 = 3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_connect2 = -3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 2.600533, 2.600533, 2.600533
+    }
+    @scale = 1
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.39008, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_connect1 = 3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect2 = -3.9008, 4.407904, 0.0, 0.0, 1.0, 0.0, 0
 }
 @PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI-IUS-ADAPTER/model
-		scale = 2.32, 2.32, 2.32
-	}
-	@scale = 1
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 0.348, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
-	@node_stack_connect1 = 1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_connect2 = -1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 2.32, 2.32, 2.32
+    }
+    @scale = 1
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.348, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 3
+    @node_stack_connect1 = 1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_connect2 = -1.5, 1.695, 0.0, 0.0, 1.0, 0.0, 0
 }
 
-//	==================================================
-//	Ares V / SLS payload attachment fitting.
+//  ==================================================
+//  Ares V / SLS payload attachment fitting.
 
-//	Dimensions: 8.230 x 2.000 m
-//	Gross Mass: 1700.00 Kg
-//	==================================================
+//  Dimensions: 8.230 x 2.000 m
+//  Gross Mass: 1700.00 Kg
+//  ==================================================
 
-	@PART[SDHIxADAPTERx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    @PART[SDHIxADAPTERx]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
 
-		MODEL
-		{
-			model	 = CMES/Structural/SDHI-IUS-ADAPTER/model
-			scale	 = 4.065, 4.065, 4.065
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+        MODEL
+        {
+            model    = CMES/Structural/SDHI-IUS-ADAPTER/model
+            scale    = 4.065, 4.065, 4.065
+            position = 0.000, 0.000, 0.000
+            rotation = 0.000, 0.000, 0.000
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
-	
-		@node_stack_top	    = 0.000, 2.830, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom  = 0.000, 0.740, 0.000, 0.000, -1.000, 0.000, 3
-		%node_stack_payload = 0.000, 1.557, 0.000, 0.000,  1.000, 0.000, 3
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@category	  = Structural
-		@title		  = Ares V / SLS Payload Adapter
-		@manufacturer = NASA
-		@description  = Structural adapter for the Ares V or Space Launch System (SLS) payloads.
+        @node_stack_top     = 0.000, 2.830, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom  = 0.000, 0.740, 0.000, 0.000, -1.000, 0.000, 3
+        %node_stack_payload = 0.000, 1.557, 0.000, 0.000,  1.000, 0.000, 3
 
-		@mass			  = 1.7000
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = false
-		%bulkheadProfiles = size3
+        @category     = Structural
+        @title        = Ares V / SLS Payload Adapter
+        @manufacturer = NASA
+        @description  = Structural adapter for the Ares V or Space Launch System (SLS) payloads.
 
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 10.000
-		}
-	}
+        @mass             = 1.7000
+        @crashTolerance   = 12
+        @breakingForce    = 250
+        @breakingTorque   = 250
+        @maxTemp          = 1073.15
+        @fuelCrossFeed    = false
+        %bulkheadProfiles = size3
+
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 10.000
+        }
+    }
 
 +PART[SDHIICPSADAPTER]:FOR[RealismOverhaul]
 {
-	%name = SDHI_Adapter_PFairing
-	%RSSROConfig = True	
+    %name = SDHI_Adapter_PFairing
+    %RSSROConfig = True
 
-	@MODEL
-	{
-		@scale = 0.525, 0.525, 0.525
-	}
-	%scale = 1
-	%rescaleFactor = 1.0
+    @MODEL
+    {
+        @scale = 0.525, 0.525, 0.525
+    }
+    %scale = 1
+    %rescaleFactor = 1.0
 
-	!node_stack_connect1 = DELETE
-	!node_stack_connect2 = DELETE
+    !node_stack_connect1 = DELETE
+    !node_stack_connect2 = DELETE
 
-	%node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
-	%node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
+    %node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 
-	%stackSymmetry = 7
-	%title = SDHI Fairing Base
-	%mass = 0.1
+    %stackSymmetry = 7
+    %title = SDHI Fairing Base
+    %mass = 0.1
 
-	%breakingForce = 2000
-	%breakingTorque = 2000
+    %breakingForce = 2000
+    %breakingTorque = 2000
 
-	MODULE
-	{
-	  name = ProceduralFairingBase
-	  baseSize=3.0
-	  sideThickness=0.05
-	  verticalStep=0.1
-	  extraRadius = 0.1
-	}
+    MODULE
+    {
+      name = ProceduralFairingBase
+      baseSize=3.0
+      sideThickness=0.05
+      verticalStep=0.1
+      extraRadius = 0.1
+    }
 
-	MODULE
-	{
-	  name = KzNodeNumberTweaker
-	  nodePrefix = connect
-	  maxNumber = 8
-	  numNodes = 2
-	  radius = 0.625
-	  shouldResizeNodes = False
-	}
+    MODULE
+    {
+      name = KzNodeNumberTweaker
+      nodePrefix = connect
+      maxNumber = 8
+      numNodes = 2
+      radius = 0.625
+      shouldResizeNodes = False
+    }
 
-	MODULE
-	{
-	  name = KzFairingBaseResizer
-	  size = 3.0
-	  costPerTonne=1000
-	  specificMass=0.0070, 0.0260, 0.0100, 0
-	  specificBreakingForce  = 1280
-	  diameterStepLarge = 1.0
-	  diameterStepSmall = 0.1
-	}
+    MODULE
+    {
+      name = KzFairingBaseResizer
+      size = 3.0
+      costPerTonne=1000
+      specificMass=0.0070, 0.0260, 0.0100, 0
+      specificBreakingForce  = 1280
+      diameterStepLarge = 1.0
+      diameterStepSmall = 0.1
+    }
 }
 +PART[SDHIICPSADAPTER]:FOR[RealismOverhaul]
 {
-	%name = SDHI_Adapter_PInterstage
-	%RSSROConfig = True	
+    %name = SDHI_Adapter_PInterstage
+    %RSSROConfig = True
 
-	@MODEL
-	{
-		@scale = 0.525, 0.525, 0.525
-	}
-	%scale = 1
-	%rescaleFactor = 1.0
-	!node_stack_connect1 = DELETE
-	!node_stack_connect2 = DELETE
+    @MODEL
+    {
+        @scale = 0.525, 0.525, 0.525
+    }
+    %scale = 1
+    %rescaleFactor = 1.0
+    !node_stack_connect1 = DELETE
+    !node_stack_connect2 = DELETE
 
-	%node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
-	%node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
-	%node_stack_top1   = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_bottom = 0.0, 0.0, 0.0, 0, -1, 0, 1
+    %node_stack_top = 0.0, 0.370, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_top1   = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 2
+    %node_stack_connect01 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect05 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect06 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect07 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect08 = 0.5, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 
-	%stackSymmetry = 7
-	%title = SDHI Interstage Base
-	%mass = 0.1
+    %stackSymmetry = 7
+    %title = SDHI Interstage Base
+    %mass = 0.1
 
-	%breakingForce = 2000
-	%breakingTorque = 2000
+    %breakingForce = 2000
+    %breakingTorque = 2000
 
-	MODULE
-	{
-	  name = ProceduralFairingAdapter
-	  baseSize=3.0
-	  topSize =3.0
-	  height=2
-	  costPerTonne=1000
-	  specificMass=0.0064, 0.0130, 0.0098, 0
-	  specificBreakingForce =6050
-	  specificBreakingTorque=6050
-	}
+    MODULE
+    {
+      name = ProceduralFairingAdapter
+      baseSize=3.0
+      topSize =3.0
+      height=2
+      costPerTonne=1000
+      specificMass=0.0064, 0.0130, 0.0098, 0
+      specificBreakingForce =6050
+      specificBreakingTorque=6050
+    }
 
-	MODULE
-	{
-	  name = ProceduralFairingBase
-	  baseSize=3.0
-	  sideThickness=0.05
-	  verticalStep=0.1
-	  fuelCrossFeed=false
-	}
+    MODULE
+    {
+      name = ProceduralFairingBase
+      baseSize=3.0
+      sideThickness=0.05
+      verticalStep=0.1
+      fuelCrossFeed=false
+    }
 
-	MODULE
-	{
-	  name = KzNodeNumberTweaker
-	  nodePrefix = connect
-	  maxNumber = 8
-	  numNodes = 4
-	  radius = 0.625
-	  shouldResizeNodes = False
-	}
+    MODULE
+    {
+      name = KzNodeNumberTweaker
+      nodePrefix = connect
+      maxNumber = 8
+      numNodes = 4
+      radius = 0.625
+      shouldResizeNodes = False
+    }
 
-	MODULE
-	{
-	  name = ModuleDecouple
-	  ejectionForce = 0
-	  explosiveNodeID = top1
-	}
+    MODULE
+    {
+      name = ModuleDecouple
+      ejectionForce = 0
+      explosiveNodeID = top1
+    }
 }
 @PART[SLS_CM_FairingAdapter]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI-IUS-ADAPTER/model
-		scale = 1.3333, 1.3333, 1.3333
-	}
-	@scale = 1
-	@rescaleFactor = 1.00
-	
-	@node_stack_bottom = 0.0, -4.973333333, 0.0, 0, -1, 0, 6
-	@node_stack_top = 0.0, 2, 0.0, 0.0, 1.0, 0.0, 3
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 1.3333, 1.3333, 1.3333
+    }
+    @scale = 1
+    @rescaleFactor = 1.00
 
-	@fx_gasBurst_white = 0.0, 3.732888, 0.0, 0.0, 1.0, 0.0, decouple
+    @node_stack_bottom = 0.0, -4.973333333, 0.0, 0, -1, 0, 6
+    @node_stack_top = 0.0, 2, 0.0, 0.0, 1.0, 0.0, 3
+
+    @fx_gasBurst_white = 0.0, 3.732888, 0.0, 0.0, 1.0, 0.0, decouple
 }
 
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) 4 - meter payload adapter.
+//  ==================================================
+//  Delta Cryogenic Second Stage (DCSS) 4 - meter payload adapter.
 
-//	Dimensions: 3.800 x 1.100 m
-//	Gross Mass: 240.00 Kg
-//	==================================================
+//  Dimensions: 3.800 x 1.100 m
+//  Gross Mass: 240.00 Kg
+//  ==================================================
 
-	@PART[PAYLOADADAPTER]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    @PART[PAYLOADADAPTER]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
 
-		@MODEL
-		{
-			@scale	  = 0.582, 0.170, 0.582
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+        @MODEL
+        {
+            @scale    = 0.582, 0.170, 0.582
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@node_stack_bottom	  = 0.000, -0.605, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	  	  = 0.000,  0.470, 0.000, 0.000,  1.000, 0.000, 3
-		%node_stack_connect01 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-		%node_stack_connect02 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-		%node_stack_connect03 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-		%node_stack_connect04 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
+        @node_stack_bottom    = 0.000, -0.605, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top       = 0.000,  0.470, 0.000, 0.000,  1.000, 0.000, 3
+        %node_stack_connect01 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
+        %node_stack_connect02 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
+        %node_stack_connect03 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
+        %node_stack_connect04 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
 
-		@fx_gasBurst_white = 0.000, 3.733, 0.000, 0.000, 1.000, 0.000, decouple
-    
-		@title		  = Delta IV DCSS PAF [4 Meters]
-		@manufacturer = Orbital ATK
-		%description  = The Payload Attach Fitting (PAF) is used for securing the spacecraft for the duration of the flight and separating it into the desired orbit. Sized for the 4 meter DCSS (1575-4 PAF).
+        @fx_gasBurst_white = 0.000, 3.733, 0.000, 0.000, 1.000, 0.000, decouple
 
-		@mass			  = 0.2400
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@stageOffset	  = 1
-		@childStageOffset = 1
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
+        @title        = Delta IV DCSS PAF [4 Meters]
+        @manufacturer = Orbital ATK
+        %description  = The Payload Attach Fitting (PAF) is used for securing the spacecraft for the duration of the flight and separating it into the desired orbit. Sized for the 4 meter DCSS (1575-4 PAF).
 
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 1.000
-		}
-	}
+        @mass             = 0.2400
+        @crashTolerance   = 12
+        %breakingForce    = 250
+        %breakingTorque   = 250
+        @maxTemp          = 1073.15
+        @stageOffset      = 1
+        @childStageOffset = 1
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size3
 
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) 5 - meter payload adapter.
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 1.000
+        }
+    }
 
-//	Dimensions: 4.700 x 1.800 m
-//	Gross Mass: 418.00 Kg
-//	==================================================
+//  ==================================================
+//  Delta Cryogenic Second Stage (DCSS) 5 - meter payload adapter.
 
-	@PART[PAYLOADADAPTER2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+//  Dimensions: 4.700 x 1.800 m
+//  Gross Mass: 418.00 Kg
+//  ==================================================
 
-		@MODEL
-		{
-			@scale	  = 0.720, 0.280, 0.720
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    @PART[PAYLOADADAPTER2]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+        @MODEL
+        {
+            @scale    = 0.720, 0.280, 0.720
+            %position = 0.000, 0.000, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
 
-		@node_stack_bottom = 0.000, -0.990, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  0.765, 0.000, 0.000,  1.000, 0.000, 3
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@fx_gasBurst_white = 0.000, 3.733, 0.000, 0.000, 1.000, 0.000, decouple
-    
-		@title		  = Delta IV DCSS PAF [5 Meters]
-		@manufacturer = Orbital ATK
-		%description  = The Payload Attach Fitting (PAF) is used for securing the spacecraft for the duration of the flight and separating it into the desired orbit. Sized for the 5 meter DCSS (1575-5 PAF).
+        @node_stack_bottom = 0.000, -0.990, 0.000, 0.000, -1.000, 0.000, 3
+        @node_stack_top    = 0.000,  0.765, 0.000, 0.000,  1.000, 0.000, 3
 
-		@mass			  = 0.4180
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@stageOffset	  = 1
-		@childStageOffset = 1
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size3
+        @fx_gasBurst_white = 0.000, 3.733, 0.000, 0.000, 1.000, 0.000, decouple
 
-		@MODULE[ModuleDecouple]
-		{
-			@ejectionForce = 1.000
-		}
-	}
+        @title        = Delta IV DCSS PAF [5 Meters]
+        @manufacturer = Orbital ATK
+        %description  = The Payload Attach Fitting (PAF) is used for securing the spacecraft for the duration of the flight and separating it into the desired orbit. Sized for the 5 meter DCSS (1575-5 PAF).
 
-//	==================================================
-//	Payload attach fitting (procedural).
+        @mass             = 0.4180
+        @crashTolerance   = 12
+        %breakingForce    = 250
+        %breakingTorque   = 250
+        @maxTemp          = 1073.15
+        @stageOffset      = 1
+        @childStageOffset = 1
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size3
 
-//	Modeled after the Delta IV Payload Attach Fitting (PAF).
+        @MODULE[ModuleDecouple]
+        {
+            @ejectionForce = 1.000
+        }
+    }
 
-//	Dimensions: N/A
-//	Gross Mass: N/A
-//	==================================================
+//  ==================================================
+//  Payload attach fitting (procedural).
 
-	@PART[SLS_CM_FairingAdapter2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+//  Modeled after the Delta IV Payload Attach Fitting (PAF).
 
-		@MODEL
-		{
-			@scale	  = 0.165, 0.060, 0.165
-			%position = 0.000, 0.215, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+//  Dimensions: N/A
+//  Gross Mass: N/A
+//  ==================================================
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @PART[SLS_CM_FairingAdapter2]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = true
 
-		@node_stack_top	   = 0.000, 0.385, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
+        @MODEL
+        {
+            @scale    = 0.165, 0.060, 0.165
+            %position = 0.000, 0.215, 0.000
+            %rotation = 0.000, 0.000, 0.000
+        }
 
-		@category	  = Aero
-		@title		  = Payload Fairing - Base (PAF) [Procedural]
-		@manufacturer = Generic
-		%description  = Structural base for mounting side fairings and your payload. Decoupler sold separately. Flat raised surface can be used for mounting additional hardware as required.
+        !mesh          = NULL
+        @scale         = 1.000
+        @rescaleFactor = 1.000
 
-		@mass			  = 0.1000
-		@crashTolerance	  = 12
-		%breakingForce 	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		@fuelCrossFeed	  = true
-		%stagingIcon	  = DECOUPLER_HOR
-		%bulkheadProfiles = size1
+        @node_stack_top    = 0.000, 0.385, 0.000, 0.000,  1.000, 0.000, 3
+        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
 
-		!MODULE[ModuleDecouple]{}
+        @category     = Aero
+        @title        = Payload Fairing - Base (PAF) [Procedural]
+        @manufacturer = Generic
+        %description  = Structural base for mounting side fairings and your payload. Decoupler sold separately. Flat raised surface can be used for mounting additional hardware as required.
 
-		MODULE
-		{
-			name		  = ProceduralFairingBase
-			baseSize	  = 1.150
-			sideThickness = 0.050
-			verticalStep  = 0.100
-		}
+        @mass             = 0.1000
+        @crashTolerance   = 12
+        %breakingForce    = 250
+        %breakingTorque   = 250
+        @maxTemp          = 1073.15
+        @fuelCrossFeed    = true
+        %stagingIcon      = DECOUPLER_HOR
+        %bulkheadProfiles = size1
 
-		MODULE
-		{
-			name			  = KzNodeNumberTweaker
-			nodePrefix		  = connect
-			maxNumber		  = 4
-			numNodes		  = 2
-			radius			  = 0.625
-			shouldResizeNodes = false
-		}
+        !MODULE[ModuleDecouple]{}
 
-		MODULE
-		{
-			name				   = KzFairingBaseResizer
-			size				   = 3.000
-			costPerTonne		   = 1000
-			specificMass		   = 0.006, 0.013, 0.009, 0.000
-			specificBreakingForce  = 500
-			specificBreakingTorque = 500
-			diameterStepLarge	   = 1.000
-			diameterStepSmall	   = 0.100
-			dragAreaScale		   = 1.500
-		}
+        MODULE
+        {
+            name          = ProceduralFairingBase
+            baseSize      = 1.150
+            sideThickness = 0.050
+            verticalStep  = 0.100
+        }
 
-		MODULE
-		{
-			name = KzFairingBaseShielding
-		}
-	}
+        MODULE
+        {
+            name              = KzNodeNumberTweaker
+            nodePrefix        = connect
+            maxNumber         = 4
+            numNodes          = 2
+            radius            = 0.625
+            shouldResizeNodes = false
+        }
+
+        MODULE
+        {
+            name                   = KzFairingBaseResizer
+            size                   = 3.000
+            costPerTonne           = 1000
+            specificMass           = 0.006, 0.013, 0.009, 0.000
+            specificBreakingForce  = 500
+            specificBreakingTorque = 500
+            diameterStepLarge      = 1.000
+            diameterStepSmall      = 0.100
+            dragAreaScale          = 1.500
+        }
+
+        MODULE
+        {
+            name = KzFairingBaseShielding
+        }
+    }
 
 @PART[SLS_CM_stackDecouplerx]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-	  @scale = 1.392, 1.2, 1.392
-	}
+    %RSSROConfig = True
+    @MODEL
+    {
+      @scale = 1.392, 1.2, 1.392
+    }
 
-	// --- node definitions ---
-	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-	@node_stack_bottom = 0.0,-0.573913032, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 0.60869564, 0.0, 0.0, 1.0, 0.0, 3
+    // --- node definitions ---
+    // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
+    @node_stack_bottom = 0.0,-0.573913032, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 0.60869564, 0.0, 0.0, 1.0, 0.0, 3
 
-	// --- FX definitions ---
-	@fx_gasBurst_white = 0.0, 0.0867356, 0.0, 0.0, 1.0, 0.0, decouple
+    // --- FX definitions ---
+    @fx_gasBurst_white = 0.0, 0.0867356, 0.0, 0.0, 1.0, 0.0, decouple
 }
 @PART[XstrutOctoX]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Structural/SDHI-IUS-ADAPTER/model
-		scale = 4, 4, 4
-	}
-	@scale = 1
-	@rescaleFactor = 1
+    %RSSROConfig = True
+    !mesh = DELETE
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 4, 4, 4
+    }
+    @scale = 1
+    @rescaleFactor = 1
 
-	@node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_bottom = 0.0, 0.00, 0.0, 0, -1, 0, 0
+    @node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_bottom = 0.0, 0.00, 0.0, 0, -1, 0, 0
 }
 
-//	==================================================
-//	Strut connector (medium strength).
+//  ==================================================
+//  Strut connector (medium strength).
 
-//	Dimensions: N/A
-//	Gross Mass: 14.00 Kg
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: 14.00 Kg
+//  ==================================================
 
-	@PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
+    @PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = True
 
-		@title		  = EAS-8 Strut Connector
-		@manufacturer = Generic
-		@description  = A medium strength structural connector.
+        @title        = EAS-8 Strut Connector
+        @manufacturer = Generic
+        @description  = A medium strength structural connector.
 
-		@mass			= 0.0140
-		@breakingForce	= 250
-		@breakingTorque = 250
-		@maxLength		= 25
+        @mass           = 0.0140
+        @breakingForce  = 250
+        @breakingTorque = 250
+        @maxLength      = 25
 
-		@MODULE[CModuleStrut]
-		{
-			@linearStrength  = 300
-			@angularStrength = 300
-		}
-	}
+        @MODULE[CModuleStrut]
+        {
+            @linearStrength  = 300
+            @angularStrength = 300
+        }
+    }
 
-//	==================================================
-//	Strut connector (high strength).
+//  ==================================================
+//  Strut connector (high strength).
 
-//	Dimensions: N/A
-//	Gross Mass: 56.00 Kg
-//	==================================================
+//  Dimensions: N/A
+//  Gross Mass: 56.00 Kg
+//  ==================================================
 
-	@PART[SUPERSTRUTCONNECTOR]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
+    @PART[SUPERSTRUTCONNECTOR]:FOR[RealismOverhaul]
+    {
+        %RSSROConfig = True
 
-		@title		  = EAS-16 Strut Connector
-		@manufacturer = Generic
-		@description  = A high strength structural connector.
+        @title        = EAS-16 Strut Connector
+        @manufacturer = Generic
+        @description  = A high strength structural connector.
 
-		@mass 			= 0.0560
-		@breakingForce	= 250
-		@breakingTorque = 250
-		@maxLength		= 25
+        @mass           = 0.0560
+        @breakingForce  = 250
+        @breakingTorque = 250
+        @maxLength      = 25
 
-		@MODULE[CModuleStrut]
-		{
-			@linearStrength  = 600
-			@angularStrength = 600
-		}
-	}
+        @MODULE[CModuleStrut]
+        {
+            @linearStrength  = 600
+            @angularStrength = 600
+        }
+    }
 
 @PART[Xtrusslrg_argonXsmall]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 1.0,1.3333,1.0
-	}
-	@node_stack_bottom = 0.0, -3.0088, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 3.0088, 0.0, 0.0, 1.0, 0.0, 3
-	@node_attach = 0.0, -3.0088, 0.0, 0.0, -1.0, 0.0
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 1.0,1.3333,1.0
+    }
+    @node_stack_bottom = 0.0, -3.0088, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 3.0088, 0.0, 0.0, 1.0, 0.0, 3
+    @node_attach = 0.0, -3.0088, 0.0, 0.0, -1.0, 0.0
 }
 @PART[Xtrusslrg_argonXsmalldccdC]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 2.46667,1.066667,2.46667
-	}
-	@node_stack_bottom = 0.0, -2.250666667, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 2.406666667, 0.0, 0.0, 1.0, 0.0, 3
-	@node_attach = 0.0, -2.70792, 0.0, 0.0, 1.0, 0.0, 0
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 2.46667,1.066667,2.46667
+    }
+    @node_stack_bottom = 0.0, -2.250666667, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 2.406666667, 0.0, 0.0, 1.0, 0.0, 3
+    @node_attach = 0.0, -2.70792, 0.0, 0.0, 1.0, 0.0, 0
 }
 @PART[Xtrusslrg_argonXsmalldccdCxx]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True	
-	@MODEL
-	{
-		@scale = 2.46667, 1.466667, 2.46667
-	}
-	@node_stack_bottom = 0.0, -3.146666667, 0.0, 0, -1, 0, 3
-	@node_stack_top = 0.0, 3.293333333, 0.0, 0.0, 1.0, 0.0, 3
-	@node_attach = 0.0, -2.70792, 0.0, 0.0, 1.0, 0.0, 0
-    
+    %RSSROConfig = True
+    @MODEL
+    {
+        @scale = 2.46667, 1.466667, 2.46667
+    }
+    @node_stack_bottom = 0.0, -3.146666667, 0.0, 0, -1, 0, 3
+    @node_stack_top = 0.0, 3.293333333, 0.0, 0.0, 1.0, 0.0, 3
+    @node_attach = 0.0, -2.70792, 0.0, 0.0, 1.0, 0.0, 0
+
         @title = Station Depot Module
-	@manufacturer = Lockheed Martin
-	@description = Flexible fuel depot for on orbit operations.
-    
+    @manufacturer = Lockheed Martin
+    @description = Flexible fuel depot for on orbit operations.
+
         @mass = 5.7
-    
+
         !RESOURCE[MonoPropellant]
         {
         }
-    
+
         !RESOURCE[ElectricCharge]
         {
         }
-    
+
         MODULE
-	{
-		name = ModuleFuelTanks
-		type = Default
-		volume = 31500
-		basemass = -1
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 31500
+        basemass = -1
         }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1145,55 +1145,56 @@
 //  ==================================================
 //  Structural docking ring.
 
-//  Dimensions: 10.000 x 0.600 m
-//  Gross Mass: 830.00 Kg
+//  Dimensions: 10 m x 0.6 m
+//  Inert Mass: 1500 Kg
 //  ==================================================
 
-    @PART[XKW3mDockingRingX]:FOR[RealismOverhaul]
+@PART[XKW3mDockingRingX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 3.325, 0.750, 3.325
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_dockingNode = 0.000,  0.000, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom      = 0.000, -0.750, 0.000, 0.000, -1.000, 0.000, 3
-
-        @title        = LCBM
-        @manufacturer = Boeing Co.
-        %description  = The Large Common Berthing Mechanism (LCBM) is a docking system designed for heavy payloads.
-
-        @mass             = 0.8300
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %bulkheadProfiles = size3
-
-        @MODULE[ModuleDockingNode]
-        {
-            @nodeType              = LCBM
-            %acquireForce          = 0.500
-            %acquireMinFwdDot      = 0.800
-            %acquireminRollDot     = -3.40282347E+38
-            %acquireRange          = 0.250
-            %acquireTorque         = 0.500
-            %captureMaxRvel        = 0.100
-            %captureMinFwdDot      = 0.998
-            %captureMinRollDot     = -3.40282347E+38
-            %captureRange          = 0.050
-            %minDistanceToReEngage = 0.250
-            %undockEjectionForce   = 0.100
-        }
+        @scale = 3.325, 0.75, 3.325
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_dockingNode = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 5
+
+    @category = Coupling
+    @title = LCBM
+    @manufacturer = Boeing Co.
+    %description = The Large Common Berthing Mechanism (LCBM) is a docking system designed for heavy payloads.
+
+    @mass = 1.5
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %bulkheadProfiles = size5
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = LCBM
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+    }
+}
 
 //  ==================================================
 //  Ares V interstage adapter.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1737,50 +1737,90 @@
 }
 
 //  ==================================================
-//  Ares V / SLS payload attachment fitting.
+//  Procedural payload attach fitting (expanded).
 
-//  Dimensions: 8.230 x 2.000 m
-//  Gross Mass: 1700.00 Kg
+//  Dimensions: N/A
+//  Inert Mass: N/A
 //  ==================================================
 
-    @PART[SDHIxADAPTERx]:FOR[RealismOverhaul]
+@PART[SDHIxADAPTERx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Structural/SDHI-IUS-ADAPTER/model
-            scale    = 4.065, 4.065, 4.065
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top     = 0.000, 2.830, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom  = 0.000, 0.740, 0.000, 0.000, -1.000, 0.000, 3
-        %node_stack_payload = 0.000, 1.557, 0.000, 0.000,  1.000, 0.000, 3
-
-        @category     = Structural
-        @title        = Ares V / SLS Payload Adapter
-        @manufacturer = NASA
-        @description  = Structural adapter for the Ares V or Space Launch System (SLS) payloads.
-
-        @mass             = 1.7000
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        @fuelCrossFeed    = false
-        %bulkheadProfiles = size3
-
-        @MODULE[ModuleDecouple]
-        {
-            @ejectionForce = 10.000
-        }
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 0.49, 0.49, 0.49
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.35, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    %node_stack_connect01 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+
+    @category = Payload
+    @title = Payload Attach Fitting - Base (Expanded) [Procedural]
+    @manufacturer = Generic
+    @description = A payload attach fitting for the Space Launch System payloads.
+
+    @mass = 0.1
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @fuelCrossFeed = True
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size0, size1
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+
+    MODULE
+    {
+        name = ProceduralFairingBase
+        baseSize = 1.8
+        sideThickness = 0.1
+        verticalStep = 0.1
+    }
+
+    MODULE
+    {
+        name = KzNodeNumberTweaker
+        nodePrefix = connect
+        maxNumber = 4
+        numNodes = 2
+        radius = 0.625
+        shouldResizeNodes = False
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseResizer
+        size = 2.0
+        diameterStepLarge = 1.0
+        diameterStepSmall = 0.1
+        costPerTonne = 1000
+        specificMass = 0.007, 0.026, 0.01, 0.0
+        specificBreakingForce = 250
+        specificBreakingTorque = 250
+        dragAreaScale = 1.5
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseShielding
+    }
+}
 
 +PART[SDHIICPSADAPTER]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -2228,28 +2228,43 @@
 //  Strut connector (medium strength).
 
 //  Dimensions: N/A
-//  Gross Mass: 14.00 Kg
+//  Inert Mass: 15 Kg
 //  ==================================================
 
-    @PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
+@PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
+{
+    @module = CompoundPart
+
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = EAS-8 Strut Connector
+    @manufacturer = Generic
+    @description = A medium strength structural connector.
+
+    @mass = 0.015
+    @dragModelType = SPHERICAL
+    @minimumDrag = 0.02
+    @maximumDrag = 0.02
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @maxLength = 50
+    %bulkheadProfiles = srf
+
+    @MODULE[CModuleStrut]
     {
-        %RSSROConfig = True
-
-        @title        = EAS-8 Strut Connector
-        @manufacturer = Generic
-        @description  = A medium strength structural connector.
-
-        @mass           = 0.0140
-        @breakingForce  = 250
-        @breakingTorque = 250
-        @maxLength      = 25
-
-        @MODULE[CModuleStrut]
-        {
-            @linearStrength  = 300
-            @angularStrength = 300
-        }
+        @linearStrength = 300
+        @angularStrength = 300
     }
+
+    %DRAG_CUBE
+    {
+        %none = True
+    }
+}
 
 //  ==================================================
 //  Strut connector (high strength).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -409,61 +409,72 @@
 //  ==================================================
 //  NASA Docking & Berthing Mechanism (NDS).
 
-//  Dimensions: 1.225 x 0.500 m
-//  Gross Mass: 200.00 Kg
+//  Dimensions: 1.725 m x 0.5 m
+//  Inert Mass: 200 Kg
 //  ==================================================
 
-    @PART[XAltairDockingPortX]:FOR[RealismOverhaul]
+@PART[XAltairDockingPortX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Structural/Altair_dockport/model
-            scale    = 1.490, 1.450, 1.490
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  0.275, 0.000, 0.000,  1.000, 0.000, 2
-        @node_stack_bottom = 0.000, -0.020, 0.000, 0.000, -1.000, 0.000, 2
-
-        @title        = NASA Docking System (NDS)
-        @manufacturer = Boeing Co. & NASA
-        @description  = The NDS is an androgynous spacecraft docking and berthing mechanism, developed for the Orion MPCV and the Commercial Crew vehicles.
-
-        @mass             = 0.200
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = true
-        %bulkheadProfiles = srf, size2
-
-        @MODULE[ModuleDockingNode]
-        {
-            @nodeType              = NASADock
-            %acquireForce          = 0.5
-            %acquireMinFwdDot      = 0.8
-            %acquireminRollDot     = -3.40282347E+38
-            %acquireRange          = 0.25
-            %acquireTorque         = 0.5
-            %captureMaxRvel        = 0.1
-            %captureMinFwdDot      = 0.998
-            %captureMinRollDot     = -3.40282347E+38
-            %captureRange          = 0.05
-            %minDistanceToReEngage = 0.25
-            %undockEjectionForce   = 0.1
-        }
-
-        !MODULE[ModuleCommand]{}
-
-        !MODULE[MechJebCore]{}
+        model = CMES/Structural/Altair_dockport/model
+        scale = 1.49, 1.45, 1.49
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.275, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.02, 0.0, 0.0, -1.0, 0.0, 2
+
+    @category = Coupling
+    @title = NASA Docking System
+    %manufacturer = Boeing Co.
+    @description = The NDS is an androgynous spacecraft docking and berthing mechanism, developed for the Orion MPCV and the Commercial Crew vehicles.
+
+    @mass = 0.2
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    %bulkheadProfiles = srf, size2
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = NASADock
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+        %stagingEnabled = False
+    }
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        passableWhenSurfaceAttached = True
+    }
+}
 
 //  ==================================================
 //  MSEV rover wheel.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1975,55 +1975,81 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (DCSS) 4 - meter payload adapter.
+//  Delta Cryogenic Second Stage (DCSS) payload attach fitting (4 meters).
 
-//  Dimensions: 3.800 x 1.100 m
-//  Gross Mass: 240.00 Kg
+//  Dimensions: 3.8 m x 1.1 m
+//  Inert Mass: 240 Kg
 //  ==================================================
 
-    @PART[PAYLOADADAPTER]:FOR[RealismOverhaul]
+@PART[PAYLOADADAPTER]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 0.582, 0.170, 0.582
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_bottom    = 0.000, -0.605, 0.000, 0.000, -1.000, 0.000, 3
-        @node_stack_top       = 0.000,  0.470, 0.000, 0.000,  1.000, 0.000, 3
-        %node_stack_connect01 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-        %node_stack_connect02 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-        %node_stack_connect03 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-        %node_stack_connect04 = 0.500,  0.100, 0.000, 0.000,  1.000, 0.000, 0
-
-        @fx_gasBurst_white = 0.000, 3.733, 0.000, 0.000, 1.000, 0.000, decouple
-
-        @title        = Delta IV DCSS PAF [4 Meters]
-        @manufacturer = Orbital ATK
-        %description  = The Payload Attach Fitting (PAF) is used for securing the spacecraft for the duration of the flight and separating it into the desired orbit. Sized for the 4 meter DCSS (1575-4 PAF).
-
-        @mass             = 0.2400
-        @crashTolerance   = 12
-        %breakingForce    = 250
-        %breakingTorque   = 250
-        @maxTemp          = 1073.15
-        @stageOffset      = 1
-        @childStageOffset = 1
-        %stagingIcon      = DECOUPLER_HOR
-        %bulkheadProfiles = size3
-
-        @MODULE[ModuleDecouple]
-        {
-            @ejectionForce = 1.000
-        }
+        @scale = 0.585, 0.17, 0.585
+        %position = 0.0, 0.6, 0.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_top  = 0.0, 1.075, 0.0, 0.0, 1.0, 0.0, 2
+    %node_stack_connect01 = 1.9, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_connect02 = 1.9, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_connect03 = 1.9, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+    %node_stack_connect04 = 1.9, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+
+    @fx_gasBurst_white = 0.0, 3.733, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Payload
+    @title = Payload Attach Fitting - DCSS (4 m)
+    @manufacturer = Orbital ATK
+    %description = The Payload Attach Fitting (PAF) is used for securing the spacecraft for the duration of the flight and separating it into the desired orbit. Sized for the 4 meter DCSS (1575-4 PAF).
+
+    @mass = 0.24
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = True
+    @stageOffset = 1
+    @childStageOffset = 1
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size2, size3
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 25
+    }
+
+    MODULE
+    {
+        name = ProceduralFairingBase
+        baseSize = 3.8
+        sideThickness = 0.1
+        verticalStep = 0.1
+    }
+
+    MODULE
+    {
+        name = KzNodeNumberTweaker
+        nodePrefix = connect
+        maxNumber = 4
+        numNodes = 2
+        radius = 1.9
+        shouldResizeNodes = False
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseShielding
+    }
+}
 
 //  ==================================================
 //  Delta Cryogenic Second Stage (DCSS) 5 - meter payload adapter.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1375,49 +1375,50 @@
 }
 
 //  ==================================================
-//  Delta IV GEM - 60 decoupler.
+//  TT - 38L radial decoupler.
 
-//  Dimensions: 0.400 x 2.300 m
-//  Gross Mass: 250.00 Kg
+//  Dimensions: 0.4 m x 2.3 m
+//  Inert Mass: 250 Kg
 //  ==================================================
 
-    @PART[CHAKAradialDecoupler]:FOR[RealismOverhaul]
+@PART[CHAKAradialDecoupler]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Structural/radialDecoupler/model
-            scale    = 1.000, 2.000, 1.000
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_attach = 0.016, 0.000, 0.000, 1.000, 0.000, 0.000
-
-        @title        = TT-38L Radial Decoupler
-        @manufacturer = Generic
-        @description  = Explosive bolt decoupler for medium sized side mounted boosters.
-
-        @mass             = 0.2500
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = false
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleAnchoredDecoupler]
-        {
-            @ejectionForce = 250.000
-        }
+        model = CMES/Structural/radialDecoupler/model
+        scale = 1.0, 2.0, 1.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.016, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = Coupling
+    @title = TT-38L Radial Decoupler
+    @manufacturer = Generic
+    @description = Explosive cord decoupler for side mounted boosters.
+
+    @mass = 0.25
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 250
+    }
+}
 
 //  ==================================================
 //  Ares V & SLS Block I/IB/II RSRM decoupler.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -2308,17 +2308,61 @@
     }
 }
 
+//  ==================================================
+//  Station propellant depot.
+
+//  Dimensions: 5.2 m x 6.5 m
+//  Inert Mass: 2500 Kg
+//  ==================================================
+
 @PART[Xtrusslrg_argonXsmall]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
     @MODEL
     {
-        @scale = 1.0,1.3333,1.0
+        @scale = 2.465, 1.465, 2.466
     }
-    @node_stack_bottom = 0.0, -3.0088, 0.0, 0, -1, 0, 3
-    @node_stack_top = 0.0, 3.0088, 0.0, 0.0, 1.0, 0.0, 3
-    @node_attach = 0.0, -3.0088, 0.0, 0.0, -1.0, 0.0
+
+    @node_stack_bottom = 0.0, -3.315, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_top = 0.0, 3.315, 0.0, 0.0, 1.0, 0.0, 4
+    @node_attach = 0.0, -2.71, 0.0, 0.0, 1.0, 0.0
+
+    @attachRules = 1,0,1,1,0
+
+    @category = FuelTank
+    @title = Exploration Station Depot
+    @manufacturer = Lockheed Martin
+    %description = Flexible propellant depot for on-orbit operations.
+
+    @mass = 2.5
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size4
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 76000
+    }
+
+    !RESOURCE,*{}
 }
+
 @PART[Xtrusslrg_argonXsmalldccdC]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -728,50 +728,52 @@
     }
 
 //  ==================================================
-//  Delta IV interstage adapter.
+//  Delta IV interstage adapter (5 m).
 
-//  Because the current RL10-B-2 has not an extensible nozzle, we cheat the length of the adapter to be 8.5 meters from the original 7.5 meters.
+//  Dimensions: 5 m x 9 m
+//  Inert Mass: 2460 Kg
 
-//  Dimensions: 5.000 x 7.500 m
-//  Gross Mass: 2460.00 Kg
+//  Because the CMES RL10B-2 does not have an extendable
+//  B cone, the length of the adapter has been increased
+//  by 1.5 meters from the original.
 //  ==================================================
 
-    @PART[XKW5mDecouplerShroudX224]:FOR[RealismOverhaul]
+@PART[XKW5mDecouplerShroudX224]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 1.666, 4.455, 1.666
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-        @node_stack_top    = 0.000, 0.250, 0.000, 0.000,  1.000, 0.000, 3
-
-        @category     = Structural
-        @title        = Interstage - Delta IV
-        @manufacturer = Orbital ATK
-        %description  = The structural adapter and explosive cord decoupler for the Delta Cryogenic Second Stage (DCSS).
-
-        @mass             = 2.4600
-        @crashTolerance   = 12
-        @maxTemp          = 1073.15
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        %stagingIcon      = DECOUPLER_HOR
-        %bulkheadProfiles = size3
-
-        @MODULE[ModuleDecouple]
-        {
-            @ejectionForce = 25.000
-        }
+        @scale = 1.666, 4.58, 1.666
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_top = 0.0, 0.25, 0.0, 0.0, 1.0, 0.0, 4
+
+    @category = Coupling
+    @title = Interstage Adapter - Delta IV DCSS (5 m)
+    @manufacturer = Orbital ATK
+    %description = The structural adapter and explosive cord decoupler for the 5 meter Delta Cryogenic Second Stage (DCSS).
+
+    @mass = 2.46
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size4
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 50
+    }
+}
 
 @PART[XXB3IUShroudXSMALLERX]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1,4 +1,20 @@
 //  ==================================================
+//  Sources:
+
+//  AIAA - From Apollo LM to Altair:                      http://www.csc.caltech.edu/references/AIAA-2009-6404.pdf
+//  NASA - Altair Lunar Lander fact sheet:                https://www.nasa.gov/centers/johnson/pdf/327564main_fs_2009_02_005_jsc_altair_web.pdf
+//  NTRS - Altair Ascent and Descent Trajectory Design:   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100035768.pdf
+//  Space Launch Report - Space Launch System Data Sheet: http://www.spacelaunchreport.com/sls0.html
+//  Norbert Brügge - Delta IV:                            http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Description/Frame.htm
+//  ULA - Delta IV user guide:                            http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//  Space Launch Report - Falcon 9:                       http://www.spacelaunchreport.com/falcon.html
+//  Spaceflight 101 - Falcon 9 v1.1:                      http://spaceflight101.com/spacerockets/falcon-9-v1-1-f9r/
+//  NASA - Orion CSM fact sheet:                          https://www.nasa.gov/sites/default/files/atoms/files/fs-2014-08-004-jsc-orion_quickfacts-web.pdf
+//  NTRS - Energy Storage Workshop:                       https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110009972.pdf
+//  NTRS - Constellation Program Li-Ion cell storage:     https://batteryworkshop.msfc.nasa.gov/presentations/06_Adv%20Li-ion%20Cells%20Constellation_CReid.pdf
+
+
+//  ==================================================
 //  Removed extra parts.
 //  ==================================================
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1102,41 +1102,45 @@
 //  Universal structural connector.
 
 //  Dimensions: N/A
-//  Gross Mass: 56.00 Kg
+//  Inert Mass: 60 Kg
 //  ==================================================
 
-    @PART[XKosmos_Strut_ConnectorX]:FOR[RealismOverhaul]
+@PART[XKosmos_Strut_ConnectorX]:FOR[RealismOverhaul]
+{
+    @module = CompoundPart
+
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = Universal Structural Connector
+    @manufacturer = Generic
+    @description = General structural re-enforcement for space exploration vehicles.
+
+    @mass = 0.06
+    @dragModelType = SPHERICAL
+    @minimumDrag = 0.02
+    @maximumDrag = 0.02
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+    !explosionPotential = NULL
+    @maxLength = 50
+    %bulkheadProfiles = srf
+
+    @MODULE[CModuleStrut]
     {
-        %RSSROConfig = true
-
-        @mesh          = Strut_Connector.mu
-        @scale         = 0.100
-        @rescaleFactor = 3.000
-        !specPower     = NULL
-        !rimFalloff    = NULL
-        !alphaCutoff   = NULL
-        @iconCenter    = -4.690, 2.650, 0.000
-
-        @title        = Universal Structural Connector
-        @manufacturer = Generic
-        @description  = General structural re-enforcement for space exploration vehicles.
-
-        @mass               = 0.0560
-        @crashTolerance     = 12
-        @breakingForce      = 250
-        @breakingTorque     = 250
-        @maxTemp            = 1973.15
-        %fuelCrossFeed      = false
-        !explosionPotential = NULL
-        @maxLength          = 25
-        %bulkheadProfiles   = srf
-
-        @MODULE[CModuleStrut]
-        {
-            @linearStrength  = 1000
-            @angularStrength = 1000
-        }
+        @linearStrength = 1200
+        @angularStrength = 1200
     }
+
+    %DRAG_CUBE
+    {
+        %none = True
+    }
+}
 
 //  ==================================================
 //  Structural docking ring.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1328,48 +1328,51 @@
 //  ==================================================
 //  Orion MPCV structural adapter.
 
-//  Dimensions: 5.000 x 1.520 m
-//  Gross Mass: 432.00 Kg
+//  Dimensions: 5.25 m x 1.5 m
+//  Inert Mass: 510 Kg
 //  ==================================================
 
-    @PART[XFASAApolloStrJ2StrJ23m5mDecX]:FOR[RealismOverhaul]
+@PART[XFASAApolloStrJ2StrJ23m5mDecX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 1.000, 0.505, 1.000
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top      =  0.000, -0.500, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom   =  0.000, -0.750, 0.000, 0.000, -1.000, 0.000, 3
-        @node_stack_connect1 =  2.870,  1.700, 0.000, 0.000,  1.000, 0.000, 2
-        @node_stack_connect2 = -2.870,  1.700, 0.000, 0.000,  1.000, 0.000, 2
-
-        @title        = Orion MPCV Adapter
-        %manufacturer = NASA
-        %description  = Structural adapter for the Orion MPCV and the Service Module protection panels.
-
-        @mass             = 0.4320
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = false
-        %stagingIcon      = DECOUPLER_HOR
-        %bulkheadProfiles = size2, size3
-
-        @MODULE[ModuleDecouple]
-        {
-            @ejectionForce = 250.000
-        }
+        @scale = 1.03125, 0.5, 1.03125
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, -0.525, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_connect1 = 2.655, 1.505, 0.0, 1.0, 0.0, 0.0, 2
+    @node_stack_connect2 = -2.655, 1.505, 0.0, -1.0, 0.0, 0.0, 2
+
+    @category = Coupling
+    @title = Orion MPCV Adapter
+    %manufacturer = Lockheed Martin
+    %description = A structural adapter for the Orion MPCV and the Service Module protection panels.
+
+    @mass = 0.51
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size2, size4
+
+    @MODULE[ModuleDecouple]
+    {
+        %explosiveNodeID = top
+        %isOmniDecoupler = False
+        @ejectionForce = 10
+    }
+}
 
 //  ==================================================
 //  Delta IV GEM - 60 decoupler.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1042,47 +1042,61 @@
 }
 
 //  ==================================================
-//  Exploration Station crew tunnel.
+//  Exploration station crew tunnel.
 
-//  Dimensions: 3.000 x 5.000 m
-//  Gross Mass: 2597.00 Kg
+//  Dimensions: 3 m x 5 m
+//  Inert Mass: 2600 Kg
 //  ==================================================
 
-    @PART[xKosmos_Balka_1_Tunnelx]:FOR[RealismOverhaul]
+@PART[xKosmos_Balka_1_Tunnelx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 3.000, 1.650, 3.000
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  2.304, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -2.304, 0.000, 0.000, -1.000, 0.000, 3
-
-        @title        = Exploration Station Crew Tunnel
-        @manufacturer = Boeing Co.
-        @description  = A structural tunnel for crew transfer for linking living quarters.
-
-        @mass             = 2.5970
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %fuelCrossFeed    = true
-        !CrewCapacity     = NULL
-        !vesselType       = NULL
-        !stackSymmetry    = NULL
-        %bulkheadProfiles = size3
-
-        !INTERNAL[xorbitalOrbInternals]{}
+        @scale = 3.0, 1.65, 3.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 2.517, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -2.517, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Structural
+    @title = Exploration Station Crew Tunnel
+    @manufacturer = Boeing Co.
+    @description = A structural tunnel for crew transfer for linking living quarters.
+
+    @mass = 2.6
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = True
+    !CrewCapacity = NULL
+    !vesselType = NULL
+    !stackSymmetry = NULL
+    %bulkheadProfiles = size3
+
+    !INTERNAL[xorbitalOrbInternals],*{}
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        surfaceAttachmentsPassable = True
+    }
+}
 
 //  ==================================================
 //  Universal structural connector.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -857,56 +857,56 @@
 }
 
 //  ==================================================
-//  Space Launch System (SLS) interstage adapter.
+//  Space Launch System Block IB/II interstage adapter.
 
-//  Dimensions: 8.384 x 13.750 m
-//  Gross Mass: 5216.40 Kg
+//  Dimensions: 8.4 m x 13.75 m
+//  Inert Mass: 5200 Kg
 //  ==================================================
 
-    @PART[X84NEWTALUSXX2]:FOR[RealismOverhaul]
+@PART[X84NEWTALUSXX2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 2.800, 7.255, 2.800
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_bottom = 0.000, 0.000, 0.000, 0.000, -1.000, 0.000, 3
-        @node_stack_top    = 0.000, 0.500, 0.000, 0.000,  1.000, 0.000, 3
-
-        %fx_gasBurst_white = 0.000, 0.500, 0.000, 0.000, 1.000, 0.000, decouple
-
-        %sound_decoupler_fire = decouple
-
-        @category     = Structural
-        @title        = Interstage - SLS
-        @manufacturer = NASA
-        %description  = The structural adapter and explosive cord decoupler for the SLS Exploration Upper Stage (EUS).
-
-        @mass             = 5.2164
-        @crashTolerance   = 12
-        @maxTemp          = 1073.15
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        %stagingIcon      = DECOUPLER_HOR
-        %bulkheadProfiles = size3
-
-        @MODULE[ModuleDecouple]
-        {
-            @ejectionForce = 1.500
-        }
-
-        !MODULE[ModuleReactionWheel]{}
-
-        !MODULE[ModuleSAS]{}
+        @scale = 2.8, 7.255, 2.8
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 5
+    @node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 5
+
+    %fx_gasBurst_white = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, decouple
+
+    %sound_decoupler_fire = decouple
+
+    @category = Coupling
+    @title = Interstage Adapter - SLS Block IB/II
+    @manufacturer = Boeing Co.
+    %description = The structural adapter and explosive cord decoupler for the Exploration Upper Stage (EUS).
+
+    @mass = 5.2
+    @crashTolerance = 16
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @breakingForce = 250
+    @breakingTorque = 250
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size5
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleSAS],*{}
+}
 
 //  ==================================================
 //  Habitat module structural adapter (small).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -92,224 +92,319 @@
 !PART[Xtrusslrg_argonXsmalldccd343gC]:FOR[RealismOverhaul]{}
 
 //  ==================================================
-//  Altair lunar lander Descent Module.
+//  Altair descent module.
 
-//  Dimensions: 7.800 x 6.200 m (stowed)
-//  Gross Mass: 35055.00 Kg
-//  Throttle Range: 12.5% to 100%
-//  Burn Time: 1104 s
-//  O/F Ratio: 5.84
+//  Dimensions: 7.8 m x 6.2 m (stowed)
+//  Gross Mass: 35055 Kg
 //  ==================================================
 
-    @PART[XAltair2descent2stageX]:FOR[RealismOverhaul]
+@PART[XAltair2descent2stageX]:FOR[RealismOverhaul]
+{
+    @module = Part
+
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = True
-
-        MODEL
-        {
-            model    = CMES/Structural/Altair_descent_stage/model
-            scale    = 1.750, 1.750, 1.750
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000, -1.000, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -3.350, 0.000, 0.000, -1.000, 0.000, 3
-
-        @title        = Altair Descent Module
-        %manufacturer = Boeing Co. & NASA
-        @description  = Altair (or Lunar Surface Access Module - LSAM) was a Constellation program asset designed for Moon landings. The descent module would be used to decelerate into a lunar orbit, undock from Orion and then land on the surface. Payload includes either a crewed outpost or cargo.
-
-        @mass             = 11.2810
-        %crashTolerance   = 12
-        %breakingForce    = 250
-        %breakingTorque   = 250
-        %maxTemp          = 1973.15
-        %fuelCrossFeed    = true
-        %bulkheadProfiles = size3
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %stagingIcon      = LIQUID_ENGINE
-
-        !MODULE[ModuleSAS]{}
-
-        !MODULE[ModuleReactionWheel]{}
-
-        !MODULE[ModuleGenerator]{}
-
-        !MODULE[ModuleDecouple]{}
-
-        @MODULE[ModuleEngines*]
-        {
-            @minThrust      = 21.34
-            @maxThrust      = 266.80
-            @heatProduction = 100
-            %ullage         = true
-            %ignitions      = 9
-            %pressureFed    = false
-
-            IGNITOR_RESOURCE
-            {
-                name   = ElectricCharge
-                amount = 0.500
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = LqdHydrogen
-                amount = 0.7338
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = LqdOxygen
-                amount = 0.2661
-            }
-
-            @PROPELLANT[LiquidFuel]
-            {
-                @name  = LqdHydrogen
-                @ratio = 0.7338
-            }
-
-            @PROPELLANT[Oxidizer]
-            {
-                @name  = LqdOxygen
-                @ratio = 0.2661
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 460.00
-                @key,1 = 1 100.00
-            }
-        }
-
-        MODULE
-        {
-            name          = ModuleEngineConfigs
-            type          = ModuleEngines
-            configuration = CECE
-            modded        = false
-
-            CONFIG
-            {
-                name           = CECE
-                minThrust      = 21.34
-                maxThrust      = 266.80
-                heatProduction = 100
-
-                PROPELLANT
-                {
-                    name  = LqdHydrogen
-                    ratio = 0.7338
-                }
-
-                PROPELLANT
-                {
-                    name  = LqdOxygen
-                    ratio = 0.2661
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 460.00
-                    key = 1 100.00
-                }
-
-            }
-        }
-
-        @MODULE[ModuleGimbal]
-        {
-            @gimbalRange            = 4.000
-            %useGimbalResponseSpeed = true
-            %gimbalResponseSpeed    = 16
-        }
-
-        @MODULE[ModuleRCS]
-        {
-            @name          = ModuleRCS
-            @thrusterPower = 0.250
-            !resourceName  = NULL
-
-            PROPELLANT
-            {
-                ratio = 1.000
-                name  = Hydrazine
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 254.00
-                @key,1 = 1 82.08
-            }
-        }
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = ServiceModule
-            volume   = 65900
-            basemass = -1
-
-            TANK
-            {
-                name      = ElectricCharge
-                amount    = 43200
-                maxAmount = 43200
-            }
-
-            TANK
-            {
-                name      = LqdHydrogen
-                amount    = 48079
-                maxAmount = 48079
-            }
-
-            TANK
-            {
-                name      = LqdOxygen
-                amount    = 17435
-                maxAmount = 17435
-            }
-
-            TANK
-            {
-                name      = Hydrazine
-                amount    = 150
-                maxAmount = 150
-            }
-
-            TANK
-            {
-                name      = Water
-                amount    = 0
-                maxAmount = 90
-            }
-        }
-
-        MODULE
-        {
-            name            = TacGenericConverter
-            converterName   = Fuel Cell
-            conversionRate  = 3.000
-            inputResources  = LqdHydrogen, 0.0001523573, LqdOxygen, 0.0000752767
-            outputResources = Water, 0.0001041667, true, ElectricCharge, 0.98, true
-        }
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
-
-        !RESOURCE[ElectricCharge]{}
-
-        !RESOURCE[MonoPropellant]{}
+        model = CMES/Structural/Altair_descent_stage/model
+        scale = 1.75, 1.75, 1.75
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.85, 0.0, 0.0, 1.0, 0.0, 3
+    %node_stack_decoupler = 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 5
+
+    @category = Engine
+
+    @mass = 11.19
+    %crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = True
+    %bulkheadProfiles = size3, size5
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    !animationName = NULL
+    !deploySpeed = NULL
+    !retractSpeed = NULL
+    !randomSpeedFactor = NULL
+
+    %engineType = RL10
+    %engineTypeMult = 4
+    %massOffset = 0
+    %ignoreMass = True
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleDecouple],*{}
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 18
+        @maxThrust = 335
+        @heatProduction = 100
+        !fxOffset = NULL
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 9
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+       	    @ratio = 0.7352
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2648
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 460
+            @key,1 = 1 100
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 4.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    @MODULE[ModuleRCS*]
+    {
+        @thrusterPower = 0.445
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.499
+        }
+
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.501
+        }
+
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 300
+            @key,1 = 1 82
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 66000
+        basemass = -1
+
+        //  Batteries 22.7 kWn.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 81720
+            maxAmount = 81720
+        }
+
+        //  Life support water mass 90 Kg.
+
+        TANK
+        {
+            name = Water
+            amount = 0
+            maxAmount = 90
+        }
+
+        //  CECE fuel mass ~3407 Kg.
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 48079
+            maxAmount = 48079
+        }
+
+        //  CECE oxidizer mass ~22387 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 17435
+            maxAmount = 17435
+        }
+
+        //  ACS fuel mass 57 Kg.
+
+        TANK
+        {
+            name = MMH
+            amount = 65
+            maxAmount = 65
+        }
+
+        //  ACS oxidizer mass 92 Kg.
+
+        TANK
+        {
+            name = MON3
+            amount = 65
+            maxAmount = 65
+        }
+
+        //  ACS pressurization Helium mass 0.23 Kg.
+
+        TANK
+        {
+            name = Helium
+            amount = 1300
+            maxAmount = 1300
+        }
+    }
+
+    !MODULE[ModuleResourceConverter],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Fuel Cell
+        StartActionName = Start Fuel Cell
+        StopActionName = Stop Fuel Cell
+        ToggleActionName = Toggle Fuel Cell
+        FillAmount = 0.975
+        AutoShutdown = False
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdHydrogen
+            Ratio = 0.000404154
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdOxygen
+            Ratio = 0.000286797
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 3.0
+            DumpExcess = True
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0003558
+            DumpExcess = True
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Altair descent module.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[XAltair2descent2stageX]:AFTER[RealismOverhaulEngines]
+{
+    @title = Altair Descent Module
+    @manufacturer = Boeing Co.
+    @description = Altair (or Lunar Surface Access Module - LSAM) was a Constellation program asset designed for Moon landings. The descent module would be used to capture into a lunar orbit, undock from Orion and then land on the surface. Payload includes either a crewed outpost or cargo.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = CECE-Base
+
+        !CONFIG,*:HAS[~name[CECE-Base],~name[CECE-High]]{}
+    }
+}
+
+//  ==================================================
+//  Altair descent module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[XAltair2descent2stageX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    !MODULE[ModuleResourceConverter],*{}
+
+    !MODULE[TacGenericConverter],*{}
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = Fuel Cell
+        StartActionName = Start Fuel Cell
+        StopActionName = Stop Fuel Cell
+        conversionRate = 3.0
+        tag = Power Generation
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdHydrogen
+            Ratio = 0.0001523573
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdOxygen
+            Ratio = 0.0000752767
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0001041667
+            DumpExcess = False
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 1.0
+            DumpExcess = True
+        }
+    }
+}
 
 //  ==================================================
 //  NASA Docking & Berthing Mechanism (NDS).


### PR DESCRIPTION
Updates and fixes for the CMES "Structural" parts.

Changelog:

* Update Altair DM to use the global engine configs.
* Add a separate fuel cell module to Altair that does not depend upon TACLS. The TACLS converter module exists (and it will be used instead of the stock resource converter) if TACLS is installed.
* Add Connected Living Space compatibility for all parts that should have it.
* Increase the battery charge and reduce the propellant mass of the Pegasus (previously Altair II) DM.
* Add KIS support for the Pegasus DM.
* Fix the length of the Delta IV 5 meter interstage adapter (was too short and was clipping the RL10 engine).
* Adjust the size of the habitation structural end adapters to add a new intermediate one.
* The radial decouplers now are tagged as "WIP-RO" since they are duplicates of the stock parts.
* Add missing decoupler FX to all parts that include decouplers.
* Update the procedural fairing bases to work with the newest PF release.
* Remove invalid part modules from many parts.
* Explicitly set the part categories (and use the new KSP 1.2 ones).
* Balance inert and gross mass values against real sources and/or other parts.
* Adjust some insane max temperature values.
* Update the part titles and the descriptions.
* Fix formatting (tabs, false spacing).

**Note 1: Each complete commit is for a separate part.**
**Note 2: Many new parts are missing from this PR. These will be included in a separate PR after this one has been merged to keep things clean.**

[Alternate diff ignoring whitespace changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1458/files?w=1)