### PR TITLE
CMES SP-600 Hab module fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -1513,7 +1513,7 @@
 {
     @description ^= :$: Supports a crew of 4 for 180 days.:
 
-    @mass -= 0.127
+    @mass -= 1.313
 
     @MODULE[ModuleFuelTanks]
     {
@@ -1522,7 +1522,7 @@
         TANK
         {
             name = Food
-            amount = 25
+            amount = 4200
             maxAmount = 4200
         }
 


### PR DESCRIPTION
Change log:

* Increase the amount of stored food to the full duration of 180 days. The new slider system does not allow fine changes to the resources. The previous value of 25 was way below the threshold and it got zeroed.