### PR TITLE
Fix FASA Explorer SRB Global config error

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Explorer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Explorer.cfg
@@ -110,6 +110,8 @@
 		basemass = -1
 		type = PSPC
 	}
+	
+	engineType = BabySergeant
 }
 
 //  ==================================================
@@ -194,6 +196,9 @@
 		basemass = -1
 		type = PSPC
 	}
+	
+	engineType = BabySergeant
+	engineTypeMult = 3
 }
 
 //  ==================================================
@@ -290,6 +295,9 @@
 		basemass = -1
 		type = PSPC
 	}
+	
+	engineType = BabySergeant
+	engineTypeMult = 11
 }
 
 //  ==================================================


### PR DESCRIPTION
The parts were not tagged with the global engine config, and so they were staying as stock.

Tested in game, KSP 1.2.2