### PR TITLE
[Bug Fix] CMES Orion parachute pack

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -950,17 +950,17 @@
         @fullyDeployedDrag = 500
         @minAirPressureToOpen = 0.04
         @clampMinAirPressure = 0.04
-        @deployAltitude = 1000
-        @deploymentSpeed = 0.12
-        @semiDeploymentSpeed = 0.5
+        @deployAltitude = 1250
+        @deploymentSpeed = 6
+        @semiDeploymentSpeed = 2
         @chuteMaxTemp = 400
     }
 
-    %MODULE
+    MODULE
     {
-        %name = ModuleDragModifier
-        %dragCubeName = SEMIDEPLOYED
-        %dragModifier = 15
+        name = ModuleDragModifier
+        dragCubeName = SEMIDEPLOYED
+        dragModifier = 15
     }
 
     @MODULE[ModuleDragModifier]


### PR DESCRIPTION
**Change log:**

* Fix the ModuleDragModifier Module Manager patch since it broke the stock parachute module if RealChute was not installed.