### PR TITLE
CMES Propulsion Updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -2092,7 +2092,7 @@
 //  ==================================================
 //  Bimodal Nuclear Thermal Rocket (BNTR).
 
-//  Dimensions: 1.56 m x 3.24 m
+//  Dimensions: 1.55 m x 4.5 m
 //  Gross Mass: 2270 Kg
 //  ==================================================
 
@@ -2104,14 +2104,15 @@
 
     @MODEL
     {
-        @scale = 0.7, 0.875, 0.7
+        @scale = 0.6, 0.6, 0.6
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 2.445, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -4.55, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.675, 0.0, 0.0, 1.0, 0.0, 2
+    %node_stack_bottom = 0.0, -3.125, 0.0, 0.0, -1.0, 0.0, 2
+    %node_attach = 0.0, 1.675, 0.0, 0.0, 1.0, 0.0
 
     @category = Engine
 
@@ -2121,9 +2122,6 @@
     @breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 573.15
-    %heatConductivity = 0.06
-    %skinInternalConductionMult = 4.0
-    %emissiveConstant = 0.8
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
@@ -2696,7 +2694,7 @@
 
     @node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 4
     @node_stack_bottom = 0.0, -2.05, 0.0, 0.0, -1.0, 0.0, 2
-    %node_stack_engine = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+    %node_stack_engine = 0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @category = Structural
     @title = Delta IV CBC Engine Mount
@@ -3248,6 +3246,19 @@
             @key,0 = 0 409
             @key,1 = 1 357
         }
+    }
+
+    !MODULE[ModuleAnimateHeat],*{}
+
+    !MODULE[FXModuleAnimateThrottle],*{}
+
+    MODULE
+    {
+        name = FXModuleAnimateThrottle
+        animationName = emissiveHeat
+        responseSpeed = 0.001
+        dependOnEngineState = True
+        dependOnThrottle = True
     }
 
     !RESOURCE,*{}

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/nervaII_kerbscalexx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/nervaII_kerbscalexx.cfg
@@ -13,10 +13,26 @@
         energy = 1.25
         speed = 1.5
         emissionMult = 0.5
-        plumePosition = 0.0, 0.0, -1.5
+        plumePosition = 0.0, 0.0, -1.25
         plumeScale = 1.0
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+    }
+
+    PLUME
+    {
+        name = Hydrogen-NTR-HighTemp
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.25
+        speed = 1.5
+        emissionMult = 0.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -26,11 +42,16 @@
         !fxOffset = NULL
     }
 
-    @MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleHybridEngine]
     {
-        @CONFIG,*
+        @CONFIG[BNTR]
         {
             %powerEffectName = Hydrogen-NTR
+        }
+
+        @CONFIG[TRITON]
+        {
+            %powerEffectName = Hydrogen-NTR-HighTemp
         }
     }
 }


### PR DESCRIPTION
Change log:

* Fix the size of the BNTR engine (was too large).
* Add extra bottom and surface attachment nodes to the BNTR engine.
* Fix the engine attachment node position of the RS-68 engine mount.
* Replace the old heat animation module of the RS-68 engine with the new one.
* Fix the BNTR plume config to support the new hybrid engine module.
* Add a separate plume for the TRITON option.