### PR TITLE
[Bug Fix] RO Aerobee engine plume

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROAerobeeSustainer.cfg
@@ -9,8 +9,11 @@
         name = Hypergolic-Lower
         transformName = thrustTransform
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.1
-        fixedScale = 0.18
+        flarePosition = 0.0, 0.0, 0.85
+        flareScale = 0.125
+        plumePosition = 0.0, 0.0, 0.1
+        plumeScale = 0.18
+        fixedScale = 1.0
         energy = 0.35
         speed = 1.0
         emissionMult = 0.75
@@ -19,7 +22,6 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Lower
-        !fxOffset = NULL
     }
 
 	@MODULE[ModuleEngineConfigs]
@@ -29,23 +31,4 @@
 			%powerEffectName = Hypergolic-Lower
 		}
 	}
-}
-
-//  ==================================================
-//  Aerobee / WAC Corporal flare configuration.
-//  ==================================================
-
-@PART[ROAerobeeSustainer]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
-{
-    @EFFECTS
-    {
-        @Hypergolic-Lower
-        {
-            @MODEL_MULTI_SHURIKEN_PERSIST[flare]
-            {
-                @localPosition = 0.0, 0.0, 0.85
-                @fixedScale = 0.125
-            }
-        }
-    }
 }


### PR DESCRIPTION
**Change log:**

* Fix the flare position.
* Remove the fxOffset parameter (now patched via the global RealPlume engine patcher).

**Notes:**

* Same issue as with the 1 kN thruster. Any parts that define AFTER RealPlume passes might also be broken.