### PR TITLE
Accurately size some bobcat soviet engines

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines.cfg
@@ -1,7 +1,7 @@
 @PART[NK33_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.85
+	%rescaleFactor = 1.49
 	//%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	//%node_stack_bottom = 0.0, -1.589812, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
@@ -38,7 +38,7 @@
 @PART[NK43_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.85
+	%rescaleFactor = 1.49
 	//%node_stack_top = 0.0, 2.352854, 0.0, 0.0, 1.0, 0.0, 2
 	//%node_stack_bottom = 0.0, -2.711397, 0.0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
@@ -186,11 +186,7 @@
 @PART[RD171_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	@MODEL
-	{
-		@scale = 1.0789, 1.0789, 1.0789
-	}
-	%rescaleFactor = 0.9268
+	%rescaleFactor = 1.4705
 	//%node_stack_top = 0.0, 1.826991, 0, 0.0, 1.0, 0.0, 4
 	//%node_stack_bottom = 0.0, -2.177579, 0, 0.0, -1.0, 0.0, 4
 	!node_attach = DELETE
@@ -227,7 +223,7 @@
 @PART[RD180_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.5625
+	%rescaleFactor = 1.4705
 	@MODEL
 	{
 		@model = Sovietengines/RD180/model
@@ -268,7 +264,7 @@
 @PART[RD191_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.5625
+	%rescaleFactor = 1.4705
 	//%node_stack_top = 0.0, 2.124936, 0, 0.0, 1.0, 0.0, 2
 	//%node_stack_bottom = 0.0, -1.840061, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE


### PR DESCRIPTION
make NK-33 family 1.49m diameter nozzle
make RD-170 RD-180 RD-191 have 1.43m diameter nozzle exits

NK-15V/43 now has a slightly too narrow nozzle exit, but engine length is about right and it's in proportion to the NK-33.