### PR TITLE
SSTU: Add Cross-feed Enabled as Default on Tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -16,6 +16,10 @@
 		%topDiameterIncrement = 0.5
 		%bottomDiameterIncrement = 0.5
 	}
+	@MODULE[ModuleToggleCrossfeed]
+	{
+		%crossfeedStatus = true
+	}
 }
 
 @PART[SSTU-SC-TANK-MUS-*]:FOR[RealismOverhaul]:NEEDS[RealFuels&SSTU]


### PR DESCRIPTION
I forget to change this, and I have seen many others on streams forget to change this which causes big issues with trying to get RCS to work and surface mounted engines.