### PR TITLE
RD-805 global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
@@ -1,0 +1,139 @@
+//  ==================================================
+//  RD-805 global engine configuration.
+
+//  Inert Mass: 120 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.5
+//  Burn Time: 1100 s
+
+//  Sources:
+
+//  Yuzhnoye Design Office - Kerolox rocket engine development: http://www.khai.edu/csp/nauchportal/Arhiv/AKTT/2013/AKTT113/Degtyar.pdf
+//  Norbert Brügge - Ukrainian rocket engines:                  http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
+//  Encyclopedia Astronautica - RD-802 engine:                  http://www.astronautix.com/r/rd-802.html
+
+//  Used by:
+
+//  * RealEngines pack
+//  ==================================================
+
+@PART[*]:HAS[#engineType[RD805]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = RD-805
+    %manufacturer = PA Yuzhmash
+    %description = A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use in upper stages. Diameter: 0.5 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 19.61
+        %minThrust = 19.61
+        %heatProduction = 30
+        %EngineType = LiquidFuel
+        @useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 6
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 8.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RD-805
+        origMass = 0.12
+
+        CONFIG
+        {
+            name = RD-805
+            minThrust = 19.61
+            minThrust = 19.61
+            gimbalRange = 8.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 6
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 0.175
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.015
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = TEATEB
+                amount = 0.175
+            }
+
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.3576
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6424
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 344
+                key = 1 172
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+
+    RESOURCE
+    {
+        name = TEATEB
+        amount = 1.05
+        maxAmount = 1.05
+        isTweakable = False
+    }
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-805]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = RD-805
+        ratedBurnTime = 1100
+        ignitionReliabilityStart = 0.995
+        ignitionReliabilityEnd = 0.997
+        ignitionDynPresFailMultiplier = 0.1
+        cycleReliabilityStart = 0.995
+        cycleReliabilityEnd = 0.997
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add a global engine configuration for the RD-805 engine.

**Notes:**

* The end values of the TestFlight reliability patch might be a bit high.
* Travis is having problems again...