### PR TITLE
Avoid testflight cfgs causing MM errors with SXT installed.

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
@@ -8,6 +8,9 @@
 	%title = AJ10 Series (Mid)
 	%manufacturer = Aerojet
 	%description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents mid-period AJ10s with a nozzle extension and restart capability. Used on Thor-Ablestar and Delta E through Delta N.
+	
+	entryCost = 1600
+		
 	MODULE
 	{
 		name = ModuleEngineConfigs


### PR DESCRIPTION
Add an entry cost to AJ10_Mid to avoid causing MM errors. without this `TestFlightRnd.cfg` tries to set values based on the entryCost field, which didn't exist on this part.

EDIT: [https://github.com/KSP-RO/RealismOverhaul/blob/master/GameData/RealismOverhaul/TestFlightRnD.cfg#L28](This) is the line causing issue, should this MM code be more robust?

