### PR TITLE
Fix TestFlight RnD entryCost checks

### DIFF
--- a/GameData/RealismOverhaul/TestFlightRnD.cfg
+++ b/GameData/RealismOverhaul/TestFlightRnD.cfg
@@ -1,17 +1,23 @@
-// Set the global TF RnD settings
+//  ==================================================
+//  Set the global TF RnD settings.
+//  ==================================================
+
 TFRNDSETTINGS
 {
     updateFrequency = 86400
+
     TEAM
     {
         points = 10.0
         costFactor = 1
     }
+
     TEAM
     {
         points = 12.5
         costFactor = 1.5
     }
+
     TEAM
     {
         points = 15.0
@@ -19,8 +25,24 @@ TFRNDSETTINGS
     }
 }
 
-// After pass: fix up RnD
-@PART[*]:HAS[@MODULE[TestFlightCore]]:AFTER[zTestFlight]
+
+//  ==================================================
+//  Before pass: check if any parts are missing an
+//  entry cost field. If so, add one and tag them.
+//  ==================================================
+
+@PART[*]:HAS[~entryCost[]]:AFTER[RealismOverhaul]
+{
+    %entryCost = 1
+
+    @description ^= :$: (Missing entryCost field)
+}
+
+//  ==================================================
+//  After pass: fix up RnD.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[TestFlightCore],#entryCost[*]]:AFTER[zTestFlight]
 {
 	@MODULE[TestFlightCore],*
 	{

--- a/GameData/RealismOverhaul/TestFlightRnD.cfg
+++ b/GameData/RealismOverhaul/TestFlightRnD.cfg
@@ -25,13 +25,12 @@ TFRNDSETTINGS
     }
 }
 
-
 //  ==================================================
 //  Before pass: check if any parts are missing an
 //  entry cost field. If so, add one and tag them.
 //  ==================================================
 
-@PART[*]:HAS[~entryCost[]]:AFTER[RealismOverhaul]
+@PART[*]:HAS[~entryCost[]]:BEFORE[zTestFlight]
 {
     %entryCost = 1
 


### PR DESCRIPTION
As reported and fixed by @SirKeplan in #1513.

Change log:

* Add an entryCost check in the TF after pass (just to make sure that an entryCost field is present).
* Add a patch to add a template entryCost field to the part config if one is missing and tag them for further fixups.

**Note:** the entryCost check is probably reduntant since we already add the missing entry cost in a previous pass.