### PR TITLE
RD-100 series global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -1,0 +1,384 @@
+//  ==================================================
+//  RD-100 series (early) global engine configuration.
+
+//  Inert Mass: 888 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 1.28
+//  Burn Time: 68 s
+
+//  NPO Energomash - Liquid rocket engines list:                    http://www.npoenergomash.ru/encikloped/dvizki/
+//  Exponenta Educational Mathematical Site - Aeroengines:          http://www.k204.ru/books/Aviadvigatel2.pdf
+//  Alternate Wars - The Development of Rocket Engines in the USSR: http://www.alternatewars.com/BBOW/Space_Engines/Germans_USSR_Engines.pdf
+//  Liquid Propellant Rocket Engines - Experimental Engines:        http://www.lpre.de/energomash/ED/index.htm
+//  Norbert Brügge - Russian liquid propellant engines:             http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//  Encyclopedia Astronautica - RD-103 engine:                      http://astronautix.com/r/rd-103.html
+//  Encyclopedia Astronautica - RD-103M engine:                     http://astronautix.com/r/rd-103m.html
+
+//  Used by:
+
+//  * RealEngines pack
+//  * Ven Stock Revamp
+
+//  Notes:
+
+//  * All the above parameters refer to the baseline
+//    RD-100 engine.
+//  * The gimbal range defined here is not a true value, since the actual engine did not have
+//    a mechanical gimbal capability for the engine and/or nozzle. Instead, we simulate the
+//    operation of the jet vanes used to steer the engine exhaust products.
+//  ==================================================
+
+@PART[*]:HAS[#engineType[RD100]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = RD-100 Series (Early)
+    %manufacturer = NPO Energomash (OKB-456)
+    %description = The RD-100 engine series were the first large scale Ethalox Russian liquid propellant rocket engines ever developed and fired. The original RD-100 engine was a 1:1 copy of the German Model 39 engine (used on the A-4 ballistic missile), with later variants (RD-101 and RD-103/M) featuring ever increasing performance to satisfy the needs of the larger R-2 and R-5 IRBMs. Diameter: 1.65 m.
+
+    @MODULE[ModuleEngines,*]
+    {
+        @minThrust = 307.0
+        @maxThrust = 307.0
+        %EngineType = LiquidFuel
+        %useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 0
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal],*
+    {
+        @gimbalRange = 2.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = RD-100
+        origMass = 0.888
+        literalZeroIgnitions = True
+
+        CONFIG
+        {
+            name = RD-100
+            minThrust = 307.0
+            maxThrust = 307.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 0
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = Ethanol75
+                ratio = 0.5305
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.4695
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.01
+                ignoreForIsp = True
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 237
+                key = 1 203
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-101
+            minThrust = 404.0
+            maxThrust = 404.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 0
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = Ethanol90
+                ratio = 0.4945
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.5055
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.01
+                ignoreForIsp = True
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 237
+                key = 1 210
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-102
+            minThrust = 428.0
+            maxThrust = 428.0
+            massMult = 0.9966
+            ullage = True
+            pressureFed = False
+            ignitions = 0
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = Ethanol90
+                ratio = 0.4945
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.5055
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.01
+                ignoreForIsp = True
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 235
+                key = 1 214
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-103
+            minThrust = 490.33
+            maxThrust = 490.33
+            heatProduction = 100
+            massMult = 0.9797
+            ullage = True
+            pressureFed = False
+            ignitions = 0
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = Ethanol90
+                ratio = 0.4945
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.5055
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.01
+                ignoreForIsp = True
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 248
+                key = 1 220
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-103M
+            minThrust = 500.14
+            maxThrust = 500.14
+            heatProduction = 100
+            massMult = 0.9763
+            ullage = True
+            pressureFed = False
+            ignitions = 0
+            cost = 150
+            techRequired = engineering101
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT
+            {
+                name = Ethanol90
+                ratio = 0.4945
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.5055
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.01
+                ignoreForIsp = True
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 248
+                key = 1 220
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-100]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = RD-100
+        ratedBurnTime = 70
+        ignitionReliabilityStart = 0.89
+        ignitionReliabilityEnd = 0.97
+        ignitionDynPresFailMultiplier = 2.0
+        cycleReliabilityStart = 0.75
+        cycleReliabilityEnd = 0.95
+        reliabilityDataRateMultiplier = 1
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-101]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = RD-101
+        ratedBurnTime = 85
+        ignitionReliabilityStart = 0.89
+        ignitionReliabilityEnd = 0.97
+        ignitionDynPresFailMultiplier = 2.0
+        cycleReliabilityStart = 0.75
+        cycleReliabilityEnd = 0.95
+        techTransfer = RD-100:50
+        reliabilityDataRateMultiplier = 1
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-102]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = RD-102
+        ratedBurnTime = 83
+        ignitionReliabilityStart = 0.89
+        ignitionReliabilityEnd = 0.97
+        ignitionDynPresFailMultiplier = 2.0
+        cycleReliabilityStart = 0.75
+        cycleReliabilityEnd = 0.95
+        techTransfer = RD-101:50
+        reliabilityDataRateMultiplier = 1
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-103]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = RD-103
+        ratedBurnTime = 130
+        ignitionReliabilityStart = 0.8
+        ignitionReliabilityEnd = 0.9
+        cycleReliabilityStart = 0.85
+        cycleReliabilityEnd = 0.93
+        techTransfer = RD-102:50
+        reliabilityDataRateMultiplier = 1
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-103M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = RD-103M
+        ratedBurnTime = 140
+        ignitionReliabilityStart = 0.85
+        ignitionReliabilityEnd = 0.93
+        cycleReliabilityStart = 0.87
+        cycleReliabilityEnd = 0.96
+        techTransfer = RD-103:50
+        reliabilityDataRateMultiplier = 1
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -4,13 +4,17 @@
 //  Inert Mass: 888 Kg
 //  Throttle Range: N/A
 //  O/F Ratio: 1.28
-//  Burn Time: 68 s
+//  Burn Time: 70 s
 
 //  NPO Energomash - Liquid rocket engines list:                    http://www.npoenergomash.ru/encikloped/dvizki/
 //  Exponenta Educational Mathematical Site - Aeroengines:          http://www.k204.ru/books/Aviadvigatel2.pdf
 //  Alternate Wars - The Development of Rocket Engines in the USSR: http://www.alternatewars.com/BBOW/Space_Engines/Germans_USSR_Engines.pdf
+//  Alternate Wars - Russian Space Engines:                         http://www.alternatewars.com/BBOW/Space_Engines/Russian_Engines.htm
 //  Liquid Propellant Rocket Engines - Experimental Engines:        http://www.lpre.de/energomash/ED/index.htm
 //  Norbert Brügge - Russian liquid propellant engines:             http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//  Encyclopedia Astronautica - RD-100 engine:                      http://astronautix.com/r/rd-100.html
+//  Encyclopedia Astronautica - RD-101 engine:                      http://astronautix.com/r/rd-101.html
+//  Encyclopedia Astronautica - RD-102 engine:                      http://astronautix.com/r/rd-102.html
 //  Encyclopedia Astronautica - RD-103 engine:                      http://astronautix.com/r/rd-103.html
 //  Encyclopedia Astronautica - RD-103M engine:                     http://astronautix.com/r/rd-103m.html
 
@@ -37,9 +41,10 @@
 
     @MODULE[ModuleEngines,*]
     {
-        @minThrust = 307.0
-        @maxThrust = 307.0
+        %minThrust = 307.0
+        %maxThrust = 307.0
         %EngineType = LiquidFuel
+        %useEngineResponseSpeed = False
         %useThrustCurve = False
         %ullage = True
         %pressureFed = False
@@ -361,6 +366,7 @@
         ratedBurnTime = 130
         ignitionReliabilityStart = 0.8
         ignitionReliabilityEnd = 0.9
+        ignitionDynPresFailMultiplier = 2.0
         cycleReliabilityStart = 0.85
         cycleReliabilityEnd = 0.93
         techTransfer = RD-102:50
@@ -376,6 +382,7 @@
         ratedBurnTime = 140
         ignitionReliabilityStart = 0.85
         ignitionReliabilityEnd = 0.93
+        ignitionDynPresFailMultiplier = 2.0
         cycleReliabilityStart = 0.87
         cycleReliabilityEnd = 0.96
         techTransfer = RD-103:50

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -6,6 +6,8 @@
 //  O/F Ratio: 1.28
 //  Burn Time: 70 s
 
+//  Sources:
+
 //  NPO Energomash - Liquid rocket engines list:                    http://www.npoenergomash.ru/encikloped/dvizki/
 //  Exponenta Educational Mathematical Site - Aeroengines:          http://www.k204.ru/books/Aviadvigatel2.pdf
 //  Alternate Wars - The Development of Rocket Engines in the USSR: http://www.alternatewars.com/BBOW/Space_Engines/Germans_USSR_Engines.pdf
@@ -43,8 +45,9 @@
     {
         %minThrust = 307.0
         %maxThrust = 307.0
+        %heatProduction = 35
         %EngineType = LiquidFuel
-        %useEngineResponseSpeed = False
+        @useEngineResponseSpeed = False
         %useThrustCurve = False
         %ullage = True
         %pressureFed = False
@@ -77,6 +80,7 @@
             name = RD-100
             minThrust = 307.0
             maxThrust = 307.0
+            heatProduction = 35
             massMult = 1.0
             ullage = True
             pressureFed = False
@@ -122,6 +126,7 @@
             name = RD-101
             minThrust = 404.0
             maxThrust = 404.0
+            heatProduction = 45
             massMult = 1.0
             ullage = True
             pressureFed = False
@@ -167,6 +172,7 @@
             name = RD-102
             minThrust = 428.0
             maxThrust = 428.0
+            heatProduction = 45
             massMult = 0.9966
             ullage = True
             pressureFed = False
@@ -212,7 +218,7 @@
             name = RD-103
             minThrust = 490.33
             maxThrust = 490.33
-            heatProduction = 100
+            heatProduction = 55
             massMult = 0.9797
             ullage = True
             pressureFed = False
@@ -258,7 +264,7 @@
             name = RD-103M
             minThrust = 500.14
             maxThrust = 500.14
-            heatProduction = 100
+            heatProduction = 57
             massMult = 0.9763
             ullage = True
             pressureFed = False


### PR DESCRIPTION
**Change log:**

* Add a new RD-100 series global engine configuration. This covers the early Russian Ethalox engines (RD-100 to RD-103M)

**Discussions:**

* [RD-103/M engine series data](https://github.com/KSP-RO/RealismOverhaul/issues/1578)
* [RealEngines v1.4 RO support](https://github.com/KSP-RO/RealismOverhaul/pull/1587)

**Notes:**

* This config completely replaces the RD-103/M global engine config. Changes are required to the VSR RD-103 engine, both to it's RO and RP-0 configs.
* The engine configs need tech and costing fields required for unlocking them (RP-0 only).
* The RD-101 and RD-102 configs need some adjustments to their TestFlight reliability data (currently impementing the ones from RD-100).
* The engines implement a new RF feature called "ground ignition only", meaning that it can only be used for first (booster) stages.