### PR TITLE
S-II Ullage adjust to GlobalEngineConfig problem

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -71,6 +71,7 @@
 	{
 		@ejectionForce = 1
 		@explosiveNodeID = top
+		stagingEnabled = True
 	}
 	MODULE
 	{
@@ -1065,6 +1066,10 @@
 	{
 		%minThrust = 101
 		%maxThrust = 101
+		%PROPELLANT[SolidFuel]
+		{
+			%name = PSPC
+		}
 		@atmosphereCurve
 		{
 			@key,0 = 0 251
@@ -1075,6 +1080,8 @@
 	{
 		@volume = 85.4
 	}
+	!RESOURCE[SolidFuel] {}
+	!engineType = DEL
 	@MODULE[ModuleEngineConfigs]
 	{
 		@CONFIG[BabySergeant]


### PR DESCRIPTION
The FASA S-II ullage motor was taking the name and properties of the BabyS engine, due to inheritance. Removing the engineType flag from this part, and re-enforcing a few properties (ie. fuel type to use) returned to expected behaviour.

Also, LEM base node for decoupling from CSM set to "stagingEnabled = True", as it was no longer showing as stage-able by default for some reason.