### PR TITLE
Remove the old FAR Aero Data patch

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_FAR.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_FAR.cfg
@@ -1,4 +1,0 @@
-@FARAeroData
-{
-	@attachNodeDiameterFactor = 1.0
-}


### PR DESCRIPTION
Not needed since FAR does not check for attachment node sizes now (uses voxels to find the exposed craft surfaces).

* Config cleanup: https://github.com/ferram4/Ferram-Aerospace-Research/commit/4fd2c65abfab4be7b59c9025db8ca13c01926d84
* Code cleanup: https://github.com/ferram4/Ferram-Aerospace-Research/commit/0828e5ac5edd926cbb0408f10594fb6401613f92#diff-5a11c5f12e26965100e9d7930d2709c3