### PR TITLE
Squad antennae CommNet support

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -31,7 +31,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 800
+        @antennaPower = 8000000
         @packetInterval = 1.0
         @packetSize = 1.28
         @packetResourceCost = 0.004
@@ -93,7 +93,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 0.32
+        @antennaPower = 32
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.0005
@@ -160,7 +160,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 578000000
+        @antennaPower = 57800000000
         @packetInterval = 1.0
         @packetSize = 2.048
         @packetResourceCost = 0.005
@@ -228,7 +228,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 2312000000
+        @antennaPower = 231200000000
         @packetInterval = 1.0
         @packetSize = 1.28
         @packetResourceCost = 0.01
@@ -289,6 +289,17 @@
     %fuelCrossFeed = False
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 288800000000
+        @packetInterval = 1.0
+        @packetSize = 1.024
+        @packetResourceCost = 0.01
+    }
 }
 
 //  ==================================================
@@ -353,7 +364,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 6728000000
+        @antennaPower = 672800000000
         @packetInterval = 1.0
         @packetSize = 0.896
         @packetResourceCost = 0.01
@@ -420,7 +431,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 125000000000
+        @antennaPower = 12500000000000
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.015
@@ -512,7 +523,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 8000000000000
+        @antennaPower = 800000000000000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.015
@@ -581,7 +592,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 32000000000000
+        @antennaPower = 3200000000000000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.015

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -357,7 +357,7 @@
     %breakingTorque = 250
     %fuelCrossFeed = False
     @maxTemp = 473.15
-    %skinMaxTemp = 173.15
+    %skinMaxTemp = 473.15
 
     @MODULE[ModuleDataTransmitter]
     {
@@ -431,7 +431,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 12500000000000
+        @antennaPower = 125000000000
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.015
@@ -523,7 +523,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 800000000000000
+        @antennaPower = 8000000000000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.015
@@ -592,7 +592,7 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 3200000000000000
+        @antennaPower = 32000000000000
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.015

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -20,9 +20,22 @@
 
     @mass = 0.005
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 800
+        @packetInterval = 1.0
+        @packetSize = 1.28
+        @packetResourceCost = 0.004
+    }
 }
 
 //  ==================================================
@@ -33,7 +46,7 @@
 
 @PART[SurfAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: Note that it is not activated by default! Effective range 200 Mm, power consumption 12 Watts, maximum data rate 1.3 Mbit/s.
+    @description ^=:$: <color=red>Note that it is not activated by default!</color> Maximum effective range approximately 200 Mm, power consumption 12 Watts, maximum data rate 1.3 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -69,9 +82,22 @@
 
     @mass = 0.003
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 0.32
+        @packetInterval = 1.0
+        @packetSize = 0.768
+        @packetResourceCost = 0.0005
+    }
 }
 
 //  ==================================================
@@ -82,7 +108,7 @@
 
 @PART[longAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: If you wonder how a 4 Mm antenna can reach the Moon, check the Realism Overhaul FAQ. Effective range 400 Mm, power consumption 1.5 Watts, maximum data rate 768 kbit/s.
+    @description ^=:$: If you wonder how a 4 Mm antenna can reach the Moon, check the Realism Overhaul FAQ. Maximum effective range approximately 400 Mm, power consumption 1.5 Watts, maximum data rate 768 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -123,9 +149,22 @@
 
     @mass = 0.01
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 578000000
+        @packetInterval = 1.0
+        @packetSize = 2.048
+        @packetResourceCost = 0.005
+    }
 }
 
 //  ==================================================
@@ -136,7 +175,7 @@
 
 @PART[mediumDishAntenna]:AFTER[RemoteTech]
 {
-    @description ^= :$: Effective range ~170 Gm, power consumption 15 Watts, maximum data rate 2 Mbit/s.
+    @description ^= :$: Maximum effective range approximately 170 Gm, power consumption 15 Watts, maximum data rate 2 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -178,9 +217,22 @@
 
     @mass = 0.025
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 2312000000
+        @packetInterval = 1.0
+        @packetSize = 1.28
+        @packetResourceCost = 0.01
+    }
 }
 
 //  ==================================================
@@ -191,7 +243,7 @@
 
 @PART[HighGainAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: Comparatively low bandwidth, on par with standard omnidirectional antennae. Effective range ~340Gm, power consumption 25 Watts, maximum data rate 1.3 Mbit/s.
+    @description ^=:$: Comparatively low bandwidth, on par with standard omnidirectional antennae. Maximum effective range approximately 340 Gm, power consumption 25 Watts, maximum data rate 1.3 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -235,8 +287,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
 }
 
 //  ==================================================
@@ -247,7 +299,7 @@
 
 @PART[HighGainAntenna5]:AFTER[RemoteTech]
 {
-    @description ^=:$: Wide angle and reasonable bandwidth among the inner planets. Effective range ~380Gm, power consumption 30 Watts, maximum data rate 1 Mbit/s.
+    @description ^=:$: Wide angle and reasonable bandwidth among the inner planets. Maximum effective range approximately 380 Gm, power consumption 30 Watts, maximum data rate 1 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -293,8 +345,19 @@
     %breakingForce = 250
     %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 173.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = RELAY
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 6728000000
+        @packetInterval = 1.0
+        @packetSize = 0.896
+        @packetResourceCost = 0.01
+    }
 }
 
 //  ==================================================
@@ -305,7 +368,7 @@
 
 @PART[RelayAntenna5]:AFTER[RemoteTech]
 {
-    @description ^= :$: Effective range -580 Gm, power consumption 35 Watts, maximum data rate 896 kbit/s.
+    @description ^= :$: Maximum effective range approximately 580 Gm, power consumption 35 Watts, maximum data rate 896 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -346,9 +409,22 @@
 
     @mass = 0.055
     @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = RELAY
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 125000000000
+        @packetInterval = 1.0
+        @packetSize = 0.768
+        @packetResourceCost = 0.015
+    }
 }
 
 //  ==================================================
@@ -384,7 +460,7 @@
 
 @PART[commDish]:AFTER[RemoteTech]
 {
-    @description ^=:$: Effective range ~2.5 Tm, power consumption 45 Watts, maximum data rate 768 kbit/s.
+    @description ^=:$: Maximum effective range approximately 2.5 Tm, power consumption 45 Watts, maximum data rate 768 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -428,8 +504,19 @@
     %breakingForce = 250
     %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = RELAY
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 8000000000000
+        @packetInterval = 1.0
+        @packetSize = 0.512
+        @packetResourceCost = 0.015
+    }
 }
 
 //  ==================================================
@@ -440,7 +527,7 @@
 
 @PART[RelayAntenna50]:AFTER[RemoteTech]
 {
-    @description ^= :$: Effective range ~20 Tm, power consumption 60 Watts, maximum data rate 512 kbit/s.
+    @description ^= :$: Maximum effective range approximately 20 Tm, power consumption 60 Watts, maximum data rate 512 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -486,8 +573,19 @@
     %breakingForce = 250
     %breakingTorque = 250
     %fuelCrossFeed = False
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = RELAY
+        @antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 32000000000000
+        @packetInterval = 1.0
+        @packetSize = 0.512
+        @packetResourceCost = 0.015
+    }
 }
 
 //  ==================================================
@@ -498,7 +596,7 @@
 
 @PART[RelayAntenna100]:AFTER[RemoteTech]
 {
-    @description ^= :$: Effective range ~40 Tm, power consumption 80 Watts, maximum data rate 384 kbit/s.
+    @description ^= :$: Maximum effective range approximately 40 Tm, power consumption 80 Watts, maximum data rate 384 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 


### PR DESCRIPTION
**Change log:**

* Fix the CommNet support
* Decrease the maximum temperatures (electronic parts).
* Improve the RT descriptions.

**Notes:**

* The CommNet ranges have been calculated with a mix of the available CommNet station ranges, meaning that they need to be placed in the tech tree accordingly.

| Antenna Name | Station Level |
| :---------------------: | :------: |
| Communotron 16-S | Level 1 |
| Communotron 16 | Level 2 |
| DTS-M1 | Level 2 |
| Communotron HG-55 | Level 2 |
| HG-5 | Level 2 |
| RA-2 | Level 2 |
| Communotron 88-88 | Level 3 |
| RA-15 | Level 3 |
| RA-100 | Level 3 |

* There is a bug regarding the CustomBarnKit DSN ranges that requires a reload of the MM patches before the correct antenna ranges are set. Reload them before entering the SPH/VAB.