### PR TITLE
SSTU-Remove UPGRADES from Fuel Tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -8,6 +8,7 @@
 		@maxTankDiameter = 20
 		@minTankDiameter = 0.1
 		@tankDiameterIncrement = 0.5
+		-UPGRADES,* { }
 	}
 	@MODULE[SSTUNodeFairing],*
 	{
@@ -32,6 +33,7 @@
 		@minTankDiameter = 0.1
 		@tankDiameterIncrement = 0.5
 		@defaultRcsThrust = 0.1
+		-UPGRADES,* { }
 	}
 	@MODULE[SSTUNodeFairing],*
 	{


### PR DESCRIPTION
This makes the SSTU parts behave much more like procedural parts. When playing a RP-0 career, the tanks, decouplers, fairings and heat shields should all be able to be adjusted.