### PR TITLE
VSR RD-100 engine updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -162,94 +162,91 @@
     }
 }
 
+//  ==================================================
+//  RD-100 series (early).
+//  ==================================================
+
 @PART[LVT15]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	@MODEL
+
+	@MODEL,0
 	{
 		%scale = 1.0, 1.0, 1.0
 	}
-	// modeling the jet vanes as four thrust transforms
-	MODEL
+
+	@MODEL,1
 	{
-		model = RealismOverhaul/emptyengine
-		position = 0.3, -1.6, 0.0
-		rotation = 0.0, 0.0, 0.0
+		@scale = 1.0, 1.0, 1.0
 	}
-	MODEL
-	{
-		model = RealismOverhaul/emptyengine
-		position = -0.3, -1.6, 0.0
-		rotation = 0.0, 0.0, 0.0
-	}
-	MODEL
-	{
-		model = RealismOverhaul/emptyengine
-		position = 0.0, -1.6, 0.3
-		rotation = 0.0, 0.0, 0.0
-	}
-	MODEL
-	{
-		model = RealismOverhaul/emptyengine
-		position = 0.0, -1.6, -0.3
-		rotation = 0.0, 0.0, 0.0
-	}
-	// top node is at 0,0,0
+
+	@scale = 1.0
 	%rescaleFactor = 1.0
-	%scale = 1.0
-	%node_stack_bottom = 0, -1.656, 0, 0, -1, 0, 1
 
-	// make radially attachable
-	@attachRules = 1,1,1,0,0
-	%node_attach = 0
-	@node_attach = #$node_stack_top$
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_bottom = 0.0, -1.56, 0.0, 0.0, -1.0, 0.0, 1
 
-	@mass = 0.87
-	@maxTemp = 1973.15
+	@mass = 0.888
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
 	!emissiveConstant = DEL
+	%stageOffset = 1
+	%childStageOffset = 1
+	@stagingIcon = LIQUID_ENGINE
+	@tags = ascent main propuls RD-100 rocket (ven (vsr
 
-	// remove LV-T15 stuff
-	!MODULE[ModuleAblator] {}
-	!RESOURCE[Ablator] {}
-	!MODULE[ModuleHeatShield] {}
+	%engineType = RD100
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
 
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 469.7
-		@maxThrust = 469.7
-		@heatProduction = 100
-		%thrustVectorTransformName = newThrustTransform
-		@atmosphereCurve
-		{
-			@key,0 = 0 244
-			@key,1 = 1 216
-		}
+		!engineID = NULL
+		@engineAccelerationSpeed = 0
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Ethanol75
-			@ratio = 0.499
+			@ratio = 0.5305
+			%DrawGauge = True
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.501
+			@ratio = 0.4695
+			%DrawGauge = False
 		}
-		!IGNITOR_RESOURCE,* {}
+
+		@PROPELLANT[Ablator]
+		{
+			@name = HTP
+			@ratio = 0.01
+			%ignoreForIsp = True
+			%DrawGauge = False
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 237
+			@key,1 = 1 203
+		}
 	}
-	// modeling the jet vanes as four thrust transforms
+
+	!MODULE[ModuleAblator],*{}
+
+	!MODULE[ModuleHeatShield],*{}
+
+	//  Placeholder gimbal module.
+
 	MODULE
 	{
 		name = ModuleGimbal
-		gimbalTransformName = newThrustTransform
-		gimbalRange = 2
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
+		gimbalTransformName = thrustTransform
+		gimbalRange = 2.0
 	}
-
-	engineType = RD103
 }
 
 // UA1205

--- a/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/LVT15.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/VenStockRevamp/LVT15.cfg
@@ -1,19 +1,36 @@
+//  ==================================================
+//  RD-100 series (early) plume setup.
+//  ==================================================
+
 @PART[LVT15]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-		%powerEffectName = Alcolox-Lower-A6
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Alcolox-Lower-A6
+        !fxOffset = NULL
+    }
+
     PLUME
     {
         name = Alcolox-Lower-A6
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.77
-        fixedScale = 1
-        energy = 1
-        speed = 1
+        plumePosition = 0.0, 0.0, 0.25
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.7
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.75
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
     }
 }


### PR DESCRIPTION
**Change log:**

* Update the Ven Stock Revamp RD-103/M engine to use the new RD-100 global engine config.
* Tweaked a bit the flare/plume relative positioning.

**Notes:**

* The jet vanes are now simulated via an imaginery gimbal module. This simplifies the part module config and allows the plume to visibly swivel around the engine exhaust.
* These changes require an update to the RP-0 tech tree placement for the engine to be viable.