### PR TITLE
RD-107/108 global engine configs updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -388,7 +388,7 @@
 		techTransfer = RD-107_8D74K,RD-107MM_8D728:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-107MM_8D728]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-107A_14D22]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -1,17 +1,16 @@
 //  ==================================================
-//  RD107/117 series
+//  RD-107/117 series global engine configuration.
 
 //  Throttle Range: N/A
 //  Burn Time: 140 s
 //  O/F Ratio: ~2.5 (differs between different configurations)
 //  Vernier range: 45 degrees
 
-
 //  Sources:
 
-//  http://www.npoenergomash.ru/dejatelnost/engines/rd107/
-//  http://www.lpre.de/energomash/RD-107/index.htm
-//  http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//  NPO Energomash - RD-107 engine:          http://www.npoenergomash.ru/dejatelnost/engines/rd107/
+//  LPRE - RD-107/RD-108 engines:            http://www.lpre.de/energomash/RD-107/index.htm
+//  Norbert Brügge - Russian Rocket Engines: http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 
 //  Used by:
 //      SXT
@@ -20,7 +19,7 @@
 
 @PART[*]:HAS[#engineType[RD107-117]]:FOR[RealismOverhaulEngines]
 {
-    %mass = 1.19
+    %category = Engine
     %title = RD-107 Series
     %manufacturer = NPO Energomash [Glushko]
     %description = Booster engine for the R-7 Semyorka and its derivatives, including the Sputnik, Luna, Voskhod, Vostok, Soyuz, and Molniya launch vehicles. Differs from the core engine series (RD-108) with a higher chamber pressure, thrust, and smaller vernier layout. The R-7 family core was supplemented for (roughly) two minutes by four strap-on boosters powered by these engines. Diameter: [1.85 m].
@@ -28,9 +27,11 @@
     @MODULE[ModuleEngines*]
     {
         %EngineType = LiquidFuel
+
+        !IGNITOR_RESOURCE,*{}
     }
 
-    !MODULE[ModuleAlternator] {}
+    !MODULE[ModuleAlternator],*{}
 
     @MODULE[ModuleGimbal]
     {
@@ -38,6 +39,8 @@
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }
+
+    !MODULE[ModuleEngineConfigs],*{}
 
     MODULE
     {
@@ -149,9 +152,9 @@
                 key = 0 313.15
                 key = 1 256.05
             }
-			
-			cost = 100
-			techRequired = advRocketry
+
+            cost = 100
+            techRequired = advRocketry
         }
 
         CONFIG
@@ -204,9 +207,9 @@
                 key = 0 314.07
                 key = 1 256.87
             }
-			
-			cost = 200
-			techRequired = heavyRocketry
+
+            cost = 200
+            techRequired = heavyRocketry
         }
 
         CONFIG
@@ -259,9 +262,9 @@
                 key = 0 315.91
                 key = 1 252.89
             }
-			
-			cost = 300
-			techRequired = heavierRocketry
+
+            cost = 300
+            techRequired = heavierRocketry
         }
 
         CONFIG
@@ -314,9 +317,9 @@
                 key = 0 319.99
                 key = 1 263.09
             }
-			
-			cost = 400
-			techRequired = experimentalRocketry
+
+            cost = 400
+            techRequired = experimentalRocketry
         }
     }
 
@@ -325,8 +328,9 @@
     RESOURCE
     {
         name = TEATEB
-        amount = 1
-        maxAmount = 1
+        amount = 1.0
+        maxAmount = 1.0
+        isTweakable = False
     }
 }
 
@@ -384,7 +388,7 @@
 		techTransfer = RD-107_8D74K,RD-107MM_8D728:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-107A_14D22]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-107MM_8D728]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -387,7 +387,7 @@
 		techTransfer = RD-108_8D75K,RD-108MM_8D727:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-108MM_8D727]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-108A_14D21]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  RD-108/118 series
+//  RD-108/118 series global engine configuration.
 
 //  Throttle Range: N/A
 //  Burn Time: 140 s
@@ -8,19 +8,19 @@
 
 //  Sources:
 
-//  http://www.npoenergomash.ru/dejatelnost/engines/rd107/
-//  http://www.lpre.de/energomash/RD-107/index.htm
-//  http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//  NPO Energomash - RD-107 engine:          http://www.npoenergomash.ru/dejatelnost/engines/rd107/
+//  LPRE - RD-107/RD-108 engines:            http://www.lpre.de/energomash/RD-107/index.htm
+//  Norbert Brügge - Russian Rocket Engines: http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 
 //  Used by:
 //      SXT
 //      Ven Stock Revamp
-//		SSTU
+//      SSTU
 //  ==================================================
 
 @PART[*]:HAS[#engineType[RD108-118]]:FOR[RealismOverhaulEngines]
 {
-    %mass = 1.278
+    %category = Engine
     %title = RD-108 Series
     %manufacturer = NPO Energomash [Glushko]
     %description = Core engine for the R-7 Semyorka and its derivatives, including the Sputnik, Luna, Voskhod, Vostok, Soyuz, and Molniya launch vehicles.  Differs from the booster engine series (RD-107) with a lower chamber pressure, thrust, and a wider vernier layout.  Powers the R-7 family core through a very long (roughly) five minute burn that starts on the pad alongside the boosters. Diameter: [1.85 m].
@@ -28,9 +28,11 @@
     @MODULE[ModuleEngines*]
     {
         %EngineType = LiquidFuel
+
+        !IGNITOR_RESOURCE,*{}
     }
 
-    !MODULE[ModuleAlternator] {}
+    !MODULE[ModuleAlternator],*{}
 
     @MODULE[ModuleGimbal]
     {
@@ -39,11 +41,13 @@
         %gimbalResponseSpeed = 16
     }
 
+    !MODULE[ModuleEngineConfigs],*{}
+
     MODULE
     {
         name = ModuleEngineConfigs
-		type = ModuleEngines
-		origMass = 1.278
+        type = ModuleEngines
+        origMass = 1.278
         configuration = RD-108_8D75PS //FIXME: missing RD-108_8D75 ???
         modded = false
 
@@ -149,9 +153,9 @@
                 key = 0 315
                 key = 1 248.10
             }
-			
-			cost = 100
-			techRequired = advRocketry
+
+            cost = 100
+            techRequired = advRocketry
         }
 
         CONFIG
@@ -204,9 +208,9 @@
                 key = 0 315.81
                 key = 1 252.79
             }
-			
-			cost = 200
-			techRequired = heavyRocketry
+
+            cost = 200
+            techRequired = heavyRocketry
         }
 
         CONFIG
@@ -258,9 +262,9 @@
                 key = 0 314.58
                 key = 1 256.87
             }
-			
-			cost = 300
-			techRequired = heavierRocketry
+
+            cost = 300
+            techRequired = heavierRocketry
         }
 
         CONFIG
@@ -313,9 +317,9 @@
                 key = 0 320.39
                 key = 1 257.48
             }
-			
-			cost = 400
-			techRequired = experimentalRocketry
+
+            cost = 400
+            techRequired = experimentalRocketry
         }
     }
 
@@ -326,6 +330,7 @@
         name = TEATEB
         amount = 1.0
         maxAmount = 1.0
+        isTweakable = False
     }
 }
 
@@ -382,7 +387,7 @@
 		techTransfer = RD-108_8D75K,RD-108MM_8D727:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-108A_14D21]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-108MM_8D727]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{


### PR DESCRIPTION
General updates to the RD-107 and RD-108 global engine configs.

Changelog:

* Update web sources.
* Add default part category.
* Remove the default part mass (should be set at the part config level at all times).
* Remove any leftover ignition sources and engine configurations (we use our own).
* Make sure that the TEATEB amount cannot be changed by the user.
* Formatting (tabs to spaces).