### PR TITLE
MarsISRUengineplume fix

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RealISRU/Mars_Methane_1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealISRU/Mars_Methane_1.cfg
@@ -4,7 +4,7 @@
 	{
 		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
-		%directThrottleEffectName = Hydrolox-Red
+		%directThrottleEffectName = Ammonialox
 	}
 	@MODULE[ModuleEngineConfigs]
     {
@@ -12,14 +12,14 @@
     }
     PLUME
     {
-        name = Hydrolox-Red
+        name = Ammonialox
         transformName = thrustTransform
         localRotation = 0,0,0
-        plumePosition = 0,0,0.3
-        plumeScale = 0.7
-		flarePosition = 0,0,0.55
-		flareScale = 0.7
-        energy = 1.0
+        plumePosition = 0,0,0.4
+        plumeScale = 1.8
+	flarePosition = 0,0,0.45
+	flareScale = 0.5
+        energy = 1.5
         speed = 1.3
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealISRU/Mars_Methane_14.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealISRU/Mars_Methane_14.cfg
@@ -4,7 +4,7 @@
 	{
 		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
-		%directThrottleEffectName = Hydrolox-Red
+		%directThrottleEffectName = Ammonialox
 	}
 	@MODULE[ModuleEngineConfigs]
     {
@@ -12,13 +12,13 @@
     }
     PLUME
     {
-        name = Hydrolox-Red
+        name = Ammonialox
         transformName = thrustTransform
         localRotation = 0,0,0
-        plumePosition = 0,0,0.3
+        plumePosition = 0,0,0.4
         plumeScale = 0.7
-		flarePosition = 0,0,0.55
-		flareScale = 0.7
+	flarePosition = 0,0,0.45
+	flareScale = 0.7
         energy = 1.0
         speed = 1.3
     }


### PR DESCRIPTION
MarsISRUengineplume fix. It had been broken at some point. Moved to the Ammonialox plume template, since no Methalox template exists.