### PR TITLE
X-405 engine updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -1,36 +1,106 @@
-//X-405 engine
-//SXT
+//  ==================================================
+//  X-405 global engine configuration.
+
+//  Gross Mass: 192 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 2.20
+//  Burn Time: 145 s
+
+//  Sources:
+
+//  NASA - Vanguard, A History (chapter 5):          https://history.nasa.gov/SP-4202/chapter5.html
+//  Norbert Brügge - Vanguard launch vehicle:        http://www.b14643.de/Spacerockets_2/United_States_7/Vanguard/Description/Frame.htm
+//  Alternate Wars - General Electric space engines: http://www.alternatewars.com/BBOW/Space_Engines/GE_Engines.htm
+//  NSSDCA - Vanguard TV3:                           https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=VAGT3
+//  Encyclopedia Astronautica - X-405 engine:        http://www.astronautix.com/x/x-405.html
+//  Designation Systems - Vanguard launch vehicle:   http://www.designation-systems.net/dusrm/app4/vanguard.html
+
+//  Used by:
+
+//  * SXT pack
+//  ==================================================
+
 @PART[*]:HAS[#engineType[X405]]:FOR[RealismOverhaulEngines]
 {
-	@title = XLR50 (Vanguard X-405) Booster
-	@manufacturer = General Electric
-	@description = Booster engine used on the Vanguard launch vehicle. Very early kerolox gas-generator engine. Diameter: [1.0 m].
-	
-	MODULE // configs for the engine
+	%category = Engine
+	%title = X-405 (XLR50-GE-2)
+	%manufacturer = General Electric (GE)
+	%description = A very early kerolox gas generator booster engine used on the Vanguard launch vehicle. Diameter: 1.0 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 134.3
+		%maxThrust = 134.3
+		%EngineType = LiquidFuel
+		@useEngineResponseTime = False
+		!engineAccelerationSpeed = NULL
+		@useThrustCurve = False
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 0
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 5.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
+	MODULE
 	{
 		name = ModuleEngineConfigs
-		type = ModuleEnginesFX
+		type = ModuleEngines
 		engineID = Engine
-		modded = false
 		configuration = X-405
-		origMass = 0.193
+		origMass = 0.192
+		literalZeroIgnitions = True
+
 		CONFIG
 		{
 			name = X-405
-			minThrust = 133.8
-			maxThrust = 133.8
+			minThrust = 134.3
+			maxThrust = 134.3
 			heatProduction = 80
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.3874
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.6126
+				DrawGauge = False
 			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.02
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
 			atmosphereCurve
 			{
 				key = 0 270
@@ -38,18 +108,26 @@
 			}
 		}
 	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
 }
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[X405],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-			name = X-405
-			ratedBurnTime = 145
-			ignitionReliabilityStart = 0.70
-			ignitionReliabilityEnd = 0.9
-			cycleReliabilityStart = 0.86
-			cycleReliabilityEnd = 0.94
-
-			techTransfer = A-4:10
+		name = X-405
+		ratedBurnTime = 145
+		ignitionReliabilityStart = 0.70
+		ignitionReliabilityEnd = 0.90
+		cycleReliabilityStart = 0.86
+		cycleReliabilityEnd = 0.94
+		techTransfer = A-4:10
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -29,8 +29,10 @@
 
 	@MODULE[ModuleEngines*]
 	{
+		%engineID = MainEngine
 		%minThrust = 134.8
 		%maxThrust = 134.8
+		%heatProduction = 78
 		%EngineType = LiquidFuel
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = NULL
@@ -57,7 +59,8 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		engineID = Engine
+		engineID = MainEngine
+		isMaster = True
 		configuration = X-405
 		origMass = 0.192
 
@@ -66,7 +69,7 @@
 			name = X-405
 			minThrust = 134.8
 			maxThrust = 134.8
-			heatProduction = 80
+			heatProduction = 78
 			massMult = 1.0
 			ullage = True
 			pressureFed = False

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -29,8 +29,8 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		%minThrust = 134.3
-		%maxThrust = 134.3
+		%minThrust = 134.8
+		%maxThrust = 134.8
 		%EngineType = LiquidFuel
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = NULL
@@ -65,8 +65,8 @@
 		CONFIG
 		{
 			name = X-405
-			minThrust = 134.3
-			maxThrust = 134.3
+			minThrust = 134.8
+			maxThrust = 134.8
 			heatProduction = 80
 			massMult = 1.0
 			ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -37,7 +37,7 @@
 		@useThrustCurve = False
 		%ullage = True
 		%pressureFed = False
-		%ignitions = 0
+		%ignitions = 1
 
 		!IGNITOR_RESOURCE,*{}
 
@@ -60,7 +60,6 @@
 		engineID = Engine
 		configuration = X-405
 		origMass = 0.192
-		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -71,7 +70,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 0
+			ignitions = 1
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -414,11 +414,11 @@
 			pressureFed = False
 			ignitions = 0
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.05
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.05
+			}
 
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -294,8 +294,6 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		%engineID = MainEngine
-
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
@@ -328,8 +326,8 @@
 	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
 	{
 		@gimbalRange = 5.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 8
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
 	}
 
 	!MODULE[ModuleRCS],*{}
@@ -358,24 +356,26 @@
 		EngineType = LiquidFuel
 		ullage = True
 		pressureFed = False
-		ignitions = 0
+		ignitions = 1
 
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
-			amount = 0.05
+			amount = 0.025
 		}
 
 		PROPELLANT
 		{
 			name = Kerosene
 			ratio = 0.3874
+			DrawGauge = False
 		}
 
 		PROPELLANT
 		{
 			name = LqdOxygen
 			ratio = 0.6126
+			DrawGauge = False
 		}
 
 		PROPELLANT
@@ -402,7 +402,6 @@
 		engineID = TurbopumpExhaust
 		isMaster = False
 		configuration = X-405-Exhaust
-		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -412,7 +411,7 @@
 			heatProduction = 0
 			ullage = True
 			pressureFed = False
-			ignitions = 0
+			ignitions = 1
 
 			IGNITOR_RESOURCE
 			{
@@ -424,7 +423,7 @@
 			{
 				name = Kerosene
 				ratio = 0.3874
-				DrawGauge = True
+				DrawGauge = False
 			}
 
 			PROPELLANT
@@ -455,11 +454,15 @@
 	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet1]]
 	{
 		@gimbalRange = 25.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
 	}
 
 	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet2]]
 	{
 		@gimbalRange = 25.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -256,133 +256,192 @@
 	engineType = RD170
 }
 
-// X-405 (Vanguard)
+//  ==================================================
+//  X-405 Vanguard engine.
+//  ==================================================
+
 @PART[SXTX405]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+
 	@MODEL
 	{
 		@scale = 2.25, 2.25, 2.25
 	}
-	@scale = 1.0
-	%rescaleFactor = 1.0
-	//%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
-	%node_stack_top = 0.0, 0.81, 0, 0.0, 1.0, 0.0, 1
-	%node_stack_bottom = 0.0, -0.723852, 0.0, 0.0, -1.0, 0.0, 1
 
-	@mass = 0.193
-	@maxTemp = 1873.15
+	@scale = 1.0
+	@rescaleFactor = 1.0
+
+	%node_stack_top = 0.0, 0.83, 0, 0.0, 1.0, 0.0, 1
+	%node_stack_bottom = 0.0, -0.723, 0.0, 0.0, -1.0, 0.0, 1
+
+	@mass = 0.192
+	@crashTolerance = 10
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+	%stageOffset = 1
+	%childStageOffset = 1
+	@bulkheadProfiles = size1
+
+	%engineType = X405
+	%engineTypeMult = 1
+	%ignoreMass = False
+	%massOffset = 0
+
+	//  Main engine.
+
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
-		%maxThrust = 133.8
-		%minThrust = 133.8
-		engineID = Engine
-		%heatProduction = 80
-		@atmosphereCurve
-		{
-			@key,0 = 0 270
-			@key,1 = 1 248
-		}
+		%engineID = MainEngine
+
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = Kerosene
 			@ratio = 0.3874
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
 			@ratio = 0.6126
 		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
+
+		PROPELLANT
 		{
-			name = ElectricCharge
-			amount = 0.5
+			name = HTP
+			ratio = 0.02
+			ignoreForIsp = True
+			DrawGauge = False
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 270
+			@key,1 = 1 248
 		}
 	}
-	MODULE // this is the turbopump exhaust
+
+	//  Main engine gimbal module.
+
+	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
 	{
-		name = ModuleEnginesRF
-		engineID = Exhaust
+		@gimbalRange = 5.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 8
+	}
+
+	!MODULE[ModuleRCS],*{}
+}
+
+//  ==================================================
+//  X-405 Vanguard engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[SXTX405]:AFTER[RealismOverhaulEngines]
+{
+	// Turbopump exhausts.
+
+	MODULE
+	{
+		name = ModuleEngines
+		engineID = TurbopumpExhaust
 		thrustVectorTransformName = fxPointA
 		exhaustDamage = False
 		ignitionThreshold = 0.1
 		minThrust = 1
 		maxThrust = 1
 		heatProduction = 0
-		fxOffset = 0, 0, 0.125
-		atmosphereCurve
-		{
-			key = 0 270
-			key = 1 248
-		}
-		PROPELLANT
-		{
-			name = Kerosene
-			ratio = 0.3874
-		}
-		PROPELLANT
-		{
-			name = LqdOxygen
-			ratio = 0.6126
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
+		EngineType = LiquidFuel
+		ullage = True
+		pressureFed = False
+		ignitions = 0
+
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
 			amount = 0.05
 		}
+
+		PROPELLANT
+		{
+			name = Kerosene
+			ratio = 0.3874
+		}
+
+		PROPELLANT
+		{
+			name = LqdOxygen
+			ratio = 0.6126
+		}
+
+		PROPELLANT
+		{
+			name = HTP
+			ratio = 0.02
+			ignoreForIsp = True
+			DrawGauge = False
+		}
+
+		atmosphereCurve
+		{
+			key = 0 270
+			key = 1 248
+		}
 	}
-	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]] // engine
-	{
-		@gimbalRange = 5.0
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 8
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	//@MODULE[ModuleJettison],*
-	//{
-		//@bottomNodeName = shroud
-	//}
-	!MODULE[ModuleEngineConfigs] {}
-	engineType = X405 //FIXME: migrate more stuff into global config?
-	MODULE // configs for the turbopump exhaust
+
+	// Turbopump exhausts engine configuration.
+
+	MODULE
 	{
 		name = ModuleEngineConfigs
-		type = ModuleEnginesFX
-		engineID = Exhaust
+		type = ModuleEngines
+		engineID = TurbopumpExhaust
 		isMaster = False
-		modded = false
 		configuration = X-405-Exhaust
+		literalZeroIgnitions = True
+
 		CONFIG
 		{
 			name = X-405-Exhaust
 			minThrust = 1
 			maxThrust = 1
 			heatProduction = 0
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.05
+            }
+
 			PROPELLANT
 			{
 				name = Kerosene
 				ratio = 0.3874
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
 				ratio = 0.6126
+				DrawGauge = False
 			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.02
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
 			atmosphereCurve
 			{
 				key = 0 270
@@ -390,23 +449,17 @@
 			}
 		}
 	}
-	// gimbals for the turbopump exhaust
+
+	// Setup the gimbals for the turbopump exhausts.
+
 	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet1]]
 	{
-		@gimbalRange = 25
-	}
-	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet2]]
-	{
-		@gimbalRange = 25
+		@gimbalRange = 25.0
 	}
 
-	!MODULE[ModuleRCS]
+	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet2]]
 	{
-	}
-	@MODULE[FXModuleLookAtConstraint]
-	{
-		!CONSTRAINLOOKFX:HAS[#targetName[jetmark1]] {}
-		!CONSTRAINLOOKFX:HAS[#targetName[jetmark2]] {}
+		@gimbalRange = 25.0
 	}
 }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTX405.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTX405.cfg
@@ -1,28 +1,56 @@
-@PART[SXTX405]:FOR[RealPlume]:NEEDS[SmokeScreen] // X-405
+//  ==================================================
+//  X-405 Vanguard engine plume setup.
+//  ==================================================
+
+@PART[SXTX405]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]:HAS[#engineID[Engine]]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Lower
-	}
-	@MODULE[ModuleEngines*]:HAS[#engineID[Exhaust]]
-	{
-		%powerEffectName = Solid-Sepmotor
-	}
-	@MODULE[ModuleEngineConfigs],*
-	{
-		%type = ModuleEnginesRF
-	}
-    PLUME //For engine
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[fxPointA]]
+    {
+        %powerEffectName = Solid-Sepmotor
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]:HAS[#configuration[X-405]]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+
+    @MODULE[ModuleEngineConfigs]:HAS[#configuration[X-405-Exhaust]]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Sepmotor
+        }
+    }
+
+    //  Main engine plume setup.
+
+    PLUME
     {
         name = Kerolox-Lower
         transformName = thrustTransform
         flarePosition = 0,0,-0.1
-        flareScale = 0.4
+        flareScale = 0.325
         plumePosition = 0,0,0
-        plumeScale = 0.4
+        plumeScale = 0.325
+        energy = 1.0
+        speed = 0.75
     }
-    PLUME //For exhaust
+
+    //  Turbopump exhaust plume setup.
+
+    PLUME
     {
         name = Solid-Sepmotor
         transformName = fxPointA
@@ -32,4 +60,3 @@
         speed = 0.5
     }
 }
-


### PR DESCRIPTION
**Change log:**

* Add some web sources to the X-405 global engine config.
* Add a default engine category.
* Add some default ModuleEngines patching (were part of the SXT X-405 part config).
* Add a template gimbal module (patches the main engine gimbal module).
* Add the missing HTP turbopump requirement and engine ignitor.
* ~~The engine can now only be ignited on the ground.~~
* Tweak the positioning of the SXT X-405 attachment nodes.
* Separate the SXT X-405 engine patching into pre and after RO engine passes (as required by the global engine config).
* Remove some deprecated field and module patches from the SXT X-405 engine.