### PR TITLE
[Maintenance] R-4D-11 global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
@@ -1,41 +1,120 @@
-// R-4D-11 ESA ATv propulsion
-// RLA
+//  ==================================================
+//  R-4D-11 global engine configuration.
+
+//  Gross Mass: 3.75 Kg
+//  Throttle Range: N/A
+//  Burn Time: 12000 s
+//  O/F Ratio: 1.65
+
+//  Sources:
+
+//  * Aerojet Rocketdyne - Bipropellant Rocket Engines: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+//  * Alternate Wars - Spacecraft Reference Engines:    http://alternatewars.com/BBOW/Space/Reference_Spacecraft_Engines.htm
+//  * Encyclopedia Astronautica - R-4D engine:          http://astronautix.com/r/r-4d.html
+//  * ESA - Automated Transfer Vehicle:                 http://esamultimedia.esa.int/docs/ATV/FS003_12_ATV_updated_launch_2008.pdf
+//  * Spaceflight101 - Automated Transfer Vehicle:      http://spaceflight101.com/spacecraft/atv
+
+//  Used by:
+
+//  * Coatl Aerospace ProbesPlus
+//  * RLA
+
+//  Notes:
+
+//  * These engines have never failed on any of their missions. Reliability is probably a moot point.
+//  * The variant represented here is the "mid-performance" one with an expansion ratio of 164:1.
+//  ==================================================
 
 @PART[*]:HAS[#engineType[R4D11]]:FOR[RealismOverhaulEngines]
 {
-	@title = R-4D-11
-	%manufacturer = Aerojet (GenCorp)
-	@description = 490N thrusters as found as the main propulsion of the ESA ATV, and used as various other control thrusters on numerous vehicles.
-	
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = R-4D-11
-		modded = false
-		origMass = 0.00363
-		CONFIG
-		{
-			name = R-4D-11
-			minThrust = 0.490
-			maxThrust = 0.490
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.50
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.50
-			}
-			atmosphereCurve
-			{
-				key = 0 312
-				key = 1 150
-			}
-		}
-	}
+    %category = Engine
+    %title = R-4D-11
+    %manufacturer = Aerojet (GenCorp)
+    %description = A 490 N bipropellant thruster as found in the propulsion system of the ESA ATV and the Orion MPCV Service Module. Also used in various other propulsion modules on numerous spacecrafts as an apogee or orbital injection motor.
+
+    @MODULE[ModuleEngines*],*
+    {
+        @minThrust = 0.490
+        @maxThrust = 0.490
+        %exhaustDamage = True
+        %heatProduction = 10
+        %EngineType = LiquidFuel
+        %ullage = False
+        %pressureFed = True
+        %ignitions = -1
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = R-4D-11
+        origMass = 0.00375
+
+        CONFIG
+        {
+            name = R-4D-11
+            minThrust = 0.490
+            maxThrust = 0.490
+            heatProduction = 10
+            massMult = 1.0
+            ullage = False
+            pressureFed = True
+            ignitions = -1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.0046
+            }
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4990
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = MON3
+                ratio = 0.5010
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 311
+                key = 1 155
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Test Flight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS@CONFIG[R4D11],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = R-4D-11
+        ratedBurnTime = 12000
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.995
+        ignitionDynPresFailMultiplier = 0.1
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.9985
+    }
 }


### PR DESCRIPTION
**Change log:**

* Add some information and documentation sources.
* Make sure that the editor fields (name, manufacturer, description) will appear even if the part config is missing them.
* Add some generic ModuleEngines patching.
* Add a ModuleEnginesConfig (may be expanded in the future with more variants).
* Change the oxidizer to MON3 and recalculate the O/F ratio.
* Add a TF config.

**Notes:**

* Required by the new Coatl Aerospace Probes+ parts (Cassini).