### PR TITLE
[Bug Fix] Squad wheels maximum speed

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -4,16 +4,27 @@
 
 @PART[roverWheel1]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.045
+    %RSSROConfig = True
+    @mass = 0.045
 
     @MODULE[ModuleWheelMotor]
     {
+        %wheelSpeedMax = 4.0
         @idleDrain = 0
 
         @RESOURCE[ElectricCharge]
         {
             @rate = 0.8
+        }
+
+        !torqueCurve,*{}
+
+        torqueCurve
+        {
+            key = 0.0 2.0 0.0 0.0
+            key = 1.3 1.5 0.0 0.0
+            key = 2.6 0.5 0.0 0.0
+            key = 4.0 0.0 0.0 0.0
         }
     }
 }
@@ -24,16 +35,27 @@
 
 @PART[roverWheel2]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.015
+    %RSSROConfig = True
+    @mass = 0.015
 
     @MODULE[ModuleWheelMotor]
     {
+        %wheelSpeedMax = 2.0
         @idleDrain = 0
 
         @RESOURCE[ElectricCharge]
         {
             @rate = 0.04
+        }
+
+        !torqueCurve,*{}
+
+        torqueCurve
+        {
+            key = 0.0 2.0 0.0 0.0
+            key = 0.6 1.5 0.0 0.0
+            key = 1.3 0.5 0.0 0.0
+            key = 2.0 0.0 0.0 0.0
         }
     }
 }
@@ -44,16 +66,27 @@
 
 @PART[wheelMed]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.085
+    %RSSROConfig = True
+    @mass = 0.085
 
     @MODULE[ModuleWheelMotor]
     {
+        %wheelSpeedMax = 8.0
         @idleDrain = 0
 
         @RESOURCE[ElectricCharge]
         {
             @rate = 1.0
+        }
+
+        !torqueCurve,*{}
+
+        torqueCurve
+        {
+            key = 0.0 2.0 0.0 0.0
+            key = 2.6 1.5 0.0 0.0
+            key = 5.3 0.5 0.0 0.0
+            key = 8.0 0.0 0.0 0.0
         }
     }
 }
@@ -64,16 +97,27 @@
 
 @PART[roverWheel3]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.750
+    %RSSROConfig = True
+    @mass = 0.75
 
     @MODULE[ModuleWheelMotor]
     {
+        %wheelSpeedMax = 16.0
         @idleDrain = 0
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 8
+            @rate = 8.0
+        }
+
+        !torqueCurve,*{}
+
+        torqueCurve
+        {
+            key = 0.0  2.0 0.0 0.0
+            key = 5.3  1.5 0.0 0.0
+            key = 10.6 0.5 0.0 0.0
+            key = 16.0 0.0 0.0 0.0
         }
     }
 }
@@ -84,10 +128,10 @@
 
 @PART[SmallGearBay]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@maxTemp = 1000
-	@mass = 0.04
-	%skinMaxTemp = 1500
+    %RSSROConfig = True
+    @maxTemp = 1000
+    @mass = 0.04
+    %skinMaxTemp = 1500
 
     @MODULE[ModuleLight]
     {
@@ -101,8 +145,8 @@
 
 @PART[GearFixed]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.015
+    %RSSROConfig = True
+    @mass = 0.015
 }
 
 //  ==================================================
@@ -111,8 +155,8 @@
 
 @PART[GearFree]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.01
+    %RSSROConfig = True
+    @mass = 0.01
 }
 
 //  ==================================================
@@ -121,10 +165,10 @@
 
 @PART[GearSmall]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.16
-	@maxTemp = 1500
-	%skinMaxTemp = 2500
+    %RSSROConfig = True
+    @mass = 0.16
+    @maxTemp = 1500
+    %skinMaxTemp = 2500
 
     @MODULE[ModuleLight]
     {
@@ -138,10 +182,10 @@
 
 @PART[GearMedium]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.48
-	@maxTemp = 1500
-	%skinMaxTemp = 2500
+    %RSSROConfig = True
+    @mass = 0.48
+    @maxTemp = 1500
+    %skinMaxTemp = 2500
 
     @MODULE[ModuleLight]
     {
@@ -155,10 +199,10 @@
 
 @PART[GearLarge]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	@mass = 0.9
-	@maxTemp = 1800
-	%skinMaxTemp = 2500
+    %RSSROConfig = True
+    @mass = 0.9
+    @maxTemp = 1800
+    %skinMaxTemp = 2500
 
     @MODULE[ModuleLight]
     {


### PR DESCRIPTION
**Change log:**

* Reduce the maximum attainable speed of the stock wheels (were too high for their applications).

**Notes:**

* 1 m/s equals to 3.6 km/h or 2.23 miles/h.
* The speed limits are summarized below:

|                   Wheel Name                 | Maximum Attainable Speed |                 Modeled After                 |
|:------------------------------------:|:----------------------------:|:-------------------------------------:|
|              RoveMax Model S2            |                  2 m/s                 |         Generic unmanned rovers        |
|             RoveMax Model M1           |                  4 m/s                 |                    Apollo LRV                    |
| TR-2L Ruggedized Vehicular Wheel |                  8 m/s                 |  Future manned Lunar/Mars rovers  |
|             RoveMax Model XL3           |                 16 m/s                |  Future cargo Lunar/Mars rovers      |

These may seem low compared to stock but remember that:

* These wheels are **rover** wheels and not drag racing ones (like in stock).
* They already have speed values much higher than the maximum for most rover vehicles (Lunokhod: 0.55 m/s, Apollo LRV: 5m/s, MER: 0.05 m/s, MSL: 0.025 m/s), although this is fine from a game-play perspective.