### PR TITLE
[Maintenance] 1 kN generic thruster plume

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  Generic 1 kN thruster plume configuration.
+//  Generic 1 kN thruster plume setup.
 //  ==================================================
 
 @PART[microEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -8,10 +8,14 @@
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,0.55
-        fixedScale = 0.25
-        energy = 1
+        plumePosition = 0.0, 0.0, 0.55
+        plumeScale = 0.25
+        flarePosition = 0.0, 0.0, -0.85
+        flareScale = 0.05
+        smokePosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
         speed = 1.5
     }
 
@@ -19,18 +23,21 @@
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.05
+        plumeScale = 0.1
+        flarePosition = 0.0, 0.0, -0.8
+        flareScale = 0.075
+        smokePosition = 0.0, 0.0, 0.0
         localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, -0.78
-        fixedScale = 0.1
+        emissionMult = 0.5
         energy = 1.0
         speed = 1.0
     }
 
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Hypergolic-OMS-Red
-        !fxOffset = NULL
-	}
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+    }
 }
 
 //  ==================================================
@@ -51,6 +58,11 @@
             %powerEffectName = Hypergolic-OMS-Red
         }
 
+        @CONFIG[MMH+MON3]
+        {
+            %powerEffectName = Hypergolic-OMS-Red
+        }
+
         @CONFIG[UDMH+NTO]
         {
             %powerEffectName = Hypergolic-OMS-Red
@@ -59,25 +71,6 @@
         @CONFIG[Cavea-B]
         {
             %powerEffectName = Hypergolic-OMS-Red
-        }
-    }
-}
-
-//  ==================================================
-//  Generic 1 kN thruster flare configuration.
-//  ==================================================
-
-@PART[microEngine]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
-{
-    @EFFECTS
-    {
-        @Hypergolic-OMS-White
-        {
-            @MODEL_MULTI_SHURIKEN_PERSIST[flare]
-            {
-                @localPosition = 0.0, 0.0, -0.85
-                @fixedScale = 0.05
-            }
         }
     }
 }


### PR DESCRIPTION
**Change log:**

* Update the plume configs to use the new RealPlume setup conventions.
* Fix a missing plume setup reference for the MMH/MON3 propellant option.
* Remove the deprecated (and broken) flare pass.