### PR TITLE
[Maintenance] Trim the size and position of some plumes

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
@@ -9,9 +9,9 @@
         name = Kerolox-Lower
         transformName = thrustTransform
         plumePosition = 0.0, 0.0, -0.075
-        plumeScale = 0.65
+        plumeScale = 0.55
         flarePosition = 0.0, 0.0, -0.45
-        flareScale = 0.85
+        flareScale = 0.7
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 1.0

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
@@ -8,10 +8,10 @@
     {
         name = Kerolox-Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.125
-        plumeScale = 1.5
-        flarePosition = 0.0, 0.0, -0.75
-        flareScale = 1.5
+        plumePosition = 0.0, 0.0, 0.15
+        plumeScale = 1.3
+        flarePosition = 0.0, 0.0, -0.65
+        flareScale = 1.25
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 0.5

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
@@ -8,10 +8,10 @@
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.4
+        plumePosition = 0.0, 0.0, 0.35
         plumeScale = 0.25
-        flarePosition = 0.0, 0.0, -0.85
-        flareScale = 0.05
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 0.0
         smokePosition = 0.0, 0.0, 0.0
         localRotation = 0.0, 0.0, 0.0
         emissionMult = 0.75
@@ -23,10 +23,10 @@
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.05
-        plumeScale = 0.2
-        flarePosition = 0.0, 0.0, -0.55
-        flareScale = 0.075
+        plumePosition = 0.0, 0.0, -0.01
+        plumeScale = 0.25
+        flarePosition = 0.0, 0.0, -0.6
+        flareScale = 0.055
         smokePosition = 0.0, 0.0, 0.0
         localRotation = 0.0, 0.0, 0.0
         emissionMult = 0.75


### PR DESCRIPTION
**Change log:**

* Fix the scaling of the RealEngines NK-9 and NK-9V engines (the scaling of the part models was corrected).
* Tweak a bit more the Squad 2 kN generic thruster plumes (SmokeScreen does not like slow KSP frame rates).