### PR TITLE
Coatl Aerospace ProbesPlus v0.15RC

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -44,14 +44,14 @@
     @bulkheadProfiles = srf
     @tags ^= :$: communications
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 750000
-		@packetInterval = 1.0
-		@packetSize = 3.84
-		@packetResourceCost = 0.01
-		@antennaCombinable = True
-	}
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 750000
+        @packetInterval = 1.0
+        @packetSize = 3.84
+        @packetResourceCost = 0.01
+        @antennaCombinable = True
+    }
 }
 
 //  ==================================================
@@ -130,13 +130,13 @@
 
     !MODULE[DMModuleScienceAnimateGeneric],*{}
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 500000
-		@packetInterval = 1.0
-		@packetSize = 6.144
-		@packetResourceCost = 0.012
-	}
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 500000
+        @packetInterval = 1.0
+        @packetSize = 6.144
+        @packetResourceCost = 0.012
+    }
 }
 
 //  ==================================================
@@ -214,14 +214,14 @@
     %fuelCrossFeed = False
     @tags ^= :$: communications
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 1500000
-		@packetInterval = 1.0
-		@packetSize = 1.024
-		@packetResourceCost = 0.018
-		@antennaCombinable = True
-	}
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 1500000
+        @packetInterval = 1.0
+        @packetSize = 1.024
+        @packetResourceCost = 0.018
+        @antennaCombinable = True
+    }
 }
 
 //  ==================================================
@@ -296,15 +296,15 @@
     %fuelCrossFeed = False
     @tags ^= :$: communications parabolic
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 3500000
-		@packetInterval = 1.0
-		@packetSize = 2.56
-		@packetResourceCost = 52.5
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 3500000
+        @packetInterval = 1.0
+        @packetSize = 2.56
+        @packetResourceCost = 52.5
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 }
 
 //  ==================================================
@@ -383,15 +383,15 @@
     @bulkheadProfiles = srf, size0
     @tags ^= :$: communications parabolic
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 1000000
-		@packetInterval = 1.0
-		@packetSize = 0.512
-		@packetResourceCost = 0.03
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 1000000
+        @packetInterval = 1.0
+        @packetSize = 0.512
+        @packetResourceCost = 0.03
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 }
 
 //  ==================================================
@@ -474,15 +474,15 @@
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic voyager
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 5.5e12
-		@packetInterval = 1.0
-		@packetSize = 0.384
-		@packetResourceCost = 0.05
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 5.5e12
+        @packetInterval = 1.0
+        @packetSize = 0.384
+        @packetResourceCost = 0.05
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 }
 
 //  ==================================================
@@ -563,15 +563,15 @@
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic pioneer
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 1.75e12
-		@packetInterval = 1.0
-		@packetSize = 0.256
-		@packetResourceCost = 0.024
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 1.75e12
+        @packetInterval = 1.0
+        @packetSize = 0.256
+        @packetResourceCost = 0.024
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 
     @MODULE[ModuleRCS*]
     {
@@ -671,15 +671,15 @@
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic ulysses
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 8.75e9
-		@packetInterval = 1.0
-		@packetSize = 0.768
-		@packetResourceCost = 0.025
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 8.75e9
+        @packetInterval = 1.0
+        @packetSize = 0.768
+        @packetResourceCost = 0.025
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 }
 
 //  ==================================================
@@ -758,13 +758,13 @@
     %fuelCrossFeed = False
     @tags ^= :$: communications
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 2.05e11
-		@packetInterval = 1.0
-		@packetSize = 0.512
-		@packetResourceCost = 0.04
-	}
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 2.05e11
+        @packetInterval = 1.0
+        @packetSize = 0.512
+        @packetResourceCost = 0.04
+    }
 }
 
 //  ==================================================
@@ -812,48 +812,48 @@
 //  4MV spacecraft bus omnidirectional antenna.
 
 //  Dimensions: - m x - m
-//  Inert Mass: 15 Kg  
+//  Inert Mass: 15 Kg
 //  ==================================================
 
 @PART[ca_vor_comm]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
-	@NODE[dishNode]
-	{
+    @NODE[dishNode]
+    {
         @size = 1
-	}
+    }
 
     @attachRules = 0,1,1,0,0,1,1,0
 
-	@title = 4MV Spacecraft Bus Antenna Array
-	@manufacturer = NPO Lavochkin
-	@description = Auxiliary dual omnidirectional conic antennae for short range, low-gain communication. Ideal for orbiter - lander communication links.
+    @title = 4MV Spacecraft Bus Antenna Array
+    @manufacturer = NPO Lavochkin
+    @description = Auxiliary dual omnidirectional conic antennae for short range, low-gain communication. Ideal for orbiter - lander communication links.
 
-	@mass = 0.015
-	@crashTolerance = 8
-	!impactTolerance = NULL
-	@maxTemp = 473.15
+    @mass = 0.015
+    @crashTolerance = 8
+    !impactTolerance = NULL
+    @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-	@bulkheadProfiles = srf
-	@tags ^= :$: communications
+    @bulkheadProfiles = srf
+    @tags ^= :$: communications
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 150000
-		@packetInterval = 1.0
-		@packetSize = 0.512
-		@packetResourceCost = 0.04
-	}
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 150000
+        @packetInterval = 1.0
+        @packetSize = 0.512
+        @packetResourceCost = 0.04
+    }
 }
 
 //  ==================================================
@@ -900,45 +900,45 @@
 //  4MV spacecraft bus parabolic antenna.
 
 //  Dimensions: 1.6 m x - m
-//  Inert Mass: 20 Kg  
+//  Inert Mass: 20 Kg
 //  ==================================================
 
 @PART[ca_vor_dish]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@MODEL
-	{
-		%scale = 1.4, 1.4, 1.4
-	}
+
+    @MODEL
+    {
+        %scale = 1.4, 1.4, 1.4
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 
-	@title = 4MV Spacecraft Bus Parabolic Antenna
-	@manufacturer = NPO Lavochkin
-	@description = The main, high gain, parabolic antenna of the 4MV spacecraft bus, able to cover the inner solar system.
+    @title = 4MV Spacecraft Bus Parabolic Antenna
+    @manufacturer = NPO Lavochkin
+    @description = The main, high gain, parabolic antenna of the 4MV spacecraft bus, able to cover the inner solar system.
 
-	@mass = 0.02
-	@crashTolerance = 8
-	!impactTolerance = NULL
-	@maxTemp = 473.15
+    @mass = 0.02
+    @crashTolerance = 8
+    !impactTolerance = NULL
+    @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     %bulkheadProfiles = size1
-	@tags ^= :$: communications
+    @tags ^= :$: communications
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 3000000000
-		@packetInterval = 1.0
-		packetSize = 1.024
-		@packetResourceCost = 0.025
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 3000000000
+        @packetInterval = 1.0
+        packetSize = 1.024
+        @packetResourceCost = 0.025
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -1,15 +1,16 @@
 //  ==================================================
 //  Sources:
 
-//  Russian Telemetry Systems:        http://mentallandscape.com/V_Telemetry.htm
-//  Voyager 1 (NSSDCA):               http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
-//  Voyager Telecommunications:       http://descanso.jpl.nasa.gov/DPSummary/Descanso4--Voyager_new.pdf
-//  The Voyager Neptune Travel Guide: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19900004096.pdf
-//  The Voyager Spacecraft:           http://www.stickings90.webspace.virginmedia.com/voyager.pdf
-//  Pioneer 11 (NSSDCA):              http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
-//  Pioneer Odyssey (Chapter 3):      http://history.nasa.gov/SP-349/ch3.htm
-//  Astronautix - Pioneer 10-11:      http://astronautix.com/p/pioneer10-11.html
-//  Ulysses Telecoms:                 http://sci.esa.int/ulysses/31016-engineering/?fbodylongid=638
+//  Russian Telemetry Systems:           http://mentallandscape.com/V_Telemetry.htm
+//  Mariner Mars - A Preliminary Report: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700009038.pdf
+//  Voyager 1 (NSSDCA):                  http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
+//  Voyager Telecommunications:          http://descanso.jpl.nasa.gov/DPSummary/Descanso4--Voyager_new.pdf
+//  The Voyager Neptune Travel Guide:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19900004096.pdf
+//  The Voyager Spacecraft:              http://www.stickings90.webspace.virginmedia.com/voyager.pdf
+//  Pioneer 11 (NSSDCA):                 http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
+//  Pioneer Odyssey (Chapter 3):         http://history.nasa.gov/SP-349/ch3.htm
+//  Astronautix - Pioneer 10-11:         http://astronautix.com/p/pioneer10-11.html
+//  Ulysses Telecoms:                    http://sci.esa.int/ulysses/31016-engineering/?fbodylongid=638
 
 //  ==================================================
 //  Conic helical omnidirectional antenna.
@@ -18,7 +19,7 @@
 //  Inert Mass: 3 Kg
 //  ==================================================
 
-@PART[antenna_cone]:FOR[RealismOverhaul]
+@PART[antenna_cone_toggle]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -39,8 +40,18 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: communications
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 750000
+		@packetInterval = 1.0
+		@packetSize = 3.84
+		@packetResourceCost = 0.01
+		@antennaCombinable = True
+	}
 }
 
 //  ==================================================
@@ -49,9 +60,9 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[antenna_cone]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[antenna_cone_toggle]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 75 Mm, power consumption 5 Watts, maximum data rate 3.8 Mbit/sec.
+    @description ^= :$: Maximum effective range 75 Mm, power consumption 5 Watts, maximum data rate 3.8 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -114,9 +125,18 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: communications
 
-    !MODULE[DMModuleScienceAnimateGeneric]{}
+    !MODULE[DMModuleScienceAnimateGeneric],*{}
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 500000
+		@packetInterval = 1.0
+		@packetSize = 6.144
+		@packetResourceCost = 0.012
+	}
 }
 
 //  ==================================================
@@ -127,7 +147,7 @@
 
 @PART[antenna_tv]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 10 Mm, power consumption 8 Watts, maximum data rate 6.1 Mbit/sec.
+    @description ^= :$: Maximum effective range 10 Mm, power consumption 8 Watts, maximum data rate 6.1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -155,7 +175,7 @@
         {
             PacketInterval = 1.0
             PacketSize = 6.144
-            PacketResourceCost = 0.005
+            PacketResourceCost = 0.004
         }
     }
 }
@@ -191,7 +211,17 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: communications
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 1500000
+		@packetInterval = 1.0
+		@packetSize = 1.024
+		@packetResourceCost = 0.018
+		@antennaCombinable = True
+	}
 }
 
 //  ==================================================
@@ -202,7 +232,7 @@
 
 @PART[antenna_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 150 Mm, power consumption 10 Watts, maximum data rate 1 Mbit/sec.
+    @description ^= :$: Maximum effective range 150 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -221,7 +251,7 @@
         IsRTActive = False
         Mode0OmniRange = 0
         Mode1OmniRange = 1500000
-        EnergyCost = 0.01
+        EnergyCost = 0.012
         DeployFxModules = 0
         ProgressFxModules = 1
 
@@ -229,7 +259,7 @@
         {
             PacketInterval = 1.0
             PacketSize = 1.024
-            PacketResourceCost = 0.005
+            PacketResourceCost = 0.006
         }
     }
 }
@@ -263,7 +293,18 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: communications parabolic
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 3500000
+		@packetInterval = 1.0
+		@packetSize = 2.56
+		@packetResourceCost = 52.5
+
+		!UPGRADES,*{}
+	}
 }
 
 //  ==================================================
@@ -274,9 +315,7 @@
 
 @PART[dish_deploy_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 1.75 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
-
-    !MODULE[ModuleDeployableAntenna],*{}
+    @description ^= :$: Maximum effective range 25 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -294,7 +333,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 3500000
+        Mode1DishRange = 50000000
         EnergyCost = 0.035
         DishAngle = 10.0
         MaxQ = 6000
@@ -305,15 +344,15 @@
         {
             PacketInterval = 1.0
             PacketSize = 2.56
-            PacketResourceCost = 0.75
+            PacketResourceCost = 0.0175
         }
     }
 }
 
 //  ==================================================
-//  Small folding parabolic antenna.
+//  Mariner Mars parabolic antenna.
 
-//  Dimensions: 0.8 m x 0.14 m
+//  Dimensions: 1.16 m x - m (extended)
 //  Inert Mass: 35 Kg
 //  ==================================================
 
@@ -323,15 +362,15 @@
 
     @MODEL
     {
-        %scale = 1.6, 1.6, 1.6
+        %scale = 1.25, 1.25, 1.25
     }
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = CA-AD1-R Folding Dish Antenna
+    @title = Mariner Mars HGA
     @manufacturer = Generic
-    @description = A medium gain directional antenna for short range, high bandwidth communications.
+    @description = A high gain parabolic antenna used on the early Mariner Mars series of spacecrafts.
 
     @mass = 0.035
     @crashTolerance = 12
@@ -340,21 +379,30 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    @bulkheadProfiles = size0, srf
+    %fuelCrossFeed = False
+    @bulkheadProfiles = srf, size0
     @tags ^= :$: communications parabolic
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 1000000
+		@packetInterval = 1.0
+		@packetSize = 0.512
+		@packetResourceCost = 0.03
+
+		!UPGRADES,*{}
+	}
 }
 
 //  ==================================================
-//  Small folding parabolic antenna.
+//  Mariner Mars parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[dish_deploy_S2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 1.25 Gm, power consumption 18 Watts, maximum data rate 4.8 Mbit/sec, gain 38 dBi.
-
-    !MODULE[ModuleDeployableAntenna],*{}
+    @description ^= :$: Maximum effective range ~340 Gm, power consumption 20 Watts, maximum data rate 1.62 Mbit/sec, gain 27 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -372,9 +420,9 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 250000
-        EnergyCost = 0.018
-        DishAngle = 28.0
+        Mode1DishRange = 1000000
+        EnergyCost = 0.02
+        DishAngle = 5.25
         MaxQ = 6000
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -382,8 +430,8 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 4.80
-            PacketResourceCost = 0.005
+            PacketSize = 1.62
+            PacketResourceCost = 0.01
         }
     }
 }
@@ -422,8 +470,19 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic voyager
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 5.5e12
+		@packetInterval = 1.0
+		@packetSize = 0.384
+		@packetResourceCost = 0.05
+
+		!UPGRADES,*{}
+	}
 }
 
 //  ==================================================
@@ -434,7 +493,7 @@
 
 @PART[dish_L]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 30 Tm, power consumption 24 Watts, maximum data rate 0.38 Mbit/sec, gain 48 dBi.
+    @description ^= :$: Maximum effective range 30 Tm, power consumption 24 Watts, maximum data rate 380 kbit/sec, gain 48 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -500,8 +559,19 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic pioneer
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 1.75e12
+		@packetInterval = 1.0
+		@packetSize = 0.256
+		@packetResourceCost = 0.024
+
+		!UPGRADES,*{}
+	}
 
     @MODULE[ModuleRCS*]
     {
@@ -531,7 +601,7 @@
 
 @PART[dish_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 15 Tm, power consumption 16 Watts, maximum data rate 0.25 Mbit/sec, gain 34 dBi.
+    @description ^= :$: Maximum effective range 15 Tm, power consumption 16 Watts, maximum data rate 0.25 Mbit/sec, gain 34 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -597,8 +667,19 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic ulysses
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 8.75e9
+		@packetInterval = 1.0
+		@packetSize = 0.768
+		@packetResourceCost = 0.025
+
+		!UPGRADES,*{}
+	}
 }
 
 //  ==================================================
@@ -609,7 +690,7 @@
 
 @PART[dish_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 1 Tm, power consumption 20 Watts, maximum data rate 0.77 Mbit/sec, gain 41 dBi.
+    @description ^= :$: Maximum effective range 1 Tm, power consumption 20 Watts, maximum data rate 0.77 Mbit/sec, gain 41 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -674,7 +755,16 @@
     !impactTolerance = NULL
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: communications
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 2.05e11
+		@packetInterval = 1.0
+		@packetSize = 0.512
+		@packetResourceCost = 0.04
+	}
 }
 
 //  ==================================================
@@ -685,7 +775,7 @@
 
 @PART[dish_tatsujin]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 5 Tm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 40 dBi.
+    @description ^= :$: Maximum effective range 5 Tm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 40 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -704,6 +794,180 @@
         IsRTActive = False
         Mode0DishRange = 0
         Mode1DishRange = 2.05e11
+        EnergyCost = 0.03
+        DishAngle = 1.2
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.512
+            PacketResourceCost = 0.01
+        }
+    }
+}
+
+//  ==================================================
+//  4MV spacecraft bus omnidirectional antenna.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 15 Kg  
+//  ==================================================
+
+@PART[ca_vor_comm]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+		%scale = 1.6, 1.6, 1.6
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@NODE[dishNode]
+	{
+        @size = 1
+	}
+
+    @attachRules = 0,1,1,0,0,1,1,0
+
+	@title = 4MV Spacecraft Bus Antenna Array
+	@manufacturer = NPO Lavochkin
+	@description = Auxiliary dual omnidirectional conic antennae for short range, low-gain communication. Ideal for orbiter - lander communication links.
+
+	@mass = 0.015
+	@crashTolerance = 8
+	!impactTolerance = NULL
+	@maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+	@bulkheadProfiles = srf
+	@tags ^= :$: communications
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 150000
+		@packetInterval = 1.0
+		@packetSize = 0.512
+		@packetResourceCost = 0.04
+	}
+}
+
+//  ==================================================
+//  4MV spacecraft bus omnidirectional antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_vor_comm]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Maximum effective range 150 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 1500000
+        EnergyCost = 0.03
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.512
+            PacketResourceCost = 0.01
+        }
+    }
+}
+
+//  ==================================================
+//  4MV spacecraft bus parabolic antenna.
+
+//  Dimensions: 1.6 m x - m
+//  Inert Mass: 20 Kg  
+//  ==================================================
+
+@PART[ca_vor_dish]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@MODEL
+	{
+		%scale = 1.4, 1.4, 1.4
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+
+	@title = 4MV Spacecraft Bus Parabolic Antenna
+	@manufacturer = NPO Lavochkin
+	@description = The main, high gain, parabolic antenna of the 4MV spacecraft bus, able to cover the inner solar system.
+
+	@mass = 0.02
+	@crashTolerance = 8
+	!impactTolerance = NULL
+	@maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    %bulkheadProfiles = size1
+	@tags ^= :$: communications
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 3000000000
+		@packetInterval = 1.0
+		packetSize = 1.024
+		@packetResourceCost = 0.025
+
+		!UPGRADES,*{}
+	}
+}
+
+//  ==================================================
+//  4MV spacecraft bus parabolic antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_vor_dish]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Maximum effective range ~380 Gm, power consumption Y Watts, maximum data rate Z Mbit/sec, gain W dBi.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0DishRange = 0
+        Mode1DishRange = 1.261e10
         EnergyCost = 0.03
         DishAngle = 1.2
         DeployFxModules = 0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -97,8 +97,8 @@
 //  ==================================================
 //  GPS antenna.
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.55 m x 0.2 m
+//  Inert Mass: 8 Kg
 //  ==================================================
 
 @PART[ca_ant_gps]:FOR[RealismOverhaul]
@@ -115,9 +115,9 @@
 
     @title = CA-KPS Omnidirectional Antenna
     @manufacturer = Generic
-    @description = This antenna provides access to the KerbNet system for very detailed tracking of the spacecraft's position. It can be used as a omni-directional antenna, but it is not very powerful.
+    @description = This antenna provides access to the KerbNet system for very detailed tracking of the spacecraft's position. It can be used as a omnidirectional antenna but it is not very efficient in that role.
 
-    @mass = 1.0
+    @mass = 0.008
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
@@ -139,9 +139,9 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_ant_gps]:FOR[RealismOverhaul]:NEEDS[RemoteTech
+@PART[ca_ant_gps]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range X Mm, power consumption Y Watts, maximum data rate Z Mbit/sec.
+    @description ^= :$: Maximum effective range 30 Mm, power consumption 10 Watts, maximum data rate 4.5 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -159,15 +159,15 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 100000
-        EnergyCost = 0.02
+        Mode1OmniRange = 300000
+        EnergyCost = 0.01
         DeployFxModules = 0
         ProgressFxModules = 1
 
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 6.144
+            PacketSize = 4.48
             PacketResourceCost = 0.005
         }
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -46,7 +46,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 750000
+        @antennaType = RELAY
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 11250
         @packetInterval = 1.0
         @packetSize = 3.84
         @packetResourceCost = 0.01
@@ -62,7 +65,7 @@
 
 @PART[antenna_cone_toggle]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 75 Mm, power consumption 5 Watts, maximum data rate 3.8 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 75 Mm, power consumption 5 Watts, maximum data rate 3.8 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -113,9 +116,9 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = CA-KPS Omnidirectional Antenna
+    @title = CA-GPS Omnidirectional Antenna
     @manufacturer = Generic
-    @description = This antenna provides access to the KerbNet system for very detailed tracking of the spacecraft's position. It can be used as a omnidirectional antenna but it is not very efficient in that role.
+    @description = This antenna provides access to the KerbNet (GPS) system for very detailed tracking of the spacecraft's position. It can be used as a omnidirectional antenna but it is not very efficient in that role.
 
     @mass = 0.008
     @crashTolerance = 8
@@ -126,9 +129,12 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 400000
+        @antennaType = RELAY
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 1800
         @packetInterval = 1.0
-        packetSize = 2.048
+        @packetSize = 2.048
         @packetResourceCost = 0.025
     }
 }
@@ -141,7 +147,7 @@
 
 @PART[ca_ant_gps]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 30 Mm, power consumption 10 Watts, maximum data rate 4.5 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 30 Mm, power consumption 10 Watts, maximum data rate 4.5 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -193,7 +199,6 @@
     @rescaleFactor = 1.0
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
-    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
     @title = CA-A01 Ground Plane Antenna
     @manufacturer = Generic
@@ -211,7 +216,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 500000
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 200
         @packetInterval = 1.0
         @packetSize = 6.144
         @packetResourceCost = 0.012
@@ -226,7 +234,7 @@
 
 @PART[antenna_tv]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 10 Mm, power consumption 8 Watts, maximum data rate 6.1 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 10 Mm, power consumption 8 Watts, maximum data rate 6.1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -279,7 +287,6 @@
     @rescaleFactor = 1.0
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
-    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
     @title = CA-A06 Omnidirectional Antenna
     @manufacturer = Generic
@@ -295,7 +302,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 1500000
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 45000
         @packetInterval = 1.0
         @packetSize = 1.024
         @packetResourceCost = 0.018
@@ -311,7 +321,7 @@
 
 @PART[antenna_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 150 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 150 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -377,7 +387,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 3500000
+        @antennaType = RELAY
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 1250000000
         @packetInterval = 1.0
         @packetSize = 2.56
         @packetResourceCost = 52.5
@@ -394,7 +407,7 @@
 
 @PART[dish_deploy_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 25 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
+    @description ^= :$: Maximum effective range approximately 25 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -431,7 +444,7 @@
 //  ==================================================
 //  Mariner Mars parabolic antenna.
 
-//  Dimensions: 1.16 m x - m (extended)
+//  Dimensions: 1.16 m x 0.5 m (extended)
 //  Inert Mass: 35 Kg
 //  ==================================================
 
@@ -464,7 +477,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 1000000
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 231200000000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.03
@@ -481,7 +497,7 @@
 
 @PART[dish_deploy_S2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range ~340 Gm, power consumption 20 Watts, maximum data rate 1.62 Mbit/sec, gain 27 dBi.
+    @description ^= :$: Maximum effective range approximately 340 Gm, power consumption 20 Watts, maximum data rate 1.62 Mbit/sec, gain 27 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -536,7 +552,6 @@
 
     @node_stack_upper = 0.0, 0.043, 0.0, 0.0, -1.0, 0.0, 1
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
-    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
     @title = Voyager 1 & 2 Parabolic Antenna
     @manufacturer = Ford Aerospace and Communications Corp.
@@ -555,7 +570,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 5.5e12
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 1800000000000000
         @packetInterval = 1.0
         @packetSize = 0.384
         @packetResourceCost = 0.05
@@ -572,7 +590,7 @@
 
 @PART[dish_L]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 30 Tm, power consumption 24 Watts, maximum data rate 380 kbit/sec, gain 48 dBi.
+    @description ^= :$: Maximum effective range approximately 30 Tm, power consumption 24 Watts, maximum data rate 380 kbit/sec, gain 48 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -625,7 +643,6 @@
     @rescaleFactor = 1.0
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
-    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
     @title = Pioneer 10 & 11 Parabolic Antenna
     @manufacturer = TRW
@@ -644,7 +661,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 1.75e12
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 450000000000000
         @packetInterval = 1.0
         @packetSize = 0.256
         @packetResourceCost = 0.024
@@ -680,7 +700,7 @@
 
 @PART[dish_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 15 Tm, power consumption 16 Watts, maximum data rate 0.25 Mbit/sec, gain 34 dBi.
+    @description ^= :$: Maximum effective range approximately 15 Tm, power consumption 16 Watts, maximum data rate 0.25 Mbit/sec, gain 34 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -733,7 +753,6 @@
     @rescaleFactor = 1.0
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
-    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
     @title = Ulysses Parabolic Antenna
     @manufacturer = Astrium GmbH
@@ -752,7 +771,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 8.75e9
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 2000000000000
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.025
@@ -769,7 +791,7 @@
 
 @PART[dish_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 1 Tm, power consumption 20 Watts, maximum data rate 0.77 Mbit/sec, gain 41 dBi.
+    @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 20 Watts, maximum data rate 0.77 Mbit/sec, gain 41 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -839,7 +861,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 2.05e11
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 50000000000000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.04
@@ -854,7 +879,7 @@
 
 @PART[dish_tatsujin]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 5 Tm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 40 dBi.
+    @description ^= :$: Maximum effective range approximately 5 Tm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 40 dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -890,7 +915,7 @@
 //  ==================================================
 //  4MV spacecraft bus omnidirectional antenna.
 
-//  Dimensions: - m x - m
+//  Dimensions: 1.425 m x 1.8 m
 //  Inert Mass: 15 Kg
 //  ==================================================
 
@@ -928,7 +953,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 150000
+        @antennaType = RELAY
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 45000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.04
@@ -943,7 +971,7 @@
 
 @PART[ca_vor_comm]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range 150 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+    @description ^= :$: Maximum effective range approximately 150 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -978,7 +1006,7 @@
 //  ==================================================
 //  4MV-1 spacecraft bus parabolic antenna.
 
-//  Dimensions: 1.6 m x - m
+//  Dimensions: 1.6 m x 0.7 m
 //  Inert Mass: 20 Kg
 //  ==================================================
 
@@ -1011,7 +1039,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 3000000000
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 288800000000
         @packetInterval = 1.0
         packetSize = 1.024
         @packetResourceCost = 0.025
@@ -1028,7 +1059,7 @@
 
 @PART[ca_vor_dish]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range ~380 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain W dBi.
+    @description ^= :$: Maximum effective range approximately 380 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain W dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -1,16 +1,16 @@
 //  ==================================================
 //  Sources:
 
-//  Russian Telemetry Systems:           http://mentallandscape.com/V_Telemetry.htm
-//  Mariner Mars - A Preliminary Report: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700009038.pdf
-//  Voyager 1 (NSSDCA):                  http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
-//  Voyager Telecommunications:          http://descanso.jpl.nasa.gov/DPSummary/Descanso4--Voyager_new.pdf
-//  The Voyager Neptune Travel Guide:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19900004096.pdf
-//  The Voyager Spacecraft:              http://www.stickings90.webspace.virginmedia.com/voyager.pdf
-//  Pioneer 11 (NSSDCA):                 http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
-//  Pioneer Odyssey (Chapter 3):         http://history.nasa.gov/SP-349/ch3.htm
-//  Astronautix - Pioneer 10-11:         http://astronautix.com/p/pioneer10-11.html
-//  Ulysses Telecoms:                    http://sci.esa.int/ulysses/31016-engineering/?fbodylongid=638
+//  Don P. Mitchell - Russian Telemetry Systems:  http://mentallandscape.com/V_Telemetry.htm
+//  NTRS - Mariner Mars - A Preliminary Report:   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700009038.pdf
+//  NTRS - Mariner Mars Telecommunication System: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720017542.pdf
+//  NSSDCA - Voyager 1 spacecraft:                http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
+//  JPL - Voyager Telecommunications:             http://descanso.jpl.nasa.gov/DPSummary/Descanso4--Voyager_new.pdf
+//  NTRS - The Voyager Neptune Travel Guide:      http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19900004096.pdf
+//  NSSDCA - Pioneer 11 spacecraft:               http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
+//  NASA - Pioneer Odyssey (Chapter 3):           http://history.nasa.gov/SP-349/ch3.htm
+//  Encyclopedia Astronautica - Pioneer 10-11:    http://astronautix.com/p/pioneer10-11.html
+//  ESA - Ulysses Telecoms:                       http://sci.esa.int/ulysses/31016-engineering/?fbodylongid=638
 
 //  ==================================================
 //  Conic helical omnidirectional antenna.
@@ -89,6 +89,85 @@
         {
             PacketInterval = 1.0
             PacketSize = 3.84
+            PacketResourceCost = 0.005
+        }
+    }
+}
+
+//  ==================================================
+//  GPS antenna.
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_ant_gps]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CA-KPS Omnidirectional Antenna
+    @manufacturer = Generic
+    @description = This antenna provides access to the KerbNet system for very detailed tracking of the spacecraft's position. It can be used as a omni-directional antenna, but it is not very powerful.
+
+    @mass = 1.0
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @tags ^= :$: communications
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 400000
+        @packetInterval = 1.0
+        packetSize = 2.048
+        @packetResourceCost = 0.025
+    }
+}
+
+//  ==================================================
+//  GPS antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_ant_gps]:FOR[RealismOverhaul]:NEEDS[RemoteTech
+{
+    @description ^= :$: Maximum effective range X Mm, power consumption Y Watts, maximum data rate Z Mbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 100000
+        EnergyCost = 0.02
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 6.144
             PacketResourceCost = 0.005
         }
     }
@@ -897,7 +976,7 @@
 }
 
 //  ==================================================
-//  4MV spacecraft bus parabolic antenna.
+//  4MV-1 spacecraft bus parabolic antenna.
 
 //  Dimensions: 1.6 m x - m
 //  Inert Mass: 20 Kg
@@ -917,9 +996,9 @@
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 
-    @title = 4MV Spacecraft Bus Parabolic Antenna
+    @title = 4MV-1 Spacecraft Bus Parabolic Antenna
     @manufacturer = NPO Lavochkin
-    @description = The main, high gain, parabolic antenna of the 4MV spacecraft bus, able to cover the inner solar system.
+    @description = The main, high gain, parabolic antenna of the 4MV-1 spacecraft bus, able to cover the inner solar system.
 
     @mass = 0.02
     @crashTolerance = 8
@@ -942,14 +1021,14 @@
 }
 
 //  ==================================================
-//  4MV spacecraft bus parabolic antenna.
+//  4MV-1 spacecraft bus parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[ca_vor_dish]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range ~380 Gm, power consumption Y Watts, maximum data rate Z Mbit/sec, gain W dBi.
+    @description ^= :$: Maximum effective range ~380 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain W dBi.
 
     !MODULE[ModuleDataTransmitter],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -612,7 +612,7 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.56, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.565, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, 0.125, 0.0, 0.0, -1.0, 0.0, 1
 
     @title = 4MV Spacecraft Bus Astrionics

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -1,15 +1,18 @@
 //  ==================================================
 //  Sources:
 
-//  Voyager 1 (NSSDCA):          http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
-//  Voyager Backgrounder:        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
-//  The Voyager Spacecraft:      http://www.stickings90.webspace.virginmedia.com/voyager.pdf
-//  Pioneer 11 (NSSDCA):         http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
-//  Pioneer Odyssey (Chapter 3): http://history.nasa.gov/SP-349/ch3.htm
-//  SSTL-150 Satellite Platform: http://www.sst-us.com/getfile/58b2f67f-44a0-43b3-9922-7ec572838f58
-//  MRO spacecraft parts:        http://mars.nasa.gov/mro/mission/spacecraft/parts/
-//  MAVEN spacecraft overview:   http://lasp.colorado.edu/home/maven/about/spacecraft/
-//  MAVEN spacecraft press kit:  http://lasp.colorado.edu/home/maven/files/2011/02/MAVEN_PressKit_Final.pdf
+//  NSSDCA - Voyager 1:                            http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
+//  NTRS - Voyager Backgrounder:                   http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
+//  The Voyager Spacecraft:                        http://www.stickings90.webspace.virginmedia.com/voyager.pdf
+//  NSSDCA - Pioneer 11:                           http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
+//  NASA - Pioneer Odyssey (Chapter 3):            http://history.nasa.gov/SP-349/ch3.htm
+//  SSTL-150 Satellite Platform:                   http://www.sst-us.com/getfile/58b2f67f-44a0-43b3-9922-7ec572838f58
+//  NASA - MRO spacecraft parts:                   http://mars.nasa.gov/mro/mission/spacecraft/parts/
+//  MAVEN spacecraft overview:                     http://lasp.colorado.edu/home/maven/about/spacecraft/
+//  MAVEN spacecraft press kit:                    http://lasp.colorado.edu/home/maven/files/2011/02/MAVEN_PressKit_Final.pdf
+//  Russian Space Web - Venera 75:                 http://www.russianspaceweb.com/venera75.html
+//  NASA - The Soviet Robotic Exploration Program: https://www.nasa.gov/pdf/643333main_huntress_presentation.pdf
+//  Encyclopedia of Science - Venera Program:      http://www.daviddarling.info/encyclopedia/V/Venera.html
 
 //  ==================================================
 //  SSTL-150 satellite bus.
@@ -51,6 +54,8 @@
 
     @MODULE[ModuleCommand]
     {
+        @hasHibernation = False
+
         @RESOURCE[ElectricCharge]
         {
             @rate = 0.05
@@ -61,6 +66,8 @@
     {
         @SASServiceLevel = 3
         %standalone = True
+
+        !UPGRADE,*{}
     }
 
     @MODULE[ModuleReactionWheel]
@@ -119,7 +126,7 @@
 
     !MODULE[ModuleRTAntenna*],*{}
 
-    MODULE
+    MODULE:NEEDS[RemoteTech]
     {
         name = ModuleSPU
         IsRTCommandStation = False
@@ -169,6 +176,8 @@
 
     @MODULE[ModuleCommand]
     {
+        @hasHibernation = False
+
         @RESOURCE[ElectricCharge]
         {
             @rate = 0.25
@@ -181,6 +190,8 @@
     {
         %SASServiceLevel = 2
         %standalone = True
+
+        !UPGRADE,*{}
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -193,7 +204,7 @@
         basemass = -1
 
         //  Voyagers did not use batteries due to their long mission lifetime and the use of RTGs for power generation.
-        //  Instead they used capacitor banks (same as with the New Horizons mission) to regulate and stabilize any transient loads.
+        //  Instead, they used capacitor banks (same as with the New Horizons mission) to regulate and stabilize any transient loads.
         //  Electric charge here is just to make it compatible with the other parts (EC generation and depletion).
 
         TANK
@@ -219,7 +230,7 @@
 
     !MODULE[ModuleRTAntenna*],*{}
 
-    MODULE
+    MODULE:NEEDS[RemoteTech]
     {
         name = ModuleSPU
         IsRTCommandStation = False
@@ -272,6 +283,8 @@
 
     @MODULE[ModuleCommand]
     {
+        @hasHibernation = False
+
         @RESOURCE[ElectricCharge]
         {
             @rate = 0.074
@@ -284,6 +297,8 @@
     {
         @SASServiceLevel = 2
         %standalone = True
+
+        !UPGRADE,*{}
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -320,7 +335,7 @@
 
     !MODULE[ModuleRTAntenna*],*{}
 
-    MODULE
+    MODULE:NEEDS[RemoteTech]
     {
         name = ModuleSPU
         IsRTCommandStation = False
@@ -440,7 +455,7 @@
 
     !MODULE[ModuleRTAntenna*],*{}
 
-    MODULE
+    MODULE:NEEDS[RemoteTech]
     {
         name = ModuleSPU
         IsRTCommandStation = False
@@ -448,4 +463,207 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Venera lander bus.
+
+//  Dimensions: - m x - m
+//  Gross Mass: 660 Kg
+//  ==================================================
+
+@PART[ca_fom_lander]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@MODEL
+	{
+		%scale = 1.4, 1.4, 1.4
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 1.525, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+
+	@title = Venera Lander Bus
+	@manufacturer = NPO Lavochkin
+	@description = The Venera 9 (4V-1) through Venera 14 (4V-1M) landers. First human made objects to land and return images from another planetary body. Designed to survive rough landings in extreme temperature and pressure environments.
+
+	@mass = 0.66
+	@crashTolerance = 16
+	@maxTemp = 873.15
+    %skinMaxTemp = 973.15
+	!explosionPotential = NULL
+	@bulkheadProfiles = size2
+	@tags ^= :$: avionics bus
+    %gTolerance = 450
+
+	@MODULE[ModuleCommand]
+	{
+		@hasHibernation = False
+
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.08
+		}
+	}
+
+	!MODULE[ModuleReactionWheel],*{}
+
+	@MODULE[ModuleSAS]
+	{
+		@SASServiceLevel = 0
+
+		!UPGRADES,*{}
+	}
+
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 5500000
+		@optimumRange = 55000
+		@packetInterval = 1.0
+		@packetSize = 0.256
+		@packetResourceCost = 0.04
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 250
+        basemass = -1
+
+        //  Batteries 500 Wh.
+        //  Supports the lander bus for a duration of at least 3 hours (descent: 1 hour, surface operations: >2 hours).
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 1800
+            maxAmount = 1800
+        }
+    }
+
+	!RESOURCE,*{}
+}
+
+//  ==================================================
+//  Venera lander bus.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_fom_lander]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Integrated communications antenna with a maximum effective range of 750 km, power consumption 30 Watts and a maximum data rate of 256 kbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 750000
+        EnergyCost = 0.03
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.256
+            PacketResourceCost = 0.01
+        }
+    }
+}
+
+//  ==================================================
+//  4MV spacecraft bus GNC system.
+
+//  Dimensions: 2.35 m x - m
+//  Gross Mass: 800 Kg
+//  ==================================================
+
+@PART[ca_vor_core]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@MODEL
+	{
+        %scale = 1.6, 1.6, 1.6
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.56, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, 0.125, 0.0, 0.0, -1.0, 0.0, 1
+	
+	@title = 4MV Spacecraft Bus Astrionics
+	@manufacturer = NPO Lavochkin
+	@description = The fourth generation of the MV common spacecraft bus. Offers improved standardized astrionics, propulsion system and telecommunications for a wide range of uncrewed missions.
+
+	@mass = 0.8
+	@crashTolerance = 8
+	@maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	!explosionPotential = NULL
+	@bulkheadProfiles = size1, size2
+	@tags ^= :$: astrionics avionics
+	
+	@MODULE[ModuleCommand]
+	{
+		@hasHibernation = False
+
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.2
+		}
+	}
+
+	!MODULE[ModuleReactionWheel],*{}
+
+	@MODULE[ModuleSAS]
+	{
+		@SASServiceLevel = 2
+
+		!UPGRADES,*{}
+	}
+
+	!MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 150
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 15840
+            maxAmount = 15840
+        }
+    }
+
+	!RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -7,8 +7,8 @@
 //  NSSDCA - Pioneer 11:                           http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
 //  NASA - Pioneer Odyssey (Chapter 3):            http://history.nasa.gov/SP-349/ch3.htm
 //  SSTL-150 Satellite Platform:                   http://www.sst-us.com/getfile/58b2f67f-44a0-43b3-9922-7ec572838f58
-//  NASA - MRO spacecraft parts:                   http://mars.nasa.gov/mro/mission/spacecraft/parts/
-//  MAVEN spacecraft overview:                     http://lasp.colorado.edu/home/maven/about/spacecraft/
+//  NASA - MRO spacecraft parts:                   http://mars.nasa.gov/mro/mission/spacecraft/parts
+//  MAVEN spacecraft overview:                     http://lasp.colorado.edu/home/maven/about/spacecraft
 //  MAVEN spacecraft press kit:                    http://lasp.colorado.edu/home/maven/files/2011/02/MAVEN_PressKit_Final.pdf
 //  Russian Space Web - Venera 75:                 http://www.russianspaceweb.com/venera75.html
 //  NASA - The Soviet Robotic Exploration Program: https://www.nasa.gov/pdf/643333main_huntress_presentation.pdf

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -140,7 +140,7 @@
 //  Voyager 1 & 2 spacecraft bus.
 
 //  Dimensions: 1.78 m x 0.8 m
-//  Gross Mass: 535 Kg
+//  Gross Mass: 510 Kg
 //  ==================================================
 
 @PART[torekka]:FOR[RealismOverhaul]
@@ -162,7 +162,7 @@
     @manufacturer = Jet Propulsion Laboratory (JPL)
     @description = Avionics and control unit for the Voyager deep space probes.
 
-    @mass = 0.43
+    @mass = 0.405
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -468,7 +468,7 @@
 //  ==================================================
 //  Venera lander bus.
 
-//  Dimensions: - m x - m
+//  Dimensions: 1.65 m x 1.5 m
 //  Gross Mass: 660 Kg
 //  ==================================================
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -475,57 +475,57 @@
 @PART[ca_fom_lander]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@MODEL
-	{
-		%scale = 1.4, 1.4, 1.4
-	}
+
+    @MODEL
+    {
+        %scale = 1.4, 1.4, 1.4
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
-	@node_stack_top = 0.0, 1.525, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.525, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 
-	@title = Venera Lander Bus
-	@manufacturer = NPO Lavochkin
-	@description = The Venera 9 (4V-1) through Venera 14 (4V-1M) landers. First human made objects to land and return images from another planetary body. Designed to survive rough landings in extreme temperature and pressure environments.
+    @title = Venera Lander Bus
+    @manufacturer = NPO Lavochkin
+    @description = The Venera 9 (4V-1) through Venera 14 (4V-1M) landers. First human made objects to land and return images from another planetary body. Designed to survive rough landings in extreme temperature and pressure environments.
 
-	@mass = 0.66
-	@crashTolerance = 16
-	@maxTemp = 873.15
+    @mass = 0.66
+    @crashTolerance = 16
+    @maxTemp = 873.15
     %skinMaxTemp = 973.15
-	!explosionPotential = NULL
-	@bulkheadProfiles = size2
-	@tags ^= :$: avionics bus
+    !explosionPotential = NULL
+    @bulkheadProfiles = size2
+    @tags ^= :$: avionics bus
     %gTolerance = 450
 
-	@MODULE[ModuleCommand]
-	{
-		@hasHibernation = False
+    @MODULE[ModuleCommand]
+    {
+        @hasHibernation = False
 
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.08
-		}
-	}
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.08
+        }
+    }
 
-	!MODULE[ModuleReactionWheel],*{}
+    !MODULE[ModuleReactionWheel],*{}
 
-	@MODULE[ModuleSAS]
-	{
-		@SASServiceLevel = 0
+    @MODULE[ModuleSAS]
+    {
+        @SASServiceLevel = 0
 
-		!UPGRADES,*{}
-	}
+        !UPGRADES,*{}
+    }
 
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 5500000
-		@optimumRange = 55000
-		@packetInterval = 1.0
-		@packetSize = 0.256
-		@packetResourceCost = 0.04
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 5500000
+        !optimumRange = NULL
+        @packetInterval = 1.0
+        @packetSize = 0.256
+        @packetResourceCost = 0.04
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -548,7 +548,7 @@
         }
     }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -603,50 +603,50 @@
 @PART[ca_vor_core]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@MODEL
-	{
+
+    @MODEL
+    {
         %scale = 1.6, 1.6, 1.6
-	}
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
-	@node_stack_top = 0.0, 0.56, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, 0.125, 0.0, 0.0, -1.0, 0.0, 1
-	
-	@title = 4MV Spacecraft Bus Astrionics
-	@manufacturer = NPO Lavochkin
-	@description = The fourth generation of the MV common spacecraft bus. Offers improved standardized astrionics, propulsion system and telecommunications for a wide range of uncrewed missions.
+    @node_stack_top = 0.0, 0.56, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, 0.125, 0.0, 0.0, -1.0, 0.0, 1
 
-	@mass = 0.8
-	@crashTolerance = 8
-	@maxTemp = 473.15
+    @title = 4MV Spacecraft Bus Astrionics
+    @manufacturer = NPO Lavochkin
+    @description = The fourth generation of the MV common spacecraft bus. Offers improved standardized astrionics, propulsion system and telecommunications for a wide range of uncrewed missions.
+
+    @mass = 0.8
+    @crashTolerance = 8
+    @maxTemp = 473.15
     %skinMaxTemp = 473.15
-	!explosionPotential = NULL
-	@bulkheadProfiles = size1, size2
-	@tags ^= :$: astrionics avionics
-	
-	@MODULE[ModuleCommand]
-	{
-		@hasHibernation = False
+    !explosionPotential = NULL
+    @bulkheadProfiles = size1, size2
+    @tags ^= :$: astrionics avionics
 
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.2
-		}
-	}
+    @MODULE[ModuleCommand]
+    {
+        @hasHibernation = False
 
-	!MODULE[ModuleReactionWheel],*{}
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2
+        }
+    }
 
-	@MODULE[ModuleSAS]
-	{
-		@SASServiceLevel = 2
+    !MODULE[ModuleReactionWheel],*{}
 
-		!UPGRADES,*{}
-	}
+    @MODULE[ModuleSAS]
+    {
+        @SASServiceLevel = 2
 
-	!MODULE[ModuleDataTransmitter],*{}
+        !UPGRADES,*{}
+    }
+
+    !MODULE[ModuleDataTransmitter],*{}
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -665,5 +665,5 @@
         }
     }
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -45,6 +45,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     %bulkheadProfiles = size0
     @tags ^= :$: avionics bus
 
@@ -67,7 +68,7 @@
         @SASServiceLevel = 3
         %standalone = True
 
-        !UPGRADE,*{}
+        !UPGRADES,*{}
     }
 
     @MODULE[ModuleReactionWheel]
@@ -169,6 +170,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     @bulkheadProfiles = size1
     @tags ^= :$: avionics jpl
 
@@ -191,7 +193,7 @@
         %SASServiceLevel = 2
         %standalone = True
 
-        !UPGRADE,*{}
+        !UPGRADES,*{}
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -276,6 +278,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     @bulkheadProfiles = size1
     @tags ^= :$: avionics pioneer trw
 
@@ -298,7 +301,7 @@
         @SASServiceLevel = 2
         %standalone = True
 
-        !UPGRADE,*{}
+        !UPGRADES,*{}
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -378,6 +381,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: bus mro osiris spacecraft
 
@@ -496,6 +500,7 @@
     @maxTemp = 873.15
     %skinMaxTemp = 973.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: avionics bus
     %gTolerance = 450
@@ -596,7 +601,7 @@
 //  ==================================================
 //  4MV spacecraft bus GNC system.
 
-//  Dimensions: 2.35 m x - m
+//  Dimensions: 2.35 m x 1.15 m
 //  Gross Mass: 800 Kg
 //  ==================================================
 
@@ -624,6 +629,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     @bulkheadProfiles = size1, size2
     @tags ^= :$: astrionics avionics
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -27,6 +27,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
@@ -39,6 +40,8 @@
         {
             @rate = 0.18
         }
+
+        !UPGRADES,*{}
     }
 }
 
@@ -69,6 +72,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
@@ -81,6 +85,8 @@
         {
             @rate = 0.12
         }
+
+        !UPGRADES,*{}
     }
 }
 
@@ -108,6 +114,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
@@ -120,6 +127,8 @@
         {
             @rate = 0.06
         }
+
+        !UPGRADES,*{}
     }
 }
 
@@ -147,6 +156,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
     @MODULE[ModuleReactionWheel]
@@ -159,6 +169,8 @@
         {
             @rate = 0.048
         }
+
+        !UPGRADES,*{}
     }
 }
 
@@ -182,6 +194,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
+    @tags ^= :$: star tracker
 
     //  Avionics batteries 15 Wh.
     //  Generic power source & sink.
@@ -213,6 +226,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
+    @tags ^= :$: star tracker
 }
 
 //  ==================================================
@@ -609,7 +623,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @exhaustDamage = True
         @minThrust = 0.485
         @maxThrust = 1.618

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -1,8 +1,7 @@
 //  ==================================================
 //  Sources:
 
-//  Blue Canyon Tech RW1 data sheet: http://bluecanyontech.com/wp-content/uploads/2016/03/RW1-Data-Sheet-5.0.pdf
-//  Blue Canyon Tech RW4 data sheet: http://bluecanyontech.com/wp-content/uploads/2016/01/RW4-Data-Sheet-2.0.pdf
+//  Blue Canyon Tech RW series datasheet: http://bluecanyontech.com/wp-content/uploads/2016/07/RW.pdf
 
 //  ==================================================
 //  RW-4A radial reaction wheel assembly.
@@ -236,6 +235,61 @@
     @rescaleFactor = 1.0
 
     @title = CAE-RM01 RCS Thruster Block
+    @manufacturer = Generic
+    @description = An RCS thruster block for attitude control of upper stages or medium - sized spacecraft.
+
+    @mass = 0.008
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @tags ^= :$: attitude block thruster
+
+    %useRcsConfig = RCSBlockHalf
+    %useRcsMass = True
+    %useRcsCostMult = 0.25
+
+    @MODULE[ModuleRCS*]
+    {
+        @thrusterPower = 0.1375
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 254
+            @key,1 = 1 82.08
+        }
+    }
+}
+
+//  ==================================================
+//  CAE-RM02 generic RCS thruster block.
+
+//  Dimensions: 0.49 m x 0.29 m
+//  Inert Mass: 15 Kg
+//  ==================================================
+
+@PART[ca_RM02]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.5, 2.5, 2.5
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CAE-RM02 RCS Thruster Block
     @manufacturer = Generic
     @description = An RCS thruster block for attitude control of upper stages or medium - sized spacecraft.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
@@ -29,16 +29,18 @@
     @crashTolerance = 12
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    %fuelCrossFeed = False
+    %fuelCrossFeed = True
     %stagingIcon = DECOUPLER_HOR
     @bulkheadProfiles = size2
     @tags ^= :$: aeroshell heat shield
     %rescaleCube = True
 
-    @MODULE[ModuleDecouple]
+    @MODULE[ModuleDecouple]:HAS[#explosiveNodeID[top]]
     {
         @ejectionForce = 25
     }
+
+    !MODULE[ModuleDecouple]:HAS[#explosiveNodeID[fomal]]
 
     @DRAG_CUBE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
@@ -1,0 +1,49 @@
+//  ==================================================
+//  Venera aeroshell decoupler.
+
+//  Dimensions: 1.6 m x 0.1 m
+//  Inert Mass: 60 Kg
+//  ==================================================
+
+@PART[ca_vor_sep1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.1, 0.0, 0.0, -1.0, 0.0, 2
+    !node_stack_fomal = NULL
+
+    @title = Venera Reentry Module Decoupler
+    @manufacturer = NPO Lavochkin
+    @description = Attaches the Venera reentry aeroshell to the 4MV spacecraft bus. Note: release it before reentry!
+
+    @mass = 0.06
+    @crashTolerance = 12
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    %stagingIcon = DECOUPLER_HOR
+    @bulkheadProfiles = size2
+    @tags ^= :$: aeroshell heat shield
+    %rescaleCube = True
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 25
+    }
+
+    @DRAG_CUBE
+    {
+        %rescaleX = 1.6
+        %rescaleY = 1.6
+        %rescaleZ = 1.6
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  Venera aeroshell decoupler.
 
-//  Dimensions: 1.6 m x 0.1 m
+//  Dimensions: 1.6 m x 0.2 m
 //  Inert Mass: 60 Kg
 //  ==================================================
 
@@ -11,14 +11,14 @@
 
     @MODEL
     {
-        %scale = 1.6, 1.6, 1.6
+        %scale = 1.6, 3.2, 1.6
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.1, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, -0.005, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.195, 0.0, 0.0, -1.0, 0.0, 2
     !node_stack_fomal = NULL
 
     @title = Venera Reentry Module Decoupler
@@ -27,6 +27,8 @@
 
     @mass = 0.06
     @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = True
@@ -40,12 +42,12 @@
         @ejectionForce = 25
     }
 
-    !MODULE[ModuleDecouple]:HAS[#explosiveNodeID[fomal]]
+    !MODULE[ModuleDecouple]:HAS[#explosiveNodeID[fomal]]{}
 
     @DRAG_CUBE
     {
         %rescaleX = 1.6
         %rescaleY = 1.6
-        %rescaleZ = 1.6
+        %rescaleZ = 3.2
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -794,13 +794,67 @@
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @PhysicsSignificance = 0
-    @bulkheadProfiles = srf
     @radiatorHeadroom = 0.63405
     @tags ^= :$: panel photovoltaic radiator
 
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.55
+
+        !UPGRADES,*{}
+    }
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 100
+        @overcoolFactor = 0.63405
+        @isCoreRadiator = True
+        %parentCoolingOnly = True
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.1
+        }
+    }
+}
+
+//  ==================================================
+//  4MV spacecraft bus solar array & radiator.
+
+//  Dimensions: - m x 1.7 m (extended)
+//  Inert Mass: 100 Kg
+//  ==================================================
+
+@PART[ca_vor_sp2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.225, 1.225, 1.225
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0
+
+    @title = CAE-E300 Solar Array & Thermal Control System
+    @manufacturer = NPO Lavochkin
+    @description = This is an alternate assembly of the 4MV spacecraft bus solar array and thermal control system, featuring only two solar array wings but with the same radiator assembly.
+
+    @mass = 0.1
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @PhysicsSignificance = 0
+    @radiatorHeadroom = 0.63405
+    @tags ^= :$: panel photovoltaic radiator
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 0.275
 
         !UPGRADES,*{}
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -247,12 +247,11 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_magneto = 0.0, 0.293, -0.06, 0.0, 0.5, 0.0, 0
-    @node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, -90.0
+    @node_stack_magneto = 0.0, 0.293, -0.06, 0.0, 1.0, -1.7, 0
     @attachRules = 0,1,0,0,0
 
     @title = Voyager MHW-RTG
-    @manufacturer = Department Of Energy [DOE]
+    @manufacturer = Department Of Energy (DOE)
     @description = The Multihundred-Watt radioisotope thermoelectric generator (MHW-RTG) as found on the Voyager spacecraft.
 
     @mass = 0.107
@@ -784,7 +783,7 @@
 
     @node_attach = 0.0, 0.0, -0.075, 0.0, 0.0, 1.0
 
-    @title = 4MV Spacecraft Bus Solar Array & Thermal Control System
+    @title = 4MV Spacecraft Bus SAW & TCS (Standard)
     @manufacturer = NPO Lavochkin
     @description = The main solar array of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability of 2 kWh. 5.25 m2
 
@@ -821,7 +820,7 @@
 //  ==================================================
 //  4MV spacecraft bus solar array & radiator.
 
-//  Dimensions: - m x 1.7 m (extended)
+//  Dimensions: 5 m x 1.7 m (extended)
 //  Inert Mass: 100 Kg
 //  ==================================================
 
@@ -839,7 +838,7 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0
 
-    @title = CAE-E300 Solar Array & Thermal Control System
+    @title = 4MV Spacecraft Bus SAW & TCS (Small)
     @manufacturer = NPO Lavochkin
     @description = This is an alternate assembly of the 4MV spacecraft bus solar array and thermal control system, featuring only two solar array wings but with the same radiator assembly.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -24,10 +24,10 @@
 //  Mars Express Bus - Simplified User Manual:        http://sci.esa.int/marsexpress/docs/mex_user_manual.pdf
 
 //  ==================================================
-//  Battery (500 Wh).
+//  Battery (1500 Wh).
 
 //  Dimensions: 0.45 m x 0.3 m
-//  Gross Mass: 8 Kg
+//  Gross Mass: 20 Kg
 //  ==================================================
 
 @PART[ca_battery_l]:FOR[RealismOverhaul]
@@ -39,9 +39,9 @@
 
     @title = CA-300i Battery
     @manufacturer = Generic
-    @description = A 500 Wh capacity battery.
+    @description = A generic rechargeable silver-oxide battery. Capacity: <color=orange>1500</color> Wh.
 
-    @mass = 0.008
+    @mass = 0.020
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -58,10 +58,10 @@
 }
 
 //  ==================================================
-//  Battery (170 Wh).
+//  Battery (800 Wh).
 
 //  Dimensions: 0.3 m x 0.175 m
-//  Gross Mass: 3 Kg
+//  Gross Mass: 10 Kg
 //  ==================================================
 
 @PART[ca_battery_m]:FOR[RealismOverhaul]
@@ -70,9 +70,9 @@
 
     @title = CA-100i Battery
     @manufacturer = Generic
-    @description = A 170 Wh capacity battery.
+    @description = A generic rechargeable silver-oxide battery. Capacity: <color=orange>800</color> Wh.
 
-    @mass = 0.003
+    @mass = 0.010
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -83,16 +83,16 @@
 
     @RESOURCE[ElectricCharge]
     {
-        @amount = 600
-        @maxAmount = 600
+        @amount = 2900
+        @maxAmount = 2900
     }
 }
 
 //  ==================================================
-//  Battery (85 Wh).
+//  Battery (440 Wh).
 
 //  Dimensions: 0.15 m x 0.065 m
-//  Gross Mass: 1 Kg
+//  Gross Mass: 5 Kg
 //  ==================================================
 
 @PART[ca_battery_s]:FOR[RealismOverhaul]
@@ -101,9 +101,9 @@
 
     @title = CA-25i Battery
     @manufacturer = Generic
-    @description = A 85 Wh capacity battery. Low profile for easier placement.
+    @description = A generic rechargeable silver-oxide battery. Low profile for easier placement. Capacity: <color=orange>440</color> Wh.
 
-    @mass = 0.001
+    @mass = 0.005
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
@@ -114,8 +114,8 @@
 
     @RESOURCE[ElectricCharge]
     {
-        @amount = 300
-        @maxAmount = 300
+        @amount = 1600
+        @maxAmount = 1600
     }
 }
 
@@ -670,7 +670,7 @@
 
     @title = Mars Odyssey Solar Array Wing (SAW)
     @manufacturer = Generic
-    @description = A very efficient Gallium Arsenide (GaAs) photovoltaic array with an eccentric pivot point to minimize it's stowed footprint. 5.88 m2
+    @description = A very efficient Gallium Arsenide (GaAs) photovoltaic array. The eccentric pivot point minimizes it's stowed footprint. 5.88 m2
 
     @mass = 0.035
     @crashTolerance = 10
@@ -709,7 +709,7 @@
     @rescaleFactor = 1.0
 
     @manufacturer = Generic
-    @description = An alternate photovoltaic system with vastly improved clearance, based on our award-winning E200 Series. 5.46 m2.
+    @description = An alternate photovoltaic system with improved clearance, based on the E200 Series. 5.46 m2.
 
     @mass = 0.04
     @crashTolerance = 10
@@ -725,5 +725,96 @@
         @chargeRate = 1.88
 
         !UPGRADES,*{}
+    }
+}
+
+//  ==================================================
+//  Venera lander bus solar array.
+
+//  Dimensions: 0.9 m x 0.2 m
+//  Inert Mass: 1 Kg
+//  ==================================================
+
+@PART[ca_fom_sp]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.25, 1.25, 1.25
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Venera Lander Bus Solar Array
+    @manufacturer = Generic
+    @description = This small and basic solar panel is used to supply electric power to the Venera lander in a hypothetical seismometer-only version.
+
+    @mass = 0.001
+    @crashTolerance = 10
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    @tags ^= :$: panel
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 0.016
+    }
+}
+
+//  ==================================================
+//  Venera solar array & radiator.
+
+//  Dimensions: 6.7 m x 1.7 m (extended)
+//  Inert Mass: 120 Kg
+//  ==================================================
+
+@PART[ca_vor_sp]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.225, 1.225, 1.225
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, -0.075, 0.0, 0.0, 1.0
+
+    @title = 4MV Spacecraft Bus Solar Array & Thermal Control System
+    @manufacturer = NPO Lavochkin
+    @description = The main solar array of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability of 2 kWh. 5.25 m2
+
+    @mass = 0.12
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @PhysicsSignificance = 0
+    @bulkheadProfiles = srf
+    @radiatorHeadroom = 0.63405
+    @tags ^= :$: panel photovoltaic radiator
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 0.55
+
+        !UPGRADES,*{}
+    }
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 100
+        @overcoolFactor = 0.63405
+        @isCoreRadiator = True
+        %parentCoolingOnly = True
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.1
+        }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -18,7 +18,7 @@
 //  Odyssey Telecommunications:                       http://descanso.jpl.nasa.gov/DPSummary/odyssey_telecom.pdf
 //  Venus Express:                                    http://esamultimedia.esa.int/docs/VENUSEXPRESSLR.pdf
 //  Venus Express - NSSDCA:                           http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=2005-045A
-//  MAVEN spacecraft overview:                        http://lasp.colorado.edu/home/maven/about/spacecraft/
+//  MAVEN spacecraft overview:                        http://lasp.colorado.edu/home/maven/about/spacecraft
 //  MAVEN spacecraft press kit:                       http://lasp.colorado.edu/home/maven/files/2011/02/MAVEN_PressKit_Final.pdf
 //  Mars Express mission overview:                    http://www.asi-proc.it/missions/mex
 //  Mars Express Bus - Simplified User Manual:        http://sci.esa.int/marsexpress/docs/mex_user_manual.pdf

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -45,8 +45,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
@@ -76,8 +76,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
@@ -107,8 +107,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
@@ -748,12 +748,13 @@
 
     @title = Venera Lander Bus Solar Array
     @manufacturer = Generic
-    @description = This small and basic solar panel is used to supply electric power to the Venera lander in a hypothetical seismometer-only version.
+    @description = This small and basic solar panel is used to supply electric power for a hypothetical seismometer-only version of the Venera lander.
 
     @mass = 0.001
     @crashTolerance = 10
     @maxTemp = 573.15
     %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
     @tags ^= :$: panel
 
     @MODULE[ModuleDeployableSolarPanel]
@@ -785,14 +786,13 @@
 
     @title = 4MV Spacecraft Bus SAW & TCS (Standard)
     @manufacturer = NPO Lavochkin
-    @description = The main solar array of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability of 2 kWh. 5.25 m2
+    @description = The main solar array of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability 2 kWh. 5.25 m2.
 
     @mass = 0.12
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @PhysicsSignificance = 0
     @radiatorHeadroom = 0.63405
     @tags ^= :$: panel photovoltaic radiator
 
@@ -840,14 +840,13 @@
 
     @title = 4MV Spacecraft Bus SAW & TCS (Small)
     @manufacturer = NPO Lavochkin
-    @description = This is an alternate assembly of the 4MV spacecraft bus solar array and thermal control system, featuring only two solar array wings but with the same radiator assembly.
+    @description = This is an alternate assembly of the 4MV spacecraft bus solar array and thermal control system, featuring only two solar array wings but with the same radiator assembly. Heat rejection capability 2 kWh. 2.7 m2.
 
     @mass = 0.1
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @PhysicsSignificance = 0
     @radiatorHeadroom = 0.63405
     @tags ^= :$: panel photovoltaic radiator
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -3,6 +3,7 @@
 
 //  Aerojet Rocketdyne bipropellant motors data sheet:   https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
 //  Alternate Wars - Aerojet General Space Engines:      http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  NTRS - Voyager Backgrounder:                         http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
 //  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN:   http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
 //  Russian Space Web - Fregat upper stage:              http://www.russianspaceweb.com/fregat.html
 //  NPO Lavochkin - Fregat upper stage:                  http://www.laspace.ru/rus/fregat_construction.php
@@ -59,7 +60,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0.55
         @maxThrust = 0.55
         @heatProduction = 17.5
@@ -452,7 +452,7 @@
 
     @title = CA-MT170 Propellant Tank (Pressurized)
     @manufacturer = Generic
-    @description = A generic inline high pressure propellant tank for use on medium - sized spacecraft.
+    @description = A generic, inline high pressure propellant tank.
 
     @mass = 0.065
     @crashTolerance = 14
@@ -478,10 +478,10 @@
 }
 
 //  ==================================================
-//  Generic pressurized propellant tank (radial).
+//  Generic pressurized propellant tank (radial cylindrical).
 
 //  Dimensions: 0.425 m x 0.8 m
-//  Inert Mass: 3 Kg
+//  Inert Mass: 15 Kg
 //  ==================================================
 
 @PART[ca_tank_mp_s]:FOR[RealismOverhaul]
@@ -498,9 +498,9 @@
 
     @title = CA-MT10 Propellant Tank (Pressurized)
     @manufacturer = Generic
-    @description = A generic radially attached high pressure propellant tank for use on upper stages or small - sized spacecraft.
+    @description = A generic, radially attached high pressure propellant tank.
 
-    @mass = 0.003
+    @mass = 0.015
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
@@ -516,7 +516,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 75
+        volume = 70
     }
 
     !RESOURCE,*{}
@@ -562,7 +562,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @exhaustDamage = True
         @minThrust = 1.275
         @maxThrust = 1.275
@@ -688,6 +687,136 @@
 }
 
 //  ==================================================
+//  Voyager 1 & 2 propulsion module.
+
+//  Dimensions: 1.7 m x 1.73 m
+//  Gross Mass: 1145 Kg
+
+//  The gross mass value includes the inert mass of the
+//  ACS thrusters and the auxiliary structural parts (23 Kg).
+//  ==================================================
+
+@PART[ca_torekkaPM]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.25, 1.25, 1.25
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_topCollar = 0.0, 0.62, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottomFair125 = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = Voyager Propulsion Module
+    %manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = The Voyager Propulsion Module is powered by a modified version of the STAR-37E solid rocket motor. It includes a Reaction Control System (RCS) for controlling the attitude of the Voyager stack for the duration of the SRM injection burn. Attach it to the bottom of the Voyager truss adapter.
+
+    @mass = 0.106
+    @crashTolerance = 8
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    @bulkheadProfiles = size1
+    @tags = attitude control star solid
+
+    %engineType = Star37E
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
+    @MODULE[ModuleRCS*]:HAS[#thrusterTransformName[RCS_transform]]
+    {
+        @thrusterPower = 0.0225
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 100
+        }
+    }
+
+    @MODULE[ModuleRCS*]:HAS[#thrusterTransformName[RCS_transformL]]
+    {
+        @thrusterPower = 0.445
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 240
+            @key,1 = 1 100
+        }
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        //thrustVectorTransformName = thrust_Transform
+        @minThrust = 68.0
+        @maxThrust = 68.0
+        @heatProduction = 100
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        @allowShutdown = False
+        //EngineType = SolidBooster
+
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 284
+            @key,1 = 1 100
+        }
+    }
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 10
+        @isOmniDecoupler = False
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = HTPB
+        volume = 586.851
+        basemass = -1
+
+        //  HTPB/AP propellant mixture mass ~1038 Kg.
+
+        TANK
+        {
+            name = HTPB
+            amount = 586.851
+            maxAmount = 586.851
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
 //  KTDU-425A engine.
 
 //  Dimensions: 0.7 m x 0.7 m
@@ -728,7 +857,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 9.86
         @maxThrust = 18.89
         @heatProduction = 100
@@ -811,6 +939,49 @@
                 key = 1 158
             }
         }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Generic pressurized propellant tank (radial spherical).
+
+//  Dimensions: 0.27 m x 0.27 m
+//  Inert Mass: 5 Kg
+//  ==================================================
+
+@PART[ca_vor_mptank]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = CAE-MT12 Propellant Tank (Pressurized)
+    @manufacturer = Generic
+    @description = A generic, radially attached high pressure propellant tank.
+
+    @mass = 0.005
+    @crashTolerance = 6
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 673.15
+    @tags ^= :$: pressurized propellant upper vacuum
+
+    //  Fill ratio 85%.
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 9.0
     }
 
     !RESOURCE,*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -92,10 +92,10 @@
 //  R-40 series bipropellant rocket engine.
 
 //  Dimensions: 0.4 m x 0.9 m
-//  Inert Mass: 12 Kg
+//  Inert Mass: 20 Kg
 
 //  The inert mass value includes the mass of the mounting
-//  structure (5 Kg).
+//  structure (10 Kg).
 //  ==================================================
 
 @PART[ca_lahar]:FOR[RealismOverhaul]
@@ -125,7 +125,7 @@
     %engineType = R40
     %engineTypeMult = 1
     %ignoreMass = False
-    %massOffset = 0
+    %massOffset = 0.01
 
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -46,13 +46,13 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
+    @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
-    @tags ^= :$: bipropellant motor
+    @tags ^= :$: bipropellant monopropellant motor
 
     %useRcsConfig = RCSBlockDouble
     %useRcsCostMult = 0.25
@@ -128,8 +128,9 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
+    @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
     @bulkheadProfiles = size1
     @tags ^= :$: aerojet attitude apogee insertion marquardt motor rocketdyne
 
@@ -193,7 +194,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = True
     @bulkheadProfiles = size2
     %stageOffset = 1
     %childStageOffset = 1
@@ -408,8 +410,9 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: inline pressurized propellant upper
 
@@ -458,8 +461,9 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: inline pressurized propellant upper vacuum
 
@@ -504,8 +508,9 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
     @tags ^= :$: pressurized propellant radial upper vacuum
 
     !MODULE[ModuleFuelTanks],*{}
@@ -556,8 +561,9 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
+    @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
     @tags ^= :$: airbus apogee safran
 
     @MODULE[ModuleEngines*]
@@ -721,6 +727,7 @@
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
+    %fuelCrossFeed = True
     @bulkheadProfiles = size1
     @tags = attitude control star solid
 
@@ -767,14 +774,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        //thrustVectorTransformName = thrust_Transform
-        @minThrust = 68.0
-        @maxThrust = 68.0
-        @heatProduction = 100
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
         @allowShutdown = False
-        //EngineType = SolidBooster
 
         @PROPELLANT[SolidFuel]
         {
@@ -852,6 +852,7 @@
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
+    %fuelCrossFeed = True
     @bulkheadProfiles = size0
     @tags ^= :$: bus spacecraft
 
@@ -971,8 +972,9 @@
     @crashTolerance = 6
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
     @tags ^= :$: pressurized propellant upper vacuum
 
     //  Fill ratio 85%.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -717,10 +717,6 @@
     @node_stack_topCollar = 0.0, 0.62, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_bottomFair125 = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
 
-    @title = Voyager Propulsion Module
-    %manufacturer = Jet Propulsion Laboratory (JPL)
-    @description = The Voyager Propulsion Module is powered by a modified version of the STAR-37E solid rocket motor. It includes a Reaction Control System (RCS) for controlling the attitude of the Voyager stack for the duration of the SRM injection burn. Attach it to the bottom of the Voyager truss adapter.
-
     @mass = 0.106
     @crashTolerance = 8
     @maxTemp = 573.15
@@ -819,6 +815,19 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Voyager 1 & 2 propulsion module.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[ca_torekkaPM]:AFTER[RealismOverhaulEngines]
+{
+    @title = Voyager Propulsion Module
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = The Voyager Propulsion Module is powered by a modified version of the STAR-37E solid rocket motor. It includes a Reaction Control System (RCS) for controlling the attitude of the Voyager stack for the duration of the SRM injection burn. Attach it to the bottom of the Voyager truss adapter.
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -1,13 +1,16 @@
 //  ==================================================
 //  Sources:
 
-//  Aerojet Rocketdyne bipropellant motors data sheet: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
-//  Alternate Wars - Aerojet General Space Engines:    http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN: http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
-//  Russian Space Web - Fregat upper stage:            http://www.russianspaceweb.com/fregat.html
-//  NPO Lavochkin - Fregat upper stage:                http://www.laspace.ru/rus/fregat_construction.php
-//  KB KhIMMASH - S5.92 engine:                        http://kbhmisaeva.ru/main.php?id=53
-//  DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY:    http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
+//  Aerojet Rocketdyne bipropellant motors data sheet:   https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+//  Alternate Wars - Aerojet General Space Engines:      http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN:   http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
+//  Russian Space Web - Fregat upper stage:              http://www.russianspaceweb.com/fregat.html
+//  NPO Lavochkin - Fregat upper stage:                  http://www.laspace.ru/rus/fregat_construction.php
+//  KB KhIMMASH - S5.92 engine:                          http://kbhmisaeva.ru/main.php?id=53
+//  Norbert Brügge - Spacecraft-propulsion blocks (KDU): http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
+//  Encyclopedia Astronautica - KTDU-425A engine:        http://www.astronautix.com/k/ktdu-425a.html
+//  NSSDC - The Venera Soviet Missions to Venus:         http://nssdc.gsfc.nasa.gov/planetary/venera.html
+//  DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY:      http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
 
 //  ==================================================
 //  Generic 0.5 kN mono/bipropellant rocket engine.
@@ -81,6 +84,8 @@
     }
 
     !MODULE[ModuleGimbal],*{}
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -108,10 +113,6 @@
     @node_stack_top = 0.0, 0.405, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_bottom = 0.0, -0.525, 0.0, 0.0, -1.0, 0.0, 1
 
-    @title = R-40 Series
-    @manufacturer = Marquardt & Aerojet Rocketdyne
-    @description = A bipropellant rocket motor burning either MMH and MON3 (R-40A/B and R-42) or Hydrazine and MON3 (R-42DM). Used for attitude control, orbital insertion or as an apogee motor.
-
     @mass = 0.012
     @crashTolerance = 10
     %breakingForce = 250
@@ -121,16 +122,13 @@
     @bulkheadProfiles = size1
     @tags ^= :$: aerojet attitude apogee insertion marquardt motor rocketdyne
 
+    %engineType = R40
+    %engineTypeMult = 1
+    %ignoreMass = False
+    %massOffset = 0
+
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 4.0
-        @maxThrust = 4.0
-        @heatProduction = 100
-        %ullage = False
-        %pressureFed = True
-        %ignitions = 50000
-
         @PROPELLANT[LiquidFuel]
         {
             @name = MMH
@@ -151,258 +149,6 @@
         }
 
         !UPGRADES,*{}
-    }
-
-    !MODULE[ModuleGimbal],*{}
-
-    !MODULE[ModuleEngineConfigs],*{}
-
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        configuration = R-40A/B
-        origMass = 0.012
-
-        CONFIG
-        {
-            name = R-40A/B
-            minThrust = 4.0
-            maxThrust = 4.0
-            heatProduction = 100
-            massMult = 1.0
-            description = Attitude control thruster developed for the Space Shuttle.
-
-            ullage = False
-            pressureFed = True
-            ignitions = 50000
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.07
-            }
-
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.5066
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = MON3
-                ratio = 0.4934
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 293
-                key = 1 150
-            }
-        }
-
-        CONFIG
-        {
-            name = R-40A/B-NTO
-            minThrust = 4.0
-            maxThrust = 4.0
-            heatProduction = 100
-            massMult = 1.0
-            description = NTO variant of the baseline R-40A/B thruster.
-
-            ullage = False
-            pressureFed = True
-            ignitions = 50000
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.07
-            }
-
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.5113
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.4887
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 293
-                key = 1 150
-            }
-        }
-
-        CONFIG
-        {
-            name = R-42
-            minThrust = 0.89
-            maxThrust = 0.89
-            heatProduction = 100
-            massMult = 0.7916
-            description = Improved steady - state firing performance.
-
-            ullage = False
-            pressureFed = True
-            ignitions = 134
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.045
-            }
-
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.5066
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = MON3
-                ratio = 0.4934
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 303
-                key = 1 150
-            }
-        }
-
-        CONFIG
-        {
-            name = R-42-NTO
-            minThrust = 0.89
-            maxThrust = 0.89
-            heatProduction = 100
-            massMult = 0.7916
-            description = NTO variant of the baseline R-42 thruster.
-
-            ullage = False
-            pressureFed = True
-            ignitions = 134
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.045
-            }
-
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.5113
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.4887
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 303
-                key = 1 150
-            }
-        }
-
-        CONFIG
-        {
-            name = R-42DM
-            minThrust = 0.89
-            maxThrust = 0.89
-            heatProduction = 100
-            massMult = 1.0416
-            description = Low thrust, high efficiency apogee motor.
-
-            ullage = False
-            pressureFed = True
-            ignitions = 134
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.045
-            }
-
-            PROPELLANT
-            {
-                name = Hydrazine
-                ratio = 0.5863
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = MON3
-                ratio = 0.4137
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 327
-                key = 1 150
-            }
-        }
-
-        CONFIG
-        {
-            name = R-42DM-NTO
-            minThrust = 0.89
-            maxThrust = 0.89
-            heatProduction = 100
-            massMult = 1.0416
-            description = NTO variant of the baseline R-42DM thruster.
-
-            ullage = False
-            pressureFed = True
-            ignitions = 134
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.045
-            }
-
-            PROPELLANT
-            {
-                name = Hydrazine
-                ratio = 0.5908
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.4092
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 327
-                key = 1 150
-            }
-        }
     }
 
     !RESOURCE,*{}
@@ -450,6 +196,8 @@
     %massOffset = 0
     %ignoreMass = True
 
+    !MODULE[ModuleCommand],*{}
+
     MODULE
     {
         name = ModuleCommand
@@ -464,14 +212,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 19.62
-        @maxThrust = 19.62
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 20
-
         @PROPELLANT[LiquidFuel]
         {
             @name = UDMH
@@ -488,7 +228,7 @@
         @atmosphereCurve
         {
             @key,0 = 0 326
-            @key,1 = 1 150
+            @key,1 = 1 158
         }
 
         !UPGRADES,*{}
@@ -496,7 +236,7 @@
 
     @MODULE[ModuleGimbal]
     {
-        @gimbalRange = 5.5
+        @gimbalRange = 5.0
         %useGimbalResponceSpeed = True
         %gimbalResponceSpeed = 16
     }
@@ -664,13 +404,13 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    //  Max fill ratio set at 90%.
+    //  Fill ratio 85%.
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1320
+        volume = 1250
     }
 
     !RESOURCE,*{}
@@ -714,13 +454,13 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    //  Max fill ratio set at 95%.
+    //  Fill ratio 85%.
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 1845
+        volume = 1650
     }
 
     !RESOURCE,*{}
@@ -759,13 +499,13 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
-    //  Max fill ratio set at 90%.
+    //  Fill ratio 85%.
 
     MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 80
+        volume = 75
     }
 
     !RESOURCE,*{}
@@ -930,6 +670,197 @@
                 key = 0 321
                 key = 1 150
             }
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  KTDU-425A engine.
+
+//  Dimensions: 0.7 m x 0.7 m
+//  Inert Mass: 70 Kg
+
+//  Note: Stats similar to the S5.92 engine.
+//  ==================================================
+
+@PART[ca_vor_engine]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_bottom = 0.0, -0.79, 0.0, 0.0, -1.0, 0.0, 0
+
+    @title = KTDU-425A
+    @manufacturer = Isayev Design Bureau (Khimmash)
+    @description = A pump-fed hypergolic vacuum engine designed for use in the 3MV, 4MV and 5MV spacecraft buses of the Mars and Venera probes.
+
+    @mass = 0.07
+    @crashTolerance = 10
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size0
+    @tags ^= :$: bus spacecraft
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+        //thrustVectorTransformName = thrust_Transform
+        @minThrust = 9.86
+        @maxThrust = 18.89
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 50
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = UDMH
+            @ratio = 0.4782
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = NTO
+            @ratio = 0.5218
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 316
+            @key,1 = 1 158
+        }
+
+        !UPGRADES,*{}
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 5.0
+        %useGimbalResponceSpeed = True
+        %gimbalResponceSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = KTDU-425A
+        origMass = 0.07
+
+        CONFIG
+        {
+            name = KTDU-425A
+            minThrust = 9.86
+            maxThrust = 18.89
+            heatProduction = 100
+            gimbalRange = 5.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 50
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.01
+            }
+
+            PROPELLANT[LiquidFuel]
+            {
+                name = UDMH
+                ratio = 0.4782
+                DrawGauge = True
+            }
+
+            PROPELLANT[Oxidizer]
+            {
+                name = NTO
+                ratio = 0.5218
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 315
+                key = 1 158
+            }
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  4MV spacecraft bus propulsion system storage tank.
+
+//  Dimensions: 1.6 m x 1.8 m
+//  Inert Mass: 300 Kg
+
+//  Note: the actual part diameter should be 1.1 m instead
+//  of 1.6 m. The diameter was preserved due to the required
+//  interoperability of the propellant tank with the astrionics
+//  module.
+//  ==================================================
+
+@PART[ca_vor_tank]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.865, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.945, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = 4MV Spacecraft Bus Propellant Tank
+    @manufacturer = NPO Lavochkin
+    @description = The main pressurized propellant storage compartment of the 4MV spacecraft bus.
+
+    @mass = 0.3
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @bulkheadProfiles = size2
+    @tags ^= :$: bus spacecraft
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 980
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 15840
+            maxAmount = 15840
         }
     }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -1,17 +1,18 @@
 //  ==================================================
 //  Sources:
 
-//  Aerojet Rocketdyne bipropellant motors data sheet:   https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
-//  Alternate Wars - Aerojet General Space Engines:      http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//  NTRS - Voyager Backgrounder:                         http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
-//  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN:   http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
-//  Russian Space Web - Fregat upper stage:              http://www.russianspaceweb.com/fregat.html
-//  NPO Lavochkin - Fregat upper stage:                  http://www.laspace.ru/rus/fregat_construction.php
-//  KB KhIMMASH - S5.92 engine:                          http://kbhmisaeva.ru/main.php?id=53
-//  Norbert Brügge - Spacecraft-propulsion blocks (KDU): http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
-//  Encyclopedia Astronautica - KTDU-425A engine:        http://www.astronautix.com/k/ktdu-425a.html
-//  NSSDC - The Venera Soviet Missions to Venus:         http://nssdc.gsfc.nasa.gov/planetary/venera.html
-//  DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY:      http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
+//  Aerojet Rocketdyne - Bipropellant motors datasheet:    https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+//  Alternate Wars - Aerojet General Space Engines:        http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  NTRS - Voyager Backgrounder:                           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
+//  Aerojet Rocketdyne - Monopropellant motors datasheet:  https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf
+//  SLD REACTION CONTROL AND PROPULSION SYSTEM DESIGN:     http://www.dtic.mil/dtic/tr/fulltext/u2/a107560.pdf
+//  Russian Space Web - Fregat upper stage:                http://www.russianspaceweb.com/fregat.html
+//  NPO Lavochkin - Fregat upper stage:                    http://www.laspace.ru/rus/fregat_construction.php
+//  KB KhIMMASH - S5.92 engine:                            http://kbhmisaeva.ru/main.php?id=53
+//  Norbert Brügge - Spacecraft-propulsion blocks (KDU):   http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
+//  Encyclopedia Astronautica - KTDU-425A engine:          http://www.astronautix.com/k/ktdu-425a.html
+//  NSSDC - The Venera Soviet Missions to Venus:           http://nssdc.gsfc.nasa.gov/planetary/venera.html
+//  AIAA - DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY: http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
 
 //  ==================================================
 //  Generic 0.5 kN mono/bipropellant rocket engine.
@@ -19,11 +20,10 @@
 //  Dimensions: 0.29 m x 0.25 m
 //  Inert Mass: 8 Kg
 
-//  Similar to the main engine that was used on the
-//  Mariner Mars series of spacecrafts.
-
-//  The gimbal range value of the jet vanes is completely
-//  hypothetical.
+//  * Similar to the main engine that was used on the
+//    Mariner Mars series of spacecrafts.
+//  * The gimbal range value of the jet vanes is
+//    completely hypothetical.
 //  ==================================================
 
 @PART[ca_jib]:FOR[RealismOverhaul]
@@ -731,10 +731,12 @@
     @bulkheadProfiles = size1
     @tags = attitude control star solid
 
-    %engineType = Star37E
+    %engineType = Star-37E
     %engineTypeMult = 1
     %ignoreMass = False
     %massOffset = 0
+
+    //  MR-106E ACS thrusters for roll control.
 
     @MODULE[ModuleRCS*]:HAS[#thrusterTransformName[RCS_transform]]
     {
@@ -749,10 +751,13 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 250
-            @key,1 = 1 100
+            @key,0 = 0 235
+            @key,1 = 1 80
         }
     }
+
+    //  MR-104A ACS thrusters for yaw and pitch control and
+    //  as vernier thrusters (injection velocity trimming).
 
     @MODULE[ModuleRCS*]:HAS[#thrusterTransformName[RCS_transformL]]
     {
@@ -767,8 +772,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 240
-            @key,1 = 1 100
+            @key,0 = 0 239
+            @key,1 = 1 80
         }
     }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -1027,7 +1027,7 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.865, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.895, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, -0.912, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = 4MV-1/2 Spacecraft Bus Propellant Tank

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -17,6 +17,12 @@
 
 //  Dimensions: 0.29 m x 0.25 m
 //  Inert Mass: 8 Kg
+
+//  Similar to the main engine that was used on the
+//  Mariner Mars series of spacecrafts.
+
+//  The gimbal range value of the jet vanes is completely
+//  hypothetical.
 //  ==================================================
 
 @PART[ca_jib]:FOR[RealismOverhaul]
@@ -33,7 +39,7 @@
 
     @title = Generic 0.5 kN Thruster
     @manufacturer = Generic
-    @description = A generic mono/bipropellant rocket motor. Can be configured within a great range of propellants.
+    @description = A generic mono/bipropellant rocket motor. Can be configured within a great range of propellants. Includes thrust vectoring control via jet vanes.
 
     @mass = 0.008
     @crashTolerance = 12
@@ -65,7 +71,7 @@
         IGNITOR_RESOURCE
         {
             name = ElectricCharge
-            amount = 0.0075
+            amount = 0.025
         }
 
         @PROPELLANT[MonoPropellant]
@@ -83,7 +89,12 @@
         !UPGRADES,*{}
     }
 
-    !MODULE[ModuleGimbal],*{}
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 2.5
+        %useGimbalResponceSpeed = True
+        %gimbalResponseSpeed = 16
+    }
 
     !RESOURCE,*{}
 }
@@ -237,8 +248,8 @@
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 5.0
-        %useGimbalResponceSpeed = True
-        %gimbalResponceSpeed = 16
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
     }
 
     @MODULE[ModuleRCS*]
@@ -702,7 +713,7 @@
 
     @title = KTDU-425A
     @manufacturer = Isayev Design Bureau (Khimmash)
-    @description = A pump-fed hypergolic vacuum engine designed for use in the 3MV, 4MV and 5MV spacecraft buses of the Mars and Venera probes.
+    @description = A gas generator hypergolic vacuum engine designed for use in the 3MV, 4MV and 5MV spacecraft buses of the Mars and Venera probes.
 
     @mass = 0.07
     @crashTolerance = 10
@@ -718,7 +729,6 @@
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
-        //thrustVectorTransformName = thrust_Transform
         @minThrust = 9.86
         @maxThrust = 18.89
         @heatProduction = 100
@@ -807,7 +817,7 @@
 }
 
 //  ==================================================
-//  4MV spacecraft bus propulsion system storage tank.
+//  4MV-1/2 spacecraft bus propulsion system storage tank.
 
 //  Dimensions: 1.6 m x 1.8 m
 //  Inert Mass: 300 Kg
@@ -831,11 +841,11 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 0.865, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.945, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.912, 0.0, 0.0, -1.0, 0.0, 2
 
-    @title = 4MV Spacecraft Bus Propellant Tank
+    @title = 4MV-1/2 Spacecraft Bus Propellant Tank
     @manufacturer = NPO Lavochkin
-    @description = The main pressurized propellant storage compartment of the 4MV spacecraft bus.
+    @description = The main pressurized propellant storage compartment of the 4MV-1/2 spacecraft bus.
 
     @mass = 0.3
     @crashTolerance = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -247,7 +247,7 @@
     %skinMaxTemp = 473.15
     @tags ^= :$: imaging soil surface temperature themis
 
-    !MODULE[ModuleResourceScanner]{}
+    !MODULE[ModuleResourceScanner],*{}
 }
 
 //  ==================================================
@@ -435,6 +435,7 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: flux infrared radiometer soil surface thermometer
 }
 
@@ -465,12 +466,87 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: pioneer sensor triaxial
 
-    !MODULE[ModuleResourceScanner]{}
+    !MODULE[ModuleResourceScanner],*{}
 
     @MODULE[DMMagBoomModule]
     {
         @resourceCost = 0.005
     }
+}
+
+//  ==================================================
+//  Vega camera & spectrometer platform.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 80 Kg
+//  ==================================================
+
+@PART[ca_vor_camera]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+		%scale = 1.6, 1.6, 1.6
+	}
+
+	@scale = 1.0
+	@rescaleFactor = 1.0
+
+	@title = Vega Camera & Spectrometer Platform
+	@manufacturer = Coatl Aerospace East
+	@description =  The VCS assembly mounts a complete orbital imaging package comprised of a Television System (TVS), a Three-Channel Spectrometer (TKS) covering the spectrum from infrared (IR) through ultraviolet (UV) and a Dust Mass Spectrometer (PUMA) for analyzing the dust particle mass and chemical composition. Features a flexible mounting system for both straight and angled mount options.
+
+	@mass = 0.08
+	@crashTolerance = 10
+	@maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    !PhysicsSignificance = NULL
+    %fuelCrossFeed = False
+	@tags ^= :$: dust mass spectrometer telescope
+}
+
+//  ==================================================
+//  Venera magnetometer.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 10 Kg
+//  ==================================================
+
+@PART[ca_vor_mag]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+		%scale = 1.6, 1.6, 1.6
+	}
+
+	@scale = 1.0
+	@rescaleFactor = 1.0
+
+	//node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+
+	@title = Venera Magnetometer 
+	@manufacturer = NPO Lavochkin
+	@description = The magnetometer instruments are used to determine the magnitude and direction of planetary magnetic fields The long boom separates these instruments from any interference caused by magnetic elements in the probe.
+
+	@mass = 0.01
+	@crashTolerance = 8
+	@maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+	@PhysicsSignificance = 0
+	@bulkheadProfiles = size0, srf
+	@tags ^= :$: sensor venera
+
+	!MODULE[ModuleResourceScanner],*{}
+
+	@MODULE[DMMagBoomModule]
+	{
+        @resourceCost = 0.05
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -6,6 +6,7 @@
 //  eoPortal - MetOp program:                                      https://directory.eoportal.org/web/eoportal/satellite-missions/m/metop
 //  eoPortal - MetOp-SG satellite missions:                        https://directory.eoportal.org/web/eoportal/satellite-missions/m/metop-sg
 //  Goddard Space Flight Center - MOLA instrument:                 https://tharsis.gsfc.nasa.gov/MOLA/Background/spec.php
+//  JHAPL - New Horizons Science Payload:                          http://pluto.jhuapl.edu/Mission/Spacecraft/Payload.php
 //  JPL - Stardust NExT SRC:                                       http://stardust.jpl.nasa.gov/mission/capsule.html
 //  JPL - Stardust launch press kit:                               http://www2.jpl.nasa.gov/files/misc/stardust.pdf
 //  NTRS - Aerodynamics of Stardust SRC:                           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040105538.pdf
@@ -15,6 +16,7 @@
 //  JPL - 2001 Mars Odyssey instruments:                           http://mars.jpl.nasa.gov/odyssey/mission/instruments
 //  University of Colorado Boulder - MAVEN IUVS instrument:        http://lasp.colorado.edu/home/maven/files/2014/10/MAVEN_IUVS.pdf
 //  University of Colorado Boulder - Cassini RPWS:                 http://lasp.colorado.edu/~horanyi/graduate_seminar/RPWS.pdf
+//  University of Colorado Boulder - MAVEN SWIA instrument:        http://lasp.colorado.edu/home/maven/science/instrument-package/swia
 //  NTRS - Voyager Backgrounder:                                   http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
 //  NASA - MRO HiRISE instrument test and calibration:             http://marsoweb.nas.nasa.gov/HiRISE/papers/other/IAF_2004_Bergstrom_revH.pdf
 //  NASA - Pioneer 10/11 Odyssey (Chapter 4):                      http://history.nasa.gov/SP-349/ch4.htm
@@ -50,6 +52,8 @@
 
     @mass = 0.46
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -60,7 +64,7 @@
 //  ==================================================
 //  Mars Global Surveyor laser altimeter (MOLA).
 
-//  Dimensions: 0.6 m x 0.33 m
+//  Dimensions: 0.7 m x 0.47 m
 //  Inert Mass: 26 Kg
 //  ==================================================
 
@@ -70,19 +74,20 @@
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.0
+        %scale = 1.22, 1.22, 1.22
     }
 
     %scale = 1.0
     @rescaleFactor = 1.0
-
-    @node_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
 
     @title = Mars Orbiter Laser Altimeter (MOLA)
     @manufacturer = McDonnell Douglas Co.
     @description = The MOLA is one of four instruments onboard the Mars Global Surveyor spacecraft. It fires repetitively a short duration infrared laser pulse towards the surface of the body and measures the time it takes for the pulse to be reflected and recorded by the telescope. That way MOLA can construct a very high definition topographic map.
 
     @mass = 0.026
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -92,8 +97,11 @@
 //  ==================================================
 //  Multi-spectral Imager
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 0.7 m x 0.27 m
+//  Inert Mass: 15 Kg
+
+//  * This instrument is a combination of the ALICE and
+//    RALPH instruments carried by New Horizons.
 //  ==================================================
 
 @PART[ca_TRIXIE]:FOR[RealismOverhaul]
@@ -102,25 +110,24 @@
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.0
+        %scale = 1.25, 1.25, 1.25
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    //@node_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
-    //@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
-
     @title = CA-TRIXIE Multi-spectral Imager
     @manufacturer = Generic
-    @description = The TRIXIE instrument pairs two camera assemblies, one UV spectrometer and one multispectral camera, in order to image and scan multiple wavelengths from Ultraviolet to Near-Infrared. This provides a good way to determine surface properties and features from orbit.
+    @description = The TRIXIE instrument pairs two camera assemblies, one UV spectrometer and one multi-spectral camera, in order to image and scan multiple wavelengths from Ultraviolet to Near-Infrared. This provides a good way to determine surface properties and features from orbit.
 
-    @mass = 1.0
+    @mass = 0.015
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @tags ^= :$: camera multispectral spectrometer
+    @tags ^= :$: camera horizons multispectral spectrometer
 }
 
 //  ==================================================
@@ -136,7 +143,7 @@
 
     @MODEL
     {
-        %scale = 0.75, 0.75, 0.75
+        %scale = 1.0, 1.0, 1.0
     }
 
     @title = CA-SC103 Accelerometer
@@ -145,10 +152,12 @@
 
     @mass = 0.001
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @tags ^= :$: seismic
+    @tags ^= :$: seismometer
 }
 
 //  ==================================================
@@ -164,7 +173,7 @@
 
     @MODEL
     {
-        %scale = 0.75, 0.75, 0.75
+        %scale = 1.0, 1.0, 1.0
     }
 
     @title = CA-SC102 Barometer
@@ -173,6 +182,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -293,7 +304,7 @@
 
     @MODEL
     {
-        %scale = 0.75, 0.75, 0.75
+        %scale = 1.0, 1.0, 1.0
     }
 
     %scale = 1.0
@@ -305,6 +316,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -374,7 +387,7 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @tags ^= :$: imaging soil surface temperature themis
+    @tags ^= :$: mars imaging mro orbiter soil reconnaissance surface temperature themis
 
     !MODULE[ModuleResourceScanner],*{}
 }
@@ -445,7 +458,7 @@
 
     @title = CA-RPWS Radio and Plasma Wave Science
     @manufacturer = Generic
-    @description = The Radio and Plasma Wave Science (RPWS) uses sensitive wideband electric/magnetic monopole and dipole antennae to receive low frequency radio transmissions caused by trapped charged particles (cyclotron waves), electrostatic discharges and whistlers (lighting) and thermal plasma. All these sources can be used to analyze the spectrum and type of the plasma, the electron density and distribution of the magnetospheres and the various lighting effects on the lower atmospheric layers.
+    @description = The Radio and Plasma Wave Science (RPWS) uses sensitive wide band electric/magnetic monopole and dipole antennae to receive low frequency radio transmissions caused by trapped charged particles (cyclotron waves), electrostatic discharges and whistlers (lighting) and thermal plasma. All these sources can be used to analyze the spectrum and type of the plasma, the electron density and distribution of the magnetospheres and the various lighting effects on the lower atmospheric layers.
 
     @mass = 0.038
     @crashTolerance = 8
@@ -501,6 +514,11 @@
 @PART[ca_SWIS]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
 
     @scale = 1.0
     @rescaleFactor = 1.0
@@ -565,7 +583,7 @@
 
     @MODEL
     {
-        %scale = 0.75, 0.75, 0.75
+        %scale = 1.0, 1.0, 1.0
     }
 
     %scale = 1.0
@@ -577,6 +595,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -608,6 +628,8 @@
 
     @mass = 0.005
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -645,7 +667,9 @@
     @description =  The VCS assembly mounts a complete orbital imaging package comprised of a Television System (TVS), a Three-Channel Spectrometer (TKS) covering the spectrum from infrared (IR) through ultraviolet (UV) and a Dust Mass Spectrometer (PUMA) for analyzing the dust particle mass and chemical composition. Features a flexible mounting system for both straight and angled mount options.
 
     @mass = 0.08
-    @crashTolerance = 10
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !PhysicsSignificance = NULL
@@ -683,6 +707,8 @@
 
     @mass = 0.01
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -724,6 +750,8 @@
 
     @mass = 1.38
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -52,7 +52,7 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    @PhysicsSignificance = 0
+    %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: ascat metop scatterometer
 }
@@ -85,7 +85,7 @@
     @mass = 0.026
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    @PhysicsSignificance = 0
+    %fuelCrossFeed = False
     @tags ^= :$: global laser mars surveyor
 }
 
@@ -119,6 +119,7 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: camera multispectral spectrometer
 }
 
@@ -146,6 +147,7 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: seismic
 }
 
@@ -173,6 +175,7 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: atmospheric pressure
 }
 
@@ -205,6 +208,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     %fuelCrossFeed = False
     @tags ^= :$: capsule container return sample
 }
@@ -303,6 +307,7 @@
     @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: gradiometer sensor
 }
 
@@ -368,6 +373,7 @@
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: imaging soil surface temperature themis
 
     !MODULE[ModuleResourceScanner],*{}
@@ -410,6 +416,11 @@
         @startEventGUIName = Deploy IUVS
         @endEventGUIName = Retract IUVS
         @actionGUIName = Toggle IUVS
+    }
+
+    @MODULE[ModuleScienceExperiment],*
+    {
+        !UPGRADES,*{}
     }
 }
 
@@ -640,6 +651,11 @@
     !PhysicsSignificance = NULL
     %fuelCrossFeed = False
     @tags ^= :$: dust mass spectrometer telescope
+
+    @MODULE[ModuleScienceExperiment],*
+    {
+        !UPGRADES,*{}
+    }
 }
 
 //  ==================================================
@@ -670,7 +686,6 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @PhysicsSignificance = 0
     @bulkheadProfiles = size0, srf
     @tags ^= :$: sensor venera
 
@@ -712,7 +727,6 @@
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    @PhysicsSignificance = 0
     @tags ^= :$: sar
 
     !MODULE[ModuleDeployableAntenna],*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -4,7 +4,8 @@
 //  ESA - ASCAT, MetOp’s Advanced Scatterometer:                   http://www.esa.int/esapub/bulletin/bullet102/Gelsthorpe102.pdf
 //  EUMETSAT - ASCAT Product Guide:                                http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_ASCAT_PRODUCT_GUIDE&RevisionSelectionMethod
 //  eoPortal - MetOp program:                                      https://directory.eoportal.org/web/eoportal/satellite-missions/m/metop
-//  Goddard Space Flight Center - MOLA instrument:                 https://tharsis.gsfc.nasa.gov/MOLA/Background/spec.php        
+//  eoPortal - MetOp-SG satellite missions:                        https://directory.eoportal.org/web/eoportal/satellite-missions/m/metop-sg
+//  Goddard Space Flight Center - MOLA instrument:                 https://tharsis.gsfc.nasa.gov/MOLA/Background/spec.php
 //  JPL - Stardust NExT SRC:                                       http://stardust.jpl.nasa.gov/mission/capsule.html
 //  JPL - Stardust launch press kit:                               http://www2.jpl.nasa.gov/files/misc/stardust.pdf
 //  NTRS - Aerodynamics of Stardust SRC:                           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040105538.pdf
@@ -21,8 +22,12 @@
 //  ==================================================
 //  MetOp scatterometer.
 
-//  Dimensions: - m x - m
-//  Inert Mass: 260 Kg
+//  Dimensions: 1.7 m x 3.8 m (retracted)
+//  Inert Mass: 460 Kg
+
+//  The inert mass value is the average between the
+//  original MetOp ASCAT instrument (420 Kg) and the
+//  MetOp-SG (500 Kg).
 //  ==================================================
 
 @PART[ca_H2RS]:FOR[RealismOverhaul]
@@ -31,31 +36,31 @@
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.0
+        %scale = 2.0, 2.0, 2.0
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
-	
-	//node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
-	@title = ASCAT
-	@manufacturer = Airbus Defend and Space
-	@description = The Advanced Scatterometer (ASCAT) is a real-aperture synthetic radar. It transmits a long radio pulse towards the surface of the body and measures the time it takes for the echo to be detected from the receiver. Simpler variants were originally used on the European ERS-1 and 2 and the Envisat Earth meteorological satellites, with evolved designs now being used by the MetOp satellite series.
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
-	@mass = 0.26
-	@crashTolerance = 8
+    @title = ASCAT
+    @manufacturer = Airbus Defend and Space
+    @description = The Advanced Scatterometer (ASCAT) is a real-aperture synthetic radar. It transmits a long radio pulse towards the surface of the body and measures the time it takes for the echo to be detected from the receiver. Simpler variants were originally used on the European ERS-1 and 2 and the Envisat Earth meteorological satellites, with evolved designs now being used by the MetOp satellite series.
+
+    @mass = 0.46
+    @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-	@PhysicsSignificance = 0
-	@bulkheadProfiles = srf
-	@tags ^= :$: ascat metop scatterometer
+    @PhysicsSignificance = 0
+    @bulkheadProfiles = srf
+    @tags ^= :$: ascat metop scatterometer
 }
 
 //  ==================================================
 //  Mars Global Surveyor laser altimeter (MOLA).
 
-//  Dimensions: - m x - m
+//  Dimensions: 0.6 m x 0.33 m
 //  Inert Mass: 26 Kg
 //  ==================================================
 
@@ -70,18 +75,51 @@
 
     %scale = 1.0
     @rescaleFactor = 1.0
-	
-	@node_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
 
-	@title = Mars Orbiter Laser Altimeter (MOLA)
-	@manufacturer = McDonnell Douglas Co.
-	@description = The MOLA is one of four instruments onboard the Mars Global Surveyor spacecraft. It fires repetitively a short duration infrared laser pulse towards the surface of the body and measures the time it takes for the pulse to be reflected and recorded by the telescope. That way MOLA can construct a very high definition topographic map.
+    @node_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
 
-	@mass = 0.026
+    @title = Mars Orbiter Laser Altimeter (MOLA)
+    @manufacturer = McDonnell Douglas Co.
+    @description = The MOLA is one of four instruments onboard the Mars Global Surveyor spacecraft. It fires repetitively a short duration infrared laser pulse towards the surface of the body and measures the time it takes for the pulse to be reflected and recorded by the telescope. That way MOLA can construct a very high definition topographic map.
+
+    @mass = 0.026
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-	@PhysicsSignificance = 0
-	@tags ^= :$: global laser mars surveyor
+    @PhysicsSignificance = 0
+    @tags ^= :$: global laser mars surveyor
+}
+
+//  ==================================================
+//  Multi-spectral Imager
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[ca_TRIXIE]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    //@node_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+    //@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = CA-TRIXIE Multi-spectral Imager
+    @manufacturer = Generic
+    @description = The TRIXIE instrument pairs two camera assemblies, one UV spectrometer and one multispectral camera, in order to image and scan multiple wavelengths from Ultraviolet to Near-Infrared. This provides a good way to determine surface properties and features from orbit.
+
+    @mass = 1.0
+    @crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @tags ^= :$: camera multispectral spectrometer
 }
 
 //  ==================================================
@@ -94,6 +132,11 @@
 @PART[ca_accelerometer]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 0.75, 0.75, 0.75
+    }
 
     @title = CA-SC103 Accelerometer
     @manufacturer = Generic
@@ -116,6 +159,11 @@
 @PART[ca_barometer]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 0.75, 0.75, 0.75
+    }
 
     @title = CA-SC102 Barometer
     @manufacturer = Generic
@@ -238,6 +286,11 @@
 @PART[ca_gravioli]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 0.75, 0.75, 0.75
+    }
 
     %scale = 1.0
     @rescaleFactor = 1.0
@@ -396,13 +449,18 @@
 //  ==================================================
 //  Voyager 1 & 2 Science Boom.
 
-//  Dimensions: 2.5 m x 0.5 m (extended)
+//  Dimensions: 3.8 m x 1.4 m (extended)
 //  Inert Mass: 103 Kg
 //  ==================================================
 
 @PART[ca_sciBoom]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.25, 1.25, 1.25
+    }
 
     @scale = 1.0
     @rescaleFactor = 1.0
@@ -494,6 +552,11 @@
 {
     %RSSROConfig = True
 
+    @MODEL
+    {
+        %scale = 0.75, 0.75, 0.75
+    }
+
     %scale = 1.0
     @rescaleFactor = 1.0
 
@@ -550,7 +613,7 @@
 //  ==================================================
 //  Vega camera & spectrometer platform.
 
-//  Dimensions: - m x - m
+//  Dimensions: 1.4 m x 0.8 m
 //  Inert Mass: 80 Kg
 //  ==================================================
 
@@ -582,7 +645,7 @@
 //  ==================================================
 //  Venera magnetometer.
 
-//  Dimensions: - m x - m
+//  Dimensions: 0.3 m x 4 m (extended)
 //  Inert Mass: 10 Kg
 //  ==================================================
 
@@ -597,8 +660,6 @@
 
     @scale = 1.0
     @rescaleFactor = 1.0
-
-    //node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
     @title = Venera Magnetometer
     @manufacturer = NPO Lavochkin
@@ -624,7 +685,7 @@
 //  ==================================================
 //  Venera Synthetic Aperture Radar (SAR) assembly.
 
-//  Dimensions: - m x - m
+//  Dimensions: 3.5 m x 2.5 m
 //  Inert Mass: 1380 Kg
 //  ==================================================
 
@@ -639,22 +700,22 @@
 
     @scale = 1.0
     @rescaleFactor = 1.0
-	
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 
-	@title = Venera Synthetic Aperture Radar Assembly
-	@manufacturer = NPO Lavochkin
-	@description = The synthetic aperture radar assembly of the Venera 15 and 16 spacecrafts. This surface mapping radar enabled the creation of high resolution topographic maps of Venus, revealing a wealth of information about the geomorphology of the planet.
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 
-	@mass = 1.38
-	@crashTolerance = 8
+    @title = Venera Synthetic Aperture Radar Assembly
+    @manufacturer = NPO Lavochkin
+    @description = The synthetic aperture radar assembly of the Venera 15 and 16 spacecrafts. This surface mapping radar enabled the creation of high resolution topographic maps of Venus, revealing a wealth of information about the geomorphology of the planet.
+
+    @mass = 1.38
+    @crashTolerance = 8
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     @PhysicsSignificance = 0
-	@tags ^= :$: sar
-	
-	!MODULE[ModuleDeployableAntenna],*{}
+    @tags ^= :$: sar
 
-	!MODULE[ModuleDataTransmitter],*{}
+    !MODULE[ModuleDeployableAntenna],*{}
+
+    !MODULE[ModuleDataTransmitter],*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -1,18 +1,88 @@
 //  ==================================================
 //  Sources:
 
-//  Stardust NExT SRC:                          http://stardust.jpl.nasa.gov/mission/capsule.html
-//  Stardust launch press kit:                  http://www2.jpl.nasa.gov/files/misc/stardust.pdf
-//  Aerodynamics of Stardust SRC:               http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040105538.pdf
-//  Genesis SRC Subsystem:                      http://genesismission.jpl.nasa.gov/gm2/spacecraft/sample.html
-//  Genesis SRC Overview:                       https://solarsystem.nasa.gov/docs/6.8_Willcockson.pdf
-//  Cassini Cosmic Dust Analyzer:               http://lasp.colorado.edu/~horanyi/graduate_seminar/Dust_Analyzer.pdf
-//  2001 Mars Odyssey instruments:              http://mars.jpl.nasa.gov/odyssey/mission/instruments
-//  MAVEN IUVS instrument:                      http://lasp.colorado.edu/home/maven/files/2014/10/MAVEN_IUVS.pdf
-//  Cassini RPWS:                               http://lasp.colorado.edu/~horanyi/graduate_seminar/RPWS.pdf
-//  Voyager Backgrounder:                       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
-//  MRO HiRISE instrument test and calibration: http://marsoweb.nas.nasa.gov/HiRISE/papers/other/IAF_2004_Bergstrom_revH.pdf
-//  Pioneer 10/11 Odyssey (Chapter 4):          http://history.nasa.gov/SP-349/ch4.htm
+//  ESA - ASCAT, MetOp’s Advanced Scatterometer:                   http://www.esa.int/esapub/bulletin/bullet102/Gelsthorpe102.pdf
+//  EUMETSAT - ASCAT Product Guide:                                http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_ASCAT_PRODUCT_GUIDE&RevisionSelectionMethod
+//  eoPortal - MetOp program:                                      https://directory.eoportal.org/web/eoportal/satellite-missions/m/metop
+//  Goddard Space Flight Center - MOLA instrument:                 https://tharsis.gsfc.nasa.gov/MOLA/Background/spec.php        
+//  JPL - Stardust NExT SRC:                                       http://stardust.jpl.nasa.gov/mission/capsule.html
+//  JPL - Stardust launch press kit:                               http://www2.jpl.nasa.gov/files/misc/stardust.pdf
+//  NTRS - Aerodynamics of Stardust SRC:                           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040105538.pdf
+//  JPL - Genesis SRC Subsystem:                                   http://genesismission.jpl.nasa.gov/gm2/spacecraft/sample.html
+//  NASA - Genesis SRC Overview:                                   https://solarsystem.nasa.gov/docs/6.8_Willcockson.pdf
+//  University of Colorado Boulder - Cassini Cosmic Dust Analyzer: http://lasp.colorado.edu/~horanyi/graduate_seminar/Dust_Analyzer.pdf
+//  JPL - 2001 Mars Odyssey instruments:                           http://mars.jpl.nasa.gov/odyssey/mission/instruments
+//  University of Colorado Boulder - MAVEN IUVS instrument:        http://lasp.colorado.edu/home/maven/files/2014/10/MAVEN_IUVS.pdf
+//  University of Colorado Boulder - Cassini RPWS:                 http://lasp.colorado.edu/~horanyi/graduate_seminar/RPWS.pdf
+//  NTRS - Voyager Backgrounder:                                   http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
+//  NASA - MRO HiRISE instrument test and calibration:             http://marsoweb.nas.nasa.gov/HiRISE/papers/other/IAF_2004_Bergstrom_revH.pdf
+//  NASA - Pioneer 10/11 Odyssey (Chapter 4):                      http://history.nasa.gov/SP-349/ch4.htm
+
+//  ==================================================
+//  MetOp scatterometer.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 260 Kg
+//  ==================================================
+
+@PART[ca_H2RS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+	
+	//node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+
+	@title = ASCAT
+	@manufacturer = Airbus Defend and Space
+	@description = The Advanced Scatterometer (ASCAT) is a real-aperture synthetic radar. It transmits a long radio pulse towards the surface of the body and measures the time it takes for the echo to be detected from the receiver. Simpler variants were originally used on the European ERS-1 and 2 and the Envisat Earth meteorological satellites, with evolved designs now being used by the MetOp satellite series.
+
+	@mass = 0.26
+	@crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	@PhysicsSignificance = 0
+	@bulkheadProfiles = srf
+	@tags ^= :$: ascat metop scatterometer
+}
+
+//  ==================================================
+//  Mars Global Surveyor laser altimeter (MOLA).
+
+//  Dimensions: - m x - m
+//  Inert Mass: 26 Kg
+//  ==================================================
+
+@PART[ca_HOLA]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+	
+	@node_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+
+	@title = Mars Orbiter Laser Altimeter (MOLA)
+	@manufacturer = McDonnell Douglas Co.
+	@description = The MOLA is one of four instruments onboard the Mars Global Surveyor spacecraft. It fires repetitively a short duration infrared laser pulse towards the surface of the body and measures the time it takes for the pulse to be reflected and recorded by the telescope. That way MOLA can construct a very high definition topographic map.
+
+	@mass = 0.026
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+	@PhysicsSignificance = 0
+	@tags ^= :$: global laser mars surveyor
+}
 
 //  ==================================================
 //  Accelerometer.
@@ -549,4 +619,42 @@
     {
         @resourceCost = 0.05
     }
+}
+
+//  ==================================================
+//  Venera Synthetic Aperture Radar (SAR) assembly.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 1380 Kg
+//  ==================================================
+
+@PART[ca_vor_sar]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+	
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+
+	@title = Venera Synthetic Aperture Radar Assembly
+	@manufacturer = NPO Lavochkin
+	@description = The synthetic aperture radar assembly of the Venera 15 and 16 spacecrafts. This surface mapping radar enabled the creation of high resolution topographic maps of Venus, revealing a wealth of information about the geomorphology of the planet.
+
+	@mass = 1.38
+	@crashTolerance = 8
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
+    @PhysicsSignificance = 0
+	@tags ^= :$: sar
+	
+	!MODULE[ModuleDeployableAntenna],*{}
+
+	!MODULE[ModuleDataTransmitter],*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -488,25 +488,25 @@
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
 
-	@scale = 1.0
-	@rescaleFactor = 1.0
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-	@title = Vega Camera & Spectrometer Platform
-	@manufacturer = Coatl Aerospace East
-	@description =  The VCS assembly mounts a complete orbital imaging package comprised of a Television System (TVS), a Three-Channel Spectrometer (TKS) covering the spectrum from infrared (IR) through ultraviolet (UV) and a Dust Mass Spectrometer (PUMA) for analyzing the dust particle mass and chemical composition. Features a flexible mounting system for both straight and angled mount options.
+    @title = Vega Camera & Spectrometer Platform
+    @manufacturer = NPO Lavochkin
+    @description =  The VCS assembly mounts a complete orbital imaging package comprised of a Television System (TVS), a Three-Channel Spectrometer (TKS) covering the spectrum from infrared (IR) through ultraviolet (UV) and a Dust Mass Spectrometer (PUMA) for analyzing the dust particle mass and chemical composition. Features a flexible mounting system for both straight and angled mount options.
 
-	@mass = 0.08
-	@crashTolerance = 10
-	@maxTemp = 473.15
+    @mass = 0.08
+    @crashTolerance = 10
+    @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !PhysicsSignificance = NULL
     %fuelCrossFeed = False
-	@tags ^= :$: dust mass spectrometer telescope
+    @tags ^= :$: dust mass spectrometer telescope
 }
 
 //  ==================================================
@@ -520,33 +520,33 @@
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
 
-	@scale = 1.0
-	@rescaleFactor = 1.0
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
-	//node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+    //node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
-	@title = Venera Magnetometer 
-	@manufacturer = NPO Lavochkin
-	@description = The magnetometer instruments are used to determine the magnitude and direction of planetary magnetic fields The long boom separates these instruments from any interference caused by magnetic elements in the probe.
+    @title = Venera Magnetometer
+    @manufacturer = NPO Lavochkin
+    @description = The magnetometer instruments are used to determine the magnitude and direction of planetary magnetic fields The long boom separates these instruments from any interference caused by magnetic elements in the probe.
 
-	@mass = 0.01
-	@crashTolerance = 8
-	@maxTemp = 473.15
+    @mass = 0.01
+    @crashTolerance = 8
+    @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-	@PhysicsSignificance = 0
-	@bulkheadProfiles = size0, srf
-	@tags ^= :$: sensor venera
+    @PhysicsSignificance = 0
+    @bulkheadProfiles = size0, srf
+    @tags ^= :$: sensor venera
 
-	!MODULE[ModuleResourceScanner],*{}
+    !MODULE[ModuleResourceScanner],*{}
 
-	@MODULE[DMMagBoomModule]
-	{
+    @MODULE[DMMagBoomModule]
+    {
         @resourceCost = 0.05
-	}
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
@@ -30,5 +30,6 @@
     @breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
     %bulkheadProfiles = size1
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
@@ -1,0 +1,34 @@
+//  ==================================================
+//  Voyager 1 & 2 SRM mounting truss.
+
+//  Dimensions: 1.7 m x 0.8 m
+//  Inert Mass: 10 Kg
+//  ==================================================
+
+@PART[ca_torekka_truss]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.325, 1.5, 1.325
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.42, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.42, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = Voyager Truss Adapter
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = This truss attaches to the bottom of the Voyager bus in order to safely and securely attach it's SRM propulsion module.
+
+    @mass = 0.01
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %bulkheadProfiles = size1
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -155,72 +155,72 @@
 {
     %RSSROConfig = True
 
-	@MODEL
-	{
-		%scale = 1.6, 1.6, 1.6
-	}
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
-	@node_stack_top = 0.0, 0.055, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -0.015, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.055, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.015, 0.0, 0.0, -1.0, 0.0, 2
 
-	@title = Venera Lander Aeroshell (Heat Shield)
-	@manufacturer = NPO Lavochkin
-	@description = This is the bottom piece of the Venera aeroshell. It is coated with ablative material to keep the lander from getting destroyed by the large reentry heat load.
-	
-	@mass = 0.55
-	@crashTolerance = 16
-	@breakingForce = 250
-	@breakingTorque = 250
-	@maxTemp = 573.15
+    @title = Venera Lander Aeroshell (Heat Shield)
+    @manufacturer = NPO Lavochkin
+    @description = This is the bottom piece of the Venera aeroshell. It is coated with ablative material to keep the lander from getting destroyed by the large reentry heat load.
+
+    @mass = 0.55
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
     %skinMaxTemp = 3773.15
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
+    %emissiveConstant = 0.6
+    %thermalMassModifier = 1.0
+    %skinMassPerArea = 4
     %fuelCrossFeed = False
     %stagingIcon = DECOUPLER_HOR
-	@bulkheadProfiles = size2
-	@thermalMassModifier = 1.0
-	@tags ^= :$: aeroshell lander
-	@CoPOffset = 0.0, 1.0, 0.0
-	@CoLOffset = 0.0, -0.15, 0.0
+    @bulkheadProfiles = size2
+    @thermalMassModifier = 1.0
+    @tags ^= :$: aeroshell lander
+    @CoPOffset = 0.0, 1.0, 0.0
+    @CoLOffset = 0.0, -0.15, 0.0
     %gTolerance = 450
 
-	@MODULE[ModuleAblator]
-	{
-		@ablativeResource = Ablator
-		%outputResource = CharredAblator
-		@outputMult = 0.75
-		@lossExp = -40000
-		@lossConst = 15000
-		@pyrolysisLossFactor = 40000
-		@reentryConductivity = 0.01
-		@ablationTempThresh = 500
-	}
+    @MODULE[ModuleAblator]
+    {
+        @ablativeResource = Ablator
+        %outputResource = CharredAblator
+        @outputMult = 0.75
+        @lossExp = -40000
+        @lossConst = 15000
+        @pyrolysisLossFactor = 40000
+        @reentryConductivity = 0.01
+        @ablationTempThresh = 500
+    }
 
-	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
-	{
-		@name = ModuleHeatShield
-		%depletedMaxTemp = 1200
-	}
+    @MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+    {
+        @name = ModuleHeatShield
+        %depletedMaxTemp = 1200
+    }
 
-	@MODULE[ModuleDecouple]
-	{
-		@ejectionForce = 0
-	}
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+    }
 
-	@RESOURCE[Ablator]
-	{
-		@amount = 200
-		@maxAmount = 200
-	}
+    @RESOURCE[Ablator]
+    {
+        @amount = 200
+        @maxAmount = 200
+    }
 
-	RESOURCE
-	{
-		name = CharredAblator
-		amount = 0
-		maxAmount = 150
-	}
+    RESOURCE
+    {
+        name = CharredAblator
+        amount = 0
+        maxAmount = 150
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -2,6 +2,7 @@
 //  Sources:
 
 //  Spacecraft Thermal Control Handbook (Chapter 9): http://matthewwturner.com/uah/IPT2008_summer/baselines/LOW%20Files/Thermal/Spacecraft%20Thermal%20Control%20Handbook/09.pdf
+//  NSSDC - The Venera Soviet Missions to Venus:     http://nssdc.gsfc.nasa.gov/planetary/venera.html
 
 //  ==================================================
 //  Thermal control system (small).
@@ -139,4 +140,87 @@
             @rate = 0.0075
         }
     }
+}
+
+//  ==================================================
+//  Venera heat shield.
+
+//  Dimensions: 2.4 m x - m (with the shroud)
+//  Gross Mass: 750 Kg
+
+//  * Stats similar to the lunar-rated heat shields.
+//  ==================================================
+
+@PART[ca_fom_heatS]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+	@MODEL
+	{
+		%scale = 1.6, 1.6, 1.6
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.055, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -0.015, 0.0, 0.0, -1.0, 0.0, 2
+
+	@title = Venera Lander Aeroshell (Heat Shield)
+	@manufacturer = NPO Lavochkin
+	@description = This is the bottom piece of the Venera aeroshell. It is coated with ablative material to keep the lander from getting destroyed by the large reentry heat load.
+	
+	@mass = 0.55
+	@crashTolerance = 16
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 573.15
+    %skinMaxTemp = 3773.15
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+    %fuelCrossFeed = False
+    %stagingIcon = DECOUPLER_HOR
+	@bulkheadProfiles = size2
+	@thermalMassModifier = 1.0
+	@tags ^= :$: aeroshell lander
+	@CoPOffset = 0.0, 1.0, 0.0
+	@CoLOffset = 0.0, -0.15, 0.0
+    %gTolerance = 450
+
+	@MODULE[ModuleAblator]
+	{
+		@ablativeResource = Ablator
+		%outputResource = CharredAblator
+		@outputMult = 0.75
+		@lossExp = -40000
+		@lossConst = 15000
+		@pyrolysisLossFactor = 40000
+		@reentryConductivity = 0.01
+		@ablationTempThresh = 500
+	}
+
+	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+	{
+		@name = ModuleHeatShield
+		%depletedMaxTemp = 1200
+	}
+
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 0
+	}
+
+	@RESOURCE[Ablator]
+	{
+		@amount = 200
+		@maxAmount = 200
+	}
+
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
+		maxAmount = 150
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -56,10 +56,139 @@
 }
 
 //  ==================================================
+//  Venera drogue parachute.
+
+//  Dimensions: 2.4 m x - m (with the shroud)
+//  Gross Mass: 150 Kg
+
+//  * The inert mass value assumes that the shroud is
+//    not massless and part of the aeroshell structure.
+//  * The part max temperature has been set high due
+//    to an occlusion checker issue.
+//  ==================================================
+
+@PART[ca_fom_drogue]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.6, 1.6, 1.6
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Venera Lander Aeroshell (Drogue Parachute)
+    @manufacturer = NPO Lavochkin
+    @description = This part is the top cover of the Venera atmospheric entry capsule. The parachute pack attaches directly to the Venera lander for deployment after re-entry and before the aeroshell separation. The smaller effective parachute area allows for faster but more harsh landings.
+
+    @mass = 0.15
+    @crashTolerance = 10
+    @maxTemp = 3773.15
+    %skinMaxTemp = 3773.15
+    %fuelCrossFeed = False
+    @stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = PARACHUTES
+    @bulkheadProfiles = size2
+    %rescaleCube = True
+    %gTolerance = 450
+
+    @MODULE[ModuleParachute]
+    {
+        @autoCutSpeed = 0.5
+        @stowedDrag = 0
+        @semiDeployedDrag = 2
+        @fullyDeployedDrag = 250
+        @minAirPressureToOpen = 0.01
+        @clampMinAirPressure = 0.01
+        @deployAltitude = 50000
+        @deploymentSpeed = 5.0
+        @semiDeploymentSpeed = 2.5
+        @chuteMaxTemp = 573.15
+    }
+
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[SEMIDEPLOYED]]
+    {
+        @dragModifier = 4.0
+    }
+
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[DEPLOYED]]
+    {
+        @dragModifier = 12.0
+    }
+
+    @MODULE[ModuleJettison]
+    {
+        @isFairing = True
+        @jettisonedObjectMass = 0.1
+        @jettisonForce = 2.5
+        @jettisonDirection = 0 0 1
+    }
+
+    @DRAG_CUBE
+    {
+        %rescaleX = 1.6
+        %rescaleY = 1.6
+        %rescaleZ = 1.6
+    }
+}
+
+//  ==================================================
+//  Venera drogue parachute.
+
+//  RealChute compatibility.
+//  ==================================================
+
+@PART[ca_fom_drogue]:FOR[RealismOverhaul]:NEEDS[RealChute]
+{
+    !sound_parachute_* = NULL
+
+    @category = none
+
+    !MODULE[ModuleParachute],*{}
+
+    !MODULE[RealChute*],*{}
+
+    MODULE
+    {
+        name = RealChuteModule
+        caseMass = 0.15
+        cutSpeed = 0.5
+        mustGoDown = True
+        deployOnGround = False
+        spareChutes = 0
+        chuteCount = 0
+        stagingEnabled = True
+
+        PARACHUTE
+        {
+            parachuteName = canopy
+            capName = cap
+            preDeploymentAnimation = semiDeploy
+            deploymentAnimation = fullDeploy
+            material = Nylon
+            preDeploymentSpeed = 2.5
+            deploymentSpeed = 5.0
+            preDeployedDiameter = 2.2
+            deployedDiameter = 4.3
+            minIsPressure = False
+            minPressure = 0.01
+            minDeployment = 65000
+            deploymentAlt = 50000
+            cutAlt = 0
+        }
+    }
+}
+
+//  ==================================================
 //  Venera main parachute.
 
 //  Dimensions: 2.4 m x - m (with the shroud)
-//  Inert Mass: 150 Kg
+//  Gross Mass: 150 Kg
 
 //  * The inert mass value assumes that the shroud is
 //    not massless and part of the aeroshell structure.
@@ -81,9 +210,9 @@
 
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 
-    @title = Venera Lander Aeroshell (Parachute Pack)
+    @title = Venera Lander Aeroshell (Main Parachute)
     @manufacturer = NPO Lavochkin
-    @description = This part is the top cover of the Venera atmospheric entry capsule. The parachute attaches directly to the Venera lander for deployment after re-entry and before the aeroshell separation.
+    @description = This part is the top cover of the Venera atmospheric entry capsule. The parachute pack attaches directly to the Venera lander for deployment after re-entry and before the aeroshell separation. The larger effective parachute area allows for slower but more soft landings.
 
     @mass = 0.15
     @crashTolerance = 10
@@ -100,14 +229,14 @@
     @MODULE[ModuleParachute]
     {
         @autoCutSpeed = 0.5
-        @stowedDrag = 0.22
-        @semiDeployedDrag = 1
+        @stowedDrag = 0
+        @semiDeployedDrag = 2
         @fullyDeployedDrag = 500
-        @minAirPressureToOpen = 0.04
-        @clampMinAirPressure = 0.04
-        @deployAltitude = 1000
-        @deploymentSpeed = 1
-        @semiDeploymentSpeed = 1
+        @minAirPressureToOpen = 0.01
+        @clampMinAirPressure = 0.01
+        @deployAltitude = 50000
+        @deploymentSpeed = 5.0
+        @semiDeploymentSpeed = 2.5
         @chuteMaxTemp = 573.15
     }
 
@@ -123,6 +252,7 @@
 
     @MODULE[ModuleJettison]
     {
+        @isFairing = True
         @jettisonedObjectMass = 0.1
         @jettisonForce = 2.5
         @jettisonDirection = 0 0 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -70,70 +70,70 @@
 @PART[ca_fom_parachute]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-	
-	@MODEL
-	{
+
+    @MODEL
+    {
         %scale = 1.6, 1.6, 1.6
-	}
+    }
 
     %scale = 1.0
-	@rescaleFactor = 1.0
+    @rescaleFactor = 1.0
 
-	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
 
-	@title = Venera Lander Aeroshell (Parachute Pack)
-	@manufacturer = NPO Lavochkin
-	@description = This part is the top cover of the Venera atmospheric entry capsule. The parachute attaches directly to the Venera lander for deployment after re-entry and before the aeroshell separation.
+    @title = Venera Lander Aeroshell (Parachute Pack)
+    @manufacturer = NPO Lavochkin
+    @description = This part is the top cover of the Venera atmospheric entry capsule. The parachute attaches directly to the Venera lander for deployment after re-entry and before the aeroshell separation.
 
-	@mass = 0.15
-	@crashTolerance = 10
-	@maxTemp = 3773.15
+    @mass = 0.15
+    @crashTolerance = 10
+    @maxTemp = 3773.15
     %skinMaxTemp = 3773.15
     %fuelCrossFeed = False
-	@stageOffset = 1
+    @stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = PARACHUTES
-	@bulkheadProfiles = size2
+    @bulkheadProfiles = size2
     %rescaleCube = True
     %gTolerance = 450
 
-	@MODULE[ModuleParachute]
-	{
-		@autoCutSpeed = 0.5
-		@stowedDrag = 0.22
-		@semiDeployedDrag = 1
-		@fullyDeployedDrag = 500
-		@minAirPressureToOpen = 0.04
-		@clampMinAirPressure = 0.04
-		@deployAltitude = 1000
-		@deploymentSpeed = 1
-		@semiDeploymentSpeed = 1
-		@chuteMaxTemp = 573.15
-	}
+    @MODULE[ModuleParachute]
+    {
+        @autoCutSpeed = 0.5
+        @stowedDrag = 0.22
+        @semiDeployedDrag = 1
+        @fullyDeployedDrag = 500
+        @minAirPressureToOpen = 0.04
+        @clampMinAirPressure = 0.04
+        @deployAltitude = 1000
+        @deploymentSpeed = 1
+        @semiDeploymentSpeed = 1
+        @chuteMaxTemp = 573.15
+    }
 
-	@MODULE[ModuleDragModifier]:HAS[#dragCubeName[SEMIDEPLOYED]]
-	{
-		@dragModifier = 2.0
-	}
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[SEMIDEPLOYED]]
+    {
+        @dragModifier = 2.0
+    }
 
-	@MODULE[ModuleDragModifier]:HAS[#dragCubeName[DEPLOYED]]
-	{
-		@dragModifier = 20.0
-	}
+    @MODULE[ModuleDragModifier]:HAS[#dragCubeName[DEPLOYED]]
+    {
+        @dragModifier = 20.0
+    }
 
-	@MODULE[ModuleJettison]
-	{
-		@jettisonedObjectMass = 0.1
-		@jettisonForce = 2.5
-		@jettisonDirection = 0 0 1
-	}
+    @MODULE[ModuleJettison]
+    {
+        @jettisonedObjectMass = 0.1
+        @jettisonForce = 2.5
+        @jettisonDirection = 0 0 1
+    }
 
-	@DRAG_CUBE
-	{
-		%rescaleX = 1.6
-		%rescaleY = 1.6
-		%rescaleZ = 1.6
-	}
+    @DRAG_CUBE
+    {
+        %rescaleX = 1.6
+        %rescaleY = 1.6
+        %rescaleZ = 1.6
+    }
 }
 
 //  ==================================================
@@ -144,7 +144,7 @@
 
 @PART[ca_fom_parachute]:FOR[RealismOverhaul]:NEEDS[RealChute]
 {
-	!sound_parachute_* = NULL
+    !sound_parachute_* = NULL
 
     @category = none
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -1,8 +1,13 @@
 //  ==================================================
+//  Sources:
+
+//  NSSDC - The Venera Soviet Missions to Venus: http://nssdc.gsfc.nasa.gov/planetary/venera.html
+
+//  ==================================================
 //  Pioneer 10 & 11 Science Package.
 
 //  Dimensions: 1.25 m x 0.6 m
-//  Gross Mass: 10 Kg
+//  Inert Mass: 10 Kg
 //  ==================================================
 
 @PART[ca_ESM]:FOR[RealismOverhaul]
@@ -48,4 +53,132 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Venera main parachute.
+
+//  Dimensions: 2.4 m x - m (with the shroud)
+//  Inert Mass: 150 Kg
+
+//  * The inert mass value assumes that the shroud is
+//    not massless and part of the aeroshell structure.
+//  * The part max temperature has been set high due
+//    to an occlusion checker issue.
+//  ==================================================
+
+@PART[ca_fom_parachute]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+	
+	@MODEL
+	{
+        %scale = 1.6, 1.6, 1.6
+	}
+
+    %scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
+
+	@title = Venera Lander Aeroshell (Parachute Pack)
+	@manufacturer = NPO Lavochkin
+	@description = This part is the top cover of the Venera atmospheric entry capsule. The parachute attaches directly to the Venera lander for deployment after re-entry and before the aeroshell separation.
+
+	@mass = 0.15
+	@crashTolerance = 10
+	@maxTemp = 3773.15
+    %skinMaxTemp = 3773.15
+    %fuelCrossFeed = False
+	@stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = PARACHUTES
+	@bulkheadProfiles = size2
+    %rescaleCube = True
+    %gTolerance = 450
+
+	@MODULE[ModuleParachute]
+	{
+		@autoCutSpeed = 0.5
+		@stowedDrag = 0.22
+		@semiDeployedDrag = 1
+		@fullyDeployedDrag = 500
+		@minAirPressureToOpen = 0.04
+		@clampMinAirPressure = 0.04
+		@deployAltitude = 1000
+		@deploymentSpeed = 1
+		@semiDeploymentSpeed = 1
+		@chuteMaxTemp = 573.15
+	}
+
+	@MODULE[ModuleDragModifier]:HAS[#dragCubeName[SEMIDEPLOYED]]
+	{
+		@dragModifier = 2.0
+	}
+
+	@MODULE[ModuleDragModifier]:HAS[#dragCubeName[DEPLOYED]]
+	{
+		@dragModifier = 20.0
+	}
+
+	@MODULE[ModuleJettison]
+	{
+		@jettisonedObjectMass = 0.1
+		@jettisonForce = 2.5
+		@jettisonDirection = 0 0 1
+	}
+
+	@DRAG_CUBE
+	{
+		%rescaleX = 1.6
+		%rescaleY = 1.6
+		%rescaleZ = 1.6
+	}
+}
+
+//  ==================================================
+//  Venera main parachute.
+
+//  RealChute compatibility.
+//  ==================================================
+
+@PART[ca_fom_parachute]:FOR[RealismOverhaul]:NEEDS[RealChute]
+{
+	!sound_parachute_* = NULL
+
+    @category = none
+
+    !MODULE[ModuleParachute],*{}
+
+    !MODULE[RealChute*],*{}
+
+    MODULE
+    {
+        name = RealChuteModule
+        caseMass = 0.15
+        cutSpeed = 0.5
+        mustGoDown = True
+        deployOnGround = False
+        spareChutes = 0
+        chuteCount = 0
+        stagingEnabled = True
+
+        PARACHUTE
+        {
+            parachuteName = canopy
+            capName = cap
+            preDeploymentAnimation = semiDeploy
+            deploymentAnimation = fullDeploy
+            material = Nylon
+            preDeploymentSpeed = 2.5
+            deploymentSpeed = 5.0
+            preDeployedDiameter = 2.2
+            deployedDiameter = 4.3
+            minIsPressure = False
+            minPressure = 0.01
+            minDeployment = 65000
+            deploymentAlt = 50000
+            cutAlt = 0
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -2,6 +2,7 @@
 //  Sources:
 
 //  NSSDC - The Venera Soviet Missions to Venus: http://nssdc.gsfc.nasa.gov/planetary/venera.html
+//  Lockheed Martin - LM900 Satellite Bus:       https://web.archive.org/web/20061002052450/http://rsdo.gsfc.nasa.gov/rapidii/Specs/lm900sp_020700.pdf
 
 //  ==================================================
 //  Pioneer 10 & 11 Science Package.
@@ -56,9 +57,133 @@
 }
 
 //  ==================================================
+//  LM900 satellite bus.
+
+//  Dimensions: 1.6 m x 1 m
+//  Gross Mass: 530 Kg
+
+//  * This is a re-purposed part, originally used as a
+//    service module for the "Quetzal" probe core.
+//  * The LM900 bus had magnetorquers, represented here
+//    as standard reaction wheels.
+//  ==================================================
+
+@PART[ca_ESM2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.775, 2.625, 1.775
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.575, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.435, 0.0, 0.0, -1.0, 0.0, 1
+
+    @category = Pods
+
+    @title = LM900 Satellite Bus
+    @manufacturer = Lockheed Martin
+    @description = A lightweight, three-axis stabilized satellite bus. Can carry a wide range of payloads.
+
+    @mass = 0.49
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    %fuelCrossFeed = True
+    @bulkheadProfiles = size1
+    %vesselType = Probe
+    %CrewCapacity = 0
+    @tags = avionics bus
+
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+        hasHibernation = False
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.18
+        }
+    }
+
+    @MODULE[ModuleSAS]
+    {
+        @SASServiceLevel = 3
+        @standalone = True
+
+        !UPGRADES,*{}
+    }
+
+    @MODULE[ModuleReactionWheel]
+    {
+        @PitchTorque = 0.0005
+        @YawTorque = 0.0005
+        @RollTorque = 0.0005
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.0625
+        }
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 75
+        basemass = -1
+
+        //  Integrated battery 50 Wh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 180
+            maxAmount = 180
+        }
+
+        //  ACS & TCM propellant 40 Kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 40
+            maxAmount = 40
+        }
+    }
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE:NEEDS[RemoteTech]
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    !MODULE[FSfuelSwitch],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
 //  Venera drogue parachute.
 
-//  Dimensions: 2.4 m x - m (with the shroud)
+//  Dimensions: 2.4 m x 0.85 m (with the shroud)
 //  Gross Mass: 150 Kg
 
 //  * The inert mass value assumes that the shroud is
@@ -187,7 +312,7 @@
 //  ==================================================
 //  Venera main parachute.
 
-//  Dimensions: 2.4 m x - m (with the shroud)
+//  Dimensions: 2.4 m x 0.85 m (with the shroud)
 //  Gross Mass: 150 Kg
 
 //  * The inert mass value assumes that the shroud is

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
@@ -1,21 +1,12 @@
 //  ==================================================
-//  Cleanup.
-//  ==================================================
-
-@PART[ca_rst|ca_jib|ca_lahar|ca_linkor|ca_trident]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
-{
-    !EFFECTS,*{}
-
-    !PLUME,*{}
-}
-
-//  ==================================================
 //  CA-RST generic engine & RCS thruster port combination
 //  plume setup.
 //  ==================================================
 
 @PART[ca_rst]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+    !PLUME,*{}
+
     PLUME
     {
         name = Hypergolic-OMS-Red
@@ -100,6 +91,8 @@
 
 @PART[ca_jib]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+    !PLUME,*{}
+
     PLUME
     {
         name = Hypergolic-OMS-Red
@@ -183,6 +176,8 @@
 
 @PART[ca_lahar]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+    !PLUME,*{}
+
     PLUME
     {
         name = Hypergolic-OMS-Red
@@ -220,6 +215,8 @@
 
 @PART[ca_linkor]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+    !PLUME,*{}
+
     PLUME
     {
         name = Hypergolic-OMS-Red
@@ -257,6 +254,8 @@
 
 @PART[ca_trident]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+    !PLUME,*{}
+
     PLUME
     {
         name = Hypergolic-OMS-Red
@@ -294,6 +293,8 @@
 
 @PART[ca_torekkaPM]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+    !PLUME,*{}
+
     PLUME
     {
         name = Solid-Vacuum

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
@@ -10,10 +10,8 @@
 }
 
 //  ==================================================
-//  CA-RST generic engine & RCS thruster port
-//  combination.
-
-//  Plume setup.
+//  CA-RST generic engine & RCS thruster port combination
+//  plume setup.
 //  ==================================================
 
 @PART[ca_rst]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -65,10 +63,8 @@
 }
 
 //  ==================================================
-//  CA-RST generic engine & RCS thruster port
-//  combination.
-
-//  Plume configuration.
+//  CA-RST generic engine & RCS thruster port combination
+//  plume configuration.
 //  ==================================================
 
 @PART[ca_rst]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
@@ -98,9 +94,8 @@
 }
 
 //  ==================================================
-//  Generic 0.5 kN mono/bipropellant rocket engine.
-
-//  Plume setup.
+//  Generic 0.5 kN mono/bipropellant rocket engine plume
+//  setup.
 //  ==================================================
 
 @PART[ca_jib]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -152,9 +147,8 @@
 }
 
 //  ==================================================
-//  Generic 0.5 kN mono/bipropellant rocket engine.
-
-//  Plume configuration.
+//  Generic 0.5 kN mono/bipropellant rocket engine plume
+//  configuration.
 //  ==================================================
 
 @PART[ca_jib]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
@@ -184,9 +178,7 @@
 }
 
 //  ==================================================
-//  R-40 series bipropellant rocket engine.
-
-//  Plume setup.
+//  R-40 series bipropellant rocket engine plume setup.
 //  ==================================================
 
 @PART[ca_lahar]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -223,9 +215,7 @@
 }
 
 //  ==================================================
-//  Fregat-M upper stage.
-
-//  Plume setup.
+//  Fregat-M upper stage plume setup.
 //  ==================================================
 
 @PART[ca_linkor]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -262,10 +252,7 @@
 }
 
 //  ==================================================
-//  Airbus Safran 400N Bi-Propellant Apogee Motor
-//  cluster.
-
-//  Plume setup.
+//  400N Bi-Propellant Apogee Motor cluster plume setup.
 //  ==================================================
 
 @PART[ca_trident]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -297,6 +284,42 @@
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+//  ==================================================
+//  STAR-37E plume setup.
+//  ==================================================
+
+@PART[ca_torekkaPM]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Solid-Vacuum
+        transformName = thrust_Transform
+        plumePosition = 0.0, 0.0, 0.7
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.55
+        flareScale = 0.4
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Vacuum
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Vacuum
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
@@ -324,3 +324,41 @@
         }
     }
 }
+
+//  ==================================================
+//  KTDU-425A engine plume setup.
+//  ==================================================
+
+@PART[ca_vor_engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    !PLUME,*{}
+
+    PLUME
+    {
+        name = Hypergolic-Upper
+        transformName = thrust_Transform
+        plumePosition = 0.0, 0.0, 0.325
+        plumeScale = 0.35
+        flarePosition = 0.0, 0.0, 0.375
+        flareScale = 0.35
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}


### PR DESCRIPTION
### **Change log:**

**General:**

* Add RO support for all the new ProbesPlus parts.
* Lower the maximum temperatures of some parts.
* Adjust the fuel cross feeding rules of some parts.
* Adjust the crash tolerances and breaking forces of some parts.

**Antenna parts:**

* Add CommNet system support to all antenna parts (not dependent on Remote Tech anymore).
* Increase the power consumption of the Pioneer omnidirectional antenna.
* Repurpose the small folding dish antenna to be the Mariner Mars HGA (as it should be in the first place).
* Small tweaks to all generic antenna parts to better fit with each other.

**Command parts:**

* Remove the upgrades from the SAS modules.
* Patch the Voyager and Pioneer command modules to not have hibernation enabled.
* Fix the RT patches (were missing some NEEDS checks).
* Tweak the inert mass of the Voyager probe core to account for the auxiliary scientific and structural parts.

**Control parts:**

* Remove the upgrades from the reaction wheel modules.

**Electrical parts:**

* Revamp the battery stats. They had too small of a capacity (compared to both other batteries and real life battery packs).

**Propulsion parts:**

* Add back the gimbal module to the generic 0.5 kN thruster (**Note 1**).
* Remove the engine module configs from the R-40 engine (now has it's own global engine config).
* Fix the typos on the gimbal module of the Fregat-M upper stage.
* Lower the utilization of the generic propellant tanks (might need further tweaking).

**Science parts:**

* Remove the upgrades from the scientific instruments.
* Fix the scaling of the Voyager Science Boom (was smaller than normal).

**Utility parts:**

* Repurpose the "Quetzal" service module to be an extra spacecraft bus (**LM900**).

### **Notes:**

**Note 1:** There is a missing closing bracket on the base part module that causes MM to fail to patch the part correctly. I have informed **raveloda** about it and it will be fixed in the next version of ProbesPlus (https://github.com/raveloda/Coatl-Aerospace/issues/56).
**Note 2:** This PR requires the following global engine configs from the main RO branch:

* **R-40** and **R-42**
* **S5.92**
* **STAR-37E** (with the https://github.com/KSP-RO/RealismOverhaul/pull/1631 bugfixes)

**Note 3:** This PR requires https://github.com/KSP-RO/RealismOverhaul/pull/1627 in order for the parachute parts to appear without RealChute installed.
**Note 4:** Due to the way RealPlume removes the stock plume nodes, the Voyager Payload Module will be missing it's RCS plumes: https://github.com/KSP-RO/RealPlume/issues/24. A fix for that is provided by https://github.com/KSP-RO/RealPlume/pull/29.