### PR TITLE
Move J-2-200klbf to Top of J-2 List

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -31,6 +31,40 @@
 		modded = false
 		CONFIG
 		{
+			name = J-2-200klbf
+			minThrust = 676.66
+			maxThrust = 889.325
+			heatProduction = 100
+			massMult = 1.02
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 424
+				key = 1 200
+			}
+			cost = -300
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 3 //Definately a FIXME right here
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
 			name = J-2
 			minThrust = 778.4388
 			maxThrust = 1023.091
@@ -98,40 +132,6 @@
 			%ullage = True
 			%pressureFed = False
 			%ignitions = 3 //was to carry three starter cartriges, http://www.astronautix.com/engines/j2s.htm
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.500
-			}
-		}
-		CONFIG
-		{
-			name = J-2-200klbf
-			minThrust = 676.66
-			maxThrust = 889.325
-			heatProduction = 100
-			massMult = 1.02
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7454
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2546
-			}
-			atmosphereCurve
-			{
-				key = 0 424
-				key = 1 200
-			}
-			cost = -300
-			
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 3 //Definately a FIXME right here
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge


### PR DESCRIPTION
It was confusing to me as a new player (and I am sure others) since the oldest, and worst version of the engine was listed on the bottom. This moves things in line with the other Engine Configs.