### PR TITLE
CMES Structural new parts & tweaks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1203,8 +1203,8 @@
 //  ==================================================
 //  Expanded Mobility Enhancer.
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.65 m x 4.9 m
+//  Inert Mass: 70 Kg
 //  ==================================================
 
 @PART[XtelescopicLadderBayX]:FOR[RealismOverhaul]
@@ -1215,7 +1215,7 @@
 
     @MODEL
     {
-        @scale = 1.2, 1.2, 1.2
+        @scale = 1.6, 1.6, 1.6
     }
 
     @scale = 1.0
@@ -1225,9 +1225,9 @@
 
     @title = Expanded Mobility Enhancer
     @manufacturer = Generic
-    description = A retractable mobility enhancer, equipped with advanced telescopic extension technology.
+    @description = A retractable mobility enhancer, equipped with advanced telescopic extension technology.
 
-    @mass = 1.0
+    @mass = 0.07
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -203,13 +203,13 @@
         PROPELLANT
         {
             name = MMH
-            ratio = 0.499
+            ratio = 0.4990
         }
 
         PROPELLANT
         {
             name = MON3
-            ratio = 0.501
+            ratio = 0.5010
         }
 
         PROPELLANT
@@ -221,8 +221,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 300
-            @key,1 = 1 82
+            @key,0 = 0 315.5
+            @key,1 = 1 100
         }
     }
 
@@ -509,7 +509,7 @@
     @category = Ground
     @title = MSEV Rover Wheel
     @manufacturer = Boeing Co.
-    @description = Rover wheel for the surface exploration vehicles and mobile habitation modules.
+    @description = A rover wheel for the surface exploration vehicles and the mobile habitation modules.
 
     @mass = 0.2
     @maxTemp = 473.15
@@ -570,6 +570,49 @@
     {
         @stressTolerance = 500
         @impactTolerance = 125
+    }
+}
+
+//  ==================================================
+//  TT - 38K radial decoupler.
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[xradialDecoupler]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Structural/decouplerRadialTT-38K/model
+        scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.01, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = Coupling
+    @title = TT-38K Radial Decoupler
+    @manufacturer = Generic
+    @description = Explosive cord decoupler for side mounted boosters.
+
+    @mass = 1.0
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = srf
+
+    @MODULE[ModuleAnchoredDecoupler]
+    {
+        @ejectionForce = 250
     }
 }
 
@@ -702,7 +745,7 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @category = Coupling
-    @title = Common Berthing Mechanism (Active)
+    @title = Common Berthing Mechanism (CBM) [Active]
     @manufacturer = Boeing Co.
     @description = A berthing mechanism used by the ISS modules (non Russian), the Multipurpose Logistics Modules (MPLM) and the resupply vehicles. This is the active component.
 
@@ -744,6 +787,131 @@
         name = ModuleConnectedLivingSpace
         passable = True
         passableWhenSurfaceAttached = True
+    }
+}
+
+//  ==================================================
+//  Common Berthing Mechanism (passive).
+
+//  Dimensions: 2.3 m x 0.56 m
+//  Inert Mass: 300 Kg
+//  ==================================================
+
+@PART[XIACBM1ee25m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 2.215, 2.215, 2.215
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.42, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+
+    @category = Coupling
+    @title = Common Berthing Mechanism  (CBM) [Passive]
+    @manufacturer = Boeing Co.
+    @description = A berthing mechanism used by the ISS modules (non Russian), the Multipurpose Logistics Modules (MPLM) and the resupply vehicles. This is the passive component.
+
+    @mass = 0.3
+    @crashTolerance = 8
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %bulkheadProfiles = size2
+
+    @MODULE[ModuleDockingNode]
+    {
+        @nodeType = CBM
+        %gendered = True
+        %genderFemale = True
+        %acquireForce = 0.5
+        %acquireMinFwdDot = 0.8
+        %acquireminRollDot = -3.40282347E+38
+        %acquireRange = 0.25
+        %acquireTorque = 0.5
+        %captureMaxRvel = 0.1
+        %captureMinFwdDot = 0.998
+        %captureMinRollDot = -3.40282347E+38
+        %captureRange = 0.05
+        %minDistanceToReEngage = 0.25
+        %undockEjectionForce = 0.1
+    }
+
+    @MODULE[ModuleLight]
+    {
+        @resourceAmount = 0.015
+    }
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        passableWhenSurfaceAttached = True
+    }
+}
+
+
+//  ==================================================
+//  Delta IV interstage adapter (4 m).
+
+//  Dimensions: 5 m x 7.5 m
+//  Inert Mass: 1620 Kg
+
+//  Because the CMES RL10B-2 does not have an extendable
+//  B cone, the length of the adapter has been increased
+//  by 1.5 meters from the original.
+//  ==================================================
+
+@PART[XDRAGON--ADAPTERX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 2.5, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0, -3.2, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -3.75, 0.0, 0.0, -1.0, 0.0, 4
+
+    @fx_gasBurst_white = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, activate
+
+    @category = Coupling
+    @title = Interstage Adapter - Delta IV DCSS (4 m)
+    @manufacturer = Orbital ATK
+    %description = The structural adapter and explosive cord decoupler for the 4 meter Delta Cryogenic Second Stage (DCSS).
+
+    @mass = 1.62
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size3, size4
+    !stackSymmetry = NULL
+
+    !MODULE[ModuleDecouple*],*{}
+
+    MODULE
+    {
+        name = ModuleDecouple
+        explosiveNodeID = top
+        isOmniDecoupler = False
+        ejectionForce = 50
     }
 }
 
@@ -848,6 +1016,49 @@
 }
 
 //  ==================================================
+//  Falcon 9 interstage adapter.
+
+//  Dimensions: 3.66 m x 6.5 m
+//  Inert Mass: 950 Kg
+//  ==================================================
+
+@PART[XXB3IUShroudXLOWERRXpxV]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.22, 3.45, 1.22
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 3.0, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = Coupling
+    @title = Interstage Adapter - Falcon 9
+    @manufacturer = SpaceX
+    @description = The interstage adapter for the Falcon 9 Second Stage.
+
+    @mass = 0.95
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !explosionPotential = NULL
+    @bulkheadProfiles = size3
+    %stagingIcon = DECOUPLER_HOR
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+}
+
+//  ==================================================
 //  Habitation module structural adapter (small).
 
 //  Dimensions: 3.75 x 0.3 m
@@ -883,6 +1094,54 @@
     !stageOffset = NULL
     !childStageOffset = NULL
     %bulkheadProfiles = size3
+
+    !MODULE[ConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+    }
+}
+
+//  ==================================================
+//  Habitation module structural adapter (medium).
+
+//  Dimensions: 5 m x 0.3 m
+//  Inert Mass: 200 Kg
+//  ==================================================
+
+@PART[XKWFlatadapter3x2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.111, 0.5, 1.111
+    }
+
+    @scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.33, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 4
+
+    @category = Structural
+    @title = HAB - 50 Adapter
+    @manufacturer = Generic
+    @description = A flat 5 meter structural adapter.
+
+    @mass = 0.2
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !stageOffset = NULL
+    !childStageOffset = NULL
+    %bulkheadProfiles = size4
 
     !MODULE[ConnectedLivingSpace],*{}
 
@@ -940,6 +1199,324 @@
         passable = True
     }
 }
+
+//  ==================================================
+//  Expanded Mobility Enhancer.
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[XtelescopicLadderBayX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.2, 1.2, 1.2
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.75, 0.0, 0.0
+
+    @title = Expanded Mobility Enhancer
+    @manufacturer = Generic
+    description = A retractable mobility enhancer, equipped with advanced telescopic extension technology.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+}
+
+//  ==================================================
+//  Stack decoupler (2.5 meters).
+
+//  Dimensions: 2.5 m x 0.1 m
+//  Inert Mass: 160 Kg
+//  ==================================================
+
+@PART[LXNPdecouplerstack4m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Structural/NOVA-CHAKA-DECOUPLER/model
+        scale = 0.5, 0.5, 0.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.065, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.065, 0.0, 0.0, -1.0, 0.0, 2
+
+    %fx_gasBurst_white = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Coupling
+    @title = SD - 25 Decoupler
+    @manufacturer = Generic
+    %description = A low profile explosive bolt decoupler for separating stages.
+
+    @mass = 0.16
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size2
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 50
+    }
+}
+
+//  ==================================================
+//  Stack decoupler (3.75 meters).
+
+//  Dimensions: 3.75 m x 0.15 m
+//  Inert Mass: 370 Kg
+//  ==================================================
+
+@PART[XNPdecouplerstack5m]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Structural/NOVA-CHAKA-DECOUPLER/model
+        scale = 0.75, 0.75, 0.75
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.1, 0.0, 0.0, -1.0, 0.0, 3
+
+    %fx_gasBurst_white = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Coupling
+    @title = SD - 37 Decoupler
+    @manufacturer = Generic
+    %description = A low profile explosive bolt decoupler for separating stages.
+
+    @mass = 0.37
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size3
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+}
+
+//  ==================================================
+//  Stack decoupler (5 meters).
+
+//  Dimensions: 5 m x 0.2 m
+//  Inert Mass: 650 Kg
+//  ==================================================
+
+@PART[XNPdecouplerstack5mX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Structural/NOVA-CHAKA-DECOUPLER/model
+        scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 4
+
+    %fx_gasBurst_white = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Coupling
+    @title = SD - 50 Decoupler
+    @manufacturer = Generic
+    %description = A low profile explosive bolt decoupler for separating stages.
+
+    @mass = 0.65
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size4
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 150
+    }
+}
+
+//  ==================================================
+//  Stack decoupler (8.125 meters).
+
+//  Dimensions: 8.125 m x 0.325 m
+//  Inert Mass: 1700 Kg
+//  ==================================================
+
+@PART[LXNPdecouplerstack3x75mob2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Structural/ORION DECOUPLER/model
+        scale = 1.625, 1.625, 1.625
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 5
+    @node_stack_top = 0.0, 0.2, 0.0, 0.0, 1.0, 0.0, 5
+
+    %fx_gasBurst_white = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Coupling
+    @title = SD - 80 Decoupler
+    @manufacturer = Generic
+    %description = A low profile explosive bolt decoupler for separating stages.
+
+    @mass = 1.7
+    @crashTolerance = 25
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !explosionPotential = NULL
+    !linearStrength = NULL
+    !angularStrength = NULL
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size5
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 200
+    }
+}
+
+//  ==================================================
+//  Falcon 9 "octaweb" engine mount structure.
+
+//  Dimensions: 3.66 m x 2.6 m
+//  Inert Mass: 680 Kg
+//  ==================================================
+
+@PART[XKK_SPX_F9_OctawebX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.29, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_engine = 0.0, -0.45, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_engine01 = -1.195, -0.45, -0.495, 0.0, -1.0, 0.0, 2
+    @node_stack_engine02 = -0.495, -0.45, -1.195, 0.0, -1.0, 0.0, 2
+    @node_stack_engine03 = 0.495, -0.45, -1.195, 0.0, -1.0, 0.0, 2
+    @node_stack_engine04 = 1.195, -0.45, -0.495, 0.0, -1.0, 0.0, 2
+    @node_stack_engine05 = 1.195, -0.45, 0.495, 0.0, -1.0, 0.0, 2
+    @node_stack_engine06 = 0.495, -0.45, 1.195, 0.0, -1.0, 0.0, 2
+    @node_stack_engine07 = -0.495, -0.45, 1.195, 0.0, -1.0, 0.0, 2
+    @node_stack_engine08 = -1.195, -0.45, 0.495, 0.0, -1.0, 0.0, 2
+
+    @category = Structural
+    @title = Falcon 9 Engine Mount
+    @manufacturer = SpaceX
+    @description = The engine mount structure for the nine Merlin engines that power the first stage of the Falcon 9 launch vehicle.
+
+    @mass = 0.68
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    !stageOffset = NULL
+    !childStageOffset = NULL
+    @bulkheadProfiles = size2, size4
+    !stacksymmetry = NULL
+    %stackSymmetry = 8
+}
+
+//  ==================================================
+//  Falcon 9 landing leg.
+
+//  Dimensions: 2.6 m x 9.5 m
+//  Inert Mass: 860 Kg
+//  ==================================================
+
+@PART[XKKLEGX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.6, 0.0, 0.0, 1.0
+
+    @category = Ground
+    @title = Falcon 9 Landing Gear
+    @manufacturer = SpaceX
+    @description = The landing gear for the SpaceX Falcon 9 launch vehicle.
+
+    @mass = 0.86
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = Lower Landing Gear
+        @endEventGUIName = Raise Landing Gear
+    }
+
+    !MODULE[FStextureSwitch*],*{}
+}
+
 //  ==================================================
 //  Exploration station crew tunnel.
 
@@ -1381,6 +1958,197 @@
 }
 
 //  ==================================================
+//  Procedural payload attach fitting (expanded).
+
+//  Dimensions: N/A
+//  Inert Mass: N/A
+//  ==================================================
+
+@PART[SDHIxADAPTERx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Structural/SDHI-IUS-ADAPTER/model
+        scale = 0.49, 0.49, 0.49
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.35, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    %node_stack_connect01 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect02 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect03 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+    %node_stack_connect04 = 0.1, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+
+    @category = Payload
+    @title = Payload Attach Fitting - Base (Expanded) [Procedural]
+    @manufacturer = Generic
+    @description = A payload attach fitting for the Space Launch System payloads.
+
+    @mass = 0.1
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @fuelCrossFeed = True
+    %stagingIcon = DECOUPLER_HOR
+    %bulkheadProfiles = size0, size1
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+
+    MODULE
+    {
+        name = ProceduralFairingBase
+        baseSize = 1.8
+        sideThickness = 0.1
+        verticalStep = 0.1
+    }
+
+    MODULE
+    {
+        name = KzNodeNumberTweaker
+        nodePrefix = connect
+        maxNumber = 4
+        numNodes = 2
+        radius = 0.625
+        shouldResizeNodes = False
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseResizer
+        size = 2.0
+        diameterStepLarge = 1.0
+        diameterStepSmall = 0.1
+        costPerTonne = 1000
+        specificMass = 0.007, 0.026, 0.01, 0.0
+        specificBreakingForce = 250
+        specificBreakingTorque = 250
+        dragAreaScale = 1.5
+    }
+
+    MODULE
+    {
+        name = KzFairingBaseShielding
+    }
+
+    MODULE
+    {
+        name = ModuleToggleCrossfeed
+        crossfeedStatus = False
+        toggleEditor = True
+        toggleFlight = True
+        enableText = Enable Cross Feed
+        disableText = Disable Cross Feed
+    }
+}
+
+//  ==================================================
+//  Orion SLS Block IB structural adapter.
+
+//  Dimensions: 8.4 m x 5 m
+//  Inert Mass: 260 Kg
+//  ==================================================
+
+@PART[SLS_CM_FairingAdapterBLOCK1B96]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.285, 0.75, 1.285
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -2.77, 0.0, 0.0, -1.0, 0.0, 5
+    @node_stack_top = 0.0, 2.05, 0.0, 0.0, 1.0, 0.0, 3
+
+    @category = Coupling
+    @title = SLS Block IB Orion Adapter
+    @manufacturer = Boeing Co.
+    @description = A structural adapter for mounting the Orion MPCV on the Exploration Upper Stage. Allows for dual - manifested payloads.
+
+    @mass = 0.26
+    !explosionPotential = NULL
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !fuelCrossFeed,* = NULL
+    %fuelCrossFeed = False
+    %stagingIcon = DECOUPLER_HOR
+    @bulkheadProfiles = size3, size5
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 50
+    }
+}
+
+//  ==================================================
+//  Space Launch System Block I interstage adapter.
+
+//  Dimensions: 8.4 m x 8.5 m
+//  Inert Mass: 1030 Kg
+//  ==================================================
+
+@PART[SLS_CM_FairingAdapter296]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.3, 1.3, 1.3
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -4.75, 0.0, 0.0, -1.0, 0.0, 5
+    @node_stack_top = 0.0, -1.5, 0.0, 0.0, 1.0, 0.0, 4
+
+    @fx_gasBurst_white = 0.0, 2.799666, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @category = Coupling
+    @title = Interstage Adapter - SLS Block I
+    @manufacturer = Boeing Co.
+    @description = The structural adapter and explosive cord decoupler for the Interim Cryogenic Second Stage (ICPS).
+
+    @mass = 1.03
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !fuelCrossFeed,* = False
+    %fuelCrossFeed = False
+    !explosionPotential = NULL
+    @bulkheadProfiles = size4, size5
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 100
+    }
+}
+
+//  ==================================================
 //  Delta Cryogenic Second Stage (DCSS) payload attach fitting (4 meters).
 
 //  Dimensions: 3.8 m x 1.1 m
@@ -1656,6 +2424,51 @@
         enableText = Enable Cross Feed
         disableText = Disable Cross Feed
     }
+}
+
+//  ==================================================
+//  Orion MPCV - DCSS adapter.
+
+//  Dimensions: 5.3 m x 1 m
+//  Inert Mass: 360 Kg
+//  ==================================================
+
+@PART[SLS_CM_stackDecouplerx30]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.405, 1.0, 1.405
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.52, 0.0, 0.0, -1.0, 0.0, 4
+    @node_stack_top = 0.0, 0.52, 0.0, 0.0, 1.0, 0.0, 4
+
+    @category = Structural
+    @title = Orion - DCSS Adapter
+    @manufacturer = Boeing Co.
+    @description = A structural adapter for mounting the Orion service module payload attach fitting to the Delta Cryogenic Second Stage (DCSS). Does not include a decoupler!
+
+    @mass = 0.36
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !explosionPotential = NULL
+    !fuelCrossFeed,* = NULL
+    %fuelCrossFeed = False
+    @bulkheadProfiles = size4
+    !stageOffset = NULL
+    !childStageOffset = NULL
+
+    !MODULE[ModuleDecouple],*{}
 }
 
 //  ==================================================


### PR DESCRIPTION
Add some brand new parts and do some tweaking. Final pass!

Change log:

* Improve the wording of some part descriptions.
* Add some trailing zeros to be consistent with the rest of the part configs.
* Add RO support for some new parts:
    * TT-38K radial decoupler
    * Common Berthing Mechanism (passive part).
    * Delta IV DCSS 4 interstage adapter.
    * Falcon 9 interstage adapter.
    * Habitation module structural adapter (small, medium and large sizes).
    * Retractable ladder.
    * Generic stack decouplers (2.5 m to 8.1 m).
    * Falcon 9 first stage engine mount.
    * Falcon 9 landing gear.
    * Procedural payload fairing base (expanded).
    * SLS Block I and IB interstage adapters.
    * DCSS - Orion MPCV structural adapter.

**Note 1:**  the radial decoupler is tagged as WIP-RO due to the fact that the part is a duplicate of a stock one. No attempt to "ROfy" it was made.
**Note 2:** the Common Berthing Mechanisms are currently not gendered and can work with the stock CBM. This might change in a future patch.
**Note 3:** the Falcon 9 "octaweb" has some issues regarding the correct attachment of the engines.
**Note 4:** the Delta IV DCSS 4 and the SLS Block I interstage adapters do not have the correct top diameter for their upper stages to fit correctly.