### PR TITLE
Add/create RO_TACLO2ToO2

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -537,3 +537,41 @@
 		}			
 	}
 }
++PART[FuelCell]:FOR[RealismOverhaul]:FINAL
+{
+	@name = RO_TACLO2ToO2
+	@title = TACLS Liquid O2 to O2 converter
+	@description = A simple device to evaporate LO2 to use for astronaut breathing oxygen.
+	
+	@mass = 0.050
+	
+	!RESOURCE[LithiumPeroxide] {}
+	
+	!MODULE[TacGenericConverter] {}
+	!MODULE[ModuleResourceConverter] {}
+
+	MODULE
+	{
+		name = TacGenericConverter
+		%converterName = LOX-O2
+		%StartActionName = Start Oxygen Generator
+		%StopActionName = Stop Oxygen Generator
+		%conversionRate = 1.0
+		INPUT_RESOURCE
+		{
+			%ResourceName = LqdOxygen
+			%Ratio = 0.0000085058788
+		}
+		INPUT_RESOURCE
+		{
+			%ResourceName = ElectricCharge
+			%Ratio = 0.025
+		}
+		OUTPUT_RESOURCE
+		{
+			%ResourceName = Oxygen
+			%Ratio = 0.006883126
+			%DumpExcess = false
+		}
+	}
+}


### PR DESCRIPTION
Add a part for RO that converts liquid oxygen to gaseous oxygen for breathing.
FASA already has this built into some service modules that do this, as it is a reasonable and realistic way to store and utilize oxygen on long term missions.