### PR TITLE
Fix duplicate ModuleFuelTanks (Falcon 1 Stage 1 M1C version)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon_Tanks.cfg
@@ -60,6 +60,9 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
+	!MODULE[ModuleFuelTanks]
+	{
+	}
 	MODULE
 	{
 		name = ModuleFuelTanks


### PR DESCRIPTION
This part ends up with 2 ModuleFuelTanks because the config does not remove or modify the existing one.