### PR TITLE
Squad Command updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -177,7 +177,8 @@
 			maxAmount = 90
 		}
 	}
-	MODULE
+
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -486,7 +487,8 @@
 			maxAmount = 31.5
 		}
 	}
-	MODULE
+
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -533,7 +535,9 @@
 			DumpExcess = False
 		}
 	}
-	!MODULE[ModuleRCS*],* {} // for VenStockRevamp
+
+	!MODULE[ModuleRCS*],*{} // for VenStockRevamp
+
 	MODULE
 	{
 		name = ModuleRCS
@@ -787,7 +791,8 @@
 			maxAmount = 2.25
 		}
 	}
-	MODULE
+
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -914,53 +919,12 @@
 			maxAmount = 4.5
 		}
 	}
-	%MODULE[TacGenericConverter]
-	{
-		%name = TacGenericConverter
-		%converterName = CO2 Scrubber
-		StartActionName = Start %CO2 Scrubber
-		StopActionName = Stop %CO2 Scrubber
-		tag = Life Support
-		GeneratesHeat = False
-		UseSpecialistBonus = True
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ConverterSkill
-		EfficiencyBonus = 1
-		%conversionRate = 2.0	// # of people - Figures based on per/person
 
-		INPUT_RESOURCE
-		{
-			ResourceName = %CarbonDioxide
-			Ratio = 0.00589121
-		}
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.01
-		}
-
-		INPUT_RESOURCE
-		{
-			ResourceName = LithiumHydroxide
-			Ratio = 0.0000085683
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = %Water
-			Ratio = 0.0032924498
-			DumpExcess = True
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Waste
-			Ratio = 0.0000257297
-			DumpExcess = False
-		}
+	@MODULE[TacGenericConverter]:NEEDS[TacLifeSupport]
+    {
+		@conversionRate = 2.0
 	}
+
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -1129,7 +1093,8 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1176,6 +1141,7 @@
 			DumpExcess = False
 		}
 	}
+
 	!MODULE[ModuleReactionWheel]
 	{
 	}
@@ -1373,7 +1339,8 @@
 			maxAmount = 101.25
 		}
 	}
-	MODULE
+
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1421,7 +1388,6 @@
 		}
 	}
 }
-
 
 @INTERNAL[landerCabinInternals|landerCabinInternalsRPM]:BEFORE[RealismOverhaul]
 {
@@ -1754,6 +1720,9 @@
 	@mass = 0.85
 	@MODULE[ModuleCommand]
 	{
+		@hasHibernation = False
+		%hibernationMultiplier = NULL
+
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.06
@@ -1801,6 +1770,9 @@
 	@mass = 0.4
 	@MODULE[ModuleCommand]
 	{
+		@hasHibernation = False
+		%hibernationMultiplier = NULL
+
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.03


### PR DESCRIPTION
General updates to the Squad Command parts.

Change log:

* Add dependency checks to all TACLS modules (less log error spamming when TACLS is not installed).
* Simplify the TACLS scrubber patch of the Mk1 Lander Can Advanced (the TACLS module is already copied over from the source part, Mk1 Lander Can).
* Remove the hibernation option from the guidance rings (both the stock and the RO clones - launch vehicle astrionics do not have such options, only the proper spacecraft buses).