### PR TITLE
As of KSP1.2, removes interstage nodes

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -289,3 +289,13 @@
 		impassablenodes = connect01, connect02, connect03, connect04, connect05, connect06, connect07, connect08
 	}
 }
+
+// As of KSP 1.2, this is used to remove the interstage nodes that appear by default.
+
+@PART[*]:HAS[@MODULE[KzNodeNumberTweaker]]:FOR[RealismOverhaul]
+{
+	%MODULE[KzNodeNumberTweaker]
+	{
+		%showInterstageNodes = false
+	}
+}


### PR DESCRIPTION
As of KSP1.2, removes interstage nodes. These appear by default normally, this stops them. The nodes will appear before you drop the part, but disappear/won't show again after you've dropped it (unless manually re-enabled?)

I tested & use this patch in my game. @rsparkyc , does this more or less line up with what you used?