### PR TITLE
Add TestFlight config for RD-180 (and 170/191)

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
@@ -220,3 +220,55 @@ PARTUPGRADE
 	
 	deleteme = 1
 }
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-170]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-170
+		ratedBurnTime = 129
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.94
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-171]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-171
+		ratedBurnTime = 129
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.94
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-171M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-171M
+		ratedBurnTime = 129
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.94
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-172-173]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-172-173
+		ratedBurnTime = 226
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -84,7 +84,7 @@
 	TESTFLIGHT
 	{
 		name = RD-180
-		ratedBurnTime = 220
+		ratedBurnTime = 226
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -78,3 +78,16 @@
 		isTweakable = False
 	}
 }
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-180]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-180
+		ratedBurnTime = 220
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
@@ -228,3 +228,55 @@ PARTUPGRADE
 	
 	deleteme = 1
 }
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-191]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-191
+		ratedBurnTime = 226
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-151]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-151
+		ratedBurnTime = 226
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-181]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-181
+		ratedBurnTime = 226
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-193]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-193
+		ratedBurnTime = 226
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}


### PR DESCRIPTION
Burn time estimated from Atlas user guide, plus allowance for documented 1 in 70 loss of performance in late burn.