### PR TITLE
Fix the Taerobee Aerobee plumes

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/Taerobee/Aerobee_Engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Taerobee/Aerobee_Engine.cfg
@@ -1,4 +1,15 @@
 //  ==================================================
+//  Cleanup.
+//  ==================================================
+
+@PART[taerobee_aerobee|taerobee_TinyTim]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+    !EFFECTS,*{}
+
+    !PLUME,*{}
+}
+
+//  ==================================================
 //  Aerobee/WAC Corporal sustainer engine plume setup.
 //  ==================================================
 
@@ -84,7 +95,7 @@
         {
             @MODEL_MULTI_SHURIKEN_PERSIST[smoke]
             {
-                @localPosition = 0.0, 0.0, -0.75
+                @localPosition = 0.0, 0.0, 0.3
             }
         }
     }


### PR DESCRIPTION
Due to the way the plume configs were made as a part of the mod release, we have to delete them before applying our own.