### PR TITLE
Generic PF updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -1,110 +1,150 @@
+//  ==================================================
+//  Procedural Fairings fairing sides.
+//  ==================================================
+
 @PART[KzProcFairingSide1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%title = Payload Fairing - Egg-Shaped [Procedural]
-	%thermalMassModifier = 2.0 // avoid borkings
+
+	@title = Payload Fairing - Egg-Shaped [Procedural]
+	@manufacturer = Generic
 }
+
 @PART[KzProcFairingSide2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%title = Payload Fairing - Conic [Procedural]
-	%thermalMassModifier = 2.0 // avoid borkings
+
+	@title = Payload Fairing - Conic [Procedural]
+	@manufacturer = Generic
 }
+
+//  ==================================================
+//  Create new PF sides for RO.
+//  ==================================================
+
 +PART[KzProcFairingSide1]:AFTER[RealismOverhaul]
 {
 	@name = KzProcFairingSide1st
+
 	@MODEL
 	{
 		texture = fairing1, RealismOverhaul/RO_RecommendedMods/Procedurals/Textures/fairingst
 	}
+
 	@title = Payload Fairing - Egg-Shaped (ST) [Procedural]
+	@manufacturer = Generic
 }
+
 +PART[KzProcFairingSide1]:AFTER[RealismOverhaul]
 {
 	@name = KzProcFairingSide1stock
+
 	@MODEL
 	{
 		texture = fairing1, RealismOverhaul/RO_RecommendedMods/Procedurals/Textures/fairingstock
 	}
+
 	@title = Payload Fairing - Egg-Shaped (Stock) [Procedural]
+	@manufacturer = Generic
 }
+
 +PART[KzProcFairingSide1]:AFTER[RealismOverhaul]
 {
 	@name = KzProcFairingSide1us
+
 	@MODEL
 	{
 		texture = fairing1, RealismOverhaul/RO_RecommendedMods/Procedurals/Textures/fairingus
 	}
+
 	@title = Payload Fairing - Egg-Shaped (US) [Procedural]
+	@manufacturer = Generic
 }
+
 +PART[KzProcFairingSide2]:AFTER[RealismOverhaul]
 {
 	@name = KzProcFairingSide2ger
+
 	@MODEL
 	{
 		texture = fairing1, RealismOverhaul/RO_RecommendedMods/Procedurals/Textures/fairingger
 	}
+
 	@title = Payload Fairing - Conic (German) [Procedural]
+	@manufacturer = Generic
 }
-@PART[*]:HAS[@MODULE[ProceduralFairingSide]]:BEFORE[RealismOverhaul]
+
+//  ==================================================
+//  PF generic patcher:
+
+//  * Set the correct part category for both the PF
+//    bases/interstages and the PF sides.
+//  * Increase the thermal mass of the sides to make
+//    them more robust.
+//  * Remove any heat shield modules and resources
+//    (breaks the mass and cost calculations).
+//  * Remove the aero shielding module from the
+//    bases/interstages (taken care by FAR).
+//  * Disable the auto-strutting of the bases/interstages
+//    due to a PF bug.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ProceduralFairing*]]:AFTER[RealismOverhaul]
 {
-	// @skinInternalConductionMult *= 0.2 // DRE multiplies by 5, leaving it for now.
-	!MODULE[ModuleHeatShield]
+	@category = Payload
+
+	%thermalMassModifier = 2.0
+
+	!MODULE[ModuleHeatShield],*{}
+
+	!MODULE[ModuleAblator],*{}
+
+	!MODULE[KzFairingBaseShielding],*{}
+
+	@MODULE[ProceduralFairingBase],*
 	{
+		%autoStrutSides = False
 	}
-	!MODULE[ModuleAblator]
-	{
-	}
-	!RESOURCE[AblativeShielding]
-	{
-	}
-	!RESOURCE[Ablator]
-	{
-	}
-	%thermalMassModifier = 2.0 // avoid borkings
+
+	!RESOURCE,*{}
 }
+
 @PART[KzResizableFairingBase]:FOR[StockRealismPLUS]
 {
 	%title = Payload Fairing - Base (Extended) [Procedural]
 }
+
 @PART[KzResizableFairingBaseRing]:FOR[StockRealismPLUS]
 {
 	%title = Payload Fairing - Base [Procedural]
 }
+
 @PART[KzResizableFairingBase*]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+
 	@MODULE[KzFairingBaseResizer]
 	{
 		%size = 3.0
 		%diameterStepLarge = 1.0
 		%diameterStepSmall = 0.1
 	}
+
 	%MODULE[ModuleDecouple]:NEEDS[!zPFFE]
 	{
 		%name = ModuleDecouple
 		%ejectionForce = 0
 		%explosiveNodeID = top
 	}
-	%thermalMassModifier = 2.0 // avoid borkings
-	
-	!MODULE[ModuleHeatShield]
-	{
-	}
-	!MODULE[ModuleAblator]
-	{
-	}
-	!RESOURCE[AblativeShielding]
-	{
-	}
-	!RESOURCE[Ablator]
-	{
-	}
 }
+
 @PART[KzInterstageAdapter2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%title = Interstage - w/ Decoupler [Procedural]
+
+	@title = Interstage - w/ Decoupler [Procedural]
+	@manufacturer = Generic
+
 	@MODULE[ProceduralFairingAdapter]
 	{
 		%baseSize = 3.0
@@ -112,25 +152,15 @@
 		%diameterStepLarge = 1.0
 		%diameterStepSmall = 0.1
 	}
-	%thermalMassModifier = 2.0 // avoid borkings
-	
-	!MODULE[ModuleHeatShield]
-	{
-	}
-	!MODULE[ModuleAblator]
-	{
-	}
-	!RESOURCE[AblativeShielding]
-	{
-	}
-	!RESOURCE[Ablator]
-	{
-	}
 }
+
 +PART[KzInterstageAdapter2]:AFTER[RealismOverhaul]
 {
 	@name = KzFlatAdapter
+
 	@title = Interstage Fairing Adapter (Flat)
+	@manufacturer = Generic
+
 	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top    = 0.0, 0.05, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_top1   = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 2
@@ -142,68 +172,90 @@
 	@node_stack_connect06 =  0.0, 0.025,  0.5, 0.0, 1.0, 0.0, 0
 	@node_stack_connect07 =  0.5, 0.025,  0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_connect08 =  0.0, 0.025, -0.5, 0.0, 1.0, 0.0, 0
+
 	@MODEL
 	{
 		@scale = 1.0, 0.25, 1.0
 		!texture = DELETE
 	}
+
 	@MODULE[ProceduralFairingAdapter]
 	{
 		%specificMass = 0.0002, 0.01, 0.005, 0
 	}
 }
+
+//  ==================================================
+//  Procedural Fairings fuselage sides.
+//  ==================================================
+
 @PART[KzProcFairingFuselage1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%title = Interstage Fairing - Egg-Shaped [Procedural]
-	%thermalMassModifier = 2.0 // avoid borkings
+
+	@title = Interstage Fairing - Egg-Shaped [Procedural]
+	@manufacturer = Generic
 }
+
 @PART[KzProcFairingFuselage2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%title = Interstage Fairing - Conic [Procedural]
-	%thermalMassModifier = 2.0 // avoid borkings
+
+	@title = Interstage Fairing - Conic [Procedural]
+	@manufacturer = Generic
 }
+
+//  ==================================================
+//  Procedural Fairings thrust plates.
+//  ==================================================
+
 @PART[KzThrustPlate]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%title = Thrust Plate [Procedural]
+
+	@title = Thrust Plate [Procedural]
+	@manufacturer = Generic
+
 	@maxTemp = 2073.15
+
 	@MODULE[KzThrustPlateResizer]
 	{
 		%size = 1.0
 		%diameterStepLarge = 1.0
 		%diameterStepSmall = 0.1
 	}
+
 	@MODULE[KzNodeNumberTweaker]
 	{
 		%radiusStepLarge = 1.0
 		%radiusStepSmall = 0.1
 	}
-	%thermalMassModifier = 2.0 // avoid borkings
-	
-	!MODULE[ModuleHeatShield]
-	{
-	}
-	!MODULE[ModuleAblator]
-	{
-	}
-	!RESOURCE[AblativeShielding]
-	{
-	}
-	!RESOURCE[Ablator]
-	{
-	}
+
+	%thermalMassModifier = 2.0
+
+	!MODULE[ModuleHeatShield],*{}
+
+	!MODULE[ModuleAblator],*{}
+
+	!RESOURCE,*{}
 }
+
 @PART[KXProcFairing]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 }
+
 @PART[ProcPayloadDec]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 }
-@PART[*]:HAS[@MODULE[ProceduralFairingSide],!MODULE[ModuleToggleCrossfeed]]:AFTER[RealismOverhaul]
+
+//  ==================================================
+//  Enable propellant cross feed for the PF fairings,
+//  fuselages and bases/interstages.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ProceduralFairing*],!MODULE[ModuleToggleCrossfeed]]:AFTER[RealismOverhaul]
 {
 	MODULE
 	{
@@ -214,9 +266,12 @@
 	}
 }
 
+//  ==================================================
+//  CLS-enabled interstage.
 
-// CLS-enabled interstage
-// Use FL-A5 based part from PFFE
+//  Use the FL-A5 part from PFFE.
+//  ==================================================
+
 @PART[squad_interstage_adapter]:AFTER[zPFFE]
 {
 	@title = Interstage Adapter (Passable)
@@ -226,7 +281,8 @@
 	{
 		%specificMass = 0.001, 0.033, 0.022, 0
 	}
-	 MODULE
+
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true


### PR DESCRIPTION
Various updates and fixes for the Procedural Fairings RO compatibility.

Change log:

* Merge all possible global PF modifiers to a single pass.
* Add a "generic" manufacturer.
* Add back a patch to remove the PF auto struts (see https://github.com/KSP-RO/RealismOverhaul/issues/1494 for more information).
* Add some white space for better readability.