### PR TITLE
RSB: Fix Common Centaur Propellant Ratio

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -430,8 +430,8 @@
         //  Centaur fuel and oxidizer mass 20830 Kg.
 
         //  Following masses calculated from a 5.5:1 mixture ratio:
+
         //  Centaur fuel mass 3204.6 Kg.
-        //  Centaur oxidizer mass 17625.4 Kg.
 
         TANK
         {
@@ -439,6 +439,8 @@
             amount = 45231.0
             maxAmount = 45231.0 // Actual tank volume is 1706ft^3 = 48308.5L
         }
+
+        //  Centaur oxidizer mass 17625.4 Kg.
 
         TANK
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -4,6 +4,7 @@
 //  Atlas V Launch Services User's Guide (2010):    http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
 //  The Centaur Upper Stage History:                http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
 //  Qualification for the MR-107S RCS thrusters:    http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
+//  Centaur Upperstage:                             http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
 //  United Launch Alliance - Atlas V:               http://www.ulalaunch.com/products_atlasv.aspx
 //  Spaceflight 101 - Atlas V:                      http://spaceflight101.com/spacerockets/atlas-v-401/
 
@@ -423,25 +424,27 @@
     {
         name = ModuleFuelTanks
         type = BalloonCryo
-        volume = 58677.05
+        volume = 60678.3
         basemass = -1
 
-        //  Centaur fuel mass 3041 Kg.
+        //  Centaur fuel and oxidizer mass 20830 Kg.
+
+        //  Following masses calculated from a 5.5:1 mixture ratio:
+        //  Centaur fuel mass 3204.6 Kg.
+        //  Centaur oxidizer mass 17625.4 Kg.
 
         TANK
         {
             name = LqdHydrogen
-            amount = 42920
-            maxAmount = 42920
+            amount = 45231.0
+            maxAmount = 45231.0 // Actual tank volume is 1706ft^3 = 48308.5L
         }
-
-        //  Centaur oxidizer mass 17788 Kg.
 
         TANK
         {
             name = LqdOxygen
-            amount = 15590
-            maxAmount = 15590
+            amount = 15447.3
+            maxAmount = 15447.3 // Actual tank volume is 570ft^3 = 16140.6L
         }
     }
 


### PR DESCRIPTION
The Real Scale Booster Atlas V Centaur has way too much LOX for RL10-A or RL10-C burning at a 5.5:1 mixture ratio. This patch changes the tank ratios to 5.5:1.