### PR TITLE
[New Parts] SNAP RTG series

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
@@ -48,6 +48,7 @@
 
 @PART[rtgMini]:FOR[RealismOverhaul]
 {
+    @name = RO-SNAP-3
     %RSSROConfig = True
 
     @MODEL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
@@ -48,7 +48,7 @@
 
 @PART[rtgMini]:FOR[RealismOverhaul]
 {
-    @name = RO-SNAP-3
+    @name = RO-SNAP-3-RTG
     %RSSROConfig = True
 
     @MODEL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
@@ -31,3 +31,293 @@
         @resourceAmount = 0.001
     }
 }
+
+//  ==================================================
+//  SNAP-3 series RTG.
+
+//  Dimensions: 0.12 m x 0.14 m
+//  Gross Mass: 2.3 Kg
+
+//  Sources:
+
+//  NTRS - Survey Of Electric Power Plants For Space Applications:   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660005486.pdf
+//  FAS - First Flights: Nuclear Power To Advance Space Exploration: https://fas.org/nuke/space/first.pdf
+//  FAS - Space Nuclear Power: Opening The Final Frontier:           https://fas.org/nuke/space/bennett0706.pdf
+//  Idaho National Laboratory - Atomic Power In Space: A History:    https://www.inl.gov/wp-content/uploads/2014/10/AtomicPowerInSpaceII-AHistory_2015_chapters1-2.pdf
+//  ==================================================
+
+@PART[rtgMini]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 0.285, 0.35, 0.285
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.0705, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_bottom = 0.0, -0.0705, 0.0, 0.0, -1.0, 0.0, 0
+    @node_attach = 0.0, -0.0705, 0.0, 0.0, -1.0, 0.0
+
+    @title = SNAP-3 Series RTG
+    @manufacturer = DOE (Department Of Energy)
+    @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency and power generation.
+
+    @mass = 0.0022
+    @crashTolerance = 16
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 1273.15
+    %skinMaxTemp = 1773.15
+    %fuelCrossFeed = False
+
+    !MODULE[ModuleGenerator],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = RTG
+        StartActionName = Start
+        StopActionName = Stop
+        AlwaysActive = True
+        FillAmount = 1.0
+        AutoShutdown = false
+        GeneratesHeat = False
+        TemperatureModifier = 2.0
+        UseSpecializationBonus = False
+        DefaultShutoffTemp = 0.5
+
+        INPUT_RESOURCE
+        {
+            ResourceName = Plutonium-238
+            Ratio = 1.6428e-10
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.0025
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedFuel
+            Ratio = 1.6428e-10
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Plutonium-238 mass approximately 0.1 Kg.
+
+    RESOURCE
+    {
+        name = Plutonium-238
+        amount = 0.00505
+        maxAmount = 0.00505
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
+        maxAmount = 0.00505
+    }
+}
+
+//  ==================================================
+//  SNAP-9 series RTG.
+
+//  Dimensions: 0.51 m x 0.27 m
+//  Gross Mass: 12 Kg
+
+//  Sources:
+
+//  NTRS - Survey Of Electric Power Plants For Space Applications:   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660005486.pdf
+//  FAS - First Flights: Nuclear Power To Advance Space Exploration: https://fas.org/nuke/space/first.pdf
+//  FAS - Space Nuclear Power: Opening The Final Frontier:           https://fas.org/nuke/space/bennett0706.pdf
+//  Idaho National Laboratory - Atomic Power In Space: A History:    https://www.inl.gov/wp-content/uploads/2014/10/AtomicPowerInSpaceII-AHistory_2015_chapters1-2.pdf
+//  ==================================================
+
++PART[rtgMini]:FOR[RealismOverhaul]
+{
+    @name = RO-SNAP-9-RTG
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.28, 0.645, 1.28
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.13, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_bottom = 0.0, -0.13, 0.0, 0.0, -1.0, 0.0, 0
+    @node_attach = 0.0, -0.13, 0.0, 0.0, -1.0, 0.0
+
+    @title = SNAP-9 Series RTG
+    @manufacturer = DOE (Department Of Energy)
+    @description = The SNAP-9 series were evolved designs of the experimental SNAP-3 series, again as part of the Transit system (precursor to the current GPS system), but now featuring over 10 times higher power generation.
+
+    @mass = 0.011
+    @crashTolerance = 16
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 1273.15
+    %skinMaxTemp = 1773.15
+    %fuelCrossFeed = False
+
+    !MODULE[ModuleGenerator],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = RTG
+        StartActionName = Start
+        StopActionName = Stop
+        AlwaysActive = True
+        FillAmount = 1.0
+        AutoShutdown = false
+        GeneratesHeat = False
+        TemperatureModifier = 2.0
+        UseSpecializationBonus = False
+        DefaultShutoffTemp = 0.5
+
+        INPUT_RESOURCE
+        {
+            ResourceName = Plutonium-238
+            Ratio = 1.6428e-10
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.025
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedFuel
+            Ratio = 1.6428e-10
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Plutonium-238 mass approximately 1 Kg.
+
+    RESOURCE
+    {
+        name = Plutonium-238
+        amount = 0.0505
+        maxAmount = 0.0505
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
+        maxAmount = 0.0505
+    }
+}
+
+//  ==================================================
+//  SNAP-19 series RTG.
+
+//  Dimensions: 0.54 m x 0.27 m
+//  Gross Mass: 15 Kg
+
+//  Sources:
+
+//  NTRS - Survey Of Electric Power Plants For Space Applications:   https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660005486.pdf
+//  FAS - First Flights: Nuclear Power To Advance Space Exploration: https://fas.org/nuke/space/first.pdf
+//  FAS - Space Nuclear Power: Opening The Final Frontier:           https://fas.org/nuke/space/bennett0706.pdf
+//  Idaho National Laboratory - Atomic Power In Space: A History:    https://www.inl.gov/wp-content/uploads/2014/10/AtomicPowerInSpaceII-AHistory_2015_chapters1-2.pdf
+//  ==================================================
+
++PART[rtgMini]:FOR[RealismOverhaul]
+{
+    @name = RO-SNAP-19-RTG
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.35, 0.645, 1.35
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.13, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_bottom = 0.0, -0.13, 0.0, 0.0, -1.0, 0.0, 0
+    @node_attach = 0.0, -0.13, 0.0, 0.0, -1.0, 0.0
+
+    @title = SNAP-19 Series RTG
+    @manufacturer = Teledyne Isotopes (Teledyne Technologies Inc.)
+    @description = The SNAP-19 series were originally developed for the Nimbus weather satellite program, complementing the regular solar arrays and countering their degradation due to radiation. Later, they were also used by the Pioneer 10 and 11 spacecrafts, along with the Viking Mars landers. Similar to the SNAP-9 series but with over 40% better conversion efficiency.
+
+    @mass = 0.014
+    @crashTolerance = 16
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 1273.15
+    %skinMaxTemp = 1773.15
+    %fuelCrossFeed = False
+
+    !MODULE[ModuleGenerator],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = RTG
+        StartActionName = Start
+        StopActionName = Stop
+        AlwaysActive = True
+        FillAmount = 1.0
+        AutoShutdown = false
+        GeneratesHeat = False
+        TemperatureModifier = 2.0
+        UseSpecializationBonus = False
+        DefaultShutoffTemp = 0.5
+
+        INPUT_RESOURCE
+        {
+            ResourceName = Plutonium-238
+            Ratio = 1.6428e-10
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.035
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedFuel
+            Ratio = 1.6428e-10
+        }
+    }
+
+    !RESOURCE,*{}
+
+    //  Plutonium-238 mass approximately 1 Kg.
+
+    RESOURCE
+    {
+        name = Plutonium-238
+        amount = 0.0505
+        maxAmount = 0.0505
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
+        maxAmount = 0.0505
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add some early (and late) RTG models: the SNAP-3, the SNAP-9 and the SNAP-19 (covers some of the empty nuclear tech tree nodes).