### PR TITLE
Added Test Flight Data for RD-180, F-1 and F-1A

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -16,7 +16,7 @@
 		type = ModuleEngines
 		modded = false
 		configuration = AJ10-137
-		origMass = 0.650
+		origMass = 0.2948  // per the above source, this was in pounds, former value is 0.650
 		CONFIG
 		{
 			name = AJ10-137


### PR DESCRIPTION
* Added rated burn times and reliability data for all three engines.
* Removed a duplicate entry on the F-1A config file for techRequired and cost.
* Allowed F-1A to throttle to 75% as is stated in the ETS Wiki