### PR TITLE
[Mod Support] RealEngines KTDU-35

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -40,7 +40,7 @@
 //  NPO Energomash - RD-180 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd180/
 //  AIAA - RD-180 Engine Production and Flight Experience: http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3998.pdf
 //  AIAA - RD-180 Engine Development and Characteristics:  http://my.fit.edu/~dkirk/4262/RD180_Presentation.pdf
-//  Liquid Propellant Rocket Engines - RD-180 engine:      http://www.lpre.de/energomash/RD-180/index.htm
+//  LPRE - RD-180 engine:                                  http://www.lpre.de/energomash/RD-180/index.htm
 //  Encyclopedia Astronautica - RD-180 engine:             http://www.astronautix.com/r/rd-180.html
 
 //  NPO Energomash - RD-191 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd191/
@@ -67,6 +67,10 @@
 //  KB KhIMMASH - S5.92 engine:                            http://kbhmisaeva.ru/main.php?id=53
 //  Encyclopedia Astronautica - S5.92 engine:              http://www.astronautix.com/s/s592.html
 
+//  Norbert Brügge - Isaev Design Bureau KDUs:             http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
+//  Encyclopedia Astronautica - KTDU-35:                   http://www.astronautix.com/k/ktdu-35.html
+//  Encyclopedia Astronautica - KTDU-66:                   http://www.astronautix.com/k/ktdu-66.html
+
 //  Encyclopedia Astronautica - RD-0105 engine:            http://astronautix.com/r/rd-0105.html
 //  Encyclopedia Astronautica - RD-0109 engine:            http://astronautix.com/r/rd-0109.html
 
@@ -77,6 +81,10 @@
 //  Encyclopedia Astronautica - NK-31 engine:              http://www.astronautix.com/n/nk-31.html
 //  Encyclopedia Astronautica - NK-39 engine:              http://www.astronautix.com/n/nk-39.html
 
+//  Yuzhnoye Design Office - RD-856 vernier engine:        http://www.yuzhnoye.com/en/technique/rocket-engines/steering/rd-856/
+//  Encyclopedia Astronautica - RD-856 vernier engine:     http://www.astronautix.com/r/rd-856.html
+
+//  LPRE - Isaev Design Bureau propulsion systems:         http://lpre.de/kbhm/index.htm
 //  Norbert Brügge - Russian rocket engines:               http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 
 //  ==================================================
@@ -1915,10 +1923,11 @@
 
     @MODULE[ModuleGimbal]
     {
-        %gimbalRangeYP = 6.0
-        %gimbalRangeYN = 6.0
-        %gimbalRangeXP = 6.0
-        %gimbalRangeXN = 6.0
+        %gimbalRange = 6.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
     }
 
     !RESOURCE,*{}
@@ -2156,6 +2165,95 @@
 }
 
 //  ==================================================
+//  KTDU-35 propulsion system.
+
+//  Dimensions: 0.88 m x 1.1 m
+//  Gross Mass: 305 Kg
+//  ==================================================
+
++PART[S5_92fversion]:FOR[RealismOverhaul]
+{
+    @name = RO-RealEngines-KTDU35
+
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.25, 1.25, 1.25
+    }
+
+    @node_stack_top = 0.0, 0.195, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.92, 0.0, 0.0, -1.0, 0.0, 1
+
+    @mass = 0.305
+    @tags = ascent isaev KTDU-35 launch progress propuls rocket S5.35 S5.60 soyuz vac
+
+    %engineType = KTDU35
+
+    //  Main engine (S5.60).
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        %engineID = MainEngine
+        @minThrust = 4.09
+        @maxThrust = 4.09
+        @heatProduction = 1
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 25
+        %stagingEnabled = True
+
+        @PROPELLANT[UDMH]
+        {
+            @ratio = 0.5052
+        }
+
+        @PROPELLANT[NTO]
+        {
+            @name = AK27
+            @ratio = 0.4948
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 278
+            @key,1 = 1 100
+        }
+    }
+
+    //  Backup engine (S5.35).
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+    {
+        %engineID = BackupEngine
+        @minThrust = 4.03
+        @maxThrust = 4.03
+        @heatProduction = 1
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 25
+        %stagingEnabled = False
+
+        @PROPELLANT[UDMH]
+        {
+            @ratio = 0.5052
+        }
+
+        @PROPELLANT[NTO]
+        {
+            @name = AK27
+            @ratio = 0.4948
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 270
+            @key,1 = 1 100
+        }
+    }
+}
+
+//  ==================================================
 //  NK-9 engine.
 
 //  Dimensions: 1.1 m x 2.9 m
@@ -2355,25 +2453,48 @@
     }
 }
 
-/// Extras
-// RD-856
+//  ==================================================
+//  RD-856 vernier engine.
+
+//  Dimensions: 0.3 m x 0.66 m
+//  Inert Mass: 28 Kg
+//  ==================================================
+
 +PART[STEERING_MOTOR_RD0110engine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
     @name = RO-RealEngines-RD-856
 
     %RSSROConfig = True
-    //%rescaleFactor = 1.0 // FIXME
-    
-    @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
-    
+
+    @MODEL
+    {
+        @scale = 0.923, 0.923, 0.923
+    }
+
+    @mass = 0.028
+    @bulkheadProfiles = srf
+    @tags = ascent cyclone icbm launch propuls R-36 RD-856 rocket vac tsyklon vernier
+
+    %engineType = RD856
+
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
+        @PROPELLANT[Kerosene]
+        {
+            @name = UDMH
+            @ratio = 0.4807
+        }
+
+        @PROPELLANT[LqdOxygen]
+        {
+            @name = NTO
+            @ratio = 0.5193
+        }
+
+        @atmosphereCurve
+        {
+            @key,1 = 0 280
+            @key,0 = 1 84
+        }
     }
-    
-    %engineType = RD856
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/KTDU35.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/KTDU35.cfg
@@ -1,0 +1,56 @@
+//  ==================================================
+//  KTDU-35 propulsion system plume setup.
+//  ==================================================
+
+@PART[RO-RealEngines-KTDU35]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hypergolic-Upper
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.15
+        plumeScale = 0.5
+        flarePosition = 0.0, 0.0, 0.2
+        flareScale = 0.45
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.25
+    }
+
+    PLUME
+    {
+        name = Hypergolic-OMS-Red
+        transformName = tt2
+        plumePosition = 0.0, 0.0, 0.4
+        plumeScale = 0.15
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 0.0
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
+    {
+        %powerEffectName = Hypergolic-Upper
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#engineID[BackupEngine]]
+    {
+        %powerEffectName = Hypergolic-OMS-Red
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD-856.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD-856.cfg
@@ -8,10 +8,10 @@
     {
         name = Hypergolic-Vernier
         transformName = thrustTransform2
-        plumePosition = 0.0, 0.0, -0.15
-        plumeScale = 2.5
+        plumePosition = 0.0, 0.0, 0.975
+        plumeScale = 1.3
         flarePosition = 0.0, 0.0, 1.0
-        flareScale = 1.0
+        flareScale = 0.0
         localRotation = 0.0, 0.0, 0.0
         fixedScale = 1.0
         energy = 0.5
@@ -23,7 +23,6 @@
     {
         %powerEffectName = Hypergolic-Vernier
         !runningEffectName = NULL
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]


### PR DESCRIPTION
**Change log:**

* Add the KTDU-35 propulsion system (used on the first generation Soyuz and Progress spacecrafts).
* Update the RD-856 extras config (new size and tags).
* Tweak the appearance of the RD-856 plume (due to resizing).

**Notes:**

* KTDU-35 global engine config: https://github.com/KSP-RO/RealismOverhaul/pull/1729
* RD-856 global engine config: https://github.com/KSP-RO/RealismOverhaul/pull/1728