### PR TITLE
Global engine patcher fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
@@ -56,7 +56,7 @@
 //  it to avoid the engine changing the mass of a part.
 //  ==================================================
 
-@PART[*]:HAS[#ignoreMass[true]]:AFTER[RealismOverhaulEngines]
+@PART[*]:HAS[#ignoreMass[*rue]]:AFTER[RealismOverhaulEngines]
 {
 	@MODULE[ModuleEngineConfigs]
 	{
@@ -65,10 +65,10 @@
 }
 
 //  ==================================================
-//  Subtract thrust from engines with verniers defined.
+//  Subtract thrust from engines with built-in verniers.
 //  ==================================================
 
-@PART[*]:HAS[#useVerniers[True]]:AFTER[RealismOverhaulEngines]
+@PART[*]:HAS[#useVerniers[*rue]]:AFTER[RealismOverhaulEngines]
 {
 	@MODULE[ModuleEngineConfigs]
     {
@@ -84,7 +84,7 @@
 //  Config cleanup.
 //  ==================================================
 
-@PART[*]:HAS[#engineType[*]]:AFTER[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[*]]:FOR[zzzTagCleanup]
 {
     !engineType = NULL
     !engineTypeMult = NULL


### PR DESCRIPTION
**Change log:**

* Make sure that both "true" and "True" are valid boolean check strings.
* Fix the tag cleanup pass for the TestFlight integration (and future global engine compatibility with RP-0).

**Notes:**

* Ping me for more info about the bullet point **No. 2** if you have questions (#1560).