### PR TITLE
Fix for Merlin massMult and fin radiator mass

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -30,7 +30,7 @@
 			minThrust = 369.2
 			maxThrust = 369.2
 			heatProduction = 100
-			MassMult = 1.0
+			massMult = 1.0
 				
 			PROPELLANT
 			{
@@ -68,7 +68,7 @@
 			minThrust = 394
 			maxThrust = 394
 			heatProduction = 100
-			MassMult = 1.0 //from wikipedia: Turbopump weight was unchanged at 150 lbs
+			massMult = 1.0 //from wikipedia: Turbopump weight was unchanged at 150 lbs
 				
 			PROPELLANT
 			{
@@ -106,7 +106,7 @@
 			minThrust = 421.6
 			maxThrust = 421.6
 			heatProduction = 100
-			MassMult = 1.2 //no good source but it should be heavier than the SL version
+			massMult = 1.2 //no good source but it should be heavier than the SL version
 			
 			PROPELLANT
 			{
@@ -144,7 +144,7 @@
 			minThrust = 482.632
 			maxThrust = 482.632
 			heatProduction = 100
-			MassMult = 0.829
+			massMult = 0.829
 			
 			PROPELLANT
 			{
@@ -190,7 +190,7 @@
 			minThrust = 246.9
 			maxThrust = 411.5 // [6]
 			heatProduction = 100
-			MassMult = 1.0
+			massMult = 1.0
 			
 			PROPELLANT
 			{
@@ -236,7 +236,7 @@
 			minThrust = 290
 			maxThrust = 722
 			heatProduction = 150
-			MassMult = 0.6184
+			massMult = 0.6184
 
 			PROPELLANT
 			{
@@ -283,7 +283,7 @@
 			minThrust = 330
 			maxThrust = 825 //[2]
 			heatProduction = 150
-			MassMult = 0.6184
+			massMult = 0.6184
 
 			PROPELLANT
 			{
@@ -331,7 +331,7 @@
 			minThrust = 330 // [5]
 			maxThrust = 914 // [3]
 			heatProduction = 150
-			MassMult = 0.6184
+			massMult = 0.6184
 
 			PROPELLANT
 			{
@@ -378,7 +378,7 @@
 			minThrust = 360
 			maxThrust = 805
 			heatProduction = 100
-			MassMult = 0.6447
+			massMult = 0.6447
 			
 			PROPELLANT
 			{
@@ -424,7 +424,7 @@
 			minThrust = 360
 			maxThrust = 934 // [2]
 			heatProduction = 225
-			MassMult = 0.6447
+			massMult = 0.6447
 			
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -30,7 +30,7 @@
 			minThrust = 369.2
 			maxThrust = 369.2
 			heatProduction = 100
-			massMult = 1.0
+			MassMult = 1.0
 				
 			PROPELLANT
 			{
@@ -68,7 +68,7 @@
 			minThrust = 394
 			maxThrust = 394
 			heatProduction = 100
-			massMult = 1.0 //from wikipedia: Turbopump weight was unchanged at 150 lbs
+			MassMult = 1.0 //from wikipedia: Turbopump weight was unchanged at 150 lbs
 				
 			PROPELLANT
 			{
@@ -106,7 +106,7 @@
 			minThrust = 421.6
 			maxThrust = 421.6
 			heatProduction = 100
-			massMult = 1.2 //no good source but it should be heavier than the SL version
+			MassMult = 1.2 //no good source but it should be heavier than the SL version
 			
 			PROPELLANT
 			{
@@ -144,7 +144,7 @@
 			minThrust = 482.632
 			maxThrust = 482.632
 			heatProduction = 100
-			massMult = 0.829
+			MassMult = 0.829
 			
 			PROPELLANT
 			{
@@ -190,7 +190,7 @@
 			minThrust = 246.9
 			maxThrust = 411.5 // [6]
 			heatProduction = 100
-			massMult = 1.0
+			MassMult = 1.0
 			
 			PROPELLANT
 			{
@@ -236,7 +236,7 @@
 			minThrust = 290
 			maxThrust = 722
 			heatProduction = 150
-			massMult = 0.6184
+			MassMult = 0.6184
 
 			PROPELLANT
 			{
@@ -283,7 +283,7 @@
 			minThrust = 330
 			maxThrust = 825 //[2]
 			heatProduction = 150
-			massMult = 0.6184
+			MassMult = 0.6184
 
 			PROPELLANT
 			{
@@ -331,7 +331,7 @@
 			minThrust = 330 // [5]
 			maxThrust = 914 // [3]
 			heatProduction = 150
-			massMult = 0.6184
+			MassMult = 0.6184
 
 			PROPELLANT
 			{
@@ -378,7 +378,7 @@
 			minThrust = 360
 			maxThrust = 805
 			heatProduction = 100
-			massMult = 0.6447
+			MassMult = 0.6447
 			
 			PROPELLANT
 			{
@@ -424,7 +424,7 @@
 			minThrust = 360
 			maxThrust = 934 // [2]
 			heatProduction = 225
-			massMult = 0.6447
+			MassMult = 0.6447
 			
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/REWORK/RO_KerbX.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_KerbX.cfg
@@ -895,7 +895,7 @@
 				key = 0 288.5
 				key = 1 253.7
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 		CONFIG
 		{
@@ -919,7 +919,7 @@
 				key = 0 304
 				key = 1 275
 			}
-			MassMult = 0.829
+			massMult = 0.829
 		}
 		CONFIG
 		{
@@ -943,7 +943,7 @@
 				key = 0 311
 				key = 1 282
 			}
-			MassMult = 0.68
+			massMult = 0.68
 		}
 	}
 	MODULE
@@ -1233,7 +1233,7 @@
 				key = 0 342
 				key = 1 200
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 		CONFIG
 		{
@@ -1257,7 +1257,7 @@
 				key = 0 340
 				key = 1 200
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -123,7 +123,7 @@
 				key = 0 340
 				key = 1 150
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -812,7 +812,7 @@
     @manufacturer = Roscosmos
     @description = A radial surface - mounted External Active Thermal Control System radiator panel.
 
-    @mass = 0.00121
+    @mass = 0.0121
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 1073.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -812,7 +812,7 @@
     @manufacturer = Roscosmos
     @description = A radial surface - mounted External Active Thermal Control System radiator panel.
 
-    @mass = 0.0121
+    @mass = 0.00121
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 1073.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fuji.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fuji.cfg
@@ -132,7 +132,7 @@
 				key = 0 307
 				key = 1 150
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -796,7 +796,7 @@
 				key = 0 282
 				key = 1 112
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 	MODULE
@@ -905,7 +905,7 @@
 				key = 0 282
 				key = 1 112
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 	MODULE
@@ -1012,7 +1012,7 @@
 				key = 0 305
 				key = 1 112
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 	@MODULE[ModuleRCS]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -803,7 +803,7 @@
 				key = 0 292
 				key = 1 112
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 		CONFIG
 		{
@@ -827,7 +827,7 @@
 				key = 0 302
 				key = 1 112
 			}
-			MassMult = 1.0
+			massMult = 1.0
 		}
 	}
 	@MODULE[ModuleGimbal]


### PR DESCRIPTION
-The Merlin config has MassMult instead of massMult (correct version) and hence doesn't work. Fix to correct capitalisation in config file. Checked and confirmed now correct in-game.

-The weight for the fin radiator does not match the source data provided (One too many zeros). Fix to mass to correct error.
