### PR TITLE
[Maintenance] Coatl Aerospace RCS updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -51,7 +51,7 @@
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = False
-    %useRcsCostMult = 0.1
+    %RcsNozzles = 24
 
     @MODULE[ModuleCommand]
     {
@@ -387,7 +387,7 @@
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = False
-    %useRcsCostMult = 0.1
+    %RcsNozzles = 16
 
     //  Average avionics power consumption 500 W.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -263,7 +263,7 @@
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
-    %useRcsCostMult = 0.25
+    %RcsNozzles = 2
 
     @MODULE[ModuleRCS*]
     {
@@ -318,7 +318,7 @@
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
-    %useRcsCostMult = 0.25
+    %RcsNozzles = 2
 
     @MODULE[ModuleRCS*]
     {
@@ -373,7 +373,7 @@
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
-    %useRcsCostMult = 0.25
+    %RcsNozzles = 4
 
     @MODULE[ModuleRCS*]
     {
@@ -434,7 +434,7 @@
 
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
-    %useRcsCostMult = 0.25
+    %RcsNozzles = 4
 
     @MODULE[ModuleRCS*]
     {
@@ -489,6 +489,7 @@
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = True
+    %RcsNozzles = 1
 
     @MODULE[ModuleRCS*]
     {
@@ -543,6 +544,7 @@
 
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = True
+    %RcsNozzles = 4
 
     @MODULE[ModuleRCS*]
     {
@@ -601,7 +603,7 @@
 
     %useRcsConfig = RCSBlockDouble
     %useRcsMass = True
-    %useRcsCostMult = 0.25
+    %RcsNozzles = 3
 
     @MODULE[ModuleRCS*]
     {
@@ -626,7 +628,7 @@
         @exhaustDamage = True
         @minThrust = 0.485
         @maxThrust = 1.618
-        @heatProduction = 100
+        @heatProduction = 11
         %ullage = False
         %pressureFed = True
         %ignitions = -1

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -56,7 +56,7 @@
 
     %useRcsConfig = RCSBlockDouble
     %useRcsCostMult = 0.25
-    %useRcsMass = True
+    %RcsNozzles = 1
 
     @MODULE[ModuleEngines*]
     {
@@ -874,7 +874,7 @@
     {
         @minThrust = 9.86
         @maxThrust = 18.89
-        @heatProduction = 100
+        @heatProduction = 35
         %ullage = True
         %pressureFed = False
         %ignitions = 50
@@ -921,7 +921,7 @@
             name = KTDU-425A
             minThrust = 9.86
             maxThrust = 18.89
-            heatProduction = 100
+            heatProduction = 35
             gimbalRange = 5.0
             massMult = 1.0
             ullage = True
@@ -934,14 +934,14 @@
                 amount = 0.01
             }
 
-            PROPELLANT[LiquidFuel]
+            PROPELLANT
             {
                 name = UDMH
                 ratio = 0.4782
                 DrawGauge = True
             }
 
-            PROPELLANT[Oxidizer]
+            PROPELLANT
             {
                 name = NTO
                 ratio = 0.5218


### PR DESCRIPTION
**Change log:**

* Update the RCS parts for the new global RCS patching system.
* Tweak the heat production of some engines.
* Fix some other stupid typos...

**Notes:**

* The SSTL-150 and LM-DS spacecraft buses have 24 and 16 RCS nozzles respectively. I hope that defining the same amount of nozzles is the correct thing to do (@NathanKell ?).