### PR TITLE
CMES Propulsion updates (part V)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -340,6 +340,111 @@
 
     !RESOURCE,*{}
 }
+
+//  ==================================================
+//  Advanced Booster.
+
+//  Dimensions: 3.71 m x 53.5 m
+//  Gross Mass: 793790 Kg
+//  ==================================================
+
+@PART[XKWsrbGlobeX5X]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 2.218, 3.4775, 2.218
+    }
+
+    @scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, -1.925, 0.0, 0.0, 0.0
+
+    @category = Engine
+
+    @mass = 84.79
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %bulkheadProfiles = srf
+
+    %engineType = ASRB
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 0
+        @maxThrust = 20337
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        &ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 266
+            @key,1 = 1 242
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 8.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAnimateEmissive],*{}
+
+    !MODULE[FXModuleAnimateThrottle],*{}
+
+    MODULE
+    {
+        name = FXModuleAnimateThrottle
+        animationName = SRBs
+        responseSpeed = 0.001
+        dependOnEngineState = True
+        dependOnThrottle = True
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 400565
+        basemass = -1
+
+        //  HTPB/AP propellant mixture mass 709000 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 400565
+            maxAmount = 400565
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
 //  ==================================================
 //  4 segment Reusable Solid Rocket Motor (RSRM).
 
@@ -501,6 +606,84 @@
         name = ModuleFuelTanks
         type = Cryogenic
         volume = 63000
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Falcon 9 second stage equipment bay.
+
+//  Dimensions: 3.66 m x 1 m
+//  Gross Mass: 140 Kg
+//  ==================================================
+
+@PART[NP_AMLVUPPER289Jx221]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.464, 0.5, 1.464
+        %rotation = 0.0, 0.0, 180.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_1 = 0.0, -3.0, 0.0, 0.0, -1.0, 0.0, 3
+
+    @category = FuelTank
+    @title = Falcon 9 Second Stage Equipment Bay
+    @manufacturer = SpaceX
+    @description = The engine mount structure and attitude control system propellant tanks for the Falcon 9 upper stage.
+
+    @mass = 0.115
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size2, size3
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 2850
+        //basemass = -1
+
+        //  Avionics batteries 360 Wh.
+        //  Supports the Falcon 9 core stage for the duration of it's flight (approximately 2 hours including passivation/deorbit operations).
+        //  Assumes that the power consumption of the avionics is 180 Watts.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 1300
+            maxAmount = 1300
+        }
+
+        //  ACS propellant gas mass ~25 Kg.
+
+        TANK
+        {
+            name = Nitrogen
+            amount = 20000
+            maxAmount = 20000
+        }
     }
 
     !RESOURCE,*{}
@@ -1362,6 +1545,193 @@
 
     !RESOURCE,*{}
 }
+
+//  ==================================================
+//  Falcon 9 First Stage propellant tank.
+
+//  Dimensions: 3.66 m x 39 m
+//  Gross Mass: 411000 Kg
+
+//  The inert mass value excludes the mass of the
+//  engine truss, the engines, the interstage and the
+//  landing struts.
+//  ==================================================
+
+@PART[xKW2mtankL0_5x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    MODEL
+    {
+        model = CMES/Propulsion/KW-AMLV-CORE/KW_Fuel_2mL2
+        scale = 1.83, 2.8, 1.83
+        position = 0.0, 18.025, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = CMES/Propulsion/KW-AMLV-CORE/KW_Fuel_2mL2
+        scale = 1.83, 2.8, 1.83
+        position = 0.0, 6.825, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    @MODEL
+    {
+        @scale = 1.83, 2.5, 1.83
+        %position = 0.0, 0.0, 0.0
+        %rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = CMES/Propulsion/KW-AMLV-CORE/KW_Fuel_2mL2
+        scale = 1.83, 3.25, 1.83
+        position = 0.0, -7.75, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 23.625, 0.0, 0.0, 1.0, 0.0, 4
+    @node_stack_bottom = 0.0, -14.25, 0.0, 0.0, -1.0, 0.0, 4
+    @node_attach = 0.0, 0.0, -2.825, 0.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = Falcon 9 First Stage Propellant Tank
+    @manufacturer = SpaceX
+    %description = The core stage propellant tank for the Falcon 9 launch vehicle.
+
+    @mass = 15.0
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size4
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    //  Tank fill ratio 95% (approximately).
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 387740
+        basemass = -1
+
+        //  Falcon 9 First Stage fuel mass ~118562 Kg.
+
+        TANK
+        {
+            name = Kerosene
+            amount = 144590
+            maxAmount = 144590
+        }
+
+        //  Falcon 9 First Stage oxidizer mass ~277436 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 243150
+            maxAmount = 243150
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Avionics batteries 33 Wh.
+    //  Supports the Falcon 9 core stage for the duration of it's flight (approximately 10 minutes including recovery).
+    //  Assumes that the power consumption of the avionics is 180 Watts.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 120
+        maxAmount = 120
+    }
+}
+
+//  ==================================================
+//  Falcon 9 Second Stage propellant tank.
+
+//  Dimensions: 3.66 m x 9 m
+//  Gross Mass: 89570 Kg
+//  ==================================================
+
+@PART[XNP_lftadj5x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 0.732, 3.0, 0.732
+    }
+
+    @node_stack_top = 0.0, 4.485, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -4.53, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 2.525, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = Falcon 9 Second Stage Propellant Tank
+    @manufacturer = SpaceX
+    %description = The upper stage propellant tank for the Falcon 9 launch vehicle.
+
+    @mass = 3.0
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size 3
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    //  Tank fill ratio 95% (approximately).
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 85000
+        basemass = -1
+
+        //  Falcon 9 Second Stage fuel mass ~25860 Kg.
+
+        TANK
+        {
+            name = Kerosene
+            amount = 31535
+            maxAmount = 31535
+        }
+
+        //  Falcon 9 Second Stage oxidizer mass ~61000 Kg.
+
+        TANK
+        {
+            name = LqdOxygen
+            amount = 53465
+            maxAmount = 53465
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
 //  ==================================================
 //  SuperDraco engine.
 
@@ -2126,70 +2496,6 @@
 
     !RESOURCE,*{}
 }
-//  ==================================================
-//  Delta IV Common Booster Core (CBC) LOX tank.
-
-//  Since tank domes are missing, we cheat the tank volume to include the propellant contained by them.
-
-//  Dimensions: 5.000 x 6.700 m
-//  Gross Mass: 177389.00 Kg
-//  Volume: 151183.17 L
-//  ==================================================
-
-    @PART[XNP_lft_?375?x3]:FOR[RealismOverhaul]
-    {
-        %RSSROConfig = true
-
-        @MODEL
-        {
-            @scale    = 1.000, 2.200, 1.000
-            %position = 0.000, 0.000, 0.000
-            %rotation = 0.000, 0.000, 0.000
-        }
-
-        !mesh          = NULL
-        @scale         = 1.000
-        @rescaleFactor = 1.000
-
-        @node_stack_top    = 0.000,  3.280, 0.000, 0.000,  1.000, 0.000, 3
-        @node_stack_bottom = 0.000, -3.280, 0.000, 0.000, -1.000, 0.000, 3
-        @node_attach       = 3.330,  0.000, 0.000, 1.000,  0.000, 0.000
-
-        @title        = Delta IV CBC LOX tank
-        @manufacturer = United Launch Alliance (ULA)
-        %description  = The cryogenic liquid oxygen tank for the Delta IV Common Booster Core (CBC).
-
-        @mass             = 4.8893
-        @crashTolerance   = 12
-        @breakingForce    = 250
-        @breakingTorque   = 250
-        @maxTemp          = 1073.15
-        %bulkheadProfiles = size3
-
-        MODULE
-        {
-            name     = ModuleFuelTanks
-            type     = Cryogenic
-            volume   = 151183.17
-            basemass = -1
-
-            TANK
-            {
-                name      = LqdOxygen
-                amount    = 151183.17
-                maxAmount = 151183.17
-            }
-        }
-
-        !MODULE[ModuleReactionWheel]{}
-
-        !MODULE[ModuleSAS]{}
-
-        !RESOURCE[LiquidFuel]{}
-
-        !RESOURCE[Oxidizer]{}
-
-    }
 
 //  ==================================================
 //  DCSS-4 LH2 tank.
@@ -2573,6 +2879,255 @@
 }
 
 //  ==================================================
+//  Large surface habitation module propellant tank.
+
+//  Dimensions: 7.5 m x 1.5 m
+//  Gross Mass: 1500 Kg
+//  ==================================================
+
+@PART[DUNARETROTANK]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.5, 0.5, 1.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 5
+
+    @category = FuelTank
+    @title = RL - I Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic pressurized propellant tank for surface habitation modules.
+
+    @mass = 1.5
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %bulkheadProfiles = size5
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 32000
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Merlin engine (surface version).
+
+//  Dimensions: 0.95 m x 2.0 m
+//  Inert Mass: 760 Kg
+//  ==================================================
+
+@PART[xmonkeyreptarx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.485, 0.0, 0.0, 1.0, 0.0, 2
+
+    @category = Engine
+
+    @mass = 0.76
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    @bulkheadProfiles = size2
+
+    %engineType = Merlin1
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 369.2
+        @maxThrust = 369.2
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3907
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6093
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 288.5
+            @key,1 = 1 253.7
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 5.0
+        @gimbalResponseSpeed = 16
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Merlin engine (surface version).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[xmonkeyreptarx]:AFTER[RealismOverhaulEngines]
+{
+    @description = The Merlin rocket engine family made by SpaceX. Surface variants.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = Merlin1A
+
+        !CONFIG,*:HAS[~name[Merlin1A],~name[Merlin1B],~name[Merlin1C],~name[Merlin1D],~name[Merlin1D+],~name[Merlin1D++]]{}
+    }
+}
+
+//  ==================================================
+//  Merlin engine (vacuum version).
+
+//  Dimensions: 2.5 m x 4.65 m
+//  Inert Mass: 910 Kg
+//  ==================================================
+
+@PART[xmonkeyreptarvacx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -2.7, 0.0, 0.0, -1.0, 0.0, 2
+
+    @category = Engine
+
+    @mass = 0.91
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    @bulkheadProfiles = size2
+
+    %engineType = Merlin1
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        @minThrust = 421.6
+        @maxThrust = 421.6
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3907
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6093
+            %DrawGauge = False
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 332.1
+            @key,1 = 1 195.5
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 5.0
+        @gimbalResponseSpeed = 16
+    }
+
+    @MODULE[FXModuleAnimateThrottle]
+    {
+        @animationName = M1DV_heat
+        @responseSpeed = 0.001
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Merlin engine (vacuum version).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[xmonkeyreptarvacx]:AFTER[RealismOverhaulEngines]
+{
+    @description = The Merlin rocket engine family made by SpaceX. Vacuum variants.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = Merlin1BVac
+
+        !CONFIG,*:HAS[~name[Merlin1BVac],~name[Merlin1CVac],~name[Merlin1DVac],~name[Merlin1DVac+]]{}
+    }
+}
+
+//  ==================================================
 //  Small radial propellant tank.
 
 //  Dimensions: 0.3 m x 0.8 m
@@ -2888,6 +3443,26 @@
 }
 
 //  ==================================================
+//  Space Launch System core booster.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[MonkeyCargoBoosterSLSADJ]:AFTER[RealismOverhaulEngines]
+{
+    @title = SLS Core Booster (Block I/IB/II)
+    @manufacturer = Boeing Co.
+    @description = The Space Launch System (SLS) core booster stage. Equipped with four RS-25E engines.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RS-25D/E
+
+        !CONFIG,*:HAS[~name[RS-25D/E]]{}
+    }
+}
+
+//  ==================================================
 //  Space Launch System Exploration Upper Stage (EUS).
 
 //  Dimensions: 8.4 m x 18.3 m
@@ -2996,5 +3571,49 @@
         name = ElectricCharge
         amount = 4500
         maxAmount = 4500
+    }
+}
+
+//  ==================================================
+//  Space Launch System Exploration Upper Stage (EUS).
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[TALUS]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.035
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.035
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.0075
+        }
     }
 }


### PR DESCRIPTION
Updates to the CMES propulsion parts. Final pass!

Change log:

* Remove the deprecated Delta IV CBC LOX part config. The tank model is now part of the CBC LH2 tank (welded).
* Add a missing global engine config patch to the SLS core booster,
* Add a missing RemoteTech patch to the Exploration Upper Stage (EUS).
* Add RO support for some brand new parts.
    * SLS "Dark Knight" Advanced Booster.
    * Falcon 9 first stage propellant tank.
    * Falcon 9 second stage propellant tank and equipment bay.
    * Large generic propellant tank for landers.
    * Merlin engines (surface and vacuum versions).