### PR TITLE
[Bug Fix] Part max pressure tolerances

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -1,4 +1,8 @@
-// Temp fix: apply crew mass in VAB/SPH
+//  ==================================================
+//  Allow the wheel modules to be deployed even if they
+//  are shielded by other parts.
+//  ==================================================
+
 @PART[*]:HAS[@MODULE[ModuleWheelDeployment]]:FOR[zzzRealismOverhaul]
 {
 	@MODULE[ModuleWheelDeployment]
@@ -7,7 +11,11 @@
 	}
 }
 
-// Set up solar panel displays.
+//  ==================================================
+//  Set up the solar panel displays to indicate their
+//  power generation in Watts.
+//  ==================================================
+
 @PART[*]:HAS[@MODULE[ModuleDeployableSolarPanel]]:FOR[ROSolar]
 {
 	@MODULE[ModuleDeployableSolarPanel],*:HAS[!RESOURCE[*]]
@@ -18,6 +26,7 @@
 			rate = #$../chargeRate$
 		}
 	}
+
 	@MODULE[ModuleDeployableSolarPanel],*
 	{
 		%flowUnits = Watts
@@ -25,6 +34,11 @@
 		%flowMult = 1000
 	}
 }
+
+//  ==================================================
+//  Do the same thing for any other electricity
+//  generators/consumers.
+//  ==================================================
 
 @PART[*]:HAS[@MODULE[*]:HAS[@RESOURCE[ElectricCharge]]]:FOR[zzzElectricityUnits]
 {
@@ -51,6 +65,7 @@
 			%displayUnitMult = 1000
 			%unitName = Watts
 		}
+
 		@OUTPUT_RESOURCE[ElectricCharge]
 		{
 			%varyTime = False
@@ -94,8 +109,8 @@
 }
 
 //  ==================================================
-//  Set pre-RO impact & G tolerances, along with node
-//  breaking force and torque.
+//  Set the pre-RO impact, G-Force and pressure tolerances,
+//  along with the attachment node breaking force/torque.
 //  ==================================================
 
 @PART[*]:HAS[~crashTolerance[>12]]:BEFORE[RealismOverhaul]
@@ -105,7 +120,12 @@
 
 @PART[*]:HAS[~gTolerance[<50]]:BEFORE[RealismOverhaul]
 {
-    %gTolerance = 100
+	%gTolerance = 100
+}
+
+@PART[*]:HAS[~maxPressure[<4000]]:BEFORE[RealismOverhaul]
+{
+	%maxPressure = 20000
 }
 
 @PART[*]:HAS[~breakingForce[]]:BEFORE[RealismOverhaul]


### PR DESCRIPTION
**Change log:**

* Add a pre-RO pass to increase the pressure limits of all parts from 4 to 20 MPa (plenty enough to land on Venus and probe the lower atmospheres of the gas giants).
* Patch comments!

Hope that i did good by basing this PR against the RO-Pap branch...