### PR TITLE
RealEngines v1.5

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -9,6 +9,12 @@
 //  Encyclopedia Astronautica - RD-58 engine:              http://astronautix.com/r/rd-58.html
 //  Norbert Brügge - Block D upper stage:                  http://www.b14643.de/Spacerockets_1/East_Europe_2/Proton/Gallery/Block-D.htm
 
+//  Encyclopedia Astronautica - RD-103 engine:             http://astronautix.com/r/rd-103.html
+//  Encyclopedia Astronautica - RD-103M engine:            http://astronautix.com/r/rd-103m.html
+
+//  NPO Energomash - RD-107/RD-108 engines:                http://www.npoenergomash.ru/eng/dejatelnost/engines/rd107/
+//  Norbert Brügge - RD-107/RD-108 engine modifications:   http://www.b14643.de/Spacerockets_1/East_Europe_1/Semyorka/Propulsion/history.htm
+
 //  Russian Space Web - RD-0110 engine:                    http://www.russianspaceweb.com/rd0110.html
 //  Encyclopedia Astronautica - RD-0110 engine:            http://www.astronautix.com/r/rd-0110.html
 
@@ -450,9 +456,9 @@
 }
 
 //  ==================================================
-//  RD-103 engine.
+//  RD-103 series engine.
 
-//  Dimensions: - m x - m
+//  Dimensions: 1.3 m x 3.05 m
 //  Gross Mass: 870 Kg
 //  ==================================================
 
@@ -470,8 +476,8 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 2.229949, 0.0, 0.0, 1.0, 0.0, 1
-    @node_stack_bottom = 0.0, -0.7800496, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_top = 0.0, 2.23, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.78, 0.0, 0.0, -1.0, 0.0, 1
 
     @mass = 0.87
     @crashTolerance = 10
@@ -483,7 +489,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch propuls R-5 RD-103 rocket surf vertikal
+    @tags = ascent irbm launch propuls R-5 RD-103 rocket surf vertikal
 
     %engineType = RD103
     %engineTypeMult = 1
@@ -492,11 +498,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        //thrustVectorTransformName = thrustTransform
-        //minThrust = 0
-        //maxThrust = 45
-        //heatProduction = 100
-
         @PROPELLANT[LiquidFuel]
         {
             @name = Ethanol90
@@ -528,9 +529,9 @@
 }
 
 //  ==================================================
-//  RD-107 engine.
+//  RD-107 series engine.
 
-//  Dimensions: - m x - m
+//  Dimensions: 2.6 m x 2.66 m
 //  Gross Mass: 1190 Kg
 //  ==================================================
 
@@ -548,8 +549,8 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.687319, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.8803589, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.685, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.88, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 1.19
     @crashTolerance = 10
@@ -561,7 +562,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch molniya propuls RD-107 RD-117 rocket soyuz surf
+    @tags = ascent fregat icbm launch molniya propuls RD-107 RD-117 rocket soyuz surf vostok voskhod
 
     %engineType = RD107-117
     %engineTypeMult = 1
@@ -570,8 +571,6 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
     {
-        //thrustVectorTransformName = TT
-        //powerEffectName = engineFlame
         @minThrust = 972.3
         @maxThrust = 972.3
         @heatProduction = 100
@@ -598,12 +597,10 @@
         !thrustCurve,*{}
     }
 
-    !MODULE[ModuleGimbal]:HAS[@gimbalTransformName[TT]],*{}
+    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[TT]],*{}
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt22]]
     {
-        //thrustVectorTransformName = tt22
-        //powerEffectName = vernierFlame
         @minThrust = 10.0
         @maxThrust = 10.0
         @heatProduction = 50
@@ -629,7 +626,16 @@
 
         !thrustCurve,*{}
     }
+}
 
+//  ==================================================
+//  RD-107 series engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[RD107]:AFTER[RealismOverhaulEngines]
+{
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[tt2]]
     {
         @gimbalRangeYP = 45.0
@@ -641,9 +647,9 @@
 }
 
 //  ==================================================
-//  RD-108 engine.
+//  RD-108 series engine.
 
-//  Dimensions: - m x - m
+//  Dimensions: 2.8 m x 2.66 m
 //  Gross Mass: 1278 Kg
 //  ==================================================
 
@@ -661,8 +667,8 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.687319, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.8803589, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.685, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.88, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 1.278
     @crashTolerance = 10
@@ -674,12 +680,15 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch molniya propuls RD-108 RD-118 rocket soyuz surf
+    @tags = ascent fregat icbm launch molniya propuls RD-108 RD-118 rocket soyuz surf vostok voskhod
+
+    %engineType = RD108-118
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
     {
-        //thrustVectorTransformName = TT
-        //powerEffectName = engineFlame
         @minThrust = 918.3
         @maxThrust = 918.3
         @heatProduction = 100
@@ -710,8 +719,6 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {
-        //thrustVectorTransformName = tt2
-        //powerEffectName = vernierFlame
         @minThrust = 10.0
         @maxThrust = 10.0
         @heatProduction = 50
@@ -737,7 +744,16 @@
 
         !thrustCurve,*{}
     }
+}
 
+//  ==================================================
+//  RD-108 series engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[RD108]:AFTER[RealismOverhaulEngines]
+{
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal2]]
     {
         @gimbalRangeYP = 0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -588,6 +588,14 @@
             @ratio = 0.6274
         }
 
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
+        }
+
         @atmosphereCurve
         {
             @key,0 = 0 306
@@ -601,21 +609,29 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt22]]
     {
-        @minThrust = 10.0
-        @maxThrust = 10.0
+        @minThrust = 38.0
+        @maxThrust = 38.0
         @heatProduction = 50
         @useThrustCurve = False
 
-        @PROPELLANT
+        @PROPELLANT[LiquidFuel]
         {
             @name = Kerosene
             @ratio = 0.3531
         }
 
-        @PROPELLANT
+        @PROPELLANT[Oxidizer]
         {
             @name = LqdOxygen
             @ratio = 0.6274
+        }
+
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
         }
 
         @atmosphereCurve
@@ -706,6 +722,14 @@
             @ratio = 0.6274
         }
 
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
+        }
+
         atmosphereCurve
         {
             @key,0 = 0 308
@@ -719,8 +743,8 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {
-        @minThrust = 10.0
-        @maxThrust = 10.0
+        @minThrust = 38.0
+        @maxThrust = 38.0
         @heatProduction = 50
         @useThrustCurve = False
 
@@ -734,6 +758,14 @@
         {
             @name = LqdOxygen
             @ratio = 0.6274
+        }
+
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
         }
 
         @atmosphereCurve

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -450,6 +450,305 @@
 }
 
 //  ==================================================
+//  RD-103 engine.
+
+//  Dimensions: - m x - m
+//  Gross Mass: 870 Kg
+//  ==================================================
+
+@PART[rd100]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 2.229949, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.7800496, 0.0, 0.0, -1.0, 0.0, 1
+
+    @mass = 0.87
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
+    @tags = ascent launch propuls R-5 RD-103 rocket surf vertikal
+
+    %engineType = RD103
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]
+    {
+        //thrustVectorTransformName = thrustTransform
+        //minThrust = 0
+        //maxThrust = 45
+        //heatProduction = 100
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Ethanol90
+            @ratio = 0.4945
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.5055
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 248
+            @key,1 = 1 220
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        %gimbalRange = 2.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
+//  RD-107 engine.
+
+//  Dimensions: - m x - m
+//  Gross Mass: 1190 Kg
+//  ==================================================
+
+@PART[RD107]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.687319, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.8803589, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 1.19
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
+    @tags = ascent launch molniya propuls RD-107 RD-117 rocket soyuz surf
+
+    %engineType = RD107-117
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
+    {
+        //thrustVectorTransformName = TT
+        //powerEffectName = engineFlame
+        @minThrust = 972.3
+        @maxThrust = 972.3
+        @heatProduction = 100
+        @useThrustCurve = False
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3531
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6274
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 306
+            @key,1 = 1 250
+        }
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal]:HAS[@gimbalTransformName[TT]],*{}
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt22]]
+    {
+        //thrustVectorTransformName = tt22
+        //powerEffectName = vernierFlame
+        @minThrust = 10.0
+        @maxThrust = 10.0
+        @heatProduction = 50
+        @useThrustCurve = False
+
+        @PROPELLANT
+        {
+            @name = Kerosene
+            @ratio = 0.3531
+        }
+
+        @PROPELLANT
+        {
+            @name = LqdOxygen
+            @ratio = 0.6274
+        }
+
+        @atmosphereCurve
+        {
+            @key = 0 306
+            @key = 1 250
+        }
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[tt2]]
+    {
+        @gimbalRangeYP = 45.0
+        @gimbalRangeYN = 45.0
+        @gimbalRangeXP = 0
+        @gimbalRangeXN = 0
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
+//  RD-108 engine.
+
+//  Dimensions: - m x - m
+//  Gross Mass: 1278 Kg
+//  ==================================================
+
+@PART[RD108]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.687319, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.8803589, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 1.278
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
+    @tags = ascent launch molniya propuls RD-108 RD-118 rocket soyuz surf
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
+    {
+        //thrustVectorTransformName = TT
+        //powerEffectName = engineFlame
+        @minThrust = 918.3
+        @maxThrust = 918.3
+        @heatProduction = 100
+        @useThrustCurve = False
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3531
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6274
+        }
+
+        atmosphereCurve
+        {
+            @key,0 = 0 308
+            @key,1 = 1 241
+        }
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[TT]],*{}
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+    {
+        //thrustVectorTransformName = tt2
+        //powerEffectName = vernierFlame
+        @minThrust = 10.0
+        @maxThrust = 10.0
+        @heatProduction = 50
+        @useThrustCurve = False
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3531
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6274
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 308
+            @key,1 = 1 241
+        }
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal2]]
+    {
+        @gimbalRangeYP = 0
+        @gimbalRangeYN = 0
+        @gimbalRangeXP = 45.0
+        @gimbalRangeXN = 45.0
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
 //  RD-0110 engine.
 
 //  Dimensions: 2.45 m x 1.55 m

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -57,6 +57,7 @@
 //  Russian Space Web - Proton Third Stage:                http://www.russianspaceweb.com/proton_stage3.html
 //  Encyclopedia Astronautica - RD-0212 engine:            http://www.astronautix.com/r/rd-0212.html
 //  Encyclopedia Astronautica - RD-0214 engine:            http://www.astronautix.com/r/rd-0214.html
+//  Russian Space Web - Sunkar launch vehicle:             http://www.russianspaceweb.com/sunkar.html
 
 //  NPO Energomash - RD-253 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd253/
 //  Russian Space Web - RD-253 engine:                     http://www.russianspaceweb.com/rd253.html
@@ -122,7 +123,7 @@
     {
         @minThrust = 840.96
         @maxThrust = 1681.93
-        @heatProduction = 200
+        @heatProduction = 185
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -234,7 +235,7 @@
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls NK-33 RD-0110R rocket surf
+    @tags = ascent launch propuls NK-33 RD-0110R rocket soyuz surf
 
     %engineType = RD0110R
     %engineTypeMult = 1
@@ -330,7 +331,7 @@
     {
         @minThrust = 878.67
         @maxThrust = 1757.34
-        @heatProduction = 200
+        @heatProduction = 180
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -405,7 +406,7 @@
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls RD-58 rocket vac
+    @tags = ascent launch propuls proton RD-58 rocket vac zenit
 
     %engineType = RD58
     %engineTypeMult = 1
@@ -416,7 +417,7 @@
     {
         @minThrust = 83.4
         @maxThrust = 83.4
-        @heatProduction = 200
+        @heatProduction = 60
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -456,7 +457,7 @@
 }
 
 //  ==================================================
-//  RD-103 series engine.
+//  RD-100 series engine.
 
 //  Dimensions: 1.3 m x 3.05 m
 //  Gross Mass: 870 Kg
@@ -489,9 +490,9 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent irbm launch propuls R-5 RD-103 rocket surf vertikal
+    @tags = ascent irbm launch propuls R-1 R-2 R-5 RD-100 RD-101 RD-102 RD-103 rocket surf vertikal
 
-    %engineType = RD103
+    %engineType = RD100
     %engineTypeMult = 1
     %ignoreMass = False
     %massOffset = 0
@@ -501,19 +502,27 @@
         @PROPELLANT[LiquidFuel]
         {
             @name = Ethanol90
-            @ratio = 0.4945
+            @ratio = 0.4695
         }
 
         @PROPELLANT[Oxidizer]
         {
             @name = LqdOxygen
-            @ratio = 0.5055
+            @ratio = 0.5305
+        }
+
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.01
+            ignoreForIsp = True
+            DrawGauge = False
         }
 
         @atmosphereCurve
         {
-            @key,0 = 0 248
-            @key,1 = 1 220
+            @key,0 = 0 237
+            @key,1 = 1 203
         }
     }
 
@@ -707,7 +716,7 @@
     {
         @minThrust = 918.3
         @maxThrust = 918.3
-        @heatProduction = 100
+        @heatProduction = 90
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -875,7 +884,7 @@
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size0, size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls RD-0110 rocket vac
+    @tags = ascent launch propuls RD-0110 rocket soyuz vac
 
     %engineType = RD0110
     %engineTypeMult = 1
@@ -887,7 +896,7 @@
         %engineID = MainEngine
         @minThrust = 269.87
         @maxThrust = 298.2
-        @heatProduction = 200
+        @heatProduction = 100
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1019,7 +1028,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size3
-    @tags = ascent launch propuls RD-0120 rocket surf
+    @tags = ascent buran energia launch polyus propuls RD-0120 rocket surf
 
     %engineType = RD0120
     %engineTypeMult = 1
@@ -1030,7 +1039,7 @@
     {
         @minThrust = 1863.26
         @maxThrust = 1961.33
-        @heatProduction = 200
+        @heatProduction = 106
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1105,7 +1114,7 @@
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = size3
-    @tags = eng mount RD-0120 struct
+    @tags = buran eng energia mount polyus RD-0120 struct
 }
 
 //  ==================================================
@@ -1142,7 +1151,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-0124 rocket vac
+    @tags = angara ascent launch propuls RD-0124 rocket soyuz vac
 
     %engineType = RD0124
     %engineTypeMult = 1
@@ -1153,7 +1162,7 @@
     {
         @minThrust = 294.3
         @maxThrust = 294.3
-        @heatProduction = 200
+        @heatProduction = 85
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1171,7 +1180,7 @@
         @atmosphereCurve
         {
             @key,0 = 0 359
-            @key,1 = 1 331
+            @key,1 = 1 245
         }
 
         !thrustCurve,*{}
@@ -1179,8 +1188,8 @@
 
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
     {
-        @gimbalRangeYP = 7.0
-        @gimbalRangeYN = 7.0
+        @gimbalRangeYP = 3.5
+        @gimbalRangeYN = 3.5
         @gimbalRangeXP = 0
         @gimbalRangeXN = 0
         @gimbalResponseSpeed = 16
@@ -1190,14 +1199,103 @@
     {
         @gimbalRangeYP = 0
         @gimbalRangeYN = 0
-        @gimbalRangeXP = 7.0
-        @gimbalRangeXN = 7.0
+        @gimbalRangeXP = 3.5
+        @gimbalRangeXN = 3.5
         @gimbalResponseSpeed = 16
     }
+}
 
-    !MODULE[ModuleAlternator],*{}
+//  ==================================================
+//  RD-0124 engine (dual).
 
-    !RESOURCE,*{}
+//  Dimensions: 3.2 m x 2.0 m
+//  Gross Mass: 980 Kg
+//  ==================================================
+
+@PART[RD0124Aengine]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.162, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.787, 0.0, 0.0, -1.0, 0.0, 3
+
+    @mass = 0.98
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size3
+    @tags = angara ascent launch propuls RD-0124A rocket sunkar soyuz vac zenit
+
+    %engineType = RD0124
+    %engineTypeMult = 2
+    %ignoreMass = False
+    %massOffset = 0.02
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 588.6
+        @maxThrust = 588.6
+        @heatProduction = 90
+        @useThrustCurve = False
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3486
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6514
+
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 359
+            @key,1 = 1 245
+        }
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRangeYP = 3.5
+        @gimbalRangeYN = 3.5
+        @gimbalRangeXP = 3.5
+        @gimbalRangeXN = 3.5
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
+//  RD-0124 engine (dual).
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[RD0124Aengine]:AFTER[RealismOverhaulEngines]
+{
+    @title = RD-0124A (Dual)
+    @manufacturer = NPO Energomash
+    @description = A dual version of the RD-0124A engine variant, developed for the Angara launch vehicle second stage (URM-2).
 }
 
 //  ==================================================
@@ -1235,7 +1333,7 @@
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls RD-0146 rocket vac
+    @tags = angara ascent kvtk launch ppts propuls RD-0146 rocket rus-m vac
 
     %engineType = RD0146
     %engineTypeMult = 1
@@ -1246,7 +1344,7 @@
     {
         @minThrust = 98.1
         @maxThrust = 98.1
-        @heatProduction = 200
+        @heatProduction = 80
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1320,7 +1418,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size4
-    @tags = ascent launch propuls RD-170 rocket surf
+    @tags = ascent energia launch propuls RD-170 rocket surf zenit
 
     %engineType = RD170
     %engineTypeMult = 1
@@ -1331,7 +1429,7 @@
     {
         @minThrust = 3952.24
         @maxThrust = 7904.49
-        @heatProduction = 200
+        @heatProduction = 112
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1405,7 +1503,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch propuls RD-180 rocket surf
+    @tags = ascent atlas launch propuls RD-180 rocket rus-m surf
 
     %engineType = RD180
     %engineTypeMult = 1
@@ -1416,7 +1514,7 @@
     {
         @minThrust = 1951.43
         @maxThrust = 4152.41
-        @heatProduction = 200
+        @heatProduction = 105
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1490,7 +1588,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-191 rocket surf
+    @tags = angara ascent launch propuls RD-191 rocket surf
 
     %engineType = RD191
     %engineTypeMult = 1
@@ -1501,7 +1599,7 @@
     {
         @minThrust = 562.92
         @maxThrust = 2084.89
-        @heatProduction = 200
+        @heatProduction = 130
         @useThrustCurve = False
 
         @PROPELLANT[LiquidFuel]
@@ -1574,7 +1672,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-0210 RD-0211 rocket vac
+    @tags = ascent launch propuls proton RD-0210 RD-0211 rocket vac
 
     %engineType = RD0210
     %engineTypeMult = 1
@@ -1671,7 +1769,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-0212 RD-0213 RD-0214 rocket vac
+    @tags = ascent launch propuls proton RD-0212 RD-0213 RD-0214 rocket vac
 
     %engineType = RD0212
     %engineTypeMult = 1
@@ -1804,7 +1902,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls RD-253 RD-275 rocket surf
+    @tags = ascent launch propuls proton RD-253 RD-275 rocket surf
 
     %engineType = RD253
     %engineTypeMult = 1
@@ -1883,7 +1981,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch propuls S.92 rocket vac
+    @tags = ascent fregat launch propuls S.92 rocket soyuz vac zenit
 
     %engineType = S5_92
     %engineTypeMult = 1
@@ -1989,7 +2087,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size1
-    @tags = ascent launch propuls S.98M rocket vac
+    @tags = ascent briz launch propuls proton rocket rokot S.98M vac
 
     %engineType = S5_98M
     %engineTypeMult = 1
@@ -2051,7 +2149,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size0
-    @tags = ascent launch propuls RD-0110 rocket vac vern
+    @tags = ascent launch propuls RD-0110 rocket soyuz vac vern
 
     %engineType = RD0110Vernier
     %engineTypeMult = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -1209,7 +1209,7 @@
 //  RD-0124 engine (dual).
 
 //  Dimensions: 3.2 m x 2.0 m
-//  Gross Mass: 980 Kg
+//  Gross Mass: 960 Kg
 //  ==================================================
 
 @PART[RD0124Aengine]:FOR[RealismOverhaul]
@@ -1229,7 +1229,7 @@
     @node_stack_top = 0.0, 1.162, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -0.787, 0.0, 0.0, -1.0, 0.0, 3
 
-    @mass = 0.98
+    @mass = 0.96
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -1244,7 +1244,7 @@
     %engineType = RD0124
     %engineTypeMult = 2
     %ignoreMass = False
-    %massOffset = 0.02
+    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1277,10 +1277,11 @@
 
     @MODULE[ModuleGimbal]
     {
-        @gimbalRangeYP = 3.5
-        @gimbalRangeYN = 3.5
-        @gimbalRangeXP = 3.5
-        @gimbalRangeXN = 3.5
+        %gimbalRange = 3.5
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
         @gimbalResponseSpeed = 16
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -1296,7 +1296,7 @@
 {
     @title = RD-0124A (Dual)
     @manufacturer = NPO Energomash
-    @description = A dual version of the RD-0124A engine variant, developed for the Angara launch vehicle second stage (URM-2).
+    @description = A dual version of the RD-0124A engine variant, developed for the second stage of the Sunkar launch vehicle.
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
@@ -8,7 +8,7 @@
     {
         name = Kerolox-Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, -0.125
+        plumePosition = 0.0, 0.0, 0.125
         plumeScale = 0.75
         flarePosition = 0.0, 0.0, -0.25
         flareScale = 0.55

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-0124A plume setup.
+//  ==================================================
+
+@PART[RD0124Aengine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -0.125
+        plumeScale = 0.75
+        flarePosition = 0.0, 0.0, -0.25
+        flareScale = 0.55
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD107.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD107.cfg
@@ -1,20 +1,20 @@
 //  ==================================================
-//  RD-0110 engine plume setup.
+//  RD-107 series plume setup.
 //  ==================================================
 
-@PART[RD0110]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RD107]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
-        name = Kerolox-Upper
-        transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.025
+        name = Kerolox-Lower
+        transformName = TT
+        plumePosition = 0.0, 0.0, -0.85
         plumeScale = 0.4
-        flarePosition = 0.0, 0.0, -0.25
-        flareScale = 0.525
+        flarePosition = 0.0, 0.0, -1.1
+        flareScale = 0.425
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
-        energy = 1.0
+        energy = 1.5
         speed = 1.0
         emissionMult = 0.5
     }
@@ -22,26 +22,26 @@
     PLUME
     {
         name = Kerolox-Vernier
-        transformName = thrustTransform2
-        plumePosition = 0.0, 0.0, -0.15
-        plumeScale = 2.5
-        flarePosition = 0.0, 0.0, 1.0
+        transformName = tt22
+        plumePosition = 0.0, 0.0, -0.05
+        plumeScale = 3.0
+        flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
-        energy = 0.5
-        speed = 0.75
+        energy = 1.5
+        speed = 0.5
         emissionMult = 0.5
     }
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
     {
-        %powerEffectName = Kerolox-Upper
+        %powerEffectName = Kerolox-Lower
         !runningEffectName = NULL
         !fxOffset = NULL
     }
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt22]]
     {
         //  Workaround for a SmokeScreen bug.
 
@@ -54,7 +54,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Upper
+            %powerEffectName = Kerolox-Lower
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
@@ -1,20 +1,20 @@
 //  ==================================================
-//  RD-0110 engine plume setup.
+//  RD-108 series plume setup.
 //  ==================================================
 
-@PART[RD0110]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RD108]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
-        name = Kerolox-Upper
-        transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.025
+        name = Kerolox-Lower
+        transformName = TT
+        plumePosition = 0.0, 0.0, -0.85
         plumeScale = 0.4
-        flarePosition = 0.0, 0.0, -0.25
-        flareScale = 0.525
+        flarePosition = 0.0, 0.0, -1.1
+        flareScale = 0.425
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
-        energy = 1.0
+        energy = 1.5
         speed = 1.0
         emissionMult = 0.5
     }
@@ -22,26 +22,26 @@
     PLUME
     {
         name = Kerolox-Vernier
-        transformName = thrustTransform2
-        plumePosition = 0.0, 0.0, -0.15
-        plumeScale = 2.5
-        flarePosition = 0.0, 0.0, 1.0
+        transformName = tt22
+        plumePosition = 0.0, 0.0, -0.05
+        plumeScale = 3.0
+        flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
-        energy = 0.5
-        speed = 0.75
+        energy = 1.5
+        speed = 0.5
         emissionMult = 0.5
     }
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
     {
-        %powerEffectName = Kerolox-Upper
+        %powerEffectName = Kerolox-Lower
         !runningEffectName = NULL
         !fxOffset = NULL
     }
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {
         //  Workaround for a SmokeScreen bug.
 
@@ -54,7 +54,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Kerolox-Upper
+            %powerEffectName = Kerolox-Lower
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
@@ -22,7 +22,7 @@
     PLUME
     {
         name = Kerolox-Vernier
-        transformName = tt22
+        transformName = tt2
         plumePosition = 0.0, 0.0, -0.05
         plumeScale = 3.0
         flarePosition = 0.0, 0.0, 0.0

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd0120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd0120.cfg
@@ -2,7 +2,7 @@
 //  RD-0120 engine plume setup.
 //  ==================================================
 
-@PART[rd0120|rd0120_RedVariant]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[rd0120]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd100.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd100.cfg
@@ -1,0 +1,36 @@
+//  ==================================================
+//  RD-103 engine plume setup.
+//  ==================================================
+
+@PART[rd100]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Alcolox-Lower-A6
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.0
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.8
+        flareScale = 0.425
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.75
+        speed = 0.75
+        emissionMult = 0.75
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Alcolox-Lower-A6
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add RO support for the new engines: RD-100, RD-107, RD-108 and RD-0124A.
* Update the RD-0110 main and vernier plume patchers to be more robust.

**Notes:**

* ~~The RD-0110 is missing the vernier plumes. This is caused by the naming of the main and vernier engine thrust transforms (they are both called "thrustTransform2"). I have contacted **Alcentar** about that and it will hopefully be fixed in the next update.~~ (should be fixed with the 1.5 update)
* The RD-100 engine requires the new RD-100 global engine config: https://github.com/KSP-RO/RealismOverhaul/pull/1611