### PR TITLE
Engine Configs general updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -7,18 +7,20 @@
 //  O/F Ratio: 1.65
 
 //  Sources:
-//      http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//      http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//      http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
+
+//      Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//      Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//      NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
 
 //  Used by:
+
 //      CMES
-//      Aerobee WAC Corporal engine
 //      Squad
 //  ==================================================
 
 @PART[*]:HAS[#engineType[AJ10_190]]:FOR[RealismOverhaulEngines]
 {
+    %category = Engine
     %title = AJ10-190
     %manufacturer = Aerojet Rocketdyne
     %description = Low thrust pressure-fed hypergolic engine. It was used on the Space Shuttle for orbital insertion, maneuvering and deorbiting. Currently used by the Orion MPCV. Diameter: [1.17 m].
@@ -28,12 +30,14 @@
         %EngineType = LiquidFuel
     }
 
-    @MODULE[ModuleGimbal],*
+    @MODULE[ModuleGimbal]
     {
-        %gimbalRange = 6.0
+        @gimbalRange = 6.0
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }
+
+    !MODULE[ModuleEngineConfigs],*{}
 
     MODULE
     {
@@ -81,7 +85,7 @@
         }
     }
 
-    !MODULE[ModuleAlternator]{}
+    !MODULE[ModuleAlternator],*{}
 
-    !RESOURCE[ElectricCharge]{}
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  AJ-60A solid rocket motor.
+//  AJ-60A solid rocket motor global engine configuration.
 
 //  Throttle Range: N/A
 //  Burn Time: 94 s
@@ -7,22 +7,34 @@
 
 //  Sources:
 
-//  http://www.rocket.com/atlas-v-solid-rocket-motor
-//  http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
-//  http://www.b14643.de/Spacerockets_2/United_States_3/Atlas_V/Description/Frame.htm
+//      Aerojet Rocketdyne - Atlas V SRM:              http://www.rocket.com/atlas-v-solid-rocket-motor
+//      United Launch Alliance - Atlas V User's Guide: http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
+//      Norbert Brügge - Atlas V:                      http://www.b14643.de/Spacerockets_2/United_States_3/Atlas_V/Description/Frame.htm
 
 //  Used by:
+
+//      BahamutoD Atlas V Pack
 //      CMES
 //      KW Rocketry
 //      Real Scale Boosters
 //  ==================================================
 
-@PART[*]:HAS[#engineType[AJ60A]]:FOR[RO-EngineConfigs]:BEFORE[RealPlume]
+@PART[*]:HAS[#engineType[AJ60A]]:FOR[RealismOverhaulEngines]
 {
-    @title = AJ60A
+    %category = Engine
+    %title = AJ-60A
     %manufacturer = Aerojet Rocketdyne
-    @description = AJ-60A is a solid rocket booster produced by Aerojet Rocketdyne. They are currently used as strap-on boosters on United Launch Alliance's Atlas V rocket. Diameter: [1.6 m].
-    
+    %description = AJ-60A is a solid rocket booster produced by Aerojet Rocketdyne. They are currently used as strap-on boosters on United Launch Alliance's Atlas V rocket. Diameter: [1.6 m].
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = SolidBooster
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
     MODULE
     {
         name = ModuleEngineConfigs
@@ -268,4 +280,8 @@
             }
         }
     }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
@@ -4,20 +4,23 @@
 //  Inert Mass: 2170 Kg (base configuration)
 //  Throttle Range: N/A
 //  Burn Time: 5400 s
-//  O/F Ratio: 0 (SNRE), 3 (TRITON)
+//  O/F Ratio: 0 (SNRE), 3.0 (TRITON)
 
 //  Sources:
-//      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
-//      http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3863_TRITON.pdf
-//      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140009579.pdf
+
+//      "Bimodal" Nuclear Thermal Rocket (BNTR) Propulsion:                    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
+//      AIAA - TRITON (TRImodal Thrust Optimized Nuclear rocket engine):       http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3863_TRITON.pdf
+//      Crewed Mars Mission using Bimodal Nuclear Thermal Electric Propulsion: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140009579.pdf
 
 //  Used by:
+
 //      BahamutoD Constellation Essentials
 //      CMES
 //  ==================================================
 
 @PART[*]:HAS[#engineType[BNTR]]:FOR[RealismOverhaulEngines]
 {
+    %category = Engine
     %title = Bimodal NTR
     %manufacturer = Aerojet Rocketdyne
     %description = Low thrust pump-fed expander nuclear engine. Evolved for the original NERVA design the BNTR, instead of wasting precious propellant mass for cooling the engine reactor, uses a power generator unit to convert the waste thermal energy into electrical power. Supports liquid Oxygen injection for increased thrust but with lower efficiency.
@@ -27,7 +30,14 @@
         %EngineType = LiquidFuel
     }
 
-    !MODULE[ModuleGimbal]{}
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 3.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
 
     MODULE
     {
@@ -121,7 +131,7 @@
         }
     }
 
-    !MODULE[ModuleAlternator]{}
+    !MODULE[ModuleAlternator],*{}
 
-    !RESOURCE[ElectricCharge]{}
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
@@ -1,37 +1,70 @@
-//Castor I
-//Squad
+//  ==================================================
+//  Castor 1 solid rocket motor global engine configuration.
+
+//  Throttle Range: N/A
+//  Burn Time: 28 s
+//  O/F Ratio: 2.12
+
+//  Sources:
+
+//      Thrust Misalignments of Fixed Solid Rocket Motors: http://rsandt.com/media/Thrust%20Misalignments%20of%20Fixed-Nozzle%20Solid%20Rocket%20Motors.pdf
+//      The Satellite Encyclopedia - Castor Series:        https://www.tbs-satellite.com/tse/online/lanc_castor.html
+
+//  Used by:
+
+//      Squad
+//  ==================================================
+
 @PART[*]:HAS[#engineType[Castor-1]]:FOR[RealismOverhaulEngines]
 {
-	@title = Castor I
+	%category = Engine
+	%title = Castor 1
 	%manufacturer = Thiokol
-	@description = The Castor I was first used for a successful suborbital launch of a Scout X-1 rocket on September 2, 1960. Castor 1 stages were also used as strap-on boosters for launch vehicles using Thor first stages, including the Delta-D. Diameter: [0.79 m].
-	
+	%description = The Castor 1 was first used for a successful suborbital launch of a Scout X-1 rocket on September 2, 1960. Castor 1 stages were also used as strap-on boosters for launch vehicles using Thor first stages, including the Delta-D. Diameter: [0.79 m].
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = SolidBooster
+	}
+
+	!MODULE[ModuleGimbal],*{}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Castor-I
+		configuration = Castor-1
 		modded = false
+
 		CONFIG
 		{
 			name = Castor-1
+			minThrust = 0
 			maxThrust = 286
 			heatProduction = 100
+
 			PROPELLANT
 			{
 				name = PSPC
-				ratio = 1
+				ratio = 1.0
 				DrawGauge = True
 			}
+
 			atmosphereCurve
 			{
 				key = 0 247
 				key = 1 232
 			}
+
 			curveResource = PSPC
+
 			// guesses (note: max is above nominal * thrust_curve_max)
+
 			chamberNominalTemp  = 1500
 			maxEngineTemp = 1745
+
 			thrustCurve
 			{
 				key = 0 0.2 0.6566457 0.6566457
@@ -45,6 +78,10 @@
 			}
 		}
 	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -58,7 +95,6 @@
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.997
 		reliabilityDataRateMultiplier = 2
-		
 		isSolid = True
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -17,7 +17,7 @@
 
 @PART[*]:HAS[#engineType[Castor-2]]:FOR[RealismOverhaulEngines]
 {
-    %category = Engine
+	%category = Engine
 	%title = Castor 2
 	%manufacturer = Thiokol
 	%description = A derivative of the Castor 1 motor, the Castor 2 featured higher specific impulse and propellant load and lower dry mass fraction as well as a longer burn time. It was used as strap-on booster starting with Delta E and was also used in all but the early Scouts. Burn time 37s. Diameter: [0.79 m].

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -1,61 +1,69 @@
-//Castor II
-//VSR
+//  ==================================================
+//  Castor 2 solid rocket motor global engine configuration.
+
+//  Throttle Range: N/A
+//  Burn Time: 38 s
+//  O/F Ratio: 2.12
+
+//  Sources:
+
+//      Thrust Misalignments of Fixed Solid Rocket Motors: http://rsandt.com/media/Thrust%20Misalignments%20of%20Fixed-Nozzle%20Solid%20Rocket%20Motors.pdf
+//      The Satellite Encyclopedia - Castor Series:        https://www.tbs-satellite.com/tse/online/lanc_castor.html
+
+//  Used by:
+
+//      Ven Stock Revamp
+//  ==================================================
+
 @PART[*]:HAS[#engineType[Castor-2]]:FOR[RealismOverhaulEngines]
 {
-	@title = Castor II
+	%title = Castor 2
 	%manufacturer = Thiokol
-	@description = A derivative of the Castor I motor, the Castor II featured higher specific impulse and propellant load and lower dry mass fraction as well as a longer burntime. It was used as strapon booster starting with Delta E and was also used in all but the early Scouts. Burn time 37s. Diameter: [0.79 m].
-	
-	@mass = 0.695
-	@maxTemp = 1000
-	
+	%description = A derivative of the Castor 1 motor, the Castor 2 featured higher specific impulse and propellant load and lower dry mass fraction as well as a longer burn time. It was used as strap-on booster starting with Delta E and was also used in all but the early Scouts. Burn time 37s. Diameter: [0.79 m].
+
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 0
-		@maxThrust = 258.92
-		@heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 262
-			@key,1 = 0 246 // guess
-		}
+		@EngineType = SolidBooster
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 2143.1
-		type = PSPC
-		basemass = -1
-	}
+
+	!MODULE[ModuleGimbal],*{}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-2
 		modded = false
+
 		CONFIG
 		{
 			name = Castor-2
+			minThrust = 0
 			maxThrust = 258.92
 			heatProduction = 100
+
 			PROPELLANT
 			{
 				name = PSPC
-				ratio = 1
+				ratio = 1.0
 				DrawGauge = True
 			}
+
 			atmosphereCurve
 			{
 				key = 0 262
 				key = 1 246 // guess
 			}
+
 			curveResource = PSPC
+
 			// guesses (note: max is above nominal * thrust_curve_max)
+
 			chamberNominalTemp  = 1600
 			maxEngineTemp = 1850
+
 			thrustCurve
 			{
 				key = 0 0.2 0.6566457 0.6566457
@@ -69,6 +77,10 @@
 			}
 		}
 	}
+
+	!MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -83,7 +95,6 @@
 		cycleReliabilityEnd = 0.9985
 		techTransfer = Castor-1:50
 		reliabilityDataRateMultiplier = 2
-		
 		isSolid = True
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -17,6 +17,7 @@
 
 @PART[*]:HAS[#engineType[Castor-2]]:FOR[RealismOverhaulEngines]
 {
+    %category = Engine
 	%title = Castor 2
 	%manufacturer = Thiokol
 	%description = A derivative of the Castor 1 motor, the Castor 2 featured higher specific impulse and propellant load and lower dry mass fraction as well as a longer burn time. It was used as strap-on booster starting with Delta E and was also used in all but the early Scouts. Burn time 37s. Diameter: [0.79 m].

--- a/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
@@ -1,20 +1,24 @@
 //  ==================================================
-//  E-1 proposed engine
+//  E-1 proposed engine global engine configuration.
 
 //  Throttle Range: N/A
 //  Burn Time: 165 s
 //  O/F Ratio: 2.15
 
 //  Sources:
-//      https://en.wikipedia.org/wiki/Rocketdyne_E-1
-//      http://www.astronautix.com/engines/e1.htm
+
+//  Wikipedia - E-1 rocket engine:                 https://en.wikipedia.org/wiki/Rocketdyne_E-1
+//  Encyclopedia Astronautica - E-1 rocket engine: http://www.astronautix.com/e/e-1.html
 
 //  Used by:
+
 //      FASA
 //      Squad
+//  ==================================================
 
 @PART[*]:HAS[#engineType[E1]]:FOR[RealismOverhaulEngines]
 {
+    %category = Engine
     %title = E-1
     %manufacturer = Rocketdyne
     %description = Pump-fed kerolox open cycle (gas generator) booster engine developed from LR79/89. Backup proposal for the first stage engine on the Titan 1 ICBM, and proposed first stage engine on the Saturn 1 but ultimately never flown (4 E-1s replaced with 8 H-1s). Diameter: [2.14 m].
@@ -26,17 +30,19 @@
 
     @MODULE[ModuleGimbal]
     {
-        @gimbalRange = 8
+        @gimbalRange = 8.0
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }
+
+    !MODULE[ModuleEngineConfigs],*{}
 
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = E1
-		origMass = 1.264 // Assuming a similiar TWR to the H-1
+		configuration = E-1
+		origMass = 1.264 // Assuming a similar TWR to the H-1
 
 		CONFIG
 		{
@@ -81,7 +87,7 @@
 				key = 1 260
 			}
 		}
-		
+
 		CONFIG
 		{
 			name = E-1-Upgrade
@@ -125,13 +131,13 @@
 				key = 0 301
 				key = 1 268
 			}
-			
+
 			techRequired = heavierRocketry
 			cost = 300 // total guess for now
 		}
 	}
 
-    !MODULE[ModuleAlternator]{}
+    !MODULE[ModuleAlternator],*{}
 
     !RESOURCE,*{}
 
@@ -145,7 +151,8 @@
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[E-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-	// Copied from H-1
+	// Copied from H-1.
+
 	TESTFLIGHT
 	{
 		name = E-1
@@ -156,9 +163,11 @@
 		cycleReliabilityEnd = 0.967
 	}
 }
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[E-1-Upgrade]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-	// Between H-1b and RS-27
+	// Between H-1b and RS-27.
+
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade

--- a/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
@@ -1,12 +1,43 @@
-//GEM 60
-//KWRocketry
-//Thrust curves based on 2012 Orbital ATK Product Catalog
+//  ==================================================
+//  GEM 60 solid rocket motor global engine configuration.
+
+//  Throttle Range: N/A
+//  Burn Time: 90 s
+//  O/F Ratio: 2.12
+
+//  Sources:
+
+//      Orbital ATK Space Propulsion Products Catalog (2012): https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
+//      Encyclopedia Astronautica - GEM 60:                   http://www.astronautix.com/g/gem60.html
+
+//  Used by:
+
+//      CMES
+//      KW Rocketry
+//      Real Scale Boosters
+//  ==================================================
+
 @PART[*]:HAS[#engineType[GEM-60]]:FOR[RealismOverhaulEngines]
 {
-	@title = GEM 60
-	%manufacturer = ATK
-	@description = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time 90 seconds. Diameter: [1.52 m].
-	
+	%category = Engine
+	%title = GEM 60
+	%manufacturer = Orbital ATK
+	%description = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time 90 seconds. Diameter: [1.52 m].
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = SolidBooster
+	}
+
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 5.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -14,23 +45,29 @@
 		configuration = GEM-60/TVC
 		origMass = 3.952
 		modded = false
+
 		CONFIG
 		{
 			name = GEM-60/TVC
 			maxThrust = 1236
 			heatProduction = 100
+			gimbalRange = 5.0
+
 			PROPELLANT
 			{
 				name = HTPB
-				ratio = 1
+				ratio = 1.0
 				DrawGauge = True
 			}
+
 			atmosphereCurve
 			{
 				key = 0 274
 				key = 1 246
 			}
+
 			curveResource = HTPB
+
 			thrustCurve
 			{
 				key = 0.99972 0.719
@@ -129,6 +166,7 @@
 				key = 0.0000 0.03
 			}
 		}
+
 		CONFIG
 		{
 			name = GEM-60/Fixed
@@ -136,18 +174,22 @@
 			gimbalRange = 0
 			heatProduction = 100
 			massMult = 0.844
+
 			PROPELLANT
 			{
 				name = HTPB
-				ratio = 1
+				ratio = 1.0
 				DrawGauge = True
 			}
+
 			atmosphereCurve
 			{
 				key = 0 274
 				key = 1 246
 			}
+
 			curveResource = HTPB
+
 			thrustCurve
 			{
 				key = 0.99972 0.719
@@ -247,4 +289,8 @@
 			}
 		}
 	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
@@ -1,29 +1,49 @@
-//	==================================================
-//	Surveyor Vernier series engine
-//	Used by:
-//		Squad
-//	==================================================
+//  ==================================================
+//  TD-339 Surveyor Vernier global engine configuration.
+
+//  Inert Mass: 9 Kg
+//  Throttle Range: 30% to 100%
+//  Burn Time: 170 s
+//  O/F Ratio: 1.5
+
+//  Sources:
+
+//      Rocketrelics - Liquid Propulsion Systems:              http://www.rocketrelics.com/liquid_propulsion.htm
+//      Alternate Wars - (Morton) Thiokol / ATK Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
+//      NSSDCA - Surveyor 1:                                   http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1966-045A
+
+//  Used by:
+
+//      Coatl Aerospace GroundOps
+//      Squad
+//  ==================================================
+
 @PART[*]:HAS[#engineType[TD339]]:FOR[RealismOverhaulEngines]
 {
-	@title = TD-339
+	%category = Engine
+	%title = TD-339
 	%manufacturer = Thiokol
-	@description = The Vernier System as used on the Surveyor Probes. Uses storable hypergolic propellants, has infinite restarts and is not subject to ullage. Throttleable down to 30%. Historically 3 of them were used on the Surveyor Probes which landed on the Moon. Diameter: [0.13 m].
-	
+	%description = The Vernier System as used on the Surveyor Probes. Uses storable hypergolic propellants, has infinite restarts and is not subject to ullage. Throttleable down to 30%. Historically 3 of them were used on the Surveyor probes which landed on the Moon. Diameter: [0.13 m].
+
+	@MODULE[ModuleEngines*]
+	{
+		%engineType = LiquidFuel
+	}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		
 		origMass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
 		configuration = TD-339
+
 		CONFIG
 		{
 			name = TD-339
-			minThrust = 0.133446648
-			maxThrust = 0.462615048
+			minThrust = 0.133
+			maxThrust = 0.462
 			heatProduction = 100
-			
 			ullage = False
 			pressureFed = True
 
@@ -32,17 +52,20 @@
 				name = ElectricCharge
 				amount = 0.01
 			}
+
 			PROPELLANT
 			{
 				name = MMH
-				ratio = 0.516
+				ratio = 0.5200
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = MON10
-				ratio = 0.484
+				ratio = 0.4800
 			}
+
 			atmosphereCurve
 			{
 				key = 0 287
@@ -50,16 +73,15 @@
 			}
 		}
 	}
-	!MODULE[ModuleAlternator]
+
+	!MODULE[ModuleAlternator],*{}
+
+	@MODULE[ModuleGimbal]
 	{
+		@gimbalRange = 6.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
 	}
-	MODULE
-	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 8
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
-	}
-	
+
+	!RESOURCE,*{}
 }


### PR DESCRIPTION
General updates to some global engine configs.

**AJ10-190:**
* Validate/fix the web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Fix the ModuleGimbal patching.
* Make the config patch override specific unwanted modules/resources.

**AJ-60A:**
* Validate/fix the web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Fix the patching pass (leftover from the early global engine config definitions).
* Make the config patch override specific unwanted modules/resources.

**Bimodal NTR:**
* Validate/fix the web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Add a small amount of gimballing.
* Make the config patch override specific unwanted modules/resources.

**Castor 1:**
* Add some web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Normalize the naming to be consistent with the rest of the Castor family SRM products.
* Fix an incorrect engine configuration name.
* Make the config patch override specific unwanted modules/resources.

**Castor 2:**
* Add some web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Normalize the naming to be consistent with the rest of the Castor family SRM products.
* Remove some entries that should be part of the actual part module config.
* Make the config patch override specific unwanted modules/resources.

**E-1:**
* Validate/fix the web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Fix an incorrect engine configuration name.
* Make the config patch override specific unwanted modules/resources.

**GEM 60:**
* Add some web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Add a ModuleGimbal module for the TVC version.
* Make the config patch override specific unwanted modules/resources.

**TD-339:**
* Add some web sources.
* Explicitly set the part category (for parts that may be misplaced).
* Round the thrust values (100 lbf in imperial units).
* Improve the O/F ratio to be closer to reality.
* Fix a bug regarding the ModuleGimbal module assigment.
* Make the config patch override specific unwanted modules/resources.