### PR TITLE
Start BDB Apollo

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Apollo.cfg
@@ -1,0 +1,173 @@
+@PART[bluedog_Apollo_Block3_ServiceModule]:FOR[RealismOverhaul]
+{
+	@rescaleFactor = 1.6
+	@mass = 1.0
+	
+	%RSSROConfig = True
+
+	!RESOURCE[ElectricCharge] {}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+
+	!MODULE[ModuleBdbBoiloff] {}
+	!MODULE[ModuleB9PartInfo] {}
+	!MODULE[ModuleB9PartSwitch] {}
+	
+	MODULE
+	{
+		name = TacGenericConverter
+		%converterName = LOX-O2
+		%StartActionName = Start Oxygen Generator
+		%StopActionName = Stop Oxygen Generator
+		%conversionRate = 3.0
+		//inputResources = LqdOxygen, 0.0000084787, ElectricCharge, 0.025
+		//outputResources = Oxygen, 0.006883126, false
+		INPUT_RESOURCE
+		{
+			%ResourceName = LqdOxygen
+			%Ratio = 0.0000084787
+		}
+		INPUT_RESOURCE
+		{
+			%ResourceName = ElectricCharge
+			%Ratio = 0.025
+		}
+		OUTPUT_RESOURCE
+		{
+			%ResourceName = Oxygen
+			%Ratio = 0.006883126
+			%DumpExcess = false
+		}
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 2090
+		basemass = -1
+		TANK
+		{
+			name = Water
+			amount = 410
+			maxAmount = 410
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 165
+			maxAmount = 165
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 165
+			maxAmount = 165
+		}
+		TANK
+		{
+			name = Aerozine50
+			amount = 488
+			maxAmount = 488
+		}
+		TANK
+		{
+			name = NTO
+			amount = 485
+			maxAmount = 485
+		}
+		TANK
+		{
+			name = MMH
+			amount = 237.6
+			maxAmount = 237.6
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 300000
+			maxAmount = 300000
+		}
+	}
+}
+
+@PART[bluedog_Apollo_Block3_ServiceEngine]:FOR[RealismOverhaul]
+{
+	%node_stack_LMA = 0.0, -1.84, 0.0, 0.0, -1.0, 0.0, 2
+	
+	@rescaleFactor = 1.6
+	@mass = 0.18
+	@maxTemp = 1973.15
+	
+	%RSSROConfig = True
+	
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 97.86
+		@maxThrust = 97.86
+		@heatProduction = 100
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+			@ratio = 0.5017
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.4983
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 314
+			@key,1 = 1 150
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+	!MODULE[ModuleGimbal] {}
+	MODULE
+	{
+		name = ModuleGimbal
+		gimbalTransformName = thrustTransform
+		gimbalRange = 4.5
+		useGimbalResponseSpeed = true
+		gimbalResponseSpeed = 16
+	}
+	engineType = LMDE
+}
+
+@PART[bluedog_Apollo_Block2_Decoupler]:FOR[RealismOverhaul]
+{
+	@rescaleFactor = 1.6
+}
+
+@PART[bluedog_Apollo_Block2_RCSquad]:FOR[RealismOverhaul]
+{
+	@rescaleFactor = 1.6
+	
+	@MODULE[ModuleRCS*]
+	{
+		@name = ModuleRCS
+		@thrusterTransformName = rcsTransform
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		@thrusterPower = 0.4136846
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.456
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.544
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 260
+			@key,1 = 1 100
+		}
+	}
+	
+	!runningEffectName = DELETE
+	
+	!EFFECTS {}
+}


### PR DESCRIPTION
Includes configuration for Apollo Block 3 SM, Block 3 SM engine (LMDE), rescaling of the block2 decoupler and block2 sm rcs quad, with switch to MMH/NTO mixture.

Masses/volumes currently WIP, but a decent start.

https://www.alternatehistory.com/wiki/doku.php?id=timelines:eyes_turned_skyward_spacecraft_and_launch_vehicle_technical_data