### PR TITLE
Update SSTU Agena Engine plumes

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8048.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8048.cfg
@@ -20,8 +20,8 @@
         name = Hypergolic-OMS-White
         transformName = LR-81-8048-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.9
-        fixedScale = 2
+        localPosition = 0,0,0.1
+        fixedScale = 0.4
         energy = 1.2
         speed = 1.5
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8096.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8096.cfg
@@ -20,8 +20,8 @@
         name = Hypergolic-OMS-White
         transformName = LR-81-8096-ThrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.9
-        fixedScale = 2
+        localPosition = 0,0,0.5
+        fixedScale = 0.6
         energy = 1.2
         speed = 1.5
     }


### PR DESCRIPTION
They went out of place with the latest release I assume.

- scaled them back to nozzle size
- fixed location of emission