### PR TITLE
Aestus/Aestus II engine updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
@@ -4,10 +4,13 @@
 //  Inert Mass: 111 Kg (Aestus), 138 Kg (Aestus II)
 //  Throttle Range: N/A
 //  O/F Ratio: 1.9
-//  Burn Time: 1100 s (Aestus), 600 s (Aestus II)
+//  Burn Time: 1100 s (Aestus), 2500 s (Aestus II)
 
 //  Sources:
 
+//  Astrium - Aestus rocket engine:           https://web.archive.org/web/20120224102231/http://cs.astrium.eads.net:80/sp/launcher-propulsion/rocket-engines/aestus-rocket-engine.html
+//  Astrium - Aestus engine data sheet:       http://projecte-hermes.upc.edu/Enginyeria%20Aeroespacial/2B/Sistemes%20Propulsius/Treball/Altres%20cursos/LL1%20AESTUS/Aestus.pdf
+//  Astrium - Aestus II rocket engine:        https://web.archive.org/web/20120824081115/http://cs.astrium.eads.net:80/sp/launcher-propulsion/rocket-engines/aestus-rs72-rocket-engine.html
 //  Norbert Brügge - Ariane 5 launch vehicle: http://www.b14643.de/Spacerockets_1/West_Europe/Ariane-5/Description/Frame.htm
 //  Norbert Brügge - European rocket engines: http://www.b14643.de/Spacerockets/Specials/European_Rocket_engines/engines.htm
 //  Encyclopedia Astronautica - Aestus:       http://www.astronautix.com/a/aestus.html
@@ -41,7 +44,7 @@
 		%EngineType = LiquidFuel
 		%ullage = True
 		%pressureFed = True
-		%ignitions = 5
+		%ignitions = 20
 
 		IGNITOR_RESOURCE,*{}
 
@@ -73,7 +76,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = True
-			ignitions = 5
+			ignitions = 20
 
 			IGNITOR_RESOURCE
 			{
@@ -110,8 +113,8 @@
 			heatProduction = 56
 			massMult = 1.2432
 			ullage = True
-			pressureFed = True
-			ignitions = 3
+			pressureFed = False
+			ignitions = 20
 
 			IGNITOR_RESOURCE
 			{
@@ -168,7 +171,7 @@
 	TESTFLIGHT
 	{
 		name = Aestus-II
-		ratedBurnTime = 600
+		ratedBurnTime = 2500
 		ignitionReliabilityStart = 0.968
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.97

--- a/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
@@ -1,65 +1,178 @@
-//Aestus
-// AIES
+//  ==================================================
+//  Aestus & Aestus II global engine configuration.
+
+//  Inert Mass: 111 Kg (Aestus), 138 Kg (Aestus II)
+//  Throttle Range: N/A
+//  O/F Ratio: 1.9
+//  Burn Time: 1100 s (Aestus), 600 s (Aestus II)
+
+//  Sources:
+
+//  Norbert Brügge - Ariane 5 launch vehicle: http://www.b14643.de/Spacerockets_1/West_Europe/Ariane-5/Description/Frame.htm
+//  Norbert Brügge - European rocket engines: http://www.b14643.de/Spacerockets/Specials/European_Rocket_engines/engines.htm
+//  Encyclopedia Astronautica - Aestus:       http://www.astronautix.com/a/aestus.html
+//  Encyclopedia Astronautica - Aestus II:    http://www.astronautix.com/a/aestus-2.html
+
+//  Used by:
+
+//  * AIES
+//  * RealFuels
+
+//  Notes:
+
+//  * The Aestus only ever had a partial failure on Flight L510 on 31 flights.
+//  * Reusing the Aestus reliability data for the Aestus II engine.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[Aestus]]:FOR[RealismOverhaulEngines]
 {
-	%title = Aestus Vacuum Engine
+	%category = Engine
+	%title = Aestus Series
 	%manufacturer = EADS Astrium
-	%description = Upper stage engine of the Ariane 5ES. Burns hypergolic propellants. Diameter: [1.5 m].
-	
+	%description = A hypergolic upper stage engine. The baseline Aestus engine is pressure fed and it used on the Ariane 5 G, GS and ES series, while the Aestus II (also known as RS-72) variant is pump-fed and develops a higher overall performance. Diameter: 1.32 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 30.0
+		%maxThrust = 30.0
+		%heatProduction = 36
+		@useEngineResponseTime = False
+		@useThrustCurve = False
+		%EngineType = LiquidFuel
+		%ullage = True
+		%pressureFed = True
+		%ignitions = 5
+
+		IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 9.5
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		origMass = 0.1665
+		type = ModuleEngines
 		configuration = Aestus
-		modded = false
+		origMass = 0.111
+
 		CONFIG
 		{
 			name = Aestus
-			maxThrust = 30
-			minThrust = 30
+			minThrust = 30.0
+			maxThrust = 30.0
+			heatProduction = 36
+			massMult = 1.0
+			ullage = True
+			pressureFed = True
+			ignitions = 5
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+
 			PROPELLANT
 			{
 				name = MMH
-				ratio = 0.464446
+				ratio = 0.4684
 				DrawGauge = true
 			}
+
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.535554
+				ratio = 0.5316
+				DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 324
 				key = 1 113
 			}
-			
+		}
+
+		CONFIG
+		{
+			name = Aestus-II
+			minThrust = 55.4
+			maxThrust = 55.4
+			heatProduction = 56
+			massMult = 1.2432
 			ullage = True
 			pressureFed = True
-			ignitions = 0 //unlimited
+			ignitions = 3
 
 			IGNITOR_RESOURCE
 			{
-				name = MMH
-				amount = 0.464446
+				name = ElectricCharge
+				amount = 0.25
 			}
-			IGNITOR_RESOURCE
+
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4684
+				DrawGauge = True
+			}
+
+			PROPELLANT
 			{
 				name = NTO
-				amount = 0.535554
+				ratio = 0.5316
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 340
+				key = 1 150
 			}
 		}
 	}
-	!RESOURCE[ElectricCharge]
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Aestus]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
 	{
+		name = Aestus
+		ratedBurnTime = 1100
+		ignitionReliabilityStart = 0.968
+		ignitionReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.985
 	}
-	!MODULE[ModuleAlternator]
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Aestus-II]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
 	{
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
+		name = Aestus-II
+		ratedBurnTime = 600
+		ignitionReliabilityStart = 0.968
+		ignitionReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.985
+		techTransfer = Aestus:50
 	}
 }

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -39,94 +39,63 @@
 	}
 	engineType = Merlin1
 }
+
+//  ==================================================
+//  Aestus engine series.
+//  ==================================================
+
 @PART[liquidEngineMiniRescale]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+
 	@MODEL
 	{
-		@scale = 2.08, 4.8, 2.08
+		@scale = 5.57, 5.867, 5.57
 	}
+
 	@rescaleFactor = 1.0
-	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 1
-	@title = Aestus II
-	%manufacturer = EADS Astrium
-	@description = Smaller MMH/NTO upper stage rocket engine that can also be used for orbital manuevers. [1.5 m]
-	@attachRules = 1,0,1,0,0
-	@mass = 0.138
-	@maxTemp = 1973.15
+
+	@node_stack_top = 0.0, -0.055, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -2.3, 0.0, 0.0, -1.0, 0.0, 2
+
+	@mass = 0.111
+	@crashTolerance = 10
+	%breakingForce = 250
+	%breakingTorque = 250
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+	%stageOffset = 1
+	%childStageOffset = 1
+	%stagingIcon = LIQUID_ENGINE
+	@bulkheadProfiles = srf, size2
+
+	%engineType = Aestus
+	%engineTypeMult = 1
+	%ignoreMass = False
+	%massOffset = 0
+
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 55.4
-		@maxThrust = 55.4
-		@heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
 			@name = MMH
-			@ratio = 0.464446
+			@ratio = 0.4684
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			@name = NTO
-			@ratio = 0.535554
+			@ratio = 0.5316
 		}
+
 		@atmosphereCurve
 		{
-			@key,0 = 0 340
-			@key,1 = 0 150
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 15
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.3
-		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 9.5 // source: http://www.astronautix.com/engines/aestus.htm for Aestus I
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = AestusII
-		origMass = 0.138
-		modded = false
-		CONFIG
-		{
-			name = AestusII
-			minThrust = 55.4
-			maxThrust = 55.4
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.464446
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.535554
-			}
-			atmosphereCurve
-			{
-				key = 0 340
-				key = 1 150
-			}
-			massMult = 1.0
+			@key,0 = 0 324
+			@key,1 = 0 113
 		}
 	}
 }
+
 @PART[solidBooster1-1Small]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMiniRescale.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/liquidEngineMiniRescale.cfg
@@ -1,26 +1,35 @@
-@PART[liquidEngineMiniRescale]:FOR[RealPlume]:NEEDS[SmokeScreen] // from FASA LMDE
+//  ==================================================
+//  Aestus series engine plume setup.
+//  ==================================================
+
+@PART[liquidEngineMiniRescale]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,-0.4
-        fixedScale = 1.5
-        energy = 1.5
-        speed = 1.5
+        plumePosition = 0.0, 0.0, -0.15
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, 0.25
+        flareScale = 0.5
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-        @CONFIG,*
-		{
-			%powerEffectName = Hypergolic-OMS-White
-		}
-	}
-}
 
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        %runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}


### PR DESCRIPTION
**Change log:**

* Port the Aestus II engine config to the main Aestus global engine config.
* Add some web sources.
* Patch some basic engine module parameters.
* Tweak the heat production values.
* Fix the inert mass value of the baseline Aestus.
* Fix (port) the gimballing range.
* Use an O/F ratio of 1.9 for both configs.
* Remove the requirement of propellants for the engine ignition and replace it with an electric one.
* Add some basic TF compatibility patches.
* Increase the size of the Aestus part module.

**Notes:**

* The Aestus and Aestus II have the same overall mechanical structure, with the addition of the turbo pump on the Aestus II (nozzle diameter, gimbal range e.t.c.)
* The diameter of the part module (1.32 m) now refers to the nozzle exhaust instead of the "tank butt" base. **This may make it more difficult to use so some feedback is required.**