### PR TITLE
[Mod Support] CMES for KSP 1.2/1.3

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
@@ -4,6 +4,8 @@
 
 !PART[PC_InflateHeatshield3HLxx]:FOR[RealismOverhaul]{}
 
+!PART[PC_InflateHeatshieldLxx]:FOR[RealismOverhaul]{}
+
 !PART[XDragon2NoseCone2X]:FOR[RealismOverhaul]{}
 
 !PART[xEMLVKosmos_URM_Fairing_Conic_SaltWV2]:FOR[RealismOverhaul]{}
@@ -14,9 +16,9 @@
 
 !PART[XKzProcFairingBaseRing8TALUS]:FOR[RealismOverhaul]{}
 
-!PART[XKzProcFairingBaseRing3_75X]:FOR[RealismOverhaul]{}
-
 !PART[XKzProcFairingBaseRing843ABNNX]:FOR[RealismOverhaul]{}
+
+!PART[XKzProcFairingBaseRing3_75X]:FOR[RealismOverhaul]{}
 
 !PART[XKW2mNoseConeXl]:FOR[RealismOverhaul]{}
 
@@ -25,7 +27,7 @@
 //  ==================================================
 //  Inflatable heat shield (10 meters).
 
-//  Dimensions: 10 m x 2.5 m
+//  Dimensions: 10 m x 2.6 m (inflated)
 //  Inert Mass: 2800 Kg
 //  ==================================================
 
@@ -45,7 +47,7 @@
     @node_stack_bottom = 0.0, -0.78, 0.0, 0.0, -1.0, 0.0, 10
     @attachRules = 1,0,1,1,0
 
-    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+    %fx_gasBurst_white = 0.0, 0.215, 0.0, 0.0, 1.0, 0.0, decouple
 
     %sound_vent_large = decouple
 
@@ -70,6 +72,9 @@
     @MODULE[ModuleDecouple]
     {
         @ejectionForce = 0
+        @menuName = Jettison Heat Shield
+        @stagingEnableText = Jettison Heat Shield Not Staged
+        @stagingDisableText = Jettison Heat Shield Staged
     }
 
     @MODULE[ModuleAnimateGeneric]
@@ -77,9 +82,10 @@
         @isOneShot = False
         @startEventGUIName = Inflate Heat Shield
         %endEventGUIName = Deflate Heat Shield
-        %actionGUIName = Toggle Heat Shield
+        %actionGUIName = Toggle Heat Shield Inflation
         %allowManualControl = True
         %allowAnimationWhileShielded = False
+        %disableAfterPlaying = True
     }
 
     !MODULE[ModuleAnimation2Value],*{}
@@ -96,7 +102,7 @@
 //  ==================================================
 //  Inflatable heat shield (15 meters).
 
-//  Dimensions: 15 m x 3.8 m
+//  Dimensions: 15 m x 3.9 m (inflated)
 //  Inert Mass: 5200 Kg
 //  ==================================================
 
@@ -106,17 +112,17 @@
 
     @MODEL
     {
-        @scale = 2.625, 2.625, 2.625
+        @scale = 2.5735, 2.5735, 2.5735
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.408, 0.0, 0.0, 1.0, 0.0, 5
-    @node_stack_bottom = 0.0, -1.185, 0.0, 0.0, -1.0, 0.0, 10
+    @node_stack_top = 0.0, 0.4, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -1.165, 0.0, 0.0, -1.0, 0.0, 10
     @attachRules = 1,0,1,1,0
 
-    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+    %fx_gasBurst_white = 0.0, 0.4, 0.0, 0.0, 1.0, 0.0, decouple
 
     %sound_vent_large = decouple
 
@@ -141,6 +147,9 @@
     @MODULE[ModuleDecouple]
     {
         @ejectionForce = 0
+        @menuName = Jettison Heat Shield
+        @stagingEnableText = Jettison Heat Shield Not Staged
+        @stagingDisableText = Jettison Heat Shield Staged
     }
 
     @MODULE[ModuleAnimateGeneric]
@@ -148,9 +157,10 @@
         @isOneShot = False
         @startEventGUIName = Inflate Heat Shield
         %endEventGUIName = Deflate Heat Shield
-        %actionGUIName = Toggle Heat Shield
+        %actionGUIName = Toggle Heat Shield Inflation
         %allowManualControl = True
         %allowAnimationWhileShielded = False
+        %disableAfterPlaying = True
     }
 
     !MODULE[ModuleAnimation2Value],*{}
@@ -167,31 +177,28 @@
 //  ==================================================
 //  Inflatable heat shield (20 meters).
 
-//  Dimensions: 20 m x 5 m
+//  Dimensions: 20 m x 6.1 m (inflated)
 //  Inert Mass: 6700 Kg
 //  ==================================================
 
-@PART[PC_InflateHeatshieldLxx]:FOR[RealismOverhaul]
+@PART[xInflatableHeatShieldxChaka2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
     @MODEL
     {
-        @scale = 3.45, 3.45, 3.45
+        @scale = 2.0, 2.0, 2.0
     }
 
-    @scale = 1.0
+    %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.543, 0.0, 0.0, 1.0, 0.0, 5
-    @node_stack_bottom = 0.0, -1.55, 0.0, 0.0, -1.0, 0.0, 10
-    @attachRules = 1,0,1,1,0
+    @node_stack_top = 0.0, 2.8, 0.0, 0.0, 1.0, 0.0, 5
+    !node_stack_mid = NULL
+    @node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 10
 
-    %fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+    @fx_gasBurst_white = 0.0, 0.13, 0.0, 0.0, 1.0, 0.0, decouple
 
-    %sound_vent_large = decouple
-
-    @category = Thermal
     @title = HIAD (20 m)
     @manufacturer = NASA
     @description = The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
@@ -201,38 +208,90 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 673.15
-    %skinMaxTemp = 2773.15
-    %skinMassPerArea = 4
-    %emissiveConstant = 0.95
-    %stageOffset = 1
-    %childStageOffset = 1
+    @skinMaxTemp = 2773.15
     %stagingIcon = DECOUPLER_HOR
-    %bulkheadProfiles = size5, size10
+    @bulkheadProfiles = size5, size10
 
     @MODULE[ModuleDecouple]
     {
         @ejectionForce = 0
+        @menuName = Jettison Heat Shield
+        @stagingEnableText = Jettison Heat Shield Not Staged
+        @stagingDisableText = Jettison Heat Shield Staged
     }
 
-    @MODULE[ModuleAnimateGeneric]
+    @MODULE[ModuleAnimateGeneric]:HAS[#animationName[InflatableHS]]
     {
-        @isOneShot = False
         @startEventGUIName = Inflate Heat Shield
-        %endEventGUIName = Deflate Heat Shield
-        %actionGUIName = Toggle Heat Shield
-        %allowManualControl = True
-        %allowAnimationWhileShielded = False
+        @endEventGUIName = Deflate Heat Shield
+        @actionGUIName = Toggle Heat Shield Inflation
+        @disableAfterPlaying = True
     }
 
-    !MODULE[ModuleAnimation2Value],*{}
+    @MODULE[ModuleJettison]
+    {
+        @isFairing = True
+    }
+}
 
-    !MODULE[ModuleEnviroSensor],*{}
+//  ==================================================
+//  Inflatable heat shield (25 meters).
 
-    !MODULE[ModuleHeatShield],*{}
+//  Dimensions: 25 m x 7.6 m (inflated)
+//  Inert Mass: 8200 Kg
+//  ==================================================
 
-    !MODULE[ModuleAeroReentry],*{}
+@PART[xInflatableHeatShieldxChaka3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
 
-    !RESOURCE,*{}
+    @MODEL
+    {
+        @scale = 2.5, 2.5, 2.5
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 3.5, 0.0, 0.0, 1.0, 0.0, 5
+    !node_stack_mid = NULL
+    @node_stack_bottom = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 10
+
+    @fx_gasBurst_white = 0.0, 0.1625, 0.0, 0.0, 1.0, 0.0, decouple
+
+    @title = HIAD (25 m)
+    @manufacturer = NASA
+    @description = The Hypersonic Inflatable Aerodynamic Decelerator (HIAD) consists of an inflatable main structure and the thermal protection system. The combination of the two creates a very light but extremely rugged aeroshell. Just remember to inflate it before entry.
+
+    @mass = 8.2
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    @skinMaxTemp = 2773.15
+    %stagingIcon = DECOUPLER_HOR
+    @bulkheadProfiles = size5, size10
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 0
+        @menuName = Jettison Heat Shield
+        @stagingEnableText = Jettison Heat Shield Not Staged
+        @stagingDisableText = Jettison Heat Shield Staged
+    }
+
+    @MODULE[ModuleAnimateGeneric]:HAS[#animationName[InflatableHS]]
+    {
+        @startEventGUIName = Inflate Heat Shield
+        @endEventGUIName = Deflate Heat Shield
+        @actionGUIName = Toggle Heat Shield Inflation
+        @disableAfterPlaying = True
+    }
+
+    @MODULE[ModuleJettison]
+    {
+        @isFairing = True
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Aero.cfg
@@ -2,6 +2,8 @@
 //  Removed extra parts.
 //  ==================================================
 
+!PART[PC_InflateHeatshield3HLxx]:FOR[RealismOverhaul]{}
+
 !PART[XDragon2NoseCone2X]:FOR[RealismOverhaul]{}
 
 !PART[xEMLVKosmos_URM_Fairing_Conic_SaltWV2]:FOR[RealismOverhaul]{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
@@ -392,7 +392,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 26.7
         @maxThrust = 26.7
         @heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
@@ -11,12 +11,12 @@
 //  Removed extra parts.
 //  ==================================================
 
-!PART[BasketTrussCX2]:FOR[RealismOverhaul]{}
-
 !PART[BasketTrussCX21y]:FOR[RealismOverhaul]{}
 
+!PART[BasketTrussCX2]:FOR[RealismOverhaul]{}
+
 //  ==================================================
-//  Delta Cryogenic Second Stage (DCSS) 4 - meter truss.
+//  Delta Cryogenic Second Stage 4 meter truss (DCSS-4).
 
 //  Dimensions: 4 m x 1.3 m
 //  Inert Mass: 220 Kg
@@ -66,7 +66,7 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (DCSS) 5 - meter truss.
+//  Delta Cryogenic Second Stage 5 meter truss (DCSS-5).
 
 //  Dimensions: 5 m x 2.6 m
 //  Inert Mass: 430 Kg
@@ -208,7 +208,7 @@
 
 @PART[BasketTrussCX]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
-    !MODULE[ModuleDataTrasmitter],*{}
+    !MODULE[ModuleDataTrasmitter],*{} 
 
     !MODULE[ModuleSPU*],*{}
 
@@ -369,7 +369,7 @@
 }
 
 //  ==================================================
-//  Aerojet Rocketdyne AJ10-190 engine.
+//  AJ10-190 engine.
 
 //  Dimensions: 1.17 m x 1.96 m
 //  Inert Mass: 118 Kg
@@ -404,9 +404,6 @@
     %bulkheadProfiles = size3
 
     %engineType = AJ10_190
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -438,7 +435,7 @@
 }
 
 //  ==================================================
-//  Aerojet Rocketdyne AJ10-190 engine.
+//  AJ10-190 engine.
 
 //  Engine configuration.
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_AerojetKerbodyne.cfg
@@ -170,6 +170,22 @@
         standalone = True
     }
 
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 450
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.0325
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
+    }
+
     !RESOURCE,*{}
 
     //  Avionics batteries 1.4 kWh.
@@ -192,6 +208,8 @@
 
 @PART[BasketTrussCX]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTrasmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -395,7 +413,6 @@
         @minThrust = 26.7
         @maxThrust = 26.7
         @heatProduction = 100
-        %exhaustDamageMultiplier = 0.75
 
         @PROPELLANT[LiquidFuel]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -359,48 +359,42 @@
 }
 
 //  ==================================================
-//  Expanded solar array.
+//  Expanded solar array wing.
 
-//  Dimensions: 15 m x 2.8 m
-//  Inert Mass: 400 Kg
+//  Dimensions: 6.3 m x 21.5 m (extended)
+//  Inert Mass: 550 Kg
 //  ==================================================
 
-@PART[xchakaKosmos_TKS_Solar_Arrayx]:FOR[RealismOverhaul]
+@PART[xCXA_SAWx]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
-    !mesh = NULL
-
     @MODEL
     {
-        @scale = 3.0, 1.2, 1.2
-        !position = NULL
-        !rotation = NULL
+        @scale = 1.0, 1.0, 1.0
     }
 
-    @node_attach = -0.2, 0.0, 0.0, 1.0, 0.0, 0.0
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    !node_stack_bottom = NULL
 
     @category = Electrical
-    @title = TKS - A Expanded Solar Array
-    @manufacturer = Generic
-    @description = High power retractable solar array for demanding payloads. 42 m2.
+    @title = Expanded Solar Array Wing (SAW)
+    %manufacturer = Boeing Co.
+    @description = A high power, steerable and retractable solar array wing for demanding payloads, similar to the ones used by the International Space Station (ISS). 96 m2.
 
-    @mass = 0.4
+    @mass = 0.55
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
-    %thermalMassModifier = 2.0
-    %emissiveConstant = 0.95
-    %heatConductivity = 0.04
     %bulkheadProfiles = srf
 
     @MODULE[ModuleDeployableSolarPanel]
     {
-        @chargeRate = 7.5
-
-        !powerCurve{}
+        @chargeRate = 6.25
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -9,17 +9,17 @@
 
 !PART[XLLLCommPole2X]:FOR[RealismOverhaul]{}
 
-!PART[XATVpanel2X]:FOR[RealismOverhaul]{}
-
 !PART[XATVpanel3X]:FOR[RealismOverhaul]{}
+
+!PART[XATVpanel2X]:FOR[RealismOverhaul]{}
 
 !PART[solarPanels7X]:FOR[RealismOverhaul]{}
 
 !PART[xB9_Utility_Light_N1_Large_Whitex]:FOR[RealismOverhaul]{}
 
-!PART[XB9_Utility_Light_N2_RedX]:FOR[RealismOverhaul]{}
-
 !PART[XB9_Utility_Light_N2_RedXl]:FOR[RealismOverhaul]{}
+
+!PART[XB9_Utility_Light_N2_RedX]:FOR[RealismOverhaul]{}
 
 //  ==================================================
 //  Fixed omnidirectional antenna.
@@ -370,7 +370,7 @@
 }
 
 //  ==================================================
-//  Expanded solar array wing.
+//  Expanded solar array wing (SAW).
 
 //  Dimensions: 6.3 m x 21.5 m (extended)
 //  Inert Mass: 550 Kg

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Electrical.cfg
@@ -56,6 +56,17 @@
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        %antennaType = RELAY
+        %antennaPower = 125000
+        @packetInterval = 1.0
+        @packetSize = 2.048
+        @packetResourceCost = 0.035
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -16,11 +16,21 @@
 
 !PART[XCXA_ACBM2RxxX]:FOR[RealismOverhaul]{}
 
-!PART[SHABLANDER-SLRx32]:FOR[RealismOverhaul]{}
+!PART[XKupolaObsModuleEXPANDED1X]:FOR[RealismOverhaul]{}
+
+!PART[XKupolaObsModuleEXPANDED3X]:FOR[RealismOverhaul]{}
+
+!PART[SHABLANDER-SLRx32af]:FOR[RealismOverhaul]{}
+
+!PART[SHABLANDER-SLRx32xa4e]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodOrionTypeS22xa]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodOrionTypeS22xa66ck]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodOrionTypeS22xa66ck2cx]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodOrionTypeS22xa66ckX4899]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodLanderxsaun]:FOR[RealismOverhaul]{}
 
@@ -30,15 +40,21 @@
 
 !PART[MonkeyPodAirlock2]:FOR[RealismOverhaul]{}
 
+!PART[MonkeyPodAirlock3x]:FOR[RealismOverhaul]{}
+
 !PART[TESTMODULEADAPTERxx]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodLanderPS]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPSPodAirlock]:FOR[RealismOverhaul]{}
 
+!PART[MonkeyPodLanderPSx3]:FOR[RealismOverhaul]{}
+
 !PART[MonkeyPodLanderPSxxxe54j]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodpsADAPTERmtv]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodpsADAPTERmtvLHSM66xsa]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodLanderOPEXPSxxxe54j]:FOR[RealismOverhaul]{}
 
@@ -211,151 +227,6 @@
 //  ==================================================
 
 @PART[x2MNode1x]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-    @description ^= :$: Supports a crew of 2 for 1 day. Air filtering unit not included.:
-
-    @mass -= 0.013
-
-    @MODULE[ModuleFuelTanks]
-    {
-        @volume = 100
-
-        TANK
-        {
-            name = Food
-            amount = 11.7
-            maxAmount = 11.7
-        }
-
-        TANK
-        {
-            name = Water
-            amount = 7.75
-            maxAmount = 7.75
-        }
-
-        TANK
-        {
-            name = Oxygen
-            amount = 1184
-            maxAmount = 1184
-        }
-
-        TANK
-        {
-            name = CarbonDioxide
-            amount = 0
-            maxAmount = 1023
-        }
-
-        TANK
-        {
-            name = Waste
-            amount = 0
-            maxAmount = 1.07
-        }
-
-        TANK
-        {
-            name = WasteWater
-            amount = 0
-            maxAmount = 9.85
-        }
-    }
-}
-
-//  ==================================================
-//  Exploration Station node.
-
-//  Dimensions: 4.5 m x 4.4 m
-//  Gross Mass: 4300 Kg
-//  ==================================================
-
-@PART[xNapHabV1x]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    @MODEL
-    {
-        @scale = 1.8, 1.8, 1.8
-    }
-
-    %scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_hatch = 0.0, 0.0, -1.9, 0.0, 0.0, -1.0, 3
-    @node_stack_front = 0.0, 2.255, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_back = 0.0, -2.255, 0.0, 0.0, -1.0, 0.0, 3
-
-    @category = Utility
-    @title = Exploration Station Node
-    @manufacturer = Boeing Co.
-    %description = Small utility node for deep space exploration with one docking node attachment point.
-
-    @mass = 4.3
-    @crashTolerance = 8
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-    %bulkheadProfiles = size3
-    !vesselType = NULL
-
-    !INTERNAL[xorbitalOrbInternals]{}
-
-    @MODULE[ModuleScienceContainer]
-    {
-        @storageRange = 2.5
-    }
-
-    !MODULE[ModuleScienceLab],*{}
-
-    !MODULE[ModuleDataTransmitter],*{}
-
-    !MODULE[ModuleCommand],*{}
-
-    !MODULE[MechJebCore],*{}
-
-    !MODULE[ModuleSAS],*{}
-
-    !MODULE[ModuleReactionWheel],*{}
-
-    !MODULE[ModuleFuelTanks],*{}
-
-    MODULE
-    {
-        name = ModuleFuelTanks
-        volume = 45
-        basemass = -1
-        type = ServiceModule
-
-        TANK
-        {
-            name = ElectricCharge
-            amount = 43200
-            maxAmount = 43200
-        }
-    }
-
-    !MODULE[ModuleConnectedLivingSpace],*{}
-
-    MODULE:NEEDS[ConnectedLivingSpace]
-    {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        surfaceAttachmentsPassable = True
-    }
-
-    !RESOUCE,*{}
-}
-
-//  ==================================================
-//  Exploration station node.
-
-//  TAC Life Support compatibility.
-//  ==================================================
-
-@PART[xNapHabV1x]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
     @description ^= :$: Supports a crew of 2 for 1 day. Air filtering unit not included.:
 
@@ -612,76 +483,101 @@
 }
 
 //  ==================================================
-//  Exploration Station utility hub.
+//  Expanded Observation Module.
 
-//  Dimensions: 4.5 m x 8.3 m
-//  Gross Mass: 8130 Kg
+//  Dimensions: 4.25 m x 2.5 m
+//  Gross Mass: 3200 Kg
 //  ==================================================
 
-@PART[x2MSleepHabV6-2x]:FOR[RealismOverhaul]
+@PART[XKupolaObsModuleEXPANDEDX]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
+    !mesh = NULL
+
     @MODEL
     {
-        @scale = 1.8, 1.8, 1.8
+        @scale = 2.1375, 2.1375, 2.1375
     }
 
-    %scale = 1.0
+    @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_hatch1 = 0.0, 0.0, -1.9, 0.0, 0.0, -1.0, 2
-    @node_stack_front = 0.0, 4.14, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_back = 0.0, -4.14, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_top = NULL
+    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 3
 
-    @category = Utility
-    @title = Exploration Station Utility Hub
-    @manufacturer = Boeing Co.
-    @description = Provides extra living space along with the addition of an extra docking node attachment point.
+    @category = Pods
+    @title = Expanded Observation Module
+    @manufacturer = Thales Alenia Space
+    %description = A larger version of the observation cupola module originally deployed on the ISS.
 
-    @mass = 8.13
+    @mass = 3.2
     @crashTolerance = 8
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-    %bulkheadProfiles = size2, size3
-    @CrewCapacity = 4
-    !vesselType = NULL
+    %fuelCrossFeed = True
+    %bulkheadProfiles = size3
 
-    !INTERNAL[xorbitalOrbInternals]{}
-
-    !MODULE[ModuleScienceContainer]
+    @INTERNAL[cupolaInternal]
     {
-        @storageRange = 2.5
+        %scaleAll = 2.1375, 2.1375, 2.1375
+
+        @MODULE[InternalSeat],*
+        {
+            %kerbalScale = 2.1375, 2.1375, 2.1375
+            %kerbalOffset = 0.0, 0.0, 0.0
+            %kerbalEyeOffset = 0.0, 0.0, 0.0
+        }
     }
 
-    !MODULE[ModuleScienceLab],*{}
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
 
-    !MODULE[ModuleDataTransmitter],*{}
+        %RESOURCE
+        {
+            %name = ElectricCharge
+            %rate = 0.375
+        }
+    }
 
-    !MODULE[ModuleCommand],*{}
-
-    !MODULE[MechJebCore],*{}
-
-    !MODULE[ModuleSAS],*{}
+    @MODULE[ModuleSAS]
+    {
+        %SASServiceLevel = 3
+    }
 
     !MODULE[ModuleReactionWheel],*{}
+
+    @MODULE[ModuleAnimateGeneric]:HAS[#animationName[KObsModuleBlastShutters]]
+    {
+        @startEventGUIName = Close Protective Shutters
+        @endEventGUIName = Open Protective Shutters
+        @toggleActionName = Toggle Protective Shutters
+        @startDeployed = False
+    }
+
+    @MODULE[ModuleLight]
+    {
+        @resourceAmount = 0.05
+    }
 
     !MODULE[ModuleFuelTanks],*{}
 
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 45
-        basemass = -1
         type = ServiceModule
+        volume = 25
+        basemass = -1
+
+        //  Batteries 6 kWh.
 
         TANK
         {
             name = ElectricCharge
-            amount = 43200
-            maxAmount = 43200
+            amount = 21600
+            maxAmount = 21600
         }
     }
 
@@ -691,75 +587,46 @@
     {
         name = ModuleConnectedLivingSpace
         passable = True
-        surfaceAttachmentsPassable = True
     }
 
     !RESOURCE,*{}
 }
 
 //  ==================================================
-//  Exploration Station utility hub.
+//  Expanded Observation Module.
 
 //  TAC Life Support compatibility.
 //  ==================================================
 
-@PART[x2MSleepHabV6-2x]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+@PART[XKupolaObsModuleEXPANDEDX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 4 for 1 day.:
+    @description ^= :$: Supports 1 crew for a single day. Includes an air filtering unit.:
 
-    @mass -=0.03
+    @mass -= 0.005
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 150
-
-        TANK
-        {
-            name = Food
-            amount = 23.4
-            maxAmount = 23.4
-        }
-
-        TANK
-        {
-            name = Water
-            amount = 15.5
-            maxAmount = 15.5
-        }
+        @volume = 55
 
         TANK
         {
             name = Oxygen
-            amount = 2368
-            maxAmount = 2368
+            amount = 592
+            maxAmount = 592
         }
 
         TANK
         {
             name = CarbonDioxide
             amount = 0
-            maxAmount = 2046
-        }
-
-        TANK
-        {
-            name = Waste
-            amount = 0
-            maxAmount = 2.14
-        }
-
-        TANK
-        {
-            name = WasteWater
-            amount = 0
-            maxAmount = 19.7
+            maxAmount = 256
         }
 
         TANK
         {
             name = LithiumHydroxide
-            amount = 3
-            maxAmount = 3
+            amount = 2.25
+            maxAmount = 2.25
         }
     }
 
@@ -771,14 +638,10 @@
         converterName = CO2 Scrubber
         StartActionName = Start CO2 Scrubber
         StopActionName = Stop CO2 Scrubber
-        conversionRate = 4.0
+        conversionRate = 1.0
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1113,7 +976,7 @@
 //  Gross Mass: 24000 Kg
 //  ==================================================
 
-@PART[SHABLANDER-SLR]:FOR[RealismOverhaul]
+@PART[SHABLANDER-SLRx32]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -10,63 +10,63 @@
 //  Removed extra parts.
 //  ==================================================
 
-!PART[XCXA_ACBMRX]:FOR[RealismOverhaul]{}
-
 !PART[XCXA_ACBM23RxxX]:FOR[RealismOverhaul]{}
 
 !PART[XCXA_ACBM2RxxX]:FOR[RealismOverhaul]{}
+
+!PART[XCXA_ACBMRX]:FOR[RealismOverhaul]{}
 
 !PART[XKupolaObsModuleEXPANDED1X]:FOR[RealismOverhaul]{}
 
 !PART[XKupolaObsModuleEXPANDED3X]:FOR[RealismOverhaul]{}
 
+!PART[MonkeyPodOrionTypeS22xa66ckX4899]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodOrionTypeS22xa66ck]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodOrionTypeS22xa]:FOR[RealismOverhaul]{}
+
+!PART[SHABLANDER-SLRx3233haaf]:FOR[RealismOverhaul]{}
+
 !PART[SHABLANDER-SLRx32af]:FOR[RealismOverhaul]{}
 
 !PART[SHABLANDER-SLRx32xa4e]:FOR[RealismOverhaul]{}
 
-!PART[MonkeyPodOrionTypeS22xa]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodOrionTypeS22xa66ck]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodOrionTypeS22xa66ck2cx]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodOrionTypeS22xa66ckX4899]:FOR[RealismOverhaul]{}
-
 !PART[MonkeyPodLanderxsaun]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodADAPTER]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodLander]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodAirlock2]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodAirlock3x]:FOR[RealismOverhaul]{}
 
-!PART[TESTMODULEADAPTERxx]:FOR[RealismOverhaul]{}
+!PART[MonkeyPodADAPTER]:FOR[RealismOverhaul]{}
 
-!PART[MonkeyPodLanderPS]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPSPodAirlock]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodLanderPSx3]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodLanderPSxxxe54j]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodpsADAPTERmtv]:FOR[RealismOverhaul]{}
-
-!PART[MonkeyPodpsADAPTERmtvLHSM66xsa]:FOR[RealismOverhaul]{}
+!PART[MonkeyPodLander]:FOR[RealismOverhaul]{}
 
 !PART[MonkeyPodLanderOPEXPSxxxe54j]:FOR[RealismOverhaul]{}
 
+!PART[MonkeyPSPodAirlock]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodpsADAPTERmtvLHSM66xsa]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodpsADAPTERmtv]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodLanderPSxxxe54j]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodLanderPSx3]:FOR[RealismOverhaul]{}
+
+!PART[MonkeyPodLanderPS]:FOR[RealismOverhaul]{}
+
 !PART[MonkeySMA8FPodLANDERPs]:FOR[RealismOverhaul]{}
 
-!PART[XKarmonyStorModule_Adffa87jgiayh]:FOR[RealismOverhaul]{}
+!PART[TESTMODULEADAPTERxx]:FOR[RealismOverhaul]{}
 
 !PART[XKarmonyStorModule_Adffa87jgi111ayh]:FOR[RealismOverhaul]{}
 
+!PART[XKarmonySMTVrS66322213G2]:FOR[RealismOverhaul]{}
+
 !PART[XKarmonySMTVrS6632221]:FOR[RealismOverhaul]{}
 
-!PART[XKarmonySMTVrS66322213G2]:FOR[RealismOverhaul]{}
+!PART[XKarmonyStorModule_Adffa87jgiayh]:FOR[RealismOverhaul]{}
 
 //  ==================================================
 //  Common Berthing Mechanism.
@@ -443,10 +443,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -497,14 +493,14 @@
 
     @MODEL
     {
-        @scale = 2.1375, 2.1375, 2.1375
+        @scale = 2.137, 2.137, 2.137
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
     !node_stack_top = NULL
-    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.965, 0.0, 0.0, -1.0, 0.0, 3
 
     @category = Pods
     @title = Expanded Observation Module
@@ -513,11 +509,12 @@
 
     @mass = 3.2
     @crashTolerance = 8
-    @breakingForce = 250
-    @breakingTorque = 250
     @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @vesselType = Station
+    @CrewCapacity = 3
     %fuelCrossFeed = True
-    %bulkheadProfiles = size3
+    @bulkheadProfiles = size3
 
     @INTERNAL[cupolaInternal]
     {
@@ -547,20 +544,14 @@
         %SASServiceLevel = 3
     }
 
-    !MODULE[ModuleReactionWheel],*{}
-
     @MODULE[ModuleAnimateGeneric]:HAS[#animationName[KObsModuleBlastShutters]]
     {
         @startEventGUIName = Close Protective Shutters
         @endEventGUIName = Open Protective Shutters
         @toggleActionName = Toggle Protective Shutters
-        @startDeployed = False
     }
 
-    @MODULE[ModuleLight]
-    {
-        @resourceAmount = 0.05
-    }
+    !MODULE[ModuleLight],*{}
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -581,6 +572,12 @@
         }
     }
 
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleScienceContainer],*{}
+
     !MODULE[ModuleConnectedLivingSpace],*{}
 
     MODULE:NEEDS[ConnectedLivingSpace]
@@ -600,26 +597,26 @@
 
 @PART[XKupolaObsModuleEXPANDEDX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports 1 crew for 1 day day of active operations. Includes an air filtering unit.:
+    @description ^= :$: Supports 3 crew for 1 day of active operations. Includes an air filtering unit.:
 
     @mass -= 0.005
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 100
+        @volume = 55
 
         TANK
         {
             name = Oxygen
-            amount = 592
-            maxAmount = 592
+            amount = 1780
+            maxAmount = 1780
         }
 
         TANK
         {
             name = CarbonDioxide
             amount = 0
-            maxAmount = 256
+            maxAmount = 1540
         }
 
         TANK
@@ -638,7 +635,7 @@
         converterName = CO2 Scrubber
         StartActionName = Start CO2 Scrubber
         StopActionName = Stop CO2 Scrubber
-        conversionRate = 1.0
+        conversionRate = 3.0
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
@@ -684,7 +681,7 @@
 //  Gross Mass: 44000 Kg
 //  ==================================================
 
-@PART[MonkeyPodOrionTypeS22]:FOR[RealismOverhaul]
+@PART[MonkeyPodOrionTypeS22xa66ck2cx]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -774,7 +771,7 @@
 //  TAC Life Support compatibility.
 //  ==================================================
 
-@PART[MonkeyPodOrionTypeS22]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+@PART[MonkeyPodOrionTypeS22xa66ck2cx]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
     @description ^= :$: Supports a crew of 8 for 18 months of active operations.:
 
@@ -842,14 +839,10 @@
         converterName = Sabatier Reactor Unit
         StartActionName = Start Sabatier Reactor
         StopActionName = Stop Sabatier Reactor
-        conversionRate = 3.0
+        conversionRate = 4.0
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -894,10 +887,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -936,10 +925,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1078,7 +1063,7 @@
 //  TAC Life Support compatibility.
 //  ==================================================
 
-@PART[SHABLANDER-SLR]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+@PART[SHABLANDER-SLRx32]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
     @description ^= :$: Supports a crew of 6 for 18 months of active operations.:
 
@@ -1146,14 +1131,10 @@
         converterName = Sabatier Reactor Unit
         StartActionName = Start Sabatier Reactor
         StopActionName = Stop Sabatier Reactor
-        conversionRate = 2.0
+        conversionRate = 3.0
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1198,10 +1179,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1240,10 +1217,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1440,14 +1413,10 @@
         converterName = Sabatier Reactor Unit
         StartActionName = Start Sabatier Reactor
         StopActionName = Stop Sabatier Reactor
-        conversionRate = 2.0
+        conversionRate = 3.0
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1492,10 +1461,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1534,10 +1499,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -1589,9 +1550,9 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_bottom = 0.0, -1.135, 0.0, 0.0, -1.0, 0.0, 2
-    @node_stack_top = 0.0, 1.135, 0.0, 0.0, 1.0, 0.0, 2
-    %node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+    @node_stack_top = 0.0, 1.355, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.355, 0.0, 0.0, -1.0, 0.0, 2
+    %node_attach = 0.0, 0.0, 1.355, 0.0, 0.0, -1.0
     @attachRules = 1,1,1,1,0
 
     @category = Utility
@@ -1856,7 +1817,7 @@
 
 @PART[orbitalorbx]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 2 for 1 day.:
+    @description ^= :$: Supports a crew of 2 for 1 day of active operations.:
 
     @mass -= 0.017
 
@@ -1926,10 +1887,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {
@@ -2215,7 +2172,7 @@
 
 @PART[XKarmonyStorModule_AdapterS6632]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Contains only an oxygen supply to support 2 crew for 1 day with a maximum capacity of 30 days. Air filtering unit included.:
+    @description ^= :$: Contains only an oxygen supply to support 2 crew for 1 day of active operations. Maximum capacity of 30 days. Air filtering unit included.:
 
     @mass -= 0.008
 
@@ -2257,10 +2214,6 @@
         tag = Life Support
         GeneratesHeat = False
         UseSpecialistBonus = False
-        SpecialistEfficiencyFactor = 0.2
-        SpecialistBonusBase = 0.05
-        ExperienceEffect = ConverterSkill
-        EfficiencyBonus = 1.0
 
         INPUT_RESOURCE
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -228,13 +228,13 @@
 
 @PART[x2MNode1x]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 2 for 1 day. Air filtering unit not included.:
+    @description ^= :$: Supports a crew of 2 for 1 day of active operations. Air filtering unit not included.:
 
     @mass -= 0.013
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 100
+        @volume = 300
 
         TANK
         {
@@ -373,13 +373,13 @@
 
 @PART[x2MSleepH3abV4-2x]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 4 for 1 day.:
+    @description ^= :$: Supports a crew of 4 for 1 day of active operations.:
 
     @mass -= 0.03
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 150
+        @volume = 500
 
         TANK
         {
@@ -600,13 +600,13 @@
 
 @PART[XKupolaObsModuleEXPANDEDX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports 1 crew for a single day. Includes an air filtering unit.:
+    @description ^= :$: Supports 1 crew for 1 day day of active operations. Includes an air filtering unit.:
 
     @mass -= 0.005
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 55
+        @volume = 100
 
         TANK
         {
@@ -776,13 +776,13 @@
 
 @PART[MonkeyPodOrionTypeS22]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 8 for 18 months.:
+    @description ^= :$: Supports a crew of 8 for 18 months of active operations.:
 
     @mass -= 7.266
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 29250
+        @volume = 32500
 
         TANK
         {
@@ -1080,13 +1080,13 @@
 
 @PART[SHABLANDER-SLR]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 6 for 18 months.:
+    @description ^= :$: Supports a crew of 6 for 18 months of active operations.:
 
     @mass -= 5.446
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 22200
+        @volume = 25000
 
         TANK
         {
@@ -1374,13 +1374,13 @@
 
 @PART[MonkeySMA8FPodLANDERPsXX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 4 for 180 days.:
+    @description ^= :$: Supports a crew of 4 for 180 days of active operations.:
 
     @mass -= 1.313
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 5000
+        @volume = 6000
 
         TANK
         {
@@ -1670,7 +1670,7 @@
 {
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 20
+        @volume = 50
 
         TANK
         {
@@ -1862,7 +1862,7 @@
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 100
+        @volume = 250
 
         TANK
         {
@@ -2221,7 +2221,7 @@
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 300
+        @volume = 1000
 
         TANK
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -1685,7 +1685,7 @@
 //  Small logistics module
 
 //  Dimensions: 4.5 m x 4.2 m
-//  Gross Mass: 4000 Kg
+//  Inert Mass: 4000 Kg
 //  ==================================================
 
 @PART[MonkeyPodpsADAPTER]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -20,25 +20,15 @@
 
 !PART[xALCOR_LanderCapsule3x]:FOR[RealismOverhaul]{}
 
-!PART[Xcupola2X]:FOR[RealismOverhaul]{}
-
-!PART[Xcupola3X]:FOR[RealismOverhaul]{}
-
 !PART[xLERroverXBodyxX]:FOR[RealismOverhaul]{}
 
 !PART[xLERroverXBod32xX]:FOR[RealismOverhaul]{}
 
-!PART[xLERDockPortSHABSSA]:FOR[RealismOverhaul]{}
-
-!PART[xLERDockPortSHABSSA3xq]:FOR[RealismOverhaul]{}
-
-!PART[xLERDockPortSHABSSA3xXq]:FOR[RealismOverhaul]{}
+!PART[xmk2LanderCabin2x]:FOR[RealismOverhaul]{}
 
 !PART[xndsport2x]:FOR[RealismOverhaul]{}
 
 !PART[xndsport3x]:FOR[RealismOverhaul]{}
-
-!PART[xndsport5x]:FOR[RealismOverhaul]{}
 
 !PART[xparachuteRadial2x]:FOR[RealismOverhaul]{}
 
@@ -1025,173 +1015,6 @@
 }
 
 //  ==================================================
-//  Expanded Observation Module.
-
-//  Dimensions: 4.25 m x 2.5 m
-//  Gross Mass: 3200 Kg
-//  ==================================================
-
-@PART[XcupolaX]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    @MODEL
-    {
-        @scale = 1.7, 1.7, 1.7
-    }
-
-    @scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 1.428, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -0.68, 0.0, 0.0, -1.0, 0.0, 3
-
-    @category = Pods
-    @title = Expanded Observation Module
-    @manufacturer = Thales Alenia Space
-    @description = A larger version of the observation cupola module originally deployed on the ISS.
-
-    @mass = 3.2
-    @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
-    @vesselType = Station
-    @bulkheadProfiles = size3
-
-    @MODULE[ModuleCommand]
-    {
-        @minimumCrew = 0
-
-        %RESOURCE
-        {
-            %name = ElectricCharge
-            %rate = 0.375
-        }
-    }
-
-    !MODULE[ModuleFuelTanks],*{}
-
-    MODULE
-    {
-        name = ModuleFuelTanks
-        type = ServiceModule
-        volume = 25
-        basemass = -1
-
-        //  Batteries 6 kWh.
-
-        TANK
-        {
-            name = ElectricCharge
-            amount = 21600
-            maxAmount = 21600
-        }
-    }
-
-    !MODULE[ModuleReactionWheel],*{}
-
-    !MODULE[ModuleScienceContainer],*{}
-
-    !MODULE[ModuleConnectedLivingSpace],*{}
-
-    MODULE:NEEDS[ConnectedLivingSpace]
-    {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        impassablenodes = top
-    }
-
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  Expanded Observation Module.
-
-//  TAC Life Support compatibility.
-//  ==================================================
-
-@PART[XcupolaX]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
-{
-    @description ^= :$: Supports 1 crew for a single day. Includes an air filtering unit.:
-
-    @mass -= 0.005
-
-    @MODULE[ModuleFuelTanks]
-    {
-        @volume = 55
-
-        TANK
-        {
-            name = Oxygen
-            amount = 592
-            maxAmount = 592
-        }
-
-        TANK
-        {
-            name = CarbonDioxide
-            amount = 0
-            maxAmount = 256
-        }
-
-        TANK
-        {
-            name = LithiumHydroxide
-            amount = 2.25
-            maxAmount = 2.25
-        }
-    }
-
-    !MODULE[TacGenericConverter],*{}
-
-    MODULE
-    {
-        name = TacGenericConverter
-        converterName = CO2 Scrubber
-        StartActionName = Start CO2 Scrubber
-        StopActionName = Stop CO2 Scrubber
-        conversionRate = 1.0
-        tag = Life Support
-        GeneratesHeat = False
-        UseSpecialistBonus = False
-
-        INPUT_RESOURCE
-        {
-            ResourceName = CarbonDioxide
-            Ratio = 0.006216
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = ElectricCharge
-            Ratio = 0.01
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = LithiumHydroxide
-            Ratio = 0.0000085683
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = Water
-            Ratio = 0.0032924498
-            DumpExcess = True
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = Waste
-            Ratio = 0.0000257297
-            DumpExcess = False
-        }
-    }
-}
-
-//  ==================================================
 //  Pegasus IA low profile ladder.
 
 //  Dimensions: 0.4 m x 0.4 m
@@ -1289,74 +1112,143 @@
 }
 
 //  ==================================================
-//  Surface Docking Mechanism (SDM).
+//  Lander Can.
 
-//  Dimensions: 1.2 m x 1.7 m
-//  Inert Mass: 350 Kg
+//  Dimensions: - m x - m
+//  Gross Mass: - Kg
 //  ==================================================
 
-@PART[xLERDockPortxs]:FOR[RealismOverhaul]
+@PART[xmk2LanderCabinx]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
+    %RSSROConfig = False
 
     !mesh = NULL
 
-    MODEL
+    @MODEL
     {
-        model = CMES/Pod/LER_dockport/model
-        scale = 1.6, 1.6, 1.6
+        @scale = 1.0, 1.0, 1.0
     }
 
-    %scale = 1.0
+    @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_attach = 0.0, -0.2, 0.0, -1.0, 0.0, 0.0
+    @node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 3
 
-    @category = Coupling
-    @title = Surface Docking Mechanism (SDM)
-    %manufacturer = Boeing Co.
-    @description = The SDM provides a safe pressurized passage for crew and cargo between surface - landed modules or exploration rovers.
+    @category = Pods
+    @title = Lander Can
+    @manufacturer = Generic
+    @description = N/A
 
-    @mass = 0.35
-    @crashTolerance = 10
-    @breakingForce = 250
-    @breakingTorque = 250
+    @mass = 1.0
+    @crashTolerance = 8
     @maxTemp = 473.15
-    %skinMaxTemp = 473.15
-    !stagingIcon = NULL
-    %bulkheadProfiles = srf
+    @skinMaxTemp = 573.15
+    @bulkheadProfiles = size3
+    %fuelCrossFeed = True
+    @CrewCapacity = 3
+    @vesselType = Lander
 
-    @MODULE[ModuleDockingNode]
+    @INTERNAL[ALCORMonkeyInternals]
     {
-        @nodeType = NASADockSurf
-        %acquireForce = 0.5
-        %acquireMinFwdDot = 0.8
-        %acquireminRollDot = -3.40282347E+38
-        %acquireRange = 0.25
-        %acquireTorque = 0.5
-        %captureMaxRvel = 0.1
-        %captureMinFwdDot = 0.998
-        %captureMinRollDot = -3.40282347E+38
-        %captureRange = 0.05
-        %minDistanceToReEngage = 0.25
-        %undockEjectionForce = 0.1
+        %scaleAll = 1.0, 1.0, 1.0
+
+        @MODULE[InternalSeat],*
+        {
+            %kerbalScale = 1.0, 1.0, 1.0
+            %kerbalOffset = 0.0, 0.0, 0.0
+            %kerbalEyeOffset = 0.0, 0.0, 0.0
+        }
     }
 
-    @MODULE[ModuleAnimateGeneric]
+    @MODULE[ModuleCommand]
     {
-        @startEventGUIName = Deploy Docking Port
-        @endEventGUIName = Retract Docking Port
-        %actionGUIName = Toggle Docking Port
-        %allowAnimationWhileShielded = False
+        @minimumCrew = 0
+
+        &RESOURCE
+        {
+            &name = ElectricCharge
+            &rate = 1.0
+        }
     }
 
-    !MODULE[ModuleConnectedLivingSpace],*{}
+    !MODULE[ModuleReactionWheel],*{}
 
-    MODULE:NEEDS[ConnectedLivingSpace]
+    @MODULE[ModuleScienceContainer]
     {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        passableWhenSurfaceAttached = True
+        @storageRange = 2.0
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 100
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Lander Can.
+
+//  TAC Life Support compatibility.
+//  ==================================================
+
+@PART[xmk2LanderCabinx]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+{
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume = 200
+    }
+
+    !MODULE[TacGenericConverter],*{}
+
+    MODULE
+    {
+        name = TacGenericConverter
+        converterName = CO2 Scrubber
+        StartActionName = Start CO2 Scrubber
+        StopActionName = Stop CO2 Scrubber
+        conversionRate = 3.0
+        tag = Life Support
+        GeneratesHeat = False
+        UseSpecialistBonus = False
+
+        INPUT_RESOURCE
+        {
+            ResourceName = CarbonDioxide
+            Ratio = 0.006216
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.01
+        }
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LithiumHydroxide
+            Ratio = 0.0000085683
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0032924498
+            DumpExcess = True
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Waste
+            Ratio = 0.0000257297
+            DumpExcess = False
+        }
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -365,7 +365,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 26.7
         @maxThrust = 26.7
         @heatProduction = 100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -123,6 +123,22 @@
 
     !MODULE[MechJebCore],*{}
 
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 1250
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.05
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
+    }
+
     !MODULE[ModuleConnectedLivingSpace],*{}
 
     MODULE:NEEDS[ConnectedLivingSpace]
@@ -154,7 +170,7 @@
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate -= 0.008
+            @rate -= 0.025
         }
     }
 
@@ -170,8 +186,8 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 250000
-        EnergyCost = 0.008
+        Mode1OmniRange = 250000000
+        EnergyCost = 0.025
         DeployFxModules = 0
         ProgressFxModules = 1
 
@@ -368,7 +384,6 @@
         @minThrust = 26.7
         @maxThrust = 26.7
         @heatProduction = 100
-        %exhaustDamageMultiplier = 0.75
         %ullage = False
         %pressureFed = True
         %ignitions = 500
@@ -383,7 +398,6 @@
         {
             @name = MON3
             @ratio = 0.501
-            @DrawGauge = False
         }
 
         @atmosphereCurve
@@ -433,6 +447,22 @@
     !MODULE[ModuleReactionWheel],*{}
 
     !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 1250
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.05
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
+    }
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -535,7 +565,7 @@
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate -= 0.015
+            @rate -= 0.05
         }
     }
 
@@ -550,9 +580,9 @@
     {
         name = ModuleRTAntenna
         IsRTActive = False
-        Mode0OmniRange = 1000000
-        Mode1OmniRange = 1000000
-        EnergyCost = 0.015
+        Mode0OmniRange = 0
+        Mode1OmniRange = 250000000
+        EnergyCost = 0.025
         DeployFxModules = 0
         ProgressFxModules = 1
 
@@ -560,7 +590,7 @@
         {
             PacketInterval = 1.0
             PacketSize = 1.024
-            PacketResourceCost = 0.05
+            PacketResourceCost = 0.025
         }
     }
 }
@@ -1111,7 +1141,7 @@
 }
 
 //  ==================================================
-//  Lander Can.
+//  Lander can.
 
 //  Dimensions: 4.0 m x 1.9 m
 //  Gross Mass: 2570 Kg
@@ -1178,6 +1208,22 @@
         @storageRange = 2.0
     }
 
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 1250
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.05
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
+    }
+
     !MODULE[ModuleFuelTanks],*{}
 
     MODULE
@@ -1199,7 +1245,55 @@
 }
 
 //  ==================================================
-//  Lander Can.
+//  Lander can.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[xmk2LanderCabinx]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.025
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 250000000
+        EnergyCost = 0.025
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.025
+        }
+    }
+}
+
+//  ==================================================
+//  Lander can.
 
 //  TAC Life Support compatibility.
 //  ==================================================
@@ -1592,7 +1686,7 @@
 //  Orion EFT Crew Module LES decoupling system.
 
 //  Dimensions: 2.7 m x 1 m
-//  Gross Mass: 600 Kg
+//  Inert Mass: 600 Kg
 //  ==================================================
 
 @PART[OrionDockingPortXx]:FOR[RealismOverhaul]
@@ -1828,7 +1922,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1760
         @maxThrust = 1760
         @heatProduction = 100
@@ -1898,7 +1991,6 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = Orion-LAS
-        modded = False
 
         CONFIG
         {
@@ -2075,6 +2167,22 @@
     @MODULE[ModuleSAS]
     {
         %SASServiceLevel = 3
+    }
+
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 0.02
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.02
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
     }
 
     !MODULE[ModuleReactionWheel],*{}
@@ -2327,6 +2435,22 @@
         @storageRange = 2.6
     }
 
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 0.02
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.02
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
+    }
+
     !MODULE[ModuleScienceLab],*{}
 
     !MODULE[MechJebCore],*{}
@@ -2493,7 +2617,7 @@
         {
             PacketInterval = 1.0
             PacketSize = 1.024
-            PacketResourceCost = 0.05
+            PacketResourceCost = 0.005
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -1058,103 +1058,6 @@
 }
 
 //  ==================================================
-//  Pegasus IA low profile ladder.
-
-//  Dimensions: 0.4 m x 0.4 m
-//  Inert Mass: 5 Kg
-//  ==================================================
-
-@PART[xladder1x]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    MODEL
-    {
-        model = CMES/Pod/ladderRadial/model
-        scale = 1.333, 1.333, 1.333
-    }
-
-    %scale = 1.0
-    %rescaleFactor = 1.0
-
-    @node_attach = -0.06, 0.0, 0.0, 1.0, 0.0, 0.0
-
-    @category = Utility
-    @title = Pegasus IA Mobility Enhancer (Low Profile)
-    @manufacturer = Generic
-    %description = The Pegasus IA Mobility Enhancer, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
-
-    @mass = 0.005
-    @crashTolerance = 14
-    %breakingForce = 250
-    %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
-    %fuelCrossFeed = False
-}
-
-//  ==================================================
-//  Mobile base chassis.
-
-//  Dimensions: 2.5 m x 5.3 m
-//  Inert Mass: 400 Kg
-//  ==================================================
-
-@PART[xLERroverBodyx]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    MODEL
-    {
-        model = CMES/Pod/LER_base/model
-        scale = 2.125, 2.125, 1.85
-    }
-
-    %scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 3
-    !node_stack_1 = NULL
-    !node_stack_2 = NULL
-    !node_stack_3 = NULL
-    !node_stack_4 = NULL
-    !node_stack_5 = NULL
-    !node_stack_6 = NULL
-
-    @category = Structural
-    @title = Mobile Base Chassis
-    @manufacturer = NASA
-    @description = A modular structural frame. Can be used as a chassis for the MMSEV rover or for mobile surface habitats.
-
-    @mass = 0.4
-    @crashTolerance = 14
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
-    !explosionPotential = NULL
-    %bulkheadProfiles = size2, size3
-    !vesselType = NULL
-    !CoMOffset = NULL
-    !CoLOffset = NULL
-
-    !MODULE[ModuleCommand],*{}
-
-    !MODULE[ModuleSAS],*{}
-
-    !MODULE[ModuleReactionWheel],*{}
-
-    !MODULE[ModuleGenerator],*{}
-
-    !RESOURCE,*{}
-}
-
-//  ==================================================
 //  Lander can.
 
 //  Dimensions: 4.0 m x 1.9 m
@@ -1416,6 +1319,103 @@
             DumpExcess = False
         }
     }
+}
+
+//  ==================================================
+//  Pegasus IA low profile ladder.
+
+//  Dimensions: 0.4 m x 0.4 m
+//  Inert Mass: 5 Kg
+//  ==================================================
+
+@PART[xladder1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/ladderRadial/model
+        scale = 1.333, 1.333, 1.333
+    }
+
+    %scale = 1.0
+    %rescaleFactor = 1.0
+
+    @node_attach = -0.06, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = Utility
+    @title = Pegasus IA Mobility Enhancer (Low Profile)
+    @manufacturer = Generic
+    %description = The Pegasus IA Mobility Enhancer, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
+
+    @mass = 0.005
+    @crashTolerance = 14
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    %fuelCrossFeed = False
+}
+
+//  ==================================================
+//  Mobile base chassis.
+
+//  Dimensions: 2.5 m x 5.3 m
+//  Inert Mass: 400 Kg
+//  ==================================================
+
+@PART[xLERroverBodyx]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    MODEL
+    {
+        model = CMES/Pod/LER_base/model
+        scale = 2.125, 2.125, 1.85
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.125, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_1 = NULL
+    !node_stack_2 = NULL
+    !node_stack_3 = NULL
+    !node_stack_4 = NULL
+    !node_stack_5 = NULL
+    !node_stack_6 = NULL
+
+    @category = Structural
+    @title = Mobile Base Chassis
+    @manufacturer = NASA
+    @description = A modular structural frame. Can be used as a chassis for the MMSEV rover or for mobile surface habitats.
+
+    @mass = 0.4
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
+    !explosionPotential = NULL
+    %bulkheadProfiles = size2, size3
+    !vesselType = NULL
+    !CoMOffset = NULL
+    !CoLOffset = NULL
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -198,7 +198,7 @@
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 350
+        @volume = 500
 
         TANK
         {
@@ -580,7 +580,7 @@
 
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 5400
+        @volume = 5500
 
         TANK
         {
@@ -1114,8 +1114,8 @@
 //  ==================================================
 //  Lander Can.
 
-//  Dimensions: - m x - m
-//  Gross Mass: - Kg
+//  Dimensions: 4.0 m x 1.9 m
+//  Gross Mass: 2570 Kg
 //  ==================================================
 
 @PART[xmk2LanderCabinx]:FOR[RealismOverhaul]
@@ -1126,21 +1126,21 @@
 
     @MODEL
     {
-        @scale = 1.0, 1.0, 1.0
+        @scale = 1.6, 1.6, 1.6
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_top = 0.0, 1.21, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -0.668, 0.0, 0.0, -1.0, 0.0, 3
 
     @category = Pods
     @title = Lander Can
     @manufacturer = Generic
-    @description = N/A
+    @description = A generic lander pod crew cabin.
 
-    @mass = 1.0
+    @mass = 2.57
     @crashTolerance = 8
     @maxTemp = 473.15
     @skinMaxTemp = 573.15
@@ -1168,7 +1168,7 @@
         &RESOURCE
         {
             &name = ElectricCharge
-            &rate = 1.0
+            &rate = 1.3
         }
     }
 
@@ -1185,8 +1185,15 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 100
+        volume = 60
         basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 43200
+            maxAmount = 43200
+        }
     }
 
     !RESOURCE,*{}
@@ -1200,9 +1207,62 @@
 
 @PART[xmk2LanderCabinx]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
+    @description ^= :$: Supports a crew of 3 for up to 21 days of active operations.:
+
+    @mass -= 0.47
+
     @MODULE[ModuleFuelTanks]
     {
-        @volume = 200
+        @volume = 2000
+
+        TANK
+        {
+            name = Food
+            amount = 370
+            maxAmount = 370
+        }
+
+        TANK
+        {
+            name = Water
+            amount = 245
+            maxAmount = 245
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 37285
+            maxAmount = 37285
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 35
+            maxAmount = 35
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 310
+            maxAmount = 310
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 1535
+            maxAmount = 1535
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 47
+            maxAmount = 47
+        }
     }
 
     !MODULE[TacGenericConverter],*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -16,19 +16,19 @@
 //  Removed extra parts.
 //  ==================================================
 
-!PART[xALCOR_LanderCapsule2x]:FOR[RealismOverhaul]{}
-
 !PART[xALCOR_LanderCapsule3x]:FOR[RealismOverhaul]{}
 
-!PART[xLERroverXBodyxX]:FOR[RealismOverhaul]{}
+!PART[xALCOR_LanderCapsule2x]:FOR[RealismOverhaul]{}
 
 !PART[xLERroverXBod32xX]:FOR[RealismOverhaul]{}
 
+!PART[xLERroverXBodyxX]:FOR[RealismOverhaul]{}
+
 !PART[xmk2LanderCabin2x]:FOR[RealismOverhaul]{}
 
-!PART[xndsport2x]:FOR[RealismOverhaul]{}
-
 !PART[xndsport3x]:FOR[RealismOverhaul]{}
+
+!PART[xndsport2x]:FOR[RealismOverhaul]{}
 
 !PART[xparachuteRadial2x]:FOR[RealismOverhaul]{}
 
@@ -73,12 +73,26 @@
     @CrewCapacity = 4
     %bulkheadProfiles = size3
 
+    @INTERNAL[ALCORInternals3]
+    {
+        %scaleAll = 1.85, 1.85, 1.85
+
+        @MODULE[InternalSeat],*
+        {
+            %kerbalScale = 1.85, 1.85, 1.85
+            %kerbalOffset = 0.0, 0.0, 0.0
+            %kerbalEyeOffset = 0.0, 0.0, 0.0
+        }
+    }
+
     @MODULE[ModuleCommand]
     {
-        RESOURCE
+        @minimumCrew = 1
+
+        %RESOURCE
         {
-            name = ElectricCharge
-            rate = 0.5
+            %name = ElectricCharge
+            %rate = 0.5
         }
     }
 
@@ -87,9 +101,13 @@
         %SASServiceLevel = 3
     }
 
-    MODULE[ModuleScienceContainer]
+    %MODULE[ModuleScienceContainer]
     {
-        @storageRange = 3.0
+        %name = ModuleScienceContainer
+        %reviewActionName = Review Stored Data
+        %storeActionName = Store Data
+        %evaOnlyStorage = True
+        %storageRange = 3.0
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -118,8 +136,6 @@
     !MODULE[ModuleGenerator],*{}
 
     !MODULE[RasterPropMonitorComputer],*{}
-
-    !MODULE[KASModuleContainer],*{}
 
     !MODULE[MechJebCore],*{}
 
@@ -208,7 +224,7 @@
 
 @PART[xALCOR_LanderCapsulex]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a crew of 2 for 7 days. Maximum capacity of up to 4 crew.:
+    @description ^= :$: Supports a crew of 2 for 7 days of active operations. Maximum capacity of up to 4 crew.:
 
     @mass -= 0.11
 
@@ -383,21 +399,19 @@
     {
         @minThrust = 26.7
         @maxThrust = 26.7
-        @heatProduction = 100
-        %ullage = False
-        %pressureFed = True
-        %ignitions = 500
+        %heatProduction = 27
+        %EngineType = LiquidFuel
 
         @PROPELLANT[LiquidFuel]
         {
             @name = MMH
-            @ratio = 0.499
+            @ratio = 0.4990
         }
 
         @PROPELLANT[Oxidizer]
         {
             @name = MON3
-            @ratio = 0.501
+            @ratio = 0.5010
         }
 
         @atmosphereCurve
@@ -565,7 +579,7 @@
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate -= 0.05
+            @rate -= 0.025
         }
     }
 
@@ -590,7 +604,7 @@
         {
             PacketInterval = 1.0
             PacketSize = 1.024
-            PacketResourceCost = 0.025
+            PacketResourceCost = 0.05
         }
     }
 }
@@ -603,7 +617,7 @@
 
 @PART[altairPod]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    @description ^= :$: Supports a 4 crew lunar sortie for up to 7 days.:
+    @description ^= :$: Supports a 4 crew lunar sortie for up to 7 days of active operations.:
 
     @mass -= 0.16
 
@@ -1180,11 +1194,11 @@
 
     @INTERNAL[ALCORMonkeyInternals]
     {
-        %scaleAll = 1.0, 1.0, 1.0
+        %scaleAll = 1.6, 1.6, 1.6
 
         @MODULE[InternalSeat],*
         {
-            %kerbalScale = 1.0, 1.0, 1.0
+            %kerbalScale = 1.6, 1.6, 1.6
             %kerbalOffset = 0.0, 0.0, 0.0
             %kerbalEyeOffset = 0.0, 0.0, 0.0
         }
@@ -1243,7 +1257,6 @@
 
     !RESOURCE,*{}
 }
-
 //  ==================================================
 //  Lander can.
 
@@ -1686,7 +1699,7 @@
 //  Orion EFT Crew Module LES decoupling system.
 
 //  Dimensions: 2.7 m x 1 m
-//  Inert Mass: 600 Kg
+//  Gross Mass: 600 Kg
 //  ==================================================
 
 @PART[OrionDockingPortXx]:FOR[RealismOverhaul]
@@ -1924,11 +1937,8 @@
     {
         @minThrust = 1760
         @maxThrust = 1760
-        @heatProduction = 100
+        @heatProduction = 50
         %EngineType = SolidBooster
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -1991,13 +2001,14 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = Orion-LAS
+        origMass = 4.13
 
         CONFIG
         {
             name = Orion-LAS
             minThrust = 1760
             maxThrust = 1760
-            heatProduction = 100
+            heatProduction = 50
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -2617,7 +2628,7 @@
         {
             PacketInterval = 1.0
             PacketSize = 1.024
-            PacketResourceCost = 0.005
+            PacketResourceCost = 0.015
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1,43 +1,43 @@
 //  ==================================================
 //  Sources:
 
-//  Orbital ATK - GEM-60 brochure:                           http://www.alternatewars.com/BBOW/Space_Engines/GEM-60.pdf
-//  Orbital ATK SRM catalog:                                 https://www.orbitalatk.com/flight-systems/propulsion-systems/launch-abort-motor/docs/orbital_atk_motor_catalog_(2012).pdf
-//  NASASpaceFlight101 - "Dark Knight" Advanced Booster:     http://www.nasaspaceflight.com/2013/01/the-dark-knights-atks-advanced-booster-revealed-for-sls/
-//  NASASpaceFlight101 - Orbital ATK Advanced Boosters:      http://www.nasaspaceflight.com/2015/02/advanced-boosters-towards-solid-future-sls/
-//  Space Launch Report - Space Launch System Data Sheet:    http://www.spacelaunchreport.com/sls0.html
-//  Space Launch Report - Delta IV:                          http://www.spacelaunchreport.com/delta4.html
-//  Norbert Brügge - Ares I:                                 http://www.b14643.de/Spacerockets_2/United_States_1/Ares-I_CLV/Description/Frame.htm
-//  Norbert Brügge - Delta IV:                               http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Description/Frame.htm
-//  Rocket & Space Technology - Delta IV:                    http://www.braeunig.us/space/specs/delta.htm
-//  Spaceflight101 - Delta IV Medium (5,2):                  http://spaceflight101.com/spacerockets/delta-iv-medium-52/
-//  ULA - Delta IV user guide:                               http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
-//  Norbert Brügge - RL10 rocket engine:                     http://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
-//  Aerojet Rocketdyne - RL10 rocket engine:                 https://www.rocket.com/rl10-engine
-//  NTRS - Cryogenic Propulsion Stage:                       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110015783.pdf
-//  AIAA - Lunar Lander Designs:                             http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf
-//  Space Launch Report - Falcon 9:                          http://www.spacelaunchreport.com/falcon.html
-//  Spaceflight 101 - Falcon 9 v1.1:                         http://spaceflight101.com/spacerockets/falcon-9-v1-1-f9r/
-//  Astronautix - Kestrel rocket engine:                     http://www.astronautix.com/k/kestrel.html
-//  Astronautix - J-2X rocket engine:                        http://www.astronautix.com/engines/j2x.htm
-//  Aerojet Rocketdyne - J-2X rocket engine:                 http://rocket.com/j-2x-engine
-//  The J-2X Upper Stage Engine: From Design to Hardware:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100034922.pdf
-//  FAA - DragonFly pad abort test:                          https://www.faa.gov/about/office_org/headquarters_offices/ast/media/20140513_DragonFly_DraftEA_Appendices%28reduced%29.pdf
-//  Aerojet Rocketdyne - Orion Service Module:               https://www.rocket.com/orion-service-module
-//  Aerojet Rocketdyne - Orion Crew Module:                  https://www.rocket.com/orion-crew-module
-//  Aerojet Rocketdyne - Orion Main Engine:                  https://www.rocket.com/orion-main-engine
-//  Spaceflight101 - Orion spacecraft overview:              http://spaceflight101.com/spacecraft/orion/
-//  NTRS - Orion European Service Module (PowerPoint):       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140008543.pdf
-//  NTRS - Orion European Service Module (Document):         http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140010527.pdf
-//  NTRS - "Bimodal" Nuclear Thermal Rocket (BNTR):          http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
-//  AIAA - "Trimodal" Nuclear Thermal Rocket (TRITON):       http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3863_TRITON.pdf
-//  NTRS - Crewed Mars Mission using BNTEP:                  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140009579.pdf
-//  Pratt & Whitney Rocketdyne - RS-68 rocket engine:        http://www.alternatewars.com/BBOW/Space_Engines/RS-68.pdf
-//  Purdue AAE - RS-68 rocket engine:                        https://engineering.purdue.edu/~propulsi/propulsion/rockets/liquids/rs68.html
-//  NASASpaceFlight101 - Exploration Upper Stage:            http://www.nasaspaceflight.com/2014/10/nasa-exploration-upper-stage-workhorse-sls/
-//  NTRS - SLS Dual Use Upper Stage (DUUS) Opportunities:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20130013953.pdf
-//  NASASpaceFlight101 - Large Upper Stage (LUS):            http://www.nasaspaceflight.com/2013/11/new-sls-options-new-large-upper-stage/
-//  Constellation Program Battery and Fuel Cell Development: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120016064.pdf
+//  Orbital ATK - GEM-60 SRM brochure:                              http://www.alternatewars.com/BBOW/Space_Engines/GEM-60.pdf
+//  Orbital ATK SRM catalog:                                        https://www.orbitalatk.com/flight-systems/propulsion-systems/docs/2016%20OA%20Motor%20Catalog.pdf
+//  NASASpaceFlight101 - "Dark Knight" Advanced Booster:            http://www.nasaspaceflight.com/2013/01/the-dark-knights-atks-advanced-booster-revealed-for-sls/
+//  NASASpaceFlight101 - Orbital ATK Advanced Boosters:             http://www.nasaspaceflight.com/2015/02/advanced-boosters-towards-solid-future-sls/
+//  Space Launch Report - Space Launch System Data Sheet:           http://www.spacelaunchreport.com/sls0.html
+//  Space Launch Report - Delta IV launch vehicle:                  http://www.spacelaunchreport.com/delta4.html
+//  Norbert Brügge - Ares I:                                        http://www.b14643.de/Spacerockets_2/United_States_1/Ares-I_CLV/Description/Frame.htm
+//  Norbert Brügge - Delta IV:                                      http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Description/Frame.htm
+//  Rocket & Space Technology - Delta IV:                           http://www.braeunig.us/space/specs/delta.htm
+//  Spaceflight101 - Delta IV Medium (5,2):                         http://spaceflight101.com/spacerockets/delta-iv-medium-52/
+//  ULA - Delta IV users guide:                                     http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//  Norbert Brügge - RL10 rocket engine:                            http://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
+//  Aerojet Rocketdyne - RL10 rocket engine:                        https://www.rocket.com/rl10-engine
+//  NTRS - Cryogenic Propulsion Stage:                              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110015783.pdf
+//  AIAA - Lunar Lander Designs:                                    http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf
+//  Space Launch Report - Falcon 9 launch vehicle:                  http://www.spacelaunchreport.com/falcon.html
+//  Spaceflight 101 - Falcon 9 v1.1 launch vehicle:                 http://spaceflight101.com/spacerockets/falcon-9-v1-1-f9r/
+//  Encyclopedia Astronautica - Kestrel rocket engine:              http://www.astronautix.com/k/kestrel.html
+//  Encyclopedia Astronautica - J-2X rocket engine:                 http://www.astronautix.com/engines/j2x.htm
+//  Aerojet Rocketdyne - J-2X rocket engine:                        http://rocket.com/j-2x-engine
+//  NTRS - The J-2X Upper Stage Engine: From Design to Hardware:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100034922.pdf
+//  FAA - DragonFly pad abort test:                                 https://www.faa.gov/about/office_org/headquarters_offices/ast/media/20140513_DragonFly_DraftEA_Appendices%28reduced%29.pdf
+//  Aerojet Rocketdyne - Orion Service Module:                      https://www.rocket.com/orion-service-module
+//  Aerojet Rocketdyne - Orion Crew Module:                         https://www.rocket.com/orion-crew-module
+//  Aerojet Rocketdyne - Orion Main Engine:                         https://www.rocket.com/orion-main-engine
+//  Spaceflight101 - Orion spacecraft overview:                     http://spaceflight101.com/spacecraft/orion/
+//  NTRS - Orion European Service Module (PowerPoint):              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140008543.pdf
+//  NTRS - Orion European Service Module (Document):                http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140010527.pdf
+//  NTRS - "Bimodal" Nuclear Thermal Rocket (BNTR):                 http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
+//  AIAA - "Trimodal" Nuclear Thermal Rocket (TRITON):              http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3863_TRITON.pdf
+//  NTRS - Crewed Mars Mission using BNTEP:                         http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140009579.pdf
+//  Pratt & Whitney Rocketdyne - RS-68 rocket engine:               http://www.alternatewars.com/BBOW/Space_Engines/RS-68.pdf
+//  Purdue AAE - RS-68 rocket engine:                               https://engineering.purdue.edu/~propulsi/propulsion/rockets/liquids/rs68.html
+//  NASASpaceFlight101 - Exploration Upper Stage:                   http://www.nasaspaceflight.com/2014/10/nasa-exploration-upper-stage-workhorse-sls/
+//  NTRS - SLS Dual Use Upper Stage (DUUS) Opportunities:           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20130013953.pdf
+//  NASASpaceFlight101 - Large Upper Stage (LUS):                   http://www.nasaspaceflight.com/2013/11/new-sls-options-new-large-upper-stage/
+//  NTRS - Constellation Program Battery and Fuel Cell Development: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120016064.pdf
 
 //  ==================================================
 //  Removed extra parts.
@@ -45,15 +45,13 @@
 
 !PART[MonkeyCargoBoosterADJ]:FOR[RealismOverhaul]{}
 
-!PART[xvulcanx]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_8_0m_6mzxx6mrtoX]:FOR[RealismOverhaul]{}
 
-!PART[xKW2mtankL2x]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_8_0m_6mzxx6drto]:FOR[RealismOverhaul]{}
 
-!PART[xKW2mtankL2x22]:FOR[RealismOverhaul]{}
+!PART[xKosmos_SepRetroxDUNA]:FOR[RealismOverhaul]{}
 
-!PART[XSLSXPANDX]:FOR[RealismOverhaul]{}
-
-!PART[XSLSXPANDXMLS]:FOR[RealismOverhaul]{}
+!PART[xKosmos_SepRe3nstrox]:FOR[RealismOverhaul]{}
 
 !PART[XROVERENGINE2b12]:FOR[RealismOverhaul]{}
 
@@ -61,21 +59,25 @@
 
 !PART[XROVERENGINE2b1223918]:FOR[RealismOverhaul]{}
 
-!PART[XNP_interstage_5m_8m_t3MTVDRIVEX]:FOR[RealismOverhaul]{}
+!PART[xKW2mtankL2x22]:FOR[RealismOverhaul]{}
+
+!PART[xKW2mtankL2x]:FOR[RealismOverhaul]{}
+
+!PART[XLFTORIONLARGEx3m]:FOR[RealismOverhaul]{}
+
+!PART[XSLSXPANDXMLS]:FOR[RealismOverhaul]{}
 
 !PART[XNP_interstage_5m_8m_t3MTVDRIVEX2]:FOR[RealismOverhaul]{}
 
+!PART[XNP_interstage_5m_8m_t3MTVDRIVEX]:FOR[RealismOverhaul]{}
+
+!PART[nervaII_kerbscale2xx2]:FOR[RealismOverhaul]{}
+
 !PART[nervaII_kerbscale2xx]:FOR[RealismOverhaul]{}
 
-!PART[XNP_lft_8_0m_6mzxx6drto]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_xtrt8mC1199987711CB8MA288x]:FOR[RealismOverhaul]{}
 
-!PART[XNP_lft_8_0m_6mzxx6drto323ehbsas]:FOR[RealismOverhaul]{}
-
-!PART[XNP_lft_8_0m_6mzxx6222X3]:FOR[RealismOverhaul]{}
-
-!PART[xKosmos_SepRetroxDUNA]:FOR[RealismOverhaul]{}
-
-!PART[xKosmos_SepRe3nstrox]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_xtrt8mC1199987711CB8MA2x]:FOR[RealismOverhaul]{}
 
 !PART[XNP_lftadj]:FOR[RealismOverhaul]{}
 
@@ -83,15 +85,13 @@
 
 !PART[XNP_lft_?375x3SHORT]:FOR[RealismOverhaul]{}
 
-!PART[XNP_lft_xtrt3mCCB8MAx232]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_W375Wx3]:FOR[RealismOverhaul]{}
 
-!PART[XNP_lft_xtrt8mC1199987711CB8MA2x]:FOR[RealismOverhaul]{}
-
-!PART[XNP_lft_W375x3SHORTWSS]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_W375x3SHOR663TWSS]:FOR[RealismOverhaul]{}
 
 !PART[XNP_lft_W375x3SHORTW55hs]:FOR[RealismOverhaul]{}
 
-!PART[XNP_lft_W375x3SHOR663TWSS]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_W375x3SHORTWSS]:FOR[RealismOverhaul]{}
 
 !PART[XDiusNP_lf222t_?375?x3i]:FOR[RealismOverhaul]{}
 
@@ -99,23 +99,29 @@
 
 !PART[IUSXNP_lft_?3322HORTx23]:FOR[RealismOverhaul]{}
 
-!PART[Xafa191m23312NTRMUNAR1X]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_xtrt3mCCB8MAx232]:FOR[RealismOverhaul]{}
+
+!PART[XNP_lft_8_0m_6mzxx6222X3191]:FOR[RealismOverhaul]{}
+
+!PART[XNP_lft_8_0m_6mzxx6222X2]:FOR[RealismOverhaul]{}
 
 !PART[Xafa191m23312NTRMUNA534naR1X]:FOR[RealismOverhaul]{}
 
-!PART[DUNARETROTANKLARGE]:FOR[RealismOverhaul]{}
+!PART[Xafa191m23312NTRMUNAR1X]:FOR[RealismOverhaul]{}
 
-!PART[DUNARETROTANKLARGE2x]:FOR[RealismOverhaul]{}
-
-!PART[DUNARETROTANKm2]:FOR[RealismOverhaul]{}
-
-!PART[NP_CHAKAEMLVENGINEx221]:FOR[RealismOverhaul]{}
+!PART[NP_CHAKAEMLVENGINE222C]:FOR[RealismOverhaul]{}
 
 !PART[XNP_interstage_5mNA_8m_tankMUNAR1X]:FOR[RealismOverhaul]{}
 
+!PART[XNP_interstage_5m_8m_tankBLOCKg874njsII]:FOR[RealismOverhaul]{}
+
 !PART[XNP_interstage_5m_8m_tankBLOCKII]:FOR[RealismOverhaul]{}
 
-!PART[XNP_interstage_5m_8m_tankBLOCKg874njsII]:FOR[RealismOverhaul]{}
+!PART[DUNARETROTANKLARGE2x]:FOR[RealismOverhaul]{}
+
+!PART[DUNARETROTANKLARGE]:FOR[RealismOverhaul]{}
+
+!PART[DUNARETROTANKm2]:FOR[RealismOverhaul]{}
 
 !PART[xmonkeyreptarCFx]:FOR[RealismOverhaul]{}
 
@@ -144,14 +150,12 @@
 
     @node_attach = 0.0, 0.0, -0.6, 0.0, 0.0, 0.0
 
-    @category = Engine
-
     @mass = 3.08
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.5
@@ -160,20 +164,14 @@
     %bulkheadProfiles = srf
 
     %engineType = GEM-60
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0
+        @minThrust = 826.5
         @maxThrust = 826.5
-        @heatProduction = 100
+        @heatProduction = 46
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -255,14 +253,12 @@
     %node_stack_parachute = 0.0, 24.715, 0.0, 0.0, 1.0, 0.0, 2
     @node_attach = 0.0, 0.0, -1.95, 0.0, 0.0, 0.0
 
-    @category = Engine
-
     @mass = 85.5
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.5
@@ -272,20 +268,14 @@
     %bulkheadProfiles = srf, size2, size3
 
     %engineType = RSRMV
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0
+        @minThrust = 15800
         @maxThrust = 15800
-        @heatProduction = 100
+        @heatProduction = 20
         @useEngineResponseTime = False
-        !engineAccelerationSpeed = NULL
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
+        @engineAccelerationSpeed = 0
 
         @PROPELLANT[SolidFuel]
         {
@@ -362,33 +352,25 @@
 
     @node_attach = 0.0, 0.0, -1.925, 0.0, 0.0, 0.0
 
-    @category = Engine
-
     @mass = 84.79
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %bulkheadProfiles = srf
 
     %engineType = ASRB
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0
+        @minThrust = 20337
         @maxThrust = 20337
-        @heatProduction = 100
+        @heatProduction = 26
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
-        &ullage = False
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -450,6 +432,8 @@
 //  Dimensions: 3.71 m x 38 m
 //  Gross Mass: 565400 Kg
 
+//  Notes:
+
 //  The inert mass value does not include the mass of
 //  the nose cone, recovery parachutes and other
 //  auxiliary modules.
@@ -475,14 +459,12 @@
     %node_stack_parachute = 0.0, 3.635, 0.0, 0.0, 1.0, 0.0, 2
     @node_attach = 0.0, 0.0, 1.97, 0.0, 0.0, -1.0
 
-    @category = Engine
-
     @mass = 65.57
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.5
@@ -493,20 +475,14 @@
     %bulkheadProfiles = srf, size2, size3
 
     %engineType = RSRM
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0
+        @minThrust = 14234.3
         @maxThrust = 14234.3
-        @heatProduction = 100
+        @heatProduction = 23
         @useEngineResponseTime = False
-        !engineAccelerationSpeed = NULL
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
+        @engineAccelerationSpeed = 0
 
         @PROPELLANT[SolidFuel]
         {
@@ -1042,32 +1018,24 @@
     @node_stack_top = 0.0, 1.95, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, -1.405, 0.0, 0.0, -1.0, 0.0, 2
 
-    @category = Engine
-
     @mass = 0.277
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.8
     %bulkheadProfiles = size2
 
     %engineType = RL10
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 111.2
         @maxThrust = 111.2
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 15
+        @heatProduction = 76
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1146,14 +1114,12 @@
     @node_stack_bottom = 0.0, -1.335, 0.0, 0.0, -1.0, 0.0, 3
     @attachRules = 1,1,1,0,0
 
-    @category = Engine
-
     @mass = 1.08
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.8
@@ -1163,19 +1129,13 @@
     %bulkheadProfiles = size3
 
     %engineType = RD253
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 1748
         @maxThrust = 1748
-        @heatProduction = 100
+        @heatProduction = 196
         @engineAccelerationSpeed = 0
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1191,8 +1151,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 294.7
-            @key,1 = 1 322.2
+            @key,0 = 0 295
+            @key,1 = 1 322
         }
     }
 
@@ -1230,8 +1190,6 @@
 
     @node_attach = 0.0, 0.0, 0.0, 1.0, 0.0, 0.0
 
-    @category = Engine
-
     @mass = 0.06
     @minimum_drag = 0.1
     @maximum_drag = 0.2
@@ -1239,7 +1197,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.8
@@ -1249,18 +1207,12 @@
     %bulkheadProfiles = srf
 
     %engineType = Kestrel_1B
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 23.1
         @maxThrust = 30.7
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = True
-        %ignitions = 4
+        @heatProduction = 63
 
         @PROPELLANT[MonoPropellant]
         {
@@ -1318,7 +1270,6 @@
     @node_attach = -0.008, 0.0, 0.0, -1.0, 0.0, 0.0
     @attachRules = 0,1,0,0,0
 
-    @category = Engine
     @title = SEP - 100 Separation Motor
     %manufacturer = Generic
     @description = A generic solid rocket motor for safe separation of discarded rocket stages.
@@ -1340,13 +1291,10 @@
     {
         @minThrust = 0
         @maxThrust = 100
-        @heatProduction = 100
+        @heatProduction = 205
         @useEngineResponseTime = False
         !engineAccelerationSpeed = NULL
         %EngineType = SolidBooster
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -1384,7 +1332,7 @@
     MODULE
     {
         name = ModuleEngineConfigs
-        type = ModuleEnginesRF
+        type = ModuleEngines
         configuration = SEP-100
         origMass = 0.05
 
@@ -1440,7 +1388,6 @@
     @node_attach = -0.008, 0.0, 0.0, -1.0, 0.0, 0.0
     @attachRules = 0,1,0,0,0
 
-    @category = Engine
     @title = SEP - 50 Separation Motor
     %manufacturer = Generic
     @description = A generic solid rocket motor for safe separation of discarded rocket stages.
@@ -1450,7 +1397,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.5
@@ -1462,13 +1409,9 @@
     {
         @minThrust = 0
         @maxThrust = 50
-        @heatProduction = 100
+        @heatProduction = 102
         @useEngineResponseTime = False
         !engineAccelerationSpeed = NULL
-        %EngineType = SolidBooster
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {
@@ -1506,7 +1449,7 @@
     MODULE
     {
         name = ModuleEngineConfigs
-        type = ModuleEnginesRF
+        type = ModuleEngines
         configuration = SEP-50
         origMass = 0.03
 
@@ -1728,10 +1671,13 @@
 //  SuperDraco engine.
 
 //  Dimensions: 0.2 m x 2 m
-//  Inert Mass: 160 Kg
+//  Gross Mass: 170 Kg
+
+//  Notes:
 
 //  The inert mass value includes the mass of the
-//  mounting hardware and the fuselage (30 Kg).
+//  SuperDraco mounting hardware and shroud (approximately
+//  40 Kg).
 //  ==================================================
 
 @PART[xLazTekSuperDracosx]:FOR[RealismOverhaul]
@@ -1751,14 +1697,12 @@
 
     @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
-    @category = Engine
-
-    @mass = 0.16
+    @mass = 0.17
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 2773.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.8
@@ -1768,14 +1712,15 @@
 
     %engineType = SuperDraco
     %engineTypeMult = 2
-    %massOffset = 0
+    %massOffset = 0.04
     %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 34.0
-        @maxThrust = 170.0
+        @minThrust = 29.2
+        @maxThrust = 146
         @exhaustDamage = True
+        @heatProduction = 98
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1831,7 +1776,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %heatConductivity = 0.06
     %skinInternalConductionMult = 4.0
     %emissiveConstant = 0.8
@@ -1840,18 +1785,12 @@
     %bulkheadProfiles = size3
 
     %engineType = J2X
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 1072
         @maxThrust = 1308
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 8
+        @heatProduction = 97
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2102,8 +2041,6 @@
     %node_stack_bottom = 0.0, -3.125, 0.0, 0.0, -1.0, 0.0, 2
     %node_attach = 0.0, 1.675, 0.0, 0.0, 1.0, 0.0
 
-    @category = Engine
-
     @mass = 2.215
     @crashTolerance = 10
     @breakingForce = 250
@@ -2117,18 +2054,12 @@
     %bulkheadProfiles = size2
 
     %engineType = BNTR
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 66.72
         @maxThrust = 66.72
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 60
+        @heatProduction = 11
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2159,7 +2090,7 @@
 //  Pegasus engine pod.
 
 //  Dimensions: 2.2 m x 1.2 m
-//  Inert Mass: 250 Kg
+//  Gross Mass: 260 Kg
 //  ==================================================
 
 @PART[nosExplorerRadialEngine]:FOR[RealismOverhaul]
@@ -2177,35 +2108,27 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @category = Engine
-
-    @mass = 0.25
+    @mass = 0.26
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
-    %heatConductivity = 0.06
-    %skinInternalConductionMult = 4.0
-    %emissiveConstant = 0.8
+    %skinMaxTemp = 673.15
     %stageOffset = 1
-    childStageOffset = 1
+    %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     %bulkheadProfiles = srf
 
     %engineType = RD0242M2
     %engineTypeMult = 2
-    %massOffset = 0.01
+    %massOffset = 0.02
     %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 30.0
-        @maxThrust = 50.0
-        @heatProduction = 100
-        %ullage = False
-        %pressureFed = False
-        %ignitions = 6
+        @minThrust = 30
+        @maxThrust = 50
+        @heatProduction = 22
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2263,7 +2186,7 @@
 {
     @title = Pegasus Engine Pod
     @manufacturer = Boeing Co. & KB Khimavtomatiki [Kosberg]
-    @description = Radially mounted engine pod, originally designed for the Pegasus Descent Module. Contains the engines and RCS thrusters for attitude control.
+    @description = Radially mounted engine pod, originally designed for the Pegasus Descent Module. Contains the main engines and the RCS thrusters for attitude control.
 }
 
 //  ==================================================
@@ -2303,13 +2226,83 @@
     @maxTemp = 473.15
     %skinMaxTemp = 573.15
     %bulkheadProfiles = size3
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Mars Transfer Vehicle drop propellant tank.
+
+//  Dimensions: 10 m x 18 m
+//  Inert Mass: 28500 Kg
+//  ==================================================
+
+@PART[XNP_lft_8_0m_6mzxx622211911]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 2.0, 3.0, 2.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 8.955, 0.0, 0.0, 1.0, 0.0, 5
+    @node_stack_bottom = 0.0, -9.05, 0.0, 0.0, -1.0, 0.0, 5
+    @node_attach = 5.03, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @category = FuelTank
+    @title = MTV - IV Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Mars Transfer Vehicle. This is a lighter, drop-tank variant, with a higher internal volume but lacks an active cryocooler system.
+
+    @mass = 28.5
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    !linearStrength = NULL
+    !angularStrength = NULL
+    !vesselType = NULL
+    %bulkheadProfiles = size5
+
+    !MODULE[ModuleActiveRadiator],*{}
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[MechJebCore],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    //  Maximum fill ratio 92%.
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 1300000
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
 }
 
 //  ==================================================
 //  Mars Transfer Vehicle main propellant tank.
 
 //  Dimensions: 10 m x 18 m
-//  Inert Mass: 28500 Kg
+//  Inert Mass: 30500 Kg
 //  ==================================================
 
 @PART[XNP_lft_8_0m_6mzxx6222]:FOR[RealismOverhaul]
@@ -2328,14 +2321,14 @@
 
     @node_stack_top = 0.0, 8.955, 0.0, 0.0, 1.0, 0.0, 5
     @node_stack_bottom = 0.0, -9.05, 0.0, 0.0, -1.0, 0.0, 5
-    @node_attach = 5.0, 0.0, 0.0, 1.0, 0.0, 0.0
+    @node_attach = 5.03, 0.0, 0.0, 1.0, 0.0, 0.0
 
     @category = FuelTank
     @title = MTV - I Propellant Tank
     @manufacturer = Boeing Co.
-    @description = A generic cryogenic propellant tank for the Mars Transfer Vehicle.
+    @description = A generic cryogenic propellant tank for the Mars Transfer Vehicle. Features an integrated active cryocooler system to keep the propellants in liquid form.
 
-    @mass = 28.5
+    @mass = 30.5
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
@@ -2345,6 +2338,19 @@
     !angularStrength = NULL
     !vesselType = NULL
     %bulkheadProfiles = size5
+
+    @MODULE[ModuleActiveRadiator]
+    {
+        @maxEnergyTransfer = 75000
+        @overcoolFactor = 0.03836
+        @isCoreRadiator = True
+        @parentCoolingOnly = False
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 10.0
+        }
+    }
 
     !MODULE[ModuleCommand],*{}
 
@@ -2358,11 +2364,14 @@
 
     !MODULE[ModuleFuelTanks],*{}
 
+    //  Maximum fill ratio 74% (includes the cryocooler equipment volume).
+
     MODULE
     {
         name = ModuleFuelTanks
         type = Cryogenic
         volume = 1050000
+        basemass = -1
     }
 
     !RESOURCE,*{}
@@ -2711,7 +2720,7 @@
 //  Inert Mass: 410 Kg
 //  ==================================================
 
-@PART[NP_CHAKAEMLVENGINE222C]:FOR[RealismOverhaul]
+@PART[NP_CHAKAEMLVENGINEx221]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -2761,6 +2770,60 @@
 }
 
 //  ==================================================
+//  Earth Departure Stage auxiliary propellant tank.
+
+//  Dimensions: 7.5 m x 2.5 m
+//  Inert Mass: 1300 Kg
+//  ==================================================
+
+@PART[NP_CHAKAEMLVENGINE2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 3.0, 1.2, 3.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 5
+    %node_stack_decoupler = 0.0, 12.0, 0.0, 0.0, 1.0, 0.0, 5
+
+    @category = FuelTank
+    @title = EDS - III Propellant Tank
+    @manufacturer = Boeing Co.
+    @description = A generic cryogenic propellant tank for the Space Launch System Earth Departure Stage (EDS).
+
+    @mass = 1.3
+    @crashTolerance = 12
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @bulkheadProfiles = size3, size5
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleGenerator],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Cryogenic
+        volume = 60000
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
 //  Large surface habitation module propellant tank.
 
 //  Dimensions: 7.5 m x 1.5 m
@@ -2776,6 +2839,7 @@
     @MODEL
     {
         @scale = 1.5, 0.5, 1.5
+        %rotation = 180.0, 0.0, 0.0
     }
 
     @scale = 1.0
@@ -2812,7 +2876,7 @@
 }
 
 //  ==================================================
-//  Merlin engine (surface version).
+//  Merlin engine (ASL versions).
 
 //  Dimensions: 0.95 m x 2.0 m
 //  Inert Mass: 760 Kg
@@ -2832,8 +2896,6 @@
 
     @node_stack_top = 0.0, 0.485, 0.0, 0.0, 1.0, 0.0, 2
 
-    @category = Engine
-
     @mass = 0.76
     @crashTolerance = 10
     @breakingForce = 250
@@ -2843,21 +2905,15 @@
     @bulkheadProfiles = size2
 
     %engineType = Merlin1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 369.2
         @maxThrust = 369.2
+        @heatProduction = 57
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
         @engineDecelerationSpeed = 0
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2873,8 +2929,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 288.5
-            @key,1 = 1 253.7
+            @key,0 = 0 288
+            @key,1 = 1 254
         }
     }
 
@@ -2883,8 +2939,6 @@
         @gimbalRange = 5.0
         @gimbalResponseSpeed = 16
     }
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -2907,7 +2961,7 @@
 }
 
 //  ==================================================
-//  Merlin engine (vacuum version).
+//  Merlin engine (VAC versions).
 
 //  Dimensions: 2.5 m x 4.65 m
 //  Inert Mass: 910 Kg
@@ -2928,8 +2982,6 @@
     @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, -2.7, 0.0, 0.0, -1.0, 0.0, 2
 
-    @category = Engine
-
     @mass = 0.91
     @crashTolerance = 12
     @breakingForce = 250
@@ -2939,21 +2991,15 @@
     @bulkheadProfiles = size2
 
     %engineType = Merlin1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @minThrust = 421.6
         @maxThrust = 421.6
+        @heatProduction = 61
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
         @engineDecelerationSpeed = 0
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2970,8 +3016,8 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 332.1
-            @key,1 = 1 195.5
+            @key,0 = 0 332
+            @key,1 = 1 195
         }
     }
 
@@ -2986,8 +3032,6 @@
         @animationName = M1DV_heat
         @responseSpeed = 0.001
     }
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -3133,8 +3177,6 @@
     @node_stack_bottom = 0.0, -2.587, 0.0, 0.0, -1.0, 0.0, 2
     @node_attach = 0.0, 2.615, 0.0, 0.0, 1.0, 0.0, 2
 
-    @category = Engine
-
     @mass = 6.6
     @crashTolerance = 12
     @breakingForce = 250
@@ -3155,10 +3197,7 @@
     {
         @minThrust = 1890
         @maxThrust = 3370
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
+        @heatProduction = 85
 
         @PROPELLANT[LiquidFuel]
         {
@@ -3242,8 +3281,6 @@
     @node_stack_top = 0.0, 9.73, 0.0, 0.0, 1.0, 0.0, 5
     %node_stack_bottom = 0.0, -54.655, 0.0, 0.0, -1.0, 0.0, 5
 
-    @category = Engine
-
     @mass = 124.47
     @crashTolerance = 12
     @breakingForce = 250
@@ -3272,12 +3309,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 1358.5
-        @maxThrust = 2319.9
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
+        @minThrust = 5434
+        @maxThrust = 8360
+        @heatProduction = 440
 
         @PROPELLANT[LiquidFuel]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -1613,8 +1613,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %bulkheadProfiles = size4
 
     !MODULE[ModuleCommand],*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -63,13 +63,15 @@
 
 !PART[XNP_interstage_5m_8m_t3MTVDRIVEX]:FOR[RealismOverhaul]{}
 
+!PART[XNP_interstage_5m_8m_t3MTVDRIVEX2]:FOR[RealismOverhaul]{}
+
 !PART[nervaII_kerbscale2xx]:FOR[RealismOverhaul]{}
 
 !PART[XNP_lft_8_0m_6mzxx6drto]:FOR[RealismOverhaul]{}
 
 !PART[XNP_lft_8_0m_6mzxx6drto323ehbsas]:FOR[RealismOverhaul]{}
 
-!PART[XXxAres1J2-XHIG33H]:FOR[RealismOverhaul]{}
+!PART[XNP_lft_8_0m_6mzxx6222X3]:FOR[RealismOverhaul]{}
 
 !PART[xKosmos_SepRetroxDUNA]:FOR[RealismOverhaul]{}
 
@@ -82,6 +84,8 @@
 !PART[XNP_lft_?375x3SHORT]:FOR[RealismOverhaul]{}
 
 !PART[XNP_lft_xtrt3mCCB8MAx232]:FOR[RealismOverhaul]{}
+
+!PART[XNP_lft_xtrt8mC1199987711CB8MA2x]:FOR[RealismOverhaul]{}
 
 !PART[XNP_lft_W375x3SHORTWSS]:FOR[RealismOverhaul]{}
 
@@ -99,15 +103,13 @@
 
 !PART[Xafa191m23312NTRMUNA534naR1X]:FOR[RealismOverhaul]{}
 
-!PART[NP_CHAKAEMLVENGINE222C]:FOR[RealismOverhaul]{}
-
 !PART[DUNARETROTANKLARGE]:FOR[RealismOverhaul]{}
 
 !PART[DUNARETROTANKLARGE2x]:FOR[RealismOverhaul]{}
 
 !PART[DUNARETROTANKm2]:FOR[RealismOverhaul]{}
 
-!PART[XNP_interstage_5m_8m_tankMUNAR1X]:FOR[RealismOverhaul]{}
+!PART[NP_CHAKAEMLVENGINEx221]:FOR[RealismOverhaul]{}
 
 !PART[XNP_interstage_5mNA_8m_tankMUNAR1X]:FOR[RealismOverhaul]{}
 
@@ -585,9 +587,9 @@
     %node_stack_decoupler = 0.0, 11.73, 0.0, 0.0, 1.0, 0.0, 5
 
     @category = FuelTank
-    @title = EDS - IV Propellant Tank
+    @title = EDS - III Propellant Tank
     @manufacturer = Boeing Co.
-    @description = A generic cryogenic propellant tank for the Earth Departure Stage (EDS). Doubles as a dual engine mount.
+    %description = A generic cryogenic propellant tank for the Earth Departure Stage (EDS). Doubles as a dual engine mount.
 
     @mass = 1.39
     @crashTolerance = 12
@@ -828,6 +830,8 @@
     !MODULE[ModuleReactionWheel],*{}
 
     !MODULE[ModuleGenerator],*{}
+
+    !MODULE[MechJebCore],*{}
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -2368,6 +2372,8 @@
 
     !MODULE[ModuleGenerator],*{}
 
+    !MODULE[MechJebCore],*{}
+
     !MODULE[ModuleFuelTanks],*{}
 
     MODULE
@@ -2723,7 +2729,7 @@
 //  Gross Mass: 410 Kg
 //  ==================================================
 
-@PART[NP_CHAKAEMLVENGINEx221]:FOR[RealismOverhaul]
+@PART[NP_CHAKAEMLVENGINE222C]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -2767,60 +2773,6 @@
         name = ModuleFuelTanks
         type = ServiceModule
         volume = 5400
-    }
-
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  Earth Departure Stage auxiliary propellant tank.
-
-//  Dimensions: 7.5 m x 2.5 m
-//  Gross Mass: 1300 Kg
-//  ==================================================
-
-@PART[NP_CHAKAEMLVENGINE2]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    @MODEL
-    {
-        @scale = 3.0, 1.2, 3.0
-    }
-
-    @scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 1.2, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 5
-    %node_stack_decoupler = 0.0, 12.0, 0.0, 0.0, 1.0, 0.0, 5
-
-    @category = FuelTank
-    @title = EDS - III Propellant Tank
-    @manufacturer = Boeing Co.
-    @description = A generic cryogenic propellant tank for the Space Launch System Earth Departure Stage (EDS).
-
-    @mass = 1.3
-    @crashTolerance = 12
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-    @bulkheadProfiles = size3, size5
-
-    !MODULE[ModuleCommand],*{}
-
-    !MODULE[ModuleGenerator],*{}
-
-    !MODULE[ModuleFuelTanks],*{}
-
-    MODULE
-    {
-        name = ModuleFuelTanks
-        type = Cryogenic
-        volume = 60000
     }
 
     !RESOURCE,*{}
@@ -3262,6 +3214,159 @@
     }
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  RS-68 engine.
+
+//  Engine configuration.
+//  ==================================================
+
+@PART[xbahars68bx]:FOR[RealismOverhaulEngines]
+{
+    //  Add an empty thrust transform to simulate the gas generator exhaust.
+    //  Used for roll control in the single - stick Delta IV variants.
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 1.0, 0.75, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    //  Main engine.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        %engineID = RS68Engine
+
+        //@CONFIG,*
+        //{
+        //    @ignitions = 10
+        //}
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        %engineID = RS68Engine
+        %isMaster = True
+
+        //OtherModules
+        //{
+        //    RS68Exhaust = RS68-GasGenerator
+        //}
+    }
+
+    //  Gas generator exhaust.
+
+    MODULE
+    {
+        name = ModuleEnginesRF
+        engineID = RS68Exhaust
+        thrustVectorTransformName = newThrustTransform
+        exhaustDamage = True
+        minThrust = 10
+        maxThrust = 10
+        ignitionThreshold = 0.1
+        heatProduction = 10
+        ullage = True
+        pressureFed = False
+        ignitions = 1
+
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 0.05
+        }
+
+        PROPELLANT
+        {
+            name = LqdHydrogen
+            ratio = 0.7285
+            DrawGauge = False
+        }
+
+        PROPELLANT
+        {
+            name = LqdOxygen
+            ratio = 0.2715
+            DrawGauge = False
+        }
+
+        atmosphereCurve
+        {
+            key = 0 220
+            key = 1 175
+        }
+    }
+
+    //MODULE
+    //{
+    //    name = ModuleEngineConfigs
+    //    type = ModuleEnginesRF
+    //    configuration = RS68-GasGenerator
+    //    engineID = RS68Exhaust
+    //    isMaster = False
+    //    modded = False
+
+    //    CONFIG
+    //    {
+    //        name = RS68-GasGenerator
+    //        minThrust = 10
+    //        maxThrust = 10
+    //        heatProduction = 10
+    //        ullage = True
+    //        pressureFed = False
+    //        ignitions = 10
+
+    //        IGNITOR_RESOURCE
+    //        {
+    //            name = ElectricCharge
+    //            amount = 0.05
+    //        }
+
+    //        PROPELLANT
+    //        {
+    //            name = LqdHydrogen
+    //            ratio = 0.7285
+    //            DrawGauge = False
+    //        }
+
+    //        PROPELLANT
+    //        {
+    //            name = LqdOxygen
+    //            ratio = 0.2715
+    //            DrawGauge = False
+    //        }
+
+    //        atmosphereCurve
+    //        {
+    //            key = 0 220
+    //            key = 1 175
+    //        }
+    //    }
+    //}
+
+    //  Main engine gimbal.
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]]
+    {
+        @gimbalRange = 6.0
+    }
+
+    //  Gas generator exhaust gimbal.
+
+    MODULE
+    {
+        name = ModuleGimbal
+        gimbalTransformName = newThrustTransform
+        gimbalRangeXP = 0
+        gimbalRangeXN = 0
+        gimbalRangeYP = 26.0
+        gimbalRangeYN = 26.0
+        useGimbalResponseSpeed = True
+        gimbalResponseSpeed = 16
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -781,7 +781,7 @@
 //  Mars Ascent Vehicle main propellant tank.
 
 //  Dimensions: 3.75 m x 3.3 m
-//  Gross Mass: 1050 Kg
+//  Inert Mass: 1050 Kg
 //  ==================================================
 
 @PART[XNP_lft_8_0m_6mzxx6]:FOR[RealismOverhaul]
@@ -1124,7 +1124,7 @@
 //  RD-253/RD-275 engine.
 
 //  Dimensions: 1.5 x 2.72 m
-//  Gross Mass: 1080 Kg
+//  Inert Mass: 1080 Kg
 //  ==================================================
 
 @PART[XKosmos_Angara_RD-275KX]:FOR[RealismOverhaul]
@@ -1210,7 +1210,7 @@
 //  Kestrel-1B engine.
 
 //  Dimensions: 0.5 m x 1.25 m
-//  Gross Mass: 60 Kg
+//  Inert Mass: 60 Kg
 //  ==================================================
 
 @PART[XKosmos_TKS_RD-0225_EngineLANDERS]:FOR[RealismOverhaul]
@@ -1394,7 +1394,6 @@
             minThrust = 0
             maxThrust = 100
             heatProduction = 100
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -1517,7 +1516,6 @@
             minThrust = 0
             maxThrust = 50
             heatProduction = 100
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -1730,7 +1728,10 @@
 //  SuperDraco engine.
 
 //  Dimensions: 0.2 m x 2 m
-//  Gross Mass: 130 Kg
+//  Inert Mass: 160 Kg
+
+//  The inert mass value includes the mass of the
+//  mounting hardware and the fuselage (30 Kg).
 //  ==================================================
 
 @PART[xLazTekSuperDracosx]:FOR[RealismOverhaul]
@@ -1752,7 +1753,7 @@
 
     @category = Engine
 
-    @mass = 0.13
+    @mass = 0.16
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
@@ -1766,19 +1767,15 @@
     %bulkheadProfiles = srf
 
     %engineType = SuperDraco
-    %engineTypeMult = 1
+    %engineTypeMult = 2
     %massOffset = 0
     %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 29.2
-        @maxThrust = 146
+        @minThrust = 34.0
+        @maxThrust = 170.0
         @exhaustDamage = True
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = -1
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1806,7 +1803,7 @@
 //  J-2X engine.
 
 //  Dimensions: 3.05 m x 4.7 m
-//  Gross Mass: 2470 Kg
+//  Inert Mass: 2470 Kg
 //  ==================================================
 
 @PART[XROVERENGINE]:FOR[RealismOverhaul]
@@ -2027,7 +2024,7 @@
 //  Mars Transfer Vehicle auxiliary propellant tank.
 
 //  Dimensions: 10 m x 6 m
-//  Gross Mass: 4420 Kg
+//  Inert Mass: 4420 Kg
 //  ==================================================
 
 @PART[XNP_interstage_5m_8m_tMTVDRIVEX]:FOR[RealismOverhaul]
@@ -2162,7 +2159,7 @@
 //  Pegasus engine pod.
 
 //  Dimensions: 2.2 m x 1.2 m
-//  Gross Mass: 250 Kg
+//  Inert Mass: 250 Kg
 //  ==================================================
 
 @PART[nosExplorerRadialEngine]:FOR[RealismOverhaul]
@@ -2203,8 +2200,8 @@
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 30
-        @maxThrust = 50
+        @minThrust = 30.0
+        @maxThrust = 50.0
         @heatProduction = 100
         %ullage = False
         %pressureFed = False
@@ -2273,7 +2270,7 @@
 //  RSRM structural extension.
 
 //  Dimensions: 3.71 m x 9 m
-//  Gross Mass: 5000 Kg
+//  Inert Mass: 5000 Kg
 //  ==================================================
 
 @PART[XNP_lft_W375SRB]:FOR[RealismOverhaul]
@@ -2503,7 +2500,7 @@
 //  Mars Transfer Vehicle auxiliary propellant tank.
 
 //  Dimensions: 10 m x 5 m
-//  Gross Mass: 4000 Kg
+//  Inert Mass: 4000 Kg
 //  ==================================================
 
 @PART[XNP_lft_xtrt3mCCB8MAx]:FOR[RealismOverhaul]
@@ -2557,7 +2554,7 @@
 //  Small surface habitation module propellant tank.
 
 //  Dimensions: 5 m x 1 m
-//  Gross Mass: 600 Kg
+//  Inert Mass: 600 Kg
 //  ==================================================
 
 @PART[Xafa191m23312NTR]:FOR[RealismOverhaul]
@@ -2611,7 +2608,7 @@
 //  Earth Departure Stage main propellant tank.
 
 //  Dimensions: 8.4 m x 11 m
-//  Gross Mass: 11600 Kg
+//  Inert Mass: 11600 Kg
 //  ==================================================
 
 @PART[XNP_lft_xtrt3mCCB8MAx2]:FOR[RealismOverhaul]
@@ -2665,7 +2662,7 @@
 //  Delta IV CBC engine mount.
 
 //  Dimensions: 5 m x 4 m
-//  Gross Mass: 1530 Kg
+//  Inert Mass: 1530 Kg
 //  ==================================================
 
 @PART[NP_CHAKAEMLVENGINE]:FOR[RealismOverhaul]
@@ -2711,7 +2708,7 @@
 //  Mars Ascent Vehicle auxiliary propellant tank.
 
 //  Dimensions: 3.75 m x 2 m
-//  Gross Mass: 410 Kg
+//  Inert Mass: 410 Kg
 //  ==================================================
 
 @PART[NP_CHAKAEMLVENGINE222C]:FOR[RealismOverhaul]
@@ -2767,7 +2764,7 @@
 //  Large surface habitation module propellant tank.
 
 //  Dimensions: 7.5 m x 1.5 m
-//  Gross Mass: 1500 Kg
+//  Inert Mass: 1500 Kg
 //  ==================================================
 
 @PART[DUNARETROTANK]:FOR[RealismOverhaul]
@@ -3016,7 +3013,7 @@
 //  Small radial propellant tank.
 
 //  Dimensions: 0.3 m x 0.8 m
-//  Gross Mass: 50 Kg
+//  Inert Mass: 50 Kg
 //  ==================================================
 
 @PART[XrcsTankRadialLongHVX]:FOR[RealismOverhaul]
@@ -3065,7 +3062,7 @@
 //  Large radial propellant tank.
 
 //  Dimensions: 0.6 m x 1.5 m
-//  Gross Mass: 370 Kg
+//  Inert Mass: 370 Kg
 //  ==================================================
 
 @PART[XrcsTankRadialLongHVXLP]:FOR[RealismOverhaul]
@@ -3114,7 +3111,7 @@
 //  RS-68 engine.
 
 //  Dimensions: 2.43 m x 5.2 m
-//  Gross Mass: 6600 Kg
+//  Inert Mass: 6600 Kg
 //  ==================================================
 
 @PART[xbahars68bx]:FOR[RealismOverhaul]
@@ -3218,7 +3215,7 @@
 //  Space Launch System core booster.
 
 //  Dimensions: 8.4 m x 46 m
-//  Gross Mass: 1091540 Kg
+//  Gross Mass: 1090540 Kg
 //  ==================================================
 
 @PART[MonkeyCargoBoosterSLSADJ]:FOR[RealismOverhaul]
@@ -3247,7 +3244,7 @@
 
     @category = Engine
 
-    @mass = 125.47
+    @mass = 124.47
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
@@ -3264,7 +3261,7 @@
 
     %engineType = SSME
     %engineTypeMult = 4
-    %massOffset = 111.36
+    %massOffset = 110.36
     %ignoreMass = False
 
     !MODULE[ModuleCommand],*{}
@@ -3275,7 +3272,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1358.5
         @maxThrust = 2319.9
         @heatProduction = 100
@@ -3473,6 +3469,22 @@
         standalone = True
     }
 
+    !MODULE[ModuleDataTrasmitter],*{}
+
+    MODULE
+    {
+        name = ModuleDataTrasmitter
+        antennaType = DIRECT
+        antennaPower = 4.5
+        packetInterval = 1.0
+        packetSize = 1.024
+        packetResourceCost = 0.0425
+        requiredResource = ElectricCharge
+        DeployFxModules = 0
+        antennaCombinable = True
+        antennaCombinableExponent = 1
+    }
+
     !RESOURCE,*{}
 
     //  Avionics batteries 1.25 kWh.
@@ -3495,6 +3507,8 @@
 
 @PART[TALUS]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTransmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -3519,7 +3533,7 @@
         name = ModuleRTAntenna
         IsRTActive = True
         Mode0OmniRange = 0
-        Mode1OmniRange = 1500000
+        Mode1OmniRange = 15000000
         EnergyCost = 0.035
 
         TRANSMITTER

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Propulsion.cfg
@@ -166,7 +166,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 826.5
         @heatProduction = 100
@@ -279,7 +278,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 15800
         @heatProduction = 100
@@ -383,7 +381,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 20337
         @heatProduction = 100
@@ -502,7 +499,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 14234.3
         @heatProduction = 100
@@ -1066,7 +1062,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 111.2
         @maxThrust = 111.2
         @heatProduction = 100
@@ -1174,7 +1169,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1748
         @maxThrust = 1748
         @heatProduction = 100
@@ -1261,7 +1255,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 23.1
         @maxThrust = 30.7
         @heatProduction = 100
@@ -1345,7 +1338,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 100
         @heatProduction = 100
@@ -1395,7 +1387,6 @@
         type = ModuleEnginesRF
         configuration = SEP-100
         origMass = 0.05
-        modded = False
 
         CONFIG
         {
@@ -1470,7 +1461,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 50
         @heatProduction = 100
@@ -1520,7 +1510,6 @@
         type = ModuleEnginesRF
         configuration = SEP-50
         origMass = 0.03
-        modded = False
 
         CONFIG
         {
@@ -1783,7 +1772,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 29.2
         @maxThrust = 146
         @exhaustDamage = True
@@ -1861,7 +1849,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1072
         @maxThrust = 1308
         @heatProduction = 100
@@ -2139,7 +2126,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 66.72
         @maxThrust = 66.72
         @heatProduction = 100
@@ -2217,7 +2203,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 30
         @maxThrust = 50
         @heatProduction = 100
@@ -2867,7 +2852,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 369.2
         @maxThrust = 369.2
         @useEngineResponseTime = False
@@ -2964,7 +2948,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 421.6
         @maxThrust = 421.6
         @useEngineResponseTime = False
@@ -3173,7 +3156,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1890
         @maxThrust = 3370
         @heatProduction = 100
@@ -3224,148 +3206,11 @@
 
 @PART[xbahars68bx]:FOR[RealismOverhaulEngines]
 {
-    //  Add an empty thrust transform to simulate the gas generator exhaust.
-    //  Used for roll control in the single - stick Delta IV variants.
-
-    MODEL
-    {
-        model = RealismOverhaul/emptyengine
-        position = 1.0, 0.75, 0.0
-        rotation = 0.0, 0.0, 0.0
-    }
-
-    //  Main engine.
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
-    {
-        %engineID = RS68Engine
-
-        //@CONFIG,*
-        //{
-        //    @ignitions = 10
-        //}
-    }
-
-    @MODULE[ModuleEngineConfigs]
-    {
-        %engineID = RS68Engine
-        %isMaster = True
-
-        //OtherModules
-        //{
-        //    RS68Exhaust = RS68-GasGenerator
-        //}
-    }
-
-    //  Gas generator exhaust.
-
-    MODULE
-    {
-        name = ModuleEnginesRF
-        engineID = RS68Exhaust
-        thrustVectorTransformName = newThrustTransform
-        exhaustDamage = True
-        minThrust = 10
-        maxThrust = 10
-        ignitionThreshold = 0.1
-        heatProduction = 10
-        ullage = True
-        pressureFed = False
-        ignitions = 1
-
-        IGNITOR_RESOURCE
-        {
-            name = ElectricCharge
-            amount = 0.05
-        }
-
-        PROPELLANT
-        {
-            name = LqdHydrogen
-            ratio = 0.7285
-            DrawGauge = False
-        }
-
-        PROPELLANT
-        {
-            name = LqdOxygen
-            ratio = 0.2715
-            DrawGauge = False
-        }
-
-        atmosphereCurve
-        {
-            key = 0 220
-            key = 1 175
-        }
-    }
-
-    //MODULE
-    //{
-    //    name = ModuleEngineConfigs
-    //    type = ModuleEnginesRF
-    //    configuration = RS68-GasGenerator
-    //    engineID = RS68Exhaust
-    //    isMaster = False
-    //    modded = False
-
-    //    CONFIG
-    //    {
-    //        name = RS68-GasGenerator
-    //        minThrust = 10
-    //        maxThrust = 10
-    //        heatProduction = 10
-    //        ullage = True
-    //        pressureFed = False
-    //        ignitions = 10
-
-    //        IGNITOR_RESOURCE
-    //        {
-    //            name = ElectricCharge
-    //            amount = 0.05
-    //        }
-
-    //        PROPELLANT
-    //        {
-    //            name = LqdHydrogen
-    //            ratio = 0.7285
-    //            DrawGauge = False
-    //        }
-
-    //        PROPELLANT
-    //        {
-    //            name = LqdOxygen
-    //            ratio = 0.2715
-    //            DrawGauge = False
-    //        }
-
-    //        atmosphereCurve
-    //        {
-    //            key = 0 220
-    //            key = 1 175
-    //        }
-    //    }
-    //}
-
     //  Main engine gimbal.
 
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]]
     {
         @gimbalRange = 6.0
-    }
-
-    //  Gas generator exhaust gimbal.
-
-    MODULE
-    {
-        name = ModuleGimbal
-        gimbalTransformName = newThrustTransform
-        gimbalRangeXP = 0
-        gimbalRangeXN = 0
-        gimbalRangeYP = 26.0
-        gimbalRangeYN = 26.0
-        useGimbalResponseSpeed = True
-        gimbalResponseSpeed = 16
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1493,7 +1493,7 @@
 }
 
 //  ==================================================
-//  Falcon 9 "octaweb" engine mount structure.
+//  Falcon 9 "OctaWeb" engine mount structure.
 
 //  Dimensions: 3.66 m x 2.6 m
 //  Inert Mass: 680 Kg

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -1111,8 +1111,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     !explosionPotential = NULL
     @bulkheadProfiles = size3
     %stagingIcon = DECOUPLER_HOR

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -5,10 +5,10 @@
 //  NASA - Altair Lunar Lander fact sheet:                https://www.nasa.gov/centers/johnson/pdf/327564main_fs_2009_02_005_jsc_altair_web.pdf
 //  NTRS - Altair Ascent and Descent Trajectory Design:   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100035768.pdf
 //  Space Launch Report - Space Launch System Data Sheet: http://www.spacelaunchreport.com/sls0.html
-//  Norbert Brügge - Delta IV:                            http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Description/Frame.htm
-//  ULA - Delta IV user guide:                            http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
-//  Space Launch Report - Falcon 9:                       http://www.spacelaunchreport.com/falcon.html
-//  Spaceflight 101 - Falcon 9 v1.1:                      http://spaceflight101.com/spacerockets/falcon-9-v1-1-f9r/
+//  Norbert Brügge - Delta IV launch vehicle:             http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Description/Frame.htm
+//  ULA - Delta IV users guide:                           http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//  Space Launch Report - Falcon 9 launch vehicle:        http://www.spacelaunchreport.com/falcon.html
+//  Spaceflight 101 - Falcon 9 v1.1 launch vehicle:       http://spaceflight101.com/spacerockets/falcon-9-v1-1-f9r/
 //  NASA - Orion CSM fact sheet:                          https://www.nasa.gov/sites/default/files/atoms/files/fs-2014-08-004-jsc-orion_quickfacts-web.pdf
 //  NTRS - Energy Storage Workshop:                       https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110009972.pdf
 //  NTRS - Constellation Program Li-Ion cell storage:     https://batteryworkshop.msfc.nasa.gov/presentations/06_Adv%20Li-ion%20Cells%20Constellation_CReid.pdf
@@ -21,29 +21,35 @@
 //  Removed extra parts.
 //  ==================================================
 
-!PART[XAltair2descent2stageDUNAX]:FOR[RealismOverhaul]{}
-
 !PART[XAltair2descent2stageDUNA9X]:FOR[RealismOverhaul]{}
 
-!PART[nosMonkeyExplorerUtilityALTAIR]:FOR[RealismOverhaul]{}
+!PART[XAltair2descent2stageDUNAX]:FOR[RealismOverhaul]{}
+
+!PART[nosMonkeyExplorerUtilityALTAIR3tga9XXX]:FOR[RealismOverhaul]{}
 
 !PART[nosMonkeyExplorerUtil19843548491ityALTAIRXXX]:FOR[RealismOverhaul]{}
 
 !PART[nosMonkeyExplorerUtilityALTAIRXXX]:FOR[RealismOverhaul]{}
 
-!PART[nosMonkeyExplorerUtilityALTAIR3tga9XXX]:FOR[RealismOverhaul]{}
-
-!PART[XwheelMed2X]:FOR[RealismOverhaul]{}
-
-!PART[XwheelMed3X]:FOR[RealismOverhaul]{}
-
-!PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
-
-!PART[xKosmos_Balka_1_Tunnel1222x]:FOR[RealismOverhaul]{}
+!PART[nosMonkeyExplorerUtilityALTAIR]:FOR[RealismOverhaul]{}
 
 !PART[xKosmos_Balka_1_Tunnel12SSAx]:FOR[RealismOverhaul]{}
 
+!PART[xKosmos_Balka_1_Tunnel1222x]:FOR[RealismOverhaul]{}
+
+!PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
+
 !PART[XKosmos_Strut_Connector2X]:FOR[RealismOverhaul]{}
+
+!PART[XKWFlatadapter77N]:FOR[RealismOverhaul]{}
+
+!PART[XKWFlatadapter3x2cc291x]:FOR[RealismOverhaul]{}
+
+!PART[XXB3IUShroudXLOWERRXV]:FOR[RealismOverhaul]{}
+
+!PART[XKW5mDecouplerShroudXMERLIN224]:FOR[RealismOverhaul]{}
+
+!PART[XKW5mDecouplerShroudX2242ab]:FOR[RealismOverhaul]{}
 
 !PART[XTALUSXX3]:FOR[RealismOverhaul]{}
 
@@ -51,25 +57,7 @@
 
 !PART[XTALUSXXXLS2A3]:FOR[RealismOverhaul]{}
 
-!PART[XXB3IUShroudXLOWERRXV]:FOR[RealismOverhaul]{}
-
-!PART[PAYLOADADAPTER22gaOPXB]:FOR[RealismOverhaul]{}
-
-!PART[PAYLOADADAPTER2OPSFFXX]:FOR[RealismOverhaul]{}
-
-!PART[XKW5mDecouplerShroudX2242ab]:FOR[RealismOverhaul]{}
-
-!PART[XKW5mDecouplerShroudXMERLIN224]:FOR[RealismOverhaul]{}
-
 !PART[XtelescopicLadderBay2X]:FOR[RealismOverhaul]{}
-
-!PART[XNPdecouplerstack4m]:FOR[RealismOverhaul]{}
-
-!PART[XNPdecouplerstack8m]:FOR[RealismOverhaul]{}
-
-!PART[XNPdecouplerstack85M?HS]:FOR[RealismOverhaul]{}
-
-!PART[XNPdecouplerstack85Mx3HSx]:FOR[RealismOverhaul]{}
 
 !PART[XNPdecouplerstack5mXDELTAK2VC3]:FOR[RealismOverhaul]{}
 
@@ -77,25 +65,33 @@
 
 !PART[XNPdecouplerstack5mXDELTAK]:FOR[RealismOverhaul]{}
 
+!PART[XNPdecouplerstack4m]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack85Mx3HSx]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack85M?HS]:FOR[RealismOverhaul]{}
+
+!PART[XNPdecouplerstack8m]:FOR[RealismOverhaul]{}
+
+!PART[XDRAGON--ADAPTERX]:FOR[RealismOverhaul]{}
+
 !PART[CHAKAradialDecouplerXX]:FOR[RealismOverhaul]{}
 
 !PART[chakaradialDecoupler1-2XXX]:FOR[RealismOverhaul]{}
 
-!PART[XKWFlatadapter77N]:FOR[RealismOverhaul]{}
-
-!PART[XKWFlatadapter3x2cc291x]:FOR[RealismOverhaul]{}
-
-!PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]{}
-
-!PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
+!PART[SLS_CM_FairingAdapterBLOCK1B96EUS]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_FairingAdapter2xce3]:FOR[RealismOverhaul]{}
 
-!PART[SLS_CM_FairingAdapter296-EM2]:FOR[RealismOverhaul]{}
-
 !PART[SLS_CM_FairingAdapter96]:FOR[RealismOverhaul]{}
 
-!PART[SLS_CM_FairingAdapterBLOCK1B96EUS]:FOR[RealismOverhaul]{}
+!PART[SLS_CM_FairingAdapter296x2]:FOR[RealismOverhaul]{}
+
+!PART[PAYLOADADAPTER22gaOPXB]:FOR[RealismOverhaul]{}
+
+!PART[PAYLOADADAPTERx3]:FOR[RealismOverhaul]{}
+
+!PART[PAYLOADADAPTER2OPSFFXX]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_stackDecouplerx302hjsans]:FOR[RealismOverhaul]{}
 
@@ -103,11 +99,13 @@
 
 !PART[xstrutConnectorc2x]:FOR[RealismOverhaul]{}
 
-!PART[Xtrusslrg_argonXsmalldccdCxx]:FOR[RealismOverhaul]{}
+!PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]{}
+
+!PART[Xtrusslrg_argonXsmalldccd2ggaC2HAxx]:FOR[RealismOverhaul]{}
 
 !PART[Xtrusslrg_argonXsmalldccd2ggaCxx]:FOR[RealismOverhaul]{}
 
-!PART[Xtrusslrg_argonXsmalldccd2ggaC2HAxx]:FOR[RealismOverhaul]{}
+!PART[Xtrusslrg_argonXsmalldccdCxx]:FOR[RealismOverhaul]{}
 
 !PART[Xtrusslrg_argonXsmalldccd343gC]:FOR[RealismOverhaul]{}
 
@@ -174,10 +172,7 @@
     {
         @minThrust = 18
         @maxThrust = 335
-        @heatProduction = 100
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 9
+        @heatProduction = 304
 
         @PROPELLANT[LiquidFuel]
         {
@@ -501,7 +496,7 @@
 //  Inert Mass: 200 Kg
 //  ==================================================
 
-@PART[XwheelMedX]:FOR[RealismOverhaul]
+@PART[xwheelMed4x]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -509,12 +504,17 @@
 
     MODEL
     {
-        model = CMES/Structural/CHAKA-WHEEL/model
+        model = CMES/Structural/roverWheelTR-2L/model
         scale = 1.333, 1.333, 1.333
     }
 
     @scale = 1.0
     @rescaleFactor = 1.0
+
+    !node_stack_connect = NULL
+    %node_attach = 0.0, 0.0, 0.0, 1.0, 0.0, 0.0
+
+    @attachRules = 0,1,0,1,0
 
     @category = Ground
     @title = MSEV Rover Wheel
@@ -522,10 +522,13 @@
     @description = A rover wheel for the surface exploration vehicles and the mobile habitation modules.
 
     @mass = 0.2
+    @crashTolerance = 16
+    @breakingForce = 250
+    @breakingTorque = 250
     @maxTemp = 473.15
     %skinMaxTemp = 473.15
     %fuelCrossFeed = False
-    %bulkheadProfiles = size2
+    %bulkheadProfiles = srf
 
     @MODULE[ModuleWheelBase]
     {
@@ -1550,10 +1553,14 @@
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
 
-    @MODULE[ModuleAnimateGeneric]
+    @MODULE[ModuleAnimateGeneric]:HAS[#animationName[deploy]]
     {
+        @isOneShot = False
         @startEventGUIName = Lower Landing Gear
         @endEventGUIName = Raise Landing Gear
+        %actionGUIName = Toggle Landing Gear
+        @allowAnimationWhileShielded = False
+        @disableAfterPlaying = True
     }
 
     !MODULE[FStextureSwitch*],*{}
@@ -2420,6 +2427,41 @@
 }
 
 //  ==================================================
+//  Strut connector (medium strength).
+
+//  Dimensions: N/A
+//  Inert Mass: 15 Kg
+//  ==================================================
+
+@PART[xstrutConnectorc1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = EAS-8 Strut Connector
+    @manufacturer = Generic
+    @description = A medium strength generic structural connector.
+
+    @mass = 0.015
+    @dragModelType = SPHERICAL
+    @minimumDrag = 0.02
+    @maximumDrag = 0.02
+    @crashTolerance = 14
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @maxLength = 50
+    %bulkheadProfiles = srf
+
+    @MODULE[CModuleStrut]
+    {
+        @linearStrength = 300
+        @angularStrength = 300
+    }
+}
+
+//  ==================================================
 //  Engine mount basket.
 
 //  Dimensions: - m x - m
@@ -2459,84 +2501,6 @@
 }
 
 //  ==================================================
-//  Strut connector (low strength).
-
-//  Dimensions: N/A
-//  Inert Mass: 8 Kg
-//  ==================================================
-
-@PART[xstrutConnectorc1x]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    @category = Structural
-    @title = EAS-2 Strut Connector
-    @manufacturer = Generic
-    @description = A low strength structural connector.
-
-    @mass = 0.008
-    @dragModelType = SPHERICAL
-    @minimumDrag = 0.02
-    @maximumDrag = 0.02
-    @crashTolerance = 10
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-    @maxLength = 50
-    %bulkheadProfiles = srf
-    !explosionPotential = NULL
-
-    @MODULE[CModuleStrut]
-    {
-        @linearStrength = 75
-        @angularStrength = 75
-    }
-}
-
-//  ==================================================
-//  Strut connector (medium strength).
-
-//  Dimensions: N/A
-//  Inert Mass: 15 Kg
-//  ==================================================
-
-@PART[XstrutConnectorMediumX]:FOR[RealismOverhaul]
-{
-    @module = CompoundPart
-
-    %RSSROConfig = True
-
-    @category = Structural
-    @title = EAS-8 Strut Connector
-    @manufacturer = Generic
-    @description = A medium strength structural connector.
-
-    @mass = 0.015
-    @dragModelType = SPHERICAL
-    @minimumDrag = 0.02
-    @maximumDrag = 0.02
-    @crashTolerance = 14
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-    @maxLength = 50
-    %bulkheadProfiles = srf
-
-    @MODULE[CModuleStrut]
-    {
-        @linearStrength = 300
-        @angularStrength = 300
-    }
-
-    %DRAG_CUBE
-    {
-        %none = True
-    }
-}
-
-//  ==================================================
 //  Strut connector (high strength).
 
 //  Dimensions: N/A
@@ -2552,7 +2516,7 @@
     @category = Structural
     @title = EAS-16 Strut Connector
     @manufacturer = Generic
-    @description = A high strength structural connector.
+    @description = A high strength generic structural connector.
 
     @mass = 0.03
     @dragModelType = SPHERICAL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -12,6 +12,10 @@
 //  NASA - Orion CSM fact sheet:                          https://www.nasa.gov/sites/default/files/atoms/files/fs-2014-08-004-jsc-orion_quickfacts-web.pdf
 //  NTRS - Energy Storage Workshop:                       https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110009972.pdf
 //  NTRS - Constellation Program Li-Ion cell storage:     https://batteryworkshop.msfc.nasa.gov/presentations/06_Adv%20Li-ion%20Cells%20Constellation_CReid.pdf
+//  NTRS - ISS Li-Ion cell batteries:                     https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160012048.pdf
+//  Space Systems/Loral - ISS power systems:              https://web.archive.org/web/20141227213842/http://sslmda.com/downloads/products/ispacest.pdf
+//  Boeing - ISS Control Moment Gyroscopes:               http://www.boeing.com/assets/pdf/defense-space/space/spacestation/systems/docs/ISS%20Motion%20Control%20System.pdf
+//  NTRS - ISS Control Moment Gyroscope Lessons Learned:  https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100021932.pdf
 
 //  ==================================================
 //  Removed extra parts.
@@ -168,11 +172,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 18
         @maxThrust = 335
         @heatProduction = 100
-        !fxOffset = NULL
         %ullage = True
         %pressureFed = False
         %ignitions = 9
@@ -582,15 +584,15 @@
 }
 
 //  ==================================================
-//  Payload pallet container.
+//  Integrated Truss Structure (power pack)
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 2.0 m x 2.8 m
+//  Gross Mass: 3800 Kg
 //  ==================================================
 
 @PART[XCXA_P6_BATTERY_TRUSSX]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = False
+    %RSSROConfig = True
 
     @MODEL
     {
@@ -602,15 +604,16 @@
 
     @node_stack_front = 0.0, 1.4, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_back = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 3
+    %node_attach = 0.0, 1.4, 0.0, 0.0, 1.0, 0.0
 
     @attachRules = 1,1,1,1,0
 
     @category = Utility
-    @title = Payload Pallet - Container
+    @title = Integrated Truss Structure - Power Pack
     @manufacturer = Generic
-    @description = A generic resupply payload pallet. Can store and carry various items and resources, both pressurized and unpressurized.
+    @description = A rigid and lightweight truss segment derived from the Integrated Truss Structure of the International Space Station (ISS). Contains battery banks and various power management modules for supplying stable and uninterrupted power.
 
-    @mass = 1.0
+    @mass = 3.8
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -619,33 +622,27 @@
     @fuelCrossFeed = True
     %bulkheadProfiles = size3
 
-    !MODULE[ModuleFuelTanks],*{}
-
-    MODULE
+    @RESOURCE[ElectricCharge]
     {
-        name = ModuleFuelTanks
-        type = ServiceModule
-        volume = 1500
-        basemass = -1
+        @amount = 35000
+        @maxAmount = 35000
     }
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
-//  Payload pallet structural truss.
+//  Integrated Truss Structure (structural truss)
 
-//  Dimensions: - m x - m
-//  Inert Mass: - Kg
+//  Dimensions: 2.0 m x 3.8 m
+//  Inert Mass: 400 Kg
 //  ==================================================
 
 @PART[XCXA_P6_LONG_SPACERX]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = False
+    %RSSROConfig = True
 
     @MODEL
     {
-        scale = 1.0, 1.0, 1.0
+        @scale = 1.0, 1.0, 1.0
     }
 
     %scale = 1.0
@@ -653,34 +650,35 @@
 
     @node_stack_front = 0.0, 1.875, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_back = 0.0, -1.875, 0.0, 0.0, -1.0, 0.0, 3
+    %node_attach = 0.0, 1.875, 0.0, 0.0, 1.0, 0.0
 
     @attachRules = 1,1,1,1,0
 
     @category = Structural
-    @title = Payload Pallet - Structural Truss
+    @title = Integrated Truss Structure - Structural Truss
     @manufacturer = Generic
-    @description = A rigid and lightweight truss segment.
+    @description = A rigid and lightweight truss segment derived from the Integrated Truss Structure of the International Space Station (ISS).
 
-    @mass = 1.0
+    @mass = 0.4
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @fuelCrossFeed = True
     %bulkheadProfiles = size3
 }
 
 //  ==================================================
-//  Payload pallet avionics.
+//  Integrated Truss Structure (avionics)
 
-//  Dimensions: - m x - m
-//  Inert Mass: 350 Kg
+//  Dimensions: 2.7 m x 1.7 m
+//  Inert Mass: 1500 Kg
 //  ==================================================
 
 @PART[xCXA_Z1x]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = False
+    %RSSROConfig = True
 
     @MODEL
     {
@@ -694,15 +692,16 @@
     !node_stack_antenna = NULL
     @node_stack_back = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 3
     !node_stack_mbm = NULL
+    %node_attach = 0.0, 0.825, 0.0, 0.0, 1.0, 0.0
 
     @attachRules = 1,1,1,1,0
 
     @category = Pods
-    @title = Payload Pallet - Avionics
+    @title = Integrated Truss Structure - Avionics
     @manufacturer = Generic
-    @description = 
+    @description = A rigid and lightweight truss segment derived from the Integrated Truss Structure of the International Space Station (ISS). Contains a command and control system (C&C), along a set of four Control Moment Gyroscopes (CMGs) for fine attitude control.
 
-    @mass = 0.35
+    @mass = 1.5
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -717,11 +716,21 @@
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.2
+            @rate = 0.45
         }
     }
 
-    !MODULE[ModuleReactionWheel],*{}
+    @MODULE[ModuleReactionWheel]
+    {
+        @PitchTorque = 1.03
+        @YawTorque = 1.03
+        @RollTorque = 1.03
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 1.05
+        }
+    }
 
     @MODULE[ModuleSAS]
     {
@@ -739,8 +748,8 @@
 
     @RESOURCE[ElectricCharge]
     {
-        @amount = 15840
-        @maxAmount = 15840
+        @amount = 1600
+        @maxAmount = 1600
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -27,11 +27,11 @@
 
 !PART[nosMonkeyExplorerUtilityALTAIRXXX]:FOR[RealismOverhaul]{}
 
+!PART[nosMonkeyExplorerUtilityALTAIR3tga9XXX]:FOR[RealismOverhaul]{}
+
 !PART[XwheelMed2X]:FOR[RealismOverhaul]{}
 
 !PART[XwheelMed3X]:FOR[RealismOverhaul]{}
-
-!PART[XKKLEG2X]:FOR[RealismOverhaul]{}
 
 !PART[xKosmos_Balka_1_Tunnel12x]:FOR[RealismOverhaul]{}
 
@@ -65,6 +65,8 @@
 
 !PART[XNPdecouplerstack85M?HS]:FOR[RealismOverhaul]{}
 
+!PART[XNPdecouplerstack85Mx3HSx]:FOR[RealismOverhaul]{}
+
 !PART[XNPdecouplerstack5mXDELTAK2VC3]:FOR[RealismOverhaul]{}
 
 !PART[XNPdecouplerstack5mXDELTAK2V]:FOR[RealismOverhaul]{}
@@ -77,11 +79,15 @@
 
 !PART[XKWFlatadapter77N]:FOR[RealismOverhaul]{}
 
+!PART[XKWFlatadapter3x2cc291x]:FOR[RealismOverhaul]{}
+
 !PART[xxSDHI_2.5_ServiceModuleAdapterL]:FOR[RealismOverhaul]{}
 
 !PART[SDHIxADAPTERx2]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_FairingAdapter2xce3]:FOR[RealismOverhaul]{}
+
+!PART[SLS_CM_FairingAdapter296-EM2]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_FairingAdapter96]:FOR[RealismOverhaul]{}
 
@@ -90,6 +96,8 @@
 !PART[SLS_CM_stackDecouplerx302hjsans]:FOR[RealismOverhaul]{}
 
 !PART[SLS_CM_stackDecouplerx302hjns]:FOR[RealismOverhaul]{}
+
+!PART[xstrutConnectorc2x]:FOR[RealismOverhaul]{}
 
 !PART[Xtrusslrg_argonXsmalldccdCxx]:FOR[RealismOverhaul]{}
 
@@ -574,6 +582,192 @@
 }
 
 //  ==================================================
+//  Payload pallet container.
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[XCXA_P6_BATTERY_TRUSSX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_front = 0.0, 1.4, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_back = 0.0, -1.4, 0.0, 0.0, -1.0, 0.0, 3
+
+    @attachRules = 1,1,1,1,0
+
+    @category = Utility
+    @title = Payload Pallet - Container
+    @manufacturer = Generic
+    @description = A generic resupply payload pallet. Can store and carry various items and resources, both pressurized and unpressurized.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @fuelCrossFeed = True
+    %bulkheadProfiles = size3
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1500
+        basemass = -1
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Payload pallet structural truss.
+
+//  Dimensions: - m x - m
+//  Inert Mass: - Kg
+//  ==================================================
+
+@PART[XCXA_P6_LONG_SPACERX]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    @MODEL
+    {
+        scale = 1.0, 1.0, 1.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_front = 0.0, 1.875, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_back = 0.0, -1.875, 0.0, 0.0, -1.0, 0.0, 3
+
+    @attachRules = 1,1,1,1,0
+
+    @category = Structural
+    @title = Payload Pallet - Structural Truss
+    @manufacturer = Generic
+    @description = A rigid and lightweight truss segment.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @fuelCrossFeed = True
+    %bulkheadProfiles = size3
+}
+
+//  ==================================================
+//  Payload pallet avionics.
+
+//  Dimensions: - m x - m
+//  Inert Mass: 350 Kg
+//  ==================================================
+
+@PART[xCXA_Z1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_front = 0.0, 0.825, 0.0, 0.0, 1.0, 0.0, 3
+    !node_stack_antenna = NULL
+    @node_stack_back = 0.0, -0.825, 0.0, 0.0, -1.0, 0.0, 3
+    !node_stack_mbm = NULL
+
+    @attachRules = 1,1,1,1,0
+
+    @category = Pods
+    @title = Payload Pallet - Avionics
+    @manufacturer = Generic
+    @description = 
+
+    @mass = 0.35
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
+    @fuelCrossFeed = True
+    %bulkheadProfiles = size3
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2
+        }
+    }
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    @MODULE[ModuleSAS]
+    {
+        @SASServiceLevel = 3
+    }
+
+    @MODULE[ModuleAnimateGeneric]
+    {
+        @startEventGUIName = Deploy Tray
+        @endEventGUIName = Retract Tray
+        @actionGUIName = Toggle Tray
+    }
+
+    !MODULE[ModuleDockingNode],*{}
+
+    @RESOURCE[ElectricCharge]
+    {
+        @amount = 15840
+        @maxAmount = 15840
+    }
+}
+
+//  ==================================================
+//  Payload pallet avionics.
+
+//  Remote Tech compatibility
+//  ==================================================
+
+@PART[xCXA_Z1x]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.02
+        }
+    }
+}
+
+//  ==================================================
 //  TT - 38K radial decoupler.
 
 //  Dimensions: - m x - m
@@ -656,6 +850,8 @@
     %fuelCrossFeed = True
     @bulkheadProfiles = size3, size5
 
+    !MODULE[ModuleReactionWheel],*{}
+
     !MODULE[ModuleFuelTanks],*{}
 
     MODULE
@@ -720,146 +916,6 @@
 
     !RESOURCE,*{}
 }
-
-//  ==================================================
-//  Common Berthing Mechanism (active).
-
-//  Dimensions: 2.3 m x 0.56 m
-//  Inert Mass: 300 Kg
-//  ==================================================
-
-@PART[XIACBM1.25m]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    @MODEL
-    {
-        @scale = 2.215, 2.215, 2.215
-    }
-    @scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 0.42, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
-
-    @category = Coupling
-    @title = Common Berthing Mechanism (CBM) [Active]
-    @manufacturer = Boeing Co.
-    @description = A berthing mechanism used by the ISS modules (non Russian), the Multipurpose Logistics Modules (MPLM) and the resupply vehicles. This is the active component.
-
-    @mass = 0.3
-    @crashTolerance = 8
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
-    %bulkheadProfiles = size2
-
-    @MODULE[ModuleDockingNode]
-    {
-        @nodeType = CBM
-        %gendered = True
-        %genderFemale = False
-        %acquireForce = 0.5
-        %acquireMinFwdDot = 0.8
-        %acquireminRollDot = -3.40282347E+38
-        %acquireRange = 0.25
-        %acquireTorque = 0.5
-        %captureMaxRvel = 0.1
-        %captureMinFwdDot = 0.998
-        %captureMinRollDot = -3.40282347E+38
-        %captureRange = 0.05
-        %minDistanceToReEngage = 0.25
-        %undockEjectionForce = 0.1
-    }
-
-    @MODULE[ModuleLight]
-    {
-        @resourceAmount = 0.015
-    }
-
-    !MODULE[ModuleConnectedLivingSpace],*{}
-
-    MODULE:NEEDS[ConnectedLivingSpace]
-    {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        passableWhenSurfaceAttached = True
-    }
-}
-
-//  ==================================================
-//  Common Berthing Mechanism (passive).
-
-//  Dimensions: 2.3 m x 0.56 m
-//  Inert Mass: 300 Kg
-//  ==================================================
-
-@PART[XIACBM1ee25m]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    @MODEL
-    {
-        @scale = 2.215, 2.215, 2.215
-    }
-
-    @scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 0.42, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 2
-
-    @category = Coupling
-    @title = Common Berthing Mechanism  (CBM) [Passive]
-    @manufacturer = Boeing Co.
-    @description = A berthing mechanism used by the ISS modules (non Russian), the Multipurpose Logistics Modules (MPLM) and the resupply vehicles. This is the passive component.
-
-    @mass = 0.3
-    @crashTolerance = 8
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
-    %bulkheadProfiles = size2
-
-    @MODULE[ModuleDockingNode]
-    {
-        @nodeType = CBM
-        %gendered = True
-        %genderFemale = True
-        %acquireForce = 0.5
-        %acquireMinFwdDot = 0.8
-        %acquireminRollDot = -3.40282347E+38
-        %acquireRange = 0.25
-        %acquireTorque = 0.5
-        %captureMaxRvel = 0.1
-        %captureMinFwdDot = 0.998
-        %captureMinRollDot = -3.40282347E+38
-        %captureRange = 0.05
-        %minDistanceToReEngage = 0.25
-        %undockEjectionForce = 0.1
-    }
-
-    @MODULE[ModuleLight]
-    {
-        @resourceAmount = 0.015
-    }
-
-    !MODULE[ModuleConnectedLivingSpace],*{}
-
-    MODULE:NEEDS[ConnectedLivingSpace]
-    {
-        name = ModuleConnectedLivingSpace
-        passable = True
-        passableWhenSurfaceAttached = True
-    }
-}
-
 
 //  ==================================================
 //  Delta IV interstage adapter (4 m).
@@ -2375,6 +2431,42 @@
     !childStageOffset = NULL
 
     !MODULE[ModuleDecouple],*{}
+}
+
+//  ==================================================
+//  Strut connector (low strength).
+
+//  Dimensions: N/A
+//  Inert Mass: 8 Kg
+//  ==================================================
+
+@PART[xstrutConnectorc1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = EAS-2 Strut Connector
+    @manufacturer = Generic
+    @description = A low strength structural connector.
+
+    @mass = 0.008
+    @dragModelType = SPHERICAL
+    @minimumDrag = 0.02
+    @maximumDrag = 0.02
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @maxLength = 50
+    %bulkheadProfiles = srf
+    !explosionPotential = NULL
+
+    @MODULE[CModuleStrut]
+    {
+        @linearStrength = 75
+        @angularStrength = 75
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Structural.cfg
@@ -587,7 +587,7 @@
 //  Integrated Truss Structure (power pack)
 
 //  Dimensions: 2.0 m x 2.8 m
-//  Gross Mass: 3800 Kg
+//  Inert Mass: 3800 Kg
 //  ==================================================
 
 @PART[XCXA_P6_BATTERY_TRUSSX]:FOR[RealismOverhaul]
@@ -663,8 +663,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
     @fuelCrossFeed = True
     %bulkheadProfiles = size3
 }
@@ -750,29 +750,6 @@
     {
         @amount = 1600
         @maxAmount = 1600
-    }
-}
-
-//  ==================================================
-//  Payload pallet avionics.
-
-//  Remote Tech compatibility
-//  ==================================================
-
-@PART[xCXA_Z1x]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
-{
-    !MODULE[ModuleDataTransmitter],*{}
-
-    !MODULE[ModuleRTAntenna*],*{}
-
-    !MODULE[ModuleSPU*],*{}
-
-    @MODULE[ModuleCommand]
-    {
-        @RESOURCE[ElectricCharge]
-        {
-            @rate -= 0.02
-        }
     }
 }
 
@@ -2443,42 +2420,6 @@
 }
 
 //  ==================================================
-//  Strut connector (low strength).
-
-//  Dimensions: N/A
-//  Inert Mass: 8 Kg
-//  ==================================================
-
-@PART[xstrutConnectorc1x]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-
-    @category = Structural
-    @title = EAS-2 Strut Connector
-    @manufacturer = Generic
-    @description = A low strength structural connector.
-
-    @mass = 0.008
-    @dragModelType = SPHERICAL
-    @minimumDrag = 0.02
-    @maximumDrag = 0.02
-    @crashTolerance = 10
-    @breakingForce = 250
-    @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-    @maxLength = 50
-    %bulkheadProfiles = srf
-    !explosionPotential = NULL
-
-    @MODULE[CModuleStrut]
-    {
-        @linearStrength = 75
-        @angularStrength = 75
-    }
-}
-
-//  ==================================================
 //  Engine mount basket.
 
 //  Dimensions: - m x - m
@@ -2515,6 +2456,42 @@
     @maxTemp = 473.15
     %skinMaxTemp = 573.15
     %bulkheadProfiles = size1
+}
+
+//  ==================================================
+//  Strut connector (low strength).
+
+//  Dimensions: N/A
+//  Inert Mass: 8 Kg
+//  ==================================================
+
+@PART[xstrutConnectorc1x]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @category = Structural
+    @title = EAS-2 Strut Connector
+    @manufacturer = Generic
+    @description = A low strength structural connector.
+
+    @mass = 0.008
+    @dragModelType = SPHERICAL
+    @minimumDrag = 0.02
+    @maximumDrag = 0.02
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
+    @maxLength = 50
+    %bulkheadProfiles = srf
+    !explosionPotential = NULL
+
+    @MODULE[CModuleStrut]
+    {
+        @linearStrength = 75
+        @angularStrength = 75
+    }
 }
 
 //  ==================================================


### PR DESCRIPTION
~~Updates for the CMES pack for **KSP 1.2**. This PR will be updated to include any future CMES updates for **KSP 1.3**.~~

**Change Log:**

**General:**

* Remove all "ModuleEnginesRF" patches (taken care by the global engine config).
* Remove any global engine config patcher fields that are not needed (https://github.com/KSP-RO/RealismOverhaul/issues/1669)
* Remove all parts that are duplicates.
* Delete references for any removed parts that do not exist anymore.
* Remove RO patches for any parts that do not exist anymore.
* Minor updates to the TACLS part descriptions.
* Remove unused fields from the TACLS converter module (specialist and experience enhancements).
* Add RO compatibility patches for all new parts (inflatable heat shields, expanded cupola, ISS trusses, generic lander can, strut connector).
* Add CommNet compatiblity (if RemoteTech is not installed).
* Increase the RT ranges of the MSEV Crew Cabin, the Altair Ascent Module and the EUS antennas (were too low).

**Hab:**

* Increase the Sabatier Reactor conversion rates of the SP - 600, SP - 800 and SP - 1000 habitation modules to halve the conversion rates of the oxygen and water reclaimers.
* Fix the ModuleFuelTanks volumes for many parts (were too low or even had negative volume).

**Pod:**

* Fix the scaling of the internal models of the MSEV Crew Cabin.

**Propulsion:**

* The main MTV propellant tank now features an integrated cryocooler module.
* Update the SuperDraco engine config to be compatible with the latest global engine config.
* Add some initial support for the RS-68 engine turbopump exhaust.
* Tweak the inert mass of the SLS core stage to account for the missing retrorockets.

**Structural:**

* The MSEV Rover Wheel can now be surface-attached, like the stock one.
* Increase the maximum temperatures of some of the Falcon 9 parts to make them able for reentry.

**Notes:**

* The Falcon 9 parts might need further maxTemp tweaks, depending on the reentry profiles.
* The proper RS-68 turbopump exhaust config is currently missing. There are some problems integrating the extra engine configs, these will be fixed due time.
* The CommNet ranges have been calculated and set with the Level 3 Tracking in mind (50 Tm).