### PR TITLE
RD-701 & RD-704 updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD701.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD701.cfg
@@ -36,17 +36,19 @@
 
     !MODULE[ModuleEngineConfigs],*{}
 
+    !MODULE[ModuleHybridEngine],*{}
+
     MODULE
     {
-        name = ModuleEngineConfigs
+        name = ModuleHybridEngine
         type = ModuleEngines
-        configuration = RD-701
+        configuration = Mode#1
         origMass = 4.42
         modded = False
 
         CONFIG
         {
-            name = RD-701
+            name = Mode#1
             minThrust = 1588
             maxThrust = 4004
             heatProduction = 100
@@ -95,6 +97,45 @@
                 key = 1 330
             }
         }
+
+        CONFIG
+        {
+            name = Mode#2
+            minThrust = 1588
+            maxThrust = 1588
+            heatProduction = 100
+            massMult = 1.0
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.7252
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2748
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 460
+                key = 1 250
+            }
+        }
     }
 
     @MODULE[ModuleGimbal]
@@ -111,5 +152,6 @@
         name = TEATEB
         amount = 1.0
         maxAmount = 1.0
+        isTweakable = False
     }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD704.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD704.cfg
@@ -22,10 +22,10 @@
 
 @PART[*]:HAS[#engineType[RD704]]:FOR[RealismOverhaulEngines]
 {
-    @category = Engine
-    @title = RD-704
-    @manufacturer = NPO Energomash [Glushko]
-    @description = A staged combustion tripropellant liquid fuel engine using Kerosene, liquid Hydrogen and liquid Oxygen. This is the single chamber version of the RD-701, originally developed for the MAKS space plane. In the booster phase of the ascent it uses a mixture of Kerosene with liquid Hydrogen and it switches to pure Hydrogen for the sustainer phase.
+    %category = Engine
+    %title = RD-704
+    %manufacturer = NPO Energomash [Glushko]
+    %description = A staged combustion tripropellant liquid fuel engine using Kerosene, liquid Hydrogen and liquid Oxygen. This is the single chamber version of the RD-701, originally developed for the MAKS space plane. In the booster phase of the ascent it uses a mixture of Kerosene with liquid Hydrogen and it switches to pure Hydrogen for the sustainer phase.
     @tags ^= :$: booster energomash throttle tripropellant upper
 
     @MODULE[ModuleEngines*]
@@ -37,17 +37,19 @@
 
     !MODULE[ModuleEngineConfigs],*{}
 
+    !MODULE[ModuleHybridEngine],*{}
+
     MODULE
     {
-        name = ModuleEngineConfigs
+        name = ModuleHybridEngine
         type = ModuleEngines
-        configuration = RD-704
+        configuration = Mode#1
         origMass = 2.42
         modded = False
 
         CONFIG
         {
-            name = RD-704
+            name = Mode#1
             minThrust = 785
             maxThrust = 2002
             heatProduction = 100
@@ -96,6 +98,45 @@
                 key = 1 356
             }
         }
+
+        CONFIG
+        {
+            name = Mode#2
+            minThrust = 785
+            maxThrust = 785
+            heatProduction = 100
+            massMult = 1.0
+
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.7252
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2748
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 460
+                key = 1 250
+            }
+        }
     }
 
     @MODULE[ModuleGimbal]
@@ -112,5 +153,6 @@
         name = TEATEB
         amount = 1.0
         maxAmount = 1.0
+        isTweakable = False
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
@@ -236,17 +236,9 @@
     %massOffset = 0
     %ignoreMass = False
 
-    MODULE
-    {
-        name = MultiModeEngine
-        primaryEngineID = Mode#1
-        secondaryEngineID = Mode#2
-    }
-
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
-        %engineID = Mode#1
         @minThrust = 1588
         @maxThrust = 4004
         @heatProduction = 100
@@ -278,41 +270,6 @@
         {
             @key,0 = 0 415
             @key,1 = 1 330
-        }
-    }
-
-    MODULE
-    {
-        name = ModuleEnginesRF
-        engineID = Mode#2
-        thrustVectorTransformName = thrustTransform
-        exhaustDamage = True
-        ignitionThreshold = 0.1
-        minThrust = 1588
-        maxThrust = 1588
-        heatProduction = 100
-        ullage = True
-        pressureFed = False
-        ignitions = 1
-
-        PROPELLANT
-        {
-            name = LqdHydrogen
-            ratio = 0.7252
-            DrawGauge = True
-        }
-
-        PROPELLANT
-        {
-            name = LqdOxygen
-            ratio = 0.2748
-            DrawGauge = False
-        }
-
-        atmosphereCurve
-        {
-            key = 0 460
-            key = 1 250
         }
     }
 
@@ -368,17 +325,9 @@
     %massOffset = 0
     %ignoreMass = False
 
-    MODULE
-    {
-        name = MultiModeEngine
-        primaryEngineID = Mode#1
-        secondaryEngineID = Mode#2
-    }
-
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
-        %engineID = Mode#1
         @minThrust = 785
         @maxThrust = 2002
         @heatProduction = 100
@@ -410,41 +359,6 @@
         {
             @key,0 = 0 407
             @key,1 = 1 356
-        }
-    }
-
-    MODULE
-    {
-        name = ModuleEnginesRF
-        engineID = Mode#2
-        thrustVectorTransformName = thrustTransform
-        exhaustDamage = True
-        ignitionThreshold = 0.1
-        minThrust = 785
-        maxThrust = 785
-        heatProduction = 100
-        ullage = True
-        pressureFed = False
-        ignitions = 1
-
-        PROPELLANT
-        {
-            name = LqdHydrogen
-            ratio = 0.7252
-            DrawGauge = True
-        }
-
-        PROPELLANT
-        {
-            name = LqdOxygen
-            ratio = 0.2748
-            DrawGauge = False
-        }
-
-        atmosphereCurve
-        {
-            key = 0 460
-            key = 1 250
         }
     }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD701.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD701.cfg
@@ -11,10 +11,10 @@
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
-        speed = 1.0
+        speed = 0.75
         emissionMult = 0.5
-        plumePosition = 0.0, 0.0, 1.75
-        plumeScale = 1.0
+        plumePosition = 0.0, 0.0, 1.5
+        plumeScale = 0.95
         flarePosition = 0.0, 0.0, 1.25
         flareScale = 1.125
     }
@@ -26,33 +26,60 @@
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
-        speed = 1.0
+        speed = 1.25
         emissionMult = 0.5
         plumePosition = 0.0, 0.0, 2.75
         plumeScale = 1.5
-        flarePosition = 0.0, 0.0, 1.75
-        flareScale = 1.5
+        flarePosition = 0.0, 0.0, 1.5
+        flareScale = 1.3
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[Mode#1]]
+    @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
         !runningEffectName = NULL
         !fxOffset = NULL
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[Mode#2]]
+    @MODULE[ModuleHybridEngine]
     {
-        %powerEffectName = Hydrolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngineConfigs]
-    {
-        @CONFIG,*
+        @CONFIG[Mode#1]
         {
             %powerEffectName = Kerolox-Lower
+        }
+
+        @CONFIG[Mode#2]
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}
+
+//  ==================================================
+//  RD-701 engine plume configuration.
+//  ==================================================
+
+@PART[RD701]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[plumeboundary]
+            {
+                @localPosition = 0.0, 0.0, -1.75
+            }
+        }
+    }
+
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[shockcone]
+            {
+                @localPosition = 0.0, 0.0, 2.0
+            }
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD704.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD704.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  RD-704 engine plume configuration.
+//  RD-704 engine plume setup.
 //  ==================================================
 
 @PART[RD704]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -11,10 +11,10 @@
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
-        speed = 1.0
+        speed = 0.75
         emissionMult = 0.5
-        plumePosition = 0.0, 0.0, 1.75
-        plumeScale = 1.0
+        plumePosition = 0.0, 0.0, 1.5
+        plumeScale = 0.95
         flarePosition = 0.0, 0.0, 1.25
         flareScale = 1.125
     }
@@ -26,33 +26,60 @@
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
-        speed = 1.0
+        speed = 1.25
         emissionMult = 0.5
         plumePosition = 0.0, 0.0, 2.75
         plumeScale = 1.5
-        flarePosition = 0.0, 0.0, 1.75
-        flareScale = 1.5
+        flarePosition = 0.0, 0.0, 1.5
+        flareScale = 1.3
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[Mode#1]]
+    @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
         !runningEffectName = NULL
         !fxOffset = NULL
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[Mode#2]]
+    @MODULE[ModuleHybridEngine]
     {
-        %powerEffectName = Hydrolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngineConfigs]
-    {
-        @CONFIG,*
+        @CONFIG[Mode#1]
         {
             %powerEffectName = Kerolox-Lower
+        }
+
+        @CONFIG[Mode#2]
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}
+
+//  ==================================================
+//  RD-704 engine plume configuration.
+//  ==================================================
+
+@PART[RD704]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[plumeboundary]
+            {
+                @localPosition = 0.0, 0.0, -1.75
+            }
+        }
+    }
+
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[shockcone]
+            {
+                @localPosition = 0.0, 0.0, 2.0
+            }
         }
     }
 }


### PR DESCRIPTION
Updates for the BobCat Soviet Engines RD-701 and RD-704.

Change log:

* Implement ModuleHybridEngines instead of the stock MultiModeEngine for better compatibility with RF.
* Change the patching of the editor parameters (title, manufacturer, description) to use the "%" MM modifier instead of the "@" (covers parts that may be missing these fields entirely).
* Disable the TEATEB ignitor resource from being tweakable by the user (no reason to change the carried amount).