### PR TITLE
RN fix soyuz descent pods

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
@@ -1628,60 +1628,6 @@
 	{ }
 	!RESOURCE[WasteWater]
 	{ }
-	!RESOURCE[SolidFuel]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 20
-		@maxThrust = 20
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = HTP
-			@ratio = 1.0
-			%DrawGauge = True
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 110
-			@key,1 = 1 97
-		}
-		%ullage = False
-		%pressureFed = False
-		%ignitions = 1
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.500
-		}
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = DM
-		modded = false
-		CONFIG
-		{
-			name = DM
-			minThrust = 20
-			maxThrust = 20
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = HTP
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 110
-				key = 1 97
-			}
-		}
-	}
 	
 	MODULE
 	{
@@ -1853,9 +1799,6 @@
 	{ }
 	!MODULE[DescentModeModule]
 	{ }
-	!RESOURCE[SolidFuel]
-	{
-	}
 	!RESOURCE[Food]
 	{ }
 	!RESOURCE[Water]
@@ -1868,49 +1811,7 @@
 	{ }
 	!RESOURCE[WasteWater]
 	{ }
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 20
-		@maxThrust = 20
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = HTP
-			@ratio = 1.0
-			%DrawGauge = True
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 110
-			@key,1 = 1 97
-		}
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = DM
-		modded = false
-		CONFIG
-		{
-			name = DM
-			minThrust = 20
-			maxThrust = 20
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = HTP
-				ratio = 1.0
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 110
-				key = 1 97
-			}
-		}
-	}
-	
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/R7/r7_sepmotors.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/R7/r7_sepmotors.cfg
@@ -38,6 +38,26 @@
         %powerEffectName = Solid-Sepmotor
 	}
 }
+@PART[ok_sa|rn_zond_sa]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+{
+    PLUME
+    {
+        name = Solid-Sepmotor            //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1.5                      //Adjust length of plume
+        speed = 1                       //Adjust speed on resize, 
+                                        //generally close to 1:1 with scale.
+    }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+        !fxOffset = DELETE
+        %powerEffectName = Solid-Sepmotor
+	}
+}
 @PART[rn_r7_blok_bvgd|rn_r7_blok_bvgd_2|rn_r7_blok_bvgd_3|rn_r7_blok_bvgd_4|rn_r7_blok_bvgd_5|rn_r7_blok_bvgd_6|rn_r7_blok_bvgd_7|rn_r7_blok_bvgd_8|rn_r7_blok_bvgd_9|rn_r7_blok_bvgd_10|rn_r7_blok_bvgd_11|rn_r7_blok_bvgd_12|rn_r7_blok_bvgd_13|rn_r7_blok_bvgd_14]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME


### PR DESCRIPTION
-I don't know what happened with this somehow the module got duplicated.
-Removed duplicate engines modules, restored solid fuel, and fixed
plume.
--Pod should autoburn at 7m off the ground if player has rnmodules.dll
somewhere in their install.