### PR TITLE
[Mod Support] KTDU-425A global engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/KTDU425A.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU425A.cfg
@@ -1,0 +1,104 @@
+//  ==================================================
+//  KTDU-425A global engine configuration.
+
+//  Inert Mass: 70 Kg
+//  Throttle Range: 52% to 100%
+//  O/F Ratio: 2.0
+//  Burn Time: 560 s
+
+//  Sources:
+
+//  Norbert Brügge - Spacecraft-propulsion blocks (KDU): http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
+//  Encyclopedia Astronautica - KTDU-425A engine:        http://www.astronautix.com/k/ktdu-425a.html
+
+//  Used by:
+
+//  * Coatl Aerospace ProbesPlus
+
+//  Notes:
+
+//  * No reliability data defined yet.
+//  ==================================================
+
+@PART[*]:HAS[#engineType[KTDU425A]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = KTDU-425A
+    %manufacturer = Isayev Design Bureau (Khimmash)
+    %description = A gas generator hypergolic vacuum engine. Designed for use in the propulsion systems of the Mars and Venera 3MV, 4MV and 5MV spacecraft buses.
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 9.86
+        @maxThrust = 18.89
+        @heatProduction = 35
+        %EngineType = LiquidFuel
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 50
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal],*
+    {
+        @gimbalRange = 5.0
+        %useGimbalResponceSpeed = True
+        %gimbalResponceSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = KTDU-425A
+        origMass = 0.07
+
+        CONFIG
+        {
+            name = KTDU-425A
+            minThrust = 9.86
+            maxThrust = 18.89
+            heatProduction = 35
+            gimbalRange = 5.0
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 50
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.01
+            }
+
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.4782
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.5218
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 315
+                key = 1 263
+            }
+        }
+    }
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}


### PR DESCRIPTION
**Change Log:**

* Add the KTDU-425A global engine config (moved from the CoatAerospace ProbesPlus KTDU-425A part config).