### PR TITLE
Advanced Booster Global Config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/ASRB_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ASRB_Config.cfg
@@ -1,0 +1,288 @@
+//  ==================================================
+//  Advanced Booster global engine configuration.
+
+//  Throttle Range: N/A
+//  Burn Time: 110 s
+//  O/F Ratio: 2.12
+
+//  NASA Space Flight - Orbital ATK Dark Knight: http://www.nasaspaceflight.com/2013/01/the-dark-knights-atks-advanced-booster-revealed-for-sls/
+//  NASA Space Flight - Advanced Boosters:       http://www.nasaspaceflight.com/2015/02/advanced-boosters-towards-solid-future-sls/
+//  Space Launch Report - SLS:                   http://www.spacelaunchreport.com/sls0.html
+
+//  Used by:
+//      CMES
+//  ==================================================
+
+@PART[*]:HAS[#engineType[ASRB]]:FOR[RealismOverhaulEngines]
+{
+    %title = Advanced Booster
+    %manufacturer = Orbital ATK
+    %description = A composite solid rocket motor designed as a drop - in replacement for the 5 Segment RSRM used on the Space Launch System (SLS) launch vehicle. It's lower inert mass along with the higher surface thrust will enable the SLS to lift more than 130 metric tonnes into low Earth orbit.
+    @tags ^= :$: advanced composite solid
+
+    @MODULE[ModuleEngines*]
+    {
+        @EngineType = SolidBooster
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 8.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = ASRB
+        origMass = 85.5
+        modded = False
+
+        CONFIG
+        {
+            name = ASRB
+            minThrust = 0
+            maxThrust = 20337
+            massMult = 1.0
+            gimbalRange = 8.0
+            curveResource = HTPB
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 265
+                key = 1 234
+            }
+
+            thrustCurve
+            {
+                key = 1.000 0.9500
+                key = 0.995 0.9549
+                key = 0.990 0.9562
+                key = 0.985 0.9562
+                key = 0.980 0.9562
+                key = 0.975 0.9562
+                key = 0.970 0.9565
+                key = 0.965 0.9574
+                key = 0.960 0.9585
+                key = 0.955 0.9616
+                key = 0.950 0.9647
+                key = 0.945 0.9682
+                key = 0.940 0.9718
+                key = 0.935 0.9751
+                key = 0.930 0.9782
+                key = 0.925 0.9811
+                key = 0.920 0.9837
+                key = 0.915 0.9863
+                key = 0.910 0.9876
+                key = 0.905 0.9889
+                key = 0.900 0.9899
+                key = 0.895 0.9908
+                key = 0.890 0.9922
+                key = 0.885 0.9940
+                key = 0.880 0.9953
+                key = 0.875 0.9953
+                key = 0.870 0.9953
+                key = 0.865 0.9953
+                key = 0.860 0.9953
+                key = 0.855 0.9953
+                key = 0.850 0.9953
+                key = 0.845 0.9953
+                key = 0.840 0.9953
+                key = 0.835 0.9951
+                key = 0.830 0.9942
+                key = 0.825 0.9933
+                key = 0.820 0.9911
+                key = 0.815 0.9889
+                key = 0.810 0.9856
+                key = 0.805 0.9820
+                key = 0.800 0.9781
+                key = 0.795 0.9740
+                key = 0.790 0.9691
+                key = 0.785 0.9630
+                key = 0.780 0.9564
+                key = 0.775 0.9478
+                key = 0.770 0.9397
+                key = 0.765 0.9349
+                key = 0.760 0.9300
+                key = 0.755 0.9236
+                key = 0.750 0.9172
+                key = 0.745 0.9117
+                key = 0.740 0.9062
+                key = 0.735 0.9007
+                key = 0.730 0.8952
+                key = 0.725 0.8896
+                key = 0.720 0.8838
+                key = 0.715 0.8760
+                key = 0.710 0.8685
+                key = 0.705 0.8627
+                key = 0.700 0.8566
+                key = 0.695 0.8496
+                key = 0.690 0.8430
+                key = 0.685 0.8370
+                key = 0.680 0.8309
+                key = 0.675 0.8248
+                key = 0.670 0.8195
+                key = 0.665 0.8144
+                key = 0.660 0.8058
+                key = 0.655 0.7980
+                key = 0.650 0.7928
+                key = 0.645 0.7891
+                key = 0.640 0.7868
+                key = 0.635 0.7800
+                key = 0.630 0.7726
+                key = 0.625 0.7672
+                key = 0.620 0.7611
+                key = 0.615 0.7543
+                key = 0.610 0.7502
+                key = 0.605 0.7463
+                key = 0.600 0.7419
+                key = 0.595 0.7388
+                key = 0.590 0.7358
+                key = 0.585 0.7287
+                key = 0.580 0.7233
+                key = 0.575 0.7194
+                key = 0.570 0.7121
+                key = 0.565 0.7048
+                key = 0.560 0.6974
+                key = 0.555 0.6926
+                key = 0.550 0.6882
+                key = 0.545 0.6841
+                key = 0.540 0.6806
+                key = 0.535 0.6785
+                key = 0.530 0.6771
+                key = 0.525 0.6757
+                key = 0.520 0.6777
+                key = 0.515 0.6808
+                key = 0.510 0.6843
+                key = 0.505 0.6871
+                key = 0.500 0.6899
+                key = 0.495 0.6927
+                key = 0.490 0.6961
+                key = 0.485 0.6991
+                key = 0.480 0.7020
+                key = 0.475 0.7061
+                key = 0.470 0.7115
+                key = 0.465 0.7173
+                key = 0.460 0.7220
+                key = 0.455 0.7244
+                key = 0.450 0.7265
+                key = 0.445 0.7318
+                key = 0.440 0.7366
+                key = 0.435 0.7413
+                key = 0.430 0.7465
+                key = 0.425 0.7505
+                key = 0.420 0.7537
+                key = 0.415 0.7563
+                key = 0.410 0.7599
+                key = 0.405 0.7644
+                key = 0.400 0.7682
+                key = 0.395 0.7723
+                key = 0.390 0.7767
+                key = 0.385 0.7796
+                key = 0.380 0.7821
+                key = 0.375 0.7846
+                key = 0.370 0.7883
+                key = 0.365 0.7926
+                key = 0.360 0.7951
+                key = 0.355 0.7976
+                key = 0.350 0.8001
+                key = 0.345 0.8041
+                key = 0.340 0.8083
+                key = 0.335 0.8119
+                key = 0.330 0.8152
+                key = 0.325 0.8182
+                key = 0.320 0.8207
+                key = 0.315 0.8226
+                key = 0.310 0.8226
+                key = 0.305 0.8233
+                key = 0.300 0.8245
+                key = 0.295 0.8246
+                key = 0.290 0.8246
+                key = 0.285 0.8246
+                key = 0.280 0.8239
+                key = 0.275 0.8227
+                key = 0.270 0.8204
+                key = 0.265 0.8173
+                key = 0.260 0.8118
+                key = 0.255 0.8070
+                key = 0.250 0.8027
+                key = 0.245 0.7977
+                key = 0.240 0.7929
+                key = 0.235 0.7885
+                key = 0.230 0.7831
+                key = 0.225 0.7778
+                key = 0.220 0.7740
+                key = 0.215 0.7689
+                key = 0.210 0.7629
+                key = 0.205 0.7557
+                key = 0.200 0.7484
+                key = 0.195 0.7412
+                key = 0.190 0.7358
+                key = 0.185 0.7292
+                key = 0.180 0.7217
+                key = 0.175 0.7141
+                key = 0.170 0.7054
+                key = 0.165 0.6969
+                key = 0.160 0.6905
+                key = 0.155 0.6827
+                key = 0.150 0.6765
+                key = 0.145 0.6722
+                key = 0.140 0.6685
+                key = 0.135 0.6665
+                key = 0.130 0.6644
+                key = 0.125 0.6612
+                key = 0.120 0.6559
+                key = 0.115 0.6512
+                key = 0.110 0.6456
+                key = 0.105 0.6390
+                key = 0.100 0.6343
+                key = 0.095 0.6275
+                key = 0.090 0.6213
+                key = 0.085 0.6160
+                key = 0.080 0.6109
+                key = 0.075 0.6035
+                key = 0.070 0.5960
+                key = 0.065 0.5890
+                key = 0.060 0.5787
+                key = 0.055 0.5673
+                key = 0.050 0.5593
+                key = 0.045 0.5478
+                key = 0.040 0.5377
+                key = 0.035 0.5235
+                key = 0.030 0.5022
+                key = 0.025 0.4735
+                key = 0.020 0.4111
+                key = 0.015 0.3361
+                key = 0.010 0.2461
+                key = 0.009 0.2241
+                key = 0.008 0.2021
+                key = 0.007 0.1855
+                key = 0.006 0.1546
+                key = 0.005 0.1206
+                key = 0.004 0.0947
+                key = 0.003 0.0668
+                key = 0.002 0.0463
+                key = 0.001 0.0263
+                key = 0.000 0.0003
+            }
+        }
+    }
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
* Add a global engine configuration for the hypothetical Orbital ATK "Dark Knight" Advanced Booster. Stats and thrust curve similar to the 5 Segment RSRM since it is supposed to be a drop-in replacement.