### PR TITLE
BE-4 engine updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
@@ -88,8 +88,8 @@
 
 			atmosphereCurve
 			{
-				key = 0 354
-				key = 1 318
+				key = 0 341
+				key = 1 305
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
@@ -2,15 +2,16 @@
 //  BE-4 global engine configuration.
 
 //  Gross Mass: 2250 Kg
-//  Throttle Range: 100% to 40%
+//  Throttle Range: 30% to 100%
 //  O/F Ratio: 3.6
 //  Burn Time: 350 s
 
 //  Sources:
 
-//  Blue Origin - BE-4 engine:                   https://www.blueorigin.com/be4
-//  United Launch Alliance - BE-4 rocket engine: http://www.ulalaunch.com/uploads/docs/BE-4_Fact_Sheet_Web_Final_2.pdf
-//  Space Launch Report - Vulcan launch vehicle: http://www.spacelaunchreport.com/vulcan.html
+//  Blue Origin - BE-4 engine:                      https://www.blueorigin.com/be4
+//  United Launch Alliance - BE-4 rocket engine:    http://www.ulalaunch.com/uploads/docs/BE-4_Fact_Sheet_Web_Final_2.pdf
+//  Space Launch Report - Vulcan launch vehicle:    http://www.spacelaunchreport.com/vulcan.html
+//  NASASpaceFlight - IAF Blue Origin presentation: https://forum.nasaspaceflight.com/index.php?topic=10685.msg1665037#msg1665037
 
 //  Used by:
 
@@ -18,7 +19,8 @@
 
 //  Notes:
 
-//  * Stupendously preliminary config as no information about the operational parameters of the engine have been released yet.
+//  * Stupendously preliminary config as no solid information about the operational parameters of the engine have been released yet.
+//  * No TestFlight compatibility since this global engine config represents unflown hardware.
 //  ==================================================
 
 @PART[*]:HAS[#engineType[BE4]]:FOR[RealismOverhaulEngines]
@@ -30,8 +32,8 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		%minThrust = 978.61
-		%maxThrust = 2446.52
+		%minThrust = 794.25
+		%maxThrust = 2647.5
 		%heatProduction = 100
 		%EngineType = LiquidFuel
 		@useThrustCurve = False
@@ -56,8 +58,8 @@
 		CONFIG
 		{
 			name = BE-4
-			minThrust = 978.61 // Guess 40% throttle.
-			maxThrust = 2446.52
+			minThrust = 794.25
+			maxThrust = 2647.5
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
@@ -4,7 +4,7 @@
 //  Gross Mass: 2250 Kg
 //  Throttle Range: 30% to 100%
 //  O/F Ratio: 3.6
-//  Burn Time: 350 s
+//  Burn Time: 400 s (minimum)
 
 //  Sources:
 
@@ -37,6 +37,9 @@
 		%heatProduction = 100
 		%EngineType = LiquidFuel
 		@useThrustCurve = False
+		@useEngineResponseTime = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
 		%ullage = True
 		%pressureFed = False
 		%ignitions = 1
@@ -104,4 +107,21 @@
 	!MODULE[ModuleAlternator],*{}
 
 	!RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[BE-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = BE-4
+		ratedBurnTime = 400
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE4_Config.cfg
@@ -1,72 +1,105 @@
-//BE-4 engine
-//VSR 
-//
-//	http://www.spacelaunchreport.com/vulcan.html
-//
-//FIXME: stupendously preliminary config
+//  ==================================================
+//  BE-4 global engine configuration.
+
+//  Gross Mass: 2250 Kg
+//  Throttle Range: 100% to 40%
+//  O/F Ratio: 3.6
+//  Burn Time: 350 s
+
+//  Sources:
+
+//  Blue Origin - BE-4 engine:                   https://www.blueorigin.com/be4
+//  United Launch Alliance - BE-4 rocket engine: http://www.ulalaunch.com/uploads/docs/BE-4_Fact_Sheet_Web_Final_2.pdf
+//  Space Launch Report - Vulcan launch vehicle: http://www.spacelaunchreport.com/vulcan.html
+
+//  Used by:
+
+//  * Ven Stock Revamp
+
+//  Notes:
+
+//  * Stupendously preliminary config as no information about the operational parameters of the engine have been released yet.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[BE4]]:FOR[RealismOverhaulEngines]
 {
+	%category = Engine
 	%title = BE-4
 	%manufacturer = Blue Origin
-	%description = The BE-4 is an oxidizer-rich staged combustion engine that burns LNG/LOX. Though initially developed for use on a Blue Origin launch vehicle, in 2014 United Launch Alliance announced that their new Vulcan booster, the successor to the Atlas V and Delta IV, will be powered by a pair of BE-4 engines.
-	
+	%description = The BE-4 is an oxidizer-rich staged combustion Methalox engine. Though initially developed for use on a Blue Origin launch vehicle, in 2014 United Launch Alliance announced that their new Vulcan launch vehicle, the successor to both the Atlas V and Delta IV launch vehicles, will be powered by a pair of BE-4 engines. Diameter: 2 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		%minThrust = 978.61
+		%maxThrust = 2446.52
+		%heatProduction = 100
+		%EngineType = LiquidFuel
+		@useThrustCurve = False
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = BE-4
-		modded = false
 		origMass = 2.25
+
 		CONFIG
 		{
 			name = BE-4
-			maxThrust = 2647.5
-			minThrust = 1060 // Guess 40% throttle
-			PROPELLANT // Guess MR = 3.25, typical for first-stage LNG/LOX
-			{
-				name = LqdMethane
-				ratio = 0.452
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.548
-			}
-			atmosphereCurve // http://www.spacelaunchreport.com/vulcan.html, 2015-11-16, generally agrees with NasaSpaceflight.com L2
-			{
-				key = 0 335
-				key = 1 310
-			}
-			
+			minThrust = 978.61 // Guess 40% throttle.
+			maxThrust = 2446.52
+			heatProduction = 100
+			massMult = 1.0
 			ullage = True
 			pressureFed = False
 			ignitions = 1
-			
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.5
 			}
-			IGNITOR_RESOURCE
+
+			PROPELLANT
 			{
-				name = TEATEB
-				amount = 1.0
+				name = LqdMethane
+				ratio = 0.4286
+				DrawGauge = True
 			}
-		
-			massMult = 1.0
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.5714
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 354
+				key = 1 318
+			}
 		}
 	}
-	@MODULE[ModuleGimbal]
+
+	@MODULE[ModuleGimbal],*
 	{
-		%gimbalRange = 8 // Guess, same as RD-180
-		%useGimbalResponseSpeed = true
+		@gimbalRange = 8.0 // Guess, same as RD-180.
+		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
 	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -571,55 +571,58 @@
 	}
 }
 
-//BE-4
+//  ==================================================
+//  BE-4 engine.
+//  ==================================================
+
 @PART[liquidEngineMiniTurbo]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+
 	@MODEL
 	{
-		%scale = 6.08, 6.08, 6.08
+		%scale = 8.75, 7.0, 8.75
 	}
-	%rescaleFactor = 1.0
-	%scale = 1.0
-	%node_stack_top    = 0.0,  0.0, 0.0, 0.0, 1.0, 0.0, 4
-	%node_stack_bottom = 0.0, -3.5568, 0.0, 0.0, -1.0, 0.0, 4
-	%category = Propulsion
 
-	%attachRules = 1,0,1,1,0
-	%mass = 4.5 //Guess (TWR 120)
-	%maxTemp = 1973.15
+	%scale = 1.0
+	@rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -4.18, 0.0, 0.0, -1.0, 0.0, 4
+
+	@mass = 4.5
+	@crashTolerance = 10
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+	!emissiveConstant = NULL
+	@bulkheadProfiles = srf, size4
+
+	%engineType = BE4
+	%engineTypeMult = 2
+	%ignoreMass = False
+	%massOffset = 0
+
 	@MODULE[ModuleEngines*]
 	{
-		%minThrust = 2120
-		%maxThrust = 5295
-		%heatProduction = 100
 		@PROPELLANT[LiquidFuel]
 		{
 			%name = LqdMethane
-			%ratio = 0.452
+			%ratio = 0.4286
 		}
+
 		@PROPELLANT[Oxidizer]
 		{
 			%name = LqdOxygen
-			%ratio = 0.548
+			%ratio = 0.5714
 		}
+
 		@atmosphereCurve
 		{
-			@key,0 = 0 335
-			@key,1 = 1 310
+			@key,0 = 0 354
+			@key,1 = 1 318
 		}
-		!IGNITOR_RESOURCE,* {}
-	}
-	!MODULE[ModuleEngineConfigs]
-	{
-	}
-	engineType = BE4
-	engineTypeMult = 2
-	RESOURCE
-	{
-		name = TEATEB
-		amount = 1.0
-		maxAmount = 1.0
 	}
 }
 


### PR DESCRIPTION
**Change Log:**

* Add some basic info and web sources to the global engine config.
* Add a default part module category.
* Add some default engine module parameters.
* ~~Tweak the minimum and maximum thrust value to correspond to a rated VAC thrust of **550000 lbf**.~~
* Update the ASL and VAC Isp values (**note 1**).
* Remove the requirement of a TEATEB resource for ignition.
* Fix the size of the VSR 2 x BE-4 engine cluster (was too small).

**Notes:**

* **Note 1:** The Isp values were calculated via the [Rocket Propulsion Analysis (RPA)](http://www.propulsion-analysis.com/index.htm) program (lite version). The throat and exhaust areas were calculated from the [BE-4 engine infographic picture](https://cdn.arstechnica.net/wp-content/uploads/2017/03/BE44.jpg). The RPA file is available from here: https://raw.githubusercontent.com/PhineasFreak/DocBin/master/DocBin/generic_files/RPA-BE-4.cfg. Updates to these values will be issued as more information becomes available.