### PR TITLE
RS-68 gimbals in global config, fix for CMES

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -33,12 +33,12 @@
         %EngineType = LiquidFuel
     }
 
-    //@MODULE[ModuleGimbal]
-    //{
-    //    @gimbalRange = 6.0
-    //    %useGimbalResponseSpeed = True
-    //    %gimbalResponseSpeed = 16
-    //}
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 6.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
 
     MODULE
     {

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -35,7 +35,7 @@
 
     @MODULE[ModuleGimbal]
     {
-        @gimbalRange = 6.0
+        %gimbalRange = 6.0 //guess based on http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf, which is re: RS-68B for Ares 5
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -26,8 +26,8 @@
 {
     %title = RS-68 Series
     %manufacturer = Aerojet Rocketdyne
-	%description = 1990s Medium TWR atmospheric engine. Using technology developed for the Space Shuttle SSME, the RS-68 is a single-use engine, featuring a simplified design with less parts and an easier construction. The RS-68 powers the Delta IV launch vehicle family and is the most powerful LH2/LOX engine ever flown. Exhaust from the gas generator is used for roll control. Diameter: [2.43 m].
-	
+    %description = 1990s Medium TWR atmospheric engine. Using technology developed for the Space Shuttle SSME, the RS-68 is a single-use engine, featuring a simplified design with less parts and an easier construction. The RS-68 powers the Delta IV launch vehicle family and is the most powerful LH2/LOX engine ever flown. Exhaust from the gas generator is used for roll control. Diameter: [2.43 m].
+    
     @MODULE[ModuleEngines*]
     {
         %EngineType = LiquidFuel
@@ -119,8 +119,8 @@
                 key = 0 412
                 key = 1 362
             }
-			cost = 500 // Cite?
-			techRequired = hydroloxTL7
+            cost = 500 // Cite?
+            techRequired = hydroloxTL7
         }
     }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
@@ -287,12 +287,6 @@
 		useGimbalResponseSpeed = true
 		gimbalResponseSpeed = 16
 	}
-	@MODULE[ModuleGimbal]
-	{
-		%gimbalRange = 6 //guess based on http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf, which is re: RS-68B for Ares 5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
 	engineType = RS68
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-68.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-68.cfg
@@ -19,8 +19,8 @@
 	}
 	@MODULE[ModuleGimbal],1
 	{
-		@gimbalRangeYP = 24
-		@gimbalRangeYN = 24
+		@gimbalRangeYP = 26
+		@gimbalRangeYN = 26
 	}
 	@MODULE[SSTUModularEngineCluster]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-68.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RS-68.cfg
@@ -19,7 +19,8 @@
 	}
 	@MODULE[ModuleGimbal],1
 	{
-		@gimbalRange = 6
+		@gimbalRangeYP = 24
+		@gimbalRangeYN = 24
 	}
 	@MODULE[SSTUModularEngineCluster]
 	{


### PR DESCRIPTION
Put the main gimbal in the global config, seems to work ok. RS-68s with the gas gen modelled need to set their specific verniers.

@PhineasFreak separate issue, but i noticed the CMES RS-68 doesn't attach inside the engine shroud, is there a missing attach node?