### PR TITLE
BobCat Soviet Engines Extras name fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_SovietEngines_Extras.cfg
@@ -1,6 +1,6 @@
 +PART[RD0120_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	@name = RD270
+	@name = RO-BobCat-RD270
 
     %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
     %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
@@ -54,7 +54,7 @@
 
 +PART[RD0120_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	@name = RD270M
+	@name = RO-BobCat-RD270M
 
     %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
     %fx_exhaustFlame_blue = 0.0, -2.728, 0.0, 0.0, 1.364, 0.0, running
@@ -110,7 +110,7 @@
 // NK-9, 9V, and 21/19/31/39.
 +PART[NK33_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	@name = NK9
+	@name = RO-BobCat-NK9
 
 	%RSSROConfig = True
 	%rescaleFactor = 1.31
@@ -133,7 +133,7 @@
 }
 +PART[NK43_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	@name = NK9V
+	@name = RO-BobCat-NK9V
 
 	%RSSROConfig = True
 	%rescaleFactor = 1.31
@@ -156,7 +156,7 @@
 }
 +PART[RD0124_StockVersion]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
-	@name = RD0110
+	@name = RO-BobCat-RD0110
 	
 	%RSSROConfig = True
 	%rescaleFactor = 1.6641
@@ -204,10 +204,10 @@
 
 +PART[RD180_StockVersion]:FIRST
 {
-    @name = RD701
+    @name = RO-BobCat-RD701
 }
 
-@PART[RD701]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+@PART[RO-BobCat-RD701]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
     %RSSROConfig = True
 
@@ -293,10 +293,10 @@
 
 +PART[RD191_StockVersion]:FIRST
 {
-    @name = RD704
+    @name = RO-BobCat-RD704
 }
 
-@PART[RD704]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+@PART[RO-BobCat-RD704]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
     %RSSROConfig = True
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9.cfg
@@ -1,4 +1,4 @@
-@PART[NK9]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-9, using halved NK-43
+@PART[RO-BobCat-NK9]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-9, using halved NK-43
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9V.cfg
@@ -1,4 +1,4 @@
-@PART[NK9V]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-9V, using halved NK-43
+@PART[RO-BobCat-NK9V]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-9V, using halved NK-43
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0110.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0110.cfg
@@ -1,4 +1,4 @@
-@PART[RD0110]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0124
+@PART[RO-BobCat-RD0110]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0124
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270.cfg
@@ -1,4 +1,4 @@
-@PART[RD270]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-270
+@PART[RO-BobCat-RD270]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-270
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270M.cfg
@@ -1,4 +1,4 @@
-@PART[RD270M]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-270M
+@PART[RO-BobCat-RD270M]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-270M
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD701.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD701.cfg
@@ -2,7 +2,7 @@
 //  RD-701 engine plume configuration.
 //  ==================================================
 
-@PART[RD701]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-BobCat-RD701]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -59,7 +59,7 @@
 //  RD-701 engine plume configuration.
 //  ==================================================
 
-@PART[RD701]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+@PART[RO-BobCat-RD701]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD704.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD704.cfg
@@ -2,7 +2,7 @@
 //  RD-704 engine plume setup.
 //  ==================================================
 
-@PART[RD704]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-BobCat-RD704]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -59,7 +59,7 @@
 //  RD-704 engine plume configuration.
 //  ==================================================
 
-@PART[RD704]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+@PART[RO-BobCat-RD704]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {


### PR DESCRIPTION
**Change log:**

* Change the name of the RO engine clones to fix conflicts with the RealEngines pack.

**Notes:**

* These changes also require the RP-0 tech tree part names to be updated.
* The actual file names were preserved since a change there would break the git file history.