### PR TITLE
SXT engines updates (part II)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -712,7 +712,7 @@
 
 //	“BIMODAL” NUCLEAR THERMAL ROCKET (BNTR) PROPULSION: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
 
-//	Dimensions: 1.87 m x 8.3 m
+//	Dimensions: 1.55 m x 4.5 m
 //	Gross Mass: 2270 Kg
 //	==================================================
 
@@ -722,7 +722,7 @@
 
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.8, 0.5425, 0.8
 	}
 
 	!mesh = NULL
@@ -731,13 +731,13 @@
 	@rescaleFactor = 1.0
 	@iconCenter = 0.0, -1.5, 0.0
 
-	@node_stack_top = 0.0, 0.14, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -8.04, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.08, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -4.36, 0.0, 0.0, -1.0, 0.0, 2
 
 	@mass = 2.27
 	@maxTemp = 573.15
 	%skinMaxTemp = 673.15
-	%bulkheadProfiles = size1
+	%bulkheadProfiles = size2
 
 	%engineType = BNTR
 	%engineTypeMult = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -550,36 +550,75 @@
 	@engineType = AJ10_Adv
 }
 
+//	==================================================
+//  STAR 17 solid rocket motor.
+
+//  Dimensions: 0.4 m x 0.69 m
+//  Gross Mass: 79 kg
+//	==================================================
+
 @PART[SXTCastor30]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
 
 	@MODEL
 	{
-		%scale = 0.36, 0.36, 0.36
+		%scale = 0.36, 0.53, 0.36
 	}
-	@node_attach = 0.0, -0.225, 0.0, 0.0, 0.0, 1.0, 0
-	@node_stack_top = 0.0, 0.2141388, 0.0, 0.0, 1.0, 0.0, 0
-	@node_stack_bottom = 0.0, -0.2653092, 0.0, 0.0, -1.0, 0.0, 0
 
-	@mass = 0.00944
-	@maxTemp = 800
+	@node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0
+	@node_stack_top = 0.0, 0.315, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.39, 0.0, 0.0, -1.0, 0.0, 0
+
+	@mass = 0.0094
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+	@bulkheadProfiles = size0
+
+	%engineType = Star-17
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
+		@minThrust = 0
 		@maxThrust = 10.943
 		@heatProduction = 100
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = NULL
+
+		@PROPELLANT[SolidFuel]
+		{
+			@name = HTPB
+		}
+
 		@atmosphereCurve
 		{
 			@key,0 = 0 286.2
 			@key,1 = 1 140
 		}
 	}
-	engineType = Star-17
-	!RESOURCE[SolidFuel] {}
-	!MODULE[ModuleGimbal] {} // just in case
 
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 39.337
+		type = HTPB
+		basemass = -1
+
+		//  HTPB/AP propellant mixture mass ~69.6 Kg.
+
+		TANK
+		{
+			name = HTPB
+			amount = 39.337
+			maxAmount = 39.337
+		}
+	}
+
+	!RESOURCE,*{}
 }
 
 +PART[SXTKD170]:FOR[RealismOverhaul]
@@ -597,13 +636,6 @@
 	@mass = 1.278
 	@maxTemp = 1973.15
 	@attachRules = 1,0,1,0,0
-
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
 
 	@MODULE[ModuleEngines*]
 	{
@@ -631,12 +663,7 @@
 			@key,0 = 0 314.79
 			@key,1 = 1 247.79
 		}
-		!IGNITOR_RESOURCE,* {}
 	}
-
-	!MODULE[ModuleEngineConfigs] {}
-	// Engine configs are loaded from shared engine configuration files.
-	// RealismOverhaul/GameData/RealismOverhaul/Engine_Configs/RO_RD107_RD117_Config.cfg
 }
 
 +PART[R7_Core_Engine]:FOR[RealismOverhaul]
@@ -677,12 +704,7 @@
 			@key,0 = 0 312.75
 			@key,1 = 1 255.74
 		}
-		!IGNITOR_RESOURCE,* {}
 	}
-
-	!MODULE[ModuleEngineConfigs] {}
-    // Engine configs are loaded from shared engine configuration files.
-    // RealismOverhaul/GameData/RealismOverhaul/Engine_Configs/RO_RD107_RD117_Config.cfg
 }
 
 //	==================================================
@@ -690,7 +712,7 @@
 
 //	“BIMODAL” NUCLEAR THERMAL ROCKET (BNTR) PROPULSION: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
 
-//	Dimensions: 1 m x 5 m
+//	Dimensions: 1.87 m x 8.3 m
 //	Gross Mass: 2270 Kg
 //	==================================================
 
@@ -700,7 +722,7 @@
 
 	@MODEL
 	{
-		@scale = 0.416, 0.416, 0.416
+		@scale = 1.0, 1.0, 1.0
 	}
 
 	!mesh = NULL
@@ -709,10 +731,8 @@
 	@rescaleFactor = 1.0
 	@iconCenter = 0.0, -1.5, 0.0
 
-	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -3.343, 0.0, 0.0, -1.0, 0.0, 1
-
-	@category = Engine
+	@node_stack_top = 0.0, 0.14, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -8.04, 0.0, 0.0, -1.0, 0.0, 1
 
 	@mass = 2.27
 	@maxTemp = 573.15
@@ -723,6 +743,37 @@
 	%engineTypeMult = 1
 	%massOffset = 0
 	%ignoreMass = False
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 66.72
+		@maxThrust = 66.72
+		@heatProduction = 100
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 60
+
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.0
+		}
+
+		PROPELLANT
+		{
+			name = EnrichedUranium
+			ratio = 1.0813e-15
+			DrawGauge = False
+			ignoreForIsp = True
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 930
+			@key,1 = 1 380
+		}
+	}
 
 	MODULE
 	{
@@ -748,12 +799,42 @@
 	@mass = 12.86
 	@maxTemp = 573.15
 	%skinMaxTemp = 673.15
-	%bulkheadProfiles = size2
 
 	%engineType = NERVAII
 	%engineTypeMult = 1
 	%massOffset = 0
 	%ignoreMass = False
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 750.0
+		@maxThrust = 867.0
+		@heatProduction = 100
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 60
+
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.0
+		}
+
+		PROPELLANT
+		{
+			name = EnrichedUranium
+			ratio = 1.0813e-15
+			DrawGauge = False
+			ignoreForIsp = True
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 850
+			@key,1 = 1 380
+		}
+	}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTCastor30.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTCastor30.cfg
@@ -1,23 +1,35 @@
-@PART[SXTCastor30]:FOR[RealPlume]:NEEDS[SmokeScreen] // Star 17, from X-248 from Sgt3
-{
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-		%powerEffectName = Solid-Vacuum
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-	}
+//  ==================================================
+//  STAR 17 plume setup.
+//  ==================================================
 
+@PART[SXTCastor30]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
     PLUME
     {
         name = Solid-Vacuum
         transformName = thrustTransform
-        flarePosition = 0,0,1.5
-        flareScale = 0.2
-        plumePosition = 0,0,1.5
-        plumeScale = 0.4
-	}
+        localPosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.0
+        energy = 1.0
+        speed = 1.75
+        flarePosition = 0.0, 0.0, 1.5
+        flareScale = 0.125
+        plumePosition = 0.0, 0.0, 1.85
+        plumeScale = 0.25
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Vacuum
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Vacuum
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVA.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVA.cfg
@@ -1,31 +1,36 @@
+//  ==================================================
+//  Bimodal NTR plume setup.
+//  ==================================================
+
 @PART[SXTNERVA]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hydrogen-NTR
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,-1.2
-        fixedScale = 1
-        energy = 1
-        speed = 1.4
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, -0.75
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.5
     }
 
     PLUME
     {
         name = Hydrolox-Upper
         transformName = thrustTransform
-        localRotation = 0,0,0
-        flarePosition = 0,0,1
-        plumePosition = 0,0,3
-        fixedScale = 1
-        energy = 1
-        speed = 1.2
+        localRotation = 0.0, 0.0, 0.0
+        flarePosition = 0.0, 0.0, -0.25
+        flareScale = 1.5
+        plumePosition = 0.0, 0.0, 0.75
+        plumeScale = 1.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.5
     }
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hydrogen-NTR
         %runningEffectName = NULL
         %fxOffset = NULL

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVA.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVA.cfg
@@ -9,7 +9,7 @@
         name = Hydrogen-NTR
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, -0.75
+        localPosition = 0.0, 0.0, -1.0
         fixedScale = 1.0
         energy = 1.0
         speed = 1.5
@@ -17,12 +17,12 @@
 
     PLUME
     {
-        name = Hydrolox-Upper
+        name = Hydrogen-NTR-HighTemp
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        flarePosition = 0.0, 0.0, -0.25
-        flareScale = 1.5
-        plumePosition = 0.0, 0.0, 0.75
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        plumePosition = 0.0, 0.0, 0.25
         plumeScale = 1.0
         fixedScale = 1.0
         energy = 1.0
@@ -45,7 +45,7 @@
 
         @CONFIG[TRITON]
         {
-            %powerEffectName = Hydrolox-Upper
+            %powerEffectName = Hydrogen-NTR-HighTemp
         }
     }
 }


### PR DESCRIPTION
**Change log:**

* Increase the length of the STAR 17 motor from 0.475 m to 0.69 m.
* Remove leftover engine response parameters (taken care by the thrust curve).
* Add a modular fuel tank for the HTPB propellant.
* Increase the size of the BNTR ~~(was 1/3 of the correct one)~~.
* Remove category definitions (taken care by the global engine configs).
* Remove other modules (taken care by the global engine configs).
* Add default engine parameters for the nuclear engines.
* Rework the plume setups for the STAR 17 and BNTR due to the size changes.