### PR TITLE
SSTU-Remove the Upgrades from the adjustable Sizes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -85,6 +85,7 @@
 		@minDiameter = 0.5
 		%maxDiameter = 20
 		%diameterIncrement = 0.5
+		-UPGRADES,* { }
 	}
 }
 @PART[SSTU-SC-GEN-RMB]:FOR[RealismOverhaul]
@@ -278,6 +279,7 @@
 		@minDiameter = 0.5
 		@maxDiameter = 20
 		@diameterIncrement = 0.5
+		-UPGRADES,* { }
 	}
 	@MODULE[KzFairingBaseResizer]
 	{
@@ -297,6 +299,7 @@
 		@minDiameter = 0.5
 		@maxDiameter = 20
 		@diameterIncrement = 0.5
+		-UPGRADES,* { }
 	}
 	@MODULE[ProceduralFairingAdapter]
 	{
@@ -317,6 +320,7 @@
 		@minDiameter = 0.5
 		@maxDiameter = 20
 		@diameterIncrement = 0.5
+		-UPGRADES,* { }
 	}
 	@MODULE[KzFairingBaseResizer]
 	{
@@ -337,6 +341,7 @@
 		@maxHeight = 15
 		@diameterIncrement = 0.5
 		@heightIncrement = 0.5
+		-UPGRADES,* { }
 	}
 }
 
@@ -350,5 +355,6 @@
 		@maxDiameter = 20
 		@diameterIncrement = 0.5
 		%currentDiameter = 1.0
+		-UPGRADES,* { }
 	}
 }


### PR DESCRIPTION
This makes the SSTU parts behave much more like procedural parts. When playing a RP-0 career, the tanks, decouplers, fairings and heat shields should all be able to be adjusted.