### PR TITLE
[Bug Fix] Communotron 16 CommNet range

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -93,7 +93,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 3200
+        @antennaPower = 320000
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.0005

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -93,7 +93,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 32
+        @antennaPower = 3200
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.0005


### PR DESCRIPTION
**Change log:**

* Increase the range of the Communotron 16 omnidirectional antenna to mach the RT stats of 400 Mm (https://github.com/KSP-RO/RealismOverhaul/issues/1686).

**Notes:**

* This is needed because CommNet does not follow the same antenna rules as RT regarding the multiple antenna multipliers.