### PR TITLE
Correct AJ10-190 fuel ratio & SSTU Orion masses

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -8,17 +8,18 @@
 
 //  Sources:
 
-//      Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//      Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//      NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
+//  Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
 //      Orion Service Module:                                       https://en.wikipedia.org/wiki/Orion_Service_Module
 //                                                                  http://oai.dtic.mil/oai/oai?verb=getRecord&metadataPrefix=html&identifier=ADA036741
 //      Orion European Service Module Propulsion System:            https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150023030.pdf
 
 //  Used by:
 
-//      CMES
-//      Squad
+//  * CMES
+//  * Squad
+//  * RealEngines pack
 //  ==================================================
 
 @PART[*]:HAS[#engineType[AJ10_190]]:FOR[RealismOverhaulEngines]
@@ -30,7 +31,21 @@
 
     @MODULE[ModuleEngines*]
     {
+        @minThrust = 26.7
+        @maxThrust = 26.7
+        %heatProduction = 28
         %EngineType = LiquidFuel
+        @useThrustCurve = False
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
+        %ullage = False
+        %pressureFed = True
+        %ignitions = 500
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
     }
 
     @MODULE[ModuleGimbal]
@@ -55,6 +70,7 @@
             name = AJ10-190-OMS
             minThrust = 26.7
             maxThrust = 26.7
+			heatProduction = 28
             massMult = 1.0
             ullage = False
             pressureFed = True
@@ -128,4 +144,22 @@
     !MODULE[ModuleAlternator],*{}
 
     !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-190]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = AJ10-190
+        ratedBurnTime = 1250
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.995
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.995
+        techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -44,12 +44,12 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         modded = False
-        configuration = AJ10-190
+        configuration = AJ10-190-OMS
         origMass = 0.125
 
         CONFIG
         {
-            name = AJ10-190
+            name = AJ10-190-OMS
             minThrust = 26.7
             maxThrust = 26.7
             massMult = 1.0
@@ -72,7 +72,44 @@
 
             PROPELLANT
             {
-                name = MON3
+                name = NTO
+                ratio = 0.5010
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 100
+            }
+        }
+        CONFIG
+        {
+            name = AJ10-190-Orion
+            minThrust = 33.4
+            maxThrust = 33.4
+            massMult = 1.0
+            ullage = False
+            pressureFed = True
+            ignitions = 500
+            techRequired = specializedCommandModules
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4990
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
                 ratio = 0.5010
                 DrawGauge = False
             }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -8,8 +8,8 @@
 
 //  Sources:
 
-//  Norbert Brügge - US Liquid Rocket Engines:				  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//  Alternate Wars - Aerojet General Space Engines:			 http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
 //  NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
 //	  Orion Service Module:									   https://en.wikipedia.org/wiki/Orion_Service_Module
 //																  http://oai.dtic.mil/oai/oai?verb=getRecord&metadataPrefix=html&identifier=ADA036741
@@ -24,84 +24,84 @@
 
 @PART[*]:HAS[#engineType[AJ10_190]]:FOR[RealismOverhaulEngines]
 {
-	%category = Engine
-	%title = AJ10-190
-	%manufacturer = Aerojet Rocketdyne
-	%description = Low thrust pressure-fed hypergolic engine. It was used on the Space Shuttle for orbital insertion, maneuvering and deorbiting. Currently used by the Orion MPCV. Diameter: [1.17 m].
+    %category = Engine
+    %title = AJ10-190
+    %manufacturer = Aerojet Rocketdyne
+    %description = Low thrust pressure-fed hypergolic engine. It was used on the Space Shuttle for orbital insertion, maneuvering and deorbiting. Currently used by the Orion MPCV. Diameter: [1.17 m].
 
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 26.7
-		@maxThrust = 26.7
-		%heatProduction = 28
-		%EngineType = LiquidFuel
-		@useThrustCurve = False
-		@useEngineResponseTime = False
-		@engineAccelerationSpeed = 0
-		@engineDecelerationSpeed = 0
-		%ullage = False
-		%pressureFed = True
-		%ignitions = 500
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 26.7
+        @maxThrust = 26.7
+        %heatProduction = 28
+        %EngineType = LiquidFuel
+        @useThrustCurve = False
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        @engineDecelerationSpeed = 0
+        %ullage = False
+        %pressureFed = True
+        %ignitions = 500
 
-		!IGNITOR_RESOURCE,*{}
+        !IGNITOR_RESOURCE,*{}
 
-		!thrustCurve,*{}
-	}
+        !thrustCurve,*{}
+    }
 
-	@MODULE[ModuleGimbal]
-	{
-		@gimbalRange = 6.0
-		%useGimbalResponseSpeed = True
-		%gimbalResponseSpeed = 16
-	}
+    @MODULE[ModuleGimbal]
+    {
+        @gimbalRange = 6.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
 
-	!MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleEngineConfigs],*{}
 
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		modded = False
-		configuration = AJ10-190-OMS
-		origMass = 0.125
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        modded = False
+        configuration = AJ10-190-OMS
+        origMass = 0.125
 
-		CONFIG
-		{
-			name = AJ10-190-OMS
-			minThrust = 26.7
-			maxThrust = 26.7
+        CONFIG
+        {
+            name = AJ10-190-OMS
+            minThrust = 26.7
+            maxThrust = 26.7
 			heatProduction = 28
-			massMult = 1.0
-			ullage = False
-			pressureFed = True
-			ignitions = 500
+            massMult = 1.0
+            ullage = False
+            pressureFed = True
+            ignitions = 500
 
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.1
-			}
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
 
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.4943
-				DrawGauge = True
-			}
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4943
+                DrawGauge = True
+            }
 
-			PROPELLANT
-			{
-				name = MON3
-				ratio = 0.5057
-				DrawGauge = False
-			}
+            PROPELLANT
+            {
+                name = MON3
+                ratio = 0.5057
+                DrawGauge = False
+            }
 
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 100
-			}
-		}
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 100
+            }
+        }
 		CONFIG
 		{
 			name = AJ10-190-Orion
@@ -139,11 +139,11 @@
 				key = 1 100
 			}
 		}
-	}
+    }
 
-	!MODULE[ModuleAlternator],*{}
+    !MODULE[ModuleAlternator],*{}
 
-	!RESOURCE,*{}
+    !RESOURCE,*{}
 }
 
 //  ==================================================
@@ -152,14 +152,14 @@
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-190]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-	TESTFLIGHT
-	{
-		name = AJ10-190
-		ratedBurnTime = 1250
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.995
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.995
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
-	}
+    TESTFLIGHT
+    {
+        name = AJ10-190
+        ratedBurnTime = 1250
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.995
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.995
+        techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,6 +61,7 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
+		modded = False
         configuration = AJ10-190-OMS
         origMass = 0.125
 
@@ -69,7 +70,7 @@
             name = AJ10-190-OMS
             minThrust = 26.7
             maxThrust = 26.7
-			heatProduction = 28
+            heatProduction = 28
             massMult = 1.0
             ullage = False
             pressureFed = True

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -11,6 +11,9 @@
 //      Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
 //      Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
 //      NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
+//      Orion Service Module:                                       https://en.wikipedia.org/wiki/Orion_Service_Module
+//                                                                  http://oai.dtic.mil/oai/oai?verb=getRecord&metadataPrefix=html&identifier=ADA036741
+//      Orion European Service Module Propulsion System:            https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150023030.pdf
 
 //  Used by:
 
@@ -66,14 +69,14 @@
             PROPELLANT
             {
                 name = MMH
-                ratio = 0.4990
+                ratio = 0.4943
                 DrawGauge = True
             }
 
             PROPELLANT
             {
-                name = NTO
-                ratio = 0.5010
+                name = MON3
+                ratio = 0.5057
                 DrawGauge = False
             }
 
@@ -103,14 +106,14 @@
             PROPELLANT
             {
                 name = MMH
-                ratio = 0.4990
+                ratio = 0.4943
                 DrawGauge = True
             }
 
             PROPELLANT
             {
-                name = NTO
-                ratio = 0.5010
+                name = MON3
+                ratio = 0.5057
                 DrawGauge = False
             }
 

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -8,12 +8,12 @@
 
 //  Sources:
 
-//  Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//  Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  Norbert Brügge - US Liquid Rocket Engines:				  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Alternate Wars - Aerojet General Space Engines:			 http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
 //  NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
-//      Orion Service Module:                                       https://en.wikipedia.org/wiki/Orion_Service_Module
-//                                                                  http://oai.dtic.mil/oai/oai?verb=getRecord&metadataPrefix=html&identifier=ADA036741
-//      Orion European Service Module Propulsion System:            https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150023030.pdf
+//	  Orion Service Module:									   https://en.wikipedia.org/wiki/Orion_Service_Module
+//																  http://oai.dtic.mil/oai/oai?verb=getRecord&metadataPrefix=html&identifier=ADA036741
+//	  Orion European Service Module Propulsion System:			https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150023030.pdf
 
 //  Used by:
 
@@ -24,125 +24,126 @@
 
 @PART[*]:HAS[#engineType[AJ10_190]]:FOR[RealismOverhaulEngines]
 {
-    %category = Engine
-    %title = AJ10-190
-    %manufacturer = Aerojet Rocketdyne
-    %description = Low thrust pressure-fed hypergolic engine. It was used on the Space Shuttle for orbital insertion, maneuvering and deorbiting. Currently used by the Orion MPCV. Diameter: [1.17 m].
+	%category = Engine
+	%title = AJ10-190
+	%manufacturer = Aerojet Rocketdyne
+	%description = Low thrust pressure-fed hypergolic engine. It was used on the Space Shuttle for orbital insertion, maneuvering and deorbiting. Currently used by the Orion MPCV. Diameter: [1.17 m].
 
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 26.7
-        @maxThrust = 26.7
-        %heatProduction = 28
-        %EngineType = LiquidFuel
-        @useThrustCurve = False
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
-        @engineDecelerationSpeed = 0
-        %ullage = False
-        %pressureFed = True
-        %ignitions = 500
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 26.7
+		@maxThrust = 26.7
+		%heatProduction = 28
+		%EngineType = LiquidFuel
+		@useThrustCurve = False
+		@useEngineResponseTime = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
+		%ullage = False
+		%pressureFed = True
+		%ignitions = 500
 
-        !IGNITOR_RESOURCE,*{}
+		!IGNITOR_RESOURCE,*{}
 
-        !thrustCurve,*{}
-    }
+		!thrustCurve,*{}
+	}
 
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 6.0
-        %useGimbalResponseSpeed = True
-        %gimbalResponseSpeed = 16
-    }
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 6.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
 
-    !MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleEngineConfigs],*{}
 
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        type = ModuleEngines
-        configuration = AJ10-190-OMS
-        origMass = 0.125
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = False
+		configuration = AJ10-190-OMS
+		origMass = 0.125
 
-        CONFIG
-        {
-            name = AJ10-190-OMS
-            minThrust = 26.7
-            maxThrust = 26.7
-            heatProduction = 28
-            massMult = 1.0
-            ullage = False
-            pressureFed = True
-            ignitions = 500
+		CONFIG
+		{
+			name = AJ10-190-OMS
+			minThrust = 26.7
+			maxThrust = 26.7
+			heatProduction = 28
+			massMult = 1.0
+			ullage = False
+			pressureFed = True
+			ignitions = 500
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.1
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
 
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.4943
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4943
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = MON3
-                ratio = 0.5057
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.5057
+				DrawGauge = False
+			}
 
-            atmosphereCurve
-            {
-                key = 0 316
-                key = 1 100
-            }
-        }
-        CONFIG
-        {
-            name = AJ10-190-Orion
-            minThrust = 33.4
-            maxThrust = 33.4
-            massMult = 1.0
-            ullage = False
-            pressureFed = True
-            ignitions = 500
-            techRequired = specializedCommandModules
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 100
+			}
+		}
+		CONFIG
+		{
+			name = AJ10-190-Orion
+			minThrust = 33.4
+			maxThrust = 33.4
+			massMult = 1.0
+			ullage = False
+			pressureFed = True
+			ignitions = 500
+			techRequired = specializedCommandModules
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.1
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
 
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.4943
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4943
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = MON3
-                ratio = 0.5057
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.5057
+				DrawGauge = False
+			}
 
-            atmosphereCurve
-            {
-                key = 0 316
-                key = 1 100
-            }
-        }
-    }
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 100
+			}
+		}
+	}
 
-    !MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleAlternator],*{}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }
 
 //  ==================================================
@@ -151,14 +152,14 @@
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-190]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
-    TESTFLIGHT
-    {
-        name = AJ10-190
-        ratedBurnTime = 1250
-        ignitionReliabilityStart = 0.98
-        ignitionReliabilityEnd = 0.995
-        cycleReliabilityStart = 0.98
-        cycleReliabilityEnd = 0.995
-        techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
-    }
+	TESTFLIGHT
+	{
+		name = AJ10-190
+		ratedBurnTime = 1250
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
+	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,8 +61,7 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-		modded = False
-        configuration = AJ10-190-OMS
+        configuration = AJ10-190
         origMass = 0.125
 
         CONFIG

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,7 +61,6 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-        modded = False
         configuration = AJ10-190-OMS
         origMass = 0.125
 
@@ -70,7 +69,7 @@
             name = AJ10-190-OMS
             minThrust = 26.7
             maxThrust = 26.7
-			heatProduction = 28
+            heatProduction = 28
             massMult = 1.0
             ullage = False
             pressureFed = True

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,7 +61,7 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-        modded = False
+		modded = False
         configuration = AJ10-190-OMS
         origMass = 0.125
 
@@ -102,43 +102,43 @@
                 key = 1 100
             }
         }
-		CONFIG
-		{
-			name = AJ10-190-Orion
-			minThrust = 33.4
-			maxThrust = 33.4
-			massMult = 1.0
-			ullage = False
-			pressureFed = True
-			ignitions = 500
-			techRequired = specializedCommandModules
+        CONFIG
+        {
+            name = AJ10-190-Orion
+            minThrust = 33.4
+            maxThrust = 33.4
+            massMult = 1.0
+            ullage = False
+            pressureFed = True
+            ignitions = 500
+            techRequired = specializedCommandModules
 
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.1
-			}
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
 
-			PROPELLANT
-			{
-				name = MMH
-				ratio = 0.4943
-				DrawGauge = True
-			}
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4943
+                DrawGauge = True
+            }
 
-			PROPELLANT
-			{
-				name = MON3
-				ratio = 0.5057
-				DrawGauge = False
-			}
+            PROPELLANT
+            {
+                name = MON3
+                ratio = 0.5057
+                DrawGauge = False
+            }
 
-			atmosphereCurve
-			{
-				key = 0 316
-				key = 1 100
-			}
-		}
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 100
+            }
+        }
     }
 
     !MODULE[ModuleAlternator],*{}

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,7 +61,7 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-		modded = False
+        modded = False
         configuration = AJ10-190-OMS
         origMass = 0.125
 

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,7 +61,7 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-        configuration = AJ10-190
+        configuration = AJ10-190-OMS
         origMass = 0.125
 
         CONFIG

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -31,7 +31,7 @@
 	@description = The Launch Abort System, or LAS, is positioned atop the Orion crew module. It is designed to protect astronauts if a problem arises during launch by pulling the spacecraft away from a failing rocket. Weighing approximately 16,000 pounds, the LAS can activate within milliseconds to pull the vehicle to safety and position the module for a safe landing. The LAS is comprised of three solid propellant rocket motors: the abort motor, an attitude control motor, and a jettison motor. 
 	@tags ^=:$:, orion, escape, sls, las, abort, orbital, atk, sstu
 	
-	@mass = 2.051
+	@mass = 5.561	// approx 16klbs or 7.3t according to https://www.nasa.gov/sites/default/files/atoms/files/orion_las_fact_sheet_8.5x11_4page_11_19_15.pdf
 	@maxTemp = 1973.15
 	%stagingIcon = DECOUPLER_VERT
 	
@@ -180,7 +180,7 @@
 	%description = An advanced command module that can hold up to 6 crew.
 	@tags ^=:$:, orion, orion-cm, module, command, csm
 	
-	@mass = 6.2471
+	@mass = 8.9461	// launch mass = 10.387t according to https://en.wikipedia.org/wiki/Orion_(spacecraft)
 	%skinMaxTemp = 3200
 	@maxTemp = 500
 	
@@ -494,7 +494,7 @@
 	%description = An advanced command module that can hold up to 6 crew. This version does not have parachutes or a heat shield and is designed to be used for orbital operations only.
 	@tags ^=:$:, orion, orion-cm, module, command, csm
 	
-	@mass = 5.9271 // Less .32 due to no Heatshield
+	@mass = 8.6261 // Less .32 due to no Heatshield
 	%skinMaxTemp = 3200
 	@maxTemp = 500
 	
@@ -709,7 +709,7 @@
 	%description = The Orion Service Module is the service module component of the Orion spacecraft, serving as its primary power and propulsion component until it is discarded at the end of each mission. In January 2013, NASA announced that the European Space Agency (ESA) will construct the service module for Exploration Mission 1, replacing the previous design. Based on ESA's Automated Transfer Vehicle (ATV), the new design is also known as the European Service Module (ESM).
 	@tags ^=:$:, orion, orion-csm, module, service, csm, eus, european
 	
-	@mass = 4.1 // 3.7 // ?
+	@mass = 5.793	// launch mass - 15.461 according to https://en.wikipedia.org/wiki/Orion_(spacecraft)
 	
 	!RESOURCE,* {}
 	MODULE
@@ -722,14 +722,14 @@
 		TANK
 		{
 			name = MON3
-			amount = 4000
-			maxAmount = 4000
+			amount = 4090.07
+			maxAmount = 4090.07
 		}
 		TANK
 		{
 			name = MMH
-			amount = 4000
-			maxAmount = 4000
+			amount = 3997.84
+			maxAmount = 3997.84
 		}
 		TANK
 		{
@@ -963,7 +963,7 @@
         type = ModuleEngines
         modded = False
         configuration = AJ10-190-Orion
-        origMass = 0.125
+        origMass = 5.793	// overrides part mass
 
         CONFIG
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -721,7 +721,7 @@
 	// http://www.esa.int/Our_Activities/Human_Spaceflight/Orion/Propulsion
 		TANK
 		{
-			name = NTO
+			name = MON3
 			amount = 4000
 			maxAmount = 4000
 		}
@@ -760,13 +760,13 @@
 		@PROPELLANT[*],0
 		{
 			%name = MMH
-			%ratio = 0.4990
+			%ratio = 0.4943
 			%resourceFlowMode = NO_FLOW
 		}
 		@PROPELLANT[*],1
 		{
-			%name = NTO
-			%ratio = 0.5010
+			%name = MON3
+			%ratio = 0.5057
 			%resourceFlowMode = NO_FLOW
 		}
 	}
@@ -780,13 +780,13 @@
 		@PROPELLANT[*],0
 		{
 			%name = MMH
-			%ratio = 0.4990
+			%ratio = 0.4943
 			%resourceFlowMode = NO_FLOW
 		}
 		@PROPELLANT[*],1
 		{
-			%name = NTO
-			%ratio = 0.5010
+			%name = MON3
+			%ratio = 0.5057
 			%resourceFlowMode = NO_FLOW
 		}
 		@atmosphereCurve
@@ -984,14 +984,14 @@
             PROPELLANT
             {
                 name = MMH
-                ratio = 0.4990
+                ratio = 0.4943
                 DrawGauge = True
             }
 
             PROPELLANT
             {
-                name = NTO
-                ratio = 0.5010
+                name = MON3
+                ratio = 0.5057
                 DrawGauge = False
             }
 
@@ -1020,14 +1020,14 @@
             PROPELLANT
             {
                 name = MMH
-                ratio = 0.4990
+                ratio = 0.4943
                 DrawGauge = True
             }
 
             PROPELLANT
             {
-                name = NTO
-                ratio = 0.5010
+                name = MON3
+                ratio = 0.5057
                 DrawGauge = False
             }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -721,7 +721,7 @@
 	// http://www.esa.int/Our_Activities/Human_Spaceflight/Orion/Propulsion
 		TANK
 		{
-			name = MON3
+			name = NTO
 			amount = 4000
 			maxAmount = 4000
 		}
@@ -755,18 +755,18 @@
 	@MODULE[ModuleEngines*]
 	{
 	// http://www.esa.int/Our_Activities/Human_Spaceflight/Orion/Propulsion
-		@minThrust = 25.7
-		@maxThrust = 25.7
+		@minThrust = 33.4
+		@maxThrust = 33.4
 		@PROPELLANT[*],0
 		{
 			%name = MMH
-			%ratio = 0.5
+			%ratio = 0.4990
 			%resourceFlowMode = NO_FLOW
 		}
 		@PROPELLANT[*],1
 		{
-			%name = MON3
-			%ratio = 0.5
+			%name = NTO
+			%ratio = 0.5010
 			%resourceFlowMode = NO_FLOW
 		}
 	}
@@ -780,13 +780,13 @@
 		@PROPELLANT[*],0
 		{
 			%name = MMH
-			%ratio = 0.5
+			%ratio = 0.4990
 			%resourceFlowMode = NO_FLOW
 		}
 		@PROPELLANT[*],1
 		{
-			%name = MON3
-			%ratio = 0.5
+			%name = NTO
+			%ratio = 0.5010
 			%resourceFlowMode = NO_FLOW
 		}
 		@atmosphereCurve
@@ -957,6 +957,87 @@
 			PacketResourceCost = 0.01
 		}
 	}
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        modded = False
+        configuration = AJ10-190-Orion
+        origMass = 0.125
+
+        CONFIG
+        {
+            name = AJ10-190-OMS
+            minThrust = 26.7
+            maxThrust = 26.7
+            massMult = 1.0
+            ullage = False
+            pressureFed = True
+            ignitions = 500
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4990
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5010
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 100
+            }
+        }
+        CONFIG
+        {
+            name = AJ10-190-Orion
+            minThrust = 33.4
+            maxThrust = 33.4
+            massMult = 1.0
+            ullage = False
+            pressureFed = True
+            ignitions = 500
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.1
+            }
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4990
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5010
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 316
+                key = 1 100
+            }
+        }
+    }
 }
 @PART[SSTU-SC-C-CM|SSTU-SC-C-CMX|SSTU-SC-C-SM]:FOR[RealismOverhaul]:NEEDS[SSTU&RemoteTech]
 {


### PR DESCRIPTION
From what I can find, the AJ10-190 did not use MMH/MON3 for fuel.  It used MMH/NTO (N2O4).

I'm also finding that the version being used on the Orion MPCV has a higher thrust rating than the version used on the Space Shuttle.