### PR TITLE
SuperDraco global engine config updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
@@ -1,60 +1,93 @@
-//	==================================================
-//	SuperDraco engine.
+//  ==================================================
+//  SuperDraco global engine configuration.
 
-//	Dimensions: 0.200 x 2.000 m
-//	Gross Mass: 130.40 Kg
-//	Chamber Pressure: 1,000 psi
-//	Throttle Range: 20% to 100%
-//	Burn Time: 300 s
-//	O/F Ratio: 1.30
+//  Inert Mass: 65 Kg
+//  Chamber Pressure: 1000 psi
+//  Throttle Range: 20% to 100%
+//  Burn Time: 350 s (minimum)
+//  O/F Ratio: 1.3
 
-// FIXME: lots of info missing/unsourced
+//  Sources:
 
-// SSTU
-// References:
-// [1] http://www.faa.gov/about/office_org/headquarters_offices/ast/media/20140513_DragonFly_DraftEA_Appendices%28reduced%29.pdf
-//	==================================================
+//  FAA - DragonFly RLV test environmental impact: http://www.faa.gov/about/office_org/headquarters_offices/ast/media/20140513_DragonFly_DraftEA_Appendices%28reduced%29.pdf
+//  SpaceX - SuperDraco 3D printed engine chamber: http://www.spacex.com/news/2014/07/31/spacex-launches-3d-printed-part-space-creates-printed-engine-chamber-crewed
+
+//  Used by:
+
+//  * CMES
+//  * SSTU
+
+//  Notes:
+
+//  * Lots of info are missing and/or are unsourced.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[SuperDraco]]:FOR[RealismOverhaulEngines]
 {
-	@title  	  = SuperDraco
-	@manufacturer = SpaceX
-	%description  = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules.
+	%category = Engine
+	%title = SuperDraco
+	%manufacturer = SpaceX
+	%description = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules. Diameter: 0.6 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 14.59
+		@maxThrust = 72.95
+		%heatProduction = 54
+		%EngineType = LiquidFuel
+		@useThrustCurve = False
+		@useEngineResponseTime = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
+		%ullage = True
+		%pressureFed = True
+		%ignitions = 0
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
 
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		type = ModuleEnginesFX
+		type = ModuleEngines
 		configuration = SuperDraco
-		modded = false
-		origMass = 0.0652
+		origMass = 0.065
+
 		CONFIG
 		{
 			name = SuperDraco
-			minThrust = 17.1
-			maxThrust = 85.5
+			minThrust = 14.59
+			maxThrust = 72.95
+			heatProduction = 54
+
 			PROPELLANT
 			{
-				name	  = MMH
-				ratio	  = 0.5629
-				DrawGauge = true
+				name = MMH
+				ratio = 0.5629
+				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name	  = NTO
-				ratio	  = 0.4370
-				DrawGauge = false
+				name = NTO
+				ratio = 0.4371
+				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
-				key = 0 280.10 //this appears to be a guess
-				key = 1 239.80
+				key = 0 280         //  This is a complete guess.
+				key = 1 240
 			}
-		
+
 			ullage = True
 			pressureFed = True
-			ignitions = 0 //no reason to limit
+			ignitions = 0           //  No reason to limit them.
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -62,8 +95,27 @@
 			}
 		}
 	}
-	!MODULE[ModuleGimbal]
+
+	!MODULE[ModuleGimbal],*{}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[SuperDraco]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
 	{
+		name = SuperDraco
+		ratedBurnTime = 350
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
 	}
-	
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
@@ -27,7 +27,7 @@
 	%category = Engine
 	%title = SuperDraco
 	%manufacturer = SpaceX
-	%description = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules. Diameter: 0.6 m.
+	%description = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules. Diameter: 0.2 m.
 
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
@@ -31,8 +31,8 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 14.59
-		@maxThrust = 72.95
+		@minThrust = 17.0
+		@maxThrust = 85.0
 		%heatProduction = 54
 		%EngineType = LiquidFuel
 		@useThrustCurve = False
@@ -60,8 +60,8 @@
 		CONFIG
 		{
 			name = SuperDraco
-			minThrust = 14.59
-			maxThrust = 72.95
+			minThrust = 17.0
+			maxThrust = 85.0
 			heatProduction = 54
 
 			PROPELLANT


### PR DESCRIPTION
**Change Log:**

* Add an extra web source.
* Add a default part config category.
* Add some default ModuleEngines patching.
* Make sure that no gimbal or alternator modules exist in the part config.
* Make sure that no resources exist in the part config.
* Add a basic TF config.

**Notes:**

* The burn time has been set as the cumulative burn time of all tests conducted with the same thrust chamber: http://www.spacex.com/news/2014/07/31/spacex-launches-3d-printed-part-space-creates-printed-engine-chamber-crewed