### PR TITLE
Squad engines updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -4,7 +4,7 @@
 
 +PART[engineLargeSkipper]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-    %name = RO-RD-253
+	%name = RO-RD-253
 }
 
 @PART[RO-RD-253]:FOR[RealismOverhaul]
@@ -21,7 +21,7 @@
 		scale = 1.238, 1.238, 1.238
 	}
 
-    %scale = 1.0
+	%scale = 1.0
 	@rescaleFactor = 1.0
 
 	@node_stack_top = 0.0, 0.02, 0.0, 0.0, 1.0, 0.0, 2
@@ -29,18 +29,18 @@
 	%node_attach = 0.0, 0.02, 0.0, 0.0, 1.0, 0.0, 2
 
 	%mass = 1.28
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RD253
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RD253
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 1635
 		@maxThrust = 1635
 		@heatProduction = 100
@@ -99,7 +99,7 @@
 		scale = 0.8415, 0.8415, 0.8415
 	}
 
-    %scale = 1.0
+	%scale = 1.0
 	@rescaleFactor = 1.0
 
 	@node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
@@ -107,18 +107,18 @@
 	%node_attach = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
 
 	%mass = 0.167
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RL10
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RL10
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 65.6
 		%minThrust = 65.6
 		%heatProduction = 100
@@ -184,18 +184,18 @@
 	@category = Engine
 
 	@mass = 0.0495
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 673.15
-    %skinMaxTemp = 673.15
+	%skinMaxTemp = 673.15
 
-    %engineType = NSTAR
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = NSTAR
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 0.000019
 		@maxThrust = 0.000092
 		@heatProduction = 0
@@ -254,18 +254,18 @@
 	%node_stack_bottom = 0.0, -1.375, 0.0, 0.0, -1.0, 0.0, 2
 
 	@mass = 0.46 // I think 844kg was for the engine + tank.
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = LR105
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = LR105
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@maxThrust = 366.1
 		@minThrust = 366.1
 		@heatProduction = 100
@@ -316,25 +316,25 @@
 		scale = 0.69, 0.69, 0.69
 	}
 
-    @scale = 1.0
+	@scale = 1.0
 	%rescaleFactor = 1.0
 
 	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
 	@mass = 0.907
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = LR79
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = LR79
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 947
 		%minThrust = 947
 		%heatProduction = 100
@@ -382,7 +382,7 @@
 		scale = 0.69, 0.69, 0.69
 	}
 
-    @scale = 1.0
+	@scale = 1.0
 	%rescaleFactor = 1.4
 
 	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
@@ -390,17 +390,17 @@
 
 	@title = E1
 	%manufacturer = Rocketdyne
-    %description = Backup Proposal for the first stage engine on the Titan 1 ICBM, and proposed first stage engine on the Saturn 1 but ultimately never flown. Diameter: [2.14 m].
+	%description = Backup Proposal for the first stage engine on the Titan 1 ICBM, and proposed first stage engine on the Saturn 1 but ultimately never flown. Diameter: [2.14 m].
 
 	@mass = 1.264
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = E1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = E1
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleGimbal]
 	{
@@ -418,7 +418,7 @@
 
 +PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-    @name = RO-H1-RS27
+	@name = RO-H1-RS27
 }
 
 @PART[RO-H1-RS27]:FOR[RealismOverhaul]
@@ -443,7 +443,7 @@
 
     @mass = 0.907
     @crashTolerance = 10
-	@maxTemp = 873.15
+    @maxTemp = 873.15
     %skinMaxTemp = 973.15
 
     %engineType = H1
@@ -516,18 +516,18 @@
 	@node_stack_bottom = 0.0, -1.235, 0.0, 0.0, -1.0, 0.0, 2
 
 	@mass = 0.72
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = LR89
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = LR89
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 758.7
 		%minThrust = 758.7
 		%heatProduction = 100
@@ -586,14 +586,14 @@
 	%node_attach = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0
 
 	@mass = 0.15
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RD58
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RD58
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
@@ -633,7 +633,7 @@
 
 @PART[RO-RD-0210]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+	%RSSROConfig = True
 
 	!mesh = DELETE
 
@@ -645,25 +645,25 @@
 		scale = 1.2, 1.2, 1.2
 	}
 
-    %scale = 1.0
+	%scale = 1.0
 	@rescaleFactor = 1.0
 
 	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
 
 	%mass = 0.566
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RD0210
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RD0210
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 582.1
 		@maxThrust = 582.1
 		@heatProduction = 100
@@ -707,25 +707,25 @@
 		scale = 1.2, 1.2, 1.2
 	}
 
-    %scale = 1.0
+	%scale = 1.0
 	%rescaleFactor = 1.0
 
 	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
 
 	%mass = 0.135
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = LMDE
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass False
+	%engineType = LMDE
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%minThrust = 4.67
 		%maxThrust = 43.9
 		%heatProduction = 100
@@ -775,18 +775,18 @@
 	%node_stack_bottom = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 2
 
 	%mass = 0.125
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RD0105
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RD0105
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%minThrust = 49.4
 		%maxThrust = 49.4
 		%heatProduction = 100
@@ -843,25 +843,25 @@
 		scale = 2.0, 4.1, 2.0
 	}
 
-    %scale = 1.0
+	%scale = 1.0
 	%rescaleFactor = 1.0
 
 	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_bottom = 0.0, -1.605, 0.0, 0.0, -1.0, 0.0, 2
 
 	%mass = 0.095
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = LMAE
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = LMAE
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 15.57
 		%minThrust = 15.57
 		%heatProduction = 100
@@ -892,19 +892,19 @@
 
 +PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	@name = RO-SurveyorVernier
+    @name = RO-SurveyorVernier
 }
 
 @PART[RO-SurveyorVernier]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
+    %RSSROConfig = True
 
-	@mass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
+    @mass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
     @crashTolerance = 10
-	@maxTemp = 873.15
+    @maxTemp = 873.15
     %skinMaxTemp = 973.15
 
-	%engineType = TD339
+    %engineType = TD339
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False
@@ -919,13 +919,13 @@
         @PROPELLANT[LiquidFuel]
         {
             @name = MMH
-            @ratio = 0.516
+            @ratio = 0.5200
         }
 
         @PROPELLANT[Oxidizer]
         {
             @name = MON10
-            @ratio = 0.484
+            @ratio = 0.4800
         }
 
         @atmosphereCurve
@@ -933,6 +933,12 @@
             @key = 0 287
             @key = 1 100
         }
+    }
+
+    MODULE
+    {
+        name = ModuleGimbal
+        gimbalTransformName = thrustTransform
     }
 }
 
@@ -949,9 +955,9 @@
 		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
 	}
 
-    !node_stack_top2 = NULL
+	!node_stack_top2 = NULL
 
-    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
+	!MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
 //  ==================================================
@@ -970,9 +976,9 @@
 	%description = Thruster for orbital maneuvers, similar to ones used in the Galileo probe.
 
 	%mass = 0.015
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	%useRcsConfig = RCSBlock4x
 	%useRcsCostMult = 0.25
@@ -980,13 +986,13 @@
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 1.618
 		%minThrust = 1.618
 		%heatProduction = 17.5
 		%ullage = False
 		%pressureFed = True
-        %ignitions = -1
+		%ignitions = -1
 
 		@atmosphereCurve
 		{
@@ -1027,9 +1033,9 @@
 		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
 	}
 
-    !node_stack_top2 = NULL
+	!node_stack_top2 = NULL
 
-    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
+	!MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
 //  ==================================================
@@ -1061,18 +1067,18 @@
 	%node_stack_bottom = 0.0, -2.93, 0.0, 0.0, -1.0, 0.0, 3
 
 	@mass = 0.65
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = AJ10_137
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = AJ10_137
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 97.86
 		@maxThrust = 97.86
 		@heatProduction = 100
@@ -1119,16 +1125,16 @@
 	}
 
 	%node_stack_top = 0.0, 0.001, 0.0, 0.0, 1.0, 0.0, 4
-    !node_stack_top2 = NULL
+	!node_stack_top2 = NULL
 	%node_attach = 0.0, 0.0, 0.001, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -2.123, 0.0, 0.0, -1.0, 0.0, 3
 
 	@MODULE[ModuleGimbal]
-    {
-        @gimbalTransformName = Gimbal
-    }
+	{
+		@gimbalTransformName = Gimbal
+	}
 
-    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
+	!MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
 //  ==================================================
@@ -1164,18 +1170,18 @@
 	// ALSO: Mass ratio of propellants are total guesses.
 	// In fact, it's 65:35 Aniline:Furfuryl Alc. Presume mass ratio for RFNA:that is same as IWFNA:UDMH for Able?
 	// And Isps of Aerobee engines, too. Hard to find docs.
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = Aerobee
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = Aerobee
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 6.7
 		%minThrust = 6.7
 		%heatProduction = 40
@@ -1222,7 +1228,7 @@
 	}
 
 	%node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-    !node_stack_top2 = NULL
+	!node_stack_top2 = NULL
 	%node_attach = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -0.111, 0.0, 0.0, -1.0, 0.0, 0
 
@@ -1254,18 +1260,18 @@
 	@node_stack_bottom = 0.0, -5.0, 0.0, 0.0, -1.0, 0.0, 3
 
 	@mass = 8.5
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = NERVA
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = NERVA
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 111
 		@maxThrust = 333
 		@heatProduction = 100
@@ -1314,11 +1320,7 @@
 		%position = 0.0, 0.0, 0.0
 		%rotation = 380., 0.0, 0.0
 	}
-	MODULE  //new, has been stripped at creation (below)
-	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-	}
+
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
@@ -1334,7 +1336,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 26.7
 		@maxThrust = 26.7
 		@heatProduction = 17.5
@@ -1367,7 +1369,7 @@
 
 @PART[omsEngine]:AFTER[RealismOverhaulEngines]
 {
-	@title = AJ10-190 [Radial]
+	@title = AJ10-190 (Radial)
 }
 
 //  ==================================================
@@ -1379,14 +1381,14 @@
 	%RSSROConfig = True
 
 	%mass = 0.024
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = LR101
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = LR101
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
@@ -1424,18 +1426,18 @@
 	%RSSROConfig = True
 
 	%mass = 0.12
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RD855
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RD855
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		%maxThrust = 83
 		%minThrust = 83
 		%heatProduction = 100
@@ -1468,19 +1470,19 @@
 {
 	%RSSROConfig = True
 
-    @description = The dual-mode active-cooling RAPIER hypersonic engine which burns Methane. SFC 2.0 lb/lbf/hr, O/F in rocket mode 2.8 to 1.
+	@description = The dual-mode active-cooling RAPIER hypersonic engine which burns Methane. SFC 2.0 lb/lbf/hr, O/F in rocket mode 2.8 to 1.
 
-    @maxTemp = 873.15
-    @crashTolerance = 10
-    %skinMaxTemp = 973.15
+	@maxTemp = 873.15
+	@crashTolerance = 10
+	%skinMaxTemp = 973.15
 
-    @MODULE[ModuleEnginesAJEJet]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdMethane
-        }
-    }
+	@MODULE[ModuleEnginesAJEJet]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdMethane
+		}
+	}
 
 	@MODULE[ModuleEngines*]:HAS[~engineID[AirBreathing]]
 	{
@@ -1488,8 +1490,6 @@
 		@minThrust = 150
 		@maxThrust = 250
 		@heatProduction = 100
-		%ullage = False
-        %pressureFed = False
 
 		@PROPELLANT[LiquidFuel]
 		{
@@ -1512,7 +1512,7 @@
 }
 
 //  ==================================================
-//  Separation motor.
+//  Separation motor (medium).
 //  ==================================================
 
 @PART[sepMotor1]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -1532,18 +1532,18 @@
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
-	@title = Separation Motor
+	@title = Separation Motor (Medium)
 	@manufacturer = Generic
 	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others.
 
 	@mass = 0.044
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@maxThrust = 98
 		@heatProduction = 17.5
 		%exhaustDamage = False
@@ -1609,9 +1609,9 @@
 	@description = Larger solid motor use to help separate one stage from another or perform ullage. Best used with others.
 
 	@mass = 0.25
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	@MODULE[ModuleEngines*]
 	{
@@ -1628,13 +1628,12 @@
 		@CONFIG[SolidFuel]
 		{
 			@maxThrust *= 4
-
 		}
 	}
 }
 
 //  ==================================================
-//  Separation motor (large & small).
+//  Separation motor (all sizes).
 
 //  TestFlight compatibility.
 //  ==================================================
@@ -1657,7 +1656,7 @@
 }
 
 //  ==================================================
-//	RD-856 (vernier engine).
+//  RD-856 (vernier engine).
 //  ==================================================
 
 @PART[smallRadialEngine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -1665,18 +1664,18 @@
 	%RSSROConfig = True
 
 	%mass = 0.027
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = RD856
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = RD856
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@maxThrust = 13
 		@minThrust = 13
 		%heatProduction = 100
@@ -1727,18 +1726,18 @@
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
 
 	@mass = 2.3
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = Castor-30XL
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = Castor-30XL
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 0
 		@maxThrust = 715
 		@heatProduction = 100
@@ -1783,22 +1782,22 @@
 		@scale = 2.3368, 4.4402956655, 2.3368
 	}
 
-    @node_stack_top = 0.0, 2.45, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -3.95, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 2.45, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -3.95, 0.0, 0.0, -1.0, 0.0, 2
 
 	@MODULE[ModuleEngines*]
 	{
 		@thrustVectorTransformName = thrustTransform
 	}
 
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalTransformName = thrustTransform
-    }
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalTransformName = thrustTransform
+	}
 }
 
 //  ==================================================
-//	Castor 120.
+//  Castor 120.
 //  ==================================================
 
 @PART[solidBooster1-1]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
@@ -1822,19 +1821,19 @@
 	@node_attach = 0.0, 0.0, -1.1811, 0.0, 0.0, 1.0
 
 	@mass = 4.35
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	%engineType = Castor-120
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
-        @minThrust = 0
+		@name = ModuleEnginesRF
+		@minThrust = 0
 		@maxThrust = 1970
 		@heatProduction = 100
 		@useEngineResponseTime = False
@@ -1847,7 +1846,7 @@
 		}
 	}
 
-    //  Placeholder gimbal module.
+	//  Placeholder gimbal module.
 
 	MODULE
 	{
@@ -1863,7 +1862,7 @@
 		basemass = -1
 	}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -1900,15 +1899,9 @@
 	%massOffset = 0
 	%ignoreMass = False
 
-	MODULE
-	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-	}
-
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 889.3
 		@maxThrust = 889.3
 		@heatProduction = 100
@@ -1951,7 +1944,7 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 
-    @crashTolerance = 10
+	@crashTolerance = 10
 	%skinMaxTemp = 2500
 	@maxTemp = 1500
 
@@ -1959,9 +1952,8 @@
 	@manufacturer = Generic
 	@description = A generic conformal RCS thruster. Use this for attitude control or translation/ullage for spaceplanes. LEO-rated heat shielding.
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.275
 		!resourceName = DELETE
 
@@ -2021,15 +2013,15 @@
 
 @PART[RO-X-248]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+	%RSSROConfig = True
 
-    !mesh = NULL
+	!mesh = NULL
 
-    !MODEL,*{}
+	!MODEL,*{}
 
 	MODEL
 	{
-        model = Squad/Parts/Engine/solidBoosterBACC/model
+		model = Squad/Parts/Engine/solidBoosterBACC/model
 		scale = 0.34544, 0.256, 0.34544
 	}
 
@@ -2038,28 +2030,28 @@
 	@node_attach = 0.0, 0.0, -0.22, 0.0, 0.0, 1.0, 0
 
 	@mass = 0.03
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	%engineType = Altair
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
-        @minThrust = 0
+		@name = ModuleEnginesRF
+		@minThrust = 0
 		@maxThrust = 12.4
 		@heatProduction = 100
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
 
-        @PROPELLANT[SolidFuel]
-        {
-            @name = PSPC
-        }
+		@PROPELLANT[SolidFuel]
+		{
+			@name = PSPC
+		}
 
 		@atmosphereCurve
 		{
@@ -2070,20 +2062,20 @@
 
 	MODULE
 	{
-        name = ModuleFuelTanks
+		name = ModuleFuelTanks
 		type = PSPC
 		volume = 119.5403
-        basemass = -1
+		basemass = -1
 
-        TANK
-        {
-            name = PSPC
-            amount = 119.5403
-            maxAmount = 119.5403
-        }
+		TANK
+		{
+			name = PSPC
+			amount = 119.5403
+			maxAmount = 119.5403
+		}
 	}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -2098,7 +2090,7 @@
     {
         @model = VenStockRevamp/Squad/Parts/Propulsion/BACC
         @scale = 0.34544, 0.256, 0.34544
-	}
+    }
 }
 
 //  ==================================================
@@ -2112,15 +2104,15 @@
 
 @PART[RO-X-258]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+	%RSSROConfig = True
 
-    !mesh = NULL
+	!mesh = NULL
 
-    !MODEL,*{}
+	!MODEL,*{}
 
 	MODEL
 	{
-        model = Squad/Parts/Engine/solidBoosterRT-5/SRB_RT5
+		model = Squad/Parts/Engine/solidBoosterRT-5/SRB_RT5
 		scale = 0.64, 1.875, 0.64
 	}
 
@@ -2132,19 +2124,19 @@
 	@node_attach = 0.0, 0.0, -0.4, 0.0, 0.0, 1.0
 
 	@mass = 0.037
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	%engineType = Altair-II
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
-        @minThrust = 22.3
+		@name = ModuleEnginesRF
+		@minThrust = 22.3
 		@maxThrust = 22.3
 		@heatProduction = 100
 		@useEngineResponseTime = False
@@ -2184,13 +2176,13 @@
 @PART[RO-X-258]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
     @MODEL
-	{
+    {
         @model = VenStockRevamp/Squad/Parts/Propulsion/BACC
         @scale = 0.4718, 0.3125, 0.4718
-	}
+    }
 
-	@node_stack_top = 0.0, 1.215, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.295, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_top = 0.0, 1.215, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -1.295, 0.0, 0.0, -1.0, 0.0, 1
     @node_attach = 0.0, 0.0, -0.28, 0.0, 0.0, 1.0
 }
 
@@ -2209,7 +2201,7 @@
 
 	!mesh = DEL
 
-    !MODEL,*{}
+	!MODEL,*{}
 
 	MODEL
 	{
@@ -2250,14 +2242,14 @@
 	%node_stack_bottom = 0.0, -1.513, 0.0, 0.0, -1.0, 0.0, 2
 
 	%mass = 0.282
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
 	%engineType = KVD1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
@@ -2322,7 +2314,7 @@
 	@MODULE[ModuleGimbal]
 	{
 		@gimbalTransformName = vern01Transform
-        !gimbalRange = NULL
+		!gimbalRange = NULL
 		%gimbalRangeXP = 5
 		%gimbalRangeXN = 5
 		%gimbalRangeYP = 15
@@ -2346,15 +2338,15 @@
 			minThrust = 4
 			maxThrust = 4
 			heatProduction = 0
-            ullage = True
-            pressureFed = False
-            ignitions = 5
+			ullage = True
+			pressureFed = False
+			ignitions = 5
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.01
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.01
+			}
 
 			PROPELLANT
 			{
@@ -2386,7 +2378,7 @@
 @PART[RO_KVD1]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
     @MODEL,0
-	{
+    {
         @model = VenStockRevamp/Squad/Parts/Propulsion/LV909
         @scale = 2.8, 4.0, 2.8
     }
@@ -2411,10 +2403,10 @@
 }
 
 //  ==================================================
-//  Star 37.
+//  STAR 37.
 //  ==================================================
 
-+PART[solidBooster_sm]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
++PART[solidBooster_sm]:FIRST
 {
     @name = RO-STAR-37
 }
@@ -2428,32 +2420,31 @@
         %scale = 0.9347, 1.174, 0.9347
     }
 
+    @MODEL:NEEDS[VenStockRevamp]
+    {
+        @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
+        @scale = 0.9347, 1.174, 0.9347
+    }
+
     %scale = 1.0
     %rescaleFactor = 1.0
 
-	@node_stack_top = 0.0, 0.65, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 1
-	@node_attach = 0.0, 0.0, -0.45, 0.0, 0.0, 1.0
+    @node_stack_top = 0.0, 0.65, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 0.0, -0.45, 0.0, 0.0, 1.0
 
-    @mass = 0.081
+    @mass = 0.082
     @crashTolerance = 10
-	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
 
-    %engineType = Star-37
+    %engineType = Star-37FM
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 54.8
-        @heatProduction = 100
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
-
         @PROPELLANT[SolidFuel]
         {
             @name = HTPB
@@ -2461,50 +2452,9 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 289.8
-            @key,1 = 1 200
+            @key,0 = 0 290
+            @key,1 = 1 145
         }
-    }
-
-    MODULE
-    {
-        name = ModuleGimbal
-        gimbalTransformName = thrustTransform
-        gimbalRange = 3.5
-        useGimbalResponseSpeed = True
-        gimbalResponseSpeed = 16
-    }
-
-    MODULE
-    {
-        name = ModuleFuelTanks
-        type = HTPB
-        volume = 602.25
-        basemass = -1
-
-        TANK
-        {
-            name = HTPB
-            amount = 602.25
-            maxAmount = 602.25
-        }
-    }
-
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  Star 37.
-
-//  Ven Stock Revamp compatibility.
-//  ==================================================
-
-@PART[RO-STAR-37]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-    @MODEL
-    {
-        @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
-        @scale = 0.9347, 1.174, 0.9347
     }
 }
 
@@ -2528,38 +2478,38 @@
 	@node_stack_top = 0.0, 0.695, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.625, 0.0, 0.0, 1.0
 
-    @mass = 0.117
-    @crashTolerance = 10
+	@mass = 0.117
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = Star-48B
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = Star-48B
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-        @minThrust = 78.0
-        @maxThrust = 78.0
-        @heatProduction = 100
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 78.0
+		@maxThrust = 78.0
+		@heatProduction = 100
+		@useEngineResponseTime = False
+		@engineAccelerationSpeed = 0
 
-        @PROPELLANT[SolidFuel]
-        {
-            @name = HTPB
-        }
+		@PROPELLANT[SolidFuel]
+		{
+			@name = HTPB
+		}
 
-        @atmosphereCurve
-        {
-            @key,0 = 0 292.1
-            @key,1 = 1 200
-        }
-    }
+		@atmosphereCurve
+		{
+			@key,0 = 0 292.1
+			@key,1 = 1 200
+		}
+	}
 
-    //  Placeholder gimbal module.
+	//  Placeholder gimbal module.
 
 	MODULE
 	{
@@ -2575,7 +2525,7 @@
 		basemass = -1
 	}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -2601,34 +2551,34 @@
 {
 	%RSSROConfig = True
 
-    !mesh = NULL
+	!mesh = NULL
 
-    !MODEL,*{}
+	!MODEL,*{}
 
-    MODEL
-    {
-        model = Squad/Parts/Engine/liquidEngineSSME/SSME
-        scale = 1.915, 2.225, 1.915
-    }
+	MODEL
+	{
+		model = Squad/Parts/Engine/liquidEngineSSME/SSME
+		scale = 1.915, 2.225, 1.915
+	}
 
-    %scale = 1.0
-    @rescaleFactor = 1.0
+	%scale = 1.0
+	@rescaleFactor = 1.0
 
-    @node_stack_bottom = 0.0, -3.475, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -3.475, 0.0, 0.0, -1.0, 0.0, 2
 
 	@mass = 3.527
-    @crashTolerance = 10
+	@crashTolerance = 10
 	@maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	%skinMaxTemp = 973.15
 
-    %engineType = SSME
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = SSME
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
+		@name = ModuleEnginesRF
 		@minThrust = 1400
 		@maxThrust = 2280
 		@heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -18,20 +18,20 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineSkipper/model
-		scale = 1.238, 1.238, 1.238
+		scale = 1.061, 1.155, 1.061
 	}
 
 	%scale = 1.0
 	@rescaleFactor = 1.0
 
-	@node_stack_top = 0.0, 0.02, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -3.74, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -3.045, 0.0, 0.0, -1.0, 0.0, 2
 	%node_attach = 0.0, 0.02, 0.0, 0.0, 1.0, 0.0, 2
 
-	%mass = 1.28
+	@mass = 1.28
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RD253
 	%engineTypeMult = 1
@@ -66,22 +66,6 @@
 }
 
 //  ==================================================
-//  RD-253 (booster engine).
-
-//  Ven Stock Revamp compatibility
-//  Diameter changed to match sources of 1.5m in diameter and 3m in length
-//  http://www.russianspaceweb.com/rd253.html
-//  ==================================================
-
-@PART[RO-RD-253]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-	@MODEL
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/Skipper
-	}
-}
-
-//  ==================================================
 //  RL10 (vacuum engine).
 //  ==================================================
 
@@ -96,20 +80,20 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineSkipper/model
-		scale = 0.8415, 0.8415, 0.8415
+		scale = 0.7015, 0.68, 0.7015
 	}
 
 	%scale = 1.0
 	@rescaleFactor = 1.0
 
 	@node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.725, 0.0, 0.0, -1.0, 0.0, 2
-	%node_attach = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.845, 0.0, 0.0, -1.0, 0.0, 2
+	@node_attach = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 2
 
-	%mass = 0.167
+	@mass = 0.167
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RL10
 	%engineTypeMult = 1
@@ -119,9 +103,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 65.6
-		%minThrust = 65.6
-		%heatProduction = 100
+		@maxThrust = 65.6
+		@minThrust = 65.6
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -140,20 +124,6 @@
 			@name = LqdOxygen
 			@ratio = 0.237
 		}
-	}
-}
-
-//  ==================================================
-//  RL10 (vacuum engine).
-
-//  Ven Stock Revamp compatibility.
-//  ==================================================
-
-@PART[engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-	@MODEL
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/Skipper
 	}
 }
 
@@ -185,8 +155,8 @@
 
 	@mass = 0.0495
 	@crashTolerance = 10
-	@maxTemp = 673.15
-	%skinMaxTemp = 673.15
+	@maxTemp = 473.15
+	%skinMaxTemp = 573.15
 
 	%engineType = NSTAR
 	%engineTypeMult = 1
@@ -200,9 +170,7 @@
 		@maxThrust = 0.000092
 		@heatProduction = 0
 
-		!PROPELLANT[ElectricCharge]
-		{
-		}
+		!PROPELLANT[ElectricCharge]{}
 
 		@PROPELLANT[XenonGas]
 		{
@@ -250,13 +218,13 @@
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
-	%node_stack_top = 0.0, 1.44, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -1.375, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 1.47, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.515, 0.0, 0.0, -1.0, 0.0, 2
 
 	@mass = 0.46 // I think 844kg was for the engine + tank.
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = LR105
 	%engineTypeMult = 1
@@ -289,7 +257,7 @@
 		}
 	}
 
-    //  Placeholder gimbal module.
+	//  Placeholder gimbal module.
 
 	MODULE
 	{
@@ -324,8 +292,8 @@
 
 	@mass = 0.907
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = LR79
 	%engineTypeMult = 1
@@ -335,9 +303,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 947
-		%minThrust = 947
-		%heatProduction = 100
+		@maxThrust = 947
+		@minThrust = 947
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -367,9 +335,15 @@
 		%gimbalResponseSpeed = 16
 	}
 }
+
+//  ==================================================
+//  E-1 (booster engine).
+//  ==================================================
+
 +PART[liquidEngine1-2]:FOR[RealismOverhaul]
 {
 	@name = RO-E1
+
 	%RSSROConfig = True
 
 	!mesh = DELETE
@@ -388,14 +362,10 @@
 	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
-	@title = E1
-	%manufacturer = Rocketdyne
-	%description = Backup Proposal for the first stage engine on the Titan 1 ICBM, and proposed first stage engine on the Saturn 1 but ultimately never flown. Diameter: [2.14 m].
-
 	@mass = 1.264
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = E1
 	%engineTypeMult = 1
@@ -407,8 +377,6 @@
 		!gimbalRange = DEL // just in case
 		%gimbalTransformName = thrustTransform
 		%gimbalRange = 10
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
 	}
 }
 
@@ -423,66 +391,65 @@
 
 @PART[RO-H1-RS27]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+	%RSSROConfig = True
 
-    !mesh = NULL
+	!mesh = NULL
 
-    !MODEL,*{}
+	!MODEL,*{}
 
-    MODEL
-    {
-        model = RealismOverhaul/Parts/Engines/OldVSRMainsail/Mainsail
-        scale = 0.69, 0.69, 0.69
-    }
+	MODEL
+	{
+		model = RealismOverhaul/Parts/Engines/OldVSRMainsail/Mainsail
+		scale = 0.69, 0.69, 0.69
+	}
 
-    %scale = 1.0
-    @rescaleFactor = 1.0
+	%scale = 1.0
+	@rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 2
 
-    @mass = 0.907
-    @crashTolerance = 10
-    @maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	@mass = 0.907
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
-    %engineType = H1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = H1
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-        @maxThrust = 947
-        @minThrust = 947
-        @heatProduction = 100
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@maxThrust = 947
+		@minThrust = 947
+		@heatProduction = 100
 
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3842
-        }
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.3842
+		}
 
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6158
-        }
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.6158
+		}
 
-        @atmosphereCurve
-        {
-            @key,0 = 0 289
-            @key,1 = 1 255
-        }
-    }
+		@atmosphereCurve
+		{
+			@key,0 = 0 289
+			@key,1 = 1 255
+		}
+	}
+
 	@MODULE[ModuleGimbal]
 	{
 		!gimbalRange = DEL // just in case
 		%gimbalTransformName = thrustTransform
 		%gimbalRange = 10
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
 	}
 }
 
@@ -517,8 +484,8 @@
 
 	@mass = 0.72
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = LR89
 	%engineTypeMult = 1
@@ -528,9 +495,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 758.7
-		%minThrust = 758.7
-		%heatProduction = 100
+		@maxThrust = 758.7
+		@minThrust = 758.7
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -575,20 +542,20 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-T45/model
-		scale = 1.625, 1.625, 1.625
+		scale = 1.975, 1.625, 1.975
 	}
 
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
 	@node_stack_top = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.315, 0.0, 0.0, -1.0, 0.0, 1
-	%node_attach = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0
+	@node_stack_bottom = 0.0, -1.445, 0.0, 0.0, -1.0, 0.0, 1
+	@node_attach = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0
 
 	@mass = 0.15
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RD58
 	%engineTypeMult = 1
@@ -597,10 +564,10 @@
 
 	@MODULE[ModuleEngines*]
 	{
-        @name = ModuleEnginesRF
-		%maxThrust = 63.7
-		%minThrust = 63.7
-		%heatProduction = 100
+		@name = ModuleEnginesRF
+		@maxThrust = 63.7
+		@minThrust = 63.7
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -628,7 +595,7 @@
 
 +PART[liquidEngine2-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-    @name = RO-RD-0210
+	@name = RO-RD-0210
 }
 
 @PART[RO-RD-0210]:FOR[RealismOverhaul]
@@ -648,13 +615,13 @@
 	%scale = 1.0
 	@rescaleFactor = 1.0
 
-	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.03, 0.0, 0.0, -1.0, 0.0, 2
 
-	%mass = 0.566
+	@mass = 0.566
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RD0210
 	%engineTypeMult = 1
@@ -710,13 +677,13 @@
 	%scale = 1.0
 	%rescaleFactor = 1.0
 
-	%node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -0.835, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.03, 0.0, 0.0, -1.0, 0.0, 2
 
-	%mass = 0.135
+	@mass = 0.135
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = LMDE
 	%engineTypeMult = 1
@@ -726,9 +693,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%minThrust = 4.67
-		%maxThrust = 43.9
-		%heatProduction = 100
+		@minThrust = 4.67
+		@maxThrust = 43.9
+		@heatProduction = 100
 
 		@PROPELLANT[LiquidFuel]
 		{
@@ -765,19 +732,24 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-909/model
-		scale = 2.0, 2.0, 2.0
+		scale = 1.75, 2.0, 1.75
+	}
+
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909
 	}
 
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
-	%node_stack_top = 0.0, 0.46, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.385, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -0.875, 0.0, 0.0, -1.0, 0.0, 2
 
-	%mass = 0.125
+	@mass = 0.125
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RD0105
 	%engineTypeMult = 1
@@ -787,9 +759,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%minThrust = 49.4
-		%maxThrust = 49.4
-		%heatProduction = 100
+		@minThrust = 49.4
+		@maxThrust = 49.4
+		@heatProduction = 100
 
 		@PROPELLANT[LiquidFuel]
 		{
@@ -812,20 +784,6 @@
 }
 
 //  ==================================================
-//  RD-0105/0109 (vacuum engine).
-
-//  Ven Stock Revamp compatibility.
-//  ==================================================
-
-@PART[liquidEngine3]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-	@MODEL
-	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909
-	}
-}
-
-//  ==================================================
 //  LMAE (vacuum engine).
 //  ==================================================
 
@@ -840,19 +798,19 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngine48-7S/model
-		scale = 2.0, 4.1, 2.0
+		scale = 3.5, 3.0, 3.5
 	}
 
 	%scale = 1.0
 	%rescaleFactor = 1.0
 
-	%node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -1.605, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.175, 0.0, 0.0, -1.0, 0.0, 2
 
-	%mass = 0.095
+	@mass = 0.095
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = LMAE
 	%engineTypeMult = 1
@@ -862,9 +820,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 15.57
-		%minThrust = 15.57
-		%heatProduction = 100
+		@maxThrust = 15.57
+		@minThrust = 15.57
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -892,54 +850,56 @@
 
 +PART[microEngine]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-    @name = RO-SurveyorVernier
+	@name = RO-SurveyorVernier
 }
 
 @PART[RO-SurveyorVernier]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+	%RSSROConfig = True
 
-    @mass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
-    @crashTolerance = 10
-    @maxTemp = 873.15
-    %skinMaxTemp = 973.15
+	@mass = 0.009 // 2.66kg for the engine alone, but for RCS we over-mass for control systems and bladder/surface-tension tanks.
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
-    %engineType = TD339
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	%engineType = TD339
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-        @minThrust = 0.134
-        @maxThrust = 0.463
-        @heatProduction = 100
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 0.134
+		@maxThrust = 0.463
+		@heatProduction = 100
 
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = MMH
-            @ratio = 0.5200
-        }
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = MMH
+			@ratio = 0.5200
+		}
 
-        @PROPELLANT[Oxidizer]
-        {
-            @name = MON10
-            @ratio = 0.4800
-        }
+		@PROPELLANT[Oxidizer]
+		{
+			@name = MON10
+			@ratio = 0.4800
+		}
 
-        @atmosphereCurve
-        {
-            @key = 0 287
-            @key = 1 100
-        }
-    }
+		@atmosphereCurve
+		{
+			@key = 0 287
+			@key = 1 100
+		}
+	}
 
-    MODULE
-    {
-        name = ModuleGimbal
-        gimbalTransformName = thrustTransform
-    }
+	//  Placeholder gimbal module.
+
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+	}
 }
 
 //  ==================================================
@@ -971,14 +931,14 @@
 {
 	%RSSROConfig = True
 
-	%title = 1kN Thruster
-	%manufacturer = Generic
-	%description = Thruster for orbital maneuvers, similar to ones used in the Galileo probe.
+	@title = 1kN Thruster
+	@manufacturer = Generic
+	@description = Thruster for orbital maneuvers, similar to ones used in the Galileo probe.
 
-	%mass = 0.015
+	@mass = 0.015
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%useRcsConfig = RCSBlock4x
 	%useRcsCostMult = 0.25
@@ -987,9 +947,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 1.618
-		%minThrust = 1.618
-		%heatProduction = 17.5
+		@maxThrust = 1.618
+		@minThrust = 1.618
+		@heatProduction = 17.5
 		%ullage = False
 		%pressureFed = True
 		%ignitions = -1
@@ -1062,14 +1022,14 @@
 		position = 0.0, 2.0, 0.0
 	}
 
-	%node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 4
-	%node_attach = 0.0, 0.016, 0.01, 0.0, 1.0, 0.0, 4
-	%node_stack_bottom = 0.0, -2.93, 0.0, 0.0, -1.0, 0.0, 3
+	@node_stack_top = 0.0, 0.01, 0.0, 0.0, 1.0, 0.0, 4
+	@node_attach = 0.0, 0.016, 0.01, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -2.93, 0.0, 0.0, -1.0, 0.0, 3
 
 	@mass = 0.65
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = AJ10_137
 	%engineTypeMult = 1
@@ -1100,7 +1060,7 @@
 		}
 	}
 
-    //  Placeholder gimbal module.
+	//  Placeholder gimbal module.
 
 	MODULE
 	{
@@ -1124,10 +1084,10 @@
 		@position = 0.0, 0.1, 0.0
 	}
 
-	%node_stack_top = 0.0, 0.001, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_top = 0.0, 0.001, 0.0, 0.0, 1.0, 0.0, 4
 	!node_stack_top2 = NULL
-	%node_attach = 0.0, 0.0, 0.001, 0.0, 1.0, 0.0, 4
-	%node_stack_bottom = 0.0, -2.123, 0.0, 0.0, -1.0, 0.0, 3
+	@node_attach = 0.0, 0.0, 0.001, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -2.123, 0.0, 0.0, -1.0, 0.0, 3
 
 	@MODULE[ModuleGimbal]
 	{
@@ -1161,18 +1121,14 @@
 		position = 0.0, 0.096, 0.0
 	}
 
-	%node_stack_top = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
-	%node_attach = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_bottom = 0.0, -0.084, 0.0, 0.0, -1.0, 0.0, 0
+	@node_stack_top = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
+	@node_attach = 0.0, 0.016, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.084, 0.0, 0.0, -1.0, 0.0, 0
 
-	// FIXME section
-	%mass = 0.008 // total guess
-	// ALSO: Mass ratio of propellants are total guesses.
-	// In fact, it's 65:35 Aniline:Furfuryl Alc. Presume mass ratio for RFNA:that is same as IWFNA:UDMH for Able?
-	// And Isps of Aerobee engines, too. Hard to find docs.
+	@mass = 0.008 // total guess
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = Aerobee
 	%engineTypeMult = 1
@@ -1182,9 +1138,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 6.7
-		%minThrust = 6.7
-		%heatProduction = 40
+		@maxThrust = 6.7
+		@minThrust = 6.7
+		@heatProduction = 40
 
 		@atmosphereCurve
 		{
@@ -1227,12 +1183,12 @@
 		%position = 0.0, 0.1, 0.0
 	}
 
-	%node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
 	!node_stack_top2 = NULL
-	%node_attach = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_bottom = 0.0, -0.111, 0.0, 0.0, -1.0, 0.0, 0
+	@node_attach = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.111, 0.0, 0.0, -1.0, 0.0, 0
 
-    !MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
+	!MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
 }
 
 //  ==================================================
@@ -1261,8 +1217,8 @@
 
 	@mass = 8.5
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = NERVA
 	%engineTypeMult = 1
@@ -1272,8 +1228,8 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		@minThrust = 111
-		@maxThrust = 333
+		@minThrust = 66.72
+		@maxThrust = 66.72
 		@heatProduction = 100
 
 		@PROPELLANT[LiquidFuel]
@@ -1285,17 +1241,18 @@
 		@PROPELLANT[Oxidizer]
 		{
 			@name = EnrichedUranium
-			@ratio = 0.00000000001
+			@ratio = 1.0813e-15
+			%ignoreForIsp = True
 		}
 
 		@atmosphereCurve
 		{
-			@key,0 = 0 925
+			@key,0 = 0 930
 			@key,1 = 1 380
 		}
 	}
 
-    //  Placeholder gimbal module.
+	//  Placeholder gimbal module.
 
 	MODULE
 	{
@@ -1318,7 +1275,7 @@
 	{
 		%scale = 11.0, 11.0, 11.0
 		%position = 0.0, 0.0, 0.0
-		%rotation = 380., 0.0, 0.0
+		%rotation = 380.0, 0.0, 0.0
 	}
 
 	@scale = 1.0
@@ -1326,8 +1283,8 @@
 
 	@mass = 0.118
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = AJ10_190
 	%engineTypeMult = 1
@@ -1351,6 +1308,7 @@
 		{
 			name = NTO
 			ratio = 0.496
+			DrawGauge = False
 		}
 
 		@atmosphereCurve
@@ -1380,10 +1338,10 @@
 {
 	%RSSROConfig = True
 
-	%mass = 0.024
+	@mass = 0.024
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = LR101
 	%engineTypeMult = 1
@@ -1393,9 +1351,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 4.523
-		%minThrust = 4.523
-		%heatProduction = 10
+		@maxThrust = 4.523
+		@minThrust = 4.523
+		@heatProduction = 10
 
 		@atmosphereCurve
 		{
@@ -1425,10 +1383,10 @@
 {
 	%RSSROConfig = True
 
-	%mass = 0.12
+	@mass = 0.12
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RD855
 	%engineTypeMult = 1
@@ -1438,9 +1396,9 @@
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
-		%maxThrust = 83
-		%minThrust = 83
-		%heatProduction = 100
+		@maxThrust = 83
+		@minThrust = 83
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -1470,11 +1428,13 @@
 {
 	%RSSROConfig = True
 
+	@title = CR-7 R.A.P.I.E.R.
+	@manufacturer = Generic
 	@description = The dual-mode active-cooling RAPIER hypersonic engine which burns Methane. SFC 2.0 lb/lbf/hr, O/F in rocket mode 2.8 to 1.
 
-	@maxTemp = 873.15
 	@crashTolerance = 10
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	@MODULE[ModuleEnginesAJEJet]
 	{
@@ -1538,8 +1498,8 @@
 
 	@mass = 0.044
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	@MODULE[ModuleEngines*]
 	{
@@ -1568,7 +1528,6 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = SolidFuel
-		modded = false
 
 		CONFIG
 		{
@@ -1591,7 +1550,7 @@
 		}
 	}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -1601,6 +1560,7 @@
 +PART[sepMotor1]:AFTER[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = sepMotorLarge
+
 	@scale = 1.0
 	%rescaleFactor = 2.0
 
@@ -1610,8 +1570,8 @@
 
 	@mass = 0.25
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	@MODULE[ModuleEngines*]
 	{
@@ -1650,7 +1610,6 @@
 		cycleReliabilityStart = 0.99
 		cycleReliabilityEnd = 0.9999 // because fail in first 5s is 10x, bump this up higher than expected.
 		reliabilityDataRateMultiplier = 0.1 // we already start reliable, so don't get data too fast
-
 		isSolid = True
 	}
 }
@@ -1665,8 +1624,8 @@
 
 	%mass = 0.027
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = RD856
 	%engineTypeMult = 1
@@ -1678,7 +1637,7 @@
 		@name = ModuleEnginesRF
 		@maxThrust = 13
 		@minThrust = 13
-		%heatProduction = 100
+		@heatProduction = 100
 
 		@atmosphereCurve
 		{
@@ -1715,20 +1674,20 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/solidBoosterRT-10/model
-		scale = 2.3368, 2.632887, 2.3368
+		scale = 2.3368, 2.633, 2.3368
 	}
 
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
-	@node_stack_bottom = 0.0, -3.294453, 0.0, 0.0, -1.0, 0.0, 2
-	@node_stack_top = 0.0, 2.699947, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -4.025, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 2.465, 0.0, 0.0, 1.0, 0.0, 2
 	@node_attach = 0.0, 0.0, -1.1684, 0.0, 0.0, 1.0, 1
 
 	@mass = 2.3
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = Castor-30XL
 	%engineTypeMult = 1
@@ -1757,7 +1716,7 @@
 		basemass = -1
 	}
 
-    //  Placeholder gimbal module.
+	//  Placeholder gimbal module.
 
 	MODULE
 	{
@@ -1765,7 +1724,7 @@
 		gimbalTransformName = thrustTransform
 	}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -1822,8 +1781,8 @@
 
 	@mass = 4.35
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = Castor-120
 	%engineTypeMult = 1
@@ -1891,8 +1850,8 @@
 
 	@mass = 1.4
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = J2T
 	%engineTypeMult = 1
@@ -1945,8 +1904,8 @@
 	%useRcsMass = True
 
 	@crashTolerance = 10
-	%skinMaxTemp = 2500
-	@maxTemp = 1500
+	@maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@title = Conformal RCS Thruster (275/445 N class)
 	@manufacturer = Generic
@@ -1957,15 +1916,13 @@
 		@thrusterPower = 0.275
 		!resourceName = DELETE
 
+		!PROPELLANT,*{}
+
 		PROPELLANT
 		{
 			ratio = 1.0
 			name = Hydrazine
 		}
-
-		!PROPELLANT[LiquidFuel]{}
-
-		!PROPELLANT[Oxidizer]{}
 
 		@atmosphereCurve
 		{
@@ -2025,14 +1982,19 @@
 		scale = 0.34544, 0.256, 0.34544
 	}
 
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/BACC
+	}
+
 	@node_stack_bottom = 0.0, -1.055, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.22, 0.0, 0.0, 1.0, 0
 
 	@mass = 0.03
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = Altair
 	%engineTypeMult = 1
@@ -2079,21 +2041,6 @@
 }
 
 //  ==================================================
-//  Altair (X-248).
-
-//  Ven Stock Revamp compatibility.
-//  ==================================================
-
-@PART[RO-X-248]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-    @MODEL
-    {
-        @model = VenStockRevamp/Squad/Parts/Propulsion/BACC
-        @scale = 0.34544, 0.256, 0.34544
-    }
-}
-
-//  ==================================================
 //  Altair-II (X-258).
 //  ==================================================
 
@@ -2125,8 +2072,8 @@
 
 	@mass = 0.037
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = Altair-II
 	%engineTypeMult = 1
@@ -2149,22 +2096,22 @@
 		}
 	}
 
-    MODULE
-    {
-        name = ModuleFuelTanks
-        type = PSPC
-        volume = 136.8
-        basemass = -1
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = PSPC
+		volume = 136.8
+		basemass = -1
 
-        TANK
-        {
-            name = PSPC
-            amount = 136.8
-            maxAmount = 136.8
-        }
-    }
+		TANK
+		{
+			name = PSPC
+			amount = 136.8
+			maxAmount = 136.8
+		}
+	}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -2175,15 +2122,15 @@
 
 @PART[RO-X-258]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
-    @MODEL
-    {
-        @model = VenStockRevamp/Squad/Parts/Propulsion/BACC
-        @scale = 0.4718, 0.3125, 0.4718
-    }
+	@MODEL
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/BACC
+		@scale = 0.4718, 0.3125, 0.4718
+	}
 
-    @node_stack_top = 0.0, 1.215, 0.0, 0.0, 1.0, 0.0, 1
-    @node_stack_bottom = 0.0, -1.295, 0.0, 0.0, -1.0, 0.0, 1
-    @node_attach = 0.0, 0.0, -0.28, 0.0, 0.0, 1.0
+	@node_stack_top = 0.0, 1.215, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.295, 0.0, 0.0, -1.0, 0.0, 1
+	@node_attach = 0.0, 0.0, -0.28, 0.0, 0.0, 1.0
 }
 
 //  ==================================================
@@ -2206,7 +2153,7 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngineLV-909/model
-		scale = 2.8, 4.0, 2.8
+		scale = 3.5, 4.0, 3.5
 	}
 
 	MODEL
@@ -2214,7 +2161,7 @@
 		model = RealismOverhaul/Models/KVDvernStock
 		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
 		scale = 1.0, 1.0, 1.0
-		position = 0.0, -1.6, -0.58
+		position = 0.0, -1.6, -0.725
 		rotation = 12.0, 0.0, 0.0
 	}
 
@@ -2223,14 +2170,14 @@
 		model = RealismOverhaul/Models/KVDvernStock
 		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
 		scale = 1.0, 1.0, 1.0
-		position = 0.0, -1.6, 0.58
+		position = 0.0, -1.6, 0.725
 		rotation = 12.0, 180, 0.0
 	}
 
 	MODEL
 	{
 		model = Squad/Parts/Structural/strutOcto/model
-		scale = 3.0, 4.5, 3.0
+		scale = 3.3, 4.5, 3.3
 		position = 0.0, 0.35, 0.0
 		rotation = 0.0, 22.5, 0.0
 	}
@@ -2238,13 +2185,13 @@
 	@scale = 1.0
 	%rescaleFactor = 1.0
 
-	%node_stack_top = 0.0, 0.9, 0.0, 0.0, 1.0, 0.0, 2
-	%node_stack_bottom = 0.0, -1.513, 0.0, 0.0, -1.0, 0.0, 2
+	%node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 2
+	%node_stack_bottom = 0.0, -1.755, 0.0, 0.0, -1.0, 0.0, 2
 
-	%mass = 0.282
+	@mass = 0.282
 	@crashTolerance = 10
-	@maxTemp = 873.15
-	%skinMaxTemp = 973.15
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
 	%engineType = KVD1
 	%engineTypeMult = 1
@@ -2278,6 +2225,8 @@
 			@key,1 = 1 150
 		}
 	}
+
+	//  Vernier engines setup.
 
 	MODULE
 	{
@@ -2330,7 +2279,6 @@
 		configuration = KVD-1-Verniers
 		engineID = vernier
 		isMaster = false
-		modded = false
 
 		CONFIG
 		{
@@ -2377,105 +2325,99 @@
 
 @PART[RO_KVD1]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
-    @MODEL,0
-    {
-        @model = VenStockRevamp/Squad/Parts/Propulsion/LV909
-        @scale = 2.8, 4.0, 2.8
-    }
+	@MODEL,0
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909
+		@scale = 3.5, 4.0, 3.5
+	}
 
-    //  Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0.
+	//  Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0.
 
-    @MODEL,1
-    {
-        @model = RealismOverhaul/Models/KVDvernVSR
-        !texture = DELETE
-        texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
-        texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
-    }
+	@MODEL,1
+	{
+		@model = RealismOverhaul/Models/KVDvernVSR
+		!texture = DELETE
+		texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
+		texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
+	}
 
-    @MODEL,2
-    {
-        @model = RealismOverhaul/Models/KVDvernVSR
-        !texture = DELETE
-        texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
-        texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
-    }
+	@MODEL,2
+	{
+		@model = RealismOverhaul/Models/KVDvernVSR
+		!texture = DELETE
+		texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
+		texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
+	}
 }
 
 //  ==================================================
 //  STAR 37.
 //  ==================================================
 
-+PART[solidBooster_sm]:FIRST
++PART[solidBooster_sm]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-    @name = RO-STAR-37
+	@name = RO-STAR-37
 }
 
 @PART[RO-STAR-37]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+	%RSSROConfig = True
 
-    @MODEL
-    {
-        %scale = 0.9347, 1.174, 0.9347
-    }
+	@MODEL
+	{
+		@scale = 0.9347, 1.174, 0.9347
+	}
 
-    @MODEL:NEEDS[VenStockRevamp]
-    {
-        @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
-        @scale = 0.9347, 1.174, 0.9347
-    }
+	%scale = 1.0
+	%rescaleFactor = 1.0
 
-    %scale = 1.0
-    %rescaleFactor = 1.0
+	@node_stack_top = 0.0, 0.65, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 1
+	@node_attach = 0.0, 0.0, -0.45, 0.0, 0.0, 1.0
 
-    @node_stack_top = 0.0, 0.65, 0.0, 0.0, 1.0, 0.0, 1
-    @node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 1
-    @node_attach = 0.0, 0.0, -0.45, 0.0, 0.0, 1.0
+	@mass = 0.082
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 
-    @mass = 0.082
-    @crashTolerance = 10
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+	%engineType = Star-37FM
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
-    %engineType = Star-37FM
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
+	@MODULE[ModuleEngines*]
+	{
+		@PROPELLANT[SolidFuel]
+		{
+			@name = HTPB
+		}
 
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[SolidFuel]
-        {
-            @name = HTPB
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 290
-            @key,1 = 1 145
-        }
-    }
+		@atmosphereCurve
+		{
+			@key,0 = 0 290
+			@key,1 = 1 145
+		}
+	}
 }
 
 //  ==================================================
-//  Star 48B.
+//  STAR 48B.
 //  ==================================================
 
 @PART[solidBooster_sm]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 
-    @MODEL
+	@MODEL
 	{
-		@scale = 1.25, 1.25, 1.25
+		@scale = 1.25, 1.4165, 1.25
 	}
 
 	%scale = 1.0
-	%rescaleFactor = 1.0
+	@rescaleFactor = 1.0
 
-	@node_stack_bottom = 0.0, -1.11, 0.0, 0.0, -1.0, 0.0, 1
-	@node_stack_top = 0.0, 0.695, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.26, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.79, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.625, 0.0, 0.0, 1.0
 
 	@mass = 0.117
@@ -2526,21 +2468,6 @@
 	}
 
 	!RESOURCE,*{}
-}
-
-//  ==================================================
-//  Star 48B.
-
-//  Ven Stock Revamp compatibility.
-//  ==================================================
-
-@PART[solidBooster_sm]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
-{
-    @MODEL
-    {
-        @model = VenStockRevamp/Squad/Parts/Propulsion/RT5
-        @scale = 1.25, 1.25, 1.25
-    }
 }
 
 //  ==================================================
@@ -2611,10 +2538,10 @@
 
 @PART[SSME]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
-    @MODEL
-    {
-        @scale = 2.5, 2.78, 2.5
-    }
+	@MODEL
+	{
+		@scale = 2.78, 2.78, 2.78
+	}
 
-    @node_stack_bottom = 0.0, -4.075, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -4.225, 0.0, 0.0, -1.0, 0.0, 2
 }


### PR DESCRIPTION
**Change log:**

* Update the propellant O/F ratio of the TD-339 engine.
* Add a missing placeholder gimbal module to the TD-339 engine.
* Fix the brackets of the AJ10-190 engine title.
* Add a "Medium" sizing tag to the baseline separation rocket to make identification in the editor easier.
* Make sure that the RCS modules are patched correctly, even if they use the new FX module.
* Update the STAR 37FM part config for the changes in the STAR 37FM global engine config.
* Merge the VSR model patches to the parent part config wherever applicable.
* Remove various other redundant fields (model paths and gimbal parameters) already covered by other patches.
* Reduce the part maximum temperatures.
* Fix the nozzle diameters and attachment node positions of some engines.
* Formatting (space to tab).

**Notes:**

* [Alternate diff ignoring white space changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1564/files?w=1)
* Some of the nozzle diameter stats for the US engines were taken from here: http://www.alternatewars.com/BBOW/Space_Engines/SP-8120_Excerpt.pdf and from various other sources for the rest of them.
* The plumes might be a bit off for some of the engines.