### PR TITLE
RL60 typo fix

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
@@ -13,7 +13,7 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		origMass = 0.159
+		origMass = 0.499
 		configuration = RL60
 		modded = false
 		CONFIG
@@ -50,7 +50,7 @@
 		CONFIG
 		{
 			name = Vinci-180
-			massMult = 3.459
+			massMult = 1.100
 			maxThrust = 180
 			minThrust = 180
 			heatProduction = 100


### PR DESCRIPTION
Sources clearly say that RL60 mass is 499 kg rather than 159 kg.