### PR TITLE
CMES Propulsion updates (part III)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2141,148 +2141,116 @@
 }
 
 //  ==================================================
-//  Altair II descent module engines & RCS.
+//  Pegasus engine pod.
 
-//  Modeled after the RD-0242M1 engine:
-//  *   Reduced the overall size.
-//  *   Reduced the maximum thrust value from 98.1 to 49 kN (single engine).
-//  *   Changed the minimum throttle value from 80% to 15%.
-
-//  Dimensions: 2.200 x 1.200 m
-//  Gross Mass: 229.00 Kg
-//  Throttle Range: 15% to 100%
-//  Burn Time: 600 s
-//  O/F Ratio: 1.70
+//  Dimensions: 2.2 m x 1.2 m
+//  Gross Mass: 250 Kg
 //  ==================================================
 
-    @PART[nosExplorerRadialEngine]:FOR[RealismOverhaul]
+@PART[nosExplorerRadialEngine]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
+        model = CMES/Propulsion/NOSRADIAL/model
+        scale = 0.6, 0.6, 0.6
+    }
 
-        MODEL
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @category = Engine
+
+    @mass = 0.25
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = srf
+
+    %engineType = RD0242M2
+    %engineTypeMult = 2
+    %massOffset = 0.01
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 30
+        @maxThrust = 50
+        @heatProduction = 100
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 6
+
+        @PROPELLANT[LiquidFuel]
         {
-            model    = CMES/Propulsion/NOSRADIAL/model
-            scale    = 0.600, 0.600, 0.600
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
+            @name = MMH
+            @ratio = 0.5036
         }
 
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @category     = Engine
-        @title        = Altair II Engine Pod
-        @manufacturer = Boeing Co. & KB Khimavtomatiki [Kosberg]
-        @description  = Radially - mounted engine pod, originally designed for the Altair II Descent Module. Contains the engines for final breaking and RCS thrusters for attitude control.
-
-        @mass             = 0.2290
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1973.15
-        %stageOffset      = 1
-        childStageOffset  = 1
-        %stagingIcon      = LIQUID_ENGINE
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleRCS]
+        @PROPELLANT[Oxidizer]
         {
-            @name          = ModuleRCS
-            @thrusterPower = 0.6732
-            !resourceName  = NULL
-
-            PROPELLANT
-            {
-                name  = Hydrazine
-                ratio = 1.000
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 242
-                @key,1 = 1 84
-            }
+            @name = NTO
+            @ratio = 0.4964
         }
 
-        //  The maximum thrust value refers to the combined thrust of all engines (two engines per pod).
-
-        @MODULE[ModuleEngines*]
+        @atmosphereCurve
         {
-            @minThrust      = 14.71
-            @maxThrust      = 98.10
-            @heatProduction = 100
-            !fxOffset       = NULL
-            %ullage         = false
-            %pressureFed    = true
-            %ignitions      = 6
-
-            IGNITOR_RESOURCE
-            {
-                name   = MMH
-                amount = 0.504
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = NTO
-                amount = 0.496
-            }
-
-            @PROPELLANT[LiquidFuel]
-            {
-                @name  = MMH
-                @ratio = 0.504
-            }
-
-            @PROPELLANT[Oxidizer]
-            {
-                @name  = NTO
-                @ratio = 0.496
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 343.00
-                @key,1 = 1 220.00
-            }
-        }
-
-        MODULE
-        {
-            name          = ModuleEngineConfigs
-            type          = ModuleEngines
-            configuration = RD-0242M2
-            modded        = false
-
-            CONFIG
-            {
-                name      = RD-0242M2
-                minThrust = 14.71
-                maxThrust = 98.10
-
-                PROPELLANT
-                {
-                    name      = MMH
-                    ratio     = 0.504
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = NTO
-                    ratio     = 0.496
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 343.00
-                    key = 1 220.00
-                }
-            }
+            @key,0 = 0 280
+            @key,1 = 1 100
         }
     }
+
+    //  Two Aerojet Rocketdyne R-4D-11 (490 N) bipropellant thrusters on each axis for fine attitude control.
+
+    @MODULE[ModuleRCS*]
+    {
+        @thrusterPower = 0.98
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.5036
+        }
+
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.4964
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 311
+            @key,1 = 1 84
+        }
+    }
+}
+
+//  ==================================================
+//  Pegasus engine pod.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[nosExplorerRadialEngine]:AFTER[RealismOverhaulEngines]
+{
+    @title = Pegasus Engine Pod
+    @manufacturer = Boeing Co. & KB Khimavtomatiki [Kosberg]
+    @description = Radially mounted engine pod, originally designed for the Pegasus Descent Module. Contains the engines and RCS thrusters for attitude control.
+}
 
 //  ==================================================
 //  RSRM inert extension.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1102,6 +1102,26 @@
 }
 
 //  ==================================================
+//  RL10 engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[XXxAres1J2-XHIGH]:AFTER[RealismOverhaulEngines]
+{
+    @title = RL10B/C/CECE Series
+    @manufacturer = Aerojet Rocketdyne
+    @description = The modern iterations of the workhorse RL10 engine (RL-10B-2, RL-10C-1 & CECE).
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RL10B-2
+
+        !CONFIG,*:HAS[~name[RL10B-2],~name[RL10C-1],~name[CECE-Base],~name[CECE-High],~name[CECE-Methane]]{}
+    }
+}
+
+//  ==================================================
 //  RD-253/RD-275 engine.
 
 //  Dimensions: 1.5 x 2.72 m

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1188,113 +1188,92 @@
 }
 
 //  ==================================================
-//  KOSMOS - CHAKA LANDER ENGINE
+//  Kestrel-1B engine.
+
+//  Dimensions: 0.5 m x 1.25 m
+//  Gross Mass: 60 Kg
 //  ==================================================
 
 @PART[XKosmos_TKS_RD-0225_EngineLANDERS]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    !mesh = DELETE
+
+    !mesh = NULL
+
     MODEL
     {
         model = CMES/Propulsion/KOSMOS - CHAKA LANDER ENGINE/model
-        scale = 2.666667, 2.666667, 2.666667
+        scale = 2.667, 2.667, 2.667
     }
-    @rescaleFactor = 1
 
-    @node_attach = 0, 0, 0, 1.0, 0.0, 0.0
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-    @fx_exhaustFlame_yellow_tiny = 0.0, 0, 0, 0.0, 1.0, 0.0, running
-    @fx_exhaustLight_yellow = 0.0, 0, 0.0, 0.0, 0.0, 1.0, running
+    @node_attach = 0.0, 0.0, 0.0, 1.0, 0.0, 0.0
 
-        @title = Kestrel 1B Retro
-    %manufacturer = SpaceX
-    @description = This engine is the evolution of the Kestrel upper stage engine. Retuned and used for Martian retropropulsion.
-        @mass = 0.175
+    @category = Engine
 
-        @MODULE[ModuleEngines*]
+    @mass = 0.06
+    @minimum_drag = 0.1
+    @maximum_drag = 0.2
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = srf
+
+    %engineType = Kestrel_1B
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
     {
-        @minThrust = 26.8
-        @maxThrust = 38.9
+        @name = ModuleEnginesRF
+        @minThrust = 23.1
+        @maxThrust = 30.7
         @heatProduction = 100
-            @PROPELLANT[LiquidFuel]
-            {
-                @name = LqdMethane
-                @ratio = 0.494
-            }
-            @PROPELLANT[Oxidizer]
-            {
-                @name = LqdOxygen
-                @ratio = 0.506
-            }
-            @atmosphereCurve
-            {
-                @key = 0 350
-                @key = 1 100
-            }
-    }
+        %ullage = True
+        %pressureFed = True
+        %ignitions = 4
 
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        origMass = 0.097
-        type = ModuleEngines
-        configuration = Kestrel-1B
-        modded = false
+        @PROPELLANT[MonoPropellant]
+        {
+            @name = LqdMethane
+            @ratio = 0.4935
+        }
 
-        CONFIG
-        {
-            name = Kestrel-1B
-            minThrust = 26.8
-            maxThrust = 38.9
-            heatProduction = 100
-            PROPELLANT
-            {
-                name = LqdMethane
-                ratio = 0.494
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.506
-            }
-            atmosphereCurve
-            {
-                key = 0 350
-                key = 1 100
-            }
-            massMult = 0.952
-        }
-    }
-
-        MODULE
-    {
-        name = ModuleEngineIgnitor
-        ignitionsAvailable = 10
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        isPressureFed = true
-        IGNITOR_RESOURCE
-        {
-            name = ElectricCharge
-            amount = 0.005
-        }
-        IGNITOR_RESOURCE
-        {
-            name = LqdMethane
-            amount = 0.494
-        }
-        IGNITOR_RESOURCE
+        PROPELLANT
         {
             name = LqdOxygen
-            amount = 0.506
-        }
-    }
-        !MODULE[ModuleCommand]
-        {
+            ratio = 0.5064
+            DrawGauge = False
         }
 
+        @atmosphereCurve
+        {
+            @key,0 = 0 300
+            @key,1 = 1 120
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 3.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1767,95 +1767,140 @@
 //  ==================================================
 //  Orion MPCV Service Module.
 
-//  Dimensions: 4.000 x 2.720 m
-//  Gross Mass: 12300.00 Kg
-//  Volume: 8400.00 L
+//  Dimensions: 4 m x 2.8 m
+//  Gross Mass: 12600 Kg
 //  ==================================================
 
-    @PART[XLFTORIONLARGE]:FOR[RealismOverhaul]
+@PART[XLFTORIONLARGE]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Propulsion/LFT_ORION/model
-            scale    = 1.075, 1.180, 1.075
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top     = 0.000,  1.325, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom  = 0.000, -1.335, 0.000, 0.000, -1.000, 0.000, 3
-        !node_stack_bottom2 = NULL
-        @node_attach        = 1.380,  0.000, 0.000, 1.000,  0.000, 0.000
-
-        @category     = FuelTank
-        @title        = Orion Service Module
-        @manufacturer = Airbus Defence & Space
-        %description  = The Service Module for the Orion MPCV. Derived from the Automatic Transfer Vehicle (ATV) Service Module.
-
-        @mass                = 3.800
-        @crashTolerance      = 12
-        @breakingForce       = 250
-        @breakingTorque      = 250
-        @maxTemp             = 1073.15
-        %fuelCrossFeed       = false
-        %bulkheadProfiles    = srf, size3
-        %emissiveConstant    = 0.850
-        %heatConductivity    = 0.700
-        %thermalMassModifier = 5
-        %radiatorHeadroom    = 0.450
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = ServiceModule
-            volume   = 8400
-            basemass = -1
-
-            //  Oxygen max capacity 16.50 Kg.
-
-            TANK
-            {
-                name      = Oxygen
-                amount    = 11700
-                maxAmount = 11700
-            }
-
-            //  Water max capacity 280.00 Kg.
-
-            TANK
-            {
-                name      = Water
-                amount    = 280
-                maxAmount = 280
-            }
-
-            //  Propellant mass 9200.00 Kg.
-
-            TANK
-            {
-                name      = MMH
-                amount    = 4008
-                maxAmount = 4008
-            }
-
-            TANK
-            {
-                name      = MON3
-                amount    = 3950
-                maxAmount = 3950
-            }
-        }
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
+        model = CMES/Propulsion/LFT_ORION/model
+        scale = 1.0667, 1.305, 1.0667
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.465, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.585, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_bottom2 = NULL
+    @node_attach = 1.38, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = Orion MPCV Service Module
+    @manufacturer = Airbus Defence & Space
+    %description = The Service Module for the Orion MPCV. Derived from the Automatic Transfer Vehicle (ATV) Service Module.
+
+    @mass = 3.8
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = srf, size3
+    %emissiveConstant = 0.85
+    %heatConductivity = 0.7
+    %thermalMassModifier = 5.0
+    %radiatorHeadroom = 0.506
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 8170
+        basemass = -1
+
+        //  Batteries 840 Wh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 3025
+            maxAmount = 3025
+        }
+
+        //  Life support water mass 280 Kg.
+
+        TANK
+        {
+            name = Water
+            amount = 280
+            maxAmount = 280
+        }
+
+        //  OME & ACS fuel mass 8600 Kg.
+
+        TANK
+        {
+            name = MMH
+            amount = 3745
+            maxAmount = 3745
+        }
+
+        //  OME & ACS mass oxidizer.
+
+        TANK
+        {
+            name = MON3
+            amount = 3760
+            maxAmount = 3760
+        }
+    }
+
+    !MODULE[ModuleActiveRadiator],*{}
+
+    MODULE
+    {
+        name = ModuleActiveRadiator
+        maxEnergyTransfer = 12500
+        overcoolFactor = 0.506
+        isCoreRadiator = True
+        maxLinksAway = 0
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.17
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Orion MPCV Service Module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[XLFTORIONLARGE]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @mass -= 0.07
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 8400
+
+        //  Oxygen 66 Kg.
+
+        TANK
+        {
+            name = Oxygen
+            amount = 46810
+            maxAmount = 46810
+        }
+    }
+}
 
 @PART[DUNARETROTANKhtv]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1681,122 +1681,87 @@
 }
 
 //  ==================================================
-//  KW2mengineSPS ORION
+//  J-2X engine.
+
+//  Dimensions: 3.05 m x 4.7 m
+//  Gross Mass: 2470 Kg
 //  ==================================================
 
 @PART[XROVERENGINE]:FOR[RealismOverhaul]
 {
-        %RSSROConfig = True
-    !mesh = DELETE
+    %RSSROConfig = True
+
+    !mesh = NULL
+
     MODEL
     {
         model = CMES/Propulsion/KW2mengineSPS ORION/model
-        scale = 1.66667, 1.66667, 1.66667
+        scale = 1.667, 1.667, 1.667
     }
-    @rescaleFactor = 1.75
 
-    @node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.2, 0.0, 0, -1, 0, 2
+    %scale = 1.0
+    @rescaleFactor = 1.0
 
-    // --- FX definitions ---
+    @node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0, -1, 0, 3
 
-    @fx_gasJet_white = 0.0, -1.33333, 0.0, 0.0, 1.0, 0.0, running
-    @fx_exhaustLight_blue = 0.0, -1.33333, 0.0, 0.0, 0.0, 1.0, running
+    @category = Engine
 
-        @title = J-2X
-    %manufacturer = Aerojet Rocketdyne
-    @description = Designed for integration into the ARES Earth Departure Stage.
-        @mass = 2.47
+    @mass = 2.47
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = size3
 
-        @MODULE[ModuleEngines*]
+    %engineType = J2X
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
     {
-        @minThrust = 915
-        @maxThrust = 1307
+        @name = ModuleEnginesRF
+        @minThrust = 1072
+        @maxThrust = 1308
         @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 8
+
         @PROPELLANT[LiquidFuel]
         {
             @name = LqdHydrogen
-            @ratio = 0.745
+            @ratio = 0.7454
         }
+
         @PROPELLANT[Oxidizer]
         {
             @name = LqdOxygen
-            @ratio = 0.255
+            @ratio = 0.2546
         }
+
         @atmosphereCurve
         {
             @key,0 = 0 448
             @key,1 = 1 200
         }
     }
+
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 7.5
-        %useGimbalResponseSpeed = true
+        %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }
-    !MODULE[ModuleAlternator]
-    {
-    }
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        configuration = J-2X
-        origMass = 1.578501
-        modded = false
 
-        CONFIG
-        {
-            name = J-2X
-            minThrust = 915
-            maxThrust = 1307
-            massMult = 0.973574409
-            heatProduction = 100
-            PROPELLANT
-            {
-                name = LqdHydrogen
-                ratio = 0.745
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.255
-            }
-            atmosphereCurve
-            {
-                key = 0 448
-                key = 1 200
-            }
-        }
-    }
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        ignitionsAvailable = 3
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        isPressureFed = false
-        IGNITOR_RESOURCE
-        {
-            name = ElectricCharge
-            amount = 0.500
-        }
-        IGNITOR_RESOURCE
-        {
-            name = LqdHydrogen
-            amount = 0.745
-        }
-        IGNITOR_RESOURCE
-        {
-            name = LqdOxygen
-            amount = 0.255
-        }
-    }
-        !MODULE[ModuleCommand]
-        {
-        }
+    !RESOURCE,*{}
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2008,196 +2008,137 @@
 }
 
 //  ==================================================
-//  Aerojet Rocketdyne Bimodal Nuclear Thermal Rocket (BNTR).
+//  Bimodal Nuclear Thermal Rocket (BNTR).
 
-//  Dimensions: 1.560 x 3.240 m
-//  Gross Mass: 2224.00 Kg
-//  Throttle Range: 33% to 100%
-//  Burn Time: 5400 s
-//  O/F Ratio: 0.00
+//  Dimensions: 1.56 m x 3.24 m
+//  Gross Mass: 2220 Kg
 //  ==================================================
 
-    @PART[nervaII_kerbscalexx]:FOR[RealismOverhaul]
+@PART[nervaII_kerbscalexx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
+        @scale = 0.7, 0.875, 0.7
+    }
 
-        @MODEL
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 2.445, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -4.55, 0.0, 0.0, -1.0, 0.0, 2
+
+    @category = Engine
+
+    @mass = 2.17
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %fuelCrossFeed = True
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = size2
+
+    %engineType = BNTR
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 111.2
+        @maxThrust = 111.2
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 10
+
+        @PROPELLANT[LiquidFuel]
         {
-            @scale    = 0.700, 0.875, 0.700
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
+            @name = LqdHydrogen
+            @ratio = 1.0
         }
 
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  2.445, 0.000, 0.000,  1.000, 0.000, 2
-        @node_stack_bottom = 0.000, -4.550, 0.000, 0.000, -1.000, 0.000, 2
-
-        @title        = Bimodal NTR [1.6 m]
-        @manufacturer = Aerojet Rocketdyne
-        @description  = The Bimodal Nuclear Thermal Rocket (BNTR) engine takes the original NERVA concept and expands it. Instead of wasting precious propellant mass for cooling the engine reactor, it uses a power generator unit to convert the waste thermal energy into electrical power.
-
-        @mass             = 2.1690
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1973.15
-        %fuelCrossFeed    = true
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %stagingIcon      = LIQUID_ENGINE
-        %bulkheadProfiles = size2
-
-        @MODULE[ModuleEngines]
+        @PROPELLANT[Oxidizer]
         {
-            @minThrust      = 22.24
-            @maxThrust      = 66.72
-            @heatProduction = 100
-            !fxOffset       = NULL
-            %ullage         = true
-            %pressureFed    = false
-            %ignitions      = 10
-
-            IGNITOR_RESOURCE
-            {
-                name   = ElectricCharge
-                amount = 0.500
-            }
-
-            @PROPELLANT[LiquidFuel]
-            {
-                @name  = LqdHydrogen
-                @ratio = 1.000
-            }
-            @PROPELLANT[Oxidizer]
-            {
-                @name  = EnrichedUranium
-                @ratio = 0.00000000001
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 925
-                @key,1 = 1 380
-            }
+            @name = EnrichedUranium
+            @ratio = 1.6428e-17
         }
 
-        !MODULE[ModuleGimbal]{}
-
-        MODULE
+        @atmosphereCurve
         {
-            name          = ModuleEngineConfigs
-            type          = ModuleEngines
-            origMass      = 2.224
-            modded        = false
-            configuration = BNTR
-
-            CONFIG
-            {
-                name           = BNTR
-                minThrust      = 22.24
-                maxThrust      = 66.72
-                heatProduction = 100
-                massMult       = 1.000
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 1.000
-                    DrawGauge = True
-                }
-
-                PROPELLANT
-                {
-                    name      = EnrichedUranium
-                    ratio     = 0.00000000001
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 925.00
-                    key = 1 380.00
-                }
-            }
-
-            CONFIG
-            {
-                name           = TRITON
-                minThrust      = 90.40
-                maxThrust      = 271.21
-                heatProduction = 100
-                massMult       = 1.100
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.250
-                    DrawGauge = True
-                }
-
-                PROPELLANT
-                {
-                    name      = LqdOxygen
-                    ratio     = 0.750
-                    DrawGauge = False
-                }
-
-                PROPELLANT
-                {
-                    name      = EnrichedUranium
-                    ratio     = 0.00000000001
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 642.00
-                    key = 1 390.00
-                }
-            }
-        }
-
-        MODULE
-        {
-            name           = ModuleGenerator
-            isAlwaysActive = true
-
-            INPUT_RESOURCE
-            {
-                name = EnrichedUranium
-                rate = 1e-13
-            }
-
-            OUTPUT_RESOURCE
-            {
-                name = ElectricCharge
-                rate = 5.000
-            }
-
-            OUTPUT_RESOURCE
-            {
-                name = DepletedUranium
-                rate = 1e-13
-            }
-        }
-
-        RESOURCE
-        {
-            name      = EnrichedUranium
-            amount    = 5
-            maxAmount = 5
-        }
-
-        RESOURCE
-        {
-            name      = DepletedUranium
-            amount    = 0
-            maxAmount = 5
+            @key,0 = 0 925
+            @key,1 = 1 380
         }
     }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleResourceConverter],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = RTG
+        StartActionName = Start RTG
+        StopActionName = Stop RTG
+        AlwaysActive = True
+        FillAmount = 1.0
+        AutoShutdown = False
+        GeneratesHeat = True
+        TemperatureModifier = 2.0
+        UseSpecializationBonus = False
+        DefaultShutoffTemp = 0.5
+
+        INPUT_RESOURCE
+        {
+            ResourceName = EnrichedUranium
+            Ratio = 1.6428e-17
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 5.0
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedUranium
+            Ratio = 1.6428e-17
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Uranium-235 pellets mass ~55 Kg.
+
+    RESOURCE
+    {
+        name = EnrichedUranium
+        amount = 5
+        maxAmount = 5
+    }
+
+    RESOURCE
+    {
+        name = DepletedUranium
+        amount = 0
+        maxAmount = 5
+    }
+}
 
 //  ==================================================
 //  Altair II descent module engines & RCS.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1951,62 +1951,61 @@
 }
 
 //  ==================================================
-//  Bimodal NTR engine mount.
+//  Mars Transfer Vehicle auxiliary propellant tank.
 
-//  Dimensions: 10.000 x 6.000 m
-//  Gross Mass: 628.00 Kg
+//  Dimensions: 10 m x 6 m
+//  Gross Mass: 4420 Kg
 //  ==================================================
 
-    @PART[XNP_interstage_5m_8m_tMTVDRIVEX]:FOR[RealismOverhaul]
+@PART[XNP_interstage_5m_8m_tMTVDRIVEX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = True
-
-        @MODEL
-        {
-            @scale    = 2.010, 1.950,   2.010
-            %position = 0.000, 0.000,   0.000
-            %rotation = 0.000, 0.000, 180.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,   2.925, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -10.000, 0.000, 0.000, -1.000, 0.000, 3
-        @node_stack_1      = 0.000,  -2.950, 0.000, 0.000, -1.000, 0.000, 3
-        !node_stack_2      = NULL
-        !node_stack_3      = NULL
-        !node_stack_4      = NULL
-
-        @category     = Structural
-        @title        = Bimodal NTR Engine Mount
-        @manufacturer = NASA
-        @description  = Structural adapter for the Bimodal NTR engines. Includes radiators for cooling the NTR engines.
-
-        @mass                = 0.6280
-        @crashTolerance      = 12
-        @breakingForce       = 250
-        @breakingTorque      = 250
-        @maxTemp             = 1073.15
-        %emissiveConstant    = 0.900
-        %heatConductivity    = 0.750
-        %thermalMassModifier = 5.000
-        %radiatorHeadroom    = 0.500
-        %bulkheadProfiles    = size3
-
-        !MODULE[ModuleCommand]{}
-
-        !MODULE[ModuleGenerator]{}
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
-
-        !RESOURCE[ElectricCharge]{}
-
-        !RESOURCE[MonoPropellant]{}
+        @scale = 2.0, 1.95, 2.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 2.925, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -2.95, 0.0, 0.0, -1.0, 0.0, 5
+    !node_stack_1 = NULL
+    !node_stack_2 = NULL
+    !node_stack_3 = NULL
+    !node_stack_4 = NULL
+
+    @category = FuelTank
+    @title = MTV - II Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Mars Transfer Vehicle.
+
+    @mass = 4.42
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size3
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 200000
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Aerojet Rocketdyne Bimodal Nuclear Thermal Rocket (BNTR).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1277,81 +1277,129 @@
 }
 
 //  ==================================================
-//  Separation Motor (large).
+//  SEP - 100 separation motor.
 
-//  Dimensions: 0.175 x 1.000 m
-//  Gross Mass: 50.00 Kg
-//  Throttle Range: N/A
-//  O/F Ratio: 2.12
+//  Dimensions: 0.175 m x 1 m
+//  Gross Mass: 50 Kg
 //  ==================================================
 
-    @PART[xKosmos_SepRetrox]:FOR[RealismOverhaul]
+@PART[xKosmos_SepRetrox]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale = 0.850, 0.850, 0.850
-        }
-
-        !mesh          = NULL
-        %scale         = 1.000
-        !Rescalefactor = NULL
-        %rescaleFactor = 1.000
-
-        @node_attach =  -0.008, 0.000, 0.000, -1.000, 0.000, 0.000
-
-        @category     = Engine
-        @title        = Separation Motor (100 kN class)
-        %manufacturer = Generic
-        @description  = Solid rocket motor for safe separation of discarded rocket stages.
-
-        @mass             = 0.0500
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1973.15
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleEngines*]
-        {
-            @minThrust               = 0
-            @maxThrust               = 100.00
-            @heatProduction          = 100
-            @useEngineResponseTime   = false
-            !engineAccelerationSpeed = NULL
-
-            @PROPELLANT[SolidFuel]
-            {
-                @name = HTPB
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 250
-                @key,1 = 1 220
-            }
-        }
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = HTPB
-            volume   = 21.00
-            basemass = -1
-
-            TANK
-            {
-                name      = HTPB
-                amount    = 11.86
-                maxAmount = 11.86
-            }
-        }
-
-        !RESOURCE[SolidFuel]{}
+        @scale = 0.85, 0.85, 0.85
     }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = -0.008, 0.0, 0.0, -1.0, 0.0, 0.0
+    @attachRules = 0,1,0,0,0
+
+    @category = Engine
+    @title = SEP - 100 Separation Motor
+    %manufacturer = Generic
+    @description = A generic solid rocket motor for safe separation of discarded rocket stages.
+
+    @mass = 0.05
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.5
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 0
+        @maxThrust = 100
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        !engineAccelerationSpeed = NULL
+        %EngineType = SolidBooster
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 220
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 16
+        basemass = -1
+
+        //  HTPB/AP propellant mixture mass ~28 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 16
+            maxAmount = 16
+        }
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEnginesRF
+        configuration = SEP-100
+        origMass = 0.05
+        modded = False
+
+        CONFIG
+        {
+            name = SEP-100
+            minThrust = 0
+            maxThrust = 100
+            heatProduction = 100
+
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 250
+                key = 1 220
+            }
+        }
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Separation Motor (medium).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1102,171 +1102,90 @@
 }
 
 //  ==================================================
-//  Aerojet Rocketdyne J-2X engine.
+//  RD-253/RD-275 engine.
 
-//  Dimensions: 3.050 x 4.700 m
-//  Gross Mass: 2430.00 Kg
-//  Throttle Range: 80% to 100%
-//  Burn Time: 431 s
-//  O/F Ratio: 5.50
+//  Dimensions: 1.5 x 2.72 m
+//  Gross Mass: 1080 Kg
 //  ==================================================
 
-    @PART[XKosmos_Angara_RD-275KX]:FOR[RealismOverhaul]
+@PART[XKosmos_Angara_RD-275KX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
-
-        MODEL
-        {
-            model    = CMES/Propulsion/Kosmos_Angara_RD-275K/model_RD-275K
-            scale    = 2.600, 2.100, 2.600
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
-        }
-
-        @node_stack_top    = 0.000,  2.325, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -2.325, 0.000, 0.000, -1.000, 0.000, 3
-        @attachRules       = 1,1,1,0,0
-
-        !mesh          = NULL
-        %scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @category     = Engine
-        @title        = J2-X [3.05 m]
-        @manufacturer = Aerojet Rocketdyne
-        %description  = The J-2X engine begun it's life as an update to the J2-S engine, which itself was a simplified J-2 engine. It was planned to have two variants, the J-2X with 1220 kN of thrust (for the Ares I launch vehicle) and the J-2XD with 1310 kN of thrust (for the Ares V Earth Departure Stage). Both designs were dropped in favor of the RL-10 engine (C2 variant) for the upper stage of the SLS.
-
-        @mass             = 2.4300
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1973.15
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %stagingIcon      = LIQUID_ENGINE
-        %bulkheadProfiles = size3
-
-        @MODULE[ModuleEngines*]
-        {
-            @minThrust      = 1046.00
-            @maxThrust      = 1307.50
-            @heatProduction = 100
-            %ullage         = true
-            %pressureFed    = false
-            %ignitions      = 3
-
-            IGNITOR_RESOURCE
-            {
-                name   = LqdHydrogen
-                amount = 0.7454
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = LqdOxygen
-                amount = 0.2545
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name   = ElectricCharge
-                amount = 0.500
-            }
-
-            @PROPELLANT[LiquidFuel]
-            {
-                @name  = LqdHydrogen
-                @ratio = 0.7454
-            }
-
-            @PROPELLANT[Oxidizer]
-            {
-                @name  = LqdOxygen
-                @ratio = 0.2545
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 448
-                @key,1 = 1 200
-            }
-        }
-
-        @MODULE[ModuleGimbal]
-        {
-            @gimbalRange            = 7.500
-            %useGimbalResponseSpeed = true
-            %gimbalResponseSpeed    = 16
-        }
-
-        MODULE
-        {
-            name          = ModuleEngineConfigs
-            type          = ModuleEngines
-            configuration = J-2X
-            modded        = false
-
-            CONFIG
-            {
-                name           = J-2X
-                minThrust      = 976.00
-                maxThrust      = 1220.00
-                heatProduction = 100
-                massMult       = 1.000
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.7454
-                    DrawGauge = True
-                }
-
-                PROPELLANT
-                {
-                    name  = LqdOxygen
-                    ratio = 0.2545
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 448
-                    key = 1 200
-                }
-            }
-
-            CONFIG
-            {
-                name           = J-2XD
-                minThrust      = 1046.00
-                maxThrust      = 1307.50
-                heatProduction = 100
-                massMult       = 1.000
-
-                PROPELLANT
-                {
-                    name      = LqdHydrogen
-                    ratio     = 0.7454
-                    DrawGauge = True
-                }
-
-                PROPELLANT
-                {
-                    name  = LqdOxygen
-                    ratio = 0.2545
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 448
-                    key = 1 200
-                }
-            }
-        }
-
-        !MODULE[ModuleAlternator]{}
-
-        !RESOURCE[ElectricCharge]{}
+        model = CMES/Propulsion/Kosmos_Angara_RD-275K/model_RD-275K
+        scale = 1.25, 1.225, 1.25
     }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.335, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.335, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Engine
+
+    @mass = 1.08
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    %bulkheadProfiles = size3
+
+    %engineType = RD253
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 1748
+        @maxThrust = 1748
+        @heatProduction = 100
+        @engineAccelerationSpeed = 0
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4061
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5939
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 294.7
+            @key,1 = 1 322.2
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 7.5
+        %useGimbalResponseSpeed = True
+        @gimbalResponseSpeed = 16
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  KOSMOS - CHAKA LANDER ENGINE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1606,113 +1606,79 @@
 //  ==================================================
 //  SuperDraco engine.
 
-//  Dimensions: 0.200 x 2.000 m
-//  Gross Mass: 130.40 Kg
-//  Throttle Range: 20% to 100%
-//  Burn Time: 300 s
-//  O/F Ratio: 1.30
+//  Dimensions: 0.2 m x 2 m
+//  Gross Mass: 130 Kg
 //  ==================================================
 
-    @PART[xLazTekSuperDracosx]:FOR[RealismOverhaul]
+@PART[xLazTekSuperDracosx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
     {
-        %RSSROConfig = true
+        model = CMES/Propulsion/LazTekSuperDracos/model
+        scale = 1.67, 1.67, 1.67
+    }
 
-        MODEL
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+
+    @category = Engine
+
+    @mass = 0.13
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.8
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = srf
+
+    %engineType = SuperDraco
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 29.2
+        @maxThrust = 146
+        @exhaustDamage = True
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = -1
+
+        @PROPELLANT[LiquidFuel]
         {
-            model    = CMES/Propulsion/LazTekSuperDracos/model
-            scale    = 1.670, 1.670, 1.670
-            position = 0.000, 0.000, 0.000
-            rotation = 0.000, 0.000, 0.000
+            @name = MMH
+            @ratio = 0.5583
         }
 
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_attach = 0.000, 0.000, 0.000, 0.000, 0.000, -1.000
-
-        @category     = Engine
-        @title        = SuperDraco
-        @manufacturer = SpaceX
-        %description  = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules.
-
-        @mass             = 0.1304
-        @crashTolerance   = 12
-        %breakingForce    = 250
-        %breakingTorque   = 250
-        @maxTemp          = 1973.15
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleEngines*]
+        @PROPELLANT[Oxidizer]
         {
-            @exhaustDamage  = true
-            @minThrust      = 29.20
-            @maxThrust      = 146.00
-            @heatProduction = 100
-            !fxOffset       = NULL
-            %ullage         = false
-            %pressureFed    = true
-
-            @PROPELLANT[MonoPropellant]
-            {
-                @name  = MMH
-                @ratio = 0.5629
-            }
-
-            PROPELLANT
-            {
-                name      = NTO
-                ratio     = 0.4370
-                DrawGauge = false
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 280.10
-                @key,1 = 1 239.80
-            }
+            @name = MON3
+            @ratio = 0.4417
         }
 
-        !MODULE[ModuleGimbal]{}
-
-        MODULE
+        @atmosphereCurve
         {
-            name          = ModuleEngineConfigs
-            type          = ModuleEngines
-            configuration = SuperDraco
-            modded        = false
-
-            CONFIG
-            {
-                name           = SuperDraco
-                minThrust      = 29.20
-                maxThrust      = 146.00
-                heatProduction = 100
-
-                PROPELLANT
-                {
-                    name      = MMH
-                    ratio     = 0.5629
-                    DrawGauge = true
-                }
-
-                PROPELLANT
-                {
-                    name      = NTO
-                    ratio     = 0.4370
-                    DrawGauge = false
-                }
-
-                atmosphereCurve
-                {
-                    key = 0 280.10
-                    key = 1 239.80
-                }
-            }
+            @key,0 = 0 280
+            @key,1 = 1 240
         }
     }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  KW2mengineSPS ORION

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1402,80 +1402,129 @@
 }
 
 //  ==================================================
-//  Separation Motor (medium).
+//  SEP - 50 separation motor.
 
-//  Dimensions: 0.175 x 0.500 m
-//  Gross Mass: 28.00 Kg
-//  Throttle Range: N/A
-//  O/F Ratio: 2.12
+//  Dimensions: 0.175 m x 0.5 m
+//  Gross Mass: 30 Kg
 //  ==================================================
 
-    @PART[xKosmos_SepRetroxMLS]:FOR[RealismOverhaul]
+@PART[xKosmos_SepRetroxMLS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
     {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale = 0.850, 0.425, 0.850
-        }
-
-        !mesh          = NULL
-        %scale         = 1.000
-        %rescaleFactor = 1.000
-
-        @node_attach =  -0.008, 0.000, 0.000, -1.000, 0.000, 0.000
-
-        @category     = Engine
-        @title        = Separation Motor (50 kN class)
-        %manufacturer = Generic
-        @description  = Solid rocket motor for safe separation of discarded rocket stages.
-
-        @mass             = 0.0280
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1973.15
-        %stageOffset      = 1
-        %childStageOffset = 1
-        %bulkheadProfiles = srf
-
-        @MODULE[ModuleEngines*]
-        {
-            @minThrust               = 0
-            @maxThrust               = 50.00
-            @heatProduction          = 100
-            @useEngineResponseTime   = false
-            !engineAccelerationSpeed = NULL
-
-            @PROPELLANT[SolidFuel]
-            {
-                @name = HTPB
-            }
-
-            @atmosphereCurve
-            {
-                @key,0 = 0 250
-                @key,1 = 1 220
-            }
-        }
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = HTPB
-            volume   = 9.60
-            basemass = -1
-
-            TANK
-            {
-                name      = HTPB
-                amount    = 5.42
-                maxAmount = 5.42
-            }
-        }
-
-        !RESOURCE[SolidFuel]{}
+        @scale = 0.85, 0.425, 0.85
     }
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_attach = -0.008, 0.0, 0.0, -1.0, 0.0, 0.0
+    @attachRules = 0,1,0,0,0
+
+    @category = Engine
+    @title = SEP - 50 Separation Motor
+    %manufacturer = Generic
+    @description = A generic solid rocket motor for safe separation of discarded rocket stages.
+
+    @mass = 0.03
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %heatConductivity = 0.06
+    %skinInternalConductionMult = 4.0
+    %emissiveConstant = 0.5
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 0
+        @maxThrust = 50
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        !engineAccelerationSpeed = NULL
+        %EngineType = SolidBooster
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 220
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 8
+        basemass = -1
+
+        //  HTPB/AP propellant mixture mass ~14 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 8
+            maxAmount = 8
+        }
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEnginesRF
+        configuration = SEP-50
+        origMass = 0.03
+        modded = False
+
+        CONFIG
+        {
+            name = SEP-50
+            minThrust = 0
+            maxThrust = 50
+            heatProduction = 100
+
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 250
+                key = 1 220
+            }
+        }
+    }
+
+    !RESOURCE,*{}
+}
 
 //  ==================================================
 //  Separation Motor (small).


### PR DESCRIPTION
Updates and fixes for the CMES "Propulsion" parts. Third pass.

Changelog:

* Update all engiine parts to use the new global engine configuration system.
* Remove invalid part modules from many parts.
* Add an active radiator module to the Orion SM.
* Upgrade the BNTR RTG generator module to the new ModuleResourceConverter.
* Explicitly set the part categories (and use the new KSP 1.2 ones).
* Balance inert and gross mass values against real sources and/or other parts.
* Adjust some insane max temperature values.
*  Update the part titles and the descriptions.
* Fix formatting (tabs, false spacing).

[Alternate diff ignoring whitespace changes](https://github.com/KSP-RO/RealismOverhaul/pull/1475/files?w=1)
