### PR TITLE
J58 plume update by JeeF (potentially trimmable config curves untouched)

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/turboFanEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/turboFanEngine.cfg
@@ -3,18 +3,337 @@
 	@MODULE[ModuleEngines*]
 	{
 		!runningEffectName = DELETE
-		%powerEffectName = Turbojet
+		%powerEffectName = Hydrolox-Lower
 		%spoolEffectName = Turbojet-Spool
 	}
-    PLUME
+  PLUME
+  {
+      name = Hydrolox-Lower
+      transformName = thrustTransform
+      localRotation = 0,0,0
+      localPosition = 0,0,-0.2
+      fixedScale = 1.5
+      energy = 1
+      speed = 1
+      emissionMult = 0.5
+      flareScale = 0.7
+      plumeScale = 0.7
+      flarePosition = 0,0,1.4
+      plumePosition = 0,0,1.4
+  }
+  EFFECTS
+  {
+    Hydrolox-Lower
     {
-        name = Turbojet
+      MODEL_MULTI_PARTICLE_PERSIST
+      {
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        fixedScale = 2.0
+        name = flare
+        modelName = RealPlume/MP_Nazari_FX/flamessme
+        emission = 0.0 0
+        emission = 0.5 -5
+        emission = 1.0 2
+        speed = 0.0 1
+        speed = 1.0 1
+        offset = -0.25
+        energy = 0.0 0.2
+        energy = 1.0 1
+        size = 0.0 0.0
+        size = 1.0 0.45
+        fixedEmissions = false
+        randomInitalVelocityOffsetMaxRadius = 0.0
+        linGrow
+        {
+          power = 1 1
+          power = 0 0
+        }
+      }
+      MODEL_MULTI_PARTICLE_PERSIST
+      {
         transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,-0.2
         fixedScale = 1.5
+        name = shockcone
+        modelName = RealPlume/MP_Nazari_FX/ssmeflame2big
+        emission = 0.0 0
+        emission = 0.01 0.2
+        emission = 1.0 50
+        speed = 0.0 1.5
+        speed = 1.0 5.5
+        offset = 0.1
+        energy = 0.0 0.3
+        energy = 1.0 0.3
+        size = 0.0 0.7
+        size = 1.0 0.3
+        fixedEmissions = false
+        randomInitalVelocityOffsetMaxRadius = 0
+        linGrow
+        {
+          density = 1 0
+          density = 0 10
+          power = 1 -2
+          power = 0 0
+        }
+        energy
+        {
+          density = 1 0.33
+          density = 0.3 0.0
+          density = 0.25 0
+          density = 0 0
+        }
+      }
+      MODEL_MULTI_PARTICLE_PERSIST
+      {
+        transformName = thrust_transform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.4
+        fixedScale = 0.7
         energy = 1
         speed = 1
-    }
+        emissionMult = 0.5
+        name = plume_red
+        modelName = RealPlume/MP_Nazari_FX/methanolflame
+        fixedEmissions = false
+        sizeClamp = 50
+        randomInitalVelocityOffsetMaxRadius = 0
+        randConeEmit
+        {
+          density = 1 0
+          density = 0 1.7
+        }
+        logGrow
+        {
+          density = 1.0 2
+          density = 0.1 10
+          density = 0.0 2
+        }
+        logGrowScale
+        {
+          density = 1.0 0.0
+          density = 0.8 1.5
+          density = 0.46 2
+          density = 0.2 2
+          density = 0.1 2
+          density = 0.0 2
+        }
+        linGrow
+        {
+          density = 1.0 0
+          density = 0.25 10
+          density = 0.0 25
+        }
+        speed
+        {
+          density = 1.0 4
+          density = 0.46 4
+          density = 0.2 5
+          density = 0.05 2.5
+          density = 0.0 2.5
+        }
+        xyForce
+        {
+          density = 1 0.5
+          density = 0.3 0.8
+          density = 0.1 0.9
+          density = 0.01 0.99
+          density = 0.0 1
+        }
+        emission
+        {
+          density = 1.0 1.125
+          density = 0.8 0.9
+          density = 0.2 2.625
+          density = 0.1 2.25
+          density = 0.05 3.75
+          density = 0.0 5.25
+          power = 1 2
+          power = 0.01 0.4
+          power = 0 0
+        }
+        energy
+        {
+          density = 1.0 1
+          density = 0.3 0.5
+          density = 0.05 0.2
+          density = 0.0 0.15
+        }
+        size
+        {
+          density = 1.0 1.2
+          density = 0.5 1
+          density = 0.2 0.8
+          density = 0.0 0.45
+        }
+      }
+      MODEL_MULTI_PARTICLE_PERSIST
+      {
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,-0.2
+        fixedScale = 2.5
+        energy = 1
+        speed = 1
+        emissionMult = 0
+        name = plume_blue
+        modelName = RealPlume/MP_Nazari_FX/noxflame
+        fixedEmissions = false
+        sizeClamp = 50
+        randomInitalVelocityOffsetMaxRadius = 0
+        randConeEmit
+        {
+          density = 1 0
+          density = 0 1.7
+        }
+        logGrow
+        {
+          density = 1.0 2
+          density = 0.1 10
+          density = 0.0 2
+        }
+        logGrowScale
+        {
+          density = 1.0 0.0
+          density = 0.8 1.5
+          density = 0.46 2
+          density = 0.2 2
+          density = 0.1 2
+          density = 0.0 2
+        }
+        linGrow
+        {
+          density = 1.0 0
+          density = 0.25 10
+          density = 0.0 25
+        }
+        speed
+        {
+          density = 1.0 4
+          density = 0.46 4
+          density = 0.2 5
+          density = 0.05 2.5
+          density = 0.0 2.5
+        }
+        xyForce
+        {
+          density = 1 0.5
+          density = 0.3 0.8
+          density = 0.1 0.9
+          density = 0.01 0.99
+          density = 0.0 1
+        }
+        emission
+        {
+          density = 1.0 0.375
+          density = 0.8 0.3
+          density = 0.2 0.875
+          density = 0.1 0.75
+          density = 0.05 1.25
+          density = 0.0 1.75
+          power = 1 2
+          power = 0.01 0.4
+          power = 0 0
+        }
+        energy
+        {
+          density = 1.0 1
+          density = 0.3 0.5
+          density = 0.05 0.5
+          density = 0.0 0.4
+        }
+        size
+        {
+          density = 1.0 1.2
+          density = 0.5 1
+          density = 0.2 0.8
+          density = 0.0 0.45
+        }
+      }
+      MODEL_MULTI_PARTICLE_PERSIST
+      {
+        transformName = thrust_transform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.4
+        fixedScale = 0.7
+        energy = 1
+        speed = 1
+        emissionMult = 0.5
+        name = plume_grey
+        modelName = RealPlume/Hoojiwana_FX/MPspike
+        fixedEmissions = false
+        sizeClamp = 50
+        randomInitalVelocityOffsetMaxRadius = 0
+        randConeEmit
+        {
+          density = 1 0
+          density = 0.5 0.5
+          density = 0.3 1
+          density = 0 3
+        }
+        logGrow
+        {
+          density = 1.0 2
+          density = 0.1 10
+          density = 0.0 2
+        }
+        logGrowScale
+        {
+          density = 1.0 0.0
+          density = 0.8 1.5
+          density = 0.46 2
+          density = 0.2 2
+          density = 0.1 2
+          density = 0.0 2
+        }
+        linGrow
+        {
+          density = 1.0 0
+          density = 0.25 10
+          density = 0.0 25
+        }
+        speed
+        {
+          density = 1.0 1
+          density = 0.46 1.5
+          density = 0.2 1.5
+          density = 0.05 1.5
+          density = 0.0 1.5
+        }
+        xyForce
+        {
+          density = 1 0.3
+          density = 0.3 0.5
+          density = 0.1 0.9
+          density = 0.01 0.99
+          density = 0.0 1
+        }
+        emission
+        {
+          density = 1.0 0
+          density = 0.8 0.2
+          density = 0.2 2.5
+          density = 0.1 2.7
+          density = 0.05 2.9
+          density = 0.0 3
+          power = 1 1
+          power = 0.01 0.2
+          power = 0 0
+        }
+        energy
+        {
+          density = 1.0 0.5
+          density = 0.3 0.5
+          density = 0.05 0.4
+          density = 0.0 0.3
+        }
+        size
+        {
+          density = 1.0 1.2
+          density = 0.5 0.5
+          density = 0.2 0.4
+          density = 0.0 0.35
+        }
+      }
 }
-


### PR DESCRIPTION
Suggested changes to the RealPlume config for the J58, adding shock cone visuals (and file size to boot). I suspect many config curve values could be pruned to keep the patch size down/in line with other RP configs, but the particle count is reasonable at the very least. 