### PR TITLE
[Bug Fix] RO Agena engine plume

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAgenaEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAgenaEngine.cfg
@@ -10,7 +10,7 @@
         %powerEffectName = Hypergolic-OMS-White
     }
 
-	@MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*
         {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAgenaEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAgenaEngine.cfg
@@ -1,39 +1,34 @@
+//  ==================================================
+//  XLR-81 Agena engine plume setup.
+//  ==================================================
+
 @PART[RO-AgenaEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-	
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic-OMS-White
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic-OMS-White
+    }
+
 	@MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
     }
+
     PLUME
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,-0.2
-        fixedScale = 2
-        energy = 1.2
-        speed = 1.5
-    }
-}
-@PART[RO-AgenaEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
-{
-    @EFFECTS
-    {
-        @Hypergolic-OMS-White
-        {
-            @MODEL_MULTI_SHURIKEN_PERSIST[flare]
-            {
-                @localPosition = 0.0, 0.0, -0.8
-                @fixedScale = 0.5
-                @emissionMult = 0.2
-            }
-        }
+        plumePosition = 0.0, 0.0, -0.5
+        plumeScale = 0.8
+        flarePosition = 0.0, 0.0, -1.55
+        flareScale = 0.15
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.75
+        energy = 1.0
+        speed = 1.0
     }
 }


### PR DESCRIPTION
**Change log:**

* Tweak the appearance of the RO Agena engine plume to fix the plume clipping the part model.
* Update the plume config setup for the new plume conventions (plume/flareScale parameters).