### PR TITLE
[Maintenance] RealEnginesPack global engine configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  RD-0110R vernier global engine configuration.
 
-//  Inert Mass: 560 Kg (single vernier engine module)
+//  Inert Mass: 140 Kg (single vernier engine module)
 //  Throttle Range: N/A
 //  O/F Ratio: 2.22
 //  Burn Time: 250 s
@@ -14,6 +14,14 @@
 //  Used by:
 
 //  * RealEngines pack
+
+//  Notes:
+
+//  * Stats refer to a single chamber of the engine.
+//    Multiply by four to get the full stats of the
+//    engine.
+//  * The inert mass does not include any other hardware
+//    (mounting, propellant lines, fairings etc).
 //  ==================================================
 
 @PART[*]:HAS[#engineType[RD0110R]]:FOR[RealismOverhaulEngines]
@@ -25,8 +33,8 @@
 
     @MODULE[ModuleEngines*]
     {
-        %minThrust = 273.2
-        %maxThrust = 273.2
+        %minThrust = 68.3
+        %maxThrust = 68.3
         %heatProduction = 60
         %EngineType = LiquidFuel
         @useThrustCurve = False
@@ -41,7 +49,11 @@
 
     @MODULE[ModuleGimbal],*
     {
-        @gimbalRange = 42.0
+        !gimbalRange = NULL
+        %gimbalRangeXP = 0
+        %gimbalRangeXN = 0
+        %gimbalRangeYP = 42.0
+        %gimbalRangeYN = 42.0
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }
@@ -53,13 +65,13 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = RD-0110R
-        origMass = 0.56
+        origMass = 0.14
 
         CONFIG
         {
             name = RD-0110R
-            minThrust = 273.2
-            maxThrust = 273.2
+            minThrust = 68.3
+            maxThrust = 68.3
             gimbalRange = 42.0
             massMult = 1.0
             ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
@@ -49,7 +49,11 @@
 
     @MODULE[ModuleGimbal],*
     {
-        @gimbalRange = 25.0
+        !gimbalRange = NULL
+        %gimbalRangeXP = 0
+        %gimbalRangeXN = 0
+        %gimbalRangeYP = 25.0
+        %gimbalRangeYN = 25.0
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }

--- a/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  RD-805 global engine configuration.
 
-//  Inert Mass: 120 Kg
+//  Inert Mass: 40 Kg
 //  Throttle Range: N/A
 //  O/F Ratio: 2.5
 //  Burn Time: 1100 s
@@ -15,6 +15,10 @@
 //  Used by:
 
 //  * RealEngines pack
+
+//  Notes:
+
+//  * Can also be identified as RD-802.
 //  ==================================================
 
 @PART[*]:HAS[#engineType[RD805]]:FOR[RealismOverhaulEngines]
@@ -22,13 +26,13 @@
     %category = Engine
     %title = RD-805
     %manufacturer = PA Yuzhmash
-    %description = A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use in upper stages. Diameter: 0.5 m.
+    %description = A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use as a standalone upper stage engine. Diameter: 0.5 m.
 
     @MODULE[ModuleEngines*]
     {
-        %minThrust = 19.61
-        %minThrust = 19.61
-        %heatProduction = 30
+        %minThrust = 19.6
+        %maxThrust = 19.6
+        %heatProduction = 69
         %EngineType = LiquidFuel
         @useThrustCurve = False
         %ullage = True
@@ -54,13 +58,14 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = RD-805
-        origMass = 0.12
+        origMass = 0.04
 
         CONFIG
         {
             name = RD-805
-            minThrust = 19.61
-            minThrust = 19.61
+            minThrust = 19.6
+            maxThrust = 19.6
+            heatProduction = 69
             gimbalRange = 8.0
             massMult = 1.0
             ullage = True
@@ -77,12 +82,6 @@
             {
                 name = ElectricCharge
                 amount = 0.015
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name = TEATEB
-                amount = 0.175
             }
 
             PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
@@ -22,7 +22,7 @@
     %category = Engine
     %title = RD-8
     %manufacturer = PA Yuzhmash
-    %description = The RD-8 is a four-chamber, staged combustion, vacuum kerolox vernier engine. It is used on the second stage of the Zenit launch vehicle family for two-axis attitude control. Diameter: 3.9 m
+    %description = The RD-8 is a four-chamber, staged combustion, vacuum kerolox vernier engine. It is used on the second stage of the Zenit launch vehicle family for two-axis attitude control. Diameter: 3.9 m.
 
     @MODULE[ModuleEngines*]
     {
@@ -42,7 +42,11 @@
 
     @MODULE[ModuleGimbal],*
     {
-        @gimbalRange = 33.0
+        !gimbalRange = NULL
+        %gimbalRangeXP = 0
+        %gimbalRangeXN = 0
+        %gimbalRangeYP = 33.0
+        %gimbalRangeYN = 33.0
         %useGimbalResponseSpeed = True
         %gimbalResponseSpeed = 16
     }
@@ -53,13 +57,13 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-        configuration = RD-8-SI
+        configuration = RD-8
         origMass = 0.38
 
         CONFIG
         {
-            name = RD-8-SI
-            description = Single ignition capability.
+            name = RD-8
+            description = Vernier engine for the Zenit second stage.
             minThrust = 78.44
             maxThrust = 78.44
             gimbalRange = 33.0
@@ -78,51 +82,6 @@
             {
                 name = TEATEB
                 amount = 2.0
-            }
-
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3670
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6330
-                DrawGauge = False
-            }
-
-            atmosphereCurve
-            {
-                key = 0 342
-                key = 1 170
-            }
-        }
-
-        CONFIG
-        {
-            name = RD-8-DI
-            description = Dual ignition capability.
-            minThrust = 78.44
-            maxThrust = 78.44
-            gimbalRange = 33.0
-            massMult = 1.0
-            ullage = True
-            pressureFed = False
-            ignitions = 2
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.06
-            }
-
-            IGNITOR_RESOURCE
-            {
-                name = TEATEB
-                amount = 1.0
             }
 
             PROPELLANT


### PR DESCRIPTION
**Change Log:**

* Update the RD-0110R engine config stats to refer to a single chamber variant.
* Update the RD-805 engine config to not include the structural mass of the RD-8 engine.
* Fix the RD-805 engine config defining "minThrust" instead of "maxThrust".
* Remove an extra TEATEB ignitor resource requirement from the RD-805 engine config.
* Remove the reduntant dual igniton RD-8 config (since it never existed IRL).
* Update the vernier gimbal modules for single axis gimbal only.