### PR TITLE
MMH/MON3 TestFlight tech transfer

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -868,7 +868,7 @@
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.999
 		reliabilityDataRateMultiplier = 0.1
-		techTransfer = NitrousOxide,HTP,Hydrazine,Cavea-B,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
+		techTransfer = NitrousOxide,HTP,Hydrazine,Cavea-B,MMH+NTO,MMH+MON3,UDMH+NTO,Aerozine50+NTO:50
 	}
 
 	TESTFLIGHT
@@ -882,7 +882,7 @@
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.999
 		reliabilityDataRateMultiplier = 0.1
-		techTransfer = Helium,Nitrogen,MMH+NTO,UDMH+NTO,Aerozine50+NTO:50
+		techTransfer = Helium,Nitrogen,MMH+NTO,MMH+MON3,UDMH+NTO,Aerozine50+NTO:50
 	}
 
 	TESTFLIGHT


### PR DESCRIPTION
Updates to the RO RCS TestFlight configs.

Change log:

* Add the MMH/MON3 bipropellant option to the TestFlight tech transfer list. No tech transfer from other options would be valid if that combination was used.