### PR TITLE
LOX->OX converter now tagged RO compatible

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -539,6 +539,7 @@
 }
 +PART[FuelCell]:FOR[RealismOverhaul]:FINAL
 {
+  %RSSROConfig = True
 	@name = RO_TACLO2ToO2
 	@title = TACLS Liquid O2 to O2 converter
 	@description = A simple device to evaporate LO2 to use for astronaut breathing oxygen.


### PR DESCRIPTION
The re-purposed small fuel cell lacked the %RSSROconf tag. Two commits because I have no clue how to work this windows shell integrated git frontend, sorry!