### PR TITLE
Fix the hibernation patching of the guidance rings

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -1721,7 +1721,7 @@
 	@MODULE[ModuleCommand]
 	{
 		@hasHibernation = False
-		%hibernationMultiplier = NULL
+		!hibernationMultiplier = NULL
 
 		@RESOURCE[ElectricCharge]
 		{
@@ -1771,7 +1771,7 @@
 	@MODULE[ModuleCommand]
 	{
 		@hasHibernation = False
-		%hibernationMultiplier = NULL
+		!hibernationMultiplier = NULL
 
 		@RESOURCE[ElectricCharge]
 		{


### PR DESCRIPTION
Uses the correct MM prefix now.