### PR TITLE
STAR 37 global engine configs updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -19,299 +19,299 @@
 
 @PART[*]:HAS[#engineType[Star-37FM]]:FOR[RealismOverhaulEngines]
 {
-	%category = Engine
-	%title = STAR 37FM
-	%manufacturer = ATK
-	%description = The STAR 37FM is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vaccum thrust. First used on the FTLSATCOM satellites as an apogee motor. Diameter: 0.93 m.
+    %category = Engine
+    %title = STAR 37FM
+    %manufacturer = ATK
+    %description = The STAR 37FM is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vaccum thrust. First used on the FTLSATCOM satellites as an apogee motor. Diameter: 0.93 m.
 
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 54.8
-		%maxThrust = 54.8
-		%heatProduction = 100
-		%EngineType = SolidBooster
-		@useEngineResponseTime = False
-		!engineAccelerationSpeed = NULL
-		@useThrustCurve = True
-		%ullage = False
-		%pressureFed = False
-		%ignitions = 1
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 54.8
+        %maxThrust = 54.8
+        %heatProduction = 100
+        %EngineType = SolidBooster
+        @useEngineResponseTime = False
+        !engineAccelerationSpeed = NULL
+        @useThrustCurve = True
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
-		!IGNITOR_RESOURCE,*{}
+        !IGNITOR_RESOURCE,*{}
 
-		!thrustCurve,*{}
-	}
+        !thrustCurve,*{}
+    }
 
-	!MODULE[ModuleGimbal],*{}
+    !MODULE[ModuleGimbal],*{}
 
-	!MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleEngineConfigs],*{}
 
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = STAR-37FM
-		origMass = 0.082
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = STAR-37FM
+        origMass = 0.082
 
-		CONFIG
-		{
-			name = STAR-37FM
-			minThrust = 54.8
-			maxThrust = 54.8
-			gimbalRange = 0
-			masMult = 1.0
-			ullage = False
-			pressureFed = False
-			ignitions = 1
-			curveResource = HTPB
+        CONFIG
+        {
+            name = STAR-37FM
+            minThrust = 54.8
+            maxThrust = 54.8
+            gimbalRange = 0
+            masMult = 1.0
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+            curveResource = HTPB
 
-			PROPELLANT
-			{
-				name = HTPB
-				ratio = 1.0
-				DrawGauge = True
-			}
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
 
-			atmosphereCurve
-			{
-				key = 0 289.8
-				key = 1 200
-			}
+            atmosphereCurve
+            {
+                key = 0 289.8
+                key = 1 200
+            }
 
-			thrustCurve
-			{
-				key = 1.000	0.2006
-				key = 0.995	0.7376
-				key = 0.990	0.6830
-				key = 0.985	0.6830
-				key = 0.980	0.6857
-				key = 0.975	0.6884
-				key = 0.970	0.6884
-				key = 0.965	0.6911
-				key = 0.960	0.6938
-				key = 0.955	0.6959
-				key = 0.950	0.6990
-				key = 0.945	0.7020
-				key = 0.940	0.7048
-				key = 0.935	0.7075
-				key = 0.930	0.7102
-				key = 0.925	0.7129
-				key = 0.920	0.7156
-				key = 0.915	0.7183
-				key = 0.910	0.7220
-				key = 0.905	0.7247
-				key = 0.900	0.7293
-				key = 0.895	0.7320
-				key = 0.890	0.7347
-				key = 0.885	0.7380
-				key = 0.880	0.7406
-				key = 0.875	0.7458
-				key = 0.870	0.7485
-				key = 0.865	0.7512
-				key = 0.860	0.7559
-				key = 0.855	0.7583
-				key = 0.850	0.7622
-				key = 0.845	0.7657
-				key = 0.840	0.7680
-				key = 0.835	0.7730
-				key = 0.830	0.7760
-				key = 0.825	0.7801
-				key = 0.820	0.7842
-				key = 0.815	0.7870
-				key = 0.810	0.7918
-				key = 0.805	0.7965
-				key = 0.800	0.8039
-				key = 0.795	0.8113
-				key = 0.790	0.8213
-				key = 0.785	0.8285
-				key = 0.780	0.8357
-				key = 0.775	0.8428
-				key = 0.770	0.8498
-				key = 0.765	0.8568
-				key = 0.760	0.8637
-				key = 0.755	0.8693
-				key = 0.750	0.8747
-				key = 0.745	0.8815
-				key = 0.740	0.8855
-				key = 0.735	0.8913
-				key = 0.730	0.8961
-				key = 0.725	0.9000
-				key = 0.720	0.9039
-				key = 0.715	0.9079
-				key = 0.710	0.9134
-				key = 0.705	0.9161
-				key = 0.700	0.9216
-				key = 0.695	0.9243
-				key = 0.690	0.9291
-				key = 0.685	0.9326
-				key = 0.680	0.9353
-				key = 0.675	0.9400
-				key = 0.670	0.9436
-				key = 0.665	0.9472
-				key = 0.660	0.9507
-				key = 0.655	0.9542
-				key = 0.650	0.9577
-				key = 0.645	0.9628
-				key = 0.640	0.9655
-				key = 0.635	0.9707
-				key = 0.630	0.9741
-				key = 0.625	0.9775
-				key = 0.620	0.9821
-				key = 0.615	0.9848
-				key = 0.610	0.9901
-				key = 0.605	0.9934
-				key = 0.600	0.9966
-				key = 0.595	1.0000
-				key = 0.590	0.9922
-				key = 0.585	0.9824
-				key = 0.580	0.9735
-				key = 0.575	0.9646
-				key = 0.570	0.9584
-				key = 0.565	0.9522
-				key = 0.560	0.9463
-				key = 0.555	0.9436
-				key = 0.550	0.9416
-				key = 0.545	0.9409
-				key = 0.540	0.9409
-				key = 0.535	0.9409
-				key = 0.530	0.9409
-				key = 0.525	0.9409
-				key = 0.520	0.9409
-				key = 0.515	0.9409
-				key = 0.510	0.9409
-				key = 0.505	0.9382
-				key = 0.500	0.9360
-				key = 0.495	0.9324
-				key = 0.490	0.9287
-				key = 0.485	0.9195
-				key = 0.480	0.9135
-				key = 0.475	0.9135
-				key = 0.470	0.9135
-				key = 0.465	0.9135
-				key = 0.460	0.9162
-				key = 0.455	0.9191
-				key = 0.450	0.9244
-				key = 0.445	0.9292
-				key = 0.440	0.9329
-				key = 0.435	0.9365
-				key = 0.430	0.9409
-				key = 0.425	0.9409
-				key = 0.420	0.9409
-				key = 0.415	0.9409
-				key = 0.410	0.9409
-				key = 0.405	0.9409
-				key = 0.400	0.9409
-				key = 0.395	0.9409
-				key = 0.390	0.9409
-				key = 0.385	0.9409
-				key = 0.380	0.9409
-				key = 0.375	0.9409
-				key = 0.370	0.9409
-				key = 0.365	0.9409
-				key = 0.360	0.9409
-				key = 0.355	0.9409
-				key = 0.350	0.9409
-				key = 0.345	0.9409
-				key = 0.340	0.9409
-				key = 0.335	0.9409
-				key = 0.330	0.9409
-				key = 0.325	0.9409
-				key = 0.320	0.9409
-				key = 0.315	0.9409
-				key = 0.310	0.9410
-				key = 0.305	0.9436
-				key = 0.300	0.9436
-				key = 0.295	0.9436
-				key = 0.290	0.9443
-				key = 0.285	0.9464
-				key = 0.280	0.9464
-				key = 0.275	0.9491
-				key = 0.270	0.9491
-				key = 0.265	0.9510
-				key = 0.260	0.9519
-				key = 0.255	0.9526
-				key = 0.250	0.9547
-				key = 0.245	0.9569
-				key = 0.240	0.9576
-				key = 0.235	0.9602
-				key = 0.230	0.9618
-				key = 0.225	0.9630
-				key = 0.220	0.9657
-				key = 0.215	0.9657
-				key = 0.210	0.9673
-				key = 0.205	0.9685
-				key = 0.200	0.9685
-				key = 0.195	0.9712
-				key = 0.190	0.9698
-				key = 0.185	0.9685
-				key = 0.180	0.9685
-				key = 0.175	0.9658
-				key = 0.170	0.9658
-				key = 0.165	0.9631
-				key = 0.160	0.9604
-				key = 0.155	0.9577
-				key = 0.150	0.9550
-				key = 0.145	0.9523
-				key = 0.140	0.9496
-				key = 0.135	0.9496
-				key = 0.130	0.9496
-				key = 0.125	0.9496
-				key = 0.120	0.9469
-				key = 0.115	0.9469
-				key = 0.110	0.9469
-				key = 0.105	0.9469
-				key = 0.100	0.9469
-				key = 0.095	0.9469
-				key = 0.090	0.9442
-				key = 0.085	0.9442
-				key = 0.080	0.9442
-				key = 0.075	0.9442
-				key = 0.070	0.9442
-				key = 0.065	0.9442
-				key = 0.060	0.9442
-				key = 0.055	0.9415
-				key = 0.050	0.9415
-				key = 0.045	0.9415
-				key = 0.040	0.9415
-				key = 0.035	0.9415
-				key = 0.030	0.9415
-				key = 0.025	0.9389
-				key = 0.020	0.9388
-				key = 0.015	0.9388
-				key = 0.010	0.9363
-				key = 0.009	0.9194
-				key = 0.008	0.8980
-				key = 0.007	0.8517
-				key = 0.006	0.7958
-				key = 0.005	0.7307
-				key = 0.004	0.6615
-				key = 0.003	0.5859
-				key = 0.002	0.4856
-				key = 0.001	0.3102
-				key = 0.000	0.0569
-			}
-		}
-	}
+            thrustCurve
+            {
+                key = 1.000 0.2006
+                key = 0.995 0.7376
+                key = 0.990 0.6830
+                key = 0.985 0.6830
+                key = 0.980 0.6857
+                key = 0.975 0.6884
+                key = 0.970 0.6884
+                key = 0.965 0.6911
+                key = 0.960 0.6938
+                key = 0.955 0.6959
+                key = 0.950 0.6990
+                key = 0.945 0.7020
+                key = 0.940 0.7048
+                key = 0.935 0.7075
+                key = 0.930 0.7102
+                key = 0.925 0.7129
+                key = 0.920 0.7156
+                key = 0.915 0.7183
+                key = 0.910 0.7220
+                key = 0.905 0.7247
+                key = 0.900 0.7293
+                key = 0.895 0.7320
+                key = 0.890 0.7347
+                key = 0.885 0.7380
+                key = 0.880 0.7406
+                key = 0.875 0.7458
+                key = 0.870 0.7485
+                key = 0.865 0.7512
+                key = 0.860 0.7559
+                key = 0.855 0.7583
+                key = 0.850 0.7622
+                key = 0.845 0.7657
+                key = 0.840 0.7680
+                key = 0.835 0.7730
+                key = 0.830 0.7760
+                key = 0.825 0.7801
+                key = 0.820 0.7842
+                key = 0.815 0.7870
+                key = 0.810 0.7918
+                key = 0.805 0.7965
+                key = 0.800 0.8039
+                key = 0.795 0.8113
+                key = 0.790 0.8213
+                key = 0.785 0.8285
+                key = 0.780 0.8357
+                key = 0.775 0.8428
+                key = 0.770 0.8498
+                key = 0.765 0.8568
+                key = 0.760 0.8637
+                key = 0.755 0.8693
+                key = 0.750 0.8747
+                key = 0.745 0.8815
+                key = 0.740 0.8855
+                key = 0.735 0.8913
+                key = 0.730 0.8961
+                key = 0.725 0.9000
+                key = 0.720 0.9039
+                key = 0.715 0.9079
+                key = 0.710 0.9134
+                key = 0.705 0.9161
+                key = 0.700 0.9216
+                key = 0.695 0.9243
+                key = 0.690 0.9291
+                key = 0.685 0.9326
+                key = 0.680 0.9353
+                key = 0.675 0.9400
+                key = 0.670 0.9436
+                key = 0.665 0.9472
+                key = 0.660 0.9507
+                key = 0.655 0.9542
+                key = 0.650 0.9577
+                key = 0.645 0.9628
+                key = 0.640 0.9655
+                key = 0.635 0.9707
+                key = 0.630 0.9741
+                key = 0.625 0.9775
+                key = 0.620 0.9821
+                key = 0.615 0.9848
+                key = 0.610 0.9901
+                key = 0.605 0.9934
+                key = 0.600 0.9966
+                key = 0.595 1.0000
+                key = 0.590 0.9922
+                key = 0.585 0.9824
+                key = 0.580 0.9735
+                key = 0.575 0.9646
+                key = 0.570 0.9584
+                key = 0.565 0.9522
+                key = 0.560 0.9463
+                key = 0.555 0.9436
+                key = 0.550 0.9416
+                key = 0.545 0.9409
+                key = 0.540 0.9409
+                key = 0.535 0.9409
+                key = 0.530 0.9409
+                key = 0.525 0.9409
+                key = 0.520 0.9409
+                key = 0.515 0.9409
+                key = 0.510 0.9409
+                key = 0.505 0.9382
+                key = 0.500 0.9360
+                key = 0.495 0.9324
+                key = 0.490 0.9287
+                key = 0.485 0.9195
+                key = 0.480 0.9135
+                key = 0.475 0.9135
+                key = 0.470 0.9135
+                key = 0.465 0.9135
+                key = 0.460 0.9162
+                key = 0.455 0.9191
+                key = 0.450 0.9244
+                key = 0.445 0.9292
+                key = 0.440 0.9329
+                key = 0.435 0.9365
+                key = 0.430 0.9409
+                key = 0.425 0.9409
+                key = 0.420 0.9409
+                key = 0.415 0.9409
+                key = 0.410 0.9409
+                key = 0.405 0.9409
+                key = 0.400 0.9409
+                key = 0.395 0.9409
+                key = 0.390 0.9409
+                key = 0.385 0.9409
+                key = 0.380 0.9409
+                key = 0.375 0.9409
+                key = 0.370 0.9409
+                key = 0.365 0.9409
+                key = 0.360 0.9409
+                key = 0.355 0.9409
+                key = 0.350 0.9409
+                key = 0.345 0.9409
+                key = 0.340 0.9409
+                key = 0.335 0.9409
+                key = 0.330 0.9409
+                key = 0.325 0.9409
+                key = 0.320 0.9409
+                key = 0.315 0.9409
+                key = 0.310 0.9410
+                key = 0.305 0.9436
+                key = 0.300 0.9436
+                key = 0.295 0.9436
+                key = 0.290 0.9443
+                key = 0.285 0.9464
+                key = 0.280 0.9464
+                key = 0.275 0.9491
+                key = 0.270 0.9491
+                key = 0.265 0.9510
+                key = 0.260 0.9519
+                key = 0.255 0.9526
+                key = 0.250 0.9547
+                key = 0.245 0.9569
+                key = 0.240 0.9576
+                key = 0.235 0.9602
+                key = 0.230 0.9618
+                key = 0.225 0.9630
+                key = 0.220 0.9657
+                key = 0.215 0.9657
+                key = 0.210 0.9673
+                key = 0.205 0.9685
+                key = 0.200 0.9685
+                key = 0.195 0.9712
+                key = 0.190 0.9698
+                key = 0.185 0.9685
+                key = 0.180 0.9685
+                key = 0.175 0.9658
+                key = 0.170 0.9658
+                key = 0.165 0.9631
+                key = 0.160 0.9604
+                key = 0.155 0.9577
+                key = 0.150 0.9550
+                key = 0.145 0.9523
+                key = 0.140 0.9496
+                key = 0.135 0.9496
+                key = 0.130 0.9496
+                key = 0.125 0.9496
+                key = 0.120 0.9469
+                key = 0.115 0.9469
+                key = 0.110 0.9469
+                key = 0.105 0.9469
+                key = 0.100 0.9469
+                key = 0.095 0.9469
+                key = 0.090 0.9442
+                key = 0.085 0.9442
+                key = 0.080 0.9442
+                key = 0.075 0.9442
+                key = 0.070 0.9442
+                key = 0.065 0.9442
+                key = 0.060 0.9442
+                key = 0.055 0.9415
+                key = 0.050 0.9415
+                key = 0.045 0.9415
+                key = 0.040 0.9415
+                key = 0.035 0.9415
+                key = 0.030 0.9415
+                key = 0.025 0.9389
+                key = 0.020 0.9388
+                key = 0.015 0.9388
+                key = 0.010 0.9363
+                key = 0.009 0.9194
+                key = 0.008 0.8980
+                key = 0.007 0.8517
+                key = 0.006 0.7958
+                key = 0.005 0.7307
+                key = 0.004 0.6615
+                key = 0.003 0.5859
+                key = 0.002 0.4856
+                key = 0.001 0.3102
+                key = 0.000 0.0569
+            }
+        }
+    }
 
-	!MODULE[ModuleAlternator],*{}
+    !MODULE[ModuleAlternator],*{}
 
-	!MODULE[ModuleFuelTanks],*{}
+    !MODULE[ModuleFuelTanks],*{}
 
-	MODULE[ModuleFuelTanks]
-	{
-		type = HTPB
-		volume = 602.26
-		basemass = -1
+    MODULE[ModuleFuelTanks]
+    {
+        type = HTPB
+        volume = 602.26
+        basemass = -1
 
-		//  HTPB/AP propellant mixture mass 1065.9 Kg.
+        //  HTPB/AP propellant mixture mass 1065.9 Kg.
 
-		TANK
-		{
-			name = HTPB
-			amount = 602.26
-			maxAmount = 602.26
-		}
-	}
+        TANK
+        {
+            name = HTPB
+            amount = 602.26
+            maxAmount = 602.26
+        }
+    }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -74,8 +74,8 @@
 
             atmosphereCurve
             {
-                key = 0 289.8
-                key = 1 200
+                key = 0 290
+                key = 1 145
             }
 
             thrustCurve

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -1,0 +1,317 @@
+//  ==================================================
+//  STAR 37FM SRM global engine configuration.
+
+//  Gross Mass: 1148 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.77
+//  Burn Time: 63 s
+
+//  Sources:
+//      Orbital ATK - Space Propulsion Products Catalog, September 2012: https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
+//      Alternate Wars - Thiokol/Morton Thiokol/ATK Space Engines:       http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
+//      Gunter's Space Page - Star 37 SRM family:                        http://space.skyrocket.de/doc_eng/star-37.htm
+//      Encyclopedia Astronautica - Star 37FM SRM:                       http://www.astronautix.com/s/star37fm.html
+
+//  Used by:
+//      ATK Propulsion Pack
+//      Coatl Aerospace GroundOps
+//  ==================================================
+
+@PART[*]:HAS[#engineType[Star-37FM]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = STAR 37FM
+	%manufacturer = ATK
+	%description = The STAR 37FM is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vaccum thrust. First used on the FTLSATCOM satellites as an apogee motor. Diameter: 0.93 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 54.8
+		%maxThrust = 54.8
+		%heatProduction = 100
+		%EngineType = SolidBooster
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = NULL
+		@useThrustCurve = True
+		%ullage = False
+		%pressureFed = False
+		%ignitions = 1
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	!MODULE[ModuleGimbal],*{}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = STAR-37FM
+		origMass = 0.082
+
+		CONFIG
+		{
+			name = STAR-37FM
+			minThrust = 54.8
+			maxThrust = 54.8
+			gimbalRange = 0
+			masMult = 1.0
+			ullage = False
+			pressureFed = False
+			ignitions = 1
+			curveResource = HTPB
+
+			PROPELLANT
+			{
+				name = HTPB
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 289.8
+				key = 1 200
+			}
+
+			thrustCurve
+			{
+				key = 1.000	0.2006
+				key = 0.995	0.7376
+				key = 0.990	0.6830
+				key = 0.985	0.6830
+				key = 0.980	0.6857
+				key = 0.975	0.6884
+				key = 0.970	0.6884
+				key = 0.965	0.6911
+				key = 0.960	0.6938
+				key = 0.955	0.6959
+				key = 0.950	0.6990
+				key = 0.945	0.7020
+				key = 0.940	0.7048
+				key = 0.935	0.7075
+				key = 0.930	0.7102
+				key = 0.925	0.7129
+				key = 0.920	0.7156
+				key = 0.915	0.7183
+				key = 0.910	0.7220
+				key = 0.905	0.7247
+				key = 0.900	0.7293
+				key = 0.895	0.7320
+				key = 0.890	0.7347
+				key = 0.885	0.7380
+				key = 0.880	0.7406
+				key = 0.875	0.7458
+				key = 0.870	0.7485
+				key = 0.865	0.7512
+				key = 0.860	0.7559
+				key = 0.855	0.7583
+				key = 0.850	0.7622
+				key = 0.845	0.7657
+				key = 0.840	0.7680
+				key = 0.835	0.7730
+				key = 0.830	0.7760
+				key = 0.825	0.7801
+				key = 0.820	0.7842
+				key = 0.815	0.7870
+				key = 0.810	0.7918
+				key = 0.805	0.7965
+				key = 0.800	0.8039
+				key = 0.795	0.8113
+				key = 0.790	0.8213
+				key = 0.785	0.8285
+				key = 0.780	0.8357
+				key = 0.775	0.8428
+				key = 0.770	0.8498
+				key = 0.765	0.8568
+				key = 0.760	0.8637
+				key = 0.755	0.8693
+				key = 0.750	0.8747
+				key = 0.745	0.8815
+				key = 0.740	0.8855
+				key = 0.735	0.8913
+				key = 0.730	0.8961
+				key = 0.725	0.9000
+				key = 0.720	0.9039
+				key = 0.715	0.9079
+				key = 0.710	0.9134
+				key = 0.705	0.9161
+				key = 0.700	0.9216
+				key = 0.695	0.9243
+				key = 0.690	0.9291
+				key = 0.685	0.9326
+				key = 0.680	0.9353
+				key = 0.675	0.9400
+				key = 0.670	0.9436
+				key = 0.665	0.9472
+				key = 0.660	0.9507
+				key = 0.655	0.9542
+				key = 0.650	0.9577
+				key = 0.645	0.9628
+				key = 0.640	0.9655
+				key = 0.635	0.9707
+				key = 0.630	0.9741
+				key = 0.625	0.9775
+				key = 0.620	0.9821
+				key = 0.615	0.9848
+				key = 0.610	0.9901
+				key = 0.605	0.9934
+				key = 0.600	0.9966
+				key = 0.595	1.0000
+				key = 0.590	0.9922
+				key = 0.585	0.9824
+				key = 0.580	0.9735
+				key = 0.575	0.9646
+				key = 0.570	0.9584
+				key = 0.565	0.9522
+				key = 0.560	0.9463
+				key = 0.555	0.9436
+				key = 0.550	0.9416
+				key = 0.545	0.9409
+				key = 0.540	0.9409
+				key = 0.535	0.9409
+				key = 0.530	0.9409
+				key = 0.525	0.9409
+				key = 0.520	0.9409
+				key = 0.515	0.9409
+				key = 0.510	0.9409
+				key = 0.505	0.9382
+				key = 0.500	0.9360
+				key = 0.495	0.9324
+				key = 0.490	0.9287
+				key = 0.485	0.9195
+				key = 0.480	0.9135
+				key = 0.475	0.9135
+				key = 0.470	0.9135
+				key = 0.465	0.9135
+				key = 0.460	0.9162
+				key = 0.455	0.9191
+				key = 0.450	0.9244
+				key = 0.445	0.9292
+				key = 0.440	0.9329
+				key = 0.435	0.9365
+				key = 0.430	0.9409
+				key = 0.425	0.9409
+				key = 0.420	0.9409
+				key = 0.415	0.9409
+				key = 0.410	0.9409
+				key = 0.405	0.9409
+				key = 0.400	0.9409
+				key = 0.395	0.9409
+				key = 0.390	0.9409
+				key = 0.385	0.9409
+				key = 0.380	0.9409
+				key = 0.375	0.9409
+				key = 0.370	0.9409
+				key = 0.365	0.9409
+				key = 0.360	0.9409
+				key = 0.355	0.9409
+				key = 0.350	0.9409
+				key = 0.345	0.9409
+				key = 0.340	0.9409
+				key = 0.335	0.9409
+				key = 0.330	0.9409
+				key = 0.325	0.9409
+				key = 0.320	0.9409
+				key = 0.315	0.9409
+				key = 0.310	0.9410
+				key = 0.305	0.9436
+				key = 0.300	0.9436
+				key = 0.295	0.9436
+				key = 0.290	0.9443
+				key = 0.285	0.9464
+				key = 0.280	0.9464
+				key = 0.275	0.9491
+				key = 0.270	0.9491
+				key = 0.265	0.9510
+				key = 0.260	0.9519
+				key = 0.255	0.9526
+				key = 0.250	0.9547
+				key = 0.245	0.9569
+				key = 0.240	0.9576
+				key = 0.235	0.9602
+				key = 0.230	0.9618
+				key = 0.225	0.9630
+				key = 0.220	0.9657
+				key = 0.215	0.9657
+				key = 0.210	0.9673
+				key = 0.205	0.9685
+				key = 0.200	0.9685
+				key = 0.195	0.9712
+				key = 0.190	0.9698
+				key = 0.185	0.9685
+				key = 0.180	0.9685
+				key = 0.175	0.9658
+				key = 0.170	0.9658
+				key = 0.165	0.9631
+				key = 0.160	0.9604
+				key = 0.155	0.9577
+				key = 0.150	0.9550
+				key = 0.145	0.9523
+				key = 0.140	0.9496
+				key = 0.135	0.9496
+				key = 0.130	0.9496
+				key = 0.125	0.9496
+				key = 0.120	0.9469
+				key = 0.115	0.9469
+				key = 0.110	0.9469
+				key = 0.105	0.9469
+				key = 0.100	0.9469
+				key = 0.095	0.9469
+				key = 0.090	0.9442
+				key = 0.085	0.9442
+				key = 0.080	0.9442
+				key = 0.075	0.9442
+				key = 0.070	0.9442
+				key = 0.065	0.9442
+				key = 0.060	0.9442
+				key = 0.055	0.9415
+				key = 0.050	0.9415
+				key = 0.045	0.9415
+				key = 0.040	0.9415
+				key = 0.035	0.9415
+				key = 0.030	0.9415
+				key = 0.025	0.9389
+				key = 0.020	0.9388
+				key = 0.015	0.9388
+				key = 0.010	0.9363
+				key = 0.009	0.9194
+				key = 0.008	0.8980
+				key = 0.007	0.8517
+				key = 0.006	0.7958
+				key = 0.005	0.7307
+				key = 0.004	0.6615
+				key = 0.003	0.5859
+				key = 0.002	0.4856
+				key = 0.001	0.3102
+				key = 0.000	0.0569
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!MODULE[ModuleFuelTanks],*{}
+
+	MODULE[ModuleFuelTanks]
+	{
+		type = HTPB
+		volume = 602.26
+		basemass = -1
+
+		//  HTPB/AP propellant mixture mass 1065.9 Kg.
+
+		TANK
+		{
+			name = HTPB
+			amount = 602.26
+			maxAmount = 602.26
+		}
+	}
+
+	!RESOURCE,*{}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -22,7 +22,7 @@
     %category = Engine
     %title = STAR 37FM
     %manufacturer = ATK
-    %description = The STAR 37FM is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vaccum thrust. First used on the FTLSATCOM satellites as an apogee motor. Diameter: 0.93 m.
+    %description = The STAR 37FM is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vacuum thrust. First used on the FTLSATCOM satellites as an apogee motor. Diameter: 0.93 m.
 
     @MODULE[ModuleEngines*]
     {
@@ -297,8 +297,9 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    MODULE[ModuleFuelTanks]
+    MODULE
     {
+        name = ModuleFuelTanks
         type = HTPB
         volume = 602.26
         basemass = -1

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -22,7 +22,7 @@
     %category = Engine
     %title = STAR 37
     %manufacturer = Thiokol
-    %description = The STAR 37 is a vacumm solid rocket motor, originally developed for the Surveyor lunar lander program as a braking stage. Later variants were used exclusively as apogee kick stages. Diameter: 0.93 m.
+    %description = The STAR 37 is a vacuum solid rocket motor, originally developed for the Surveyor lunar lander program as a braking stage. Later variants were used exclusively as apogee kick stages. Diameter: 0.93 m.
 
     @MODULE[ModuleEngines*]
     {
@@ -297,8 +297,9 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    MODULE[ModuleFuelTanks]
+    MODULE
     {
+        name = ModuleFuelTanks
         type = HTPB
         volume = 317.8
         basemass = -1

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -75,7 +75,7 @@
             atmosphereCurve
             {
                 key = 0 260
-                key = 1 220
+                key = 1 130
             }
 
             thrustCurve

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -1,251 +1,317 @@
-//Star 37
-//ATKPack
-//Sources:
-//Orbital ATK Space Propulsion Products Catalog, September 2012
+//  ==================================================
+//  STAR 37 SRM global engine configuration.
+
+//  Gross Mass: 626 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.77
+//  Burn Time: 42 s
+
+//  Sources:
+//      Orbital ATK - Space Propulsion Products Catalog, September 2012: https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
+//      Alternate Wars - Thiokol/Morton Thiokol/ATK Space Engines:       http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
+//      Gunter's Space Page - Star 37 SRM family:                        http://space.skyrocket.de/doc_eng/star-37.htm
+//      Encyclopedia Astronautica - Star 37 SRM:                         http://www.astronautix.com/s/star37.html
+
+//  Used by:
+//      ATK Propulsion Pack
+//      Coatl Aerospace GroundOps
+//  ==================================================
+
 @PART[*]:HAS[#engineType[Star-37]]:FOR[RealismOverhaulEngines]
 {
-	@title = Star 37
-	%manufacturer = ATK
-	@description = The Star 37 is a type of solid rocket motor used by many space propulsion and launch vehicle stages. It is used almost exclusively as an upper stage. Diameter: [0.93 m].
-	
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = Star-37FM
-		modded = false
-		CONFIG
-		{
-			name = Star-37FM
-			minThrust = 54.8
-			maxThrust = 54.8
-			masMult = 1
-			gimbalRange = 0
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = HTPB
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 289.8
-				key = 1 200
-			}
-			curveResource = HTPB
-			thrustCurve
-			{
-				key = 	1	0.2006
-				key = 	0.995	0.7376
-				key = 	0.99	0.683
-				key = 	0.985	0.683
-				key = 	0.98	0.6857
-				key = 	0.975	0.6884
-				key = 	0.97	0.6884
-				key = 	0.965	0.6911
-				key = 	0.96	0.6938
-				key = 	0.955	0.6959
-				key = 	0.95	0.699
-				key = 	0.945	0.702
-				key = 	0.94	0.7048
-				key = 	0.935	0.7075
-				key = 	0.93	0.7102
-				key = 	0.925	0.7129
-				key = 	0.92	0.7156
-				key = 	0.915	0.7183
-				key = 	0.91	0.722
-				key = 	0.905	0.7247
-				key = 	0.9	0.7293
-				key = 	0.895	0.732
-				key = 	0.89	0.7347
-				key = 	0.885	0.738
-				key = 	0.88	0.7406
-				key = 	0.875	0.7458
-				key = 	0.87	0.7485
-				key = 	0.865	0.7512
-				key = 	0.86	0.7559
-				key = 	0.855	0.7583
-				key = 	0.85	0.7622
-				key = 	0.845	0.7657
-				key = 	0.84	0.768
-				key = 	0.835	0.773
-				key = 	0.83	0.776
-				key = 	0.825	0.7801
-				key = 	0.82	0.7842
-				key = 	0.815	0.787
-				key = 	0.81	0.7918
-				key = 	0.805	0.7965
-				key = 	0.8	0.8039
-				key = 	0.795	0.8113
-				key = 	0.79	0.8213
-				key = 	0.785	0.8285
-				key = 	0.78	0.8357
-				key = 	0.775	0.8428
-				key = 	0.77	0.8498
-				key = 	0.765	0.8568
-				key = 	0.76	0.8637
-				key = 	0.755	0.8693
-				key = 	0.75	0.8747
-				key = 	0.745	0.8815
-				key = 	0.74	0.8855
-				key = 	0.735	0.8913
-				key = 	0.73	0.8961
-				key = 	0.725	0.9
-				key = 	0.72	0.9039
-				key = 	0.715	0.9079
-				key = 	0.71	0.9134
-				key = 	0.705	0.9161
-				key = 	0.7	0.9216
-				key = 	0.695	0.9243
-				key = 	0.69	0.9291
-				key = 	0.685	0.9326
-				key = 	0.68	0.9353
-				key = 	0.675	0.94
-				key = 	0.67	0.9436
-				key = 	0.665	0.9472
-				key = 	0.66	0.9507
-				key = 	0.655	0.9542
-				key = 	0.65	0.9577
-				key = 	0.645	0.9628
-				key = 	0.64	0.9655
-				key = 	0.635	0.9707
-				key = 	0.63	0.9741
-				key = 	0.625	0.9775
-				key = 	0.62	0.9821
-				key = 	0.615	0.9848
-				key = 	0.61	0.9901
-				key = 	0.605	0.9934
-				key = 	0.6	0.9966
-				key = 	0.595	1
-				key = 	0.59	0.9922
-				key = 	0.585	0.9824
-				key = 	0.58	0.9735
-				key = 	0.575	0.9646
-				key = 	0.57	0.9584
-				key = 	0.565	0.9522
-				key = 	0.56	0.9463
-				key = 	0.555	0.9436
-				key = 	0.55	0.9416
-				key = 	0.545	0.9409
-				key = 	0.54	0.9409
-				key = 	0.535	0.9409
-				key = 	0.53	0.9409
-				key = 	0.525	0.9409
-				key = 	0.52	0.9409
-				key = 	0.515	0.9409
-				key = 	0.51	0.9409
-				key = 	0.505	0.9382
-				key = 	0.5	0.936
-				key = 	0.495	0.9324
-				key = 	0.49	0.9287
-				key = 	0.485	0.9195
-				key = 	0.48	0.9135
-				key = 	0.475	0.9135
-				key = 	0.47	0.9135
-				key = 	0.465	0.9135
-				key = 	0.46	0.9162
-				key = 	0.455	0.9191
-				key = 	0.45	0.9244
-				key = 	0.445	0.9292
-				key = 	0.44	0.9329
-				key = 	0.435	0.9365
-				key = 	0.43	0.9409
-				key = 	0.425	0.9409
-				key = 	0.42	0.9409
-				key = 	0.415	0.9409
-				key = 	0.41	0.9409
-				key = 	0.405	0.9409
-				key = 	0.4	0.9409
-				key = 	0.395	0.9409
-				key = 	0.39	0.9409
-				key = 	0.385	0.9409
-				key = 	0.38	0.9409
-				key = 	0.375	0.9409
-				key = 	0.37	0.9409
-				key = 	0.365	0.9409
-				key = 	0.36	0.9409
-				key = 	0.355	0.9409
-				key = 	0.35	0.9409
-				key = 	0.345	0.9409
-				key = 	0.34	0.9409
-				key = 	0.335	0.9409
-				key = 	0.33	0.9409
-				key = 	0.325	0.9409
-				key = 	0.32	0.9409
-				key = 	0.315	0.9409
-				key = 	0.31	0.941
-				key = 	0.305	0.9436
-				key = 	0.3	0.9436
-				key = 	0.295	0.9436
-				key = 	0.29	0.9443
-				key = 	0.285	0.9464
-				key = 	0.28	0.9464
-				key = 	0.275	0.9491
-				key = 	0.27	0.9491
-				key = 	0.265	0.951
-				key = 	0.26	0.9519
-				key = 	0.255	0.9526
-				key = 	0.25	0.9547
-				key = 	0.245	0.9569
-				key = 	0.24	0.9576
-				key = 	0.235	0.9602
-				key = 	0.23	0.9618
-				key = 	0.225	0.963
-				key = 	0.22	0.9657
-				key = 	0.215	0.9657
-				key = 	0.21	0.9673
-				key = 	0.205	0.9685
-				key = 	0.2	0.9685
-				key = 	0.195	0.9712
-				key = 	0.19	0.9698
-				key = 	0.185	0.9685
-				key = 	0.18	0.9685
-				key = 	0.175	0.9658
-				key = 	0.17	0.9658
-				key = 	0.165	0.9631
-				key = 	0.16	0.9604
-				key = 	0.155	0.9577
-				key = 	0.15	0.955
-				key = 	0.145	0.9523
-				key = 	0.14	0.9496
-				key = 	0.135	0.9496
-				key = 	0.13	0.9496
-				key = 	0.125	0.9496
-				key = 	0.12	0.9469
-				key = 	0.115	0.9469
-				key = 	0.11	0.9469
-				key = 	0.105	0.9469
-				key = 	0.1	0.9469
-				key = 	0.095	0.9469
-				key = 	0.09	0.9442
-				key = 	0.085	0.9442
-				key = 	0.08	0.9442
-				key = 	0.075	0.9442
-				key = 	0.07	0.9442
-				key = 	0.065	0.9442
-				key = 	0.06	0.9442
-				key = 	0.055	0.9415
-				key = 	0.05	0.9415
-				key = 	0.045	0.9415
-				key = 	0.04	0.9415
-				key = 	0.035	0.9415
-				key = 	0.03	0.9415
-				key = 	0.025	0.9389
-				key = 	0.02	0.9388
-				key = 	0.015	0.9388
-				key = 	0.01	0.9363
-				key = 	0.009	0.9194
-				key = 	0.008	0.898
-				key = 	0.007	0.8517
-				key = 	0.006	0.7958
-				key = 	0.005	0.7307
-				key = 	0.004	0.6615
-				key = 	0.003	0.5859
-				key = 	0.002	0.4856
-				key = 	0.001	0.3102
-				key = 	0	0.0569
-			}
-		}
-	}
+    %category = Engine
+    %title = STAR 37
+    %manufacturer = Thiokol
+    %description = The STAR 37 is a vacumm solid rocket motor, originally developed for the Surveyor lunar lander program as a braking stage. Later variants were used exclusively as apogee kick stages. Diameter: 0.93 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 54.8
+        %maxThrust = 54.8
+        %heatProduction = 100
+        %EngineType = SolidBooster
+        @useEngineResponseTime = False
+        !engineAccelerationSpeed = NULL
+        @useThrustCurve = True
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = STAR-37
+        origMass = 0.063
+
+        CONFIG
+        {
+            name = STAR-37
+            minThrust = 43.5
+            maxThrust = 43.5
+            gimbalRange = 0
+            masMult = 1.0
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+            curveResource = HTPB
+
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 260
+                key = 1 220
+            }
+
+            thrustCurve
+            {
+                key = 1.000 0.2006
+                key = 0.995 0.7376
+                key = 0.990 0.6830
+                key = 0.985 0.6830
+                key = 0.980 0.6857
+                key = 0.975 0.6884
+                key = 0.970 0.6884
+                key = 0.965 0.6911
+                key = 0.960 0.6938
+                key = 0.955 0.6959
+                key = 0.950 0.6990
+                key = 0.945 0.7020
+                key = 0.940 0.7048
+                key = 0.935 0.7075
+                key = 0.930 0.7102
+                key = 0.925 0.7129
+                key = 0.920 0.7156
+                key = 0.915 0.7183
+                key = 0.910 0.7220
+                key = 0.905 0.7247
+                key = 0.900 0.7293
+                key = 0.895 0.7320
+                key = 0.890 0.7347
+                key = 0.885 0.7380
+                key = 0.880 0.7406
+                key = 0.875 0.7458
+                key = 0.870 0.7485
+                key = 0.865 0.7512
+                key = 0.860 0.7559
+                key = 0.855 0.7583
+                key = 0.850 0.7622
+                key = 0.845 0.7657
+                key = 0.840 0.7680
+                key = 0.835 0.7730
+                key = 0.830 0.7760
+                key = 0.825 0.7801
+                key = 0.820 0.7842
+                key = 0.815 0.7870
+                key = 0.810 0.7918
+                key = 0.805 0.7965
+                key = 0.800 0.8039
+                key = 0.795 0.8113
+                key = 0.790 0.8213
+                key = 0.785 0.8285
+                key = 0.780 0.8357
+                key = 0.775 0.8428
+                key = 0.770 0.8498
+                key = 0.765 0.8568
+                key = 0.760 0.8637
+                key = 0.755 0.8693
+                key = 0.750 0.8747
+                key = 0.745 0.8815
+                key = 0.740 0.8855
+                key = 0.735 0.8913
+                key = 0.730 0.8961
+                key = 0.725 0.9000
+                key = 0.720 0.9039
+                key = 0.715 0.9079
+                key = 0.710 0.9134
+                key = 0.705 0.9161
+                key = 0.700 0.9216
+                key = 0.695 0.9243
+                key = 0.690 0.9291
+                key = 0.685 0.9326
+                key = 0.680 0.9353
+                key = 0.675 0.9400
+                key = 0.670 0.9436
+                key = 0.665 0.9472
+                key = 0.660 0.9507
+                key = 0.655 0.9542
+                key = 0.650 0.9577
+                key = 0.645 0.9628
+                key = 0.640 0.9655
+                key = 0.635 0.9707
+                key = 0.630 0.9741
+                key = 0.625 0.9775
+                key = 0.620 0.9821
+                key = 0.615 0.9848
+                key = 0.610 0.9901
+                key = 0.605 0.9934
+                key = 0.600 0.9966
+                key = 0.595 1.0000
+                key = 0.590 0.9922
+                key = 0.585 0.9824
+                key = 0.580 0.9735
+                key = 0.575 0.9646
+                key = 0.570 0.9584
+                key = 0.565 0.9522
+                key = 0.560 0.9463
+                key = 0.555 0.9436
+                key = 0.550 0.9416
+                key = 0.545 0.9409
+                key = 0.540 0.9409
+                key = 0.535 0.9409
+                key = 0.530 0.9409
+                key = 0.525 0.9409
+                key = 0.520 0.9409
+                key = 0.515 0.9409
+                key = 0.510 0.9409
+                key = 0.505 0.9382
+                key = 0.500 0.9360
+                key = 0.495 0.9324
+                key = 0.490 0.9287
+                key = 0.485 0.9195
+                key = 0.480 0.9135
+                key = 0.475 0.9135
+                key = 0.470 0.9135
+                key = 0.465 0.9135
+                key = 0.460 0.9162
+                key = 0.455 0.9191
+                key = 0.450 0.9244
+                key = 0.445 0.9292
+                key = 0.440 0.9329
+                key = 0.435 0.9365
+                key = 0.430 0.9409
+                key = 0.425 0.9409
+                key = 0.420 0.9409
+                key = 0.415 0.9409
+                key = 0.410 0.9409
+                key = 0.405 0.9409
+                key = 0.400 0.9409
+                key = 0.395 0.9409
+                key = 0.390 0.9409
+                key = 0.385 0.9409
+                key = 0.380 0.9409
+                key = 0.375 0.9409
+                key = 0.370 0.9409
+                key = 0.365 0.9409
+                key = 0.360 0.9409
+                key = 0.355 0.9409
+                key = 0.350 0.9409
+                key = 0.345 0.9409
+                key = 0.340 0.9409
+                key = 0.335 0.9409
+                key = 0.330 0.9409
+                key = 0.325 0.9409
+                key = 0.320 0.9409
+                key = 0.315 0.9409
+                key = 0.310 0.9410
+                key = 0.305 0.9436
+                key = 0.300 0.9436
+                key = 0.295 0.9436
+                key = 0.290 0.9443
+                key = 0.285 0.9464
+                key = 0.280 0.9464
+                key = 0.275 0.9491
+                key = 0.270 0.9491
+                key = 0.265 0.9510
+                key = 0.260 0.9519
+                key = 0.255 0.9526
+                key = 0.250 0.9547
+                key = 0.245 0.9569
+                key = 0.240 0.9576
+                key = 0.235 0.9602
+                key = 0.230 0.9618
+                key = 0.225 0.9630
+                key = 0.220 0.9657
+                key = 0.215 0.9657
+                key = 0.210 0.9673
+                key = 0.205 0.9685
+                key = 0.200 0.9685
+                key = 0.195 0.9712
+                key = 0.190 0.9698
+                key = 0.185 0.9685
+                key = 0.180 0.9685
+                key = 0.175 0.9658
+                key = 0.170 0.9658
+                key = 0.165 0.9631
+                key = 0.160 0.9604
+                key = 0.155 0.9577
+                key = 0.150 0.9550
+                key = 0.145 0.9523
+                key = 0.140 0.9496
+                key = 0.135 0.9496
+                key = 0.130 0.9496
+                key = 0.125 0.9496
+                key = 0.120 0.9469
+                key = 0.115 0.9469
+                key = 0.110 0.9469
+                key = 0.105 0.9469
+                key = 0.100 0.9469
+                key = 0.095 0.9469
+                key = 0.090 0.9442
+                key = 0.085 0.9442
+                key = 0.080 0.9442
+                key = 0.075 0.9442
+                key = 0.070 0.9442
+                key = 0.065 0.9442
+                key = 0.060 0.9442
+                key = 0.055 0.9415
+                key = 0.050 0.9415
+                key = 0.045 0.9415
+                key = 0.040 0.9415
+                key = 0.035 0.9415
+                key = 0.030 0.9415
+                key = 0.025 0.9389
+                key = 0.020 0.9388
+                key = 0.015 0.9388
+                key = 0.010 0.9363
+                key = 0.009 0.9194
+                key = 0.008 0.8980
+                key = 0.007 0.8517
+                key = 0.006 0.7958
+                key = 0.005 0.7307
+                key = 0.004 0.6615
+                key = 0.003 0.5859
+                key = 0.002 0.4856
+                key = 0.001 0.3102
+                key = 0.000 0.0569
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE[ModuleFuelTanks]
+    {
+        type = HTPB
+        volume = 317.8
+        basemass = -1
+
+        //  HTPB/AP propellant mixture mass 562.5 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 317.8
+            maxAmount = 317.8
+        }
+    }
+
+    !RESOURCE,*{}
 }


### PR DESCRIPTION
**Change log:**

* Rebuild the STAR 37 config to use the baseline STAR 37 operational parameters.
* Create a new STAR 37FM config for the Squad STAR 37 motor.
* Add by default a modular fuel tank with the correct propellant mass.
* Set some default engine parameters.

**Notes:**

* Open discussion for the RO STAR 37 variants here: https://github.com/KSP-RO/RealismOverhaul/issues/1556