### PR TITLE
Saturn V S-II ullage motor global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg
@@ -59,7 +59,7 @@
 
             PROPELLANT
             {
-                name = HPTB
+                name = HTPB
                 ratio = 1.0
                 DrawGauge = True
             }

--- a/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg
@@ -1,0 +1,78 @@
+//  ==================================================
+//  Saturn V S-II ullage motor global engine configuration.
+
+//  Throttle Range: N/A
+//  Burn Time: 3.75 s
+//  O/F Ratio: 2.77
+
+//  Sources:
+//      NASA - Saturn V Flight Manual: http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
+
+//  Used by:
+//      FASA
+//      Real Scale Boosters
+//      OLDD Saturn V
+//  ==================================================
+
+@PART[*]:HAS[#engineType[SIIUllageMotor]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = S-II Ullage Motor
+    %manufacturer = Thiokol
+    %description = The ullage motor of the Saturn V S-II stage. Attaches to the upper part of the S-II interstage, in sets of 4 to 8.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 102.3
+        %maxThrust = 102.3
+        %heatProduction = 100
+        %EngineType = SolidBooster
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        !IGNITOR_RESOURCE,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = S-II-Ullage
+        origMass = 0.104
+        modded = False
+
+        CONFIG
+        {
+            name = S-II-Ullage
+            minThrust = 102.3
+            maxThrust = 102.3
+            massMult = 1.0
+
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+
+            PROPELLANT
+            {
+                name = HPTB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 256
+                key = 1 216
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
Preliminary global engine configuration for the Saturn V S-II ullage motor.

Points of intererest/discussion that i'd like to apply not only for that engine config but for every one available in RO:

* [Is it a good idea to patch the original ModuleEngines module like that?](https://github.com/PhineasFreak/RealismOverhaul/blob/abb637c24af1922ccd5e1a8eabbfd8e831e0d4d3/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg#L24-L35) I have seen fields and modules being patched for a specific part but not for others and i feel it would be nice to have some consistency over these.
* [Should the minimum thrust be the same as the maximum thrust?](https://github.com/PhineasFreak/RealismOverhaul/blob/abb637c24af1922ccd5e1a8eabbfd8e831e0d4d3/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg#L52) I remember @NathanKell saying that the minimum thrust for solids should be zero in order to allow thrust customization but i do not find it realistic (the propellant grain and overall structure of the motor must be changed in reality to reflect this).
* Should we have the ModuleFuelTanks that defines the propellant type and amount within the global engine config (for solid rocket motors only)? This was also a point that @SirKeplan raised for PR #1523.

**Note:** i might be taking this too far...