### PR TITLE
wrong docking node type

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_DockingPorts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_DockingPorts.cfg
@@ -116,7 +116,7 @@
 	@mass = 0.3
 	@MODULE[ModuleDockingNode]
 	{
-		@nodeType = ApolloGeneric
+		@nodeType = Apollo
 		%acquireForce = 0.5 // 2
 		%acquireMinFwdDot = 0.8 // 0.7
 		%acquireminRollDot = -3.40282347E+38


### PR DESCRIPTION
Pretty sure Apollo-size docking nodeType should be "Apollo" and not "ApolloGeneric".