### PR TITLE
[Mod Support] RealEngines v1.6/1.7

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_American.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_American.cfg
@@ -5,6 +5,117 @@
 //  SpaceX - SuperDraco 3D printed engine chamber: http://www.spacex.com/news/2014/07/31/spacex-launches-3d-printed-part-space-creates-printed-engine-chamber-crewed
 
 //  ==================================================
+//  NAA 75-110-A engine series.
+
+//  Dimensions: 1.78 m x 2.65 m
+//  Gross Mass: 670 Kg
+//  ==================================================
+
+@PART[A7]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 0.75, 0.75, 0.75
+    }
+
+    //  Modeling the jet vanes as four thrust transforms.
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.285, -1.39, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = -0.285, -1.39, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.0, -1.39, 0.285
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.0, -1.39, -0.285
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.195, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -1.23, 0.0, 0.0, -1.0, 0.0, 1
+
+    @mass = 0.67
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = size1
+    @tags = A-6 A-7 explorer juno jupiter launch mercury MRLV PGM-11 propuls redstone rocket surf
+
+    %engineType = NAA75_110
+
+    @MODULE[ModuleEngines*]
+    {
+        @thrustVectorTransformName = newThrustTransform
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Ethanol75
+            @ratio = 0.5266
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.4734
+        }
+
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0175
+            ignoreForIsp = True
+            DrawGauge = False
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 249
+            @key,1 = 1 216
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalTransformName = newThrustTransform
+        %gimbalRange = 2.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
+    }
+}
+
+//  ==================================================
 //  SuperDraco engine.
 
 //  Dimensions: 0.8 m x 0.67 m

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -67,6 +67,16 @@
 //  KB KhIMMASH - S5.92 engine:                            http://kbhmisaeva.ru/main.php?id=53
 //  Encyclopedia Astronautica - S5.92 engine:              http://www.astronautix.com/s/s592.html
 
+//  Encyclopedia Astronautica - RD-0105 engine:            http://astronautix.com/r/rd-0105.html
+//  Encyclopedia Astronautica - RD-0109 engine:            http://astronautix.com/r/rd-0109.html
+
+//  Norbert Brügge - N-1 NK series engine variants:        http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm
+//  Encyclopedia Astronautica - NK-9 engine:               http://www.astronautix.com/n/nk-9.html
+//  Encyclopedia Astronautica - NK-9V engine:              http://www.astronautix.com/n/nk-9v.html
+//  Encyclopedia Astronautica - NK-21 engine:              http://www.astronautix.com/n/nk-21.html
+//  Encyclopedia Astronautica - NK-31 engine:              http://www.astronautix.com/n/nk-31.html
+//  Encyclopedia Astronautica - NK-39 engine:              http://www.astronautix.com/n/nk-39.html
+
 //  Norbert Brügge - Russian rocket engines:               http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 
 //  ==================================================
@@ -98,9 +108,9 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.086, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_top = 0.0, 1.085, 0.0, 0.0, 1.0, 0.0, 2
     !node_stack_center = NULL
-    @node_stack_bottom = 0.0, -2.266, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -2.265, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 1.24
     @crashTolerance = 10
@@ -115,9 +125,6 @@
     @tags = ascent launch propuls NK-33 rocket surf
 
     %engineType = NK33
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -238,7 +245,6 @@
     @tags = ascent launch propuls NK-33 RD-0110R rocket soyuz surf
 
     %engineType = RD0110R
-    %engineTypeMult = 1
     %ignoreMass = True
     %massOffset = 0.54
 
@@ -307,8 +313,8 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.086, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -3.705, 0.0, 0.0, -1.0, 0.0, 3
+    @node_stack_top = 0.0, 1.085, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -3.7, 0.0, 0.0, -1.0, 0.0, 3
 
     @mass = 1.4
     @crashTolerance = 10
@@ -323,9 +329,6 @@
     @tags = ascent launch propuls NK-43 rocket vac
 
     %engineType = NK43
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -409,9 +412,6 @@
     @tags = ascent launch propuls proton RD-58 rocket vac zenit
 
     %engineType = RD58
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -473,33 +473,36 @@
     {
         @scale = 1.0, 1.0, 1.0
     }
-    
-    // modeling the jet vanes as four thrust transforms
+
+    // Modeling the jet vanes as four thrust transforms.
+
     MODEL
     {
         model = RealismOverhaul/emptyengine
         position = 0.3, -0.77, 0.0
         rotation = 0.0, 0.0, 0.0
     }
+
     MODEL
     {
         model = RealismOverhaul/emptyengine
         position = -0.3, -0.77, 0.0
         rotation = 0.0, 0.0, 0.0
     }
+
     MODEL
     {
         model = RealismOverhaul/emptyengine
         position = 0.0, -0.77, 0.3
         rotation = 0.0, 0.0, 0.0
     }
+
     MODEL
-     {
+    {
         model = RealismOverhaul/emptyengine
         position = 0.0, -0.77, -0.3
         rotation = 0.0, 0.0, 0.0
-        @scale = 1.0, 1.0, 1.0
-     }
+    }
 
     @scale = 1.0
     @rescaleFactor = 1.0
@@ -520,13 +523,11 @@
     @tags = ascent irbm launch propuls R-1 R-2 R-5 RD-100 RD-101 RD-102 RD-103 rocket surf vertikal
 
     %engineType = RD100
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
         %thrustVectorTransformName = newThrustTransform
+
         @PROPELLANT[LiquidFuel]
         {
             @name = Ethanol90
@@ -603,9 +604,6 @@
     @tags = ascent fregat icbm launch molniya propuls RD-107 RD-117 rocket soyuz surf vostok voskhod
 
     %engineType = RD107-117
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
     {
@@ -737,9 +735,6 @@
     @tags = ascent fregat icbm launch molniya propuls RD-108 RD-118 rocket soyuz surf vostok voskhod
 
     %engineType = RD108-118
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[TT]]
     {
@@ -916,9 +911,6 @@
     @tags = ascent launch propuls RD-0110 rocket soyuz vac
 
     %engineType = RD0110
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1060,9 +1052,6 @@
     @tags = ascent buran energia launch polyus propuls RD-0120 rocket surf
 
     %engineType = RD0120
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1183,9 +1172,6 @@
     @tags = angara ascent launch propuls RD-0124 rocket soyuz vac
 
     %engineType = RD0124
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1272,8 +1258,6 @@
 
     %engineType = RD0124
     %engineTypeMult = 2
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1366,9 +1350,6 @@
     @tags = angara ascent kvtk launch ppts propuls RD-0146 rocket rus-m vac
 
     %engineType = RD0146
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1451,9 +1432,6 @@
     @tags = ascent energia launch propuls RD-170 rocket surf zenit
 
     %engineType = RD170
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1536,9 +1514,6 @@
     @tags = ascent atlas launch propuls RD-180 rocket rus-m surf
 
     %engineType = RD180
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1621,9 +1596,6 @@
     @tags = angara ascent launch propuls RD-191 rocket surf
 
     %engineType = RD191
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1705,9 +1677,6 @@
     @tags = ascent launch propuls proton RD-0210 RD-0211 rocket vac
 
     %engineType = RD0210
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -1802,12 +1771,13 @@
     @tags = ascent launch propuls proton RD-0212 RD-0213 RD-0214 rocket vac
 
     %engineType = RD0212
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
-    @MODULE[ModuleEngines*]
+    //  Main engine.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
+        %engineID = MainEngine
+
         @PROPELLANT[LiquidFuel]
         {
             @name = UDMH
@@ -1826,74 +1796,50 @@
             @key,1 = 1 220
         }
     }
-}
 
-//  ==================================================
-//  RD-0212 engine.
+    //  Vernier engine.
 
-//  Engine configuration.
-//  ==================================================
-
-@PART[RD0212]:AFTER[RealismOverhaulEngines]
-{
-    //  Vernier engine setup.
-
-    MODULE
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
     {
-        name = ModuleEngines
-        engineID = VernierEngine
-        thrustVectorTransformName = thrustTransform2
-        exhaustDamage = True
-        ignitionThreshold = 0.1
-        minThrust = 30.89
-        maxThrust = 30.89
-        heatProduction = 100
-        EngineType = LiquidFuel
-        ullage = True
-        pressureFed = False
-        ignitions = 1
+        %engineID = VernierEngine
+        @minThrust = 30.89
+        @maxThrust = 30.89
+        @heatProduction = 100
+        @useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
 
-        IGNITOR_RESOURCE
+        @PROPELLANT[LiquidFuel]
         {
-            name = ElectricCharge
-            amount = 0.025
+            @name = UDMH
+            @ratio = 0.4135
         }
 
-        PROPELLANT
+        @PROPELLANT[Oxidizer]
         {
-            name = UDMH
-            ratio = 0.4135
-            DrawGauge = True
+            @name = NTO
+            @ratio = 0.5865
         }
 
-        PROPELLANT
+        @atmosphereCurve
         {
-            name = NTO
-            ratio = 0.5865
-            DrawGauge = False
+            @key,0 = 0 294
+            @key,1 = 1 147
         }
 
-        atmosphereCurve
-        {
-            key = 0 294
-            key = 1 147
-        }
+        !thrustCurve,*{}
     }
 
     //  Vernier gimbal setup.
 
-    !MODULE[ModuleGimbal],*{}
-
-    MODULE
+    @MODULE[ModuleGimbal]
     {
-        name = ModuleGimbal
-        gimbalTransformName = gimbal
-        gimbalRangeYP = 0.0
-        gimbalRangeYN = 0.0
-        gimbalRangeXP = 45.0
-        gimbalRangeXN = 45.0
-        useGimbalResponseSpeed = True
-        gimbalResponseSpeed = 16
+        @gimbalRangeYP = 0
+        @gimbalRangeYN = 0
+        @gimbalRangeXP = 45.0
+        @gimbalRangeXN = 45.0
+        @gimbalResponseSpeed = 16
     }
 }
 
@@ -1935,9 +1881,6 @@
     @tags = ascent launch propuls proton RD-253 RD-275 rocket surf
 
     %engineType = RD253
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -2014,9 +1957,6 @@
     @tags = ascent fregat launch propuls S.92 rocket soyuz vac zenit
 
     %engineType = S5_92
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     //  Main engine.
 
@@ -2054,6 +1994,9 @@
         %engineID = GasGenerator
         @minThrust = 0.02
         @maxThrust = 0.02
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 50
 
         @PROPELLANT[LiquidFuel]
         {
@@ -2120,9 +2063,6 @@
     @tags = ascent briz launch propuls proton rocket rokot S.98M vac
 
     %engineType = S5_98M
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -2182,9 +2122,6 @@
     @tags = ascent launch propuls RD-0110 rocket soyuz vac vern
 
     %engineType = RD0110Vernier
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
 
     @MODULE[ModuleEngines*]
     {
@@ -2216,87 +2153,139 @@
     }
 }
 
+//  ==================================================
+//  NK-9 engine.
 
-/// Extras
-// NK-9, 9V, and 21/19/31/39.
+//  Dimensions: 1.3 m x 3.5 m
+//  Gross Mass: 316 Kg
+//  ==================================================
+
 +PART[NK33engine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
     @name = RO-RealEngines-NK9
 
     %RSSROConfig = True
-    %rescaleFactor = 0.88
-    
-    %mass = 0.316 // guess TWR of 120
-    @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
-    
+
+    @MODEL
+    {
+        @scale = 0.88, 0.88, 0.88
+    }
+
+    @node_stack_top = 0.0, 0.956, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.994, 0.0, 0.0, -1.0, 0.0, 2
+
+    @mass = 0.316
+    @tags = ascent launch propuls NK-9 rocket surf
+
+    %engineType = NK9
+
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
+        @PROPELLANT[Kerosene]
+        {
+            @ratio = 0.3557
+        }
+
+        @PROPELLANT[LqdOxygen]
+        {
+            @ratio = 0.6443
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 328
+            @key,1 = 1 286
+        }
     }
-    
-    %engineType = NK9
 }
+
+//  ==================================================
+//  NK-9V series engine (9V/21/19/31/39).
+
+//  Dimensions: 2.23 m x 4.7 m
+//  Gross Mass: 450 Kg
+//  ==================================================
 
 +PART[NK43engine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
     @name = RO-RealEngines-NK9V
 
     %RSSROConfig = True
-    %rescaleFactor = 0.88
-    
-    %mass = 0.45
-    @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
-    
+
+    @MODEL
+    {
+        @scale = 0.88, 0.88, 0.88
+    }
+
+    @node_stack_top = 0.0, 0.955, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -3.255, 0.0, 0.0, -1.0, 0.0, 3
+
+    @mass = 0.45
+    @bulkheadProfiles = size3
+    @tags = ascent launch propuls NK-9V NK-19 NK-21 NK-31 NK-39 rocket vac
+
+    %engineType = NK9V
+
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
+        @PROPELLANT[Kerosene]
+        {
+            @ratio = 0.3576
+        }
+
+        @PROPELLANT[LqdOxygen]
+        {
+            @ratio = 0.6424
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 345
+            @key,1 = 1 240
+        }
     }
-    
-    %engineType = NK9V
 }
 
-// RD-0105/9
+//  ==================================================
+//  RD-0105 series engine.
+
+//  Dimensions: 0.76 m x 1.58 m
+//  Gross Mass: 125 Kg
+//  ==================================================
+
 +PART[S5_92fversion]:FOR[RealismOverhaul]
 {
     @name = RO-RealEngines-RD0105
+
     %RSSROConfig = True
 
+    @MODEL
+    {
+        @scale = 1.9, 1.9, 1.9
+    }
+
+    @node_stack_top = 0.0, 0.295, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.42, 0.0, 0.0, -1.0, 0.0, 2
+
     @mass = 0.125
-    @crashTolerance = 10
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
-    %stageOffset = 1
-    %childStageOffset = 1
-    %stagingIcon = LIQUID_ENGINE
-    @bulkheadProfiles = size1
-    @tags = ascent vostok luna launch propuls rocket vac
+    @bulkheadProfiles = size2
+    @tags = ascent vostok luna launch propuls RD-0105 RD-0109 rocket vac
 
     %engineType = RD0105
-    %engineTypeMult = 1
-    %ignoreMass = False
-    %massOffset = 0
     %useVerniers = True
     %vernierThrust = 0.5
 
-    //  Gas generator exhaust.
+    //  Main engine.
 
-    //  The thrust values have been set to 1/100 of
-    //  the nominal thrust value of the main engine.
-    //  True values unknown.
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = GasGenerator
-        @minThrust = 0.5
-        @maxThrust = 0.5
+        %engineID = MainEngine
+        @minThrust = 49.4
+        @maxThrust = 49.4
+        @heatProduction = 51
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
 
         @PROPELLANT[UDMH]
         {
@@ -2317,22 +2306,49 @@
         }
     }
 
-    // FIXME should this gimbal even be here, or just verniers?
-	@MODULE[ModuleGimbal]
+    //  Vernier engines.
+    //  The model provides two separate thrust transforms but the Blok-E had four vernier engines.
+    //  So, we double the thrust available from each vernier engine.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {
-        %gimbalRange = 5.0
+        %engineID = VenierEngine
+        @minThrust = 0.84
+        @maxThrust = 0.84
+        @heatProduction = 1
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[UDMH]
+        {
+            @name = Kerosene
+            @ratio = 0.3594
+        }
+
+        @PROPELLANT[NTO]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6406
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 326
+            @key,1 = 1 100
+        }
+    }
+
+    // Vernier gimbal setup.
+
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalTransformName = tt2
+        @gimbalRange = 7.0
         !gimbalRangeYP = NULL
         !gimbalRangeYN = NULL
         !gimbalRangeXP = NULL
         !gimbalRangeXN = NULL
         %gimbalResponseSpeed = 16
-    }
-    MODULE
-    {
-        name = ModuleGimbal
-        gimbalTransformName = tt2
-        gimbalRange = 45
-        useGimbalResponseSpeed = True
-        gimbalResponseSpeed = 16
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -1802,9 +1802,9 @@
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
     {
         %engineID = VernierEngine
-        @minThrust = 30.89
-        @maxThrust = 30.89
-        @heatProduction = 100
+        @minThrust = 30.9
+        @maxThrust = 30.9
+        @heatProduction = 4
         @useThrustCurve = False
         %ullage = True
         %pressureFed = False
@@ -1831,9 +1831,11 @@
         !thrustCurve,*{}
     }
 
+    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal1]],*{}
+
     //  Vernier gimbal setup.
 
-    @MODULE[ModuleGimbal]
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
     {
         @gimbalRangeYP = 0
         @gimbalRangeYN = 0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -122,7 +122,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
-    @tags = ascent launch propuls NK-33 rocket surf
+    @tags = ascent launch NK-33 propuls rocket surf
 
     %engineType = NK33
 
@@ -242,7 +242,7 @@
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size2
     !stackSymmetry = NULL
-    @tags = ascent launch propuls NK-33 RD-0110R rocket soyuz surf
+    @tags = ascent launch NK-33 propuls RD-0110R rocket soyuz surf
 
     %engineType = RD0110R
     %ignoreMass = True
@@ -326,7 +326,7 @@
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = size3
-    @tags = ascent launch propuls NK-43 rocket vac
+    @tags = ascent launch NK-43 propuls rocket vac
 
     %engineType = NK43
 
@@ -474,33 +474,33 @@
         @scale = 1.0, 1.0, 1.0
     }
 
-    // Modeling the jet vanes as four thrust transforms.
+    //  Modeling the jet vanes as four thrust transforms.
 
     MODEL
     {
         model = RealismOverhaul/emptyengine
-        position = 0.3, -0.77, 0.0
+        position = 0.25, -0.8, 0.0
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
         model = RealismOverhaul/emptyengine
-        position = -0.3, -0.77, 0.0
+        position = -0.25, -0.8, 0.0
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
         model = RealismOverhaul/emptyengine
-        position = 0.0, -0.77, 0.3
+        position = 0.0, -0.8, 0.25
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
         model = RealismOverhaul/emptyengine
-        position = 0.0, -0.77, -0.3
+        position = 0.0, -0.8, -0.25
         rotation = 0.0, 0.0, 0.0
     }
 
@@ -2175,7 +2175,7 @@
     @node_stack_bottom = 0.0, -1.994, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 0.316
-    @tags = ascent launch propuls NK-9 rocket surf
+    @tags = ascent GR-1 icbm launch N-1 NK-9 propuls rocket surf
 
     %engineType = NK9
 
@@ -2222,7 +2222,7 @@
 
     @mass = 0.45
     @bulkheadProfiles = size3
-    @tags = ascent launch propuls NK-9V NK-19 NK-21 NK-31 NK-39 rocket vac
+    @tags = ascent launch N-1 NK-9V NK-19 NK-21 NK-31 NK-39 propuls rocket UR-700 vac
 
     %engineType = NK9V
 
@@ -2269,7 +2269,7 @@
 
     @mass = 0.125
     @bulkheadProfiles = size2
-    @tags = ascent vostok luna launch propuls RD-0105 RD-0109 rocket vac
+    @tags = ascent launch luna propuls RD-0105 RD-0109 rocket vac voskhod vostok
 
     %engineType = RD0105
     %useVerniers = True
@@ -2307,8 +2307,8 @@
     }
 
     //  Vernier engines.
-    //  The model provides two separate thrust transforms but the Blok-E had four vernier engines.
-    //  So, we double the thrust available from each vernier engine.
+    //  The model provides two separate vernier thrust transforms but the Blok-E had four vernier engines.
+    //  So, we double the thrust available from each vernier engine (420 N for each one).
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/A7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/A7.cfg
@@ -1,0 +1,70 @@
+//  ==================================================
+//  NAA-75-110 A-Series engine plume setup.
+//  ==================================================
+
+@PART[A7]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Alcolox-Lower-A6
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -0.075
+        plumeScale = 0.4
+        flarePosition = 0.0, 0.0, 0.975
+        flareScale = 0.45
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.75
+        speed = 1.0
+        emissionMult = 0.75
+    }
+
+    PLUME
+    {
+        name = Hydynelox-A7
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -1.4
+        plumeScale = 0.45
+        flarePosition = 0.0, 0.0, 0.25
+        flareScale = 0.55
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.5
+        speed = 1.0
+        emissionMult = 0.75
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Alcolox-Lower-A6
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
+    }
+}
+
+//  ==================================================
+//  NAA-75-110 A-Series engine plume configuration.
+//  ==================================================
+
+@PART[A7]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[A-6]
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
+
+        @CONFIG[A-7]
+        {
+            %powerEffectName = Hydynelox-A7
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
@@ -1,0 +1,35 @@
+//  ==================================================
+//  NK-9 engine plume setup.
+//  ==================================================
+
+@PART[RO-RealEngines-NK9]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -0.075
+        plumeScale = 0.65
+        flarePosition = 0.0, 0.0, -0.45
+        flareScale = 0.85
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
@@ -1,0 +1,35 @@
+//  ==================================================
+//  NK-9V engine series plume setup.
+//  ==================================================
+
+@PART[RO-RealEngines-NK9V]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.125
+        plumeScale = 1.5
+        flarePosition = 0.0, 0.0, -0.75
+        flareScale = 1.5
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0105.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0105.cfg
@@ -1,0 +1,57 @@
+//  ==================================================
+//  RD-0105 engine series plume setup.
+//  ==================================================
+
+@PART[RO-RealEngines-RD0105]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.05
+        plumeScale = 0.5
+        flarePosition = 0.0, 0.0, -0.125
+        flareScale = 0.525
+        smokeScale = 0.25
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.75
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = tt2
+        plumePosition = 0.0, 0.0, -0.025
+        plumeScale = 1.0
+        flarePosition = 0.0, 0.0, -0.05
+        flareScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.75
+        speed = 0.75
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+    {
+        %powerEffectName = Kerolox-Vernier
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add RO compatibility for the NAA-75-110 engine.
* Remove unneeded global engine config parameters (https://github.com/KSP-RO/RealismOverhaul/issues/1669).
* Tweak the positions of the thrust transforms (used as jet vanes) to be at the exact positions relatively to the engine exhaust.
* Trim the attachment node positions of the NK-33 and NK-43 engines.
* Fix the vernier engines of the RD-0212 engine.
* Fix the scale of the RD-0105 series engine.
* Add some missing RF fields from the S5.92 and the RD-0105 series engine verniers (could ignite infinite times and did not suffer from ullage).
* Add plume configs for all new and extra engines.

**Notes:**

* Requires the updated NAA-75-110 global engine configuration: https://github.com/KSP-RO/RealismOverhaul/pull/1707
* The gimbal modules of the NK-33/43 (and extras, NK-9/V series) now work correctly.
* The RD-108 verniers are still broken though...

Tagging @NathanKell, @Theysen and @SirKeplan for reviewing and testing.