### PR TITLE
[Bugfix] Generic RCS thruster mass

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -82,7 +82,6 @@
 	{
 		@origMass *= 0.125
 		nozzleCount = #$../RcsNozzles$
-		@nozzleCount += 4
 		@origMass *= #$nozzleCount$
 		!nozzleCount = NULL
 	}


### PR DESCRIPTION
**Change Log:**

* Remove the extra **nozzleCount** field that breaks the inert mass of the generic linear RCS thrusters.