### PR TITLE
RD-100 engine variants costing

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -131,6 +131,7 @@
             ullage = True
             pressureFed = False
             ignitions = 0
+            cost = 200
 
             IGNITOR_RESOURCE
             {
@@ -177,6 +178,7 @@
             ullage = True
             pressureFed = False
             ignitions = 0
+            cost = 250
 
             IGNITOR_RESOURCE
             {
@@ -223,6 +225,8 @@
             ullage = True
             pressureFed = False
             ignitions = 0
+            cost = 700
+            techRequired = engineering101
 
             IGNITOR_RESOURCE
             {
@@ -269,7 +273,7 @@
             ullage = True
             pressureFed = False
             ignitions = 0
-            cost = 150
+            cost = 850
             techRequired = engineering101
 
             IGNITOR_RESOURCE


### PR DESCRIPTION
**Change log:**

* Add costs for the early RD-100 variants.

**Notes:**

* The cost values for the RD-103 and RD-103M variants were recalculated to use a base cost of 150 (same as the A-4 engine) to keep the final costs same as before. The costing of the RD-101 and RD-102 variants might be off compared to these later variants though.