### PR TITLE
Gemini Life Support

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -364,22 +364,22 @@
 		%conversionRate = 2.0	// # of people - Figures based on per/person
 		//inputResources = CarbonDioxide, 0.006216, ElectricCharge, 0.010, LithiumHydroxide, 0.00001189
 		//outputResources = Waste, 0.00003932, false
-		%INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
 			%ResourceName = ElectricCharge
 			%Ratio = 0.1
 		}
-		%INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
 			%ResourceName = CarbonDioxide
 			%Ratio = 0.006216
 		}
-		%INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
 			%ResourceName = LithiumHydroxide
 			%Ratio = 0.00001189
 		}
-		%OUTPUT_RESOURCE
+		OUTPUT_RESOURCE
 		{
 			%ResourceName = Waste
 			%Ratio = 0.00003932


### PR DESCRIPTION
I noticed that when there is a % in front of the INPUT_RESOURCE and OUTPUT_RESOURCE, for some reason no EC was being used and no CO2 was being removed when the AirFilter was turned on.  I'm not sure why the problem only existed for those two resources (Lithium was being used and Waste was being generated) but everything appears to work when I removed the %.