### PR TITLE
RD-0210 and RD-0212 global config updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -1,30 +1,45 @@
 //  ==================================================
-//  RD-0210
+//  RD-0210/0211 global engine configuration.
 
+//  Inert Mass: 566 Kg
 //  Throttle Range: N/A
 //  Burn Time: 230 s
 //  O/F Ratio: 2.6
 
 //  Sources:
-//      http://www.lpre.de/kbkha/RD-0203/index.htm
-//      http://www.russianspaceweb.com/rd0210.html
-//      http://www.astronautix.com/engines/rd0210.htm
+
+//  KB Khimavtomatika - RD-0210 engine:                http://www.kbkha.ru/?p=8&cat=8&prod=33
+//  Liquid Propellant Rocket Engines - RD-0210 engine: http://www.lpre.de/kbkha/RD-0203/index.htm
+//  Russian Space Web - RD-0210 engine:                http://www.russianspaceweb.com/rd0210.html
+//  Encyclopedia Astronautica - RD-0210 engine:        http://www.astronautix.com/engines/rd0210.htm
 
 //  Used by:
-//      Squad
-//      Tantares
+
+//  * RealEngines pack
+//  * Squad
+//  * Tantares
 //  ==================================================
 
 @PART[*]:HAS[#engineType[RD0210]]:FOR[RealismOverhaulEngines]
 {
-    @mass = 0.566
-    %title = RD-0210
-    %manufacturer = KB Khimavtomatika
-    %description = A series of engines found on the second stage of the Proton series launcher. All the four second stage engines gimbal. Diameter: [1.47 m].
+    %title = RD-0210/0211
+    %manufacturer = Voronezh Mechanical Plant (VMZ)
+    %description = A staged combustion, hypergolic vacuum rocket engine. Used as a power plant on the second stage of the Proton launch vehicle family. Features a two-axis gimbal mechanism for attitude control. Diameter: 1.47 m.
 
     @MODULE[ModuleEngines*]
     {
+        %minThrust = 584.77
+        %maxThrust = 584.77
+        %heatProduction = 100
         %EngineType = LiquidFuel
+        @useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
     }
 
     @MODULE[ModuleGimbal]
@@ -34,69 +49,72 @@
         %gimbalResponseSpeed = 16
     }
 
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = RD-0210
-		origMass = 0.566
-		modded = false
+    !MODULE[ModuleEngineConfigs],*{}
 
-		CONFIG
-		{
-			name = RD-0210
-			minThrust = 582.1
-			maxThrust = 582.1
-			heatProduction = 100
-				
-			ullage = True
-			pressureFed = False
-			ignitions = 1
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RD-0210
+        origMass = 0.566
 
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 1
-			}
+        CONFIG
+        {
+            name = RD-0210
+            minThrust = 584.77
+            maxThrust = 584.77
+            gimbalRange = 3.25
+            ullage = True
+            pressureFed = False
+            ignitions = 1
 
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.4135
-				DrawGauge = True
-			}
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
 
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.5865
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.4135
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5865
                 DrawGauge = False
-			}
+            }
 
-			atmosphereCurve
-			{
-				key = 0 327
-				key = 1 225
-			}
-		}
-	}
+            atmosphereCurve
+            {
+                key = 0 327
+                key = 1 164
+            }
+        }
+    }
 
-    !MODULE[ModuleAlternator]{}
+    !MODULE[ModuleAlternator],*{}
 
     !RESOURCE,*{}
 }
 
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0210]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-	TESTFLIGHT
-	{
-		name = RD-0210
-		ratedBurnTime = 238
-		ignitionReliabilityStart = 0.944
-		ignitionReliabilityEnd = 0.999
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.889
-		cycleReliabilityEnd = 0.993
-	}
+    TESTFLIGHT
+    {
+        name = RD-0210
+        ratedBurnTime = 238
+        ignitionReliabilityStart = 0.944
+        ignitionReliabilityEnd = 0.999
+        ignitionDynPresFailMultiplier = 0.1
+        cycleReliabilityStart = 0.889
+        cycleReliabilityEnd = 0.993
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -30,7 +30,7 @@
     {
         %minThrust = 584.77
         %maxThrust = 584.77
-        %heatProduction = 100
+        %heatProduction = 140
         %EngineType = LiquidFuel
         @useThrustCurve = False
         %ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -1,15 +1,120 @@
-// Engine is in RO_BobCat_Proton.cfg
+//  ==================================================
+//  RD-0212 global engine configuration.
+
+//  Inert Mass: 910 Kg
+//  Throttle Range: N/A
+//  Burn Time: 250 s
+//  O/F Ratio: 2.54
+
+//  Sources:
+
+//  KB Khimavtomatika - RD-0213 engine:         http://www.kbkha.ru/?p=8&cat=8&prod=33
+//  Russian Space Web - RD-0212 engine:         http://www.russianspaceweb.com/rd0212.html
+//  Russian Space Web - Proton Third Stage:     http://www.russianspaceweb.com/proton_stage3.html
+//  Encyclopedia Astronautica - RD-0212 engine: http://www.astronautix.com/r/rd-0212.html
+//  Encyclopedia Astronautica - RD-0214 engine: http://www.astronautix.com/r/rd-0214.html
+
+//  Used by:
+
+//  * BobCat Soviet Engines pack
+//  * RealEngines pack
+
+//  Notes:
+
+//  * The RD-0212 propulsion module is a combination of the RD-0213 main engine and four RD-0214 vernier engines.
+//  * The inert mass value includes the mass of the vernier engines (90 Kg each).
+//  ==================================================
+
+@PART[*]:HAS[#engineType[RD0212]]:FOR[RealismOverhaulEngines]
+{
+    %title = RD-0212
+    %manufacturer = Voronezh Mechanical Plant (VMZ)
+    %description = A gas generator, hypergolic vacuum rocket engine. Used as the power plant on the third stage of Proton launch vehicle family. Features four integrated vernier engines for three-axis attitude control. Diameter: 1.47 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 584.77
+        %maxThrust = 584.77
+        %heatProduction = 100
+        %EngineType = LiquidFuel
+        @useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RD-0212
+        origMass = 0.91
+
+        CONFIG
+        {
+            name = RD-0212
+            minThrust = 584.77
+            maxThrust = 584.77
+            gimbalRange = 0
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.4192
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5808
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 327
+                key = 1 164
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0212]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-	TESTFLIGHT
-	{
-		name = RD-0212
-		ratedBurnTime = 230
-		ignitionReliabilityStart = 0.857
-		ignitionReliabilityEnd = 0.995
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.857
-		cycleReliabilityEnd = 0.992
-	}
+    TESTFLIGHT
+    {
+        name = RD-0212
+        ratedBurnTime = 250
+        ignitionReliabilityStart = 0.857
+        ignitionReliabilityEnd = 0.995
+        ignitionDynPresFailMultiplier = 0.1
+        cycleReliabilityStart = 0.857
+        cycleReliabilityEnd = 0.992
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -47,7 +47,12 @@
         !thrustCurve,*{}
     }
 
-    !MODULE[ModuleGimbal],*{}
+    @MODULE[ModuleGimbal],*
+    {
+        @gimbalRange = 45.0
+        %useGimbalResponseSpeed = True
+        gimbalResponseSpeed = 16
+    }
 
     !MODULE[ModuleEngineConfigs],*{}
 
@@ -63,7 +68,7 @@
             name = RD-0212
             minThrust = 584.77
             maxThrust = 584.77
-            gimbalRange = 0
+            gimbalRange = 45.0
             ullage = True
             pressureFed = False
             ignitions = 1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -35,7 +35,7 @@
     {
         %minThrust = 584.77
         %maxThrust = 584.77
-        %heatProduction = 100
+        %heatProduction = 90
         %EngineType = LiquidFuel
         @useThrustCurve = False
         %ullage = True


### PR DESCRIPTION
**Change log:**

* Minor updates to the RD-0210 global config to include some patching for the parent engine module and add safeguards for the rest of the required modules.
* Add a complete RD-0212 global engine config, since the old one only included the parameters of the TF integration.

**Notes:**

* [Alternate diff ignoring white space changes.](https://github.com/KSP-RO/RealismOverhaul/pull/1565/files?w=1)