### PR TITLE
[Bugfix] Remove the AJ10 Early generator module

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -214,6 +214,10 @@
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-37]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {


### PR DESCRIPTION
**Change log:**

* Remove the alternator module and EC resource from the AJ10 Early variants (can be replicated with the SXT AJ10 part).