### PR TITLE
RealEngines updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -589,7 +589,7 @@
         minThrust = 6.0
         maxThrust = 6.0
         heatProduction = 100
-        EngineType = LiquidEEngine
+        EngineType = LiquidFuel
         ullage = True
         pressureFed = False
         ignitions = 1
@@ -1373,7 +1373,7 @@
         minThrust = 30.89
         maxThrust = 30.89
         heatProduction = 100
-        EngineType = LiquidEEngine
+        EngineType = LiquidFuel
         ullage = True
         pressureFed = False
         ignitions = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -1467,8 +1467,8 @@
     @MODULE[ModuleEngines*]
     {
         !engineID = NULL
-        @minThrust = 1627.90
-        @maxThrust = 1627.90
+        @minThrust = 1627.9
+        @maxThrust = 1627.9
         @heatProduction = 200
         @useThrustCurve = False
 
@@ -1507,7 +1507,7 @@
 //  ==================================================
 //  S5.92 engine.
 
-//  Dimensions: 0.43 m x 0.95 m
+//  Dimensions: 0.4 m x 0.96 m
 //  Inert Mass: 75 Kg
 //  ==================================================
 
@@ -1569,8 +1569,10 @@
     }
 
     //  Gas generator exhaust.
+
     //  The thrust values have been set to 1/100 of
     //  the nominal thrust value of the main engine.
+    //  True values unknown.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {
@@ -1611,7 +1613,7 @@
 //  ==================================================
 //  S5.98M engine.
 
-//  Dimensions: - m x - m
+//  Dimensions: 0.425 m x 0.97 m
 //  Inert Mass: 95 Kg
 //  ==================================================
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -8,32 +8,55 @@
 //  Encyclopedia Astronautica - NK-43 engine:              http://www.astronautix.com/n/nk-43.html
 //  Encyclopedia Astronautica - RD-58 engine:              http://astronautix.com/r/rd-58.html
 //  Norbert Brügge - Block D upper stage:                  http://www.b14643.de/Spacerockets_1/East_Europe_2/Proton/Gallery/Block-D.htm
+
 //  Russian Space Web - RD-0110 engine:                    http://www.russianspaceweb.com/rd0110.html
 //  Encyclopedia Astronautica - RD-0110 engine:            http://www.astronautix.com/r/rd-0110.html
+
 //  Liquid Propellant Rocket Engines - RD-0120 engine:     http://www.lpre.de/kbkha/RD-0120/index.htm
 //  AIAA - RD-0120 design, development and history:        http://lpre.de/resources/articles/AIAA-1995-2540.pdf
 //  Russian Space Web - RD-0120 engine:                    http://russianspaceweb.com/rd0120.html
 //  Encyclopedia Astronautica - RD-0120 engine:            http://astronautix.com/r/rd-0120.html
+
 //  Liquid Propellant Rocket Engines - RD-0124 engine:     http://www.lpre.de/kbkha/RD-0124/index.htm
 //  AIAA - GG and SC Cycle Rocket Engines Turbopumps:      http://rocket-propulsion.info/resources/articles/AIAA-2005-3946.pdf
 //  Russian Space Web - RD-0124 engine:                    http://www.russianspaceweb.com/rd0124.html
 //  Encyclopedia Astronautica - RD-0124 engine:            http://www.astronautix.com/r/rd-0124.html
+
 //  Russian Space Web - RD-0146 engine:                    http://www.russianspaceweb.com/rd0146.html
 //  AIAA - The First Russian LOX-LH2 Expander Cycle LRE:   http://www.lpre.de/resources/articles/AIAA-2006-4904_RD0146.pdf
 //  Encyclopedia Astronautica - RD-0146 engine:            http://www.astronautix.com/r/rd-0146.html
+
 //  Liquid Propellant Rocket Engines - RD-170 engine:      http://www.lpre.de/energomash/RD-170/index.htm
 //  AIAA - RD-170, A Different Approach to LV Propulsion:  http://rocket-propulsion.info/resources/articles/AIAA-1993-2415.pdf
 //  Russian Space Web - RD-170 engine:                     http://www.russianspaceweb.com/rd170.html
 //  Encyclopedia Astronautica - RD-170 engine:             http://www.astronautix.com/r/rd-170.html
+
 //  NPO Energomash - RD-180 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd180/
 //  AIAA - RD-180 Engine Production and Flight Experience: http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3998.pdf
 //  AIAA - RD-180 Engine Development and Characteristics:  http://my.fit.edu/~dkirk/4262/RD180_Presentation.pdf
 //  Liquid Propellant Rocket Engines - RD-180 engine:      http://www.lpre.de/energomash/RD-180/index.htm
 //  Encyclopedia Astronautica - RD-180 engine:             http://www.astronautix.com/r/rd-180.html
+
 //  NPO Energomash - RD-191 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd191/
 //  Russian Space Web - RD-191 engine:                     http://russianspaceweb.com/rd191.html
 //  Encyclopedia Astronautica - RD-191 engine:             http://www.astronautix.com/r/rd-191.html
+
+//  NPO Energomash - RD-253 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd253/
+//  Russian Space Web - RD-253 engine:                     http://www.russianspaceweb.com/rd253.html
+//  Encyclopedia Astronautica - RD-253 engine:             http://www.astronautix.com/r/rd-253-11d48.html
+
+//  KB KhIMMASH - KVD-1 & S5.92 Brochure:                  http://www.k204.ru/books/vrd/wiki2/PDF/Himmash.pdf
+//  KB KhIMMASH - S5.92 engine:                            http://kbhmisaeva.ru/main.php?id=53
+//  Encyclopedia Astronautica - S5.92 engine:              http://www.astronautix.com/s/s592.html
+
 //  Norbert Brügge - Russian rocket engines:               http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+
+
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
+
+!PART[RD0120CAP_engine_inclination]:FOR[RealismOverhaul]{}
 
 //  ==================================================
 //  NK-33 engine.
@@ -66,8 +89,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls NK-33 rocket
+    @tags = ascent launch propuls NK-33 rocket surf
 
     %engineType = NK33
     %engineTypeMult = 1
@@ -76,7 +102,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 840.96
         @maxThrust = 1681.93
         @heatProduction = 200
@@ -103,20 +128,143 @@
         !thrustCurve,*{}
     }
 
-    !MODULE[ModuleGimbal],*{}
-
-    MODULE
+    @MODULE[ModuleGimbal]
     {
-        name = ModuleGimbal
-        gimbalTransformName = thrustTransform
-        gimbalRange = 6.0
-        useGimbalResponseSpeed = True
-        gimbalResponseSpeed = 16
+        %gimbalRange = 6.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
     }
 
     !MODULE[ModuleAlternator],*{}
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Soyuz-2-1V first stage RD-0110R vernier assembly.
+
+//  Dimensions: 2.66 m x 2.65 m
+//  Inert Mass: 1100 Kg
+
+//  The inert mass value includes the mass of the main
+//  and vernier engines mounting hardware (540 Kg).
+//  ==================================================
+
+@PART[NK33attachment]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    //  Mounting structure.
+
+    @MODEL,0
+    {
+        @scale = 0.8512, 0.8512, 0.8512
+    }
+
+    //  +X vernier.
+
+    @MODEL,1
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = -1.0, -1.45, 0.0
+    }
+
+    //  -X vernier.
+
+    @MODEL,2
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 1.0, -1.45, 0.0
+    }
+
+    //  +Y vernier.
+
+    @MODEL,3
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 0.0, -1.45, -1.0
+    }
+
+    //  -Y vernier.
+
+    @MODEL,4
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 0.0, -1.45, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.745, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.62, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom1 = 0.0, 1.425, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 1.1
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size2
+    !stackSymmetry = NULL
+    @tags = ascent launch propuls NK-33 RD-0110R rocket surf
+
+    %engineType = RD0110R
+    %engineTypeMult = 1
+    %ignoreMass = True
+    %massOffset = 0.54
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3853
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6147
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 298
+            @key,1 = 1 259
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRangeYP = 0
+        @gimbalRangeYN = 0
+        @gimbalRangeXP = 45.0
+        @gimbalRangeXN = 45.0
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
+//  Soyuz-2-1V first stage RD-0110R vernier assembly.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[NK33attachment]:AFTER[RealismOverhaulEngines]
+{
+    @title = Soyuz-2-1V Vernier Assembly
+    @manufacturer = Voronezh Mechanical Plant
+    @description = The vernier assembly of the Soyuz-2-1V launch vehicle first stage.
 }
 
 //  ==================================================
@@ -149,8 +297,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size3
-    @tags = ascent launch propuls NK-43 rocket
+    @tags = ascent launch propuls NK-43 rocket vac
 
     %engineType = NK43
     %engineTypeMult = 1
@@ -159,7 +310,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 878.67
         @maxThrust = 1757.34
         @heatProduction = 200
@@ -186,15 +336,14 @@
         !thrustCurve,*{}
     }
 
-    !MODULE[ModuleGimbal],*{}
-
-    MODULE
+    @MODULE[ModuleGimbal]
     {
-        name = ModuleGimbal
-        gimbalTransformName = thrustTransform
-        gimbalRange = 6.0
-        useGimbalResponseSpeed = True
-        gimbalResponseSpeed = 16
+        %gimbalRange = 6.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
     }
 
     !MODULE[ModuleAlternator],*{}
@@ -233,9 +382,12 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls RD-58 rocket
+    @tags = ascent launch propuls RD-58 rocket vac
 
     %engineType = RD58
     %engineTypeMult = 1
@@ -244,7 +396,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 83.4
         @maxThrust = 83.4
         @heatProduction = 200
@@ -267,6 +418,8 @@
             @key,0 = 0 349
             @key,1 = 1 175
         }
+
+        !thrustCurve,*{}
     }
 
     @MODULE[ModuleGimbal]
@@ -358,9 +511,12 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size0, size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls RD-0110 rocket
+    @tags = ascent launch propuls RD-0110 rocket vac
 
     %engineType = RD0110
     %engineTypeMult = 1
@@ -369,7 +525,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
+        %engineID = MainEngine
         @minThrust = 269.87
         @maxThrust = 298.2
         @heatProduction = 200
@@ -396,6 +552,69 @@
         !thrustCurve,*{}
     }
 
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  RD-0110 engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[RD0110engine]:AFTER[RealismOverhaulEngines]
+{
+    //  Vernier engine setup.
+
+    !MODULE[ModuleEngines*],*:HAS[#thrustVectorTransformName[thrustTransform2]]{}
+
+    MODULE
+    {
+        name = ModuleEngines
+        engineID = VernierEngine
+        thrustVectorTransformName = thrustTransform2
+        exhaustDamage = True
+        ignitionThreshold = 0.1
+        minThrust = 6.0
+        maxThrust = 6.0
+        heatProduction = 100
+        EngineType = LiquidEEngine
+        ullage = True
+        pressureFed = False
+        ignitions = 1
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 0.02
+        }
+
+        PROPELLANT
+        {
+            name = Kerosene
+            ratio = 0.3853
+            DrawGauge = False
+        }
+
+        PROPELLANT
+        {
+            name = LqdOxygen
+            ratio = 0.6147
+            DrawGauge = False
+        }
+
+        atmosphereCurve
+        {
+            key = 0 330
+            key = 1 165
+        }
+    }
+
+    //  Vernier gimbal setup.
+
+    !MODULE[ModuleGimbal],*{}
+
     MODULE
     {
         name = ModuleGimbal
@@ -407,10 +626,6 @@
         useGimbalResponseSpeed = True
         gimbalResponseSpeed = 16
     }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -443,8 +658,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size3
-    @tags = ascent launch propuls RD-0120 rocket
+    @tags = ascent launch propuls RD-0120 rocket surf
 
     %engineType = RD0120
     %engineTypeMult = 1
@@ -453,89 +671,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 1863.26
-        @maxThrust = 1961.33
-        @heatProduction = 200
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdHydrogen
-            @ratio = 0.7286
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.2714
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 455
-            @key,1 = 1 359
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 11.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  RD-0120 engine (red nozzle variant).
-
-//  Dimensions: 2.93 m x 4.7 m
-//  Gross Mass: 3450 Kg
-//  ==================================================
-
-@PART[rd0120_RedVariant]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    @MODEL
-    {
-        @scale = 1.0, 1.0, 1.0
-    }
-
-    @scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 2.782, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -1.932, 0.0, 0.0, -1.0, 0.0, 3
-
-    @mass = 1.5
-    @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
-    @bulkheadProfiles = size3
-    @tags = ascent launch propuls RD-0120 rocket
-
-    %engineType = RD0120
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
-
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
         @minThrust = 1863.26
         @maxThrust = 1961.33
         @heatProduction = 200
@@ -581,7 +716,7 @@
 //  RD-0120 engine mount.
 
 //  Dimensions: 3.1 m x 4.4 m
-//  Inert Mass: 1650 Kg
+//  Inert Mass: 430 Kg
 //  ==================================================
 
 @PART[RD0120CAP]:FOR[RealismOverhaul]
@@ -606,7 +741,7 @@
     @title = RD-0120 Engine Mount
     @description = A generic engine mount and turbopump shroud for the RD-0120 engine.
 
-    @mass = 1.65
+    @mass = 0.43
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
@@ -646,8 +781,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-0124 rocket
+    @tags = ascent launch propuls RD-0124 rocket vac
 
     %engineType = RD0124
     %engineTypeMult = 1
@@ -656,7 +794,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 294.3
         @maxThrust = 294.3
         @heatProduction = 200
@@ -736,9 +873,12 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls RD-0146 rocket
+    @tags = ascent launch propuls RD-0146 rocket vac
 
     %engineType = RD0146
     %engineTypeMult = 1
@@ -747,7 +887,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 98.1
         @maxThrust = 98.1
         @heatProduction = 200
@@ -765,22 +904,23 @@
             @ratio = 0.2681
         }
 
-        atmosphereCurve
+        @atmosphereCurve
         {
-            key = 0 463
-            key = 1 155
+            @key,0 = 0 463
+            @key,1 = 1 155
         }
 
         !thrustCurve,*{}
     }
 
-    !MODULE[ModuleGimbal],*{}
-
-    MODULE
+    @MODULE[ModuleGimbal]
     {
-        name = ModuleGimbal
-        gimbalTransformName = thrustTransform
-        gimbalRange = 4.0
+        %gimbalRange = 4.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
     }
 
     !MODULE[ModuleAlternator],*{}
@@ -819,8 +959,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size4
-    @tags = ascent launch propuls RD-170 rocket
+    @tags = ascent launch propuls RD-170 rocket surf
 
     %engineType = RD170
     %engineTypeMult = 1
@@ -829,7 +972,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 3952.24
         @maxThrust = 7904.49
         @heatProduction = 200
@@ -902,8 +1044,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch propuls RD-180 rocket
+    @tags = ascent launch propuls RD-180 rocket surf
 
     %engineType = RD180
     %engineTypeMult = 1
@@ -912,7 +1057,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1951.43
         @maxThrust = 4152.41
         @heatProduction = 200
@@ -985,8 +1129,11 @@
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-191 rocket
+    @tags = ascent launch propuls RD-191 rocket surf
 
     %engineType = RD191
     %engineTypeMult = 1
@@ -995,7 +1142,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 562.92
         @maxThrust = 2084.89
         @heatProduction = 200
@@ -1038,6 +1184,158 @@
 }
 
 //  ==================================================
+//  RD-253/275 engine.
+
+//  Dimensions: 3.5 m x 2.8 m
+//  Gross Mass: 1080 Kg
+//  ==================================================
+
+@PART[RD275]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.116, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.373, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 1.545, 0.0, 0.0, 1.0, 0.0
+
+    @mass = 1.08
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size2
+    @tags = ascent launch propuls RD-253 RD-275 rocket surf
+
+    %engineType = RD253
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        !engineID = NULL
+        @minThrust = 1627.90
+        @maxThrust = 1627.90
+        @heatProduction = 200
+        @useThrustCurve = False
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4071
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5929
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 316
+            @key,1 = 1 285
+        }
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRangeYP = 6.0
+        @gimbalRangeYN = 6.0
+        @gimbalRangeXP = 0
+        @gimbalRangeXN = 0
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  S5.92 engine.
+
+//  Dimensions: 0.43 m x 0.95 m
+//  Inert Mass: 75 Kg
+//  ==================================================
+
+@PART[S5_92]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.158, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.81, 0.0, 0.0, -1.0, 0.0, 1
+
+    @mass = 0.075
+    @crashTolerance = 10
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @tags = ascent launch propuls S.92 rocket vac
+
+    %engineType = S5_92
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4782
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5218
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 327
+            @key,1 = 1 158
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        %gimbalRange = 5.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
 //  RD-0110 vernier engine.
 
 //  Dimensions: 0.325 m x 0.7 m
@@ -1060,27 +1358,25 @@
 
     @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 
-    @title = RD-0110 Vernier Engine
-    @manufacturer = Voronezh Mechanical Plant (VMZ)
-    @description = The vernier engine for the RD-0110 engine. Four of them are used for pitch, yaw and roll control on the Block I upper stage of the Soyuz U and FG launch vehicle variants.
-
     @mass = 0.01
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size0
-    @tags = ascent launch propuls RD-0110 rocket vern
+    @tags = ascent launch propuls RD-0110 rocket vac vern
+
+    %engineType = RD0110Vernier
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 6.0
-        @maxThrust = 6.0
-        @heatProduction = 200
-        @useThrustCurve = False
-
         @PROPELLANT[LiquidFuel]
         {
             @name = Kerosene
@@ -1098,8 +1394,6 @@
             @key,0 = 0 330
             @key,1 = 1 165
         }
-
-        !thrustCurve,*{}
     }
 
     @MODULE[ModuleGimbal]
@@ -1108,10 +1402,5 @@
         @gimbalRangeYN = 0
         @gimbalRangeXP = 25.0
         @gimbalRangeXN = 25.0
-        @gimbalResponseSpeed = 16
     }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -41,6 +41,17 @@
 //  Russian Space Web - RD-191 engine:                     http://russianspaceweb.com/rd191.html
 //  Encyclopedia Astronautica - RD-191 engine:             http://www.astronautix.com/r/rd-191.html
 
+//  KB Khimavtomatika - RD-0210 engine:                    http://www.kbkha.ru/?p=8&cat=8&prod=33
+//  Liquid Propellant Rocket Engines - RD-0210 engine:     http://www.lpre.de/kbkha/RD-0203/index.htm
+//  Russian Space Web - RD-0210 engine:                    http://www.russianspaceweb.com/rd0210.html
+//  Encyclopedia Astronautica - RD-0210 engine:            http://www.astronautix.com/engines/rd0210.htm
+
+//  KB Khimavtomatika - RD-0213 engine:                    http://www.kbkha.ru/?p=8&cat=8&prod=33
+//  Russian Space Web - RD-0212 engine:                    http://www.russianspaceweb.com/rd0212.html
+//  Russian Space Web - Proton Third Stage:                http://www.russianspaceweb.com/proton_stage3.html
+//  Encyclopedia Astronautica - RD-0212 engine:            http://www.astronautix.com/r/rd-0212.html
+//  Encyclopedia Astronautica - RD-0214 engine:            http://www.astronautix.com/r/rd-0214.html
+
 //  NPO Energomash - RD-253 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd253/
 //  Russian Space Web - RD-253 engine:                     http://www.russianspaceweb.com/rd253.html
 //  Encyclopedia Astronautica - RD-253 engine:             http://www.astronautix.com/r/rd-253-11d48.html
@@ -51,12 +62,13 @@
 
 //  Norbert Brügge - Russian rocket engines:               http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 
-
 //  ==================================================
 //  Removed extra parts.
 //  ==================================================
 
 !PART[RD0120CAP_engine_inclination]:FOR[RealismOverhaul]{}
+
+!PART[S5_92]:FOR[RealismOverhaul]{}
 
 //  ==================================================
 //  NK-33 engine.
@@ -444,7 +456,7 @@
 //  Gross Mass: 410 Kg
 //  ==================================================
 
-@PART[RD0110engine]:FOR[RealismOverhaul]
+@PART[RD0110]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -563,11 +575,9 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RD0110engine]:AFTER[RealismOverhaulEngines]
+@PART[RD0110]:AFTER[RealismOverhaulEngines]
 {
     //  Vernier engine setup.
-
-    !MODULE[ModuleEngines*],*:HAS[#thrustVectorTransformName[thrustTransform2]]{}
 
     MODULE
     {
@@ -1184,6 +1194,235 @@
 }
 
 //  ==================================================
+//  RD-0210/0211 engine.
+
+//  Dimensions: 1.47 m x 2.23 m
+//  Gross Mass: 566 Kg
+//  ==================================================
+
+@PART[RD0210]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.331, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.907, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 0.566
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size2
+    @tags = ascent launch propuls RD-0210 RD-0211 rocket vac
+
+    %engineType = RD0210
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4135
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5865
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 313
+            @key,1 = 1 220
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        %gimbalRange = 3.25
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
+//  RD-0212 engine.
+
+//  Dimensions: 1.47 m x 2.9 m
+//  Gross Mass: 910 Kg
+//  ==================================================
+
+@PART[RD0212]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL,0
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @MODEL,1
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = -2.035, 1.6, 0.0
+    }
+
+    @MODEL,2
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 2.035, 1.6, 0.0
+    }
+
+    @MODEL,3
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 0.0, 1.6, -2.035
+    }
+
+    @MODEL,4
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 0.0, 1.6, 2.035
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.575, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.907, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 0.91
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size2
+    @tags = ascent launch propuls RD-0212 RD-0213 RD-0214 rocket vac
+
+    %engineType = RD0212
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4192
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5808
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 313
+            @key,1 = 1 220
+        }
+    }
+}
+
+//  ==================================================
+//  RD-0212 engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[RD0212]:AFTER[RealismOverhaulEngines]
+{
+    //  Vernier engine setup.
+
+    MODULE
+    {
+        name = ModuleEngines
+        engineID = VernierEngine
+        thrustVectorTransformName = thrustTransform2
+        exhaustDamage = True
+        ignitionThreshold = 0.1
+        minThrust = 30.89
+        maxThrust = 30.89
+        heatProduction = 100
+        EngineType = LiquidEEngine
+        ullage = True
+        pressureFed = False
+        ignitions = 1
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 0.025
+        }
+
+        PROPELLANT
+        {
+            name = UDMH
+            ratio = 0.4135
+            DrawGauge = True
+        }
+
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.5865
+            DrawGauge = False
+        }
+
+        atmosphereCurve
+        {
+            key = 0 294
+            key = 1 147
+        }
+    }
+
+    //  Vernier gimbal setup.
+
+    !MODULE[ModuleGimbal],*{}
+
+    MODULE
+    {
+        name = ModuleGimbal
+        gimbalTransformName = gimbal
+        gimbalRangeYP = 0.0
+        gimbalRangeYN = 0.0
+        gimbalRangeXP = 45.0
+        gimbalRangeXN = 45.0
+        useGimbalResponseSpeed = True
+        gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
 //  RD-253/275 engine.
 
 //  Dimensions: 3.5 m x 2.8 m
@@ -1272,7 +1511,7 @@
 //  Inert Mass: 75 Kg
 //  ==================================================
 
-@PART[S5_92]:FOR[RealismOverhaul]
+@PART[S5_92fversion]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -1296,6 +1535,7 @@
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
     @tags = ascent launch propuls S.92 rocket vac
 
     %engineType = S5_92
@@ -1303,8 +1543,41 @@
     %ignoreMass = False
     %massOffset = 0
 
-    @MODULE[ModuleEngines*]
+    //  Main engine.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
+        %engineID = MainEngine
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4782
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5218
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 327
+            @key,1 = 1 158
+        }
+    }
+
+    //  Gas generator exhaust.
+    //  The thrust values have been set to 1/100 of
+    //  the nominal thrust value of the main engine.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+    {
+        %engineID = GasGenerator
+        @minThrust = 0.02
+        @maxThrust = 0.02
+
         @PROPELLANT[LiquidFuel]
         {
             @name = UDMH
@@ -1331,7 +1604,68 @@
         !gimbalRangeYN = NULL
         !gimbalRangeXP = NULL
         !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
+        %gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
+//  S5.98M engine.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 95 Kg
+//  ==================================================
+
+@PART[S5_98M]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.158, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.811, 0.0, 0.0, -1.0, 0.0, 1
+
+    @mass = 0.095
+    @crashTolerance = 10
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
+    @tags = ascent launch propuls S.98M rocket vac
+
+    %engineType = S5_98M
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4782
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5218
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 370
+            @key,1 = 1 235
+        }
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
@@ -239,7 +239,6 @@
     %RSSROConfig = True
 
     !mesh = NULL
-    rescaleFactor = 1
 
     @MODEL
     {
@@ -249,9 +248,10 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.7022473, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.9684762, 0.0, 0.0, -1.0, 0.0, 2
-    @node_attach = 0.0, 1.116298, 0.0, 0.0, 1.0, 0.0
+    %node_stack_engine = 0.0, 3.075, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.702, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.968, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 1.117, 0.0, 0.0, 1.0, 0.0
 
     @mass = 1.125
     @crashTolerance = 10
@@ -287,7 +287,7 @@
         @atmosphereCurve
         {
             @key,0 = 0 350
-            @key,1 = 1 310
+            @key,1 = 1 175
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
@@ -14,15 +14,15 @@
 //  Norbert Brügge - Ukrainian rocket engines:                  http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
 
 //  ==================================================
-//  Zenit second stage RD-8 vernier and propellant tank
-//  assembly.
+//  Zenit second stage RD-8 vernier engine and RG-1
+//  propellant tank assembly.
 
 //  Dimensions: 3.9 m x 4.35 m
 //  Inert Mass: 1880 Kg
 
 //  The inert mass value includes the mass of the main
-//  engine mounting hardware and the integrated propellant
-//  tank (1500 Kg).
+//  engine mounting hardware and the integrated RG-1
+//  propellant tank (1500 Kg).
 //  ==================================================
 
 @PART[RD120attachment_styleZenit2st]:FOR[RealismOverhaul]
@@ -143,7 +143,8 @@
 }
 
 //  ==================================================
-//  Zenit second stage RD-8 vernier assembly.
+//  Zenit second stage RD-8 vernier engine and RG-1
+//  propellant tank assembly.
 
 //  Engine configuration.
 //  ==================================================
@@ -152,7 +153,7 @@
 {
     @title = Zenit Vernier Assembly
     @manufacturer = Yuzhnoye Design Bureau (OKB-586)
-    @description = The RD-8 vernier assembly of the Zenit second stage. Includes a propellant tank.
+    @description = The RD-8 vernier engine and propellant tank assembly of the Zenit second stage.
 }
 
 //  ==================================================
@@ -188,7 +189,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size0
-    @tags = ascent launch propuls RD-802 rocket vernier
+    @tags = ascent launch propuls RD-805 rocket vernier
 
     %engineType = RD805
     %engineTypeMult = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
@@ -1,0 +1,292 @@
+//  ==================================================
+//  Sources:
+
+//  Yuzhnoye Design Office - RD-8 engine:                       http://www.yuzhnoye.com/en/technique/rocket-engines/steering/rd-8
+//  Encyclopedia Astronautica - RD-8 engine:                    http://www.astronautix.com/r/rd-8.html
+
+//  Encyclopedia Astronautica - RD-802 engine:                  http://www.astronautix.com/r/rd-802.html
+//  Yuzhnoye Design Office - Kerolox rocket engine development: http://www.khai.edu/csp/nauchportal/Arhiv/AKTT/2013/AKTT113/Degtyar.pdf
+
+//  NPO Energomash - RD-120 engine:                             http://www.npoenergomash.ru/eng/dejatelnost/engines/rd120/
+//  Moscow Aviation Institute - V.P. Glushko Energomash RPA:    http://www.k204.ru/books/vrd/wiki2/PDF/Emash.pdf
+//  Encyclopedia Astronautica: RD-120 engine:                   http://astronautix.com/r/rd-120.html
+
+//  Norbert Brügge - Ukrainian rocket engines:                  http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
+
+//  ==================================================
+//  Zenit second stage RD-8 vernier and propellant tank
+//  assembly.
+
+//  Dimensions: 3.9 m x 4.35 m
+//  Inert Mass: 1880 Kg
+
+//  The inert mass value includes the mass of the main
+//  engine mounting hardware and the integrated propellant
+//  tank (1500 Kg).
+//  ==================================================
+
+@PART[RD120attachment_styleZenit2st]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    //  Mounting structure.
+
+    @MODEL,0
+    {
+        @scale = 0.9125, 0.9125, 0.9125
+    }
+
+    //  +X vernier.
+
+    @MODEL,1
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 1.5, 0.187, 0.0
+    }
+
+    //  -X vernier.
+
+    @MODEL,2
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = -1.5, 0.187, 0.0
+    }
+
+    //  +Y vernier.
+
+    @MODEL,3
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 0.0, 0.187, 1.5
+    }
+
+    //  -Y vernier.
+
+    @MODEL,4
+    {
+        @scale = 1.0, 1.0, 1.0
+        @position = 0.0, 0.187, -1.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 3.842, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.525, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom2 = 0.0, 0.65, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_1 = NULL
+    !node_stack_2 = NULL
+    !node_stack_3 = NULL
+    !node_stack_4 = NULL
+
+    @mass = 1.88
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size3
+    !stackSymmetry = NULL
+    @tags = ascent launch propuls RD-8 rocket Zenit upper
+
+    %engineType = RD8
+    %engineTypeMult = 1
+    %ignoreMass = True
+    %massOffset = 1.5
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3670
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6330
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 342
+            @key,1 = 1 170
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRangeYP = 0
+        @gimbalRangeYN = 0
+        @gimbalRangeXP = 33.0
+        @gimbalRangeXN = 33.0
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    //  Simulate the integrated toroidal kerosene
+    //  propellant tank of the Zenit second stage.
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Default
+        volume = 26940
+        basemass = -1
+    }
+}
+
+//  ==================================================
+//  Zenit second stage RD-8 vernier assembly.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[RD120attachment_styleZenit2st]:AFTER[RealismOverhaulEngines]
+{
+    @title = Zenit Vernier Assembly
+    @manufacturer = Yuzhnoye Design Bureau (OKB-586)
+    @description = The RD-8 vernier assembly of the Zenit second stage. Includes a propellant tank.
+}
+
+//  ==================================================
+//  RD-805 engine.
+
+//  Dimensions: 0.7 m x 0.95 m
+//  Inert Mass: 120 Kg
+//  ==================================================
+
+@PART[RD8]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+
+    @mass = 0.12
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size0
+    @tags = ascent launch propuls RD-802 rocket vernier
+
+    %engineType = RD805
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3576
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6424
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 344
+            @key,1 = 1 172
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 8.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+    }
+}
+
+//  ==================================================
+//  RD-120 engine.
+
+//  Dimensions: 3.55 m x 4.7 m
+//  Inert Mass: 1125 Kg
+//  ==================================================
+
+@PART[RD120]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+    rescaleFactor = 1
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.7022473, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.9684762, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 1.116298, 0.0, 0.0, 1.0, 0.0
+
+    @mass = 1.125
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size2
+    @tags = ascent launch propuls RD-120 rocket
+
+    %engineType = RD120
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3486
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6514
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 350
+            @key,1 = 1 310
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK33attachment.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK33attachment.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-0110R vernier engine plume setup.
+//  ==================================================
+
+@PART[NK33attachment]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform2
+        plumePosition = 0.0, 0.0, -0.15
+        plumeScale = 2.5
+        flarePosition = 0.0, 0.0, 1.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 2.0
+        speed = 0.75
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Vernier
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Vernier
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0110.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0110.cfg
@@ -1,0 +1,60 @@
+//  ==================================================
+//  RD-0110 engine plume setup.
+//  ==================================================
+
+@PART[RD0110]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.025
+        plumeScale = 0.4
+        flarePosition = 0.0, 0.0, -0.25
+        flareScale = 0.525
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform2
+        plumePosition = 0.0, 0.0, -0.15
+        plumeScale = 2.5
+        flarePosition = 0.0, 0.0, 1.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 0.75
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[VernierEngine]]
+    {
+        //  Workaround for a SmokeScreen bug.
+
+        !powerEffectName = NULL
+        %runningEffectName = Kerolox-Vernier
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
@@ -8,10 +8,10 @@
     {
         name = Hypergolic-Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.0
-        plumeScale = 1.0
+        plumePosition = 0.0, 0.0, 0.25
+        plumeScale = 1.25
         flarePosition = 0.0, 0.0, 0.0
-        flareScale = 1.0
+        flareScale = 1.25
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
@@ -1,17 +1,17 @@
 //  ==================================================
-//  RD-0110 engine plume setup.
+//  RD-0210/0211 engine plume setup.
 //  ==================================================
 
-@PART[RD0110engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RD0210]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
-        name = Kerolox-Upper
+        name = Hypergolic-Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.025
-        plumeScale = 0.4
-        flarePosition = 0.0, 0.0, -0.25
-        flareScale = 0.525
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
@@ -21,7 +21,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Kerolox-Upper
+        %powerEffectName = Hypergolic-Upper
         !runningEffectName = NULL
         !fxOffset = NULL
     }
@@ -30,7 +30,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Upper
+            %powerEffectName = Hypergolic-Upper
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
@@ -8,10 +8,10 @@
     {
         name = Hypergolic-Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.0
-        plumeScale = 1.0
+        plumePosition = 0.0, 0.0, 0.25
+        plumeScale = 1.25
         flarePosition = 0.0, 0.0, 0.0
-        flareScale = 1.0
+        flareScale = 1.25
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
@@ -19,10 +19,34 @@
         emissionMult = 0.5
     }
 
-    @MODULE[ModuleEngines*]
+    PLUME
+    {
+        name = Hypergolic-OMS-Red
+        transformName = thrustTransform2
+        plumePosition = 0.0, 0.0, 0.4
+        plumeScale = 0.4
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.25
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
     {
         %powerEffectName = Hypergolic-Upper
         !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[VernierEngine]]
+    {
+        //  Workaround for a SmokeScreen bug.
+
+        !powerEffectName = NULL
+        %runningEffectName = Hypergolic-OMS-Red
         !fxOffset = NULL
     }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-0212 engine plume setup.
+//  ==================================================
+
+@PART[RD0212]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-120 engine plume setup.
+//  ==================================================
+
+@PART[RD120]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, -0.4
+        flareScale = 1.4
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120attachment_styleZenit2st.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120attachment_styleZenit2st.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-8 vernier assembly plume setup.
+//  ==================================================
+
+@PART[RD120attachment_styleZenit2st]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform2
+        plumePosition = 0.0, 0.0, -0.55
+        plumeScale = 4.25
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 0.75
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Vernier
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Vernier
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD275.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD275.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-253/275 engine plume setup.
+//  ==================================================
+
+@PART[RD275]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-Lower
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.125
+        plumeScale = 1.85
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.75
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Lower
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-Lower
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-8 vernier engine plume setup.
+//  ==================================================
+
+@PART[RD8]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform2
+        plumePosition = 0.0, 0.0, -0.55
+        plumeScale = 4.25
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 0.75
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Vernier
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Vernier
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  RD-8 vernier engine plume setup.
+//  RD-805 engine plume setup.
 //  ==================================================
 
 @PART[RD8]:FOR[RealPlume]:NEEDS[SmokeScreen]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
@@ -8,20 +8,42 @@
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 1.2
-        plumeScale = 0.8
+        plumePosition = 0.0, 0.0, 0.35
+        plumeScale = 0.65
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        speed = 1.125
+        emissionMult = 0.75
     }
 
-    @MODULE[ModuleEngines*]
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = tt2
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 0.03
+        flarePosition = 0.0, 0.0, -0.86
+        flareScale = 0.03
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.75
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
     {
         %powerEffectName = Hypergolic-OMS-Red
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[GasGenerator]]
+    {
+        %powerEffectName = Hypergolic-OMS-White
         !runningEffectName = NULL
         !fxOffset = NULL
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
@@ -1,27 +1,27 @@
 //  ==================================================
-//  RD-0110 vernier engine plume setup.
+//  S5.92 engine plume setup.
 //  ==================================================
 
-@PART[STEERING_MOTOR_RD0110engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[S5_92fversion]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
-        name = Kerolox-Vernier
+        name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, -0.15
-        plumeScale = 2.5
-        flarePosition = 0.0, 0.0, 1.0
+        plumePosition = 0.0, 0.0, 1.2
+        plumeScale = 0.8
+        flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
-        energy = 0.5
-        speed = 0.75
+        energy = 1.0
+        speed = 1.0
         emissionMult = 0.5
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Kerolox-Vernier
+        %powerEffectName = Hypergolic-OMS-Red
         !runningEffectName = NULL
         !fxOffset = NULL
     }
@@ -30,7 +30,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Vernier
+            %powerEffectName = Hypergolic-OMS-Red
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  S5.98M engine plume setup.
+//  ==================================================
+
+@PART[S5_98M]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-Red
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-Red
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
@@ -8,15 +8,15 @@
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.0
-        plumeScale = 1.0
+        plumePosition = -0.025, 0.0, 0.35
+        plumeScale = 0.65
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
+        speed = 1.125
+        emissionMult = 0.75
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/STEERING_MOTOR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/STEERING_MOTOR.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-0110 vernier engine plume setup.
+//  ==================================================
+
+@PART[STEERING_MOTOR_RD0110engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform2
+        plumePosition = 0.0, 0.0, -0.15
+        plumeScale = 2.5
+        flarePosition = 0.0, 0.0, 1.0
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 0.75
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Vernier
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Vernier
+        }
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add RO support for all the new engines (RD-0110R, RD-0210, RD-0212, RD-253, S5.92, S5.98M, RD-0110 Vernier, RD-8, RD-805, RD-120).
* Fix all the instances of the of the RD-0110 engine part name.
* Remove the config of the RD-0120 engine red nozzle variant (was removed from the pack).

**Notes:**

* Some part config names were changed. The RealPlume configs have been edited for these changes.
* These engines require the following global engine configs to operate:
    - RD-8 (#1552)
    - RD-0110R (#1553)
    - RD-0110 Vernier (#1554)
    - RD-120 (#1555)
    - S5.92 and S5.98M (#1557)
    - RD-805 (#1562)
    - RD-0210 and RD-0212 (#1565)