### PR TITLE
STAR 37 TestFlight config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -12,6 +12,7 @@
 //  Alternate Wars - Thiokol/Morton Thiokol/ATK Space Engines:       http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
 //  Gunter's Space Page - Star 37 SRM family:                        http://space.skyrocket.de/doc_eng/star-37.htm
 //  Encyclopedia Astronautica - Star 37 SRM:                         http://www.astronautix.com/s/star37.html
+//  NTRS - FAILURE ANALYSIS OF SOLID ROCKET MOTORS:                  https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720026092.pdf
 
 //  Used by:
 

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -333,6 +333,7 @@
     TESTFLIGHT
     {
         name = STAR-37
+        isSolid = True
         ratedBurnTime = 42
         ignitionReliabilityStart = 0.98
         ignitionReliabilityEnd = 0.995

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -34,9 +34,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        %minThrust = 54.8
-        %maxThrust = 54.8
-        %heatProduction = 100
+        %minThrust = 43.5
+        %maxThrust = 43.5
+        %heatProduction = 73
         %EngineType = SolidBooster
         @useEngineResponseTime = False
         !engineAccelerationSpeed = NULL
@@ -66,6 +66,7 @@
             name = STAR-37
             minThrust = 43.5
             maxThrust = 43.5
+            heatProduction = 73
             gimbalRange = 0
             masMult = 1.0
             ullage = False

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -7,14 +7,21 @@
 //  Burn Time: 42 s
 
 //  Sources:
-//      Orbital ATK - Space Propulsion Products Catalog, September 2012: https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
-//      Alternate Wars - Thiokol/Morton Thiokol/ATK Space Engines:       http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
-//      Gunter's Space Page - Star 37 SRM family:                        http://space.skyrocket.de/doc_eng/star-37.htm
-//      Encyclopedia Astronautica - Star 37 SRM:                         http://www.astronautix.com/s/star37.html
+
+//  Orbital ATK - Space Propulsion Products Catalog, September 2012: https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
+//  Alternate Wars - Thiokol/Morton Thiokol/ATK Space Engines:       http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
+//  Gunter's Space Page - Star 37 SRM family:                        http://space.skyrocket.de/doc_eng/star-37.htm
+//  Encyclopedia Astronautica - Star 37 SRM:                         http://www.astronautix.com/s/star37.html
 
 //  Used by:
-//      ATK Propulsion Pack
-//      Coatl Aerospace GroundOps
+
+//  * ATK Propulsion Pack
+//  * Coatl Aerospace GroundOps
+
+//  Notes:
+
+//  * Reusing the thrust curve from the STAR 37FM solid
+//    rocket motor global engine config.
 //  ==================================================
 
 @PART[*]:HAS[#engineType[Star-37]]:FOR[RealismOverhaulEngines]
@@ -315,4 +322,21 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[STAR-37]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = STAR-37
+        ratedBurnTime = 42
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.995
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.995
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -335,9 +335,9 @@
         name = STAR-37
         isSolid = True
         ratedBurnTime = 42
-        ignitionReliabilityStart = 0.98
+        ignitionReliabilityStart = 0.958
         ignitionReliabilityEnd = 0.995
-        cycleReliabilityStart = 0.98
+        cycleReliabilityStart = 0.958
         cycleReliabilityEnd = 0.995
     }
 }


### PR DESCRIPTION
**Change log:**

* Add TestFlight compatibilty data to the STAR 37 SRM.

**Notes:**

* There were never really any failures of a STAR 37 SRM (given the low count of uses - 7), with the only real failure being on the Surveyor 2 mission. But, 87.5% reliability seems to be too low for such an advanced motor so i am reusing the STAR 37E reliability values for now.

**Sources:**

[FAILURE ANALYSIS OF SOLID ROCKET MOTORS (page 18)](https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720026092.pdf)