### PR TITLE
Fix (part of) SHIP LR91

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SHIP/Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SHIP/Engines.cfg
@@ -205,6 +205,30 @@
 
 	%engineType = LR91
 
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 355.9
+		@maxThrust = 355.9
+		%engineID = mainEngine
+		@heatProduction = 100
+		@atmosphereCurve
+		{
+			@key,0 = 0 308
+			@key,1 = 1 160
+		}
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.421
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.578
+		}
+		!IGNITOR_RESOURCE,* {}
+	}
+
 	// Vernier
 	MODEL
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SHIP/Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SHIP/Engines.cfg
@@ -5,16 +5,16 @@
 @PART[SHIP_LR_71]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	@node_stack_top = 0.0, 1.27, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -2.3, 0.0, 0.0, -1.0, 0.0, 1
-	
+
 	@rescaleFactor = 0.87
-	
+
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
-	
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
 
@@ -32,13 +32,13 @@
 {
 	@name = SHIP_E1
 	%RSSROConfig = True
-	
+
 	@rescaleFactor *= 1.4
-	
+
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
-	
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
 
@@ -55,13 +55,13 @@
 @PART[SHIP_HG_3_SL]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	%mass = 1.578501
 	%maxTemp = 1973.15
-	
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
-	
+
 	%engineType = HG3
 }
 
@@ -72,10 +72,10 @@
 @PART[SHIP_HG_3_VAC]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	%mass = 1.578501
 	%maxTemp = 1973.15
-	
+
 	@MODULE[ModuleEngines*]
 	{
 		@atmosphereCurve
@@ -84,10 +84,10 @@
 			@key,1 = 1 280
 		}
 	}
-	
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
-	
+
 	%engineType = HG3
 }
 
@@ -98,15 +98,15 @@
 @PART[SHIP_LR_87_3579]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
-	
-	
+
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
-	
+
 	%engineType = LR87
 	%engineTypeMult = 2
 	%clusterMultiplier = 1.5 // 2 engines, but ganged together. 1.5 is about right.
@@ -115,7 +115,7 @@
 @PART[SHIP_LR_87_3579]:AFTER[RealismOverhaulEnginesPost]
 {
 	@title = LR87-AJ-3, 5, 7, 9
-	@MODULE[ModuleEngineConfigs] 
+	@MODULE[ModuleEngineConfigs]
 	{
 		!CONFIG[LR87-AJ-11] {}
 		!CONFIG[LR87-AJ-11A] {}
@@ -130,15 +130,15 @@
 @PART[SHIP_LR_87_11]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
-	
-	
+
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
-	
+
 	%engineType = LR87
 	%engineTypeMult = 2
 	%clusterMultiplier = 1.5 // 2 engines, but ganged together. 1.5 is about right.
@@ -147,7 +147,7 @@
 @PART[SHIP_LR_87_11]:AFTER[RealismOverhaulEnginesPost]
 {
 	@title = LR87-AJ-11, 11A
-	@MODULE[ModuleEngineConfigs] 
+	@MODULE[ModuleEngineConfigs]
 	{
 		!CONFIG[LR87-AJ-3] {}
 		!CONFIG[LR87-AJ-5] {}
@@ -166,15 +166,15 @@
 @PART[SHIP_LR_87_LH2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
-	
-	
+
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
-	
+
 	%engineType = LR87LH2
 	%engineTypeMult = 2
 	%clusterMultiplier = 1.5 // 2 engines, but ganged together. 1.5 is about right.
@@ -187,24 +187,24 @@
 @PART[SHIP_LR_91]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	%RSSROConfig = True
-	
+
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
-	
+
 	!mesh = DEL
-	
+
 	MODEL
 	{
 		model = SHIP/ENGINES/LR_91/model
 	}
-	
-	
+
+
 	!MODULE[ModuleEngineConfigs] {}
 	!MODULE[ModuleEngineIgnitor] {}
-	
+
 	%engineType = LR91
-	
+
 	// Vernier
 	MODEL
 	{
@@ -247,4 +247,3 @@
 		gimbalRange = 35
 	}
 }
-


### PR DESCRIPTION
The engine having the wrong engineID was causing bad things to happen.

Doesn't fix the gimbal transform oriented the wrong way, plume in the wrong place, and who knows if the vernier actually works