### PR TITLE
Configure BDB X-405H

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Vega.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Vega.cfg
@@ -1,0 +1,119 @@
+// X-405H
+
+@PART[bluedog_Vega_Engine]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @MODEL
+    {
+        %scale = 1.11, 1.11, 1.11
+    }
+
+    %scale = 1.11
+
+    %category = Engine
+    %title = X-405 (XLR50-GE-2)
+    %manufacturer = General Electric (GE)
+    %description = Engine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
+
+    @mass = 0.193
+    @maxTemp = 573.15
+    @skinMaxTemp = 673.15
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        @name = ModuleEnginesRF
+        %maxThrust = 156.3
+        %minThrust = 156.3
+        engineID = Engine
+        %heatProduction = 80
+
+        ullage = True
+        pressureFed = False
+        ignitions = 2
+
+        %runningEffectName:NEEDS[RealPlume,SmokeScreen] = Kerolox-Vernier
+
+        !atmosphereCurve {}
+        atmosphereCurve
+        {
+            // Now Ed Kyle says 311 rather than b14364.de saying 307.
+            key = 0 311 // simmed from RPA given chamber characterists and SL Isp.
+            key = 1 213 // upped Pc to 700 (max for 405)
+        }
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3874
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6126
+        }
+
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0146
+            ignoreForIsp = True
+            DrawGauge = False
+        }
+        !IGNITOR_RESOURCE,* {}
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 0.5
+        }
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform
+            multiplier = 0.98
+        }
+
+        THRUST_TRANSFORM
+        {
+            name = vernierTransform
+
+            // Note - there are really two of them on this model, the normal one and an invisible one on the other side to balance
+            multiplier = 0.01
+        }
+    }
+
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[vernierTransform]] {}
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]] // engine
+    {
+        @gimbalRange = 5.0
+        %useGimbalResponseSpeed = true
+        %gimbalResponseSpeed = 16
+    }
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[vernierTransform]]
+    {
+        @gimbalRange = 25
+        @gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleAlternator],* {}
+    !RESOURCE,* {}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[bluedog_Vega_Engine]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = X-405H
+        ratedBurnTime = 195
+        ignitionReliabilityStart = 0.80
+        ignitionReliabilityEnd = 0.94
+        cycleReliabilityStart = 0.86
+        cycleReliabilityEnd = 0.96
+        techTransfer = X-405:50
+    }
+}


### PR DESCRIPTION
For just the one config, it doesn't seem worth using engineType = X405
and then having another patch to remove the unneeded configs and fix the
thrust.  If we ever end up having multiple X-405H configs per #1819 I
will implement it that way.