### PR TITLE
Fixed the mass on the AJ10-137

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -16,7 +16,7 @@
 		type = ModuleEngines
 		modded = false
 		configuration = AJ10-137
-		origMass = 0.650
+		origMass = 0.2948  // per the above source, this was in pounds, former value is 0.650
 		CONFIG
 		{
 			name = AJ10-137


### PR DESCRIPTION
Per the www.alternatewaers.com source in the file, the amount that was in for the mass of .650 was incorrect. The weight listed on the source is in pounds of 650 pounds. This converts properly to KSP weight as 0.2948.