### PR TITLE
Squad fuel cells updates/fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -548,39 +548,80 @@
 	}
 }
 
-//fuel cells
-//Smithsonian exhibit: http://airandspace.si.edu/collections/artifact.cfm?object=nasm_A19730934000
-//"Normal power output for each power plant is 563 to 1420 watts, with a maximum of 2300 watts.
-// 111.8 x 55.9cm, 111.1kg (44 x 22 in., 245lb.)"
-// Lo and behold, this works out so that two cells' maximum amounts to three cell nominal.
-// I presume redundancy, that Apollo could still work on two cells; in that case, the max value isn't a
-// temporary peak load, but could be sustained.
-// Stock large fuel cell (6x array) is ~1.6/1m and 240kg, more than twice the apollo cells.
-// giving it not quite twice the apollo output, and the small cell 1/6th of that.
-// round numbers, because easier to work with in VAB.
+//  ==================================================
+//  Fuel Cells.
+
+//  Smithsonian exhibit: http://airandspace.si.edu/collections/artifact.cfm?object=nasm_A19730934000
+
+//  "Normal power output for each power plant is 563 to 1420 watts, with a maximum of 2300 watts.
+//  111.8 x 55.9cm, 111.1kg (44 x 22 in., 245lb.)"
+
+//  Lo and behold, this works out so that two cells' maximum amounts to three cell nominal.
+//  I presume redundancy, that Apollo could still work on two cells; in that case, the max value isn't a
+//  temporary peak load, but could be sustained.
+
+//  Stock large fuel cell (6x array) is ~1.6/1m and 240kg, more than twice the Apollo cells.
+//  giving it not quite twice the Apollo output, and the small cell 1/6th of that.
+//  round numbers, because easier to work with in VAB.
+//  ==================================================
 
 @PART[FuelCell]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@description = A 750W fuel cell. Consumes about 41 liters LH2 / 29 liters LOX per week. These figures were determined by ground tests and include boiloff, but actual hydrogen boiloff may be considerably higher depending on situation and the surface:volume ratio of your tanks.
-	!MODULE[ModuleResourceConverter]
+
+	@manufacturer = Generic
+	@description = A 750W fuel cell. Consumes about 41 liters of LH2 and 29 liters of LOX per week. These figures were determined by ground tests and include boil-off. The actual hydrogen boil-off rate may be considerably higher depending on the situation and the surface to volume ratio of your storage tanks.
+
+	@MODULE[ModuleResourceConverter]:NEEDS[!TacLifeSupport]
 	{
+		name = ModuleResourceConverter
+		ConverterName = Fuel Cell
+		StartActionName = Start Fuel Cell
+		StopActionName = Stop Fuel Cell
+		ToggleActionName = Toggle Fuel Cell
+		FillAmount = 0.95
+		AutoShutdown = False
+		GeneratesHeat = False
+		UseSpecialistBonus = False
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LqdHydrogen
+			Ratio = 0.0001010385
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LqdOxygen
+			Ratio = 0.00007169925
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.75
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00008895
+			DumpExcess = True
+		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Fuel Cell
 		StartActionName = Start Fuel Cell
 		StopActionName = Stop Fuel Cell
-		tag = Life Support
-		GeneratesHeat = False
-		UseSpecialistBonus = True
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ConverterSkill
-		EfficiencyBonus = 1
+		ToggleActionName = Toggle Fuel Cell
 		conversionRate = 0.75
+		tag = Power Production
+		GeneratesHeat = False
+		UseSpecialistBonus = False
 
 		INPUT_RESOURCE
 		{
@@ -591,20 +632,19 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = LqdOxygen
-			Ratio = 0.000095599 //1kW based on FASAGemini
+			Ratio = 0.000095599
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.0
 		}
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Water
 			Ratio = 0.0001186
-			DumpExcess = True
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
 			DumpExcess = True
 		}
 	}
@@ -613,25 +653,60 @@
 @PART[FuelCellArray]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@description = A 4.5kW fuel cell. Consumes about 245 liters LH2 / 175 liters LOX per week. These figures were determined by ground tests and include boiloff, but actual hydrogen boiloff may be considerably higher depending on situation and the surface:volume ratio of your tanks.
-	!MODULE[ModuleResourceConverter]
+
+	@manufacturer = Generic
+	@description = A 4.5kW fuel cell. Consumes about 245 liters of LH2 and 175 liters of LOX per week. These figures were determined by ground tests and include boil-off. The actual hydrogen boil-off rate may be considerably higher depending on the situation and the surface to volume ratio of your storage tanks.
+
+	@MODULE[ModuleResourceConverter]:NEEDS[!TacLifeSupport]
 	{
+		name = ModuleResourceConverter
+		ConverterName = Fuel Cell
+		StartActionName = Start Fuel Cell
+		StopActionName = Stop Fuel Cell
+		ToggleActionName = Toggle Fuel Cell
+		FillAmount = 0.95
+		AutoShutdown = False
+		GeneratesHeat = False
+		UseSpecialistBonus = False
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LqdHydrogen
+			Ratio = 0.000606231
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LqdOxygen
+			Ratio = 0.0004301955
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 4.5
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0005337
+			DumpExcess = True
+		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Fuel Cell
 		StartActionName = Start Fuel Cell
 		StopActionName = Stop Fuel Cell
-		tag = Life Support
-		GeneratesHeat = False
-		UseSpecialistBonus = True
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ConverterSkill
-		EfficiencyBonus = 1
+		ToggleActionName = Toggle Fuel Cell
 		conversionRate = 4.5
+		tag = Power Production
+		GeneratesHeat = False
+		UseSpecialistBonus = False
 
 		INPUT_RESOURCE
 		{
@@ -642,7 +717,14 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = LqdOxygen
-			Ratio = 0.000095599 //1kW based on FASAGemini
+			Ratio = 0.000095599
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.0
+			DumpExcess = True
 		}
 
 		OUTPUT_RESOURCE
@@ -651,17 +733,13 @@
 			Ratio = 0.0001186
 			DumpExcess = True
 		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
-			DumpExcess = True
-		}
 	}
 }
 
-// Service bays
+//  ==================================================
+//  Service bays
+//  ==================================================
+
 @PART[ServiceBay_125]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -683,6 +761,7 @@
 	%emissiveConstant = 0.2
 	!MODULE[ModuleConductionMultiplier] {}
 }
+
 @PART[ServiceBay_250]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
Update the Squad fuel cells for KSP 1.2.

Change log:

* Add a "Generic" manufacturer.
* Small edits to the part descriptions.
* Fuel cells can now operate without the hard dependency of TACLS. If TACLS is installed then they will use it's conversion module though.