### PR TITLE
CMES Propulsion updates (part II)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -843,59 +843,58 @@
 }
 
 //  ==================================================
-//  Ares V / SLS extension tank barrel.
+//  Earth Departure Stage auxiliary propellant tank.
 
-//  Dimensions: 8.400 x 2.000 m
-//  Gross Mass: 55405.00 Kg
-//  Volume: 150000.00 L
+//  Dimensions: 8.4 m x 2 m
+//  Inert Mass: 3310 Kg
 //  ==================================================
 
-    @PART[XNP_lft_W375x3SHORTW]:FOR[RealismOverhaul]
+@PART[XNP_lft_W375x3SHORTW]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 1.685, 1.000, 1.685
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  1.490, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -1.490, 0.000, 0.000, -1.000, 0.000, 3
-        %node_attach       = 3.350,  0.000, 0.000, 1.000,  0.000, 0.000
-
-        @category     = FuelTank
-        @title        = Ares V / SLS Tank Extension
-        @manufacturer = NASA
-        %description  = A 3 - meter tank extension for the Ares V or the Space Launch System (SLS).
-
-        @mass             = 3.2000
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %bulkheadProfiles = size3
-
-        MODULE
-        {
-            name   = ModuleFuelTanks
-            type   = Cryogenic
-            volume = 150000
-        }
-
-        !MODULE[ModuleSAS]{}
-
-        !MODULE[ModuleReactionWheel]{}
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
+        @scale = 1.685, 1.0, 1.685
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.49, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -1.49, 0.0, 0.0, -1.0, 0.0, 5
+    %node_attach = 3.35, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = EDS - II Propellant Tank
+    @manufacturer = Boeing Co.
+    %description = A generic cryogenic propellant tank for the Earth Departure Stage (EDS).
+
+    @mass = 3.31
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size5
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 150000
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Delta Cryogenic Second Stage (DCSS) 4 - meter LOX tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1015,284 +1015,91 @@
 }
 
 //  ==================================================
-//  Aerojet Rocketdyne RL-10 engine.
+//  RL10 engine.
 
-//  Modeled after the RL-10B-2 and RL-10C1 variants (long nozzle extensions).
+//  Dimensions: 2.13 m x 4.14 m
+//  Inert Mass: 277 Kg
+
+//  Modeled after the RL10B-2 and RL10C-1 variants (long nozzle extensions).
 //  Includes the CECE variants (Base, High Thrust & Methane).
-
-//  Dimensions: 2.130 x 4.140 m (extended)
-//  Gross Mass: 277.00 Kg
-//  Throttle Range: N/A
-//  Burn Time: 465 s
-//  O/F Ratio: 6.00
 //  ==================================================
 
-    @PART[XXxAres1J2-XHIGH]:FOR[RealismOverhaul]
+@PART[XXxAres1J2-XHIGH]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Propulsion/J2X/model
-            scale    = 1.200, 1.200, 1.200
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        %scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  1.720, 0.000, 0.000,  1.000, 0.000, 2
-        @node_stack_bottom = 0.000, -1.405, 0.000, 0.000, -1.000, 0.000, 2
-
-        @title        = RL-10 [2.13 m]
-        %manufacturer = Aerojet Rocketdyne
-        @description  = The modern iterations of the workhorse RL-10 engine (RL-10B-1/2, RL-10C-1/2 & CECE).
-
-        @mass           = 0.2770
-        @crashTolerance = 12
-        @breakingForce  = 250
-        @breakingTorque = 250
-        @maxTemp        = 1973.15
-
-        @MODULE[ModuleEngines*]
-        {
-            @minThrust      = 110.10
-            @maxThrust      = 110.10
-            @heatProduction = 100
-
-            IGNITOR_RESOURCE
-            {
-                name   = ElectricCharge
-                amount = 0.500
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = LqdHydrogen
-                amount = 0.7285
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = LqdOxygen
-                amount = 0.2714
-            }
-
-            @PROPELLANT[LiquidFuel]
-            {
-                @name  = LqdHydrogen
-                @ratio = 0.7285
-            }
-
-            @PROPELLANT[Oxidizer]
-            {
-                @name  = LqdOxygen
-                @ratio = 0.2714
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 465.5
-                @key,1 = 1 235.0
-            }
-        }
-
-        @MODULE[ModuleGimbal]
-        {
-            @gimbalRange            = 4.000
-            %useGimbalResponseSpeed = true
-            %gimbalResponseSpeed    = 16
-        }
-
-        MODULE
-        {
-            name          = ModuleEngineConfigs
-            type          = ModuleEngines
-            configuration = RL-10B-2
-            modded        = false
-            origMass      = 0.2770
-
-            CONFIG
-            {
-                name           = RL-10B-2
-                minThrust      = 110.10
-                maxThrust      = 110.10
-                heatProduction = 100
-                massMult       = 1.0000
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.7285
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.2714
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 465.5
-                    key = 1 235.0
-                }
-            }
-
-            CONFIG
-            {
-                name           = RL-10C-1
-                minThrust      = 106.30
-                maxThrust      = 106.30
-                heatProduction = 100
-                massMult       = 0.6895
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.7285
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.2714
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 458
-                    key = 1 235
-                }
-            }
-
-            CONFIG
-            {
-                name           = RL-10C-2
-                minThrust      = 111.20
-                maxThrust      = 111.20
-                heatProduction = 100
-                massMult       = 0.6895
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.7285
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.2714
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 458
-                    key = 1 235
-                }
-            }
-
-            CONFIG
-            {
-                name           = CECE-Base
-                minThrust      = 5.34
-                maxThrust      = 66.70
-                heatProduction = 100
-                massMult       = 0.5776
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.763
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.237
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 460             //http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf
-                    key = 1 100
-                }
-            }
-
-            CONFIG
-            {
-                name           = CECE-High
-                minThrust      = 111.20
-                maxThrust      = 111.20
-                heatProduction = 100
-                massMult       = 0.7581
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.763
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.237
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 465
-                    key = 1 100
-                }
-            }
-
-            CONFIG
-            {
-                name           = CECE-Methane
-                minThrust      = 22.20
-                maxThrust      = 66.70
-                heatProduction = 100
-                massMult       = 0.7581     //http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf
-
-                PROPELLANT
-                {
-                    name      = LqdMethane
-                    ratio     = 0.4922
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.5078
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 360             //http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf
-                    key = 1 100
-                }
-            }
-        }
-
-        !MODULE[ModuleAlternator]{}
-
-        !RESOURCE[ElectricCharge]{}
+        model = CMES/Propulsion/J2X/model
+        scale = 1.2, 1.2, 1.2
     }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.95, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.405, 0.0, 0.0, -1.0, 0.0, 2
+
+    @category = Engine
+
+    @mass = 0.277
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %bulkheadProfiles = size2
+
+    %engineType = RL10
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 111.2
+        @maxThrust = 111.2
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 15
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 0.7335
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2665
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 462
+            @key,1 = 1 235
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 4.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Aerojet Rocketdyne J-2X engine.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -781,88 +781,66 @@
 }
 
 //  ==================================================
-//  Mars Ascent Vehicle (MAV) tank.
+//  Mars Ascent Vehicle main propellant tank.
 
-//  Dimensions: 3.700 x 3.300 m
-//  Gross Mass: 39953.52 Kg
-//  Volume: 31900.00 L
+//  Dimensions: 3.75 m x 3.3 m
+//  Gross Mass: 1050 Kg
 //  ==================================================
 
-    @PART[XNP_lft_8_0m_6mzxx6]:FOR[RealismOverhaul]
+@PART[XNP_lft_8_0m_6mzxx6]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Propulsion/DRTO/model
-            scale    = 0.743, 0.550, 0.743
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  1.643, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -1.660, 0.000, 0.000, -1.000, 0.000, 3
-        @node_attach       = 1.890,  0.000, 0.000, 1.000,  0.000, 0.000
-
-        @category     = FuelTank
-        @title        = MAV Tank
-        @manufacturer = NASA
-        @description  = The propellant tank for the Mars Ascent Vehicle (MAV).
-
-        @mass             = 3.6510
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        !linearStrength   = NULL
-        !angularStrength  = NULL
-        !vesselType       = NULL
-        %bulkheadProfiles = size3
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = ServiceModule
-            volume   = 31900
-            basemass = -1
-
-            TANK
-            {
-                name      = MMH
-                amount    = 18099
-                maxAmount = 18099
-            }
-
-            TANK
-            {
-                name      = NTO
-                amount    = 14052
-                maxAmount = 14052
-            }
-        }
-
-        !MODULE[ModuleCommand]{}
-
-        !MODULE[ModuleReactionWheel]{}
-
-        !MODULE[ModuleSAS]{}
-
-        !MODULE[MechJebCore]{}
-
-        !MODULE[ModuleGenerator]{}
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
-
-        !RESOURCE[MonoPropellant]{}
-
-        !RESOURCE[ElectricCharge]{}
+        model = CMES/Propulsion/DRTO/model
+        scale = 0.75, 0.55, 0.75
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.643, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.66, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 1.89, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = MAV - I Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic pressurized propellant tank for the Mars Ascent Vehicle (MAV).
+
+    @mass = 1.05
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !linearStrength = NULL
+    !angularStrength = NULL
+    !vesselType = NULL
+    %bulkheadProfiles = size3
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 30000
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Ares V / SLS extension tank barrel.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -897,65 +897,65 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (DCSS) 4 - meter LOX tank.
+//  DCSS-4 LOX tank.
 
-//  Dimensions: 3.200 x 3.500 m
-//  Gross Mass: 405.50 Kg
-//  Volume: 15362.00 L
+//  Dimensions: 3.2 m x 3.5 m
+//  Gross Mass: 17950 Kg
 //  ==================================================
 
-    @PART[XIUSLOWERXxxxtall2G]:FOR[RealismOverhaul]
+@PART[XIUSLOWERXxxxtall2G]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = True
-
-        @MODEL
-        {
-            @scale    = 1.275, 1.750, 1.275
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top1    = 0.000,  0.600, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_top     = 0.000,  1.700, 0.000, 0.000,  1.000, 0.000, 2
-        @node_stack_bottom  = 0.000, -1.700, 0.000, 0.000, -1.000, 0.000, 2
-        @node_stack_bottom1 = 0.000, -0.575, 0.000, 0.000, -1.000, 0.000, 3
-        @node_attach        = 1.670,  0.000, 0.000, 1.000,  0.000, 0.000
-
-        @category     = FuelTank
-        @title        = Delta IV DCSS LOX Tank [4 Meters]
-        @manufacturer = United Launch Alliance (ULA)
-        @description  = This cryogenic liquid oxygen tank forms the lower portion of the 4 meter DCSS stage for the Delta IV family of launch vehicles.
-
-        @mass             = 0.4055
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %bulkheadProfiles = size2, size3
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = Cryogenic
-            volume   = 15362
-            basemass = -1
-
-            TANK
-            {
-                name      = LqdOxygen
-                amount    = 15362
-                maxAmount = 15362
-            }
-        }
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
+        @scale = 1.275, 1.75, 1.275
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.7, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_top1 = 0.0, 0.6, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.7, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom1 = 0.0, -0.575, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 1.67, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = Delta IV DCSS LOX Tank (4 Meters)
+    @manufacturer = United Launch Alliance (ULA)
+    @description = This cryogenic liquid oxygen tank forms the lower portion of the 4 meter DCSS stage for the Delta IV family of launch vehicles.
+
+    @mass = 0.41
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size2, size3
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 15620
+        basemass = -1
+
+        //  DCSS-4 oxidizer mass 17822 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 15620
+            maxAmount = 15620
+        }
+    }
+
+    !RESOURCE,*{}
 
 //  ==================================================
 //  Delta Cryogenic Second Stage (DCSS) 5 - meter LOX tank.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -958,61 +958,61 @@
     !RESOURCE,*{}
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (DCSS) 5 - meter LOX tank.
+//  DCSS-5 LOX tank.
 
-//  Dimensions: 3.200 x 4.000 m
-//  Gross Mass: 465.40 Kg
-//  Volume: 20433.00 L
+//  Dimensions: 3.2 m x 4 m
+//  Gross Mass: 23780 Kg
 //  ==================================================
 
-    @PART[XIUSLOWERXxxxtall]:FOR[RealismOverhaul]
+@PART[XIUSLOWERXxxxtall]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 1.275, 2.000, 1.275
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        @node_stack_top     = 0.000,  0.750, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_top1    = 0.000,  1.950, 0.000, 0.000,  1.000, 0.000, 2
-        @node_stack_bottom  = 0.000, -1.950, 0.000, 0.000, -1.000, 0.000, 2
-        @node_stack_bottom1 = 0.000, -0.725, 0.000, 0.000, -1.000, 0.000, 3
-        @node_attach        = 1.670,  0.000, 0.000, 1.000,  0.000, 0.000
-
-        @category     = FuelTank
-        @title        = Delta IV DCSS LOX Tank [5 Meters]
-        @manufacturer = United Launch Alliance (ULA)
-        @description  = This cryogenic liquid oxygen tank forms the lower portion of the 5 meter DCSS stage for the Delta IV family of launch vehicles.
-
-        @mass             = 0.4654
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %bulkheadProfiles = size2, size3
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = Cryogenic
-            volume   = 20433
-            basemass = -1
-
-            TANK
-            {
-                name      = LqdOxygen
-                amount    = 20433
-                maxAmount = 20433
-            }
-        }
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
+        @scale = 1.275, 2.0, 1.275
     }
+
+    @node_stack_top = 0.0, 1.95, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_top1 = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.95, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom1 = 0.0, -0.725, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 1.67, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = Delta IV DCSS LOX Tank (5 Meters)
+    @manufacturer = United Launch Alliance (ULA)
+    @description = This cryogenic liquid oxygen tank forms the lower portion of the 5 meter DCSS stage for the Delta IV family of launch vehicles.
+
+    @mass = 0.47
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size2, size3
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 20360
+        basemass = -1
+
+        //  DCSS-5 oxidizer mass 23587 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 20360
+            maxAmount = 20360
+        }
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Aerojet Rocketdyne RL-10 engine.


### PR DESCRIPTION
Updates and fixes for the CMES "Propulsion" parts. Second pass.

Changelog:

* Update all engiine parts to use the new global engine configuration system.
* Remove invalid part modules from many parts.
* Remove the small separation motor and replace it with the (old) medium one.
* Separate the RL10 configs so that only the B/C and CECE versions are available (due to it's bell structure).
* Explicitly set the part categories (and use the new KSP 1.2 ones).
* Balance inert and gross mass values against real sources and/or other parts.
* Adjust some insane max temperature values.
* Update the part titles and the descriptions.
* Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes](https://github.com/KSP-RO/RealismOverhaul/pull/1472/files?w=1)