### PR TITLE
SSTU: Orion: Fix missing '}' causing the european service module config to not be applied

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -624,6 +624,7 @@
 			ResourceName = ElectricCharge
 			Ratio = 0.01
 		}
+	}
 
 	@MODULE[ModuleRCS]
 	{


### PR DESCRIPTION
A config node was not terminated, causing things below it to not work