### PR TITLE
RealEngines heat production fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -79,7 +79,7 @@
         @name = ModuleEnginesRF
         @minThrust = 840.96
         @maxThrust = 1681.93
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -162,7 +162,7 @@
         @name = ModuleEnginesRF
         @minThrust = 878.67
         @maxThrust = 1757.34
-        @heatProduction = 00
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -247,7 +247,7 @@
         @name = ModuleEnginesRF
         @minThrust = 83.4
         @maxThrust = 83.4
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -372,7 +372,7 @@
         @name = ModuleEnginesRF
         @minThrust = 269.87
         @maxThrust = 298.2
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -456,7 +456,7 @@
         @name = ModuleEnginesRF
         @minThrust = 1863.26
         @maxThrust = 1961.33
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -538,7 +538,7 @@
         @name = ModuleEnginesRF
         @minThrust = 1863.26
         @maxThrust = 1961.33
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -659,7 +659,7 @@
         @name = ModuleEnginesRF
         @minThrust = 294.3
         @maxThrust = 294.3
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -750,7 +750,7 @@
         @name = ModuleEnginesRF
         @minThrust = 98.1
         @maxThrust = 98.1
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -832,7 +832,7 @@
         @name = ModuleEnginesRF
         @minThrust = 3952.24
         @maxThrust = 7904.49
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -915,7 +915,7 @@
         @name = ModuleEnginesRF
         @minThrust = 1951.43
         @maxThrust = 4152.41
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -998,7 +998,7 @@
         @name = ModuleEnginesRF
         @minThrust = 562.92
         @maxThrust = 2084.89
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1078,7 +1078,7 @@
         @name = ModuleEnginesRF
         @minThrust = 6.0
         @maxThrust = 6.0
-        @heatProduction = 100
+        @heatProduction = 200
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]


### PR DESCRIPTION
Change log:

* Increase the heat production to make the heat animations show up.
* Fix a bad heat production value on the NK-43 engine.

**Note:** the rest of the heat animation fixes will be part of the RealEngines pack itself.