### PR TITLE
STAR 37E SRM global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -335,9 +335,9 @@
         name = STAR-37E
         isSolid = True
         ratedBurnTime = 42
-        ignitionReliabilityStart = 0.98
+        ignitionReliabilityStart = 0.958
         ignitionReliabilityEnd = 0.995
-        cycleReliabilityStart = 0.98
+        cycleReliabilityStart = 0.958
         cycleReliabilityEnd = 0.995
         techTransfer = STAR-37:50
     }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -9,9 +9,10 @@
 //  Sources:
 
 //  Alternate Wars - Thiokol, Morton Thiokol, ATK engines: http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
-//  Gunter's Space Page - STAR 37 family:                  http://space.skyrocket.de/doc_eng/star-37.htm
-//  Encyclopedia Astronautica - STAR 37E rocket motor:     http://www.astronautix.com/s/star37e.html
+//  Gunter's Space Page - Star 37 family:                  http://space.skyrocket.de/doc_eng/star-37.htm
+//  Encyclopedia Astronautica - Star 37E rocket motor:     http://www.astronautix.com/s/star37e.html
 //  Space Launch Report - Extended Long Tank Delta:        http://www.spacelaunchreport.com/thorh10.html
+//  NTRS - FAILURE ANALYSIS OF SOLID ROCKET MOTORS:        https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720026092.pdf
 
 //  Used by:
 

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -35,7 +35,7 @@
     {
         %minThrust = 68.8
         %maxThrust = 68.8
-        %heatProduction = 100
+        %heatProduction = 95
         %EngineType = SolidBooster
         @useEngineResponseTime = False
         !engineAccelerationSpeed = NULL
@@ -65,7 +65,7 @@
             name = STAR-37E
             minThrust = 68.8
             maxThrust = 68.8
-            heatProduction = 100
+            heatProduction = 95
             gimbalRange = 0
             masMult = 1.0
             ullage = False

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -1,0 +1,344 @@
+//  ==================================================
+//  STAR 37E SRM global engine configuration.
+
+//  Gross Mass: 1123 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.77
+//  Burn Time: 42 s
+
+//  Sources:
+
+//  Alternate Wars - Thiokol, Morton Thiokol, ATK engines: http://www.alternatewars.com/BBOW/Space_Engines/Thiokol_ATK_Engines.htm
+//  Gunter's Space Page - STAR 37 family:                  http://space.skyrocket.de/doc_eng/star-37.htm
+//  Encyclopedia Astronautica - STAR 37E rocket motor:     http://www.astronautix.com/s/star37e.html
+//  Space Launch Report - Extended Long Tank Delta:        http://www.spacelaunchreport.com/thorh10.html
+
+//  Used by:
+
+//  * Coatl Aerospace ProbesPlus pack
+
+//  Notes:
+
+//  * Reusing the thrust curve from the STAR 37FM solid
+//    rocket motor global engine config.
+//  ==================================================
+
+@PART[*]:HAS[#engineType[Star-37E]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = STAR 37E
+    %manufacturer = Morton Thiokol
+    %description = The STAR 37E is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vacuum thrust. First used on the Delta 1000 launch vehicle family as a third stage kick motor. Diameter: 0.93 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        %minThrust = 68.8
+        %maxThrust = 68.8
+        %heatProduction = 100
+        %EngineType = SolidBooster
+        @useEngineResponseTime = False
+        !engineAccelerationSpeed = NULL
+        @useThrustCurve = True
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = STAR-37E
+        origMass = 0.083
+
+        CONFIG
+        {
+            name = STAR-37E
+            minThrust = 68.8
+            maxThrust = 68.8
+            heatProduction = 100
+            gimbalRange = 0
+            masMult = 1.0
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+            curveResource = HTPB
+
+            PROPELLANT
+            {
+                name = HTPB
+                ratio = 1.0
+                DrawGauge = True
+            }
+
+            atmosphereCurve
+            {
+                key 0 = 284
+                key 1 = 140
+            }
+
+            thrustCurve
+            {
+                key = 1.000 0.2006
+                key = 0.995 0.7376
+                key = 0.990 0.6830
+                key = 0.985 0.6830
+                key = 0.980 0.6857
+                key = 0.975 0.6884
+                key = 0.970 0.6884
+                key = 0.965 0.6911
+                key = 0.960 0.6938
+                key = 0.955 0.6959
+                key = 0.950 0.6990
+                key = 0.945 0.7020
+                key = 0.940 0.7048
+                key = 0.935 0.7075
+                key = 0.930 0.7102
+                key = 0.925 0.7129
+                key = 0.920 0.7156
+                key = 0.915 0.7183
+                key = 0.910 0.7220
+                key = 0.905 0.7247
+                key = 0.900 0.7293
+                key = 0.895 0.7320
+                key = 0.890 0.7347
+                key = 0.885 0.7380
+                key = 0.880 0.7406
+                key = 0.875 0.7458
+                key = 0.870 0.7485
+                key = 0.865 0.7512
+                key = 0.860 0.7559
+                key = 0.855 0.7583
+                key = 0.850 0.7622
+                key = 0.845 0.7657
+                key = 0.840 0.7680
+                key = 0.835 0.7730
+                key = 0.830 0.7760
+                key = 0.825 0.7801
+                key = 0.820 0.7842
+                key = 0.815 0.7870
+                key = 0.810 0.7918
+                key = 0.805 0.7965
+                key = 0.800 0.8039
+                key = 0.795 0.8113
+                key = 0.790 0.8213
+                key = 0.785 0.8285
+                key = 0.780 0.8357
+                key = 0.775 0.8428
+                key = 0.770 0.8498
+                key = 0.765 0.8568
+                key = 0.760 0.8637
+                key = 0.755 0.8693
+                key = 0.750 0.8747
+                key = 0.745 0.8815
+                key = 0.740 0.8855
+                key = 0.735 0.8913
+                key = 0.730 0.8961
+                key = 0.725 0.9000
+                key = 0.720 0.9039
+                key = 0.715 0.9079
+                key = 0.710 0.9134
+                key = 0.705 0.9161
+                key = 0.700 0.9216
+                key = 0.695 0.9243
+                key = 0.690 0.9291
+                key = 0.685 0.9326
+                key = 0.680 0.9353
+                key = 0.675 0.9400
+                key = 0.670 0.9436
+                key = 0.665 0.9472
+                key = 0.660 0.9507
+                key = 0.655 0.9542
+                key = 0.650 0.9577
+                key = 0.645 0.9628
+                key = 0.640 0.9655
+                key = 0.635 0.9707
+                key = 0.630 0.9741
+                key = 0.625 0.9775
+                key = 0.620 0.9821
+                key = 0.615 0.9848
+                key = 0.610 0.9901
+                key = 0.605 0.9934
+                key = 0.600 0.9966
+                key = 0.595 1.0000
+                key = 0.590 0.9922
+                key = 0.585 0.9824
+                key = 0.580 0.9735
+                key = 0.575 0.9646
+                key = 0.570 0.9584
+                key = 0.565 0.9522
+                key = 0.560 0.9463
+                key = 0.555 0.9436
+                key = 0.550 0.9416
+                key = 0.545 0.9409
+                key = 0.540 0.9409
+                key = 0.535 0.9409
+                key = 0.530 0.9409
+                key = 0.525 0.9409
+                key = 0.520 0.9409
+                key = 0.515 0.9409
+                key = 0.510 0.9409
+                key = 0.505 0.9382
+                key = 0.500 0.9360
+                key = 0.495 0.9324
+                key = 0.490 0.9287
+                key = 0.485 0.9195
+                key = 0.480 0.9135
+                key = 0.475 0.9135
+                key = 0.470 0.9135
+                key = 0.465 0.9135
+                key = 0.460 0.9162
+                key = 0.455 0.9191
+                key = 0.450 0.9244
+                key = 0.445 0.9292
+                key = 0.440 0.9329
+                key = 0.435 0.9365
+                key = 0.430 0.9409
+                key = 0.425 0.9409
+                key = 0.420 0.9409
+                key = 0.415 0.9409
+                key = 0.410 0.9409
+                key = 0.405 0.9409
+                key = 0.400 0.9409
+                key = 0.395 0.9409
+                key = 0.390 0.9409
+                key = 0.385 0.9409
+                key = 0.380 0.9409
+                key = 0.375 0.9409
+                key = 0.370 0.9409
+                key = 0.365 0.9409
+                key = 0.360 0.9409
+                key = 0.355 0.9409
+                key = 0.350 0.9409
+                key = 0.345 0.9409
+                key = 0.340 0.9409
+                key = 0.335 0.9409
+                key = 0.330 0.9409
+                key = 0.325 0.9409
+                key = 0.320 0.9409
+                key = 0.315 0.9409
+                key = 0.310 0.9410
+                key = 0.305 0.9436
+                key = 0.300 0.9436
+                key = 0.295 0.9436
+                key = 0.290 0.9443
+                key = 0.285 0.9464
+                key = 0.280 0.9464
+                key = 0.275 0.9491
+                key = 0.270 0.9491
+                key = 0.265 0.9510
+                key = 0.260 0.9519
+                key = 0.255 0.9526
+                key = 0.250 0.9547
+                key = 0.245 0.9569
+                key = 0.240 0.9576
+                key = 0.235 0.9602
+                key = 0.230 0.9618
+                key = 0.225 0.9630
+                key = 0.220 0.9657
+                key = 0.215 0.9657
+                key = 0.210 0.9673
+                key = 0.205 0.9685
+                key = 0.200 0.9685
+                key = 0.195 0.9712
+                key = 0.190 0.9698
+                key = 0.185 0.9685
+                key = 0.180 0.9685
+                key = 0.175 0.9658
+                key = 0.170 0.9658
+                key = 0.165 0.9631
+                key = 0.160 0.9604
+                key = 0.155 0.9577
+                key = 0.150 0.9550
+                key = 0.145 0.9523
+                key = 0.140 0.9496
+                key = 0.135 0.9496
+                key = 0.130 0.9496
+                key = 0.125 0.9496
+                key = 0.120 0.9469
+                key = 0.115 0.9469
+                key = 0.110 0.9469
+                key = 0.105 0.9469
+                key = 0.100 0.9469
+                key = 0.095 0.9469
+                key = 0.090 0.9442
+                key = 0.085 0.9442
+                key = 0.080 0.9442
+                key = 0.075 0.9442
+                key = 0.070 0.9442
+                key = 0.065 0.9442
+                key = 0.060 0.9442
+                key = 0.055 0.9415
+                key = 0.050 0.9415
+                key = 0.045 0.9415
+                key = 0.040 0.9415
+                key = 0.035 0.9415
+                key = 0.030 0.9415
+                key = 0.025 0.9389
+                key = 0.020 0.9388
+                key = 0.015 0.9388
+                key = 0.010 0.9363
+                key = 0.009 0.9194
+                key = 0.008 0.8980
+                key = 0.007 0.8517
+                key = 0.006 0.7958
+                key = 0.005 0.7307
+                key = 0.004 0.6615
+                key = 0.003 0.5859
+                key = 0.002 0.4856
+                key = 0.001 0.3102
+                key = 0.000 0.0569
+            }
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 581.85
+        basemass = -1
+
+        //  HTPB/AP propellant mixture mass ~1038 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 581.85
+            maxAmount = 581.85
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[STAR-37E]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = STAR-37E
+        isSolid = True
+        ratedBurnTime = 42
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.995
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.995
+        techTransfer = STAR-37:50
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add a global engine config for the STAR 37E SRM.

**Notes:**

* Due to the difficulty of obtaining a thrust curve for this variant i am reusing the STAR 37FM thrust curve.
* The TestFlight config is not 100% correct. This variant flew 23 times (over a span of ~4 years) with only a single failure (~0.9583% success rate).