### PR TITLE
CMES Propulsion updates (part III)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3060,81 +3060,66 @@
     %bulkheadProfiles = size3
 }
 
-//	==================================================
-//	Mars Transfer Vehicle (MTV) main tank.
+//  ==================================================
+//  Mars Transfer Vehicle main propellant tank.
 
-//	Dimensions: 10.000 x 18.000 m
-//	Gross Mass: 124152.00 Kg
-//	Volume: 1343000.00 L
-//	==================================================
+//  Dimensions: 10 m x 18 m
+//  Inert Mass: 28500 Kg
+//  ==================================================
 
-	@PART[XNP_lft_8_0m_6mzxx6222]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XNP_lft_8_0m_6mzxx6222]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 2.010, 3.000, 2.010
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 2.0, 3.0, 2.0
+    }
 
-		@node_stack_top	   = 0.000,  8.955, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -9.050, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 5.000,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-        @title		  = MTV LH2 Tank
-        @manufacturer = NASA
-        @description  = A cryogenic liquid hydrogen tank for deep space journeys.
-		
-		@mass			  = 29.0000
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		!linearStrength	  = NULL
-		!angularStrength  = NULL
-		!vesselType		  = NULL
-		%bulkheadProfiles = size3
+    @node_stack_top = 0.0, 8.955, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -9.05, 0.0, 0.0, -1.0, 0.0, 5
+    @node_attach = 5.0, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = Cryogenic
-			volume	 = 1343000
-			basemass = -1
+    @category = FuelTank
+    @title = MTV - I Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Mars Transfer Vehicle.
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 1343000
-				maxAmount = 1343000
-			}
-		}
+    @mass = 28.5
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !linearStrength = NULL
+    !angularStrength = NULL
+    !vesselType = NULL
+    %bulkheadProfiles = size5
 
-		!MODULE[ModuleCommand]{}
+    !MODULE[ModuleCommand],*{}
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleSAS],*{}
 
-		!MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleReactionWheel],*{}
 
-		!MODULE[MechJebCore]{}
+    !MODULE[ModuleGenerator],*{}
 
-		!MODULE[ModuleGenerator]{}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 1050000
+    }
 
-		!RESOURCE[Oxidizer]{}
-
-		!RESOURCE[ElectricCharge]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Delta Cryogenic Second Stage (DCSS) 5 - meter LH2 tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2909,149 +2909,104 @@
     }
 }
 
-//	==================================================
-//	Altair II descent module engines & RCS.
+//  ==================================================
+//  Pegasus engine pod.
 
-//	Modeled after the RD-0242M1 engine:
-//	*	Reduced the overall size.
-//	*	Reduced the maximum thrust value from 98.1 to 49 kN (single engine).
-//	*	Changed the minimum throttle value from 80% to 15%.
+//  Dimensions: 2.2 m x 1.2 m
+//  Gross Mass: 250 Kg
+//  ==================================================
 
-//	Dimensions: 2.200 x 1.200 m
-//	Gross Mass: 229.00 Kg
-//	Throttle Range: 15% to 100%
-//	Burn Time: 600 s
-//	O/F Ratio: 1.70
-//	==================================================
+@PART[nosExplorerRadialEngine]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-	@PART[nosExplorerRadialEngine]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    !mesh = NULL
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/NOSRADIAL/model
-			scale	 = 0.600, 0.600, 0.600
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    MODEL
+    {
+        model = CMES/Propulsion/NOSRADIAL/model
+        scale = 0.6, 0.6, 0.6
+    }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = Engine
-		@title		  = Altair II Engine Pod
-		@manufacturer = Boeing Co. & KB Khimavtomatiki [Kosberg]
-		@description  = Radially - mounted engine pod, originally designed for the Altair II Descent Module. Contains the engines for final breaking and RCS thrusters for attitude control.
+    @category = Engine
 
-		@mass			  = 0.2290
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp 		  = 1973.15
-		%stageOffset	  = 1
-		childStageOffset  = 1
-		%stagingIcon	  = LIQUID_ENGINE
-		%bulkheadProfiles = srf
+    @mass = 0.25
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = srf
 
-		@MODULE[ModuleRCS]
-		{
-			@name		   = ModuleRCS
-			@thrusterPower = 0.6732
-			!resourceName  = NULL
+    %engineType = RD0242M2
+    %engineTypeMult = 2
+    %massOffset = 0.01
+    %ignoreMass = False
 
-			PROPELLANT
-			{
-				name  = Hydrazine
-				ratio = 1.000
-			}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 30
+        @maxThrust = 50
+        @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 6
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 242
-				@key,1 = 1 84
-			}
-		}
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+            @ratio = 0.5036
+        }
 
-		//	The maximum thrust value refers to the combined thrust of all engines (two engines per pod).
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.4964
+        }
 
-		@MODULE[ModuleEngines*]
-		{
-			@minThrust	    = 14.71
-			@maxThrust	    = 98.10
-			@heatProduction = 100
-			!fxOffset	    = NULL
-			%ullage		    = false
-			%pressureFed    = true
-			%ignitions	    = 6
+        @atmosphereCurve
+        {
+            @key,0 = 0 280
+            @key,1 = 1 100
+        }
+    }
 
-			IGNITOR_RESOURCE
-			{
-				name   = MMH
-				amount = 0.504
-			}
+    //  Two Aerojet Rocketdyne R-4D-11 (490 N) bipropellant thrusters on each axis for fine attitude control.
 
-			IGNITOR_RESOURCE
-			{
-				name   = NTO
-				amount = 0.496
-			}
+    @MODULE[ModuleRCS*]
+    {
+        @thrusterPower = 0.98
+        !resourceName = NULL
 
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = MMH
-				@ratio = 0.504
-			}
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.5036
+        }
 
-			@PROPELLANT[Oxidizer]
-			{
-				@name  = NTO
-				@ratio = 0.496
-			}
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.4964
+        }
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 343.00
-				@key,1 = 1 220.00
-			}
-		}
-
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			configuration = RD-0242M2
-			modded		  = false
-
-			CONFIG
-			{
-				name	  = RD-0242M2
-				minThrust = 14.71
-				maxThrust = 98.10
-
-				PROPELLANT
-				{
-					name 	  = MMH
-					ratio	  = 0.504
-					DrawGauge = true
-				}
-
-				PROPELLANT
-				{
-					name 	  = NTO
-					ratio	  = 0.496
-					DrawGauge = false
-				}
-
-				atmosphereCurve
-				{
-					key = 0 343.00
-					key = 1 220.00
-				}
-			}
-		}
-	}
+        @atmosphereCurve
+        {
+            @key,0 = 0 311
+            @key,1 = 1 84
+        }
+    }
+}
 
 //	==================================================
 //	RSRM inert extension.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3021,44 +3021,44 @@
     @description = Radially mounted engine pod, originally designed for the Pegasus Descent Module. Contains the engines and RCS thrusters for attitude control.
 }
 
-//	==================================================
-//	RSRM inert extension.
+//  ==================================================
+//  RSRM structural extension.
 
-//	Dimensions: 3.770 x 3.000 m
-//	Gross Mass: 8400.00 Kg
-//	==================================================
+//  Dimensions: 3.77 m x 3 m
+//  Gross Mass: 8400 Kg
+//  ==================================================
 
-	@PART[XNP_lft_W375SRB]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XNP_lft_W375SRB]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 0.755, 2.500, 0.755
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 0.755, 2.5, 0.755
+    }
 
-		@node_stack_top	   = 0.000,  3.730, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -3.730, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 1.990,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = Structural
-		@title		  = RSRM Extension (Inert)
-		@manufacturer = Orbital ATK
-		%description  = An extension for the RSRMs. Does not contain propellant.
+    @node_stack_top = 0.0, 3.73, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -3.73, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 0.0, 1.99, 0.0, 1.0, 0.0, 0.0
 
-		@mass			  = 8.4000
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%bulkheadProfiles = size3
-	}
+    @category = Structural
+    @title = RSRM Structural Extension
+    @manufacturer = Orbital ATK
+    %description = A structural extension for the RSRM. Does not contain propellant.
+
+    @mass = 8.4
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size3
+}
 
 //	==================================================
 //	Mars Transfer Vehicle (MTV) main tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3250,68 +3250,69 @@
 
 	}
 
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) 4 - meter LH2 tank.
+//  ==================================================
+//  DCSS-4 LH2 tank.
 
-//	Dimensions: 4.000 x 3.000 m
-//	Gross Mass: 991.50 Kg
-//	Volume: 41233 L
-//	==================================================
+//  Dimensions: 4 m x 3 m
+//  Gross Mass: 1000 Kg
+//  ==================================================
 
-	@PART[IUSXNP_lft_?3322HORT]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[IUSXNP_lft_?3322HORT]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 0.805, 1.000, 0.805
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 0.805, 1.0, 0.805
+    }
 
-		@node_stack_top	   = 0.000,  1.455, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -1.455, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 3.333,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title	 	  = Delta IV DCSS LH2 Tank [4 Meters]
-		@manufacturer = United Launch Alliance (ULA)
-		@description  = The liquid hydrogen tank for the Delta IV 4 meter DCSS.
+    @node_stack_top = 0.0, 1.455, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.455, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 3.333, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		@mass			  = 0.9915
-		crashTolerance	  = 12
-		breakingForce	  = 250
-		breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
-	
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = Cryogenic
-			volume	 = 41233
-			basemass = -1
+    @category = FuelTank
+    @title = Delta IV DCSS LH2 Tank (4 Meters)
+    @manufacturer = United Launch Alliance (ULA)
+    @description = The liquid hydrogen tank for the Delta IV 4 meter DCSS.
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 41233
-				maxAmount = 41233
-			}
-		}
-		
-		!MODULE[ModuleReactionWheel]{}
+    @mass = 1.0
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size3
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleSAS],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    !MODULE[ModuleReactionWheel],*{}
 
-		!RESOURCE[Oxidizer]{}    
-	}
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 43000
+        basemass = -1
+
+        //  DCSS-4 fuel mass 3047 Kg.
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 43000
+            maxAmount = 43000
+        }
+    }
+
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Mars Transfer Vehicle (MTV) service module tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3121,68 +3121,69 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Delta Cryogenic Second Stage (DCSS) 5 - meter LH2 tank.
+//  ==================================================
+//  DCSS-5 LH2 tank.
 
-//	Dimensions: 5.100 x 2.850 m
-//	Gross Mass: 1536.60 Kg
-//	Volume: 54844.00 L
-//	==================================================
+//  Dimensions: 5 m x 2.85 m
+//  Gross Mass: 1540 Kg
+//  ==================================================
 
-	@PART[IUSXNP_lft_?375x3S222HORT]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[IUSXNP_lft_?375x3S222HORT]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale 	  = 1.000, 0.950, 1.000
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 1.0, 0.95, 1.0
+    }
 
-		@node_stack_top	   = 0.000,  1.420, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -1.420, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 3.333,  0.000, 0.000, 1.000,  0.000, 0.000
-    
-		@category	  = FuelTank
-		@title		  = Delta IV DCSS LH2 Tank [5 Meters]
-		@manufacturer = United Launch Alliance (ULA)
-		%description  = The liquid hydrogen tank for the 5 meter DCSS.
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@mass			  = 1.5366
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @node_stack_top = 0.0, 1.42, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_bottom = 0.0, -1.42, 0.0, 0.0, -1.0, 0.0, 4
+    @node_attach = 3.333, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = Cryogenic
-			volume	 = 54844
-			basemass = -1
+    @category = FuelTank
+    @title = Delta IV DCSS LH2 Tank (5 Meters)
+    @manufacturer = United Launch Alliance (ULA)
+    %description = The liquid hydrogen tank for the 5 meter DCSS.
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 54844
-				maxAmount = 54844
-			}
-		}
+    @mass = 1.54
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size4
 
-		!MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleSAS],*{}
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleReactionWheel],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[Oxidizer]{}
-	}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 56045
+        basemass = -1
+
+        //  DCSS-5 fuel mass 4032 Kg.
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 56045
+            maxAmount = 56045
+        }
+    }
+
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Delta IV Common Booster Core (CBC) LOX tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2719,63 +2719,62 @@
 	}
 }
 
-//	==================================================
-//	Bimodal NTR engine mount.
+//  ==================================================
+//  Mars Transfer Vehicle auxiliary propellant tank.
 
-//	Dimensions: 10.000 x 6.000 m
-//	Gross Mass: 628.00 Kg
-//	==================================================
+//  Dimensions: 10 m x 6 m
+//  Gross Mass: 4420 Kg
+//  ==================================================
 
-	@PART[XNP_interstage_5m_8m_tMTVDRIVEX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
+@PART[XNP_interstage_5m_8m_tMTVDRIVEX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 2.010, 1.950,   2.010
-			%position = 0.000, 0.000,   0.000
-			%rotation = 0.000, 0.000, 180.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 2.0, 1.95, 2.0
+    }
 
-		@node_stack_top	   = 0.000,   2.925, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -10.000, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_1	   = 0.000,  -2.950, 0.000, 0.000, -1.000, 0.000, 3
-		!node_stack_2	   = NULL
-		!node_stack_3	   = NULL
-		!node_stack_4	   = NULL
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = Structural
-        @title		  = Bimodal NTR Engine Mount
-		@manufacturer = NASA
-		@description  = Structural adapter for the Bimodal NTR engines. Includes radiators for cooling the NTR engines.
+    @node_stack_top = 0.0, 2.925, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -2.95, 0.0, 0.0, -1.0, 0.0, 5
+    !node_stack_1 = NULL
+    !node_stack_2 = NULL
+    !node_stack_3 = NULL
+    !node_stack_4 = NULL
 
-		@mass		  	 	 = 0.6280
-		@crashTolerance	 	 = 12
-		@breakingForce	 	 = 250
-		@breakingTorque	 	 = 250
-		@maxTemp		  	 = 1073.15
-		%emissiveConstant	 = 0.900
-		%heatConductivity	 = 0.750
-		%thermalMassModifier = 5.000
-		%radiatorHeadroom    = 0.500
-		%bulkheadProfiles	 = size3
+    @category = FuelTank
+    @title = MTV - II Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Mars Transfer Vehicle.
 
-		!MODULE[ModuleCommand]{}
+    @mass = 4.42
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size3
 
-		!MODULE[ModuleGenerator]{}
+    !MODULE[ModuleCommand],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    !MODULE[ModuleGenerator],*{}
 
-		!RESOURCE[Oxidizer]{}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[ElectricCharge]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 200000
+    }
 
-		!RESOURCE[MonoPropellant]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Aerojet Rocketdyne Bimodal Nuclear Thermal Rocket (BNTR).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2372,116 +2372,82 @@
 		!RESOURCE[SolidFuel]{}
 	}
 
-//	==================================================
-//	SuperDraco engine.
+//  ==================================================
+//  SuperDraco engine.
 
-//	Dimensions: 0.200 x 2.000 m
-//	Gross Mass: 130.40 Kg
-//	Throttle Range: 20% to 100%
-//	Burn Time: 300 s
-//	O/F Ratio: 1.30
-//	==================================================
+//  Dimensions: 0.2 m x 2 m
+//  Gross Mass: 130 Kg
+//  ==================================================
 
-	@PART[xLazTekSuperDracosx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[xLazTekSuperDracosx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/LazTekSuperDracos/model
-			scale	 = 1.670, 1.670, 1.670
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
- 
-		@node_attach = 0.000, 0.000, 0.000, 0.000, 0.000, -1.000
+    MODEL
+    {
+        model = CMES/Propulsion/LazTekSuperDracos/model
+        scale = 1.67, 1.67, 1.67
+    }
 
-		@category	  = Engine
-		@title  	  = SuperDraco
-		@manufacturer = SpaceX
-		%description  = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules.
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@mass			  = 0.1304
-		@crashTolerance	  = 12
-		%breakingForce	  = 250
-		%breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%bulkheadProfiles = srf
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
-		@MODULE[ModuleEngines*]
-		{
-			@exhaustDamage  = true
-			@minThrust 		= 29.20
-			@maxThrust 		= 146.00
-			@heatProduction = 100
-			!fxOffset 		= NULL
-			%ullage			= false
-			%pressureFed	= true
+    @category = Engine
 
-			@PROPELLANT[MonoPropellant]
-			{
-				@name  = MMH
-				@ratio = 0.5629
-			}
+    @mass = 0.13
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = srf
 
-			PROPELLANT
-			{
-				name	  = NTO
-				ratio	  = 0.4370
-				DrawGauge = false
-			}
+    %engineType = SuperDraco
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 280.10
-				@key,1 = 1 239.80
-			}
-		}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 29.2
+        @maxThrust = 146
+        @exhaustDamage = True
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = -1
 
-		!MODULE[ModuleGimbal]{}
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+            @ratio = 0.5583
+        }
 
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			configuration = SuperDraco
-			modded		  = false
+        @PROPELLANT[Oxidizer]
+        {
+            @name = MON3
+            @ratio = 0.4417
+        }
 
-			CONFIG
-			{
-				name		   = SuperDraco
-				minThrust	   = 29.20
-				maxThrust	   = 146.00
-				heatProduction = 100
+        @atmosphereCurve
+        {
+            @key,0 = 0 280
+            @key,1 = 1 240
+        }
+    }
 
-				PROPELLANT
-				{
-					name	  = MMH
-					ratio	  = 0.5629
-					DrawGauge = true
-				}
-
-				PROPELLANT
-				{
-					name	  = NTO
-					ratio	  = 0.4370
-					DrawGauge = false
-				}
-
-				atmosphereCurve
-				{
-					key = 0 280.10
-					key = 1 239.80
-				}
-			}
-		}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	KW2mengineSPS ORION

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3008,6 +3008,19 @@
     }
 }
 
+//  ==================================================
+//  Pegasus engine pod.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[nosExplorerRadialEngine]:AFTER[RealismOverhaulEngines]
+{
+    @title = Pegasus Engine Pod
+    @manufacturer = Boeing Co. & KB Khimavtomatiki [Kosberg]
+    @description = Radially mounted engine pod, originally designed for the Pegasus Descent Module. Contains the engines and RCS thrusters for attitude control.
+}
+
 //	==================================================
 //	RSRM inert extension.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2449,123 +2449,88 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	KW2mengineSPS ORION
-//	==================================================
+//  ==================================================
+//  J-2X engine.
+
+//  Dimensions: 3.05 m x 4.7 m
+//  Gross Mass: 2470 Kg
+//  ==================================================
 
 @PART[XROVERENGINE]:FOR[RealismOverhaul]
 {
-    	%RSSROConfig = True
-	!mesh = DELETE
-	MODEL
-	{
-		model = CMES/Propulsion/KW2mengineSPS ORION/model
-		scale = 1.66667, 1.66667, 1.66667
-	}
-	@rescaleFactor = 1.75
+    %RSSROConfig = True
 
-	@node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.2, 0.0, 0, -1, 0, 2
+    !mesh = NULL
 
-	// --- FX definitions ---
+    MODEL
+    {
+        model = CMES/Propulsion/KW2mengineSPS ORION/model
+        scale = 1.667, 1.667, 1.667
+    }
 
-	@fx_gasJet_white = 0.0, -1.33333, 0.0, 0.0, 1.0, 0.0, running
-	@fx_exhaustLight_blue = 0.0, -1.33333, 0.0, 0.0, 0.0, 1.0, running
-    
-        @title = J-2X
-	%manufacturer = Aerojet Rocketdyne
-	@description = Designed for integration into the ARES Earth Departure Stage.
-        @mass = 2.47
-    
-        @MODULE[ModuleEngines*]
-	{
-		@minThrust = 915
-		@maxThrust = 1307
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 0.745
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.255
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 448
-			@key,1 = 1 200
-		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 7.5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		configuration = J-2X
-		origMass = 1.578501
-		modded = false
-		
-		CONFIG
-		{
-			name = J-2X
-			minThrust = 915
-			maxThrust = 1307
-			massMult = 0.973574409
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.745
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.255
-			}
-			atmosphereCurve
-			{
-				key = 0 448
-				key = 1 200
-			}
-		}
-	}
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		ignitionsAvailable = 3
-		autoIgnitionTemperature = 800
-		ignitorType = Electric
-		useUllageSimulation = true
-		isPressureFed = false
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.500
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdHydrogen
-			amount = 0.745
-		}
-		IGNITOR_RESOURCE
-		{
-			name = LqdOxygen
-			amount = 0.255
-		}
-	}
-        !MODULE[ModuleCommand]
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0, -1, 0, 3
+
+    @category = Engine
+
+    @mass = 2.47
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = size3
+
+    %engineType = J2X
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1072
+        @maxThrust = 1308
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 8
+
+        @PROPELLANT[LiquidFuel]
         {
+            @name = LqdHydrogen
+            @ratio = 0.7454
         }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2546
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 448
+            @key,1 = 1 200
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 7.5
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !RESOURCE,*{}
 }
 
 //	==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3024,8 +3024,8 @@
 //  ==================================================
 //  RSRM structural extension.
 
-//  Dimensions: 3.77 m x 3 m
-//  Gross Mass: 8400 Kg
+//  Dimensions: 3.71 m x 9 m
+//  Gross Mass: 5000 Kg
 //  ==================================================
 
 @PART[XNP_lft_W375SRB]:FOR[RealismOverhaul]
@@ -3036,22 +3036,22 @@
 
     @MODEL
     {
-        @scale = 0.755, 2.5, 0.755
+        @scale = 0.742, 3.0, 0.742
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 3.73, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -3.73, 0.0, 0.0, -1.0, 0.0, 3
-    @node_attach = 0.0, 1.99, 0.0, 1.0, 0.0, 0.0
+    @node_stack_top = 0.0, 4.445, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -4.53, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 1.85, 0.0, 0.0, 1.0, 0.0, 0.0
 
     @category = Structural
     @title = RSRM Structural Extension
     @manufacturer = Orbital ATK
-    %description = A structural extension for the RSRM. Does not contain propellant.
+    %description = A structural extension for the 4 Segment RSRM. Does not contain propellant.
 
-    @mass = 8.4
+    @mass = 5.0
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2533,98 +2533,143 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Orion MPCV Service Module.
+//  ==================================================
+//  Orion MPCV Service Module.
 
-//	Dimensions: 4.000 x 2.720 m
-//	Gross Mass: 12300.00 Kg
-//	Volume: 8400.00 L
-//	==================================================
+//  Dimensions: 4 m x 2.8 m
+//  Gross Mass: 12600 Kg
+//  ==================================================
 
-	@PART[XLFTORIONLARGE]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XLFTORIONLARGE]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/LFT_ORION/model
-			scale	 = 1.075, 1.180, 1.075
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    MODEL
+    {
+        model = CMES/Propulsion/LFT_ORION/model
+        scale = 1.0667, 1.305, 1.0667
+    }
 
-		@node_stack_top	    = 0.000,  1.325, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom  = 0.000, -1.335, 0.000, 0.000, -1.000, 0.000, 3
-		!node_stack_bottom2 = NULL
-		@node_attach	    = 1.380,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title		  = Orion Service Module
-		@manufacturer = Airbus Defence & Space
-		%description  = The Service Module for the Orion MPCV. Derived from the Automatic Transfer Vehicle (ATV) Service Module.
+    @node_stack_top = 0.0, 1.465, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.585, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_bottom2 = NULL
+    @node_attach = 1.38, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		@mass			 	 = 3.800
-		@crashTolerance	 	 = 12
-		@breakingForce	 	 = 250
-		@breakingTorque	 	 = 250
-		@maxTemp		 	 = 1073.15
-		%fuelCrossFeed		 = false
-		%bulkheadProfiles	 = srf, size3
-		%emissiveConstant	 = 0.850
-		%heatConductivity	 = 0.700	
-		%thermalMassModifier = 5
-		%radiatorHeadroom	 = 0.450
+    @category = FuelTank
+    @title = Orion MPCV Service Module
+    @manufacturer = Airbus Defence & Space
+    %description = The Service Module for the Orion MPCV. Derived from the Automatic Transfer Vehicle (ATV) Service Module.
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			volume	 = 8400
-			basemass = -1
+    @mass = 3.8
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = srf, size3
+    %emissiveConstant = 0.85
+    %heatConductivity = 0.7
+    %thermalMassModifier = 5.0
+    %radiatorHeadroom = 0.506
 
-			//	Oxygen max capacity 16.50 Kg.
+    !MODULE[ModuleReactionWheel],*{}
 
-			TANK
-			{
-				name	  = Oxygen
-				amount	  = 11700
-				maxAmount = 11700
-			}
+    !MODULE[ModuleFuelTanks],*{}
 
-			//	Water max capacity 280.00 Kg.
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 8170
+        basemass = -1
 
-			TANK
-			{
-				name	  = Water
-				amount	  = 280
-				maxAmount = 280
-			}
+        //  Batteries 840 Wh.
 
-			//	Propellant mass 9200.00 Kg.
+        TANK
+        {
+            name = ElectricCharge
+            amount = 3025
+            maxAmount = 3025
+        }
 
-			TANK
-			{
-				name	  = MMH
-				amount	  = 4008
-				maxAmount = 4008
-			}
+        //  Life support water mass 280 Kg.
 
-			TANK
-			{
-				name	  = MON3
-				amount	  = 3950
-				maxAmount = 3950
-			}
-		}
+        TANK
+        {
+            name = Water
+            amount = 280
+            maxAmount = 280
+        }
 
-		!RESOURCE[LiquidFuel]{}
+        //  OME & ACS fuel mass 8600 Kg.
 
-		!RESOURCE[Oxidizer]{}
-	}
+        TANK
+        {
+            name = MMH
+            amount = 3745
+            maxAmount = 3745
+        }
+
+        //  OME & ACS mass oxidizer.
+
+        TANK
+        {
+            name = MON3
+            amount = 3760
+            maxAmount = 3760
+        }
+    }
+
+    !MODULE[ModuleActiveRadiator],*{}
+
+    MODULE
+    {
+        name = ModuleActiveRadiator
+        maxEnergyTransfer = 12500
+        overcoolFactor = 0.506
+        isCoreRadiator = True
+        maxLinksAway = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.17
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Orion MPCV Service Module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[XLFTORIONLARGE]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @mass -= 0.07
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 8400
+
+        //  Oxygen 66 Kg.
+
+        TANK
+        {
+            name = Oxygen
+            amount = 46810
+            maxAmount = 46810
+        }
+    }
+}
 
 @PART[DUNARETROTANKhtv]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2776,197 +2776,138 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Aerojet Rocketdyne Bimodal Nuclear Thermal Rocket (BNTR).
+//  ==================================================
+//  Bimodal Nuclear Thermal Rocket (BNTR).
 
-//	Dimensions: 1.560 x 3.240 m
-//	Gross Mass: 2224.00 Kg
-//	Throttle Range: 33% to 100%
-//	Burn Time: 5400 s
-//	O/F Ratio: 0.00
-//	==================================================
+//  Dimensions: 1.56 m x 3.24 m
+//  Gross Mass: 2220 Kg
+//  ==================================================
 
-	@PART[nervaII_kerbscalexx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[nervaII_kerbscalexx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 0.700, 0.875, 0.700
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 0.7, 0.875, 0.7
+    }
 
-		@node_stack_top    = 0.000,  2.445, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, -4.550, 0.000, 0.000, -1.000, 0.000, 2
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@title		  = Bimodal NTR [1.6 m]
-		@manufacturer = Aerojet Rocketdyne
-		@description  = The Bimodal Nuclear Thermal Rocket (BNTR) engine takes the original NERVA concept and expands it. Instead of wasting precious propellant mass for cooling the engine reactor, it uses a power generator unit to convert the waste thermal energy into electrical power.
+    @node_stack_top = 0.0, 2.445, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -4.55, 0.0, 0.0, -1.0, 0.0, 2
 
-		@mass		      = 2.1690
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1973.15
-		%fuelCrossFeed	  = true
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = LIQUID_ENGINE
-		%bulkheadProfiles = size2
+    @category = Engine
 
-		@MODULE[ModuleEngines]
-		{
-			@minThrust	    = 22.24
-			@maxThrust	    = 66.72
-			@heatProduction = 100
-			!fxOffset	    = NULL
-			%ullage		    = true
-			%pressureFed	= false
-			%ignitions	    = 10
+    @mass = 2.17
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %fuelCrossFeed = True
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = size2
 
-			IGNITOR_RESOURCE
-			{
-				name   = ElectricCharge
-				amount = 0.500
-			}
+    %engineType = BNTR
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
 
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = LqdHydrogen
-				@ratio = 1.000
-			}
-			@PROPELLANT[Oxidizer]
-			{
-				@name  = EnrichedUranium
-				@ratio = 0.00000000001
-			}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 111.2
+        @maxThrust = 111.2
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 10
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 925
-				@key,1 = 1 380
-			}
-		}
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 1.0
+        }
 
-		!MODULE[ModuleGimbal]{}
+        @PROPELLANT[Oxidizer]
+        {
+            @name = EnrichedUranium
+            @ratio = 1.6428e-17
+        }
 
-		MODULE
-		{
-			name	 	  = ModuleEngineConfigs
-			type	 	  = ModuleEngines
-			origMass  	  = 2.224
-			modded	      = false
-			configuration = BNTR
+        @atmosphereCurve
+        {
+            @key,0 = 0 925
+            @key,1 = 1 380
+        }
+    }
 
-			CONFIG
-			{
-				name		   = BNTR
-				minThrust	   = 22.24
-				maxThrust	   = 66.72
-				heatProduction = 100
-				massMult	   = 1.000
+    !MODULE[ModuleGimbal],*{}
 
-				PROPELLANT
-				{
-					name   	  = LqdHydrogen
-					ratio	  = 1.000
-					DrawGauge = True
-				}
+    !MODULE[ModuleGenerator],*{}
 
-				PROPELLANT
-				{
-					name	  = EnrichedUranium
-					ratio	  = 0.00000000001
-					DrawGauge = false
-				}
+    !MODULE[ModuleResourceConverter],*{}
 
-				atmosphereCurve
-				{
-					key = 0 925.00
-					key = 1 380.00
-				}
-			}
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = RTG
+        StartActionName = Start RTG
+        StopActionName = Stop RTG
+        AlwaysActive = True
+        FillAmount = 1.0
+        AutoShutdown = False
+        GeneratesHeat = True
+        TemperatureModifier = 2.0
+        UseSpecializationBonus = False
+        DefaultShutoffTemp = 0.5
 
-			CONFIG
-			{
-				name		   = TRITON
-				minThrust	   = 90.40
-				maxThrust	   = 271.21
-				heatProduction = 100
-				massMult	   = 1.100
-				
-				PROPELLANT
-				{
-					name   	  = LqdHydrogen
-					ratio	  = 0.250
-					DrawGauge = True
-				}
+        INPUT_RESOURCE
+        {
+            ResourceName = EnrichedUranium
+            Ratio = 1.6428e-17
+        }
 
-				PROPELLANT
-				{
-					name	  = LqdOxygen
-					ratio	  = 0.750
-					DrawGauge = False
-				}
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 5.0
+        }
 
-				PROPELLANT
-				{
-					name	  = EnrichedUranium
-					ratio	  = 0.00000000001
-					DrawGauge = false
-				}
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedUranium
+            Ratio = 1.6428e-17
+        }
+    }
 
-				atmosphereCurve
-				{
-					key = 0 642.00
-					key = 1 390.00
-				}
-			}
-		}
+    !RESOURCE,*{}
 
-		MODULE
-		{
-			name		   = ModuleGenerator
-			isAlwaysActive = true
+    //  Uranium-235 pellets mass ~55 Kg.
 
-			INPUT_RESOURCE
-			{
-				name = EnrichedUranium
-				rate = 1e-13
-			}
+    RESOURCE
+    {
+        name = EnrichedUranium
+        amount = 5
+        maxAmount = 5
+    }
 
-			OUTPUT_RESOURCE
-			{
-				name = ElectricCharge
-				rate = 5.000
-			}
-
-			OUTPUT_RESOURCE
-			{
-				name = DepletedUranium
-				rate = 1e-13
-			}
-		}
-
-		RESOURCE
-		{
-			name 	  = EnrichedUranium
-			amount	  = 5
-			maxAmount = 5
-		}
-
-		RESOURCE
-		{
-			name	  = DepletedUranium
-			amount	  = 0
-			maxAmount = 5
-		}
-	}
+    RESOURCE
+    {
+        name = DepletedUranium
+        amount = 0
+        maxAmount = 5
+    }
+}
 
 //	==================================================
 //	Altair II descent module engines & RCS.


### PR DESCRIPTION
Updates and fixes for the CMES "Propulsion" parts. Third pass.

Changelog:

* Update all engiine parts to use the new global engine configuration system.
* Remove invalid part modules from many parts.
* Add an active radiator module to the Orion SM.
* Upgrade the BNTR RTG generator module to the new ModuleResourceConverter.
* Fix the volumes of the DCSS 4 and 5 LH2 tanks.
* Explicitly set the part categories (and use the new KSP 1.2 ones).
* Balance inert and gross mass values against real sources and/or other parts.
* Adjust some insane max temperature values.
* Update the part titles and the descriptions.
* Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes](https://github.com/KSP-RO/RealismOverhaul/pull/1466/files?w=1)