### PR TITLE
Separate the S5.92 and S5.98M engine configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -7,17 +7,21 @@
 //  Burn Time: 2000 s
 
 //  Sources:
-//      KhIMMASH Research Institute - KVD-1 & S5.92 Brochure: http://www.k204.ru/books/vrd/wiki2/PDF/Himmash.pdf
-//      KhIMMASH Research Institute - S5.92 engine:           http://kbhmisaeva.ru/main.php?id=53
-//      Encyclopedia Astronautica - S5.92 engine:             http://www.astronautix.com/s/s592.html
+
+//  KhIMMASH Research Institute - KVD-1 & S5.92 Brochure: http://www.k204.ru/books/vrd/wiki2/PDF/Himmash.pdf
+//  KhIMMASH Research Institute - S5.92 engine:           http://kbhmisaeva.ru/main.php?id=53
+//  Encyclopedia Astronautica - S5.92 engine:             http://www.astronautix.com/s/s592.html
 
 //  Used by:
-//      CoatAerospace ProbesPlus pack
-//      RealEngines
+
+//  * CoatAerospace ProbesPlus pack
+//  * RealEngines pack
 
 //  Notes:
-//      The gimballing system uses the gas generator output via two gimbaled exhausts.
-//      The gimbal range of this mechanism is unknown. Normalized at 5 degrees for now.
+
+//  * The gimballing system uses a rail system (pantograph) to translate the engine on the X and Y axis by +/-0.3 m.
+//  * The gimbal range of this mechanism for the stock gimbal module is dependent on the distance between the
+//    engine thrust transform and the CoM. Normalized at 5 degrees for now.
 //  ==================================================
 
 @PART[*]:HAS[#engineType[S5_92]]:FOR[RealismOverhaulEngines]
@@ -66,7 +70,6 @@
             name = S5.92-BT
             minThrust = 19.61
             maxThrust = 19.61
-            heatProduction = 100
             gimbalRange = 5.0
             massMult = 1.0
             ullage = True
@@ -105,7 +108,6 @@
             name = S5.92-MT
             minThrust = 13.73
             maxThrust = 13.73
-            heatProduction = 100
             gimbalRange = 5.0
             massMult = 1.0
             ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -24,7 +24,7 @@
 {
     %category = Engine
     %title = S5.92
-    %manufacturer = NPO Lavochkin
+    %manufacturer = KB KhIMMASH
     %description = A gas generator cycle hypergolic vacuum engine. Used on the Fregat upper stage series. Diameter: 0.46 m.
 
     @MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -31,7 +31,7 @@
     {
         %minThrust = 19.61
         %maxThrust = 19.61
-        %heatProduction = 100
+        %heatProduction = 35
         %EngineType = LiquidFuel
         %useThrustCurve = False
         %ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -25,14 +25,14 @@
     %category = Engine
     %title = S5.92
     %manufacturer = KB KhIMMASH
-    %description = A gas generator cycle hypergolic vacuum engine. Used on the Fregat upper stage series. Diameter: 0.46 m.
+    %description = A gas generator cycle hypergolic vacuum engine. Used on the Fregat upper stage series. Diameter: 0.85 m.
 
     @MODULE[ModuleEngines*]
     {
         %minThrust = 19.61
         %maxThrust = 19.61
         %heatProduction = 100
-        %EngineType = LiquidEngine
+        %EngineType = LiquidFuel
         %useThrustCurve = False
         %ullage = True
         %pressureFed = False

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -1,80 +1,164 @@
-// S5.92
-// RLA
-//
+//  ==================================================
+//  S5.92 global engine configuration.
+
+//  Inert Mass: 75 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.0 (varies between the nominal and low thrust configurations)
+//  Burn Time: 2000 s
+
+//  Sources:
+//      KhIMMASH Research Institute - KVD-1 & S5.92 Brochure: http://www.k204.ru/books/vrd/wiki2/PDF/Himmash.pdf
+//      KhIMMASH Research Institute - S5.92 engine:           http://kbhmisaeva.ru/main.php?id=53
+//      Encyclopedia Astronautica - S5.92 engine:             http://www.astronautix.com/s/s592.html
+
+//  Used by:
+//      CoatAerospace ProbesPlus pack
+//      RealEngines
+
+//  Notes:
+//      The gimballing system uses the gas generator output via two gimbaled exhausts.
+//      The gimbal range of this mechanism is unknown. Normalized at 5 degrees for now.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[S5_92]]:FOR[RealismOverhaulEngines]
 {
-	@title = S5.92/98M
-	%manufacturer = KB KhIMMASH
-	@description = The S5.92/98M are used in the Briz-M and Fregat upper stages using storable propellant. Diameter: [2.25 m].
-	
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = S5.92
-		origMass = 0.075
-		modded = false
-		CONFIG
-		{
-			name = S5.92
-			minThrust = 19.6
-			maxThrust = 19.6
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.478
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.522
-			}
-			atmosphereCurve
-			{
-				key = 0 327
-				key = 1 150
-			}
-			massMult = 1.0
-		}
-		CONFIG
-		{
-			name = S5.98M
-			minThrust = 19.62
-			maxThrust = 19.62
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.478
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.522
-			}
-			atmosphereCurve
-			{
-				key = 0 326
-				key = 1 150
-			}
-			massMult = 1.267
-		}
-	}
+    %category = Engine
+    %title = S5.92
+    %manufacturer = NPO Lavochkin
+    %description = A gas generator cycle hypergolic vacuum engine. Used on the Fregat upper stage series. Diameter: 0.46 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 19.61
+        %maxThrust = 19.61
+        %heatProduction = 100
+        %EngineType = LiquidEngine
+        %useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 50
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal],*
+    {
+        @gimbalRange = 5.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    !MODULE[ModuleHybridEngine],*{}
+
+    MODULE
+    {
+        name = ModuleHybridEngine
+        type = ModuleEngines
+        configuration = S5.92-BT
+        origMass = 0.075
+
+        CONFIG
+        {
+            name = S5.92-BT
+            minThrust = 19.61
+            maxThrust = 19.61
+            heatProduction = 100
+            gimbalRange = 5.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 50
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.01
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.4782
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5218
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 327
+                key = 1 158
+            }
+        }
+
+        CONFIG
+        {
+            name = S5.92-MT
+            minThrust = 13.73
+            maxThrust = 13.73
+            heatProduction = 100
+            gimbalRange = 5.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 50
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.01
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.4782
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5218
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 158
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
 }
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5_92]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-	TESTFLIGHT
-	{
-		name = S5-92
-		ratedBurnTime = 3200
-		ignitionReliabilityStart = 0.8
-		ignitionReliabilityEnd = 0.989
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.889
-		cycleReliabilityEnd = 0.946
-	}
+    TESTFLIGHT
+    {
+        name = S5-92
+        ratedBurnTime = 2000
+        ignitionReliabilityStart = 0.8
+        ignitionReliabilityEnd = 0.989
+        ignitionDynPresFailMultiplier = 0.1
+        cycleReliabilityStart = 0.889
+        cycleReliabilityEnd = 0.946
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -26,7 +26,7 @@
         %minThrust = 19.61
         %maxThrust = 19.61
         %heatProduction = 100
-        %EngineType = LiquidEngine
+        %EngineType = LiquidFuel
         %useThrustCurve = False
         %ullage = True
         %pressureFed = False

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -25,7 +25,7 @@
     {
         %minThrust = 19.61
         %maxThrust = 19.61
-        %heatProduction = 100
+        %heatProduction = 30
         %EngineType = LiquidFuel
         %useThrustCurve = False
         %ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -1,0 +1,111 @@
+//  ==================================================
+//  S5.98M global engine configuration.
+
+//  Inert Mass: 95 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.0
+//  Burn Time: 3200 s
+
+//  Sources:
+//      KhIMMASH Research Institute - S5.98M engine: http://kbhmisaeva.ru/main.php?id=52
+//      Encyclopedia Astronautica - S5.98M engine:   http://www.astronautix.com/s/s598m.html
+
+//  Used by:
+//      RLA
+//  ==================================================
+
+@PART[*]:HAS[#engineType[S5_98M]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = S5.98M
+    %manufacturer = NPO Lavochkin
+    %description = A staged combustion cycle hypergolic vacuum engine. Used on the Briz upper stage series. Diameter: 0.95 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 19.61
+        %maxThrust = 19.61
+        %heatProduction = 100
+        %EngineType = LiquidEngine
+        %useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 8
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = S5.98M
+        origMass = 0.095
+
+        CONFIG
+        {
+            name = S5.98M
+            minThrust = 19.61
+            maxThrust = 19.61
+            heatProduction = 100
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 8
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.01
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.4782
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5218
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 328
+                key = 1 150
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5_98M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = S5-98M
+        ratedBurnTime = 3200
+        ignitionReliabilityStart = 0.8
+        ignitionReliabilityEnd = 0.989
+        ignitionDynPresFailMultiplier = 0.1
+        cycleReliabilityStart = 0.889
+        cycleReliabilityEnd = 0.946
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -18,7 +18,7 @@
 {
     %category = Engine
     %title = S5.98M
-    %manufacturer = NPO Lavochkin
+    %manufacturer = KB KhIMMASH
     %description = A staged combustion cycle hypergolic vacuum engine. Used on the Briz upper stage series. Diameter: 0.95 m.
 
     @MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -7,11 +7,14 @@
 //  Burn Time: 3200 s
 
 //  Sources:
-//      KhIMMASH Research Institute - S5.98M engine: http://kbhmisaeva.ru/main.php?id=52
-//      Encyclopedia Astronautica - S5.98M engine:   http://www.astronautix.com/s/s598m.html
+
+//  KhIMMASH Research Institute - S5.98M engine: http://kbhmisaeva.ru/main.php?id=52
+//  Encyclopedia Astronautica - S5.98M engine:   http://www.astronautix.com/s/s598m.html
 
 //  Used by:
-//      RLA
+
+//  * RealEngines pack
+//  * RLA
 //  ==================================================
 
 @PART[*]:HAS[#engineType[S5_98M]]:FOR[RealismOverhaulEngines]


### PR DESCRIPTION
**Change log:**

* Separate the S5.92 and the S5.98M global engine configurations.
* Create a new global engine configuration for the S5.98M engine.
* Increase the ignition count of the S5.92 engine.
* Add the low thrust config of the S5.92. It can be toggled in-flight (ModuleHybridEngine) between the nominal and the low thrust options.
* Other general patching updates and fixes.