### PR TITLE
[Bugfix] SXT Sputnik 1 mass

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -7,18 +7,23 @@
 	{
 	}
 
-        // I'm not sure if we *should* rescale the probe. Advice plz!
+	// I'm not sure if we *should* rescale the probe. Advice plz!
+
 	// %rescaleFactor = 0.624
 	@title = Sputnik PS-1
 	@manufacturer = NPO Energomash
 	@description = The first satellite to orbit the Earth.
 	@node_stack_bottom = 0.0, -0.515425, 0.0, 0.0, -1.0, 0.0, 0
-	@mass = 0.0836
+	@mass = 0.081
+	@maxTemp = 773.15
+	@skinMaxTemp = 873.15
+
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 2851.2
 		@maxAmount = 2851.2
 	}
+
 	@MODULE[ModuleCommand]
 	{
 		@RESOURCE[ElectricCharge]
@@ -26,18 +31,8 @@
 			@rate = 0.001
 		}
 	}
-	!MODULE[ModuleReactionWheel]
-	{
-	}
-	@MODULE[ModuleRTAntennaPassive]
-	{
-		@TechRequired = start
-		@OmniRange = 2000
-		@TRANSMITTER
-		{
-			@PacketResourceCost = 0.01385
-		}
-	}
+
+	!MODULE[ModuleReactionWheel]{}
 }
 
 // Change the Stayputnik to a 50k passive antenna.
@@ -60,10 +55,12 @@
 {
 	%RSSROConfig = True
 	@mass = 0.0005
+	@maxTemp = 773.15
+	@skinMaxTemp = 873.15
 	@title = Sputnik PS-1 Antenna
 	@manufacturer = NPO Energomash
 	@description = Small whip antenna for the Sputnik PS-1 satellite.
-	
+
 	MODULE
 	{
 		name = ModuleDataTransmitter


### PR DESCRIPTION
**Change Log:**

* Fix the gross mass of the SXT Sputnik 1 probe core to match the IRL one at 83 Kg (81 Kg probe + 4 * 0.5 Kg antennae).
* Remove an extra RT patching pass (already done in a separate pass).
* Reduce the max temperatures of the probe core and the antenna to saner values.