### PR TITLE
BNTR global engine config updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
@@ -1,10 +1,10 @@
 //  ==================================================
-//  Bimodal NTR global engine configuration.
+//  "Bimodal" NTR global engine configuration.
 
-//  Inert Mass: 2170 Kg (base configuration)
+//  Inert Mass: 2270 Kg
 //  Throttle Range: N/A
 //  Burn Time: 5400 s
-//  O/F Ratio: 0 (SNRE), 3.0 (TRITON)
+//  O/F Ratio: 0 (BNTR), 3.0 (TRITON)
 
 //  Sources:
 
@@ -16,6 +16,7 @@
 
 //      BahamutoD Constellation Essentials
 //      CMES
+//      SXT
 //  ==================================================
 
 @PART[*]:HAS[#engineType[BNTR]]:FOR[RealismOverhaulEngines]
@@ -23,7 +24,7 @@
     %category = Engine
     %title = Bimodal NTR
     %manufacturer = Aerojet Rocketdyne
-    %description = Low thrust pump-fed expander nuclear engine. Evolved for the original NERVA design the BNTR, instead of wasting precious propellant mass for cooling the engine reactor, uses a power generator unit to convert the waste thermal energy into electrical power. Supports liquid Oxygen injection for increased thrust but with lower efficiency.
+    %description = Low thrust pump-fed expander nuclear engine. Evolved for the original NERVA design the Bimodal NTR, instead of wasting precious propellant mass for cooling the engine reactor, uses a Brayton cycle electricity generator unit to convert the waste thermal energy into useful electrical power. It also supports liquid oxygen injection (TRITON - trimodal operation) for increased thrust but with the cost of a lower overall efficiency.
 
     @MODULE[ModuleEngines*]
     {
@@ -39,23 +40,27 @@
 
     !MODULE[ModuleEngineConfigs],*{}
 
+    !MODULE[ModuleHybridEngine],*{}
+
     MODULE
     {
-        name = ModuleEngineConfigs
+        name = ModuleHybridEngine
         type = ModuleEngines
-        configuration = SNRE
+        configuration = BNTR
         modded = False
-        origMass = 2.17
+        origMass = 2.215
 
         CONFIG
         {
-            name = SNRE
-            minThrust = 111.2
-            maxThrust = 111.2
+            name = BNTR
+            minThrust = 66.72
+            maxThrust = 66.72
             massMult = 1.0
+            throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
             ullage = True
             pressureFed = False
-            ignitions = 10
+            ignitions = 60
 
             IGNITOR_RESOURCE
             {
@@ -73,14 +78,14 @@
             PROPELLANT
             {
                 name = EnrichedUranium
-                ratio = 0.0000000001
+                ratio = 1.0813e-15
                 DrawGauge = False
                 ignoreForIsp = True
             }
 
             atmosphereCurve
             {
-                key = 0 925
+                key = 0 930
                 key = 1 380
             }
         }
@@ -88,12 +93,14 @@
         CONFIG
         {
             name = TRITON
-            minThrust = 271.2
-            maxThrust = 271.2
-            massMult = 1.1
+            minThrust = 182.37
+            maxThrust = 182.37
+            massMult = 1.0
+            throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
             ullage = True
             pressureFed = False
-            ignitions = 10
+            ignitions = 60
 
             IGNITOR_RESOURCE
             {
@@ -104,34 +111,69 @@
             PROPELLANT
             {
                 name = LqdHydrogen
-                ratio = 0.8429
+                ratio = 0.8430
                 DrawGauge = True
             }
 
             PROPELLANT
             {
                 name = LqdOxygen
-                ratio = 0.1571
+                ratio = 0.1570
                 DrawGauge = False
             }
 
             PROPELLANT
             {
                 name = EnrichedUranium
-                ratio = 0.0000000001
+                ratio = 1.0813e-15
                 DrawGauge = False
                 ignoreForIsp = True
             }
 
             atmosphereCurve
             {
-                key = 0 642
+                key = 0 645
                 key = 1 390
             }
         }
     }
 
     !MODULE[ModuleAlternator],*{}
+
+    !MODULE[ModuleResourceConverter],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Brayton Generator
+        StartActionName = Start Brayton Generator
+        StopActionName = Stop Brayton Generator
+        AlwaysActive = False
+        FillAmount = 1.0
+        AutoShutdown = False
+        GeneratesHeat = True
+        TemperatureModifier = 2.0
+        UseSpecializationBonus = False
+        DefaultShutoffTemp = 0.75
+
+        INPUT_RESOURCE
+        {
+            ResourceName = EnrichedUranium
+            Ratio = 1.0813e-15
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 25.0
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedUranium
+            Ratio = 1.0813e-15
+        }
+    }
 
     !RESOURCE,*{}
 
@@ -140,6 +182,7 @@
         name = EnrichedUranium
         amount = 5
         maxAmount = 5
+        isTweakable = False
     }
 
     RESOURCE
@@ -147,5 +190,6 @@
         name = DepletedUranium
         amount = 0
         maxAmount = 5
+        isTweakable = False
     }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
@@ -134,4 +134,18 @@
     !MODULE[ModuleAlternator],*{}
 
     !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = EnrichedUranium
+        amount = 5
+        maxAmount = 5
+    }
+
+    RESOURCE
+    {
+        name = DepletedUranium
+        amount = 0
+        maxAmount = 5
+    }
 }


### PR DESCRIPTION
Change log:

* Improve the part description.
* Re-evaluate the thrust and mass values for each operating mode.
* Replace the ModuleEngineConfigs with ModuleHybridEngine to make it
possible to switch between the bimodal and trimodal modes in flight.
* Increase the amount of ignitions (no reason to keep it low).
* Add spool-up time to the trimodal mode.
* Change the requested Uranium ratio to be 1/lambda (lambda = 703800000
years).
* Add a generator module (Brayton converter).
* Add the required resources for operation to the global engine config itself instead of relying on the standard RO part config. This also fixes the missing resources from the BahamutoD Constellation Essentials BNTR engine.
* Disable the above nuclear fuel resources from being tweakable.