### PR TITLE
[Maintenance ] AJ10-190 tech transfer

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -8,15 +8,15 @@
 
 //  Sources:
 
-// Norbert Brügge - US Liquid Rocket Engines: 						http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
-//  Alternate Wars - Aerojet General Space Engines:              	http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//  NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: 	http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
+//  Norbert Brügge - US Liquid Rocket Engines:                  http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Alternate Wars - Aerojet General Space Engines:             http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  NSTS Shuttle Reference Manual - ORBITAL MANEUVERING SYSTEM: http://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-oms.html
 
 //  Used by:
 
-//      CMES
-//      Squad
-//		RealEngines
+//  * CMES
+//  * Squad
+//  * RealEngines pack
 //  ==================================================
 
 @PART[*]:HAS[#engineType[AJ10_190]]:FOR[RealismOverhaulEngines]
@@ -58,7 +58,6 @@
     {
         name = ModuleEngineConfigs
         type = ModuleEngines
-        modded = False
         configuration = AJ10-190
         origMass = 0.125
 
@@ -107,7 +106,6 @@
 }
 
 //  ==================================================
-//  AJ10-190 global engine configuration.
 //  TestFlight compatibility.
 //  ==================================================
 
@@ -121,5 +119,6 @@
         ignitionReliabilityEnd = 0.995
         cycleReliabilityStart = 0.98
         cycleReliabilityEnd = 0.995
+        techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
     }
 }


### PR DESCRIPTION
**Change Log:**

* Add TF tech transfer to the AJ10-190 global engine configuration.

**Notes:**

* Interoperates with https://github.com/KSP-RO/RealismOverhaul/pull/1825.