### PR TITLE
RD-0242M2 Global Config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
@@ -1,0 +1,82 @@
+//  ==================================================
+//  RD-0242M2 global engine configuration.
+
+//  Inert Mass: 120 Kg
+//  Throttle Range: 60% to 100%
+//  Burn Time: 380 s
+//  O/F Ratio: 1.65
+
+//  Modeled after the RD-0242M1 engine:
+//  *   Reduced the overall size to half of the original.
+//  *   Reduced the maximum thrust value from 98 kN to 50 kN.
+//  *   Changed the minimum throttle value from 80% to 60%.
+
+//  Astronautix - RD-0242M1: http://www.astronautix.com/engines/rd0242m1.htm
+
+//  Used by:
+//      CMES
+//  ==================================================
+
+@PART[*]:HAS[#engineType[RD0242M2]]:FOR[RealismOverhaulEngines]
+{
+    %title = RD-0242M2
+    %manufacturer = KB Khimavtomatiki [Kosberg]
+    %description = The RD-0242M2 is a deep - throttle capable derivative of the RD-0242M1 upper stage engine engine. Modified to use Monomethyl Hydrazine (MMH) instead of Unsymmetrical Dimethylhydrazine (UDMH).
+    @tags ^= :$: throttle upper
+
+    @MODULE[ModuleEngines*]
+    {
+        @EngineType = LiquidEngine
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RD-0242M2
+        origMass = 0.12
+        modded = False
+
+        CONFIG
+        {
+            name = RD-0242M2
+            minThrust = 30.0
+            maxThrust = 50.0
+            ullage = False
+            pressureFed = True
+            ignitions = 6
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.5036
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.4964
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 280
+                key = 1 100
+            }
+        }
+    }
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
* Add a global engine configuration for the hypothetical RD-0242M2 engine (a variant of the hypergolic RD-0242M1 engine).