### PR TITLE
Enable ignitions for the RD-100

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -51,7 +51,7 @@
         %useThrustCurve = False
         %ullage = True
         %pressureFed = False
-        %ignitions = 0
+        %ignitions = 1
 
         !IGNITOR_RESOURCE,*{}
 
@@ -84,7 +84,7 @@
             massMult = 1.0
             ullage = True
             pressureFed = False
-            ignitions = 0
+            ignitions = 1
 
             IGNITOR_RESOURCE
             {
@@ -130,7 +130,7 @@
             massMult = 1.0
             ullage = True
             pressureFed = False
-            ignitions = 0
+            ignitions = 1
             cost = 200
 
             IGNITOR_RESOURCE
@@ -177,7 +177,7 @@
             massMult = 0.9966
             ullage = True
             pressureFed = False
-            ignitions = 0
+            ignitions = 1
             cost = 250
 
             IGNITOR_RESOURCE
@@ -224,7 +224,7 @@
             massMult = 0.9797
             ullage = True
             pressureFed = False
-            ignitions = 0
+            ignitions = 1
             cost = 700
             techRequired = engineering101
 
@@ -272,7 +272,7 @@
             massMult = 0.9763
             ullage = True
             pressureFed = False
-            ignitions = 0
+            ignitions = 1
             cost = 850
             techRequired = basicRocketry
 


### PR DESCRIPTION
- reports stated the engine can't be ignited anymore
- added 1 ignition to every derivative

- please check if I didn't break anything since there should have been a reason why this was 0 before and it worked (based on my memories)