### PR TITLE
Fix the Mk-1.2 Pod Ven Revamp RCS

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -687,6 +687,12 @@
 	%scale = 1.0
 	@node_stack_bottom = 0.0, -0.7859536, 0.0, 0.0, -1.0, 0.0, 4
 	@node_stack_top = 0.0, 1.9568316, 0.0, 0.0, 1.0, 0.0, 2
+
+	@MODULE[ModuleRCS*]
+	{
+		@name = ModuleRCSFX
+		%runningEffectName = running
+	}
 }
 
 @INTERNAL[PodCockpit|PodCockpitRPM]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]


### PR DESCRIPTION
The stock pod uses the simplified ModuleRCS but VSR replaces it with ModuleRCSFX.