### PR TITLE
Shielded PP tank fix

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -88,6 +88,7 @@
 	{
 		@type = Structural
 		!typeAvailable,* = DEL
+		typeAvailable = Fuselage
 		typeAvailable = Structural
 	}
 }


### PR DESCRIPTION
**Change Log:**

* Add back the "Fuselage" option of the shielded PP tank (was removed by https://github.com/KSP-RO/RealismOverhaul/commit/1ec5e784fe97640b224be7469785178b8c7acbd0#diff-272064a024f200ee99abfcc49536c4bfL90)