### PR TITLE
[Maintenance] AJ10-137 global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -1,7 +1,7 @@
 //  ==================================================
 //  AJ10-137 (Apollo SPS) global engine configuration.
 
-//  Inert Mass: - Kg
+//  Inert Mass: 295 Kg
 //  Throttle Range: N/A
 //  Burn Time: 750 s
 //  O/F Ratio: 1.6

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -8,9 +8,10 @@
 
 //  Sources:
 
-//  NTRS - Apollo CSM Propulsion Systems Overview:  https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090015391.pdf
-//  NTRS - Remembering The Giants (chapter 5):      https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027319.pdf
-//  Alternate Wars - Aerojet General Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  NTRS - Apollo Spacecraft Engine Specific Impulse: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700026467.pdf
+//  NTRS - Apollo CSM Propulsion Systems Overview:    https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090015391.pdf
+//  NTRS - Remembering The Giants (chapter 5):        https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027319.pdf
+//  Alternate Wars - Aerojet General Space Engines:   http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
 
 //  Used by:
 
@@ -31,8 +32,8 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 88.96
-		@maxThrust = 88.96
+		@minThrust = 90.0
+		@maxThrust = 90.0
 		%heatProduction = 38
 		%EngineType = LiquidFuel
 		@useThrustCurve = False
@@ -60,8 +61,8 @@
 		CONFIG
 		{
 			name = AJ10-137
-			minThrust = 88.96
-			maxThrust = 88.96
+			minThrust = 90.0
+			maxThrust = 90.0
 			heatProduction = 38
 			gimbalRange = 4.5
 

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -1,48 +1,93 @@
-// AJ10-137 (SPS)
-// Squad, FASA, OLDD, KW, SSTU
-//
-// ------Sources--------
-// http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//
+//  ==================================================
+//  AJ10-137 (Apollo SPS) global engine configuration.
+
+//  Inert Mass: - Kg
+//  Throttle Range: N/A
+//  Burn Time: 750 s
+//  O/F Ratio: 1.6
+
+//  Sources:
+
+//  NTRS - Apollo CSM Propulsion Systems Overview:  https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090015391.pdf
+//  NTRS - Remembering The Giants (chapter 5):      https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100027319.pdf
+//  Alternate Wars - Aerojet General Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+
+//  Used by:
+
+//  * FASA
+//  * KW Rocketry
+//  * OLDD Saturn V
+//  * Squad
+//  * SSTU
+//  ==================================================
+
 @PART[*]:HAS[#engineType[AJ10_137]]:FOR[RealismOverhaulEngines]
 {
-	@title = AJ10-137 (Service Propulsion System)
+	%category = Engine
+	%title = AJ10-137 (Service Propulsion System)
 	%manufacturer = Aerojet
-	@description = The Aerojet AJ10-137 rocket engine used on the Apollo Service Module as the Service Propulsion System. Diameter: [3.9 m].
-	
+	%description = The Aerojet AJ10-137 rocket engine used on the Apollo Service Module as the Service Propulsion System. Diameter: 3.9 m.
+
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 88.96
+		@maxThrust = 88.96
+		%heatProduction = 38
+		%EngineType = LiquidFuel
+		@useThrustCurve = False
+		@useEngineResponseTime = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
+		%ullage = True
+		%pressureFed = True
+		%ignitions = 50
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		modded = false
 		configuration = AJ10-137
-		origMass = 0.2948  // per the above source, this was in pounds, former value is 0.650
+		origMass = 0.295    // Per the above sources, this was in pounds, former value is 0.650.
+
 		CONFIG
 		{
 			name = AJ10-137
-			minThrust = 97.86
-			maxThrust = 97.86
-			heatProduction = 100
+			minThrust = 88.96
+			maxThrust = 88.96
+			heatProduction = 38
+			gimbalRange = 4.5
+
 			PROPELLANT
 			{
 				name = Aerozine50
 				ratio = 0.5017
 				DrawGauge = True
 			}
+
 			PROPELLANT
 			{
 				name = NTO
 				ratio = 0.4983
+				DrawGauge = False
 			}
+
 			atmosphereCurve
 			{
 				key = 0 314
 				key = 1 150
 			}
-			
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 36
+
+			ullage = True
+			pressureFed = True
+			ignitions = 50
+
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -50,13 +95,33 @@
 			}
 		}
 	}
-	!MODULE[ModuleAlternator]
-	{
-	}
+
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
+
 	@MODULE[ModuleGimbal]
 	{
 		@gimbalRange = 4.5
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
+	}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-137]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = AJ10-137
+		ratedBurnTime = 750
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-138:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -17,6 +17,7 @@
 //  * FASA
 //  * KW Rocketry
 //  * OLDD Saturn V
+//  * RealEngines pack
 //  * Squad
 //  * SSTU
 //  ==================================================


### PR DESCRIPTION
**Change Log:**

* Add some general config information and sources.
* Add a default engine module patching pass (for the RealEngines pack).
* Tweak the thrust values (references put the vacuum thrust between 20000 and 20500 lbf - 89 to 91 kN).
* Increase the ignition count (references put the ignition count between 50 and 80).
* Add TestFlight compatibility.

**Notes:**

* Some AJ10 variants (AJ10-101A, AJ10-118D) have been omitted from the TF transfer list.