### PR TITLE
[Bugfix] RD-100 zero ignitions text

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -74,7 +74,6 @@
         type = ModuleEngines
         configuration = RD-100
         origMass = 0.888
-        literalZeroIgnitions = True
 
         CONFIG
         {


### PR DESCRIPTION
**Change Log:**

* Fix the confusing leftover "Zero Ignitions" text (introduced with https://github.com/KSP-RO/RealismOverhaul/commit/bfa381c75780af993c5ab5814a686ef3ad750409#diff-65ffd9fface05cd86cba6dfba21bb57e)