### PR TITLE
[Bug Fix] Coatl Aerospace ProbesPlus & GroundOps

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -37,8 +37,8 @@
     @crashTolerance = 16
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.155
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     @bulkheadProfiles = size0, size1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -34,8 +34,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: high directional planar
 
@@ -127,8 +127,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !impactTolerance = NULL
     %fuelCrossFeed = False
     @tags ^= :$: low omnidirectional

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
@@ -30,8 +30,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -33,24 +33,21 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 973.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^= :$: thiokol
 
     %engineType = TD339
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
         @exhaustDamage = True
         @minThrust = 0.13
         @maxThrust = 0.46
-        @heatProduction = 100
+        @heatProduction = 21
         %ullage = False
         %pressureFed = True
         %ignitions = -1
@@ -58,19 +55,19 @@
         @PROPELLANT[LiquidFuel]
         {
             @name = MMH
-            @ratio = 0.9
+            @ratio = 0.5200
         }
 
         @PROPELLANT[Oxidizer]
         {
             @name = NTO
-            @ratio = 1.1
+            @ratio = 0.4800
         }
 
         @atmosphereCurve
         {
             @key,0 = 0 285
-            @key,1 = 1 80
+            @key,1 = 1 100
         }
     }
 
@@ -109,17 +106,14 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^= :$: motor retro solid thiokol
 
     %engineType = Star-37
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
@@ -30,8 +30,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: surveyor
 }
@@ -63,8 +63,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: sampler surface
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -38,8 +38,8 @@
     @mass = 0.003
     @crashTolerance = 8
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: communications
@@ -122,8 +122,8 @@
 
     @mass = 0.008
     @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: communications
 
@@ -207,8 +207,8 @@
     @mass = 0.003
     @crashTolerance = 10
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: communications
 
@@ -295,8 +295,8 @@
     @mass = 0.003
     @crashTolerance = 8
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: communications
 
@@ -380,8 +380,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: communications parabolic
 
@@ -469,8 +469,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf, size0
     @tags ^= :$: communications parabolic
@@ -562,8 +562,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic voyager
@@ -653,8 +653,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic pioneer
@@ -763,8 +763,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     %bulkheadProfiles = srf, size1
     @tags ^= :$: communications parabolic ulysses
@@ -854,8 +854,8 @@
     %breakingForce = 250
     %breakingTorque = 250
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: communications
 
@@ -945,8 +945,8 @@
     @mass = 0.015
     @crashTolerance = 8
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: communications
@@ -1031,8 +1031,8 @@
     @mass = 0.02
     @crashTolerance = 8
     !impactTolerance = NULL
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     %bulkheadProfiles = size1
     @tags ^= :$: communications

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -42,8 +42,8 @@
 
     @mass = 0.1
     @crashTolerance = 10
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     %bulkheadProfiles = size0
@@ -167,8 +167,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     @bulkheadProfiles = size1
@@ -275,8 +275,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     @bulkheadProfiles = size1
@@ -378,8 +378,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     @bulkheadProfiles = size2
@@ -504,6 +504,7 @@
     @bulkheadProfiles = size2
     @tags ^= :$: avionics bus
     %gTolerance = 450
+    %maxPressure = 10500
 
     @MODULE[ModuleCommand]
     {
@@ -626,8 +627,8 @@
 
     @mass = 0.8
     @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     @bulkheadProfiles = size1, size2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -25,8 +25,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
@@ -70,8 +70,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
@@ -112,8 +112,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
@@ -154,8 +154,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: assembly RW wheel
 
@@ -191,8 +191,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: star tracker
 
@@ -223,8 +223,8 @@
 
     @mass = 0.001
     @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: star tracker
 }
@@ -256,8 +256,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: attitude block thruster
 
@@ -311,8 +311,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: attitude block thruster
 
@@ -366,8 +366,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: attitude block thruster
 
@@ -427,8 +427,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: attitude block thruster
 
@@ -482,8 +482,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: attitude block thruster
 
@@ -536,8 +536,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: attitude block thruster
 
@@ -591,8 +591,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
@@ -29,8 +29,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     %stagingIcon = DECOUPLER_HOR
     @bulkheadProfiles = size2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -45,8 +45,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
@@ -76,8 +76,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
@@ -107,8 +107,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: battery storage
 
@@ -122,7 +122,7 @@
 //  ==================================================
 //  Pioneer 10/11 SNAP-19 RTG.
 
-//  Dimensions: 3 m x 0.4 (extended)
+//  Dimensions: 3 m x 0.4 m (extended)
 //  Gross Mass: 30 Kg
 
 //  The Pioneer RTG boom includes two SNAP-19 RTG modules.
@@ -186,7 +186,7 @@
         INPUT_RESOURCE
         {
             ResourceName = Plutonium-238
-            Ratio = 1.6428e-10
+            Ratio = 6.342e-11
         }
 
         OUTPUT_RESOURCE
@@ -198,7 +198,7 @@
         OUTPUT_RESOURCE
         {
             ResourceName = DepletedFuel
-            Ratio = 1.6428e-10
+            Ratio = 6.342e-11
         }
     }
 
@@ -291,7 +291,7 @@
         INPUT_RESOURCE
         {
             ResourceName = Plutonium-238
-            Ratio = 1.6428e-10
+            Ratio = 4.32e-10
         }
 
         OUTPUT_RESOURCE
@@ -303,7 +303,7 @@
         OUTPUT_RESOURCE
         {
             ResourceName = DepletedFuel
-            Ratio = 1.6428e-10
+            Ratio = 4.32e-10
         }
     }
 
@@ -393,7 +393,7 @@
         INPUT_RESOURCE
         {
             ResourceName = Plutonium-238
-            Ratio = 1.6428e-10
+            Ratio = 2.59e-10
         }
 
         OUTPUT_RESOURCE
@@ -405,7 +405,7 @@
         OUTPUT_RESOURCE
         {
             ResourceName = DepletedFuel
-            Ratio = 1.6428e-10
+            Ratio = 2.59e-10
         }
     }
 
@@ -461,8 +461,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: Express Venus
 
@@ -503,8 +503,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: Express Mars
 
@@ -542,8 +542,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: mariner panel photovoltaic
 
@@ -581,8 +581,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: mariner panel photovoltaic
 
@@ -635,8 +635,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: Mars MAVEN
 
@@ -675,8 +675,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: mars odyssey panel photovoltaic
 
@@ -714,8 +714,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: panel photovoltaic
 
@@ -752,8 +752,8 @@
 
     @mass = 0.001
     @crashTolerance = 10
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: panel
 
@@ -790,8 +790,8 @@
 
     @mass = 0.12
     @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.63405
     @tags ^= :$: panel photovoltaic radiator
@@ -844,8 +844,8 @@
 
     @mass = 0.1
     @crashTolerance = 8
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.63405
     @tags ^= :$: panel photovoltaic radiator

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -46,8 +46,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
@@ -128,8 +128,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @bulkheadProfiles = size1
     @tags ^= :$: aerojet attitude apogee insertion marquardt motor rocketdyne
@@ -193,8 +193,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @bulkheadProfiles = size2
     %stageOffset = 1
@@ -410,8 +410,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: inline pressurized propellant upper
@@ -461,8 +461,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: inline pressurized propellant upper vacuum
@@ -508,8 +508,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: pressurized propellant radial upper vacuum
 
@@ -561,8 +561,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: airbus apogee safran
 
@@ -719,8 +719,8 @@
 
     @mass = 0.106
     @crashTolerance = 8
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %stageOffset = 1
     %childStageOffset = 1
     %fuelCrossFeed = True
@@ -860,8 +860,8 @@
 
     @mass = 0.07
     @crashTolerance = 10
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     %stageOffset = 1
     %childStageOffset = 1
@@ -986,8 +986,8 @@
     @crashTolerance = 6
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @tags ^= :$: pressurized propellant upper vacuum
 
@@ -1038,8 +1038,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @bulkheadProfiles = size2
     @tags ^= :$: bus spacecraft

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -54,8 +54,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: ascat metop scatterometer
@@ -88,8 +88,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: global laser mars surveyor
 }
@@ -124,8 +124,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: camera horizons multispectral spectrometer
 }
@@ -154,8 +154,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: seismometer
 }
@@ -184,8 +184,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: atmospheric pressure
 }
@@ -217,8 +217,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     %fuelCrossFeed = False
     @tags ^= :$: capsule container return sample
@@ -251,8 +251,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: counter dust
 }
@@ -284,8 +284,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: analyzer particle plasma
@@ -318,8 +318,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: gradiometer sensor
 }
@@ -351,8 +351,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: cosmic element synthesis
 }
@@ -384,8 +384,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: mars imaging mro orbiter soil reconnaissance surface temperature themis
 
@@ -419,8 +419,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: iuvs maven uv ultraviolet spectrometer
 
@@ -464,8 +464,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: cassini
 }
@@ -497,8 +497,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = srf
     @tags ^= :$: voyager
@@ -531,8 +531,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: analyzer electron ion maven
 }
@@ -564,8 +564,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: hirise mro
 }
@@ -597,8 +597,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: flux infrared radiometer soil surface thermometer
 }
@@ -630,8 +630,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: pioneer sensor triaxial
 
@@ -670,8 +670,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     !PhysicsSignificance = NULL
     %fuelCrossFeed = False
     @tags ^= :$: dust mass spectrometer telescope
@@ -709,8 +709,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @bulkheadProfiles = size0, srf
     @tags ^= :$: sensor venera
@@ -752,8 +752,8 @@
     @crashTolerance = 8
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @tags ^= :$: sar
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
@@ -28,8 +28,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     %bulkheadProfiles = size1
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -31,15 +31,15 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.6129
+    @radiatorHeadroom = 0.3413
 
     @MODULE[ModuleActiveRadiator]
     {
         @maxEnergyTransfer = 2.0
-        @overcoolFactor = 0.6129
+        @overcoolFactor = 0.3413
         @isCoreRadiator = True
         %parentCoolingOnly = True
 
@@ -77,15 +77,15 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.6129
+    @radiatorHeadroom = 0.3413
 
     @MODULE[ModuleActiveRadiator]
     {
         @maxEnergyTransfer = 2.5
-        @overcoolFactor = 0.6129
+        @overcoolFactor = 0.3413
         @isCoreRadiator = True
         %parentCoolingOnly = True
 
@@ -123,15 +123,15 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.6129
+    @radiatorHeadroom = 0.3413
 
     @MODULE[ModuleActiveRadiator]
     {
         @maxEnergyTransfer = 5.0
-        @overcoolFactor = 0.6129
+        @overcoolFactor = 0.3413
         @isCoreRadiator = True
         %parentCoolingOnly = True
 
@@ -174,7 +174,7 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
+    @maxTemp = 873.15
     %skinMaxTemp = 3773.15
     %emissiveConstant = 0.6
     %thermalMassModifier = 1.0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -32,8 +32,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @radiatorHeadroom = 0.6129
     @tags ^= :$: pioneer science
@@ -93,8 +93,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = True
     @bulkheadProfiles = size1
     %vesselType = Probe


### PR DESCRIPTION
**Change log:**

* Increase the maximum temperatures of the parts (excluding some for the Venera) from 473.15 K to 873.15 K (flat) to make them useful again in space around Venus and Mercury (per @NathanKell and @pap1723).
* Fix the maximum pressure tolerance of the Venera lander (up to 10.5 MPa now).
* Fix the decay rates of the RTGs. They now have an operational life of approximately 50 years.
* Remove unneeded global engine config fields (https://github.com/KSP-RO/RealismOverhaul/issues/1669).