### PR TITLE
NearFuture Reactors Update

### DIFF
--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -285,10 +285,17 @@ RESOURCE_DEFINITION
 @RESOURCE_DEFINITION[DepletedUranium]:FOR[RealismOverhaul]
 {
   @unitCost = -1.097
+  @density = 0.001
+}
+@RESOURCE_DEFINITION[DepletedFuel]:FOR[RealismOverhaul]
+{
+  @unitCost = -1.097
+  @density = 0.001
 }
 @RESOURCE_DEFINITION[EnrichedUranium]:FOR[RealismOverhaul]
 {
   @unitCost = 54.85
+  @density = 0.001
 }
 @RESOURCE_DEFINITION[LeadBallast]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -29,14 +29,15 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	@RESOURCE[DepletedUranium]
+	@mass = 0.266
+	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 400
+		@maxAmount = 800
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 400
-		@maxAmount = 400
+		@amount = 800
+		@maxAmount = 800
 	}
 }
 @PART[nuclearfuel-125]:FOR[RealismOverhaul]
@@ -46,7 +47,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	@RESOURCE[DepletedUranium]
+	@mass = 0.133
+	@RESOURCE[DepletedFuel]
 	{
 		@maxAmount = 400
 	}
@@ -63,7 +65,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	@RESOURCE[DepletedUranium]
+	@mass = 0.033
+	@RESOURCE[DepletedFuel]
 	{
 		@maxAmount = 100
 	}
@@ -75,7 +78,7 @@
 }
 @PART[nuclear-recycler-25]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
+	%RSSROConfig = False
 	!MODULE[TweakScale]
 	{
 	}
@@ -132,66 +135,128 @@
 		@HeatRadiatedClosed = 15
 	}
 }
+// ==================================================
+// TOPAZ-I 
+
+// Source = [http://www.world-nuclear.org/information-library/non-power-nuclear-applications/transport/nuclear-reactors-for-space.aspx]
+// Source = [http://www.svengrahn.pp.se/trackind/RORSAT/RORSAT.html]
+//
+// Designed for 12kg Uranium for 3 years operation, single use unretrievable, to be sent to graveyard orbit. 5 years mentioned although "not reliable"
+// 135kW thermal power, 5 kWe chosen although 6kWe is also quoted with mention of decreased reliability
+// Weighs 320kg including cooling (doubtable whether sufficient due to never performing reliably in orbit), known to be a bit "light on shielding"
+// 10 radiators required to balance the low shielding and borderline cooling, and offset large mass/ton jump from BES-5
+//
+// Situated in middle node in tech tree due to being an upgrade on BES-5, and actually "inspired by TOPAZ-II" despite numeric designation
+// ==================================================
 @PART[reactor-375]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
+	%RSSROConfig = True
 	!MODULE[TweakScale]
 	{
 	}
 	!mesh = DELETE
 	MODEL
 	{
-		model = NearFutureElectrical/Parts/FissionReactors/reactor-375/reactor-375
-		scale = 1.0, 1.0, 1.0
+		model = NearFutureElectrical/Parts/FissionReactors/reactor-0625/reactor-0625
+		scale = 0.816, 1.270815, 0.816
 	}
-	@node_stack_top = 0.0, 0.9629021, 0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, -0.8371854, 0, 0.0, -1.0, 0.0, 3
+	@rescaleFactor = 0.60  // roughly 60% size of SAFE 400
+	@node_stack_top = 0.0, 0.80569671, 0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.644303205, 0, 0.0, -1.0, 0.0, 0
 	!node_attach = DELETE
-	@title = NEED INPUT
-	@description = NEED INPUT
+	@title = TOPAZ-I
+	@TechRequired = largeNuclearPower
+	@description = I. V. Kurchatov Institute of Atomic Energy. Tested in 1970s and flown twice in 1987. Evolution of the TOPAZ-II design. Designed to operate for 3 years.
 	@attachRules = 1,0,1,1,1
-	@mass = 5.4
+	@mass = 0.32
+	-MODULE[FissionReact*]
+	{
+	}
+	MODULE
+	{
+		name = FissionReactor
+		StartActionName = Start Reactor
+		StopActionName = Deactivate Reactor
+	
+		UseStagingIcon = true
+		UseForcedActivation = true
+		UseSpecializationBonus = false
+		AutoShutdown = true
+		DefaultShutoffTemp = 0.90
+	
+		HeatGeneration = 250 // requires 10 fin radiators
+		NominalTemperature = 823
+		CriticalTemperature = 1373
+		CoreDamageRate = 0.01
+		GeneratorSpinupRate = 0.03
+
+		EngineerLevelForRepair = 5
+		MaxRepairPercent = 75
+		MaxTempForRepair = 330
+ 
+		FuelName = EnrichedUranium
+ 
+		// Heating
+		GeneratesHeat = false
+		TemperatureModifier
+		{
+			key = 0 0 // 250
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000076
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.000000076
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[ModuleCoreHeat]
+	{
+		@CoreTempGoal = 823 	
+		@CoreShutdownTemp = 2273 
+		@MaxCoolant = 5 
+	}
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 2000
-		@ThermalPower = 4000
-		@ThermalPowerResponseRate = 125
-		@BurnRate = 0.000006
-		@MinPowerPercent = 0.2
-		@CurrentPowerPercent = 0.2
-		@MaxCoreTemperature = 420
-		@MeltdownCoreTemperature = 2100
-		@CoreTemperatureResponseRate = 5
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+		@PowerGeneration = 5 // 5kWe 
+		@HeatUsed = 5
 	}
+	
 	@RESOURCE[ElectricCharge]
-	{
-		@amount = 50400
-		@maxAmount = 50400
-	}
-	@RESOURCE[DepletedUranium]
-	{
-		@maxAmount = 320
-	}
-	@RESOURCE[EnrichedUranium]
 	{
 		@amount = 320
 		@maxAmount = 320
 	}
+	@RESOURCE[DepletedFuel]
+	{
+		@maxAmount = 12
+	}
+	@RESOURCE[EnrichedUranium]
+	{
+		@amount = 12 // designed for 12kg fuel 
+		@maxAmount = 12 
+	}
 }
+// ==================================================
+// RAPID-L Fast Breeder Reactor
+//
+// Source = [http://www.iaea.org/inis/collection/NCLCollectionStore/_Public/37/002/37002589.pdf?r=1] (in Japanese)
+//
+// JAERI design, it is a USDOE project entrant but has no connection outside of that
+// Meltdown temp 1615K due to coolant evaporation
+//
+// 750kg Uranium for 200kWe for 10 years, refuellable definitely once, potentially more than once
+// 5MWt thermal power, ~3.5tons of cooling and shielding, ~7.6t in total. ~4m tall, using previous values
+// 8 fin radiators required chosen due to size, taking into consideration ~3.5t added cooling and shielding mass already
+//
+// Positioned at middle node in tech tree due to providing significant power, while also weighing a significant amount
+// ==================================================
 @PART[reactor-25]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -204,112 +269,216 @@
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-25/reactor-25
 		scale = 0.8, 1.908027, 0.8
 	}
-	@node_stack_top = 0.0, 2.77495814772, 0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -3.7250411121, 0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 3.27495814772, 0, 0.0, 1.0, 0.0, 2 
+	@node_stack_bottom = 0.0, -3.4250411121, 0, 0.0, -1.0, 0.0, 2
 	!node_attach = DELETE
-	@title = USDOE RAPID-L Nuclear Reactor
-	@description = Design based for lunar bases.
+	@title = RAPID-L Nuclear Reactor 
+	@TechRequired = largeNuclearPower
+	@description = Early 2000s Japanese Atomic Energy Research Institute design for lunar bases. Designed for 10 years of operation.
 	@attachRules = 1,0,1,1,1
-	@mass = 7.6
+	@mass = 7.6 // with shielding and cooling, the pit-buried design weighs equivalent 670kg on Moon, 4050kg on Earth
+	-MODULE[FissionReact*]
+	{
+	}
+	MODULE
+	{
+		name = FissionReactor
+		StartActionName = Start Reactor
+		StopActionName = Deactivate Reactor
+	
+		UseStagingIcon = true
+		UseForcedActivation = true
+		UseSpecializationBonus = false
+		AutoShutdown = true
+		DefaultShutoffTemp = 0.90
+	
+		HeatGeneration = 400 // Requires 16 fin radiators
+		NominalTemperature = 673
+		CriticalTemperature = 1615
+		CoreDamageRate = 0.01
+		GeneratorSpinupRate = 0.03
+
+		EngineerLevelForRepair = 5
+		MaxRepairPercent = 75
+		MaxTempForRepair = 330
+ 
+		FuelName = EnrichedUranium
+ 
+		// Heating
+		GeneratesHeat = false
+		TemperatureModifier
+		{
+			key = 0 0 // 10000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.00000238 // 750kg fuel for 10 years
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.00000238
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[ModuleCoreHeat]
+	{
+		@CoreTempGoal = 673 	
+		@CoreShutdownTemp = 2273 
+		@MaxCoolant = 8 
+	}
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 200
-		@ThermalPower = 5000
-		@ThermalPowerResponseRate = 35
-		@BurnRate = 0.000007
-		@MinPowerPercent = 0.2
-		@CurrentPowerPercent = 0.2
-		@MaxCoreTemperature = 400
-		@MeltdownCoreTemperature = 2100
-		@CoreTemperatureResponseRate = 3
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+		@PowerGeneration = 200 // 200kWe
+		@HeatUsed = 8
 	}
+	
 	@RESOURCE[ElectricCharge]
 	{
-		@amount = 50400
-		@maxAmount = 50400
+		@amount = 7600
+		@maxAmount = 7600
 	}
-	@RESOURCE[DepletedUranium]
+	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 500
+		@maxAmount = 750
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 500
-		@maxAmount = 500
+		@amount = 750 // designed for 750kg fuel that lasts 10 years
+		@maxAmount = 750 
 	}
 }
+// ==================================================
+// BES-5 Fast Fission Nuclear Reactor
+//
+// [source = http://www.world-nuclear.org/information-library/non-power-nuclear-applications/transport/nuclear-reactors-for-space.aspx]
+// [source = http://www.svengrahn.pp.se/trackind/RORSAT/RORSAT.html]
+//
+// Designed for 4 months, with 30kg Uranium fuel. Intended to be sent to graveyard orbit
+// 400mm diameter, 600mm long for reactor alone, cooling & shielding probably adds ~300mm based on drawings
+// Mass 385kg, 3kWe and 100kWt. Had sufficient shielding and seemingly adequate cooling
+// 6 fin radiators required for balance, and also to fit in with the other reactors
+//
+// Position in tech true due to being earliest chronologically and also based on power/mass ratio
+// ==================================================
 @PART[reactor-25-2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
 	!mesh = DELETE
 	MODEL
 	{
-		model = NearFutureElectrical/Parts/FissionReactors/reactor-25-2/reactor-25-2
-		scale = 1.84, 4.064981, 1.84
+		model = NearFutureElectrical/Parts/FissionReactors/reactor-0625/reactor-0625
+		scale = 0.816, 1.270815, 0.816
 	}
-	@rescaleFactor = 1.0
-	@node_stack_top = 0.0, 12.4278664113, 0, 0.0, 1.0, 0.0, 4
-	@node_stack_bottom = 0.0, -9.572131894199, 0, 0.0, -1.0, 0.0, 4
-	!node_attach = DELETE
-	@title = NuScale Nuclear Reactor
-	@description = Massive Reactor - Good luck.
+	@rescaleFactor = 0.633  // roughly 63% size of SAFE 400
+	@node_stack_top = 0.0, 0.80569671, 0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.644303205, 0, 0.0, -1.0, 0.0, 0
+	// test !node_attach = DELETE 
+	@title = BES-5
+	@TechRequired = nuclearPower
+	
+	@description = I. V. Kurchatov Institute of Atomic Energy. Launched into orbit on 31 separate missions from 1967 to 1988. Designed to operate for 4 months.
 	@attachRules = 1,0,1,1,1	
-	@mass = 450
+	@mass = 0.385
+	-MODULE[FissionReact*]
+	{
+	}
+	MODULE
+	{
+		name = FissionReactor
+		StartActionName = Start Reactor
+		StopActionName = Deactivate Reactor
+	
+		UseStagingIcon = true
+		UseForcedActivation = true
+		UseSpecializationBonus = false
+		AutoShutdown = true
+		DefaultShutoffTemp = 0.90
+	
+		HeatGeneration = 150 // Requires 6 fin radiators
+		NominalTemperature = 823
+		CriticalTemperature = 1373
+		CoreDamageRate = 0.01
+		GeneratorSpinupRate = 0.03
+
+		EngineerLevelForRepair = 5
+		MaxRepairPercent = 75
+		MaxTempForRepair = 330
+ 
+		FuelName = EnrichedUranium
+ 
+		// Heating
+		GeneratesHeat = false
+		TemperatureModifier
+		{
+			key = 0 0 //7500
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.00000289 // 30kg fuel for 4 months
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.00000289
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[ModuleCoreHeat]
+	{
+		@CoreTempGoal = 823 	
+		@CoreShutdownTemp = 2273 
+		@MaxCoolant = 3 
+	}
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 45000
-		@ThermalPower = 145000
-		@ThermalPowerResponseRate = 120
-		@BurnRate = 0.000008
-		@MinPowerPercent = 0.2
-		@CurrentPowerPercent = 0.2
-		@MaxCoreTemperature = 520
-		@MeltdownCoreTemperature = 2200
-		@CoreTemperatureResponseRate = 3
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+		@PowerGeneration = 3 // 3kWe
+		@HeatUsed = 3
 	}
+	
 	@RESOURCE[ElectricCharge]
 	{
-		@amount = 50400
-		@maxAmount = 50400
+		@amount = 385
+		@maxAmount = 385
 	}
-	@RESOURCE[DepletedUranium]
+	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 750
+		@maxAmount = 30
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 750
-		@maxAmount = 750
+		@amount = 30 // designed for 30kg fuel 
+		@maxAmount = 30 
+	}
+	@MODULE[ModuleB9PartSwitch]
+	{
+		@SUBTYPE[Inline] 
+		{
+			@name = TopNode
+			@node = top
+		}
 	}
 }
+// ==================================================
+// TOPAZ-II 
+//
+// source = [http://www.world-nuclear.org/information-library/non-power-nuclear-applications/transport/nuclear-reactors-for-space.aspx]
+// source = [http://fti.neep.wisc.edu/neep602/SPRING00/lecture35.pdf] 6kWe here is design requirement not actual achieved
+//
+// Mass 1061kg, 135kWt, 10kWe. Designed for 12kg fuel for 3 years
+// 12 radiators due to balance, plus fitting in with the other reactors
+//
+// Tech tree placement due to providing similar power/mass ratio as BES-5, less than others
+// ==================================================
 @PART[reactor-125]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -323,54 +492,97 @@
 		scale = 1.12, 1.855994, 1.12
 	}
 	@rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.6744777868, 0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -2.2255224054, 0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 2.3744777868, 0, 0.0, 1.0, 0.0, 1 
+	@node_stack_bottom = 0.0, -1.8255224054, 0, 0.0, -1.0, 0.0, 1 
 	!node_attach = DELETE
-	@title = TOPAZ-II Nuclear Reactor
-	@description = I. V. Kurchatov Institute of Atomic Energy. Related to the TOPAZ-I, a nuclear fission reactor found in around 30 satellites put into orbit by the Soviet Union.
+	@title = TOPAZ-II 
+	@TechRequired = nuclearPower
+	
+	@description = I. V. Kurchatov Institute of Atomic Energy. Related to the TOPAZ-I. Early 1960s design. Designed for 3 years of operation.
 	@attachRules = 1,0,1,1,1
 	@mass = 1.061
+	-MODULE[FissionReact*]
+	{
+	}
+	MODULE
+	{
+		name = FissionReactor
+		StartActionName = Start Reactor
+		StopActionName = Deactivate Reactor
+	
+		UseStagingIcon = true
+		UseForcedActivation = true
+		UseSpecializationBonus = false
+		AutoShutdown = true
+		DefaultShutoffTemp = 0.90
+	
+		HeatGeneration = 300 // Requires 12 fin radiators
+		NominalTemperature = 823
+		CriticalTemperature = 1373
+		CoreDamageRate = 0.01
+		GeneratorSpinupRate = 0.03
+
+		EngineerLevelForRepair = 5
+		MaxRepairPercent = 75
+		MaxTempForRepair = 330
+ 
+		FuelName = EnrichedUranium
+ 
+		// Heating
+		GeneratesHeat = false
+		TemperatureModifier
+		{
+			key = 0 0 //7500
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000126 // 12kg fuel for 3 years
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.000000126
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[ModuleCoreHeat]
+	{
+		@CoreTempGoal = 823 	
+		@CoreShutdownTemp = 2273 
+		@MaxCoolant = 6 
+	}
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 5.5
-		@ThermalPower = 135
-		@ThermalPowerResponseRate = 5.5
-		@BurnRate = 0.000001
-		@MinPowerPercent = 0.1
-		@CurrentPowerPercent = 0.1
-		@MaxCoreTemperature = 550
-		@MeltdownCoreTemperature = 1100
-		@CoreTemperatureResponseRate = 5
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+		@PowerGeneration = 10 // 10kWe
+		@HeatUsed = 6
 	}
+	
 	@RESOURCE[ElectricCharge]
 	{
-		@amount = 50400
-		@maxAmount = 50400
+		@amount = 1060
+		@maxAmount = 1060
 	}
-	@RESOURCE[DepletedUranium]
+	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 100
+		@maxAmount = 12
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 100
-		@maxAmount = 100
+		@amount = 12 // designed for 12kg fuel only
+		@maxAmount = 12 
 	}
 }
+// ==================================================
+// SAFE 400
+
+// Most stats kept from previous config, there is a paywall to access most stats. Assuming previous stats
+// 656kg, 400kWt, 100kWe which is exceptional hence tech tree placement
+// Data for SAFE 30 indicates 30kWt, 17.1kWe weighing "roughly a third of a ton" including cooling
+// However reactors don't scale linearly, nevertheless it requires 12 radiators for a level of balance
+// ==================================================
 @PART[reactor-0625]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -386,43 +598,76 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.80569671, 0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -0.644303205, 0, 0.0, -1.0, 0.0, 0
-	!node_attach = DELETE
+	// test !node_attach = DELETE
 	@title = NASA SAFE-400 Nuclear Reactor
-	@description = Safe Affordable Fission Engine. Small and lightweight but powerful reactor enabled by new technology.
+	@TechRequired = advNuclearPower
+	@description = Safe Affordable Fission Engine. Small and lightweight but powerful reactor enabled by new technology. Early 2000s design. Designed for 4 years of operation.
 	@attachRules = 1,0,1,1,1
 	@mass = 0.656
+	-MODULE[FissionReact*]
+	{
+	}
+	MODULE
+	{
+		name = FissionReactor
+		StartActionName = Start Reactor
+		StopActionName = Deactivate Reactor
+	
+		UseStagingIcon = true
+		UseForcedActivation = true
+		UseSpecializationBonus = false
+		AutoShutdown = true
+		DefaultShutoffTemp = 0.90
+	
+		HeatGeneration = 600 // 12 fin rads although extendable rads are recommended here
+		NominalTemperature = 583
+		CriticalTemperature = 873
+		CoreDamageRate = 0.01
+		GeneratorSpinupRate = 0.03
+
+		EngineerLevelForRepair = 5
+		MaxRepairPercent = 75
+		MaxTempForRepair = 330
+ 
+		FuelName = EnrichedUranium
+ 
+		// Heating
+		GeneratesHeat = false
+		TemperatureModifier
+		{
+			key = 0 0 //7500
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.0000004 // 4 years, see above
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.0000004
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[ModuleCoreHeat]
+	{
+		@CoreTempGoal = 583 	
+		@CoreShutdownTemp = 1073 
+		@MaxCoolant = 12 
+	}
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 100
-		@ThermalPower = 400
-		@ThermalPowerResponseRate = 2
-		@BurnRate = 0.0000004
-		@MinPowerPercent = 0.4
-		@CurrentPowerPercent = 0.4
-		@MaxCoreTemperature = 310
-		@MeltdownCoreTemperature = 600
-		@CoreTemperatureResponseRate = 5
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+		@PowerGeneration = 100 //100kWe
+		@HeatUsed = 12
 	}
 	@RESOURCE[ElectricCharge]
 	{
-		@amount = 50400
-		@maxAmount = 50400
+		@amount = 655
+		@maxAmount = 655
 	}
-	@RESOURCE[DepletedUranium]
+	@RESOURCE[DepletedFuel]
 	{
 		@maxAmount = 50
 	}


### PR DESCRIPTION
**Please read issue 3 detailed near the bottom as it involves a potential issue with a lot of engines**

Fix to update Near Future reactor configs to work with update 1.2 

**Note 0**: Apologies for the amount of writing, however a lot of explanation and reasoning is required for this PR. 

**Note 1**: I am aware of work done such as by Schnobs, etc. however I have not seen any progress on the reactor configs in the past few months (years?) so I decided to have a stab at updating the configs. I have kept to as realistic values as possible, however certain estimations and changes have been made taking realism and balance into consideration. Feel free to critique and ask for changes, I aim to help RO first and foremost. Sources provided for all data, and reasoning for estimations where data is missing is also provided.

**Note 2**: I removed the 455 ton reactor and replaced it with a BES-5 Reactor (FYI flown 31 times, compared to 2 times for next most common reactor). I also added the TOPAZ-I in the 3.75m reactor slot (the aforementioned twice-flown reactor) which I believe gives a more realistic and useful lineup.

**Note 3**: Due to the strange way NF heat is handled, coupled with the fact that the mass quoted for most of the reactors includes the cooling systems, the required cooling has been kept to a value that is low enough to be believably realistic (and not look stupid with 50 large extendable radiators required), but high enough to require enough radiators to look and behave realistically. The exception is the SAFE 400, which based on its power-to-mass ratio should require a lot of added cooling.

**Changelog:**
- The modules have changed for NF Reactors, as a result the current patches don't patch much and stock stats are therefore used in-game. Applied fix to update to new modules (FissionReactor and FissionGenerator).

- Resource [DepletedUranium] is now referred to as [DepletedFuel] in NF. Applied fix for this change.

- Module CoreHeat has been added for all reactors with correct stats.

- All descriptions were changed/updated, one contained a factually incorrect statement (the BES-5 was used on 31 missions, the Topaz-1 was used on 2 missions) and the others were brought more in line with other RO descriptions (include decade, etc.).

- The uranium barrels have had their masses and capacity changed to reflect more realistic and useful values(the 1.25m and 2.5m barrels were very close in stats). See issue 1 below.

- In real life, all of these reactors take 6-24hrs to heat up. A value of 8hrs heat up has been applied across the board (without the addition of the GeneratorSpinupRate field which NF supports, the values are typically ~30mins so it is not too far fetched).

- Replaced 455-ton NuScale with BES-5 reactor.

- Added TOPAZ-I in place of the unused 3.75m reactor.

- Added a commented-out fix to resource definition to change mass of 1 unit Uranium from 11kg to 1kg. See issue 3 below.

- Reduced electric charge storage to more realistic levels, scaled to mass. Although storage should probably be removed for full realism as that is what proc batteries are for. Reduced to 1MJ/ton for now.

- Full source and basic part information provided as comments for all 5 reactors in config file.

- The FissionReactor modules are first deleted before being re-added due to issues with altering the input and output resource ratios, not due to inefficiency.

- The order that the reactors appear in the tech tree has been changed to a more logical order with the 2 new additions.

- Nuclear Reprocessor has been changed to WIP as I haven't looked at updating it to work with 1.2 yet, although it is clear that it currently does not work.

- B9PartSwitch modules fixed for BES-5 and SAFE 400 as they removed nodes by default (bottom and top respectively).

**Issues**

1) All of these reactors are designed in real life for either single use, or in the case of the RAPID-L (and maybe the SAFE 400) two uses at most. In other words, you shouldn't be able to just turn on and off the reactor as you please. One possible route is to use ModuleGenerator with the ability to shut down once started removed, similar to an SRB. Ideally I'd remove the barrels also, or else make them specific to the Rapid-L and SAFE 400 designs. However I have left them for now, with the disincentive of taking 8 hours to heat up to try to negate this behaviour.

2) In order to tweak the heat generated to levels low enough for an appropriate number of radiators, it shows up a relatively arbitrary number for the cooling required/heat generated as a result. This can't be fixed unless ChrisAdderley changes NFE to accommodate this somehow (which is quite an ask for a superficial issue), but for now arbitrary numbers in the display will have to stay.

3) The mass of 1 unit of uranium is currently set to 11kg and I'm not sure why? I have examined the other places that the resource EnrichedUranium is used, and it only appears to be for the engines such as NERVA I and II, Atomic Age, Bimodal, Laztek, Novapunch, and CMES nuclear engines. In each case, changing the mass from 11kg to 1kg does not break anything immediately (consumption of kg/s goes down, but the actual consumption in units/s will stay the same i.e. fuel will last just as long as before) although the ratios for those parts might have to be revisited if they are written for a density of 11kg. I've left the fix in for now and will edit based on what the consensus is about changing the density, although if changing this value causes an issue please point it out. Just making sure that people are aware the NERVA II carries 165kg of Uranium and not 15kg for example. The fix to density should probably happen in RO_Resources.cfg if it is approved (my bad, just wanted to get it out there first). It makes more sense to have 1 unit = 1kg. 

4) Using the stock NFE models isn't quite aesthetically appropriate but I do not have the time to model them myself plus very little data exists on the appearance of the SAFE 400, etc. The 2 new reactors have been sized appropriately from NFE models however.

5) The TOPAZ-I fuel consumption is below the minimum threshold coded by ChrisAdderley, and therefore it will always show that the reactor has a "very long" time left. Again, no fix for this from my side. However it should still be clear from the part description and the current fuel level what the situation is at any time so this issue can be ignored.

**Future Work**

1) Adding more reactors including the SNAP-10A, KiloPower 1kWe to 10kWe series, SAFE 30, SAFE 300, etc.

2) Update Nuclear Reprocessor to the same standard.

3) Look at the NFE radiators.
