### PR TITLE
Coatl Aerospace GroundOps v0.15RC bug fixes & tweaks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -31,7 +31,7 @@
 
     @title = Surveyor Core
     @manufacturer = Hughes Aircraft Company
-    @description = The main assembly of the Surveyor lander. Includes a set of three landing legs, attitude control system and propellant for its 3 vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
+    @description = The main assembly of the Surveyor lander. Includes a set of three landing legs and propellant for it's three vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
 
     @mass = 0.15
     @crashTolerance = 16

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -31,7 +31,7 @@
 
     @title = Surveyor Core
     @manufacturer = Hughes Aircraft Company
-    @description = The main assembly of the Surveyor lander. Includes a set of three landing legs and propellant for it's three vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
+    @description = The main assembly of the Surveyor lander. Includes a set of three landing legs and propellant for it's three vernier engines and it's attitude control system (sold separately). A solid fueled retro-motor is required for normal landing operations.
 
     @mass = 0.15
     @crashTolerance = 16

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -31,13 +31,16 @@
 
     @title = Surveyor Core
     @manufacturer = Hughes Aircraft Company
-    @description = The main assembly of the Surveyor lander. Includes a set of landing legs, attitude control system and propellant for its 3 vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
+    @description = The main assembly of the Surveyor lander. Includes a set of three landing legs, attitude control system and propellant for its 3 vernier engines (sold separately). A solid fueled retro-motor is required for normal landing operations.
 
     @mass = 0.15
     @crashTolerance = 16
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !explosionPotential = NULL
+    %fuelCrossFeed = True
     @bulkheadProfiles = size0, size1
     @tags ^= :$: hughes
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -32,8 +32,11 @@
 
     @mass = 0.02
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+    %fuelCrossFeed = False
     @tags ^= :$: high directional planar
 
     @MODULE[ModuleDeployableSolarPanel]
@@ -61,7 +64,7 @@
 
 @PART[ca_landv_hga]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+    @description ^= :$: Effective range approximately 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -122,9 +125,12 @@
 
     @mass = 0.005
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     !impactTolerance = NULL
+    %fuelCrossFeed = False
     @tags ^= :$: low omnidirectional
 
     @MODULE[ModuleDataTransmitter]
@@ -147,7 +153,7 @@
 
 @PART[ca_landv_omni]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range 225 Mm, power consumption 10 Watts, maximum data rate 128 kbit/sec.
+    @description ^= :$: Effective range approximately 225 Mm, power consumption 10 Watts, maximum data rate 128 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
@@ -24,13 +24,15 @@
 
     @title = Surveyor Battery Pack
     @manufacturer = Hughes Aircraft Company
-    @description =  The main battery pack of the Surveyor lunar lander. Capacity: <color=orange>3650</color> Wh.
+    @description = The main battery pack of the Surveyor lunar lander. Capacity: <color=orange>3650</color> Wh.
 
     @mass = 0.05
     @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    !PhysicsSignificance = NULL
+    %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
     @RESOURCE[ElectricCharge]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -31,8 +31,11 @@
 
     @mass = 0.0025
     @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^= :$: thiokol
@@ -104,8 +107,11 @@
 
     @mass = 0.065
     @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
+    %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^= :$: motor retro solid thiokol
@@ -117,6 +123,8 @@
 
     @MODULE[ModuleEngines*]
     {
+        @allowShutdown = False
+
         @PROPELLANT[SolidFuel]
         {
             @name = HTPB

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
@@ -28,6 +28,8 @@
 
     @mass = 0.005
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
@@ -59,7 +61,10 @@
 
     @mass = 0.005
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
+    @tags ^= :$: sampler surface
 }


### PR DESCRIPTION
Small bug fixes & tweaks for the Coatl Aerospace GroundOps parts.

**Change log:**

* Set some missing fuel cross feed rules.
* Do not allow the STAR-37 SRM to be turned off.
* Add a missing tag to the Surveyor soil scoop.
* Minor improvements to the part descriptions.