### PR TITLE
[Maintenance] NAA-75-110 global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -1,69 +1,187 @@
-//NAA 75-110 engine
-//FASA
+//  ==================================================
+//  NAA 75-110 engine series global engine configuration.
+
+//  Inert Mass: 670 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 1.3
+//  Burn Time: 145 s (A-6), 155 s (A-7)
+
+//  Sources:
+
+//  DTIC - History of the Redstone Missile System:                     http://www.dtic.mil/docs/citations/ADA434109
+//  Alternate Wars - Historic American Engineering Record AL-129-A:    http://www.alternatewars.com/BBOW/Space_Engines/HAER_AL-129-A.pdf
+//  Heroic Relics - Redstone Rocket Engines (A-6 and A-7):             http://heroicrelics.org/info/redstone/redstone-engines.html
+//  Heroic Relics - A-6 Redstone engine specifications:                http://heroicrelics.org/info/redstone/redstone-engines/A-6%20Redstone%20Engine%20Specifications.pdf
+//  Heroic Relics - A-7 Redstone engine specifications:                http://heroicrelics.org/info/redstone/redstone-engines/A-7%20Redstone%20Engine%20System%20Description.pdf
+//  Alternate Wars - NAA, Rocketdyne, Boeing Rocketdyne Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//  NASA - Explorer-I and Jupiter-C:                                   https://history.nasa.gov/sputnik/expinfo.html
+//  Norbert Brügge - Juno I launch vehicle:                            http://www.b14643.de/Spacerockets_2/United_States_2/Redstone/Description/Frame.htm
+//  Encyclopedia Astronautica - A-6 engine:                            http://astronautix.com/a/a-6.html
+//  Encyclopedia Astronautica - A-7 engine:                            http://astronautix.com/a/a-7.html
+
+//  Used by:
+
+//  * FASA
+//  * RealEngines pack
+
+//  Notes:
+
+//  * The gimbal range defined here is not a true value, since the actual engine did not have
+//    a mechanical gimbal capability for the engine and/or nozzle. Instead, we simulate the
+//    operation of the jet vanes used to steer the engine exhaust products.
+//  ==================================================
+
 @PART[*]:HAS[#engineType[NAA75_110]]:FOR[RealismOverhaulEngines]
 {
-	@title = NAA-75-110 A-Series
-	%manufacturer = Rocketdyne
-	@description = Used on the Redstone missile.  Designed for Ethanol/LOx (A-6) (1.5 O/F Ratio), it was later adapted to burn Hydyne/LOx (A-7) (1.73 O/F Ratio)(higher performance (12%) yet more toxic) for use in Jupiter C / Juno I.  When Redstone MRLV was adapted from Jupiter C for manned use the A7 was switched back to Ethanol, accepting slightly lower performance for lack of toxicity. Thrust Vector Control was provided by carbon thrust vanes (add the Redstone Fin / Thrust vane part in 4x symmetry), and additional attitude control was provided by actuating fins. Mass includes thrust frame. Diameter: [1.77 m].
-	
+	%category = Engine
+	%title = NAA-75-110 A-Series
+	%manufacturer = North American Aviation (NAA)
+	%description = The power plant of the PGM-11 Redstone Short Range Ballistic Missile (SRBM). Originally designed for Ethanol/LOX (A-6) it was later adapted to use Hydyne/LOx (A-7) with approximately 6% higher performance (yet more toxic) for use in Jupiter-C / Juno I. When the Redstone was adapted from Jupiter-C for manned use under the Project Mercury (Mercury-Redstone Launch Vehicle - MRLV), the A-7 was switched back to Ethalox, accepting a slightly lower performance for the lack of toxicity. Thrust Vector Control (TVC) was provided by carbon thrust vanes and additional attitude control was provided by actuating fins placed in the guidance section. Diameter: 1.77 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 395.9
+		@maxThrust = 395.9
+		%heatProduction = 41
+		%EngineType = LiquidFuel
+		@allowShutdown = False
+		@useEngineResponseTime = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
+		%useThrustCurve = False
+		%ullage = True
+		%pressureFed = False
+		%ignitions = 1
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 2.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
-		name = ModuleEngineConfigs	
+		name = ModuleEngineConfigs
+		type = ModuleEngines
 		configuration = A-6
-		modded = false
-		origMass = 0.987
+		origMass = 0.67
+
 		CONFIG
 		{
-			// Source: http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
 			name = A-6
 			minThrust = 395.9
 			maxThrust = 395.9
-			heatProduction = 100
+			heatProduction = 41
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
 			PROPELLANT
 			{
 				name = Ethanol75
-				ratio = 0.491
+				ratio = 0.5266
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.509
+				ratio = 0.4734
+				DrawGauge = False
 			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.0175
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
 			atmosphereCurve
 			{
 				key = 0 249
-				key = 1 218
+				key = 1 216
 			}
 		}
+
 		CONFIG
 		{
 			name = A-7
-			minThrust = 416.18
-			maxThrust = 416.18
-			heatProduction = 100
+			minThrust = 416.2
+			maxThrust = 416.2
+			heatProduction = 45
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
 			PROPELLANT
 			{
 				name = Hydyne
-				ratio = 0.435
+				ratio = 0.5232
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.565
+				ratio = 0.4768
+				DrawGauge = False
 			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.0175
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
 			atmosphereCurve
 			{
 				key = 0 265
 				key = 1 235
 			}
+
 			cost = 150
 			entryCost = 4500
-			techRequired = engineering101 // really it's somewhere in between basic and general rocketry
+			techRequired = engineering101 // Really it's somewhere in between basic and general rocketry.
 		}
 	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
 }
+
+//  ==================================================
+//  NAA 75-110 engine series.
+
+//  TestFlight compatibility.
+//  ==================================================
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[A-6]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -73,22 +191,21 @@
 		ignitionReliabilityStart = 0.7
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.87
-		cycleReliabilityEnd = 0.95 // manrating
-		
-		techTransfer = A-4:20 // A-4/V-2 deriv
+		cycleReliabilityEnd = 0.95      // Man-rated.
+		techTransfer = A-4:20           // A-4/V-2 derivative.
 	}
 }
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[A-7]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = A-7
-		ratedBurnTime = 165
+		ratedBurnTime = 155
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.87
 		cycleReliabilityEnd = 0.92
-
 		techTransfer = A-6:30
 	}
 }


### PR DESCRIPTION
**Change log:**

* Add some web sources and general config notes.
* Add some default part and engine module patching.
* Fix the inert mass value (the previous one assumed the FASA configuration that includes the thrust frame, engine fuselage and stabilization winglets).
* Add a gimbal module (simulates the jet vanes).
* Use an O/F ratio of 1.3 for both engine variants.
* Tweak the heat production values.
* Use the average value for the ASL Isp value of the A-6 variant (values are reported to be between 214 s and 218 s).
* Add the requirement of HTP for the turbopump.
* Add ignition and ullage parameters.
* Make sure that no other engine configs, alternator modules and/or resources exist in the part module.
* Decrease the rated burn time of the A-7 variant from 165 s to 155 s.

**Notes:**

* From the **Historic American Engineering Record AL-129-A** (page 54) we find that the operational O/F ratio for the A-6 was 1.3. The propellant tanks were **lengthened** for the Jupiter-C/Juno-I variants so we can assume that the O/F ratio for the A-7 engine remained similar to the A-6 one (the 1.73 reported previously was the **ideal** ratio between the propellants and not an operational one). It should probably be tweaked even further.
* The thrust increase does not match the reported percentage increase. Using the reported ASL thrust values (78000 lbf to 83000 lbf) we get an increase of ~6.4%.
* The HTP usage values were calculated from the overall propellant load of a Redstone SRBM, as reported by the **History of the Redstone Missile System** (page 72).
* The FASA NAA-75-110 engine part config will need to be updated to add the missing mass of the engine fuselage and the rest of the structural parts.