### PR TITLE
RD-103 global engine config updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD103_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD103_Config.cfg
@@ -3,13 +3,15 @@
 
 //  Inert Mass: 870 Kg (RD-103), 867 Kg (RD-103M)
 //  Throttle Range: N/A
-//  O/F Ratio: 1.44 (RD-103), 1.69 (RD-103M)
-//  Burn Time: 125 s
+//  O/F Ratio: 1.44
+//  Burn Time: 130 s (RD-103), 140 s (RD-103M)
 
 //  Sources:
 
 //  NPO Energomash - Liquid rocket engines list:                    http://www.npoenergomash.ru/encikloped/dvizki/
+//  Exponenta Educational Mathematical Site - Aeroengines:          http://www.k204.ru/books/Aviadvigatel2.pdf
 //  Alternate Wars - The Development of Rocket Engines in the USSR: http://www.alternatewars.com/BBOW/Space_Engines/Germans_USSR_Engines.pdf
+//  Liquid Propellant Rocket Engines - Experimental Engines:        http://www.lpre.de/energomash/ED/index.htm
 //  Norbert Brügge - Russian liquid propellant engines:             http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 //  Encyclopedia Astronautica - RD-103 engine:                      http://astronautix.com/r/rd-103.html
 //  Encyclopedia Astronautica - RD-103M engine:                     http://astronautix.com/r/rd-103m.html
@@ -47,7 +49,7 @@
 		!thrustCurve,*{}
 	}
 
-	@MODULE[ModuleGimbal]
+	@MODULE[ModuleGimbal],*
 	{
 		@gimbalRange = 2.0
 		%useGimbalResponseSpeed = True
@@ -119,21 +121,20 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 1
-
 			cost = 150
 			techRequired = engineering101 // In reality, it should be somewhere in between Basic and General rocketry (1952 - 1955).
 
 			PROPELLANT
 			{
 				name = Ethanol90
-				ratio = 0.4546
+				ratio = 0.4945
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5454
+				ratio = 0.5055
 				DrawGauge = False
 			}
 
@@ -173,7 +174,7 @@
 	TESTFLIGHT
 	{
 		name = RD-103
-		ratedBurnTime = 112
+		ratedBurnTime = 130
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.9
 		cycleReliabilityStart = 0.85
@@ -187,7 +188,7 @@
 	TESTFLIGHT
 	{
 		name = RD-103M
-		ratedBurnTime = 130
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.93
 		cycleReliabilityStart = 0.87

--- a/GameData/RealismOverhaul/Engine_Configs/RD103_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD103_Config.cfg
@@ -1,84 +1,173 @@
-// RD-103
-// VSR
+//  ==================================================
+//  RD-103 series global engine configuration.
+
+//  Inert Mass: 870 Kg (RD-103), 867 Kg (RD-103M)
+//  Throttle Range: N/A
+//  O/F Ratio: 1.44 (RD-103), 1.69 (RD-103M)
+//  Burn Time: 125 s
+
+//  Sources:
+
+//  NPO Energomash - Liquid rocket engines list:                    http://www.npoenergomash.ru/encikloped/dvizki/
+//  Alternate Wars - The Development of Rocket Engines in the USSR: http://www.alternatewars.com/BBOW/Space_Engines/Germans_USSR_Engines.pdf
+//  Norbert Brügge - Russian liquid propellant engines:             http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//  Encyclopedia Astronautica - RD-103 engine:                      http://astronautix.com/r/rd-103.html
+//  Encyclopedia Astronautica - RD-103M engine:                     http://astronautix.com/r/rd-103m.html
+
+//  Used by:
+
+//  * Ven Stock Revamp
+
+//  Notes:
+
+//  The gimbal range defined here is not a true value, since the actual engine did not have
+//  a mechanical gimbal capability for the engine and/or nozzle. Instead, we simulate the
+//  operation of the jet vanes used to steer the engine exhaust products.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[RD103]]:FOR[RealismOverhaulEngines]
 {
-	@title = RD-103
-	@manufacturer = NPO Energomash
-	@description = Early Russian ethanol/LOX booster engine, derived from the V-2 engine. Broadly similar to the (similar pedigree) NAA75-110 engine used on the American Redstone, this engine powered the R-5 'Victory' theater ballistic missile. Diameter: [1.65 m].
-	
+	%category = Engine
+	%title = RD-103 Series
+	%manufacturer = NPO Energomash
+	%description = Early Russian Ethalox booster engine, derived from the V-2 engine. Broadly similar to the (similar pedigree) NAA75-110 engine used on the American Redstone, this engine powered the R-5 'Victory' theater ballistic missile series. Diameter: 1.65 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 490.33
+		%maxThrust = 490.33
+		%heatProduction = 100
+		%useThrustCurve = False
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 2.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
-		name = ModuleEngineConfigs	
+		name = ModuleEngineConfigs
+		type = ModuleEngines
 		configuration = RD-103
-		modded = false
 		origMass = 0.87
+
 		CONFIG
 		{
 			name = RD-103
-			minThrust = 469.7
-			maxThrust = 469.7
+			minThrust = 490.33
+			maxThrust = 490.33
 			heatProduction = 100
-			PROPELLANT
-			{
-				name = Ethanol75
-				ratio = 0.499
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.501
-			}
-			atmosphereCurve
-			{
-				key = 0 244
-				key = 1 216
-			}
+			massMult = 1.0
 			ullage = True
+			pressureFed = False
 			ignitions = 1
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.500
-			}
-		}
-		CONFIG
-		{
-			name = RD-103M
-			minThrust = 484.9
-			maxThrust = 484.9
-			heatProduction = 100
+
 			PROPELLANT
 			{
-				name = Ethanol75
-				ratio = 0.461
+				name = Ethanol90
+				ratio = 0.4945
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.539
+				ratio = 0.5055
+				DrawGauge = False
 			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
 			atmosphereCurve
 			{
 				key = 0 248
 				key = 1 220
 			}
-			ullage = True
-			ignitions = 1
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
-				amount = 0.500
+				amount = 0.5
 			}
+		}
+
+		CONFIG
+		{
+			name = RD-103M
+			minThrust = 500.14
+			maxThrust = 500.14
+			heatProduction = 100
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
 			cost = 150
-			techRequired = engineering101 // really it's somewhere in between basic and general rocketry
+			techRequired = engineering101 // In reality, it should be somewhere in between Basic and General rocketry (1952 - 1955).
+
+			PROPELLANT
+			{
+				name = Ethanol90
+				ratio = 0.4546
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.5454
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 248
+				key = 1 220
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 		}
 	}
-	!MODULE[ModuleAlternator]
-	{
-	}
+
+	!MODULE[ModuleAlternator],{}
+
+	!RESOURCE,*{}
 }
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-103]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -92,6 +181,7 @@
 		reliabilityDataRateMultiplier = 1
 	}
 }
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-103M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT


### PR DESCRIPTION
**Change log:**

* Add basic engine information and web sources.
* Add a default part editor category.
* Add some default ModuleEngines parameters.
* Add a pseudo-gimbal module (for the jet vanes).
* Convert the fuel from 75% w/w Ethanol to 90% w/w.
* Add the requirement of HTP as a resource (for spinning the turbo pump).
* Fix the rated VAC thrust values.
* Fix the ASL and VAC Isp values.
* Fix the O/F ratios.
* Remove any alternator modules and resources from the part module.
* Increase the rated burn times of both versions.

**Discussion:** https://github.com/KSP-RO/RealismOverhaul/issues/1578

**Notes:**

* The HTP consumption might need some tweaking upwards, since the engine is more powerful than the A-4 engine (requiring a bigger turbo pump to push the propellants at the correct flow rates).