### PR TITLE
Increase merlin burn time

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -617,7 +617,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1A
-		ratedBurnTime = 170
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -630,7 +630,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1B
-		ratedBurnTime = 170
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -658,7 +658,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1C
-		ratedBurnTime = 255
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -686,7 +686,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D
-		ratedBurnTime = 270
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -700,7 +700,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D+
-		ratedBurnTime = 240
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -714,7 +714,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D++
-		ratedBurnTime = 240
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -4,7 +4,7 @@
 //  Gross Mass: 760 Kg (baseline Merlin 1 variant)
 //  Throttle Range: 39% to 100% (throttleable variants)
 //  O/F Ratio: ~2.17 (differs between versions)
-//  Burn Time: ~240 s (ASL variants), ~400 s (VAC variants)
+//  Burn Time: ~240 s (single mission, ASL variants), ~400 s (VAC variants)
 
 //  Sources:
 

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -657,7 +657,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1C
-		ratedBurnTime = 170
+		ratedBurnTime = 255
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -685,7 +685,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D
-		ratedBurnTime = 180
+		ratedBurnTime = 270
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -699,7 +699,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D+
-		ratedBurnTime = 162
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -713,7 +713,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D++
-		ratedBurnTime = 162
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -4,7 +4,7 @@
 //  Gross Mass: 760 Kg (baseline Merlin 1 variant)
 //  Throttle Range: 39% to 100% (throttleable variants)
 //  O/F Ratio: ~2.17 (differs between versions)
-//  Burn Time: ~170 s (ASL variants), ~400 s (VAC variants)
+//  Burn Time: ~240 s (ASL variants), ~400 s (VAC variants)
 
 //  Sources:
 
@@ -15,6 +15,7 @@
 //  [5] https://twitter.com/elonmusk/status/728753234811060224 (min thrust of Merlin1D+ is ~40%)
 //  [6] http://www.spacex.com/press/2012/12/19/spacex-falcon-9-upper-stage-engine-successfully-completes-full-mission-duration
 //  [7] http://www.spacex.com/press/2012/12/19/spacex-completes-development-merlin-regeneratively-cooled-rocket-engine
+//  [8] https://www.youtube.com/watch?v=rUDLxFUMC9c (eyeballed burn times)
 
 //  Used by:
 


### PR DESCRIPTION
The current Merlin 1 burn times are too short, as far as I can tell.

Watching the CRS-10 technical webcast (all T times in seconds): https://www.youtube.com/watch?v=rUDLxFUMC9c

Ignition occurs at T-3. MECO appears to be at T+146. Total: 149 seconds (Guessing times based on callouts, the timeline at the bottom of the video appears to be incorrect)
Boostback burn begins at ~T+183s. Boostback burn ends at ~T+213. Total: 30 seconds
Entry burn begins at ~T+393. Entry burn ends at ~T+410. Total: 17 seconds
Landing burn begins at ~T+462. Landing burn ends at ~T+481. Total: 19 seconds

The total burn time is 215 seconds.

I would suggest raising the rated burn time of all the Merlin engines to at least this number plus some reasonable padding. 240 seconds seems like a reasonable compromise. I don't have any source for "rated" burn time, but SpaceX static fires each stage for at least a few seconds at McGregor and at the pad before each mission, plus given that they claim the engine is designed to be used for multiple missions with minimal refurbishment, this seems like a reasonable amount of padding. I could even see raising it higher, but I'm hesitant to do so without some source beyond YouTube.

It's certainly likely that the engine, even if it can run multiple mission durations without being overhauled, could not run them in one straight burn, so setting this to a massively high number would also not seem reasonable. However, the current RO rated burn time is clearly too low to emulate existing SpaceX missions, so I feel pretty comfortable at least raising it this much without additional sources.