### PR TITLE
[Mod Support] RealScaleBoosters for KSP 1.2/1.3

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Agena.cfg
@@ -1,8 +1,8 @@
 //  ==================================================
 //  Sources:
 
-//  AGENA D MISSION CAPABILITIES AND RESTRAINTS: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
-//  Reusable Agena Study:                        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
+//  NTRS - AGENA D MISSION CAPABILITIES AND RESTRAINTS: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
+//  NTRS - Reusable Agena Study:                        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
 
 //  ==================================================
 //  Agena D.
@@ -40,8 +40,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleRCS*]
     {
@@ -131,6 +131,8 @@
 
 @PART[RSBtankAgenaD]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTrasmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -186,8 +188,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
@@ -28,8 +28,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -51,8 +51,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 773.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleCommand]
     {
@@ -160,6 +160,8 @@
 
 @PART[RSBtankAresIstage2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTrasmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -215,8 +217,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     //  Three Aerojet Rocketdyne MR-80 (3100 N) RCS thrusters for roll control but only two active at launch (one for redundancy).
 
@@ -300,8 +302,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    @skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    @skinMaxTemp = 573.15
 
     //  Three Aerojet Rocketdyne MR-80 (3100 N) RCS thrusters for roll control.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
@@ -29,8 +29,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -2.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -62,8 +62,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -92,8 +92,8 @@
     @mass = 0.15
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -127,8 +127,8 @@
     @mass = 0.165
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -162,8 +162,8 @@
     @mass = 0.125
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -189,8 +189,8 @@
     @mass = 0.23
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -211,8 +211,8 @@
     @mass = 0.425
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -242,8 +242,8 @@
     @mass = 0.538
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -274,8 +274,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     //  56 N Gas Hydrogen (GH2) attitude control thrusters for each axis (using liquid hydrogen directly for now).
 
@@ -358,6 +358,8 @@
 
 @PART[RSBtankArianeVescA]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTrasmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -409,8 +411,6 @@
     {
         @scale = 1.0, 0.9, 1.0
     }
-
-    //  Pitch control thrusters.
 
     //  Roll control thrusters.
 
@@ -491,8 +491,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleSeeThroughObject],*{}
 
@@ -586,8 +586,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -639,14 +639,17 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 280
         @maxThrust = 280
+        @heatProduction = 14
+        %ullage = False
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[SolidFuel]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
@@ -25,8 +25,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -58,8 +58,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -86,8 +86,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 773.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @stagingIcon = LIQUID_ENGINE
 
     !MODULE[ModuleDecouple],*{}
@@ -104,10 +104,12 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0.88
         @maxThrust = 0.88
-        @heatProduction = 100
+        @heatProduction = 0
+        %ullage = False
+        %pressureFed = True
+        %ignitions = -1
 
         @PROPELLANT[MonoPropellant]
         {
@@ -201,6 +203,8 @@
 
 @PART[RSBathenaOAM]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTransmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -271,8 +275,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -1,12 +1,12 @@
 //  ==================================================
 //  Sources:
 
-//  Atlas V Launch Services User's Guide (2010):    http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
-//  The Centaur Upper Stage History:                http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
-//  Qualification for the MR-107S RCS thrusters:    http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
-//  Centaur Upperstage:                             http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
-//  United Launch Alliance - Atlas V:               http://www.ulalaunch.com/products_atlasv.aspx
-//  Spaceflight 101 - Atlas V:                      http://spaceflight101.com/spacerockets/atlas-v-401/
+//  ULA - Atlas V Launch Services User's Guide (2010): http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
+//  ULA - The Centaur Upper Stage History:             http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/TheCentaurUpperStageVehicleHistory.pdf
+//  ULA - Qualification for the MR-107S RCS thrusters: http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
+//  ULA - Centaur Upperstage:                          http://www.ulalaunch.com/uploads/docs/Published_Papers/Upper_Stages/CentaurUpperstageApplicabilityforSeveralDayMissionDurationswithMinorInsulationModificationsAIAA20075845.pdf
+//  ULA - United Launch Alliance - Atlas V:            http://www.ulalaunch.com/products_atlasv.aspx
+//  Spaceflight 101 - Atlas V:                         http://spaceflight101.com/spacerockets/atlas-v-401/
 
 //  ==================================================
 //  Atlas V 400 series LPF.
@@ -27,8 +27,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -60,8 +60,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -93,8 +93,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -125,8 +125,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -157,8 +157,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -189,8 +189,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -221,8 +221,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -253,8 +253,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -284,8 +284,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -312,8 +312,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -335,8 +335,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -361,8 +361,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %vesselIcon = Probe
 
     //  Two sets of RCS thrusters for three axis control and ullage.
@@ -371,25 +371,25 @@
 
     @MODULE[ModuleRCS]
     {
-        @thrusterPower = 0.04
+        @thrusterPower = 0.428
         !resourceName = NULL
 
         !transformMultipliers,*{}
 
         transformMultipliers
         {
-            trf0 = 1.0
-            trf1 = 1.0
-            trf2 = 1.0
-            trf3 = 1.0
-            trf4 = 1.0
-            trf5 = 1.0
-            trf6 = 1.0
-            trf7 = 1.0
-            trf8 = 0.675
-            trf9 = 0.675
-            trf10 = 0.675
-            trf11 = 0.675
+            trf0  = 0.0935
+            trf1  = 0.0935
+            trf2  = 0.0935
+            trf3  = 0.0935
+            trf4  = 0.0935
+            trf5  = 0.0935
+            trf6  = 0.0935
+            trf7  = 0.0935
+            trf8  = 0.0631
+            trf9  = 0.0631
+            trf10 = 0.0631
+            trf11 = 0.0631
         }
 
         PROPELLANT
@@ -552,8 +552,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -581,8 +581,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     !stageOffset = NULL
     !childStageOffset = NULL
 }
@@ -607,8 +607,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -630,8 +630,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -659,8 +659,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -674,14 +674,14 @@
 {
     %RSSROConfig = True
 
-    @title =  Atlas V Common Core Booster
+    @title = Atlas V Common Core Booster
     @manufacturer = United United Launch Alliance (ULA)
     @description = This common booster core can either function as a single core, or center core, or strap-on booster.
 
     @mass = 15.075
     @crashTolerance = 12
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @breakingForce = 250
     @breakingTorque = 250
 
@@ -713,11 +713,12 @@
         }
     }
 
+    //  Eight STAR 5F solid rocket motors (6 kN each) to aid the separation of the Centaur upper stage.
+
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 49.8
-        @maxThrust = 49.8
+        @minThrust = 48
+        @maxThrust = 48
         @heatProduction = 100
         %ullage = False
         %pressureFed = False
@@ -726,6 +727,12 @@
         @PROPELLANT[SolidFuel]
         {
             @name = HTPB
+        }
+
+        atmosphereCurve
+        {
+            @key,0 = 0 254
+            @key,1 = 1 160
         }
     }
 
@@ -782,8 +789,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Carrack.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Carrack.cfg
@@ -22,8 +22,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -0.75, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -55,8 +55,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -0.5, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -88,8 +88,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -111,8 +111,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -168,8 +168,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleSeeThroughObject],*{}
 
@@ -266,12 +266,12 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
-//  Athena/Carrack aft interstage adapter.
+//  Athena & Carrack aft interstage adapter.
 
 //  Dimensions: 2.36 m x 1.5 m
 //  Inert Mass: 120 Kg
@@ -289,8 +289,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
@@ -1,14 +1,14 @@
 //  ==================================================
 //  Sources:
 
-//  Delta IV - United Launch Alliance:                http://www.ulalaunch.com/products_deltaiv.aspx
-//  Delta IV Launch Services User's Guide:            http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
-//  Delta IV Medium+ 4.2 - Spaceflight 101:           http://spaceflight101.com/spacerockets/delta-iv-medium-42/
-//  LRO/LCROSS Centaur MR-106 thruster qualification: http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
-//  Delta III Payload Planners Guide:                 https://web.archive.org/web/20011119102909/http://www.boeing.com/defense-space/space/delta/docs/DELTA_III_PPG_2000.PDF
-//  Delta II Payload Planners Guide:                  http://www.ulalaunch.com/uploads/docs/DeltaIIPayloadPlannersGuide2007.pdf
-//  Delta II Data Sheet - Space Launch Report:        http://spacelaunchreport.com/delta2.html
-//  Delta II 7920 - Spaceflight 101:                  http://spaceflight101.com/spacerockets/delta-ii-7920/
+//  ULA - Delta IV launch vehicle:                          http://www.ulalaunch.com/products_deltaiv.aspx
+//  ULA - Delta IV Launch Services User's Guide:            http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//  Spaceflight 101 - Delta IV Medium+ 4.2:                 http://spaceflight101.com/spacerockets/delta-iv-medium-42/
+//  ULA - LRO/LCROSS Centaur MR-106 thruster qualification: http://www.ulalaunch.com/uploads/docs/Published_Papers/Supporting_Technologies/DeltaQualificationTestofAerojetHydrazineThrustersforUseonCentaurduringtheLROandLCROSSMissions20095481.pdf
+//  Boeing Co. - Delta III Payload Planners Guide:          https://web.archive.org/web/20011119102909/http://www.boeing.com/defense-space/space/delta/docs/DELTA_III_PPG_2000.PDF
+//  ULA - Delta II Payload Planners Guide:                  http://www.ulalaunch.com/uploads/docs/DeltaIIPayloadPlannersGuide2007.pdf
+//  Space Launch Report - Delta II Data Sheet:              http://spacelaunchreport.com/delta2.html
+//  Spaceflight 101 - Delta II 7920:                        http://spaceflight101.com/spacerockets/delta-ii-7920/
 
 //  ==================================================
 //  Delta II payload fairing (stretched).
@@ -29,8 +29,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -61,8 +61,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -94,8 +94,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -127,8 +127,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -160,8 +160,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -193,8 +193,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -226,8 +226,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -251,7 +251,7 @@
 {
     %RSSROConfig = True
 
-    @title = Delta II Payload Fairing Base [Short]
+    @title = Delta II Payload Fairing Base (Short)
     @manufacturer = McDonnell Douglas
     @description = A short 2.4 meter procedural payload fairing base designed for the Delta II launch vehicle family core booster.
 
@@ -259,8 +259,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -274,7 +274,7 @@
 {
     %RSSROConfig = True
 
-    @title = Delta II Payload Fairing Base [Long]
+    @title = Delta II Payload Fairing Base (Long)
     @manufacturer = McDonnell Douglas
     @description = A long 2.4 meter procedural payload fairing base designed for the Delta II launch vehicle family Delta F and K upper stages.
 
@@ -282,8 +282,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -305,8 +305,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -328,8 +328,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -359,8 +359,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -395,8 +395,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -431,8 +431,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 473.15
 
     @MODULE[ModuleDecouple]
     {
@@ -459,8 +459,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -482,8 +482,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleCommand]
     {
@@ -576,6 +576,8 @@
 
 @PART[RSBtankDelta2K]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTransmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -613,7 +615,7 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (Delta III version).
+//  Delta Cryogenic Upper Stage.
 
 //  Dimensions: 4 m x 6.8 m
 //  Gross Mass: 19170 Kg
@@ -623,16 +625,16 @@
 {
     %RSSROConfig = True
 
-    @title = Delta Cryogenic Second Stage 4M (Delta III)
+    @title = Delta Cryogenic Upper Stage (DCUS)
     @manufacturer = Boeing Co.
-    @description = The Delta Cryogenic Second Stage (DCSS) used on the Delta III launch vehicle. Contains guidance capability.
+    @description = The Delta Cryogenic Upper Stage (DCUS) used on the Delta III launch vehicle. Contains guidance capability.
 
     @mass = 2.2
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -734,8 +736,7 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (Delta IV 4 - meter
-//  version).
+//  Delta Cryogenic Second Stage (4 meter variant).
 
 //  Dimensions: 4 m x 12.1 m
 //  Gross Mass: 23720 Kg
@@ -748,9 +749,9 @@
 {
     %RSSROConfig = True
 
-    @title = Delta Cryogenic Second Stage 4M (Delta IV)
+    @title = Delta Cryogenic Second Stage (DCSS-4)
     @manufacturer = United Launch Alliance (ULA)
-    @description = The 4 meter variant of the Delta Cryogenic Second Stage (DCSS-4) used on the Delta IV Medium 4, 4+ and 5+. Contains guidance capability.
+    @description = The 4 meter variant of the Delta Cryogenic Second Stage (DCSS-4) used on the Delta IV Medium 4 and 4+. Contains guidance capability.
 
     @mass = 2.42
     @crashTolerance = 12
@@ -859,8 +860,7 @@
 }
 
 //  ==================================================
-//  Delta Cryogenic Second Stage (Delta IV 5 - meter
-//  version).
+//  Delta Cryogenic Second Stage (5 meter variant).
 
 //  Dimensions: 5 m x 13 m
 //  Gross Mass: 31110 Kg
@@ -873,16 +873,16 @@
 {
     %RSSROConfig = True
 
-    @title = Delta Cryogenic Second Stage 5M (Delta IV)
+    @title = Delta Cryogenic Second Stage (DCSS-5)
     @manufacturer = United Launch Alliance (ULA)
-    @description = The 5 meter variant of the Delta Cryogenic Second Stage (DCSS-5). Contains guidance capability.
+    @description = The 5 meter variant of the Delta Cryogenic Second Stage (DCSS-5) used on the Delta IV Medium 5+ and Delta IV Heavy. Contains guidance capability.
 
     @mass = 3.06
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -991,6 +991,8 @@
 
 @PART[RSBtankDelta3dcss4m|RSBtankDeltaIVdcss4m|RSBtankDeltaIVdcss5m]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTransmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -1054,8 +1056,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1076,14 +1078,14 @@
 
     @title = Delta III Interstage Adapter
     @manufacturer = Boeing Co.
-    @description = The Thor 8000/DCSS interstage adapter for the Delta III.
+    @description = The Thor 8000/DCUS interstage adapter for the Delta III.
 
     @mass = 0.74
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1138,8 +1140,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1166,8 +1168,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @fuelCrossFeed = True
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1231,8 +1233,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @fuelCrossFeed = True
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1296,8 +1298,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -1319,8 +1321,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -1344,8 +1346,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1408,8 +1410,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -72,6 +72,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -2.46, 0.0, 0.0, -1.0, 0.0, 2
+
     @mass = 0.1
     @crashTolerance = 10
     @breakingForce = 250
@@ -142,6 +147,9 @@
 @PART[RSBengineArianeVSRB]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
     @mass = 35.9
     @crashTolerance = 10
@@ -230,6 +238,9 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
     @mass = 1.2
     @crashTolerance = 10
     @breakingForce = 250
@@ -311,6 +322,9 @@
 @PART[RSBdelta3srm]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
     @mass = 2.2
     @crashTolerance = 10
@@ -400,6 +414,9 @@
 @PART[RSBdelta3srmG]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
     @node_attach = 0.575, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 
@@ -498,6 +515,9 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
     @mass = 3.08
     @crashTolerance = 10
     @breakingForce = 250
@@ -582,6 +602,9 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
     @mass = 3.95
     @crashTolerance = 10
     @breakingForce = 250
@@ -641,6 +664,11 @@
 @PART[RSBengineAresSRB]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -23.71, 0.0, 0.0, -1.0, 0.0, 3
 
     @mass = 85.5
     @crashTolerance = 10
@@ -706,6 +734,9 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
     @mass = 1.115
     @crashTolerance = 10
     @breakingForce = 250
@@ -763,6 +794,19 @@
 }
 
 //  ==================================================
+//  Castor 30 solid rocket motor.
+
+//  Part configuration.
+//  ==================================================
+
+@PART[RSBengineCastor30]:AFTER[RealismOverhaulEngines]
+{
+    @title = Castor 30
+    @manufacturer = Orbital ATK
+    @description = The Castor 30 is a fairly wide-purpose solid rocket motor, functioning as an upper stage for a variety of launch vehicles or as a strap-on booster.
+}
+
+//  ==================================================
 //  Castor 120 solid rocket motor.
 
 //  Dimensions: 2.36 m x 9.02 m
@@ -772,6 +816,9 @@
 @PART[RSBengineCastor120]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
     @mass = 4.12
     @crashTolerance = 10
@@ -831,6 +878,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -4.625, 0.0, 0.0, -1.0, 0.0, 3
+
     @mass = 8.39
     @crashTolerance = 10
     @breakingForce = 250
@@ -878,6 +930,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -4.625, 0.0, 0.0, -1.0, 0.0, 3
+
     @mass = 8.195
     @crashTolerance = 10
     @breakingForce = 250
@@ -924,6 +981,11 @@
 @PART[RSBengineF1B]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -3.75, 0.0, 0.0, -1.0, 0.0, 3
 
     @mass = 9.66
     @crashTolerance = 10
@@ -977,6 +1039,11 @@
 @PART[RSBengineH1]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -1.392, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 0.988
     @crashTolerance = 10
@@ -1047,7 +1114,11 @@
         @scale = 1.0, 1.175, 1.0
     }
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
     @node_stack_top = 0.0, 0.235, 0.0, 0.0, 1.0, 0.0, 2
+    %node_stack_bottom = 0.0, -1.538, 0.0, 0.0, -1.0, 0.0, 2
 
     @crashTolerance = 10
     @breakingForce = 250
@@ -1106,6 +1177,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -2.775, 0.0, 0.0, -1.0, 0.0, 2
+
     @mass = 1.78
     @crashTolerance = 10
     @breakingForce = 250
@@ -1157,6 +1233,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -3.96, 0.0, 0.0, -1.0, 0.0, 2
+
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -1200,6 +1281,9 @@
 @PART[RSBengineLR101]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
     @mass = 0.024
     @crashTolerance = 12
@@ -1273,6 +1357,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -1.48, 0.0, 0.0, -1.0, 0.0, 3
+
     @mass = 5.48
     @crashTolerance = 10
     @breakingForce = 250
@@ -1330,6 +1419,11 @@
 @PART[RSBengineRL10A3|RSBengineRL10A42]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -1.165, 0.0, 0.0, -1.0, 0.0, 2
 
     @crashTolerance = 10
     @breakingForce = 250
@@ -1400,6 +1494,11 @@
 @PART[RSBengineRL10B2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -2.325, 0.0, 0.0, -1.0, 0.0, 2
 
     @crashTolerance = 10
     @breakingForce = 250
@@ -1480,11 +1579,14 @@
 
     @MODEL
     {
-        @scale = 1.415, 1.472, 1.415
+        @scale = 2.037, 2.2965, 2.037
     }
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
     @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.6, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -3.635, 0.0, 0.0, -1.0, 0.0, 2
     @node_stack_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 
     @mass = 3.53
@@ -1542,6 +1644,11 @@
     {
         @scale = 0.6, 1.0, 0.6
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -1.55, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 1.027
     @crashTolerance = 10
@@ -1610,6 +1717,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -2.5, 0.0, 0.0, -1.0, 0.0, 2
+
     @mass = 6.6
     @crashTolerance = 10
     @breakingForce = 250
@@ -1671,6 +1783,9 @@
     {
         @scale = 1.0, 0.966, 1.0
     }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 19.42, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -19.04, 0.0, 0.0, -1.0, 0.0, 3
@@ -1739,6 +1854,11 @@
 {
     %RSSROConfig = True
 
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -1.947, 0.0, 0.0, -1.0, 0.0, 2
+
     @mass = 0.9
     @crashTolerance = 10
     @breakingForce = 250
@@ -1789,6 +1909,11 @@
 @PART[RSBengineVulcain2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -2.485, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 1.8
     @crashTolerance = 10
@@ -1842,6 +1967,11 @@
 @PART[RSBengineXLR81]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    %node_stack_bottom = 0.0, -1.16, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 0.134
     @crashTolerance = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -1,65 +1,65 @@
 //  ==================================================
 //  Sources:
 
-//  Reusable Agena Study:                           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
-//  Heroicrelics - LR101 engine:                    http://heroicrelics.org/info/lr-101/lr-101.html
-//  Atlas & Atlas - Agena propulsion:               http://www.b14643.de/Spacerockets_2/United_States_4/Atlas/Propulsion/engines.htm
-//  Norbert Brügge - Vikas engine family:           http://www.b14643.de/Spacerockets_1/India/Vikas/Vikas.htm
+//  NTRS - Reusable Agena Study:                        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
+//  Heroicrelics - LR101 engine:                        http://heroicrelics.org/info/lr-101/lr-101.html
+//  Norbert Brügge -  Atlas propulsion systems:         http://www.b14643.de/Spacerockets_2/United_States_4/Atlas/Propulsion/engines.htm
+//  Norbert Brügge - Vikas engine family:               http://www.b14643.de/Spacerockets_1/India/Vikas/Vikas.htm
 
-//  Orbital ATK SRM Catalog (2012):                 http://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
+//  Orbital ATK - Propulsion Products Catalog:          https://www.orbitalatk.com/flight-systems/propulsion-systems/docs/2016%20OA%20Motor%20Catalog.pdf
 
-//  Aerojet Rocketdyne - AJ-60A SRM:                http://www.rocket.com/atlas-v-solid-rocket-motor
-//  NPO Energomash - RD-180 engine:                 http://www.lpre.de/energomash/RD-180/index.htm
-//  Atlas V Launch Services User's Guide (2010):    http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
-//  Norbert Brügge - Atlas V:                       http://www.b14643.de/Spacerockets_2/United_States_3/Atlas_V/Description/Frame.htm
-//  Rocket and Space Technology - Atlas family:     http://www.braeunig.us/space/specs/atlas.htm
-//  United Launch Alliance - Atlas V:               http://www.ulalaunch.com/products_atlasv.aspx
-//  Space Launch Report - Atlas V:                  http://spacelaunchreport.com/atlas5.html
+//  Aerojet Rocketdyne - AJ-60A SRM:                    http://www.rocket.com/atlas-v-solid-rocket-motor
+//  NPO Energomash - RD-180 engine:                     http://www.lpre.de/energomash/RD-180/index.htm
+//  Atlas V Launch Services User's Guide (2010):        http://www.ulalaunch.com/uploads/docs/AtlasVUsersGuide2010.pdf
+//  Norbert Brügge - Atlas V:                           http://www.b14643.de/Spacerockets_2/United_States_3/Atlas_V/Description/Frame.htm
+//  Rocket and Space Technology - Atlas family:         http://www.braeunig.us/space/specs/atlas.htm
+//  United Launch Alliance - Atlas V:                   http://www.ulalaunch.com/products_atlasv.aspx
+//  Space Launch Report - Atlas V:                      http://spacelaunchreport.com/atlas5.html
 
-//  Spaceflight 101 - Delta II 7920:                http://spaceflight101.com/spacerockets/delta-ii-7920/
-//  Rocket and Space Technology - Delta family:     http://www.braeunig.us/space/specs/delta.htm
-//  Astronautix - RS-27 engine:                     http://www.astronautix.com/engines/rs27.htm
-//  Aerojet Rocketdyne RS-27 engine:                http://rocket.com/rs-27a-engine
-//  Ares V and RS-68B:                              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf
-//  RS-68 & Linear Aerospike:                       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000025317.pdf
-//  Delta IV Launch Services User's Guide:          http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
-//  Pratt & Whitney - RS-68 propulsion system:      http://hamawy.net/resume/job/www.pw.utc.com/products/pwr/assets/pwr_rs-68.pdf
-//  Pratt & Whitney Rocketdyne Propulsion brochure: http://hamawy.net/resume/job/www.pw.utc.com/products/pwr/assets/pwr_propulsion_product_brochure.pdf
+//  Spaceflight 101 - Delta II 7920:                    http://spaceflight101.com/spacerockets/delta-ii-7920/
+//  Rocket and Space Technology - Delta family:         http://www.braeunig.us/space/specs/delta.htm
+//  Encyclopedia Astronautica - RS-27 engine:           http://www.astronautix.com/engines/rs27.htm
+//  Aerojet Rocketdyne - RS-27 engine:                  http://rocket.com/rs-27a-engine
+//  NTRS - Ares V and RS-68B:                           http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf
+//  NTRS - RS-68 & Linear Aerospike:                    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000025317.pdf
+//  Delta IV Launch Services User's Guide:              http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//  Pratt & Whitney - RS-68 propulsion system:          http://hamawy.net/resume/job/www.pw.utc.com/products/pwr/assets/pwr_rs-68.pdf
+//  Pratt & Whitney Rocketdyne Propulsion brochure:     http://hamawy.net/resume/job/www.pw.utc.com/products/pwr/assets/pwr_propulsion_product_brochure.pdf
 
-//  Aerojet Rocketdyne - RS-25 engine:              https://www.rocket.com/rs-25-engine
-//  REPORT OF THE SSME ASSESSMENT TEAM:             http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19930012456.pdf
-//  Norbert Brügge - RS-25 engine:                  http://www.b14643.de/Spacerockets/Specials/RS-25_SSME/index.htm
-//  SSME - The Relentless Pursuit of Improvement:   http://www.alternatewars.com/BBOW/Space_Engines/SSME_Pursuit_Improvement.pdf
+//  Aerojet Rocketdyne - RS-25 engine:                  https://www.rocket.com/rs-25-engine
+//  NTRS - REPORT OF THE SSME ASSESSMENT TEAM:          http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19930012456.pdf
+//  Norbert Brügge - RS-25 engine:                      http://www.b14643.de/Spacerockets/Specials/RS-25_SSME/index.htm
+//  SSME - The Relentless Pursuit of Improvement:       http://www.alternatewars.com/BBOW/Space_Engines/SSME_Pursuit_Improvement.pdf
 
-//  SLS Cryogenic Propulsion Stage:                 http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110015783.pdf
-//  Aerojet Rocketdyne - RL-10 engine:              https://www.rocket.com/rl10-engine
-//  Norbert Brügge - RL-10 engine family:           http://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
-//  Pratt & Whitney Rocketdyne - RL-10B-2 brochure: http://www.alternatewars.com/BBOW/Space_Engines/RL10B-2.pdf
-//  Pratt & Whitney Rocketdyne - RL-10 brochure:    http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4.pdf
-//  Pratt & Whitney Rocketdyne - RL-10A-4 brochure: http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4-1_-2.pdf
+//  NTRS - SLS Cryogenic Propulsion Stage:              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110015783.pdf
+//  Aerojet Rocketdyne - RL-10 engine:                  https://www.rocket.com/rl10-engine
+//  Norbert Brügge - RL-10 engine family:               http://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
+//  Pratt & Whitney Rocketdyne - RL-10B-2 brochure:     http://www.alternatewars.com/BBOW/Space_Engines/RL10B-2.pdf
+//  Pratt & Whitney Rocketdyne - RL-10 brochure:        http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4.pdf
+//  Pratt & Whitney Rocketdyne - RL-10A-4 brochure:     http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4-1_-2.pdf
 
-//  Avio Space - Ariane 5:                          http://www.avio.com/files/catalog/pdf/booster_per_il_lanciatore_ariane_5_23.pdf
-//  Ariane 5 User's Manual (July 2011):             http://www.arianespace.com/wp-content/uploads/2015/09/Ariane5_users_manual_Issue5_July2011.pdf
-//  Rocket and Space Technology - Ariane 5:         http://www.braeunig.us/space/specs/ariane.htm
-//  Ariane 5 - Space Launch Report:                 http://spacelaunchreport.com/ariane5.html
-//  ESA - EAP-241 boosters:                         http://www.esa.int/Our_Activities/Launchers/Launch_vehicles/Boosters_EAP
-//  Vulcain 2 brochure:                             http://www.space-propulsion.com/brochures/launcher-propulsion/Vulcain2.pdf
-//  Safran Snecma HM-7 engine brochure:             https://web.archive.org/web/20130714113757/http://www.snecma.com/IMG/files/fiche_hm7b_ang_2011_modulvoir_file_fr.pdf
+//  Avio Space - Ariane 5:                              http://www.avio.com/files/catalog/pdf/booster_per_il_lanciatore_ariane_5_23.pdf
+//  Arianespace - Ariane 5 User's Manual (July 2011):   http://www.arianespace.com/wp-content/uploads/2015/09/Ariane5_users_manual_Issue5_July2011.pdf
+//  Rocket and Space Technology - Ariane 5:             http://www.braeunig.us/space/specs/ariane.htm
+//  Ariane 5 - Space Launch Report:                     http://spacelaunchreport.com/ariane5.html
+//  ESA - EAP-241 boosters:                             http://www.esa.int/Our_Activities/Launchers/Launch_vehicles/Boosters_EAP
+//  Airbus Safran Launchers - Vulcain 2 brochure:       http://www.space-propulsion.com/brochures/launcher-propulsion/Vulcain2.pdf
+//  Safran Snecma -  HM-7 engine brochure:              https://web.archive.org/web/20130714113757/http://www.snecma.com/IMG/files/fiche_hm7b_ang_2011_modulvoir_file_fr.pdf
 
-//  Saturn V Flight Manual:                         http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
-//  F-1 engine fact sheet:                          http://history.msfc.nasa.gov/saturn_apollo/documents/F-1_Engine.pdf
-//  Bringing the Saturn F-1 Engine Back to Life:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140011656.pdf
-//  SLS Liquid Advanced Booster:                    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150021451.pdf
+//  NASA - Saturn V Flight Manual:                      http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
+//  NASA - F-1 engine fact sheet:                       http://history.msfc.nasa.gov/saturn_apollo/documents/F-1_Engine.pdf
+//  NTRS - Bringing the Saturn F-1 Engine Back to Life: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140011656.pdf
+//  NTRS - SLS Liquid Advanced Booster:                 http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150021451.pdf
 
-//  J-2 engine fact sheet:                          https://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf
-//  Advanced Transportation Systems Studies:        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19940016798.pdf
-//  US Spacecraft Reference Engines:                http://www.alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
-//  Aerojet Rocketdyne - J-2X engine:               http://rocket.com/j-2x-engine
-//  Astronautix - J-2X engine:                      http://www.astronautix.com/engines/j2x.htm
-//  The J-2X Engine: From Design to Hardware:       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100034922.pdf
+//  NASA - J-2 engine fact sheet:                       https://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf
+//  NTRS - Advanced Transportation Systems Studies:     http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19940016798.pdf
+//  Alternate Wars - US Spacecraft Reference Engines:   http://www.alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
+//  Aerojet Rocketdyne - J-2X engine:                   http://rocket.com/j-2x-engine
+//  Encyclopedia Astronautica - J-2X engine:            http://www.astronautix.com/engines/j2x.htm
+//  NTRS - The J-2X Engine: From Design to Hardware:    http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100034922.pdf
 
-//  Norbert Brügge - US Space Rocket Engines:       http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//  Norbert Brügge - Russian Rocket Engines:        http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
+//  Norbert Brügge - US Space Rocket Engines:           http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Norbert Brügge - Russian Rocket Engines:            http://www.b14643.de/Spacerockets/Diverse/Russian_Rocket_engines/engines.htm
 
 //  ==================================================
 //  AJ10-118 series engine.
@@ -76,8 +76,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
 
     %engineType = AJ10_Adv
     %engineTypeMult = 1
@@ -86,10 +86,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 42.7
         @maxThrust = 42.7
-        @heatProduction = 100
+        @heatProduction = 35
 
         @PROPELLANT[LiquidFuel]
         {
@@ -156,8 +155,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^=:$: eap
@@ -169,10 +168,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 6709
         @maxThrust = 6709
-        @heatProduction = 100
+        @heatProduction = 20
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -239,8 +237,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -252,9 +250,9 @@
     @MODULE[ModuleEngines*]
     {
         @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 643.83
-        @heatProduction = 100
+        @minThrust = 643
+        @maxThrust = 643
+        @heatProduction = 60
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -317,8 +315,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -329,10 +327,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 884.3
         @maxThrust = 884.3
-        @heatProduction = 100
+        @heatProduction = 46
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -343,7 +340,7 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 277.8
+            @key,0 = 0 278
             @key,1 = 1 251
         }
     }
@@ -413,8 +410,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -425,10 +422,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 874.52
-        @heatProduction = 100
+        @minThrust = 874.5
+        @maxThrust = 874.5
+        @heatProduction = 44
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -439,7 +435,7 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 279.8
+            @key,0 = 0 280
             @key,1 = 1 251
         }
     }
@@ -513,8 +509,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -525,9 +521,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0
+        @minThrust = 1248.9
         @maxThrust = 1248.9
-        @heatProduction = 100
+        @heatProduction = 46
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -538,7 +534,7 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 275.2
+            @key,0 = 0 275
             @key,1 = 1 245
         }
     }
@@ -592,8 +588,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -604,10 +600,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1688.4
         @maxThrust = 1688.4
-        @heatProduction = 100
+        @heatProduction = 49
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -660,8 +655,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -672,10 +667,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 16330
         @maxThrust = 16330
-        @heatProduction = 100
+        @heatProduction = 21
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -733,8 +727,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^=:$: castor orbital atk
@@ -746,10 +740,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 350.69
-        @heatProduction = 100
+        @minThrust = 350.7
+        @maxThrust = 350.7
+        @heatProduction = 38
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -809,8 +802,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -823,7 +816,7 @@
     {
         @minThrust = 0
         @maxThrust = 1957.2
-        @heatProduction = 100
+        @heatProduction = 55
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -874,8 +867,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -887,12 +880,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 7740.5
         @maxThrust = 7740.5
-        @heatProduction = 100
-        !engineAccelerationSpeed = NULL
-        !engineDecelerationSpeed = NULL
+        @heatProduction = 115
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -925,8 +917,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -938,12 +930,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 5513.8
         @maxThrust = 9189.6
-        @heatProduction = 100
-        !engineAccelerationSpeed = NULL
-        !engineDecelerationSpeed = NULL
+        @heatProduction = 142
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -980,8 +971,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -993,12 +984,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 6347
         @maxThrust = 8815
-        @heatProduction = 100
-        !engineAccelerationSpeed = NULL
-        !engineDecelerationSpeed = NULL
+        @heatProduction = 112
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1015,7 +1005,7 @@
         @atmosphereCurve
         {
             @key,0 = 0 299
-            @key,1 = 1 272.3
+            @key,1 = 1 272
         }
     }
 
@@ -1037,8 +1027,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 523.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1050,10 +1040,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 1020
         @maxThrust = 1020
-        @heatProduction = 100
+        @heatProduction = 123
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1115,8 +1104,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1128,10 +1117,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 64.8
         @maxThrust = 64.8
-        @heatProduction = 100
+        @heatProduction = 47
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1168,8 +1156,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1181,7 +1169,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 787.7
         @maxThrust = 1023.1
         @heatProduction = 100
@@ -1226,8 +1213,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1073.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1239,10 +1226,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1071.7
         @maxThrust = 1307
-        @heatProduction = 100
+        @heatProduction = 97
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1275,8 +1261,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1291,7 +1277,7 @@
         @name = ModuleEnginesRF
         @minThrust = 5.11
         @maxThrust = 5.11
-        @heatProduction = 100
+        @heatProduction = 20
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1355,8 +1341,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1370,10 +1356,10 @@
     {
         @name = ModuleEnginesRF
         @minThrust = 1951.4
-        @maxThrust = 4152
-        @heatProduction = 100
-        !engineAccelerationSpeed = NULL
-        !engineDecelerationSpeed = NULL
+        @maxThrust = 4152.0
+        @heatProduction = 105
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1417,8 +1403,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1430,10 +1416,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 99.1
         @maxThrust = 99.1
-        @heatProduction = 100
+        @heatProduction = 110
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1493,8 +1478,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1516,10 +1501,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 110.1
         @maxThrust = 110.1
-        @heatProduction = 100
+        @heatProduction = 76
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1587,8 +1571,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1603,7 +1587,7 @@
         @name = ModuleEnginesRF
         @minThrust = 1400.7
         @maxThrust = 2278.8
-        @heatProduction = 100
+        @heatProduction = 120
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1647,8 +1631,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
 
     %engineType = H1
     %engineTypeMult = 1
@@ -1657,10 +1641,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1023
         @maxThrust = 1023
-        @heatProduction = 100
+        @heatProduction = 120
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1718,8 +1701,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    &skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    &skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1731,12 +1714,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 1958
         @maxThrust = 3560
-        @heatProduction = 100
-        !engineAccelerationSpeed = NULL
-        !engineDecelerationSpeed = NULL
+        @heatProduction = 90
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1783,17 +1765,12 @@
     @node_stack_top = 0.0, 19.42, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -19.04, 0.0, 0.0, -1.0, 0.0, 3
 
-    @category = Engine
-    @title = STS RSRM
-    @manufacturer = Thiokol
-    @description = This is the Space Shuttle's Four-Segment SRB. These Solid Rocket Boosters provided most of the lift-off thrust to get the Space Shuttle moving. Mostly recoverable and refurbished for future flights. A similar SRB would have been used in the DIRECT Jupiter program, if it had ever come to fruition.
-
     @mass = 65.77
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1804,10 +1781,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 14234.3
         @maxThrust = 14234.3
-        @heatProduction = 100
+        @heatProduction = 23
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -1860,8 +1836,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1873,10 +1849,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 804.5
         @maxThrust = 804.5
-        @heatProduction = 100
+        @heatProduction = 108
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1911,16 +1886,12 @@
 {
     %RSSROConfig = True
 
-    @title = Vulcain Series
-    @manufacturer = Snecma S.A.
-    @description = Hydrolox gas generator booster engine. Used in the first stage of the Ariane 5 launch vehicle.
-
     @mass = 1.8
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1932,12 +1903,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1359
         @maxThrust = 1359
-        @heatProduction = 100
-        !engineAccelerationSpeed = NULL
-        !engineDecelerationSpeed = NULL
+        @heatProduction = 133
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -1986,10 +1956,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 67
         @maxThrust = 67
-        @heatProduction = 100
+        @heatProduction = 57
 
         @PROPELLANT[LiquidFuel]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -80,9 +80,6 @@
     %skinMaxTemp = 673.15
 
     %engineType = AJ10_Adv
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -146,11 +143,6 @@
 {
     %RSSROConfig = True
 
-    @category = Engine
-    @title = P241A EAP
-    @manufacturer = Avio/Regulus/SABCA
-    @description = A steel casing solid rocket motor used in pairs by the Ariane 5 launch vehicle for the initial phases of the flight.
-
     @mass = 35.9
     @crashTolerance = 10
     @breakingForce = 250
@@ -162,9 +154,6 @@
     @tags ^=:$: eap
 
     %engineType = EAP-241
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -215,6 +204,19 @@
 }
 
 //  ==================================================
+//  P241A EAP (Étages d’Accélération à Poudre)
+
+//  Part configuration.
+//  ==================================================
+
+@PART[RSBengineArianeVSRB]:AFTER[RealismOverhaulEngines]
+{
+    @title = P241A EAP
+    @manufacturer = Avio/Regulus/SABCA
+    @description = A steel casing solid rocket motor used in pairs by the Ariane 5 launch vehicle for the initial phases of the flight.
+}
+
+//  ==================================================
 //  GEM-40 series solid rocket motor.
 
 //  Dimensions: 1.01 m x 11.05 m
@@ -228,11 +230,6 @@
 {
     %RSSROConfig = True
 
-    @category = Engine
-    @title = GEM-40 Series
-    @manufacturer = Orbital ATK
-    @description = The GEM-40 is a graphite composite epoxy solid rocket motor used by the Delta II for thrust augmentation. There are two versions of the motor, the ground ignited with a standard nozzle exit cone and the air-lit with an extended nozzle exit cone.
-
     @mass = 1.2
     @crashTolerance = 10
     @breakingForce = 250
@@ -243,13 +240,9 @@
     %childStageOffset = 1
 
     %engineType = GEM-40
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 643
         @maxThrust = 643
         @heatProduction = 60
@@ -293,6 +286,19 @@
 }
 
 //  ==================================================
+//  GEM-40 series solid rocket motor.
+
+//  Part configuration.
+//  ==================================================
+
+@PART[RSBdelta2srm]:AFTER[RealismOverhaulEngines]
+{
+    @title = GEM-40 Series
+    @manufacturer = Orbital ATK
+    @description = The GEM-40 is a graphite composite epoxy solid rocket motor used by the Delta II for thrust augmentation. There are two versions of the motor, the ground ignited with a standard nozzle exit cone and the air-lit with an extended nozzle exit cone.
+}
+
+//  ==================================================
 //  GEM-46 series solid rocket motor (non vectoring version).
 
 //  Dimensions: 1.15 m x 14.7 m
@@ -306,11 +312,6 @@
 {
     %RSSROConfig = True
 
-    @category = Engine
-    @title = GEM-46 LDXL
-    @manufacturer = Orbital ATK
-    @description = The GEM-46 is a graphite composite epoxy solid rocket motor used by the Delta III for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC). This is the non-vectoring version.
-
     @mass = 2.2
     @crashTolerance = 10
     @breakingForce = 250
@@ -321,9 +322,6 @@
     %childStageOffset = 1
 
     %engineType = GEM-46
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -377,6 +375,10 @@
 
 @PART[RSBdelta3srm]:AFTER[RealismOverhaulEngines]
 {
+    @title = GEM-46 LDXL
+    @manufacturer = Orbital ATK
+    @description = The GEM-46 is a graphite composite epoxy solid rocket motor used by the Delta III for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC). This is the non-vectoring version.
+
     @MODULE[ModuleEngineConfigs]
     {
         @configuration = GEM-46/Fixed-Ground
@@ -401,11 +403,6 @@
 
     @node_attach = 0.575, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 
-    @category = Engine
-    @title = GEM-46 LDXL-TVC
-    @manufacturer = Orbital ATK
-    @description = The GEM-46 is a graphite composite epoxy solid rocket motor used by the Delta III for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC). This is the vectoring version.
-
     @mass = 2.28
     @crashTolerance = 10
     @breakingForce = 250
@@ -416,9 +413,6 @@
     %childStageOffset = 1
 
     %engineType = GEM-46
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -481,6 +475,10 @@
 
 @PART[RSBdelta3srmG]:AFTER[RealismOverhaulEngines]
 {
+    @title = GEM-46 LDXL-TVC
+    @manufacturer = Orbital ATK
+    @description = The GEM-46 is a graphite composite epoxy solid rocket motor used by the Delta III for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC). This is the vectoring version.
+
     @MODULE[ModuleEngineConfigs]
     {
         @configuration = GEM-46/TVC-Ground
@@ -500,11 +498,6 @@
 {
     %RSSROConfig = True
 
-    @category = Engine
-    @title = GEM-60 Series
-    @manufacturer = Orbital ATK
-    @description = The GEM-60 is a graphite composite epoxy solid rocket motor used by the Delta IV for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC).
-
     @mass = 3.08
     @crashTolerance = 10
     @breakingForce = 250
@@ -515,9 +508,6 @@
     %childStageOffset = 1
 
     %engineType = GEM-60
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -569,6 +559,19 @@
 }
 
 //  ==================================================
+//  GEM-60 series solid rocket motor.
+
+//  Part configuration.
+//  ==================================================
+
+@PART[RSBdeltaIVsrm]:AFTER[RealismOverhaulEngines]
+{
+    @title = GEM-60 Series
+    @manufacturer = Orbital ATK
+    @description = The GEM-60 is a graphite composite epoxy solid rocket motor used by the Delta IV for thrust augmentation. There are two versions of the motor, one with fixed nozzle and one with thrust vectoring control (TVC).
+}
+
+//  ==================================================
 //  AJ-60A solid rocket motor.
 
 //  Dimensions: 1.58 m x 20 m
@@ -578,11 +581,6 @@
 @PART[RSBengineAtlasSRB]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
-    @category = Engine
-    @title = AJ-60A
-    @manufacturer = Aerojet Rocketdyne
-    @description = A graphite epoxy composite solid rocket motor used by the Atlas V 400 and 500 series for thrust augmentation.
 
     @mass = 3.95
     @crashTolerance = 10
@@ -594,9 +592,6 @@
     %childStageOffset = 1
 
     %engineType = AJ60A
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -647,10 +642,6 @@
 {
     %RSSROConfig = True
 
-    @title = 5 Segment RSRM
-    @manufacturer = Orbital ATK
-    @description = A 5 segment Reusable Solid Rocket Motor. It was designed originally for the Space Shuttle and later adapted for the Ares I and Ares V launch vehicles before cancellation. It is used now by the Space Launch System Block I and IB.
-
     @mass = 85.5
     @crashTolerance = 10
     @breakingForce = 250
@@ -661,9 +652,6 @@
     %childStageOffset = 1
 
     %engineType = RSRMV
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -718,11 +706,6 @@
 {
     %RSSROConfig = True
 
-    @category = Engine
-    @title = Castor 30
-    @manufacturer = Orbital ATK
-    @description = The Castor 30 is a fairly wide-purpose solid rocket motor, functioning as an upper stage for a variety of launch vehicles or as a strap-on booster.
-
     @mass = 1.115
     @crashTolerance = 10
     @breakingForce = 250
@@ -734,9 +717,6 @@
     @tags ^=:$: castor orbital atk
 
     %engineType = Castor-30A
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -793,11 +773,6 @@
 {
     %RSSROConfig = True
 
-    @category = Engine
-    @title = Castor 120
-    @manufacturer = Orbital ATK
-    @description = The Castor 120 is a fairly wide-purpose solid rocket motor, functioning as first and upper stages for a variety of launch vehicles, or as strap-ons.
-
     @mass = 4.12
     @crashTolerance = 10
     @breakingForce = 250
@@ -808,13 +783,10 @@
     %childStageOffset = 1
 
     %engineType = Castor-120
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0
+        @minThrust = 1957.2
         @maxThrust = 1957.2
         @heatProduction = 55
         @useEngineResponseTime = False
@@ -859,10 +831,6 @@
 {
     %RSSROConfig = True
 
-    @title = F-1/A Series
-    @manufacturer = Rocketdyne
-    @description = The massive Rocketdyne F-1 engine used on the first stage of the Saturn V. One of the largest, most powerful rocket engines ever built.
-
     @mass = 8.39
     @crashTolerance = 10
     @breakingForce = 250
@@ -874,9 +842,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = F1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -924,9 +889,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = F-1A_ETS
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -963,10 +925,6 @@
 {
     %RSSROConfig = True
 
-    @title = F-1B
-    @manufacturer = Aerojet Rocketdyne
-    @description = High thrust gas generator engine. Derivative of the Saturn V F-1 engine with a simplified design and smaller size but with improved thrust and specific impulse. Designed for use by the Space Launch System Block II as a drop-in replacement for the 5 segment RSRMs.
-
     @mass = 9.66
     @crashTolerance = 10
     @breakingForce = 250
@@ -978,9 +936,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = F1B
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1034,9 +989,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = H1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1097,10 +1049,6 @@
 
     @node_stack_top = 0.0, 0.235, 0.0, 0.0, 1.0, 0.0, 2
 
-    @title = HM-7 Series
-    @manufacturer = Snecma S.A.
-    @description = Hydrolox gas generator upper stage engine. Direct descendant of the HM4 engine, the first non-American cryogenic engine. Used on the Ariane 4 H10 and the Ariane 5 ESC-A upper stages.
-
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -1111,9 +1059,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = HM7
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1138,6 +1083,19 @@
 }
 
 //  ==================================================
+//  HM-7 series engine.
+
+//  Part configuration.
+//  ==================================================
+
+@PART[RSBengineHM7B]:AFTER[RealismOverhaulEngines]
+{
+    @title = HM-7 Series
+    @manufacturer = Snecma S.A.
+    @description = Hydrolox gas generator upper stage engine. Direct descendant of the HM4 engine, the first non-American cryogenic engine. Used on the Ariane 4 H10 and the Ariane 5 ESC-A upper stages.
+}
+
+//  ==================================================
 //  J-2 series engine.
 
 //  Dimensions: 2.1 m x 3.5 m
@@ -1147,10 +1105,6 @@
 @PART[RSBengineJ2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
-    @title = J-2 Series
-    @manufacturer = Rocketdyne
-    @description = The Rocketdyne J-2 rocket engine found on the Saturn S-IVB and S-II stages.
 
     @mass = 1.78
     @crashTolerance = 10
@@ -1163,9 +1117,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = J2
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1206,10 +1157,6 @@
 {
     %RSSROConfig = True
 
-    @title = J-2X
-    @manufacturer = Aerojet Rocketdyne
-    @description = The J-2X engine begun as an update to the J2-S engine, which itself was a simplified J-2 engine. It was planned to have two variants, the J-2X with 1220 kN of thrust (for the Ares I launch vehicle) and the J-2XD with 1307 kN of thrust (for the Ares V Earth Departure Stage). Both designs were dropped in favor of the RL-10 engine (C2 variant) for the upper stage of the SLS.
-
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -1220,9 +1167,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = J2X
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1268,13 +1212,9 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = LR101
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 5.11
         @maxThrust = 5.11
         @heatProduction = 20
@@ -1333,10 +1273,6 @@
 {
     %RSSROConfig = True
 
-    @title = RD-180
-    @manufacturer = NPO Energomash
-    @description = Kerolox staged combustion booster engine, a smaller version of the RD-170 with two combustion chambers. Main engine of the Atlas V launch vehicle.
-
     @mass = 5.48
     @crashTolerance = 10
     @breakingForce = 250
@@ -1354,7 +1290,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1951.4
         @maxThrust = 4152.0
         @heatProduction = 105
@@ -1396,10 +1331,6 @@
 {
     %RSSROConfig = True
 
-    @title = RL10-A/C Series
-    @manufacturer = Aerojet Rocketdyne
-    @description = Hydrolox restartable expander-cycle vacuum engine. Initially developed by Pratt & Whitney designated as XLR115 and with a vacuum specific impulse of 422 seconds and rated thrust of only 66 kN. Later, the management transferred to the Marshall Space Flight Center and the engine was renamed into RL10. Since then, it has been upgraded many times, now achieving a specific impulse of up to 465 seconds and over 100 kN of thrust. Used by the workhorse Atlas Centaur high energy upper stage, the Saturn I upper stage and the Delta IV Cryogenic Second Stage (DCSS). Includes the A and C variants.
-
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -1410,9 +1341,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = RL10
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1451,6 +1379,8 @@
 @PART[RSBengineRL10A3|RSBengineRL10A42]:AFTER[RealismOverhaulEngines]
 {
     @title = RL10-A/C Series
+    @manufacturer = Aerojet Rocketdyne
+    @description = Hydrolox restartable expander-cycle vacuum engine. Initially developed by Pratt & Whitney designated as XLR115 and with a vacuum specific impulse of 422 seconds and rated thrust of only 66 kN. Later, the management transferred to the Marshall Space Flight Center and the engine was renamed into RL10. Since then, it has been upgraded many times, now achieving a specific impulse of up to 465 seconds and over 100 kN of thrust. Used by the workhorse Atlas Centaur high energy upper stage, the Saturn I upper stage and the Delta IV Cryogenic Second Stage (DCSS). Includes the A and C variants.
 
     @MODULE[ModuleEngineConfigs]
     {
@@ -1471,10 +1401,6 @@
 {
     %RSSROConfig = True
 
-    @title = RL10-B/CECE Series
-    @manufacturer = Aerojet Rocketdyne
-    @description = Hydrolox restartable expander-cycle vacuum engine. Initially developed by Pratt & Whitney designated as XLR115 and with a vacuum specific impulse of 422 seconds and rated thrust of only 66 kN. Later, the management transferred to the Marshall Space Flight Center and the engine was renamed into RL10. Since then, it has been upgraded many times, now achieving a specific impulse of up to 465 seconds and over 100 kN of thrust. Used by the workhorse Atlas Centaur high energy upper stage, the Saturn I upper stage and the Delta IV Cryogenic Second Stage (DCSS). Includes the B and CECE variants.
-
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
@@ -1485,9 +1411,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = RL10
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleAnimateGeneric]
     {
@@ -1530,6 +1453,8 @@
 @PART[RSBengineRL10B2]:AFTER[RealismOverhaulEngines]
 {
     @title = RL10-B/CECE Series
+    @manufacturer = Aerojet Rocketdyne
+    @description = Hydrolox restartable expander-cycle vacuum engine. Initially developed by Pratt & Whitney designated as XLR115 and with a vacuum specific impulse of 422 seconds and rated thrust of only 66 kN. Later, the management transferred to the Marshall Space Flight Center and the engine was renamed into RL10. Since then, it has been upgraded many times, now achieving a specific impulse of up to 465 seconds and over 100 kN of thrust. Used by the workhorse Atlas Centaur high energy upper stage, the Saturn I upper stage and the Delta IV Cryogenic Second Stage (DCSS). Includes the B and CECE variants.
 
     @MODULE[ModuleEngineConfigs]
     {
@@ -1562,11 +1487,6 @@
     @node_stack_bottom = 0.0, -1.6, 0.0, 0.0, -1.0, 0.0, 2
     @node_stack_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 
-    @category = Engine
-    @title = RS-25 Series
-    @manufacturer = Aerojet Rocketdyne
-    @description = Hydrolox high thrust reusable engine. Used on the Space Shuttle and the Space Launch System.
-
     @mass = 3.53
     @crashTolerance = 10
     @breakingForce = 250
@@ -1578,13 +1498,9 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = SSME
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1400.7
         @maxThrust = 2278.8
         @heatProduction = 120
@@ -1635,9 +1551,6 @@
     %skinMaxTemp = 673.15
 
     %engineType = H1
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1708,9 +1621,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = RS68
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1775,9 +1685,6 @@
     %childStageOffset = 1
 
     %engineType = RSRM
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1843,9 +1750,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = Vikas
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1897,9 +1801,6 @@
     %stagingIcon = LIQUID_ENGINE
 
     %engineType = Vulcain
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
@@ -1946,13 +1847,10 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 523.15
+    %skinMaxTemp = 673.15
 
     %engineType = Agena
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_PSLV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_PSLV.cfg
@@ -2,8 +2,8 @@
 //  Sources:
 
 //  Indian Space Research Organization - PLSV: http://www.isro.gov.in/launchers/pslv
-//  Spaceflight101 - PSLV:                     http://spaceflight101.com/spacerockets/pslv/
-//  Space Launch Report - PSLV:                http://spacelaunchreport.com/pslv.html
+//  Spaceflight101 - PSLV launch vehicle:      http://spaceflight101.com/spacerockets/pslv/
+//  Space Launch Report - PSLV launch vehicle: http://spacelaunchreport.com/pslv.html
 
 //  ==================================================
 //  PSLV payload fairing.
@@ -24,8 +24,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -57,8 +57,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -80,8 +80,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -103,8 +103,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -126,8 +126,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -155,18 +155,17 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @stagingIcon = LIQUID_ENGINE
 
     !MODULE[ModuleDecouple],*{}
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 14.8
         @maxThrust = 14.8
-        @heatProduction = 100
+        @heatProduction = 0
 
         @PROPELLANT[LiquidFuel]
         {
@@ -244,12 +243,16 @@
 
     !MODULE[ModuleEngineConfigs],*{}
 
+    //  Ignition count just enough for a trans-Martian multi-perigee injection burn.
+    //  Using an O/F ratio of 2.16 (ideal MMH/NTO burn ratio).
+    //  The engine inert mass is completely hypothetical.
+
     MODULE
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = L-2-5
-        modded = False
+        origMass = 0.12
 
         CONFIG
         {
@@ -257,10 +260,7 @@
             minThrust = 14.8
             maxThrust = 14.8
             heatProduction = 100
-
-            //  Ignition count just enough for a trans-Martian multi-perigee injection burn.
-            //  Using an O/F ratio of 2.16 (ideal MMH/NTO burn ratio).
-
+            massMult = 1.0
             ullage = True
             pressureFed = True
             ignitions = 7
@@ -308,6 +308,8 @@
 
 @PART[RSBtankPSLVps4]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTransmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -378,8 +380,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -405,8 +407,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleRCS]
     {
@@ -453,17 +455,16 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 244
         @maxThrust = 244
-        @heatProduction = 100
+        @heatProduction = 25
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -505,17 +506,17 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = PS3-S7
-        modded = False
+        origMass = 1.15
 
         CONFIG
         {
             name = PS3-S7
             minThrust = 244
             maxThrust = 244
-            heatProduction = 100
+            heatProduction = 25
+            massMult = 1.0
             gimbalRange = 2.0
             curveResource = HTPB
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -557,8 +558,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -668,17 +669,16 @@
 
     @mass = 0.015
     @crashTolerance = 10
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 18
-        @heatProduction = 100
+        @heatProduction = 128
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -736,17 +736,16 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 0
         @maxThrust = 30
-        @heatProduction = 100
+        @heatProduction = 77
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -804,8 +803,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -833,17 +832,16 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 502.6
-        @heatProduction = 100
+        @minThrust = 662
+        @maxThrust = 662
+        @heatProduction = 28
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -892,14 +890,14 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = PSOM-S9/Ground
-        modded = False
+        origMass = 2.0
 
         CONFIG
         {
             name = PSOM-S9/Ground
             minThrust = 662
             maxThrust = 662
-            heatProduction = 100
+            heatProduction = 35
             massMult = 1.0
             gimbalRange = 0
             curveResource = HTPB
@@ -927,7 +925,7 @@
             name = PSOM-S9/Ground-TVC
             minThrust = 662
             maxThrust = 662
-            heatProduction = 100
+            heatProduction = 35
             massMult = 1.0
             gimbalRange = 2.0
             curveResource = HTPB
@@ -955,7 +953,7 @@
             name = PSOM-S9/Air
             minThrust = 716
             maxThrust = 716
-            heatProduction = 100
+            heatProduction = 41
             massMult = 1.0
             gimbalRange = 0
             curveResource = HTPB
@@ -973,7 +971,7 @@
 
             atmosphereCurve
             {
-                key = 0 281.6
+                key = 0 282
                 key = 1 262
             }
         }
@@ -1000,21 +998,20 @@
     @manufacturer = ISRO
     @description = Used in the PSLV rockets, these boosters are typically used such that two or four are lit at lift-off, with the remainder being air-lit during ascent. There are two versions, one with fixed nozzle and one with thrust vectoring control (TVC).
 
-    @mass = 2
+    @mass = 2.0
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 864
-        @heatProduction = 100
+        @minThrust = 662
+        @maxThrust = 662
+        @heatProduction = 35
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -1063,18 +1060,17 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = PSOM-S12/Ground
-        modded = False
+        origMass = 2.0
 
         CONFIG
         {
             name = PSOM-S12/Ground
             minThrust = 662
             maxThrust = 662
-            heatProduction = 100
+            heatProduction = 35
             massMult = 1.0
             gimbalRange = 0
             curveResource = HTPB
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -1098,11 +1094,10 @@
             name = PSOM-S12/Ground-TVC
             minThrust = 662
             maxThrust = 662
-            heatProduction = 100
+            heatProduction = 35
             massMult = 1.0
             gimbalRange = 2.0
             curveResource = HTPB
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -1126,11 +1121,10 @@
             name = PSOM-S12/Air
             minThrust = 716
             maxThrust = 716
-            heatProduction = 100
+            heatProduction = 41
             massMult = 1.0
             gimbalRange = 0
             curveResource = HTPB
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -1144,7 +1138,7 @@
 
             atmosphereCurve
             {
-                key = 0 281.6
+                key = 0 282
                 key = 1 262
             }
         }
@@ -1173,17 +1167,16 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
-        @maxThrust = 4707
-        @heatProduction = 100
+        @minThrust = 4860
+        @maxThrust = 4860
+        @heatProduction = 18
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
 
@@ -1257,18 +1250,17 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = PS1-D
-        modded = False
+        origMass = 29.78
 
         CONFIG
         {
             name = PS1-D
-            minThrust = 4800
-            maxThrust = 4800
-            heatProduction = 100
+            minThrust = 4860
+            maxThrust = 4860
+            heatProduction = 18
             massMult = 1.0
             gimbalRange = 5.0
             curveResource = HTPB
-
             ullage = False
             pressureFed = False
             ignitions = 1
@@ -1337,8 +1329,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_STS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_STS.cfg
@@ -1,11 +1,11 @@
 //  ==================================================
 //  Sources:
 
-//  Direct Launcher official web page:              http://www.directlauncher.org/
-//  NASA Experience with the STS External Tank:     http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19990047392.pdf
-//  NASA Human Spaceflight - External Tank:         http://spaceflight.nasa.gov/shuttle/reference/shutref/et/
-//  Space Shuttle Propulsion Systems:               http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19910018886.pdf
-//  Shuttle Booster Separation Motor Qualification: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950018020.pdf
+//  Direct Launcher - Official web page:                   http://www.directlauncher.org/
+//  NTRS - NASA Experience with the STS External Tank:     http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19990047392.pdf
+//  NASA - Human Spaceflight - External Tank:              http://spaceflight.nasa.gov/shuttle/reference/shutref/et/
+//  NTRS - Space Shuttle Propulsion Systems:               http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19910018886.pdf
+//  NTRS - Shuttle Booster Separation Motor Qualification: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950018020.pdf
 
 //  ==================================================
 //  Jupiter procedural fairing base.
@@ -26,8 +26,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -48,8 +48,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @bulkheadProfiles = size2, size5
     %noFuelCrossFeedNode = bottom
 }
@@ -75,8 +75,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -128,8 +128,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @bulkheadProfiles = size1, size5
 
     @MODULE[ModuleDecouple]
@@ -157,8 +157,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @bulkheadProfiles = size1, size5
 
     @MODULE[ModuleDecouple]
@@ -184,18 +184,17 @@
 
     @mass = 1.86
     @crashTolerance = 12
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     @fuelCrossFeed = False
 
     //  Each nose cone contains four separation motors with each motor rated for 89.2 kN of vacuum thrust.
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 356.8
         @maxThrust = 356.8
-        @heatProduction = 100
+        @heatProduction = 20
 
         @PROPELLANT[SolidFuel]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -1,20 +1,20 @@
 //  ==================================================
 //  Sources:
 
-//  Apollo by the Numbers (Key Facts):                              http://history.nasa.gov/SP-4029/Apollo_18-12_Launch_Vehicle-Spacecraft_Key_Facts.htm
-//  Apollo by the Numbers (Ground Ignition Weights):                http://history.nasa.gov/SP-4029/Apollo_18-19_Ground_Ignition_Weights.htm
-//  Saturn V Flight Manual:                                         http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
-//  Saturn IB Flight Manual:                                        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740021163.pdf
-//  SE 7-1 engine:                                                  http://www.spaceaholic.com/index.php/Detail/Object/Show/object_id/21
-//  Remembering the Giants - Apollo Rocket Propulsion Development:  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027314.pdf
-//  Spacecraft Reference Engines:                                   http://alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
-//  Saturn V Instrument Unit:                                       http://history.msfc.nasa.gov/saturn_apollo/documents/Instrument_Unit.pdf
-//  Saturn I Summary:                                               http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660014308.pdf
-//  Saturn I Pegasus Satellite:                                     http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650007038.pdf
-//  Saturn I Flight Test Evaluation:                                http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19640013313.pdf
-//  Saturn I Electrical Power and Systems Integration:              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650012954.pdf
-//  ETS Saturn IC & Multibody:                                      http://wiki.alternatehistory.com/doku.php/timelines/eyes_turned_skyward_spacecraft_and_launch_vehicle_technical_data
-//  LARGE LAUNCH VEHICLE SYSTEM FOR A MANNED LUNAR LANDING PROGRAM: http://www.pdf-archive.com/2013/04/27/ae61-0967-saturn-c-3-c-4-nova/ae61-0967-saturn-c-3-c-4-nova.pdf
+//  NASA - Apollo by the Numbers (Key Facts):                              http://history.nasa.gov/SP-4029/Apollo_18-12_Launch_Vehicle-Spacecraft_Key_Facts.htm
+//  NASA - Apollo by the Numbers (Ground Ignition Weights):                http://history.nasa.gov/SP-4029/Apollo_18-19_Ground_Ignition_Weights.htm
+//  NASA - Saturn V Flight Manual:                                         http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
+//  NTRS - Saturn IB Flight Manual:                                        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740021163.pdf
+//  SpaceAHolic - SE 7-1 engine:                                           http://www.spaceaholic.com/index.php/Detail/Object/Show/object_id/21
+//  NASA - Remembering the Giants - Apollo Rocket Propulsion Development:  http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027314.pdf
+//  Alternate Wars - Spacecraft Reference Engines:                         http://alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
+//  NTRS - Saturn V Instrument Unit:                                       http://history.msfc.nasa.gov/saturn_apollo/documents/Instrument_Unit.pdf
+//  NTRS - Saturn I Summary:                                               http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660014308.pdf
+//  NTRS - Saturn I Pegasus Satellite:                                     http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650007038.pdf
+//  NTRS - Saturn I Flight Test Evaluation:                                http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19640013313.pdf
+//  NTRS - Saturn I Electrical Power and Systems Integration:              http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650012954.pdf
+//  Eyes Turned Skywards - ETS Saturn IC & Multibody:                      http://wiki.alternatehistory.com/doku.php/timelines/eyes_turned_skyward_spacecraft_and_launch_vehicle_technical_data
+//  NASA - LARGE LAUNCH VEHICLE SYSTEM FOR A MANNED LUNAR LANDING PROGRAM: http://www.pdf-archive.com/2013/04/27/ae61-0967-saturn-c-3-c-4-nova/ae61-0967-saturn-c-3-c-4-nova.pdf
 
 //  ==================================================
 //  Saturn Multibody nose cone.
@@ -35,8 +35,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -58,8 +58,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -81,8 +81,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -104,8 +104,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -127,8 +127,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -150,8 +150,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
 }
 
 //  ==================================================
@@ -181,8 +181,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 
     @MODULE[ModuleCommand]
@@ -225,8 +225,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 
     @MODULE[ModuleCommand]
@@ -258,6 +258,8 @@
 
 @PART[RSBprobeSaturn2|RSBprobeSaturn]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
+    !MODULE[ModuleDataTransmitter],*{}
+
     !MODULE[ModuleSPU*],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -318,8 +320,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -377,8 +379,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -442,24 +444,24 @@
 
     @mass = 0.075
     @crashTolerance = 12
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     //  One SE 7-1 (320 N) thruster for ullage and three TR-204 (667 N) thrusters for attitude control.
 
     @MODULE[ModuleRCS*]
     {
-        @thrusterPower = 0.667
+        @thrusterPower = 2.321
         !resourceName = NULL
 
         !transformMultipliers,*{}
 
         transformMultipliers
         {
-            trf0 = 1.0
-            trf1 = 1.0
-            trf2 = 1.0
-            trf3 = 0.47976
+            trf0 = 0.2874
+            trf1 = 0.2874
+            trf2 = 0.2874
+            trf3 = 0.1379
         }
 
         PROPELLANT
@@ -544,17 +546,16 @@
     @manufacturer = Thiokol
 
     @crashTolerance = 12
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 15
         @maxThrust = 15
-        @heatProduction = 100
+        @heatProduction = 41
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -612,17 +613,16 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    @skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    @skinMaxTemp = 673.15
 
     //  Four 155 kN retro motors (inert 104 Kg - gross 226 Kg).
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 620
         @maxThrust = 620
-        @heatProduction = 100
+        @heatProduction = 116
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -685,17 +685,16 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
 
     //  Four 163 kN retro motors (inert 50 Kg - gross 170 Kg).
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 652
         @maxThrust = 652
-        @heatProduction = 100
+        @heatProduction = 120
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -759,8 +758,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -822,8 +821,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -883,17 +882,16 @@
 
     @mass = 0.104
     @crashTolerance = 12
-    @maxTemp = 1023.15
-    %skinMaxTemp = 1773.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
-        @minThrust = 0
+        @minThrust = 102
         @maxThrust = 102
-        @heatProduction = 100
+        @heatProduction = 104
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -958,8 +956,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleDecouple]
     {
@@ -986,17 +984,16 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
 
     //  Eight 155 kN retro motors (inert 104 Kg - gross 226 Kg).
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 1240
         @maxThrust = 1240
-        @heatProduction = 100
+        @heatProduction = 120
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -1059,8 +1056,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1068,10 +1065,9 @@
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 2697.6
         @maxThrust = 2697.6
-        @heatProduction = 100
+        @heatProduction = 120
         %ullage = False
         %pressureFed = False
         %ignitions = 1
@@ -1161,8 +1157,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1222,8 +1218,8 @@
 
     @mass = 0.85
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1244,8 +1240,8 @@
 
     @mass = 0.6
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1266,8 +1262,8 @@
 
     @mass = 0.85
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1288,8 +1284,8 @@
 
     @mass = 0.6
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1309,8 +1305,8 @@
 
     @mass = 0.35
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1331,8 +1327,8 @@
 
     @mass = 2.4
     @crashTolerance = 14
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @breakingForce = 250
     @breakingTorque = 250
 
@@ -1361,8 +1357,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1421,8 +1417,8 @@
 
     @mass = 0.2
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1442,8 +1438,8 @@
 
     @mass = 0.2
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     !explosionPotential = NULL
 }
 
@@ -1466,8 +1462,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1529,8 +1525,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1592,8 +1588,8 @@
     @crashTolerance = 6
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 2100
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1654,8 +1650,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @bulkheadProfiles = size5, size6
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1689,8 +1685,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @bulkheadProfiles = size6, size10
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1724,8 +1720,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
     @bulkheadProfiles = size7, size10
 
     !MODULE[ModuleFuelTanks],*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Structural.cfg
@@ -17,8 +17,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 473.15
+    %skinMaxTemp = 573.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -45,7 +45,7 @@
 
     @mass = 0.075
     @crashTolerance = 16
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 573.15
     @maxLength = 25
 }


### PR DESCRIPTION
**Change log:**

**General:**

* Lower all max and skin temps to normal (saner) values.
* Make sure than no part that supports RT will ever have a stock antenna module (still need to add CommNet support since the base package does not provide it yet).
* Tweak the heat production values of all engine modules.
* Remove any ModuleEnginesRF fields (now patched by the RO global configs).
* Remove any redundant global engine config parameters (https://github.com/KSP-RO/RealismOverhaul/issues/1669).
* Update some broken web links.

**Atlas:**

* Fix the RCS thrust modifiers of the Centaur V upper stage.
* Add a missing Isp curve to the Atlas V CCB separation motors.

**Delta:**

* Fix the naming of the Delta III and Delta IV upper stages.

**Engines:**

* Add bottom attachment nodes to all liquid-fueled engines.
* Remove some part manufacturer & description fields (not needed).
* Update some specific engines to use custom manufacturer & description fields.
* Fix the scale of the RS-25 engine.

**PSLV:**

* Fix the rated VAC thrust of the PS-1 solid rocket motor.
* Add some missing original mass and mass multiplier fields to the PSOM solid rocket motors series.

**Saturn:**

* Fix the RCS thrust modifiers of the APS.