### PR TITLE
CST-100 Pack updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Aero.cfg
@@ -19,26 +19,28 @@
 
     %scale = 1.0
     @rescaleFactor = 1.0
-	
+
     @node_stack_top = 0.0, 0.465, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -0.515, 0.0, 0.0, -1.0, 0.0, 3
 
+    @category = Thermal
     @title = CST-100 Heat Shield
     @manufacturer = Boeing Co.
     @description = The heat shield for CST-100 "Starliner" command module.
 
     @mass = 0.23
     @crashTolerance = 12
-    @maxTemp = 2473.15
-    %skinMaxTemp = 3673.15
+    @maxTemp = 773.15
+    %skinMaxTemp = 2773.15
     %stageOffset = 1
     %chilStageOffset = 1
     %stagingIcon = DECOUPLER_HOR
+    %fuelCrossFeed = False
     @bulkheadProfiles = size3
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 15
+        @ejectionForce = 5
     }
 
     @MODULE[ModuleAblator]
@@ -52,10 +54,13 @@
         %charMax = 1
     }
 
-    @RESOURCE[Ablator]
+    !RESOURCE,*{}
+
+    RESOURCE
     {
-        @amount = 970
-        @maxAmount = 970
+        name = Ablator
+        amount = 970
+        maxAmount = 970
     }
 
     RESOURCE
@@ -70,7 +75,7 @@
 //  CST-100 forward nose cone.
 
 //  Dimensions: 2.03 m x 0.6 m
-//  Gross Mass: 70 Kg
+//  Gross Mass: 100 Kg
 //  ==================================================
 
 @PART[cstNoseCone]:FOR[RealismOverhaul]
@@ -90,14 +95,15 @@
 
     @node_stack_bottom = 0.0, -0.05, 0.0, 0.0, -1.0, 0.0, 1
 
+    @category = Aero
     @title = CST-100 Nose Cone
     @manufacturer = Boeing Co.
-    @description = A protective nose cone for the CST-100 "Starliner" NASA Docking System.
+    @description = A protective nose cone for the NASA Docking System of the CST-100 Starliner.
 
-    @mass = 0.07
+    @mass = 0.1
     @crashTolerance = 14
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %fuelCrossFeed = False
     %stageOffset = 1
     %chilStageOffset = 1
@@ -106,6 +112,6 @@
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 5
+        @ejectionForce = 2.5
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -1,12 +1,14 @@
 //  ==================================================
+//  Sources:
+
+//  Boeing - Design Considerations for a Commercial Crew Transportation System: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//  Boeing - CST-100 Commercial Crew Transportation System overview:            http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+
+//  ==================================================
 //  CST-100 command module.
 
 //  Dimensions: 4.65 m x 2.6 m
-//  Gross Mass: 4610 Kg
-
-//  Sources:
-
-//  Boeing CST-100 Commercial Crew Transportation System: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  Gross Mass: 4500 Kg
 //  ==================================================
 
 @PART[CST-100?capsule]:FOR[RealismOverhaul]
@@ -32,26 +34,43 @@
     @manufacturer = Boeing Co.
     @description = The command module of the CST-100 "Starliner" Commercial Crew Transportation System (COTS). Designed to be reusable for up to 10 times.
 
-    @mass = 4.4
+    @mass = 4.35
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
+    %CoMOffset = 0.0, -1.0, 0.0
     @bulkheadProfiles = size1, size3
+
+    @INTERNAL[CST100internal]
+    {
+        %scaleAll = 1.24, 1.24, 1.24
+
+        @MODULE[InternalSeat],*
+        {
+            %kerbalScale = 1.24, 1.24, 1.24
+            %kerbalOffset = 0.0, 0.0, 0.0
+            %kerbalEyeOffset = 0.0, 0.0, 0.0
+        }
+    }
 
     @MODULE[ModuleCommand]
     {
         @minimumCrew = 0
+        %hasHibernation = True
+        %hibernationMultiplier = 0.625
 
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.6
         }
     }
 
-    !MODULE[ModuleReactionWheel]{}
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleSAS],*{}
 
     MODULE
     {
@@ -59,10 +78,12 @@
         SASServiceLevel = 3
     }
 
+    !MODULE[CoMShifter],*{}
+
     MODULE
     {
         name = CoMShifter
-        DescentModeCoM = 0.0, 0.0, -0.3
+        DescentModeCoM = 0.0, 0.0, 0.3
     }
 
     @MODULE[ModuleScienceContainer]
@@ -70,9 +91,9 @@
         @storageRange = 2.5
     }
 
-    !MODULE[ModuleConductionMultiplier]{}
+    !MODULE[ModuleConductionMultiplier],*{}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.445
         !resourceName = NULL
@@ -86,7 +107,7 @@
         PROPELLANT
         {
             name = Helium
-            ratio = 150.0
+            ratio = 10.0
             ignoreForIsp = True
         }
 
@@ -97,23 +118,25 @@
         }
     }
 
+    !MODULE[ModuleFuelTanks],*{}
+
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 510
+        volume = 180
         basemass = -1
 
-        //  Batteries 550 Wh.
+        //  Batteries 1.5 kWh.
 
         TANK
         {
             name = ElectricCharge
-            amount = 2000
-            maxAmount = 2000
+            amount = 5400
+            maxAmount = 5400
         }
 
-        //  ACS propellant 150 Kg.
+        //  ACS propellant mass 150 Kg.
 
         TANK
         {
@@ -122,22 +145,103 @@
             maxAmount = 150
         }
 
-        //  ACS pressurization 4 Kg.
+        //  ACS pressurization gas mass ~0.27 Kg.
 
         TANK
         {
             name = Helium
-            amount = 22500
-            maxAmount = 22500
+            amount = 1500
+            maxAmount = 1500
         }
+    }
 
-        //  Crew supplies.
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        impassablenodes = bottom
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.025
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 800000
+        EnergyCost = 0.025
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.01
+        }
+    }
+}
+
+//  ==================================================
+//  CST-100 command module.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[CST-100?capsule]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @description ^= :$: Supports a crew of 7 for 2 days.:
+
+    @mass -= 0.07
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.01
+        }
+    }
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 460
 
         TANK
         {
             name = Food
-            amount = 40.94
-            maxAmount = 81.88
+            amount = 102.37
+            maxAmount = 102.37
         }
 
         TANK
@@ -150,15 +254,15 @@
         TANK
         {
             name = Oxygen
-            amount = 4150
-            maxAmount = 4150
+            amount = 4145
+            maxAmount = 4145
         }
 
         TANK
         {
             name = Waste
             amount = 0
-            maxAmount = 7.45
+            maxAmount = 9.32
         }
 
         TANK
@@ -183,83 +287,6 @@
         }
     }
 
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  CST-100 command module.
-
-//  Connected Living Space compatibility.
-//  ==================================================
-
-@PART[CST-100?capsule]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
-{
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        impassablenodes = bottom
-    }
-}
-
-//  ==================================================
-//  CST-100 command module.
-
-//  Remote Tech compatibility.
-//  ==================================================
-
-@PART[CST-100?capsule]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-{
-    @MODULE[ModuleCommand]
-    {
-        @RESOURCE[ElectricCharge]
-        {
-            @rate -= 0.015
-        }
-    }
-
-    MODULE
-    {
-        name = ModuleSPU
-    }
-
-    MODULE
-    {
-        name = ModuleRTAntenna
-        IsRTActive = True
-        Mode0OmniRange = 0
-        Mode1OmniRange = 800000
-        EnergyCost = 0.015
-        DeployFxModules = 0
-        ProgressFxModules = 1
-
-        TRANSMITTER
-        {
-            PacketInterval = 0.2
-            PacketSize = 0.47
-            PacketResourceCost = 0.05
-        }
-    }
-}
-
-//  ==================================================
-//  CST-100 command module.
-
-//  TAC Life Support compatibility.
-//  ==================================================
-
-@PART[CST-100?capsule]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-    @description ^= :$: Supports a crew of 7 for 2 days.:
-
-    @MODULE[ModuleCommand]
-    {
-        @RESOURCE[ElectricCharge]
-        {
-            @rate -= 0.01
-        }
-    }
-
     MODULE
     {
         name = TacGenericConverter
@@ -268,11 +295,7 @@
         StopActionName = Stop CO2 Scrubber
         tag = Life Support
         GeneratesHeat = False
-        UseSpecialistBonus = True
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1
+        UseSpecialistBonus = False
         conversionRate = 7.0
 
         INPUT_RESOURCE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Engine.cfg
@@ -1,13 +1,13 @@
 //  ==================================================
+//  Sources:
+
+//  Encyclopedia Astronautica - RS-88 engine: http://astronautix.com/r/rs-88.html
+
+//  ==================================================
 //  CST-100 RS-88 quad engine block
 
 //  Dimensions: 0.65 m x 0.7 m
 //  Gross Mass: 1000 Kg
-
-//  Sources:
-
-//  RS-88 Pad Abort Demonstrator Thrust Chamber Assembly: http://www.beyondearth.com/news-2/pwr-analyzing-cst-100-abort-engine-tests
-//  Astronautix - RS-88:                                  http://astronautix.com/engines/rs88.htm
 //  ==================================================
 
 @PART[RS88]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -29,11 +29,8 @@
 
     @mass = 1.0
     @crashTolerance = 10
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
-    %heatConductivity = 0.06
-    @skinInternalConductionMult = 4.0
-    @emissiveConstant = 0.8
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %chileStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -79,8 +76,8 @@
 
 @PART[RS88]:AFTER[RealismOverhaulEngines]
 {
-    @title = CST-100 LAE
-    @description = Four of these engines are used by the CST-100 "Starliner" spacecraft for launch aborts and orbital maneuvering.
+    @title = CST-100 Launch Abort Engines (LAE)
+    @description = The launch abort system of the CST-100 "Starliner" spacecraft. Uses four RS-88 engines (hypergolic variant).
 
     @MODULE[ModuleEngineConfigs]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_FuelTank.cfg
@@ -1,13 +1,15 @@
 //  ==================================================
+//  Sources:
+
+//  Boeing - Design Considerations for a Commercial Crew Transportation System: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//  Boeing - CST-100 Commercial Crew Transportation System overview:            http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  Spectrolab - XTJ Solar Cells data sheet:                                    http://www.spectrolab.com/DataSheets/cells/PV%20XTJ%20Cell%205-20-10.pdf
+
+//  ==================================================
 //  CST-100 service module.
 
 //  Dimensions: 5.4 m x 2.5 m
-//  Gross Mass: 6220 Kg
-
-//  Sources:
-
-//  Design Considerations for a Commercial Crew Transportation System: http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
-//  Boeing CST-100 Commercial Crew Transportation System:              http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/CCDev2%20Boeing%20CST-100%20Overview.pdf
+//  Gross Mass: 6100 Kg
 //  ==================================================
 
 @PART[CST-100?Service?Module]:FOR[RealismOverhaul]
@@ -26,29 +28,31 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 0.195, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -0.85, 0.0, 0.0, -1.0, 0.0, 3
-    @node_stack_bottom_2 = 0.0, -1.445, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -1.445, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom_2 = 0.0, -0.85, 0.0, 0.0, -1.0, 0.0, 1
 
+    @category = FuelTank
     @title = CST-100 Service Module
     @manufacturer = Boeing Co.
     @description = The service module for the CST-100 "Starliner" spacecraft.
 
-    @mass = 3.9
+    @mass = 3.89
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = True
     @bulkheadProfiles = size1, size3
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 5
+        @ejectionForce = 15
     }
-	
-    @MODULE[ModuleRCS]
+
+    @MODULE[ModuleRCS*]
     {
-        @thrusterPower = 0.22
+        @thrusterPower = 0.44
         !resourceName = NULL
 
         PROPELLANT
@@ -63,42 +67,37 @@
             ratio = 0.501
         }
 
-        PROPELLANT
-        {
-            name = Helium
-            ratio = 10.0
-            ignoreForIsp = True
-        }
-
         @atmosphereCurve
         {
-            @key,0 = 0 220
-            @key,1 = 1 85
+            @key,0 = 0 320
+            @key,1 = 1 110
         }
     }
 
     @MODULE[ModuleDeployableSolarPanel]
     {
-        @chargeRate = 1.0
+        @chargeRate = 3.0
     }
+
+    !MODULE[ModuleFuelTanks],*{}
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 2180
+        volume = 2000
         basemass = -1
 
-        //  Electricity 37.5 kWh
+        //  Batteries 3.5 kWh
 
         TANK
         {
             name = ElectricCharge
-            amount = 135000
-            maxAmount = 135000
+            amount = 12600
+            maxAmount = 12600
         }
 
-        //  Cooling & life support water 200 Kg.
+        //  Cooling & life support water mass 200 Kg.
 
         TANK
         {
@@ -107,7 +106,7 @@
             maxAmount = 200
         }
 
-        //  RS-88 fuel 680 Kg.
+        //  RS-88 and ACS fuel mass 766 Kg.
 
         TANK
         {
@@ -116,22 +115,13 @@
             maxAmount = 871
         }
 
-        //  RS-88 oxidizer 1120 Kg.
+        //  RS-88 and ACS oxidizer mass 1245 Kg.
 
         TANK
         {
             name = MON3
             amount = 875
             maxAmount = 875
-        }
-
-        //  ACS pressurization ~3.2 Kg.
-
-        TANK
-        {
-            name = Helium
-            amount = 18000
-            maxAmount = 18000
         }
     }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Structural.cfg
@@ -23,20 +23,21 @@
     @node_stack_top = 0.0, 1.16, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -1.51, 0.0, 0.0, -1.0, 0.0, 3
 
-    @title = CST-100 Atlas Adapter
+    @category = Coupling
+    @title = CST-100 Atlas V Adapter
     @manufacturer = Boeing Co.
     @description = A structural adapter to connect the service module of the CST-100 to the Atlas V launch vehicles.
 
     @mass = 0.12
     @crashTolerance = 14
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %stagingIcon = DECOUPLER_HOR
     %bulkheadProfiles = size3
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 5
+        @ejectionForce = 15
     }
 }
 
@@ -65,20 +66,21 @@
     @node_stack_top = 0.0, 0.84, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -1.11, 0.0, 0.0, -1.0, 0.0, 3
 
+    @category = Coupling
     @title = CST-100 4M Adapter
     @manufacturer = Boeing Co.
     @description = A structural adapter to connect the service module of the CST-100 to 4.65 meter parts.
 
     @mass = 0.09
     @crashTolerance = 14
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %stagingIcon = DECOUPLER_HOR
     %bulkheadProfiles = size3
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 5
+        @ejectionForce = 15
     }
 }
 
@@ -107,19 +109,20 @@
     @node_stack_top = 0.0, 1.16, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -1.325, 0.0, 0.0, -1.0, 0.0, 3
 
+    @category = Coupling
     @title = CST-100 3M Adapter
     @manufacturer = Boeing Co.
     @description = A structural adapter to connect the service module of the CST-100 to 3.75 meter parts.
 
     @mass = 0.1
     @crashTolerance = 14
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %stagingIcon = DECOUPLER_HOR
     %bulkheadProfiles = size3
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 5
+        @ejectionForce = 15
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Utility.cfg
@@ -8,7 +8,7 @@
 //  CST-100 parachute pack.
 
 //  Dimensions: 2.7 m x 0.65 m
-//  Gross Mass: 250 Kg
+//  Gross Mass: 260 Kg
 //  ==================================================
 
 @PART[cstparachute]:FOR[RealismOverhaul]
@@ -33,20 +33,21 @@
     @manufacturer = Boeing Co.
     @description = The parachute pack for the CST-100 "Starliner" command module.
 
-    @mass = 0.3
+    @mass = 0.26
     %crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @stageOffset = 1
     @childStageOffset = 1
     %stagingIcon = PARACHUTES
+    %fuelCrossFeed = False
     @bulkheadProfiles = size1
 
     @MODULE[ModuleParachute]
     {
-        @deployAltitude = 1000
+        @deployAltitude = 2500
         @chuteMaxTemp = 423.15
     }
 
@@ -57,9 +58,9 @@
         dragModifier = 15
     }
 
-    @MODULE[ModuleDragModifier]
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[DEPLOYED]]
     {
-        @dragModifier = 150
+        @dragModifier = 125
     }
 }
 
@@ -75,14 +76,14 @@
 
     @category = none
 
-    @mass = 0.1
+    !MODULE[ModuleParachute],*{}
 
-    !MODULE[ModuleParachute]{}
+    !MODULE[RealChute*],*{}
 
     MODULE
     {
         name = RealChuteModule
-        caseMass = 0.2
+        caseMass = 0.133
         timer = 0
         mustGoDown = True
         spareChutes = 0
@@ -92,14 +93,14 @@
         PARACHUTE
         {
             material = Nylon
-            preDeployedDiameter = 3.5
-            deployedDiameter = 41
+            preDeployedDiameter = 2.7
+            deployedDiameter = 53.4
             minIsPressure = False
             minDeployment = 3200
-            deploymentAlt = 750
+            deploymentAlt = 1200
             cutAlt = -1
-            preDeploymentSpeed = 2
-            deploymentSpeed = 6
+            preDeploymentSpeed = 2.5
+            deploymentSpeed = 5.0
             preDeploymentAnimation = semiDeploy
             deploymentAnimation = fullyDeploy
             parachuteName = canopy
@@ -177,7 +178,8 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
-    @title = NASA Docking System [Passive]
+    @category = Coupling
+    @title = NASA Docking System (Passive)
     @manufacturer = Boeing Co.
     @description = The NASA Docking System (NDS) is a spacecraft docking and berthing mechanism for US human spaceflight vehicles, such as the Orion Multi-Purpose Crew Vehicle and the Commercial Crew vehicles.
 
@@ -185,8 +187,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 773.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %bulkheadProfiles = srf, size1
 
     @MODULE[ModuleDockingNode]
@@ -206,7 +208,16 @@
         %minDistanceToReEngage = 0.25
         %undockEjectionForce = 0.1
         @stagingEnabled = False
-	}
+    }
+
+    !MODULE[ModuleConnectedLivingSpace],*{}
+
+    MODULE:NEEDS[ConnectedLivingSpace]
+    {
+        name = ModuleConnectedLivingSpace
+        passable = True
+        passableWhenSurfaceAttached = True
+    }
 }
 
 //  ==================================================
@@ -235,7 +246,8 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
-    @title = NASA Docking System [Active]
+    @category = Coupling
+    @title = NASA Docking System (Active)
     @manufacturer = Boeing Co.
     @description = The NASA Docking System (NDS) is a spacecraft docking and berthing mechanism for US human spaceflight vehicles, such as the Orion Multi-Purpose Crew Vehicle and the Commercial Crew vehicles.
 
@@ -243,8 +255,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 773.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %bulkheadProfiles = srf, size1
 
     @MODULE[ModuleDockingNode]
@@ -264,18 +276,11 @@
         %minDistanceToReEngage = 0.25
         %undockEjectionForce = 0.1
         @stagingEnabled = False
-	}
-}
+    }
 
-//  ==================================================
-//  NASA Docking System (NDS).
+    !MODULE[ModuleConnectedLivingSpace],*{}
 
-// Connected Living Space compatibility.
-//  ==================================================
-
-@PART[ndsport1|ndsport3]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
-{
-    MODULE
+    MODULE:NEEDS[ConnectedLivingSpace]
     {
         name = ModuleConnectedLivingSpace
         passable = True
@@ -310,6 +315,7 @@
     @node_stack_top = 0.0, -0.03, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_bottom = 0.0, -0.545, 0.0, 0.0, -1.0, 0.0, 1
 
+    @category = Coupling
     @title = NASA International Docking Adapter
     @manufacturer = NASA
     @description = The International Docking Adapter (IDA) is a spacecraft docking system adapter being developed to convert APAS-95 to the NASA Docking System (NDS)/ International Docking System Standard (IDSS).
@@ -318,11 +324,11 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 773.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @bulkheadProfiles = srf, size1
 
-    @MODULE[ModuleDockingNode],1
+    @MODULE[ModuleDockingNode]:HAS[#nodeTransformName[Dock01]]
     {
         @nodeType = APAS8995
         %acquireForce = 0.5
@@ -339,7 +345,7 @@
         @stagingEnabled = False
     }
 
-    @MODULE[ModuleDockingNode],2
+    @MODULE[ModuleDockingNode]:HAS[#nodeTransformName[Dock01]]
     {
         @nodeType = NDS
         %acquireForce = 0.5
@@ -355,17 +361,10 @@
         %undockEjectionForce = 0.1
         @stagingEnabled = False
     }
-}
 
-//  ==================================================
-//  International Docking Adapter.
+    !MODULE[ModuleConnectedLivingSpace],*{}
 
-// Connected Living Space compatibility.
-//  ==================================================
-
-@PART[idaONE]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[RealismOverhaul]:NEEDS[ConnectedLivingSpace]
-{
-    MODULE
+    MODULE:NEEDS[ConnectedLivingSpace]
     {
         name = ModuleConnectedLivingSpace
         passable = True

--- a/GameData/RealismOverhaul/RealPlume_Configs/CST/RS88.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CST/RS88.cfg
@@ -8,22 +8,27 @@
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 0.75
+        flarePosition = 0.0, 0.0, -3.0
+        flareScale = 0.175
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, -2.0
-        fixedScale = 1.75
-        energy = 1.25
-        speed = 1.75
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
     }
 
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-White
+        !runningEffectName = NULL
         !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        @CONFIG,*
+        @CONFIG[LAE]
         {
             %powerEffectName = Hypergolic-OMS-White
         }


### PR DESCRIPTION
Changelog:

* Explicitly set the categories of the parts to use the new ones.
* Separate the TACLS resources to it's own MM pass.
* Increase the power generation of the SM and consumption of the CM.
* Fix the scale of the internal model.
* Add hibernation to the CM (requires 1 kW of keep-alive power).
* Make the RCS patches compatible with the new RCSFX module.
* Fix the Helium consumption of the CM RCS.
* Merge the Connected Living Space patches to the parent part config patch (less MM passes).
* Increase a bit the power consumption of the RT antenna and normalize the data transmittion rate to 1 Mbps.
* Remove some unneeded fields from the TACLS scrubber.
* Fix the engine attachment node of the SM.
* Increase the Isp of the SM RCS (assumed monopropellant Isp but used bipropellant configs).
* Decrease the amount of carried electricity (not needed with the new solar array).
* Tweak the parachute parameters to open in a higher altitude (was too low before).
* Adjust the ejection force of the adapters, CST nose cone and heat shield.
* Fix the RealPlume config of the LAE.
* Reduce the maximum temperatures.
* Make module patching a bit more bulletproof.
* Minor adjustments to the part masses.
* Minor edits to the part descriptions.