### PR TITLE
[Mod Support] KTDU-35 global engine configuration

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/KTDU35.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU35.cfg
@@ -1,0 +1,179 @@
+//  ==================================================
+//  KTDU-35 propulsion system global engine configuration.
+
+//  Inert Mass: 305 Kg
+//  Throttle Range: N/A
+//  O/F Ratio: 1.85
+//  Burn Time: 500 s
+
+//  Sources:
+
+//  LPRE - Isaev Design Bureau propulsion systems: http://lpre.de/kbhm/index.htm
+//  Norbert Brügge - Isaev Design Bureau KDUs:     http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
+//  Encyclopedia Astronautica - KTDU-35:           http://www.astronautix.com/k/ktdu-35.html
+//  Encyclopedia Astronautica - KTDU-66:           http://www.astronautix.com/k/ktdu-66.html
+
+//  Used by:
+
+//  * RealEngines pack
+
+//  Notes:
+
+//  * The KTDU-35 propulsion system in reality consists of a S5.60
+//    main engine (SKD) and a S5.35 backup engine (DKD).
+//  ==================================================
+
+@PART[*]:HAS[#engineType[KTDU35]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = KTDU-35
+    %manufacturer = Isaev Design Bureau
+    %description = The KTDU-35 is a gas generator hypergolic propulsion system, capable of multiple ignitions and used on the first generation Soyuz and Progress spacecrafts (the 7K series). It consists of the single nozzle S5.60 main engine and the dual nozzle S5.35 backup engine. In the case of a failure of the main engine, the backup one assumes it's position. Diameter: 1.0 m.
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 4.09
+        @maxThrust = 4.09
+        %heatProduction = 1
+        @allowShutdown = True
+        %EngineType = LiquidFuel
+        @useEngineResponseSpeed = False
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
+        @useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 25
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleGimbal],*{}
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = S5_60
+        engineID = MainEngine
+        isMaster = True
+        origMass = 0.305
+
+        CONFIG
+        {
+            name = S5_60
+            minThrust = 4.09
+            maxThrust = 4.09
+            heatProduction = 1
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 25
+
+            OtherModules
+            {
+                BackupEngine = S5_35
+            }
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.5052
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = AK27
+                ratio = 0.4948
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 278
+                key = 1 100
+            }
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = S5_35
+        engineID = BackupEngine
+        isMaster = False
+
+        CONFIG
+        {
+            name = S5_35
+            minThrust = 4.03
+            maxThrust = 4.03
+            heatProduction = 1
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 25
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.5052
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = AK27
+                ratio = 0.4948
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 270
+                key = 1 100
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  KTDU-35 propulsion system global engine configuration.
+
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[KTDU-35]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = KTDU-35
+        ratedBurnTime = 500
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.995
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.995
+    }
+}


### PR DESCRIPTION
**Change log:**

* Add the KTDU-35 propulsion system global engine configuration (required by the RealEngines pack).

**Notes:**

* The TestFlight config is a generic one but these engines probably never failed though.