### PR TITLE
FASA Atlas correction

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Atlas.cfg
@@ -217,18 +217,19 @@
 	@title = Atlas SLV-3C/D Fuel Tank
 	@description = The fuel tank for the Atlas SLV-3C/D. Historically used with the Centaur D1 to send 1.75T (3C) or 1.80T (3D) to GTO.  Reduce fuel by 3t to setup the earlier 3C.
 	@mass = 2.392	// Adjust mass so that empty mass of tank, decoupler, LR105-NA6 engine and 8x small seperation motors adds up to 3.534t which was dry mass (including residuals) of AC-13
+	// Volume set to match values from AC-13
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume = 111483.1
 		@TANK[Kerosene]
 		{
-			@amount = 35700.2
-			@maxAmount = 35700.2
+			@amount = 35788.9
+			@maxAmount = 35788.9
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 75552.7
-			@maxAmount = 75552.7
+			@amount = 75694.2
+			@maxAmount = 75694.2
 		}
 	}
 }
@@ -259,13 +260,13 @@
 		@volume = 99267.0
 		@TANK[Kerosene]
 		{
-			@amount = 35788.9
-			@maxAmount = 35788.9
+			@amount = 31122.4
+			@maxAmount = 31122.4
 		}
 		@TANK[LqdOxygen]
 		{
-			@amount = 75694.2
-			@maxAmount = 75694.2
+			@amount = 68144.6
+			@maxAmount = 68144.6
 		}
 	}
 }


### PR DESCRIPTION
I just noticed that when I submitted #1434 awhile back, I transposed the fuel quantities for the LV-3C and SLV-3C tanks.  Volumes on both tanks were set correctly.  Only fuel quantities were transposed.  This corrects that mistake.