### PR TITLE
CMES BNTR & RS-68 mount

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2093,7 +2093,7 @@
 //  Bimodal Nuclear Thermal Rocket (BNTR).
 
 //  Dimensions: 1.56 m x 3.24 m
-//  Gross Mass: 2220 Kg
+//  Gross Mass: 2270 Kg
 //  ==================================================
 
 @PART[nervaII_kerbscalexx]:FOR[RealismOverhaul]
@@ -2115,7 +2115,7 @@
 
     @category = Engine
 
-    @mass = 2.17
+    @mass = 2.215
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -2138,12 +2138,12 @@
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
-        @minThrust = 111.2
-        @maxThrust = 111.2
+        @minThrust = 66.72
+        @maxThrust = 66.72
         @heatProduction = 100
         %ullage = True
         %pressureFed = False
-        %ignitions = 10
+        %ignitions = 60
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2154,70 +2154,20 @@
         @PROPELLANT[Oxidizer]
         {
             @name = EnrichedUranium
-            @ratio = 1.6428e-17
+            @ratio = 1.0813e-15
+            %ignoreForIsp = True
         }
 
         @atmosphereCurve
         {
-            @key,0 = 0 925
+            @key,0 = 0 930
             @key,1 = 1 380
         }
     }
 
     !MODULE[ModuleGenerator],*{}
 
-    !MODULE[ModuleResourceConverter],*{}
-
-    MODULE
-    {
-        name = ModuleResourceConverter
-        ConverterName = RTG
-        StartActionName = Start RTG
-        StopActionName = Stop RTG
-        AlwaysActive = True
-        FillAmount = 1.0
-        AutoShutdown = False
-        GeneratesHeat = True
-        TemperatureModifier = 2.0
-        UseSpecializationBonus = False
-        DefaultShutoffTemp = 0.5
-
-        INPUT_RESOURCE
-        {
-            ResourceName = EnrichedUranium
-            Ratio = 1.6428e-17
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = ElectricCharge
-            Ratio = 5.0
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = DepletedUranium
-            Ratio = 1.6428e-17
-        }
-    }
-
     !RESOURCE,*{}
-
-    //  Uranium-235 pellets mass ~55 Kg.
-
-    RESOURCE
-    {
-        name = EnrichedUranium
-        amount = 5
-        maxAmount = 5
-    }
-
-    RESOURCE
-    {
-        name = DepletedUranium
-        amount = 0
-        maxAmount = 5
-    }
 }
 
 //  ==================================================
@@ -2746,6 +2696,7 @@
 
     @node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 4
     @node_stack_bottom = 0.0, -2.05, 0.0, 0.0, -1.0, 0.0, 2
+    %node_stack_engine = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @category = Structural
     @title = Delta IV CBC Engine Mount


### PR DESCRIPTION
Change log:

* Update the BNTR part config for the latest changes of the BNTR global engine config.
* Add an extra stack node to the RS-68 Engine Mount to make installation of the CMES RS-68 engine easier (#1488).

@SirKeplan the RS-68 gas exhaust will have to wait, since i have some problems making that work correctly.