### PR TITLE
CMES Propulsion updates (part IV)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -4075,6 +4075,26 @@
     }
 }
 
+//  ==================================================
+//  Space Launch System core booster.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[MonkeyCargoBoosterSLSADJ]:AFTER[RealismOverhaulEngines]
+{
+    @title = SLS Core Booster (Block I/IB/II)
+    @manufacturer = Boeing Co.
+    @description = The Space Launch System (SLS) core booster stage. Equipped with four RS-25E engines.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RS-25D/E
+
+        !CONFIG,*:HAS[~name[RS-25D/E]]{}
+    }
+}
+
 //	==================================================
 //	Space Launch System Exploration Upper Stage (EUS).
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3497,68 +3497,59 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Ares V Bimodal NTR LH2 tank.
+//  ==================================================
+//  Small surface habitation module propellant tank.
 
-//	Dimensions: 8.384 x 11.000 m
-//	Gross Mass: 12621.00 Kg
-//	Volume: 573000.00 L
-//	==================================================
+//  Dimensions: 5 m x 1 m
+//  Gross Mass: 600 Kg
+//  ==================================================
 
-	@PART[Xafa191m23312NTR]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[Xafa191m23312NTR]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 1.675, 3.680, 1.675
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 1.0, 0.325, 1.0
+    }
 
-		@node_stack_top	   = 0.000,  5.500, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -5.400, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 5.500,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title		  = Ares V Bimodal NTR LH2 Tank
-		@manufacturer = NASA
-		@description  = A cryogenic liquid hydrogen tank for the Ares V launch vehicles. To be used in conjunction with the Bimodal NTR engines.
+    @node_stack_top = 0.0, 0.48, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_bottom = 0.0, -0.48, 0.0, 0.0, -1.0, 0.0, 4
+    @node_attach = 2.0, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		@mass		      = 12.6210
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @category = FuelTank
+    @title = RL - II Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic pressurized propellant tank for surface habitation modules.
 
-		!MODULE[ModuleReactionWheel]{}
+    @mass = 0.6
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size4
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleSAS],*{}
 
-        MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = Cryogenic
-			volume	 = 573000
-			basemass = -1
+    !MODULE[ModuleReactionWheel],*{}
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 573000
-				maxAmount = 573000
-			}
-		}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 18000
+    }
 
-		!RESOURCE[Oxidizer]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Ares V Earth Departure Stage (EDS) LH2 tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3605,55 +3605,50 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Delta IV Common Booster Core (CBC) RS-68 engine mount & shroud.
+//  ==================================================
+//  Delta IV CBC engine mount.
 
-//	Dimensions: 5.000 x 4.000 m
-//	Gross Mass: 1525.00 Kg
-//	==================================================
+//  Dimensions: 5 m x 4 m
+//  Gross Mass: 1530 Kg
+//  ==================================================
 
-	@PART[NP_CHAKAEMLVENGINE]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[NP_CHAKAEMLVENGINE]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 2.000, 2.000,   2.000
-			%position = 0.000, 0.000,   0.000
-			%rotation = 0.000, 0.000, 180.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 2.0, 2.0, 2.0
+        %rotation = 0.0, 0.0, 180.0
+    }
 
-		@node_stack_top	   = 0.000,  2.000, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -2.050, 0.000, 0.000, -1.000, 0.000, 3
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = Structural
-		@title		  = Delta IV CBC Engine Mount
-		@manufacturer = Orbital ATK
-		@description  = The RS-68 engine mount for the Delta IV Common Booster Core (CBC).
+    @node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_bottom = 0.0, -2.05, 0.0, 0.0, -1.0, 0.0, 2
 
-		@mass			  = 1.5250
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @category = Structural
+    @title = Delta IV CBC Engine Mount
+    @manufacturer = Orbital ATK
+    @description = The RS-68 engine mount for the Delta IV Common Booster Core (CBC).
 
-		!MODULE[ModuleCommand]{}
+    @mass = 1.53
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size2, size4
 
-		!MODULE[ModuleGenerator]{}
+    !MODULE[ModuleCommand],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    !MODULE[ModuleGenerator],*{}
 
-		!RESOURCE[Oxidizer]{}
-
-		!RESOURCE[MonoPropellant]{}
-
-		!RESOURCE[ElectricCharge]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Mars Ascent Vehicle (MAV) engine mount.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3934,166 +3934,146 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Space Launch System (SLS) core booster.
+//  ==================================================
+//  Space Launch System core booster.
 
-//	This is a hypothetical design, using five instead of four RS-25E engines. Uses the data from October 22, 2015 for the Block I, Block IB & Block II.
+//  Dimensions: 8.4 m x 46 m
+//  Gross Mass: 1091540 Kg
+//  ==================================================
 
-//	Dimensions: 8.384 x 62.54 m
-//	Gross Mass: 1091536.00 Kg
-//	Throttle Range: 67% to 100%
-//	Burn Time: 476 s
-//	O/F Ratio: 6.03
-//	Volume: 2665855.00 L
-//	==================================================
+@PART[MonkeyCargoBoosterSLSADJ]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-	@PART[MonkeyCargoBoosterSLSADJ]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+    !mesh = NULL
 
-		@MODEL
-		{
-			@scale	  = 1.600, 1.600, 1.600
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    @MODEL
+    {
+        @scale = 1.6, 1.6, 1.6
+    }
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/SLS-EXPANSION/model
-			scale	 = 1.685, 0.750, 1.685
-			position = 0.000, 4.500, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    MODEL
+    {
+        model = CMES/Propulsion/MLS-EXPANSION/model
+        scale = 1.685, 1.250, 1.685
+        position = 0.0, 6.0, 0.0
+    }
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@node_stack_top    = 0.000,   6.740, 0.000, 0.000,  1.000, 0.000, 3
-		%node_stack_bottom = 0.000, -54.655, 0.000, 0.000, -1.000, 0.000, 3
+    @node_stack_top = 0.0, 9.73, 0.0, 0.0, 1.0, 0.0, 5
+    %node_stack_bottom = 0.0, -54.655, 0.0, 0.0, -1.0, 0.0, 5
 
-		@category	  = Engine
-		@title		  = SLS Core Booster (Block I / IB / II)
-		@manufacturer = NASA
-		@description  = The Space Launch System (SLS) core booster stage. Equipped with five RS-25E engines.
+    @category = Engine
 
-		@mass			  = 125.4650
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%stageOffset	  = 1
-		%childStageOffset = 1
-		%stagingIcon	  = LIQUID_ENGINE
-		@CoMOffset		  = 0.000, -27.000, 0.000
+    @mass = 125.47
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @CoMOffset = 0.0, 0.0, 0.0
+    %bulkheadProfiles = size5
 
-		!MODULE[ModuleCommand]{}
+    %engineType = SSME
+    %engineTypeMult = 4
+    %massOffset = 111.36
+    %ignoreMass = False
 
-		!MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleCommand],*{}
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleReactionWheel],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    !MODULE[ModuleSAS],*{}
 
-		!RESOURCE[Oxidizer]{}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1358.5
+        @maxThrust = 2319.9
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
 
-        @MODULE[ModuleEngines*]
-		{
-			@minThrust		= 6995.49
-			@maxThrust		= 10441.04
-			@heatProduction = 100
-			!fxOffset		= NULL
-			%ullage			= true
-			%pressureFed	= false
-			%ignitions		= 1
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 0.7285
+        }
 
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = LqdHydrogen
-				@ratio = 0.7275
-			}
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2715
+        }
 
-			@PROPELLANT[Oxidizer]
-			{
-				@name  = LqdOxygen
-				@ratio = 0.2724
-			}
+        @atmosphereCurve
+        {
+            @key,0 = 0 453
+            @key,1 = 1 363
+        }
+    }
 
-			@atmosphereCurve
-			{
-				@key,0 = 0 452.00
-				@key,1 = 1 366.00
-			}
-		}
+    !MODULE[ModuleGimbal],*{}
 
-		MODULE
-		{
-			name 				= KM_Gimbal_3
-			gimbalTransformName = thrustTransform
-			yawGimbalRange 		= 8.000
-			pitchGimbalRange 	= 8.000
-			gimbalConstrain 	= 8.000
-			responseSpeed 		= 16
-			enableRoll 			= true
-		}
+    MODULE
+    {
+        name = ModuleGimbal
+        gimbalTransformName = thrustTransform
+        gimbalRange = 8.0
+        useGimbalResponseSpeed = True
+        gimbalResponseSpeed = 16
+    }
 
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			configuration = RS-25E
-			modded		  = false
+    !MODULE[ModuleFuelTanks],*{}
 
-			CONFIG
-			{
-				name	  = RS-25E
-				minThrust = 6995.49
-				maxThrust = 10441.04
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 2665850
+        basemass = -1
 
-				PROPELLANT
-				{
-					name	  = LqdHydrogen
-					ratio	  = 0.7275
-					DrawGauge = true
-				}
+        //  SLS core stage fuel mass 137420 Kg.
 
-				PROPELLANT
-				{
-					name  = LqdOxygen
-					ratio = 0.2724
-				}
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 1939600
+            maxAmount = 1939600
+        }
 
-				atmosphereCurve
-				{
-					key = 0 452.00
-					key = 1 366.00
-				}
-			}
-		}
-	
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = Cryogenic
-			volume	 = 2665855
-			basemass = -1
+        //  SLS core stage oxidizer mass 828650 Kg.
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 1939607
-				maxAmount = 1939607
-			}
+        TANK
+        {
+            name = LqdOxygen
+            amount = 726250
+            maxAmount = 726250
+        }
+    }
 
-			TANK
-			{
-				name	  = LqdOxygen
-				amount	  = 726248
-				maxAmount = 726248
-			}
-		}
-	}
+    !RESOURCE,*{}
+
+    //  Avionics batteries 33 Wh.
+    //  Supports the core stage for the duration of it's flight (approximately 8 minutes).
+    //  Assumes that the power consumption of the avionics is 250 Watts.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 120
+        maxAmount = 120
+    }
+}
 
 //	==================================================
 //	Space Launch System Exploration Upper Stage (EUS).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3443,77 +3443,59 @@
 		!RESOURCE[Oxidizer]{}    
 	}
 
-//	==================================================
-//	Mars Transfer Vehicle (MTV) service module tank.
+//  ==================================================
+//  Mars Transfer Vehicle auxiliary propellant tank.
 
-//	Dimensions: 10.000 x 5.000 m
-//	Gross Mass: 10038.30 Kg
-//	Volume: 283000.00 L
-//	==================================================
+//  Dimensions: 10 m x 5 m
+//  Gross Mass: 4000 Kg
+//  ==================================================
 
-	@PART[XNP_lft_xtrt3mCCB8MAx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XNP_lft_xtrt3mCCB8MAx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 2.000, 1.650, 2.000
-			@position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 2.0, 1.0, 2.0
+    }
 
-		@node_stack_top	   = 0.000,  2.450, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -2.450, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 4.000,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-        @title		  = MTV Service Module
-        @manufacturer = NASA
-        @description = The service module for the MTV Bimodal NTR stage.
-		
-        @mass			  = 8.8335
-		crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @node_stack_top = 0.0, 1.485, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -1.485, 0.0, 0.0, -1.0, 0.0, 5
+    @node_attach = 4.5, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		!MODULE[ModuleReactionWheel]{}
+    @category = FuelTank
+    @title = MTV - III Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic pressurized propellant tank for the Mars Transfer Vehicle.
 
-		!MODULE[ModuleSAS]{}
+    @mass = 4.0
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size5
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			volume	 = 283000
-			basemass = -1
+    !MODULE[ModuleSAS],*{}
 
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 1200
-				maxAmount = 1200
-			}
+    !MODULE[ModuleReactionWheel],*{}
 
-			TANK
-			{
-				name	  = ElectricCharge
-				amount	  = 43200
-				maxAmount = 43200
-			}
-		}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 160000
+    }
 
-		!RESOURCE[Oxidizer]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Ares V Bimodal NTR LH2 tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -4206,3 +4206,47 @@
         maxAmount = 4500
     }
 }
+
+//  ==================================================
+//  Space Launch System Exploration Upper Stage (EUS).
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[TALUS]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.035
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.035
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.0075
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3706,74 +3706,59 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Ares V Earth Departure Stage (EDS) LOX tank.
+//  ==================================================
+//  Earth Departure Stage auxiliary propellant tank.
 
-//	Dimensions: 8.384 x 4.000 m
-//	Gross Mass: 5506.33 Kg
-//	Volume: 153254.00 L
-//	==================================================
+//  Dimensions: 7.5 m x 2.5 m
+//  Gross Mass: 1300 Kg
+//  ==================================================
 
-	@PART[XNP_interstage_5m_8m_tankMUNAR1X]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = True
+@PART[NP_CHAKAEMLVENGINE2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 1.500, 1.400,   1.500
-			%position = 0.000, 0.000,   0.000
-			%rotation = 0.000, 0.000, 180.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 3.0, 1.2, 3.0
+    }
 
-		@node_stack_bottom = 0.000, -2.100,  0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_top	   = 0.000,  2.100,  0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_1	   = 0.000, -7.500,  0.000, 0.000, -1.000, 0.000, 3
-		%node_stack_left   = 0.000, -2.100,  1.600, 0.000, -1.000, 0.000, 3
-		%node_stack_right  = 0.000, -2.100, -1.600, 0.000, -1.000, 0.000, 3
-    
-		@category	  = FuelTank
-        @title		  = Ares V EDS LOX Tank
-        @manufacturer = NASA
-        @description  = The Liquid Oxygen tank for the Ares V launch vehicle Earth Departure Stage.
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@mass			  = 5.5063
-		@crashTolerance   = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 5
+    %node_stack_decoupler = 0.0, 12.0, 0.0, 0.0, 1.0, 0.0, 5
 
-        !MODULE[ModuleCommand]{}
+    @category = FuelTank
+    @title = EDS - III Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Space Launch System Earth Departure Stage (EDS).
 
-		!MODULE[ModuleGenerator]{}
+    @mass = 1.3
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @bulkheadProfiles = size3, size5
 
-        MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = Cryogenic
-			volume	 = 153254
-			basemass = -1
+    !MODULE[ModuleCommand],*{}
 
-			TANK
-			{
-				name	  = LqdOxygen
-				amount	  = 153254
-				maxAmount = 153254
-			}
-		}
+    !MODULE[ModuleGenerator],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[Oxidizer]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 60000
+    }
 
-		!RESOURCE[MonoPropellant]{}
-
-		!RESOURCE[ElectricCharge]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Generic RCS tank (small).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3809,60 +3809,54 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Generic RCS tank (large).
+//  ==================================================
+//  Large radial propellant tank.
 
-//	Dimensions: 0.600 x 1.500 m
-//	Gross Mass: 370.00 Kg
-//	Volume: 330.00 L
-//	==================================================
+//  Dimensions: 0.6 m x 1.5 m
+//  Gross Mass: 370 Kg
+//  ==================================================
 
-	@PART[XrcsTankRadialLongHVXLP]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XrcsTankRadialLongHVXLP]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/ROVER-RCS/model
-			scale	 = 1.000, 1.000, 1.000
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
+    MODEL
+    {
+        model = CMES/Propulsion/ROVER-RCS/model
+        scale = 1.0, 1.0, 1.0
+    }
 
-		@node_attach = 0.000, 0.000, -0.075, 0.000, 0.000, -1.000
+    %scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title		  = RCS Tank [330 L]
-		%manufacturer = Generic
-		@description  = A high pressure RCS propellant tank.
+    @node_attach = 0.0, 0.0, -0.075, 0.0, 0.0, -1.0
 
-		@mass			  = 0.0378
-		%breakingForce	  = 250
-		breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = srf
+    @category = FuelTank
+    @title = RMT - II Propellant Tank
+    %manufacturer = Generic
+    @description = A general purpose, radially mounted, pressurized propellant tank.
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			volume	 = 330
-			basemass = -1
+    @mass = 0.04
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = srf
 
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 330
-				maxAmount = 330
-			}
-		}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[MonoPropellant]{}
-	}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 330
+    }
+
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Aerojet Rocketdyne RS - 68 engine.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3858,200 +3858,81 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Aerojet Rocketdyne RS - 68 engine.
+//  ==================================================
+//  RS-68 engine.
 
-//	Dimensions: 2.430 x 5.200 m
-//	Gross Mass: 6597.00 Kg
-//	Throttle Range: 60% to 100%
-//	Burn Time: 249 s
-//	O/F Ratio: 6.00
-//	==================================================
+//  Dimensions: 2.43 m x 5.2 m
+//  Gross Mass: 6600 Kg
+//  ==================================================
 
-	@PART[xbahars68bx]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[xbahars68bx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/rs68b/model
-			scale	 = 1.000, 1.000, 1.000
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
+    MODEL
+    {
+        model = CMES/Propulsion/rs68b/model
+        scale = 1.0, 1.0, 1.0
+    }
 
-		@node_stack_top    = 0.000,  2.615, 0.000, 0.000,  1.000, 0.000, 2
-		@node_stack_bottom = 0.000, -2.587, 0.000, 0.000, -1.000, 0.000, 2
-		@node_attach	   = 0.000,  2.615, 0.000, 0.000,  1.000, 0.000, 2
+    %scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = Engine
-		@title		  = RS-68 [2.3 m]
-		@manufacturer = Aerojet Rocketdyne
-		@description  = The RS-68 is gas generator engine design, powered by liquid hydrogen and liquid oxygen. It is used on the Common Booster Core (CBC) of the Delta IV launch vehicle. 
+    @node_stack_top = 0.0, 2.615, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -2.587, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 2.615, 0.0, 0.0, 1.0, 0.0, 2
 
-		@mass    		  = 6.597
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1973.15
-		%bulkheadProfiles = size2
+    @category = Engine
 
-		@MODULE[ModuleEngines*]
-		{
-			@minThrust		= 1734.84
-			@maxThrust		= 2891.40
-			@heatProduction	= 100
-			!fxOffset		= NULL
-			%ullage			= true
-			%pressureFed	= false
-			%ignitions		= 1
+    @mass = 6.6
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %bulkheadProfiles = size2
 
-			IGNITOR_RESOURCE
-			{
-				name   = LqdHydrogen
-				amount = 0.7285
-			}
+    %engineType = RS68
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
 
-			IGNITOR_RESOURCE
-			{
-				name   = LqdOxygen
-				amount = 0.2714
-			}
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1890
+        @maxThrust = 3370
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
 
-			IGNITOR_RESOURCE
-			{
-				name   = ElectricCharge
-				amount = 0.500
-			}
-
-			@PROPELLANT[LiquidFuel]
-			{
-				@name  = LqdHydrogen
-				@ratio = 0.7285
-			}
-
-			@PROPELLANT[Oxidizer]
-			{
-				@name  = LqdOxygen
-				@ratio = 0.2714
-			}
-
-			@atmosphereCurve
-			{
-				@key,0 = 0 409.10
-				@key,1 = 1 356.90
-			}
-		}
-
-		@MODULE[ModuleGimbal]
-		{
-			@gimbalRange			= 6.000
-			%useGimbalResponseSpeed = true
-			%gimbalResponseSpeed 	= 16
-		}
-
-		MODULE
-		{
-			name		  = ModuleEngineConfigs
-			type		  = ModuleEngines
-			origMass	  = 6.597
-			configuration = RS-68
-			modded		  = false
-
-			CONFIG
-			{
-				name	  = RS-68
-				minThrust = 1734.84
-				maxThrust = 2891.40
-
-				PROPELLANT
-				{
-					name	  = LqdHydrogen
-					ratio	  = 0.7285
-					DrawGauge = true
-				}
-
-				PROPELLANT
-				{
-					name 	  = LqdOxygen
-					ratio	  = 0.2714
-					DrawGauge = false
-				}
-
-				atmosphereCurve
-				{
-					key = 0 409.10
-					key = 1 356.90
-				}
-			}
-
-			CONFIG
-			{
-				name	  = RS-68A
-				minThrust = 1838.69
-				maxThrust = 3064.49
-				massMult  = 1.0216
-
-				PROPELLANT
-				{
-					name	  = LqdHydrogen
-					ratio	  = 0.7285
-					DrawGauge = true
-				}
-
-				PROPELLANT
-				{
-					name 	  = LqdOxygen
-					ratio	  = 0.2714
-					DrawGauge = false
-				}
-
-				atmosphereCurve
-				{
-					key = 0 415.20
-					key = 1 364.00
-				}
-			}
-
-			CONFIG
-			{
-				name	  = RS-68B
-				minThrust = 1873.62
-				maxThrust = 3122.70
-				massMult  = 1.0290
-
-				PROPELLANT
-				{
-					name	  = LqdHydrogen
-					ratio	  = 0.7285
-					DrawGauge = true
-				}
-
-				PROPELLANT
-				{
-					name 	  = LqdOxygen
-					ratio	  = 0.2714
-					DrawGauge = false
-				}
-
-				atmosphereCurve
-				{
-					key = 0 420.00
-					key = 1 369.90
-				}
-			}
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 0.7285
         }
 
-		!MODULE[ModuleEngineConfigs]{}
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2715
+        }
 
-		!MODULE[ModuleAlternator]{}
+        @atmosphereCurve
+        {
+            @key,0 = 0 409
+            @key,1 = 1 357
+        }
+    }
 
-		!RESOURCE[ElectricCharge]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Space Launch System (SLS) core booster.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3551,70 +3551,59 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Ares V Earth Departure Stage (EDS) LH2 tank.
+//  ==================================================
+//  Earth Departure Stage main propellant tank.
 
-//	Dimensions: 8.384 x 11.000 m
-//	Gross Mass: 10412.67 Kg
-//	Volume: 448742.00 L
-//	==================================================
+//  Dimensions: 8.4 m x 11 m
+//  Gross Mass: 11600 Kg
+//  ==================================================
 
-	@PART[XNP_lft_xtrt3mCCB8MAx2]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XNP_lft_xtrt3mCCB8MAx2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 1.675, 3.680, 1.675
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 1.68, 3.68, 1.68
+    }
 
-		@node_stack_top	   = 0.000,  5.500, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -5.400, 0.000, 0.000, -1.000, 0.000, 3
-		@node_attach	   = 5.500,  0.000, 0.000, 1.000,  0.000, 0.000
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title		  = Ares V EDS LH2 Tank
-		@manufacturer = NASA
-		@description  = The Liquid Hydrogen tank for the Ares V launch vehicle Earth Departure Stage.
+    @node_stack_top = 0.0, 5.5, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -5.5, 0.0, 0.0, -1.0, 0.0, 5
+    @node_attach = 5.5, 0.0, 0.0, 1.0, 0.0, 0.0
 
-		@mass		      = 10.4126
-		@crashTolerance   = 12
-		@breakingForce    = 250
-		@breakingTorque   = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @category = FuelTank
+    @title = EDS - I Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Space Launch System Earth Departure Stage (EDS).
 
-		!MODULE[ModuleReactionWheel]{}
+    @mass = 11.6
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size3
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleSAS],*{}
 
-        MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = BalloonCryo
-			volume	 = 448742
-			basemass = -1
+    !MODULE[ModuleReactionWheel],*{}
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 448742
-				maxAmount = 448742
-			}
-		}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[LiquidFuel]{}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 560000
+    }
 
-		!RESOURCE[Oxidizer]{}
-
-		!RESOURCE[MonoPropellant]{}
-	}
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Delta IV Common Booster Core (CBC) RS-68 engine mount & shroud.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -4095,83 +4095,114 @@
     }
 }
 
-//	==================================================
-//	Space Launch System Exploration Upper Stage (EUS).
+//  ==================================================
+//  Space Launch System Exploration Upper Stage (EUS).
 
-//	Dimensions: 8.384 x 18.300 m
-//	Gross Mass: 141168.00 Kg
-//	Volume: 357813.00 L
-//	==================================================
+//  Dimensions: 8.4 m x 18.3 m
+//  Gross Mass: 141170 Kg
+//  ==================================================
 
-	@PART[TALUS]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[TALUS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 1.170, 1.300, 1.170
-			%position = 0.000, 0.000, 0.000
-			%rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 1.17, 1.3, 1.17
+    }
 
-		@node_stack_top	   =  0.000,   6.680,  0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom =  0.000, -11.500,  0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_1	   = -1.820,  -8.000, -1.820, 0.000, -1.000, 0.000, 3
-		@node_stack_2	   =  1.820,  -8.000, -1.820, 0.000, -1.000, 0.000, 3
-		@node_stack_3	   = -1.820,  -8.000,  1.820, 0.000, -1.000, 0.000, 3
-		@node_stack_4	   =  1.820,  -8.000,  1.820, 0.000, -1.000, 0.000, 3
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title		  = SLS EUS
-		@manufacturer = Boeing Co.
-		@description  = The Exploration Upper Stage (EUS) for the Space Launch System Block IB and II.
+    @node_stack_top = 0.0, 6.68, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -11.5, 0.0, 0.0, -1.0, 0.0, 5
+    @node_stack_1 = -1.82, -8.0, -1.82, 0.0, -1.0, 0.0, 2
+    @node_stack_2 = 1.82, -8.0, -1.82, 0.0, -1.0, 0.0, 2
+    @node_stack_3 = -1.82, -8.0, 1.82, 0.0, -1.0, 0.0, 2
+    @node_stack_4 = 1.82, -8.0, 1.82, 0.0, -1.0, 0.0, 2
 
-		@mass			  = 11.8786
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = size3
+    @category = FuelTank
+    @title = Exploration Upper Stage
+    @manufacturer = Boeing Co.
+    @description = The Exploration Upper Stage (EUS) for the Space Launch System Blocks IB and II.
 
-		!MODULE[ModuleCommand]{}
+    @mass = 11.88
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %vesselType = Probe
+    %CrewCapacity = 0
+    %bulkheadProfiles = size2, size5
+    %stackSymmetry = 3
+    %NoCrossFeedNodeKey = stack
 
-		!MODULE[MechJebCore]{}
+    !MODULE[ModuleReactionWheel],*{}
 
-		!MODULE[ModuleSAS]{}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!MODULE[ModuleReactionWheel]{}
-    
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = BalloonCryo
-			volume	 = 357813
-			basemass = -1
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 357810
+        basemass = -1
 
-			TANK
-			{
-				name	  = LqdHydrogen
-				amount	  = 260689
-				maxAmount = 260689
-			}
+        //  EUS fuel mass ~18470 kg.
 
-			TANK
-			{
-				name	  = LqdOxygen
-				amount	  = 97124
-				maxAmount = 97124
-			}
-		}
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 260690
+            maxAmount = 260690
+        }
 
-		!RESOURCE[LiquidFuel]{}
+        //  EUS oxidizer mass ~110814 kg.
 
-		!RESOURCE[Oxidizer]{}
+        TANK
+        {
+            name = LqdOxygen
+            amount = 97120
+            maxAmount = 97120
+        }
+    }
 
-		!RESOURCE[ElectricCharge]{}
+    !MODULE[ModuleCommand],*{}
 
-		!RESOURCE[MonoPropellant]{}
-	}
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.25
+        }
+    }
+
+    !MODULE[ModuleSAS],*{}
+
+    MODULE
+    {
+        name = ModuleSAS
+        SASServiceLevel = 3
+        standalone = True
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 1.25 kWh.
+    //  Supports the EUS for up up 5 hours (launch & orbital operations).
+    //  Assumes that the power consumption of the avionics is 250 Watts.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 4500
+        maxAmount = 4500
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3650,54 +3650,61 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Mars Ascent Vehicle (MAV) engine mount.
+//  ==================================================
+//  Mars Ascent Vehicle auxiliary propellant tank.
 
-//	Dimensions: 3.700 x 1.900 m
-//	Gross Mass: 685.10 Kg
-//	==================================================
+//  Dimensions: 3.75 m x 2 m
+//  Gross Mass: 410 Kg
+//  ==================================================
 
-	@PART[NP_CHAKAEMLVENGINEx221]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[NP_CHAKAEMLVENGINEx221]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		@MODEL
-		{
-			@scale	  = 1.485, 0.950,   1.485
-			%position = 0.000, 0.000,   0.000
-			%rotation = 0.000, 0.000, 180.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		@scale		   = 1.000
-		@rescaleFactor = 1.000
+    @MODEL
+    {
+        @scale = 1.5, 1.0, 1.5
+    }
 
-		@node_stack_top	   = 0.000,  0.950, 0.000, 0.000,  1.000, 0.000, 3
-		@node_stack_bottom = 0.000, -0.950, 0.000, 0.000, -1.000, 0.000, 3
-		@node_stack_1	   = 0.000, -0.200, 0.000, 0.000,  1.000, 0.000, 3
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = Structural
-		@title		  = MAV Engine Mount
-		@manufacturer = NASA
-		@description  = The engine mount for the Mars Ascent Vehicle (MAV).
+    @node_stack_top = 0.0, 0.95, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_1 = 0.0, -0.2, 0.00, 0.0, 1.0, 0.0, 3
 
-		@mass			  = 0.6851
-		@crashTolerance	  = 12
-		@breakingForce	  = 250
-		@breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		!fuelCrossFeed,*  = NULL
-		fuelCrossFeed	  = true
-		%bulkheadProfiles = size3
+    @category = FuelTank
+    @title = MAV - II Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic pressurized propellant tank for the Mars Ascent Vehicle (MAV).
 
-		!MODULE[ModuleCommand]{}
+    @mass = 0.41
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !fuelCrossFeed,* = NULL
+    %fuelCrossFeed = True
+    %bulkheadProfiles = size3
 
-		!MODULE[ModuleGenerator]{}
+    !MODULE[ModuleCommand],*{}
 
-		!RESOURCE[MonoPropellant]{}
+    !MODULE[ModuleGenerator],*{}
 
-		!RESOURCE[ElectricCharge]{}
-	}
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 5400
+    }
+
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Ares V Earth Departure Stage (EDS) LOX tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -3760,60 +3760,54 @@
     !RESOURCE,*{}
 }
 
-//	==================================================
-//	Generic RCS tank (small).
+//  ==================================================
+//  Small radial propellant tank.
 
-//	Dimensions: 0.300 x 0.800 m
-//	Gross Mass: 50.00 Kg
-//	Volume: 45.00 L
-//	==================================================
+//  Dimensions: 0.3 m x 0.8 m
+//  Gross Mass: 50 Kg
+//  ==================================================
 
-	@PART[XrcsTankRadialLongHVX]:FOR[RealismOverhaul]
-	{
-		%RSSROConfig = true
+@PART[XrcsTankRadialLongHVX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-		MODEL
-		{
-			model	 = CMES/Propulsion/ROVER-RCS/model
-			scale	 = 0.500, 0.500, 0.500
-			position = 0.000, 0.000, 0.000
-			rotation = 0.000, 0.000, 0.000
-		}
+    !mesh = NULL
 
-		!mesh		   = NULL
-		%scale		   = 1.000
-		@rescaleFactor = 1.000
+    MODEL
+    {
+        model = CMES/Propulsion/ROVER-RCS/model
+        scale = 0.5, 0.5, 0.5
+    }
 
-		@node_attach = 0.000, 0.000, -0.075, 0.000, 0.000, -1.000
+    %scale = 1.0
+    @rescaleFactor = 1.0
 
-		@category	  = FuelTank
-		@title		  = RCS Tank [45 L].
-		%manufacturer = Generic
-		@description  = A high pressure RCS propellant tank.
+    @node_attach = 0.0, 0.0, -0.075, 0.0, 0.0, -1.0
 
-		@mass			  = 0.0051
-		%breakingForce	  = 250
-		breakingTorque	  = 250
-		@maxTemp		  = 1073.15
-		%bulkheadProfiles = srf
+    @category = FuelTank
+    @title = RMT - I Propellant Tank
+    %manufacturer = Generic
+    @description = A general purpose, radially mounted, pressurized propellant tank.
 
-		MODULE
-		{
-			name	 = ModuleFuelTanks
-			type	 = ServiceModule
-			volume	 = 45
-			basemass = -1
+    @mass = 0.005
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = srf
 
-			TANK
-			{
-				name	  = Hydrazine
-				amount	  = 45
-				maxAmount = 45
-			}
-		}
+    !MODULE[ModuleFuelTanks],*{}
 
-		!RESOURCE[MonoPropellant]{}
-	}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 45
+    }
+
+    !RESOURCE,*{}
+}
 
 //	==================================================
 //	Generic RCS tank (large).


### PR DESCRIPTION
Updates and fixes for the CMES "Propulsion" parts. Fourth pass.

Changelog:

* Update all engiine parts to use the new global engine configuration system.
* Remove invalid part modules from many parts.
* Remove all engine variants other than the D and E from the SLS Core Stage.
* Add RemoteTech compatibility for the Exploration Upper Stage.
* Explicitly set the part categories (and use the new KSP 1.2 ones).
* Balance inert and gross mass values against real sources and/or other parts.
* Adjust some insane max temperature values.
* Update the part titles and the descriptions.
* Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes](https://github.com/KSP-RO/RealismOverhaul/pull/1467/files?w=1)