### PR TITLE
Coatl Aerospace GroundOps RO compatibility

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -5,7 +5,7 @@
 //  JPL - Surveyor 1-7 missions:            http://www2.jpl.nasa.gov/missions/past/surveyor.html
 //  Gunter's Space Page - Surveyor program: http://space.skyrocket.de/doc_sdat/surveyor.htm
 //  NASA Press Kit - Surveyor A project:    https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
-//  Surveyor III Mission Report:            https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+//  NASA - Surveyor III Mission Report:     https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
 
 //  ==================================================
 //  Surveyor probe core.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -1,0 +1,131 @@
+//  ==================================================
+//  Sources:
+
+//  NSSDCA - Surveyor 1 spacecraft:         http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1966-045A
+//  JPL - Surveyor 1-7 missions:            http://www2.jpl.nasa.gov/missions/past/surveyor.html
+//  Gunter's Space Page - Surveyor program: http://space.skyrocket.de/doc_sdat/surveyor.htm
+//  NASA Press Kit - Surveyor A project:    https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  Surveyor III Mission Report:            https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+
+//  ==================================================
+//  Surveyor probe core.
+
+//  Dimensions: 4.26 m x 1.45 m (extended)
+//  Gross Mass: 240 Kg
+//  ==================================================
+
+@PART[ca_landv_core]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@MODEL
+	{
+        %scale = 1.435, 1.435, 1.435
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+	
+	@node_stack_top = 0.0, 0.55, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+
+	@title = Surveyor Core
+	@manufacturer = Hughes Aircraft Company
+	@description = The main assembly of the Surveyor lander. Includes a set of landing legs, attitude control system and propellant for its 3 vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
+
+	@mass = 0.150
+	@crashTolerance = 16
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	!explosionPotential = NULL
+	@bulkheadProfiles = size0, size1
+	@tags ^= :$: hughes
+
+	@MODULE[ModuleCommand]
+    {
+		@hasHibernation = False
+
+		@RESOURCE[ElectricCharge]
+        {
+			@rate = 0.03
+		}
+	}
+
+	!MODULE[ModuleReactionWheel],*{}
+
+	@MODULE[ModuleSAS]
+    {
+        %SASServiceLevel = 2
+	}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 100
+        basemass = -1
+
+        //  Avionics batteries 4.4 kWh.
+        //  Includes the average capacity of the auxiliary battery (600 Wh, single - use).
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 15840
+            maxAmount = 15840
+        }
+
+        //  Vernier engine fuel mass ~32.9 Kg.
+
+        TANK
+        {
+            name = MMH
+            amount = 38
+            maxAmount = 38
+        }
+
+        //  Vernier engine oxidizer mass ~49.2 Kg.
+
+        TANK
+        {
+            name = MON10
+            amount = 35
+            maxAmount = 35
+        }
+
+        //  ACS propellant mass ~2.04 Kg.
+
+        TANK
+        {
+            name = Nitrogen
+            amount = 1600
+            maxAmount = 1600
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Surveyor probe core.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_landv_core]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -4,7 +4,7 @@
 //  NSSDCA - Surveyor 1 spacecraft:         http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1966-045A
 //  JPL - Surveyor 1-7 missions:            http://www2.jpl.nasa.gov/missions/past/surveyor.html
 //  Gunter's Space Page - Surveyor program: http://space.skyrocket.de/doc_sdat/surveyor.htm
-//  NASA Press Kit - Surveyor A project:    https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  NTRS - Surveyor A project:              https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
 //  NASA - Surveyor III Mission Report:     https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
 
 //  ==================================================
@@ -17,46 +17,46 @@
 @PART[ca_landv_core]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@MODEL
-	{
+
+    @MODEL
+    {
         %scale = 1.435, 1.435, 1.435
-	}
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 0.55, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
+    @rescaleFactor = 1.0
 
-	@title = Surveyor Core
-	@manufacturer = Hughes Aircraft Company
-	@description = The main assembly of the Surveyor lander. Includes a set of landing legs, attitude control system and propellant for its 3 vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
+    @node_stack_top = 0.0, 0.55, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.125, 0.0, 0.0, -1.0, 0.0, 1
 
-	@mass = 0.150
-	@crashTolerance = 16
+    @title = Surveyor Core
+    @manufacturer = Hughes Aircraft Company
+    @description = The main assembly of the Surveyor lander. Includes a set of landing legs, attitude control system and propellant for its 3 vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
+
+    @mass = 0.15
+    @crashTolerance = 16
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-	!explosionPotential = NULL
-	@bulkheadProfiles = size0, size1
-	@tags ^= :$: hughes
+    !explosionPotential = NULL
+    @bulkheadProfiles = size0, size1
+    @tags ^= :$: hughes
 
-	@MODULE[ModuleCommand]
+    @MODULE[ModuleCommand]
     {
-		@hasHibernation = False
+        @hasHibernation = False
 
-		@RESOURCE[ElectricCharge]
+        @RESOURCE[ElectricCharge]
         {
-			@rate = 0.03
-		}
-	}
+            @rate = 0.03
+        }
+    }
 
-	!MODULE[ModuleReactionWheel],*{}
+    !MODULE[ModuleReactionWheel],*{}
 
-	@MODULE[ModuleSAS]
+    @MODULE[ModuleSAS]
     {
         %SASServiceLevel = 2
-	}
+    }
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -1,0 +1,158 @@
+//  ==================================================
+//  Sources:
+
+//  NASA Press Kit - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  Surveyor III Mission Report:         https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+
+//  ==================================================
+//  Surveyor solar array & high gain antenna.
+
+//  Dimensions: 1 m x 1.5 m (extended)
+//  Inert Mass: 20 Kg
+//  ==================================================
+
+@PART[ca_landv_hga]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@MODEL
+	{
+        %scale = 1.435, 1.435, 1.435
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+	
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+	@node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+	
+	@title = Surveyor Planar Antenna and Solar Array
+	@manufacturer = Hughes Aircraft Company
+	@description = The planar high gain antenna and solar array for the Surveyor lander.
+	
+	@mass = 0.02
+	@crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	@tags ^= :$: high directional planar
+	
+	@MODULE[ModuleDeployableSolarPanel]
+    {
+		@chargeRate = 0.09
+	}
+}
+
+//  ==================================================
+//  Surveyor solar array & high gain antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_landv_hga]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Effective range 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0DishRange = 0
+        Mode1DishRange = 750000
+        DishAngle = 5.0
+        EnergyCost = 0.01
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.512
+            PacketResourceCost = 0.005
+        }
+    }
+}
+
+//  ==================================================
+//  Surveyor low gain antenna.
+
+//  Dimensions: 0.04 m x 1.45 m (extended)
+//  Inert Mass: 5 Kg
+//  ==================================================
+
+@PART[ca_landv_omni]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+        %scale = 1.435, 1.435, 1.435
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+	@title = Surveyor Omni Antenna
+	@manufacturer = Hughes Aircraft Company
+	@description = The omnidirectional low gain antenna for the Surveyor lander.
+
+	@mass = 0.005
+	@crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	!impactTolerance = NULL
+	@tags ^= :$: low omnidirectional
+}
+
+//  ==================================================
+//  Surveyor low gain antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_landv_omni]:FOR[RealismOverhaul]
+{
+    @description ^= :$: Effective range 225 Mm, power consumption 10 Watts, maximum data rate 128 kbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 2250000
+        EnergyCost = 0.01
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.128
+            PacketResourceCost = 0.005
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -1,8 +1,8 @@
 //  ==================================================
 //  Sources:
 
-//  NASA Press Kit - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
-//  Surveyor III Mission Report:         https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
+//  NTRS - Surveyor A project:          https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  NASA - Surveyor III Mission Report: https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf
 
 //  ==================================================
 //  Surveyor solar array & high gain antenna.
@@ -39,6 +39,14 @@
 	@MODULE[ModuleDeployableSolarPanel]
     {
 		@chargeRate = 0.09
+	}
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 4934
+		@packetInterval = 1.0
+		@packetSize = 0.512
+		@packetResourceCost = 0.015
 	}
 }
 
@@ -115,6 +123,14 @@
     %skinMaxTemp = 473.15
 	!impactTolerance = NULL
 	@tags ^= :$: low omnidirectional
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 444
+		@packetInterval = 1.0
+		@packetSize = 2
+		@packetResourceCost = 12.0
+	}
 }
 
 //  ==================================================
@@ -143,7 +159,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 2250000
+        Mode1OmniRange = 225000
         EnergyCost = 0.01
         DeployFxModules = 0
         ProgressFxModules = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -14,40 +14,40 @@
 @PART[ca_landv_hga]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@MODEL
-	{
+
+    @MODEL
+    {
         %scale = 1.435, 1.435, 1.435
-	}
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
-	
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
-	@node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
-	
-	@title = Surveyor Planar Antenna and Solar Array
-	@manufacturer = Hughes Aircraft Company
-	@description = The planar high gain antenna and solar array for the Surveyor lander.
-	
-	@mass = 0.02
-	@crashTolerance = 8
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+
+    @title = Surveyor Planar Antenna and Solar Array
+    @manufacturer = Hughes Aircraft Company
+    @description = The planar high gain antenna and solar array for the Surveyor lander.
+
+    @mass = 0.02
+    @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-	@tags ^= :$: high directional planar
-	
-	@MODULE[ModuleDeployableSolarPanel]
-    {
-		@chargeRate = 0.09
-	}
+    @tags ^= :$: high directional planar
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 4934
-		@packetInterval = 1.0
-		@packetSize = 0.512
-		@packetResourceCost = 0.015
-	}
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 0.09
+    }
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 5000
+        @packetInterval = 1.0
+        @packetSize = 0.512
+        @packetResourceCost = 0.015
+    }
 }
 
 //  ==================================================
@@ -102,35 +102,35 @@
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
+    @MODEL
+    {
         %scale = 1.435, 1.435, 1.435
-	}
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
-	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
-	@title = Surveyor Omni Antenna
-	@manufacturer = Hughes Aircraft Company
-	@description = The omnidirectional low gain antenna for the Surveyor lander.
+    @title = Surveyor Omni Antenna
+    @manufacturer = Hughes Aircraft Company
+    @description = The omnidirectional low gain antenna for the Surveyor lander.
 
-	@mass = 0.005
-	@crashTolerance = 8
+    @mass = 0.005
+    @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-	!impactTolerance = NULL
-	@tags ^= :$: low omnidirectional
+    !impactTolerance = NULL
+    @tags ^= :$: low omnidirectional
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 444
-		@packetInterval = 1.0
-		@packetSize = 2
-		@packetResourceCost = 12.0
-	}
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 1012.5
+        @packetInterval = 1.0
+        @packetSize = 0.128
+        @packetResourceCost = 0.015
+    }
 }
 
 //  ==================================================
@@ -159,7 +159,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 225000
+        Mode1OmniRange = 2250000
         EnergyCost = 0.01
         DeployFxModules = 0
         ProgressFxModules = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -43,6 +43,9 @@
 
     @MODULE[ModuleDataTransmitter]
     {
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
         @antennaPower = 500000
         @packetInterval = 1.0
         @packetSize = 0.512
@@ -115,7 +118,7 @@
 
     @title = Surveyor Omni Antenna
     @manufacturer = Hughes Aircraft Company
-    @description = The omnidirectional low gain antenna for the Surveyor lander.
+    @description = The omnidirectional low gain antenna for the Surveyor lander. Can serve as a backup for the main planar antenna.
 
     @mass = 0.005
     @crashTolerance = 8
@@ -126,6 +129,9 @@
 
     @MODULE[ModuleDataTransmitter]
     {
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
         @antennaPower = 101250
         @packetInterval = 1.0
         @packetSize = 0.128
@@ -139,7 +145,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_landv_omni]:FOR[RealismOverhaul]
+@PART[ca_landv_omni]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
     @description ^= :$: Effective range 225 Mm, power consumption 10 Watts, maximum data rate 128 kbit/sec.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -43,7 +43,7 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 5000
+        @antennaPower = 500000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.015
@@ -126,7 +126,7 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 1012.5
+        @antennaPower = 101250
         @packetInterval = 1.0
         @packetSize = 0.128
         @packetResourceCost = 0.015

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  Sources:
 
-//  NASA Press Kit - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  NTRS - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
 
 //  ==================================================
 //  Surveyor battery pack.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
@@ -1,0 +1,41 @@
+//  ==================================================
+//  Sources:
+
+//  NASA Press Kit - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+
+//  ==================================================
+//  Surveyor battery pack.
+
+//  Dimensions: 0.215 m x 0.3 m
+//  Gross Mass: 50 Kg
+//  ==================================================
+
+@PART[ca_landv_battery]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+        %scale = 2.0, 2.0, 2.0
+	}
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+	
+	@title = Surveyor Battery Pack
+	@manufacturer = Hughes Aircraft Company
+	@description =  The main battery pack of the Surveyor lunar lander. Capacity: <color=orange>3650</color> Wh.
+	
+	@mass = 0.05
+	@crashTolerance = 10
+	@maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	!PhysicsSignificance = NULL
+	@tags ^= :$: battery storage
+
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 13140
+		@maxAmount = 13140
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
@@ -14,28 +14,28 @@
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
+    @MODEL
+    {
         %scale = 2.0, 2.0, 2.0
-	}
+    }
 
     %scale = 1.0
     @rescaleFactor = 1.0
-	
-	@title = Surveyor Battery Pack
-	@manufacturer = Hughes Aircraft Company
-	@description =  The main battery pack of the Surveyor lunar lander. Capacity: <color=orange>3650</color> Wh.
-	
-	@mass = 0.05
-	@crashTolerance = 10
-	@maxTemp = 473.15
-    %skinMaxTemp = 473.15
-	!PhysicsSignificance = NULL
-	@tags ^= :$: battery storage
 
-	@RESOURCE[ElectricCharge]
-	{
-		@amount = 13140
-		@maxAmount = 13140
-	}
+    @title = Surveyor Battery Pack
+    @manufacturer = Hughes Aircraft Company
+    @description =  The main battery pack of the Surveyor lunar lander. Capacity: <color=orange>3650</color> Wh.
+
+    @mass = 0.05
+    @crashTolerance = 10
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    !PhysicsSignificance = NULL
+    @tags ^= :$: battery storage
+
+    @RESOURCE[ElectricCharge]
+    {
+        @amount = 13140
+        @maxAmount = 13140
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  Sources:
 
-//  NTRS - Surveyor A project:                             https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  NASA Press Kit - Surveyor A project:                   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
 //  Rocketrelics - Liquid Propulsion Systems:              http://www.rocketrelics.com/liquid_propulsion.htm
 //  Alternate Wars - (Morton) Thiokol / ATK Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
 //  Orbital ATK - SRM Products Catalog (2012):             https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
@@ -18,66 +18,65 @@
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
+    @MODEL
+    {
         %scale = 1.495, 1.495, 1.495
-	}
-	
+    }
+
     @scale = 1.0
-	@rescaleFactor = 1.0
-	
-	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
-	@node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
-	
-	@mass = 0.0025
-	@crashTolerance = 10
-	@maxTemp = 573.15
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+
+    @mass = 0.0025
+    @crashTolerance = 10
+    @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
-	@tags ^= :$: thiokol
+    @tags ^= :$: thiokol
 
     %engineType = TD339
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False
 
-	@MODULE[ModuleEngines*]
+    @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-		@exhaustDamage = True
-		@minThrust = 0.13
-		@maxThrust = 0.46
-		@heatProduction = 100
+        @exhaustDamage = True
+        @minThrust = 0.13
+        @maxThrust = 0.46
+        @heatProduction = 100
         %ullage = False
         %pressureFed = True
         %ignitions = -1
 
-		@PROPELLANT[LiquidFuel]
+        @PROPELLANT[LiquidFuel]
         {
             @name = MMH
-			@ratio = 0.5200
-		}
+            @ratio = 0.9
+        }
 
-		@PROPELLANT[Oxidizer]
+        @PROPELLANT[Oxidizer]
         {
             @name = NTO
-			@ratio = 0.4800
-		}
+            @ratio = 1.1
+        }
 
-		@atmosphereCurve
-		{
-			@key,0 = 0 287
-			@key,1 = 1 100
-		}
-	}
-	
-	@MODULE[ModuleGimbal]
+        @atmosphereCurve
+        {
+            @key,0 = 0 285
+            @key,1 = 1 80
+        }
+    }
+
+    @MODULE[ModuleGimbal]
     {
-		@gimbalRange = 6.0
+        @gimbalRange = 6.0
         %useGimbalResponseSpeed = True
         %gimbalResponceSpeed = 16
-	}
+    }
 }
 
 //  ==================================================
@@ -91,44 +90,47 @@
 {
     %RSSROConfig = True
 
-	@scale = 1.0
+    @MODEL
+    {
+        %scale = 1.7, 1.7, 1.7
+    }
+
+    @scale = 1.0
     @rescaleFactor = 1.0
 
-	@MODEL
-	{
-        %scale = 1.7, 1.7, 1.7
-	}
+    @node_stack_topFair = 0.0, 0.665, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.465, 0.0, 0.0, -1.0, 0.0, 1
 
-	@node_stack_topFair = 0.0, 0.665, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.465, 0.0, 0.0, -1.0, 0.0, 1
-
-	@mass = 0.065
-	@crashTolerance = 10
-	@maxTemp = 573.15
+    @mass = 0.065
+    @crashTolerance = 10
+    @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
-	@tags ^= :$: motor retro solid thiokol
+    @tags ^= :$: motor retro solid thiokol
 
     %engineType = Star-37
     %engineTypeMult = 1
     %massOffset = 0
     %ignoreMass = False
 
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-		
-		@PROPELLANT[SolidFuel]
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[SolidFuel]
         {
             @name = HTPB
-		}
-		
+        }
+
         @atmosphereCurve
-		{
-			@key,0 = 0 260
-			@key,1 = 1 200
-		}
-	}
+        {
+            @key,0 = 0 260
+            @key,1 = 1 200
+        }
+    }
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -1,0 +1,190 @@
+//  ==================================================
+//  Sources:
+
+//  NASA Press Kit - Surveyor A project:                   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  Rocketrelics - Liquid Propulsion Systems:              http://www.rocketrelics.com/liquid_propulsion.htm
+//  Alternate Wars - (Morton) Thiokol / ATK Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
+//  Orbital ATK SRM Catalog (2012):                        https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
+//  Smithsonian National Air and Space Museum - TD-339:    https://airandspace.si.edu/collection-objects/space-propulsion-reaction-motors-td-339-surveyor-vernier-rocket-system-nasm
+
+//  ==================================================
+//  TD-339 engine.
+
+//  Dimensions: 0.14 m x 0.33 m
+//  Inert Mass: 2.5 Kg
+//  ==================================================
+
+@PART[ca_landv_vernier]:FOR[RealismOverhal]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+        %scale = 1.495, 1.495, 1.495
+	}
+	
+    @scale = 1.0
+	@rescaleFactor = 1.0
+	
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+	@node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+	
+	@mass = 0.0025
+	@crashTolerance = 10
+	@maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+	@tags ^= :$: thiokol
+
+    %engineType = TD339
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+	@MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+		@exhaustDamage = True
+		@minThrust = 0.13
+		@maxThrust = 0.46
+		@heatProduction = 100
+        %ullage = False
+        %pressureFed = True
+        %ignitions = -1
+
+		@PROPELLANT[LiquidFuel]
+        {
+            @name = MMH
+			@ratio = 0.9
+		}
+
+		@PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+			@ratio = 1.1
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 285
+			@key,1 = 1 80
+		}
+	}
+	
+	@MODULE[ModuleGimbal]
+    {
+		@gimbalRange = 6.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponceSpeed = 16
+	}
+}
+
+//  ==================================================
+//  STAR 37 SRM.
+
+//  Dimensions: 0.94 m x 1.47 m
+//  Gross Mass: 625 Kg
+//  ==================================================
+
+@PART[ca_landv_srm]:FOR[RealismOverhal]
+{
+    %RSSROConfig = True
+
+	@scale = 1.0
+    @rescaleFactor = 1.0
+
+	@MODEL
+	{
+        %scale = 1.7, 1.7, 1.7
+	}
+
+	@node_stack_bottom = 0.0, -0.274, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+	//node_attach = 0.0, 0.0, -0.274, 0.0, 0.0, 1.0, 1
+
+	@mass = 0.065
+	@crashTolerance = 10
+	@maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+	@tags ^= :$: motor retro solid thiokol
+
+    %engineType = Star-37
+    %engineTypeMult = 1
+    %massOffset = 0
+    %ignoreMass = False
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 0
+		@maxThrust = 54.8
+		@heatProduction = 100
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = NULL
+		@allowShutdown = False
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+		
+		@PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+		}
+		
+        @atmosphereCurve
+		{
+			@key,0 = 0 260
+			@key,1 = 1 200
+		}
+	}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 317.8
+        basemass = -1
+
+        //  HTPB/AP propellant mixture ~562.5 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 317.8
+            maxAmount = 317.8
+        }
+    }
+
+	//MODULE
+	//{
+	//	name = ModuleDecouple
+	//	ejectionForce = 20
+	//	explosiveNodeID = top
+	//	isOmniDecoupler = true
+	//	menuName = Jettison Retromotor
+	//	stagingEnabled = False
+	//	stagingEnableText = SRM Jettison Not Staged
+	//	stagingDisableText = SRM Jettison Staged
+	//}
+
+	!RESOURCE,*{}
+}
+
+//  ==================================================
+//  STAR 37 SRM.
+
+//  Engine configuration
+//  ==================================================
+
+@PART[ca_landv_srm]:AFTER[RealismOverhalEngines]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        !CONFIG,*:HAS[~name[STAR-37]]{}
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -1,10 +1,10 @@
 //  ==================================================
 //  Sources:
 
-//  NASA Press Kit - Surveyor A project:                   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  NTRS - Surveyor A project:                             https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
 //  Rocketrelics - Liquid Propulsion Systems:              http://www.rocketrelics.com/liquid_propulsion.htm
 //  Alternate Wars - (Morton) Thiokol / ATK Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
-//  Orbital ATK SRM Catalog (2012):                        https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
+//  Orbital ATK - SRM Products Catalog (2012):             https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
 //  Smithsonian National Air and Space Museum - TD-339:    https://airandspace.si.edu/collection-objects/space-propulsion-reaction-motors-td-339-surveyor-vernier-rocket-system-nasm
 
 //  ==================================================
@@ -14,7 +14,7 @@
 //  Inert Mass: 2.5 Kg
 //  ==================================================
 
-@PART[ca_landv_vernier]:FOR[RealismOverhal]
+@PART[ca_landv_vernier]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -56,19 +56,19 @@
 		@PROPELLANT[LiquidFuel]
         {
             @name = MMH
-			@ratio = 0.9
+			@ratio = 0.5200
 		}
 
 		@PROPELLANT[Oxidizer]
         {
             @name = NTO
-			@ratio = 1.1
+			@ratio = 0.4800
 		}
 
 		@atmosphereCurve
 		{
-			@key,0 = 0 285
-			@key,1 = 1 80
+			@key,0 = 0 287
+			@key,1 = 1 100
 		}
 	}
 	
@@ -99,9 +99,9 @@
         %scale = 1.7, 1.7, 1.7
 	}
 
-	@node_stack_bottom = 0.0, -0.274, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_topFair = 0.0, 0.665, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
-	//node_attach = 0.0, 0.0, -0.274, 0.0, 0.0, 1.0, 1
+	@node_stack_bottom = 0.0, -0.465, 0.0, 0.0, -1.0, 0.0, 1
 
 	@mass = 0.065
 	@crashTolerance = 10
@@ -118,16 +118,7 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
-		@minThrust = 0
-		@maxThrust = 54.8
-		@heatProduction = 100
-		@useEngineResponseTime = False
-		!engineAccelerationSpeed = NULL
 		@allowShutdown = False
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
 		
 		@PROPELLANT[SolidFuel]
         {
@@ -140,51 +131,4 @@
 			@key,1 = 1 200
 		}
 	}
-
-    !MODULE[ModuleFuelTanks],*{}
-
-    MODULE
-    {
-        name = ModuleFuelTanks
-        type = HTPB
-        volume = 317.8
-        basemass = -1
-
-        //  HTPB/AP propellant mixture ~562.5 Kg.
-
-        TANK
-        {
-            name = HTPB
-            amount = 317.8
-            maxAmount = 317.8
-        }
-    }
-
-	//MODULE
-	//{
-	//	name = ModuleDecouple
-	//	ejectionForce = 20
-	//	explosiveNodeID = top
-	//	isOmniDecoupler = true
-	//	menuName = Jettison Retromotor
-	//	stagingEnabled = False
-	//	stagingEnableText = SRM Jettison Not Staged
-	//	stagingDisableText = SRM Jettison Staged
-	//}
-
-	!RESOURCE,*{}
-}
-
-//  ==================================================
-//  STAR 37 SRM.
-
-//  Engine configuration
-//  ==================================================
-
-@PART[ca_landv_srm]:AFTER[RealismOverhalEngines]
-{
-    @MODULE[ModuleEngineConfigs]
-    {
-        !CONFIG,*:HAS[~name[STAR-37]]{}
-    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
@@ -1,0 +1,65 @@
+//  ==================================================
+//  Sources:
+
+//  NASA Press Kit - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+
+//  ==================================================
+//  Surveyor camera.
+
+//  Dimensions: 0.1 m x 0.425 m
+//  Gross Mass: 5 Kg
+//  ==================================================
+
+@PART[ca_landv_cam_s1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.25, 1.25, 1.25
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Surveyor Landing Survey Camera
+    @manufacturer = Hughes Aircraft Company
+    @description = The main survey television camera of the Surveyor lander. The integrated mirror can be rotated by 360 degrees to create panoramas of the landing site.
+
+    @mass = 0.005
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @tags ^= :$: surveyor
+}
+
+//  ==================================================
+//  Surveyor soil scoop.
+
+//  Dimensions: 0.15 m x 0.35 m
+//  Inert Mass: 5 Kg
+//  ==================================================
+
+@PART[ca_landv_soilScoop]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Surveyor Soil Mechanics Surface Sampler
+    @manufacturer = Hughes Aircraft Company
+    @description = The soil mechanics surface sampler is an instrument designed to test the physical properties of the topsoil (density, porosity, resistivity) and to expose subsoil material for photography.
+
+    @mass = 0.005
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  Sources:
 
-//  NASA Press Kit - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
+//  NTRS - Surveyor A project: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660022877.pdf
 
 //  ==================================================
 //  Surveyor camera.

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_GroundOps.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_GroundOps.cfg
@@ -10,7 +10,7 @@
 }
 
 //  ==================================================
-//  TD-339 engine plume configuration.
+//  TD-339 engine plume setup.
 //  ==================================================
 
 @PART[ca_landv_vernier]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -19,15 +19,15 @@
     {
         name = Hypergolic-OMS-Red
         transformName = Thrust_transform
+        plumePosition = 0.0, 0.0, 0.4
+        plumeScale = 0.15
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
         speed = 1.0
-		emissionMult = 0.5
-		plumePosition = 0.0, 0.0, 0.0
-		plumeScale = 1.0
-		flarePosition = 0.0, 0.0, 0.0
-		flareScale = 1.0
+        emissionMult = 0.5
     }
 
     @MODULE[ModuleEngines*]
@@ -47,7 +47,7 @@
 }
 
 //  ==================================================
-//  STAR 37 SRM plume configuration.
+//  STAR 37 SRM plume setup.
 //  ==================================================
 
 @PART[ca_landv_srm]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -56,15 +56,15 @@
     {
         name = Solid-Vacuum
         transformName = Thrust_transform
+        plumePosition = 0.0, 0.0, 0.5
+        plumeScale = 0.9
+        flarePosition = 0.0, 0.0, 0.4
+        flareScale = 0.475
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0
         speed = 1.0
-		emissionMult = 0.5
-		plumePosition = 0.0, 0.0, 0.0
-		plumeScale = 1.0
-		flarePosition = 0.0, 0.0, 0.0
-		flareScale = 1.0
+        emissionMult = 0.5
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_GroundOps.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_GroundOps.cfg
@@ -1,0 +1,84 @@
+//  ==================================================
+//  Cleanup.
+//  ==================================================
+
+@PART[ca_landv_vernier|ca_landv_srm]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+    !EFFECTS,*{}
+
+    !PLUME,*{}
+}
+
+//  ==================================================
+//  TD-339 engine plume configuration.
+//  ==================================================
+
+@PART[ca_landv_vernier]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-OMS-Red
+        transformName = Thrust_transform
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+		emissionMult = 0.5
+		plumePosition = 0.0, 0.0, 0.0
+		plumeScale = 1.0
+		flarePosition = 0.0, 0.0, 0.0
+		flareScale = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-Red
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+//  ==================================================
+//  STAR 37 SRM plume configuration.
+//  ==================================================
+
+@PART[ca_landv_srm]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Solid-Vacuum
+        transformName = Thrust_transform
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+		emissionMult = 0.5
+		plumePosition = 0.0, 0.0, 0.0
+		plumeScale = 1.0
+		flarePosition = 0.0, 0.0, 0.0
+		flareScale = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Vacuum
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Vacuum
+        }
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add RO support for the Coatl Aerospace GroundOps pack. Currently includes the Surveyor lander.

**Notes:**

* The Surveyor lander is currently lacking the Nitrogen ACS thrusters. Use your own for controlling the attitude while in free flight.
* ~~The antenna ranges for the stock antenna modules have been calculated with the maximum effective range of the Tracking Station (level 3 - 50 Tm). From the perspective of spaceflight history, the correct Tracking Station level would be 2 (500 Gm) so the antenna ranges will be vastly lower. Need some feedback on that end, as it will also directly help the ProbesPlus pack.~~