### PR TITLE
[Maintenance] RSB updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Agena.cfg
@@ -40,8 +40,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleRCS*]
     {
@@ -188,8 +188,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ares_I.cfg
@@ -28,8 +28,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -51,8 +51,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleCommand]
     {
@@ -217,8 +217,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     //  Three Aerojet Rocketdyne MR-80 (3100 N) RCS thrusters for roll control but only two active at launch (one for redundancy).
 
@@ -302,8 +302,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    @skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     //  Three Aerojet Rocketdyne MR-80 (3100 N) RCS thrusters for roll control.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
@@ -1,36 +1,37 @@
 //  ==================================================
 //  Sources:
 
-//  Ariane 5 User's Manual (July 2011):            http://www.arianespace.com/wp-content/uploads/2015/09/Ariane5_users_manual_Issue5_July2011.pdf
-//  Ariane 5 - Spaceflight101:                     http://spaceflight101.com/spacerockets/ariane-5-eca/
-//  Ariane 5 - Norbert Brügge:                     http://www.b14643.de/Spacerockets_1/West_Europe/Ariane-5/Description/Frame.htm
-//  Ariane 5 brochure:                             http://esamultimedia.esa.int/multimedia/publications/ariane5/offline/download.pdf
-//  Ariane 5 Attitude Control System:              http://www.space-propulsion.com/spacecraft-propulsion/showcase/ariane5-attitude-control-system.html
-//  Airbus Safran Monopropellant Thrusters:        http://www.space-propulsion.com/brochures/hydrazine-thrusters/hydrazine-thrusters.pdf
-//  Ariane 5 ME Upper Stage ACS Development:       http://www.ecosimpro.com/wp-content/uploads/2015/02/SP2014_2938390_Kajon.pdf
-//  ESC-A Upper Stage Ballistic Flight Simulation: http://www.ecosimpro.com/wp-content/uploads/2015/02/AIAA_2009_armin.pdf
+//  Arianspace - Ariane 5 User's Manual (July 2011):           http://www.arianespace.com/wp-content/uploads/2011/07/Ariane5_Users-Manual_October2016.pdf
+//  Spaceflight101 - Ariane 5 ECA launch vehicle:              http://spaceflight101.com/spacerockets/ariane-5-eca/
+//  Space Launch Report - Ariane 5 launch vehicle:             http://www.spacelaunchreport.com/ariane5.html
+//  Norbert Brügge - Ariane 5 launch vehicle:                  http://www.b14643.de/Spacerockets_1/West_Europe/Ariane-5/Description/Frame.htm
+//  ESA - Ariane 5 launch vehicle brochure:                    http://esamultimedia.esa.int/multimedia/publications/ariane5/offline/download.pdf
+//  ArianeGroup OPS - Ariane 5 Attitude Control System:        http://www.space-propulsion.com/spacecraft-propulsion/showcase/ariane5-attitude-control-system.html
+//  ArianeGroup OPS - Hydrazine thrusters brochure:            http://www.space-propulsion.com/brochures/hydrazine-thrusters/hydrazine-thrusters.pdf
+//  EcosimPro - Ariane 5 ME Upper Stage ACS Development:       http://www.ecosimpro.com/wp-content/uploads/2015/02/SP2014_2938390_Kajon.pdf
+//  EcosimPro - ESC-A Upper Stage Ballistic Flight Simulation: http://www.ecosimpro.com/wp-content/uploads/2015/02/AIAA_2009_armin.pdf
 
 //  ==================================================
 //  Ariane 5 payload fairing.
 
 //  Dimensions: 5.4 m x 17 m
-//  Inert Mass: 1337 Kg (per halve)
+//  Inert Mass: 1300 Kg (per halve)
 //  ==================================================
 
 @PART[RSB_PLF_ArianeV5m]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
-    @title = Ariane 5 ECA PLF
+    @title = Ariane 5 ECA/ES PLF (Long)
     @manufacturer = RUAG Space
-    @description = The 5.4 meter graphite epoxy composite payload fairing for the Ariane 5 launch vehicle family.
+    @description = The long (17 meter) graphite epoxy composite payload fairing for the Ariane 5 launch vehicle family.
 
-    @mass = 1.337
+    @mass = 1.3
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -2.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -62,8 +63,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -87,13 +88,13 @@
 
     @title = Ariane 5 PAS 1194VS
     @manufacturer = Airbus Defence and Space
-    @description = A 1.25 meter Payload Adapter System for the Ariane 5 launch vehicle family.
+    @description = A 1.25 meter Payload Adapter System (PAS) for the Ariane 5 launch vehicle family.
 
     @mass = 0.15
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -122,13 +123,13 @@
 
     @title = Ariane 5 PAS 1663
     @manufacturer = Airbus Defence and Space
-    @description = A 1.875 meter Payload Adapter System for the Ariane 5 launch vehicle family.
+    @description = A 1.875 meter Payload Adapter System (PAS) for the Ariane 5 launch vehicle family.
 
     @mass = 0.165
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -157,13 +158,13 @@
 
     @title = Ariane 5 PAS 2624VS
     @manufacturer = Airbus Defence and Space
-    @description = A 2.5 meter Payload Adapter System for the Ariane 5 launch vehicle family.
+    @description = A 2.5 meter Payload Adapter System (PAS) for the Ariane 5 launch vehicle family.
 
     @mass = 0.125
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -182,7 +183,7 @@
 {
     %RSSROConfig = True
 
-    @title = Ariane 5 ECA Payload Adapter
+    @title = Ariane 5 ECA/ES Payload Adapter
     @manufacturer = Airbus Defence and Space
     @description = A 5 meter generic payload adapter for the Ariane 5 launch vehicle family. Note: it does not include a decoupler!
 
@@ -205,14 +206,14 @@
     %RSSROConfig = True
 
     @title = Ariane 5 SYLDA5 (Standard)
-    @manufacturer = Airbus Defence and Space
-    @description = The standard version of the SYLDA5 carrying structure (4.9 m).
+    @manufacturer = Airbus Safran Launchers (ASL)
+    @description = The standard (4.9 meters) version of the SYLDA5 carrying structure.
 
     @mass = 0.425
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -236,14 +237,14 @@
     %RSSROConfig = True
 
     @title = Ariane 5 SYLDA5 (Extra Extended)
-    @manufacturer = Airbus Defence and Space
-    @description = The extra extended version of the SYLDA5 carrying structure (7 m).
+    @manufacturer = Airbus Safran Launchers (ASL)
+    @description = The extra extended (7 meters) version of the SYLDA5 carrying structure.
 
     @mass = 0.538
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -259,25 +260,76 @@
 //  Ariane 5 ESC-A (Étage Supérieur Cryotechnique).
 
 //  Dimensions: 5.4 m x 4.7 m
-//  Gross Mass: 19350 Kg
+//  Gross Mass: 19770 Kg
+
+//  Notes:
+
+//  * The gross mass figure does not include the mass
+//    of the interstage adapter (720 Kg).
+//  * The gross mass figure includes the mass of the
+//    Vehicle Equipment Bay (1300 Kg).
 //  ==================================================
 
 @PART[RSBtankArianeVescA]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
+    //  Helium pressurization tank (dummy).
+
+    MODEL
+    {
+        model = RealScaleBoosters/Parts/Agena/RSBtankSpehereAgena
+        scale = 1.75, 1.75, 1.75
+        position = 0.0, -2.65, -1.1
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    //  Roll control thrusters.
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/lp_rcs
+        scale = 1.0, 1.0, 1.0
+        position = 2.64, 1.8, 0.1
+        rotation = 90.0, 15.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/lp_rcs
+        scale = 1.0, 1.0, 1.0
+        position = -2.64, 1.8, -0.1
+        rotation = -90.0, 15.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/lp_rcs
+        scale = 1.0, 1.0, 1.0
+        position = 2.64, 1.8, -0.1
+        rotation = -90.0, -15.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/Models/lp_rcs
+        scale = 1.0, 1.0, 1.0
+        position = -2.64, 1.8, 0.1
+        rotation = 90.0, -15.0, 0.0
+    }
+
     @title = Ariane 5 ESC-A
     @manufacturer = Airbus Defence and Space
-    @description = The second stage of the Ariane 5 launch vehicle family (ESC-A variant). Contains guidance capability.
+    @description = The ESC-A second stage variant of the Ariane 5 launch vehicle family. Includes avionics and RCS thrusters for attitude control of the EPC-E stage after booster separation and for precise injection of the ESC-A upper stage and the payload.
 
-    @mass = 4.45
+    @mass = 4.87
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
-    //  56 N Gas Hydrogen (GH2) attitude control thrusters for each axis (using liquid hydrogen directly for now).
+    //  Two sets of 56 N Gaseous Hydrogen (GH2) attitude control thrusters for each axis (using liquid hydrogen directly for now).
 
     @MODULE[ModuleRCS*]
     {
@@ -294,6 +346,35 @@
         {
             @key,0 = 0 180
             @key,1 = 1 85
+        }
+    }
+
+    //  Two sets of Airbus Safran 400 N thrusters for roll control.
+
+    MODULE
+    {
+        name = ModuleRCS
+        thrusterTransformName = RCStransform
+        thrusterPower = 0.4
+        stagingEnabled = True
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 10.0
+            ignoreForIsp = True
+        }
+
+        atmosphereCurve
+        {
+            key = 0 216
+            key = 1 85
         }
     }
 
@@ -348,6 +429,24 @@
         amount = 2160
         maxAmount = 2160
     }
+
+    //  ESC-A ACS propellant mass 156 Kg (maximum of four tanks, each with a capacity of 85 L).
+
+    RESOURCE
+    {
+        name = Hydrazine
+        amount = 78
+        maxAmount = 156
+    }
+
+    //  ESC-A ACS pressurization gas mass ~0.2 Kg.
+
+    RESOURCE
+    {
+        name = Nitrogen
+        amount = 1600
+        maxAmount = 1600
+    }
 }
 
 //  ==================================================
@@ -397,10 +496,15 @@
 }
 
 //  ==================================================
-//  Ariane 5 EPC/ESC-A interstage adapter.
+//  Ariane 5 EPC-E and ESC-A/ES interstage adapter.
 
 //  Dimensions: 5.4 m x 2.7 m
-//  Gross Mass: 720 Kg
+//  Inert Mass: 720 Kg
+
+//  Notes:
+
+//  * The interstage adapter is part of the ESC-A and
+//    not of the EPC-E (decouples from the bottom).
 //  ==================================================
 
 @PART[RSBdecouplerArianeV]:FOR[RealismOverhaul]
@@ -412,159 +516,29 @@
         @scale = 1.0, 0.9, 1.0
     }
 
-    //  Roll control thrusters.
-
-    MODEL
-    {
-        model = RealismOverhaul/Models/LinearRCS
-        scale = 0.5, 0.5, 0.5
-        position = 2.64, 0.8, 0.1
-        rotation = 90.0, 15.0, 0.0
-    }
-
-    MODEL
-    {
-        model = RealismOverhaul/Models/LinearRCS
-        scale = 0.5, 0.5, 0.5
-        position = -2.64, 0.8, -0.1
-        rotation = -90.0, 15.0, 0.0
-    }
-
-    MODEL
-    {
-        model = RealismOverhaul/Models/LinearRCS
-        scale = 0.5, 0.5, 0.5
-        position = 2.64, 0.8, -0.1
-        rotation = -90.0, -15.0, 0.0
-    }
-
-    MODEL
-    {
-        model = RealismOverhaul/Models/LinearRCS
-        scale = 0.5, 0.5, 0.5
-        position = -2.64, 0.8, 0.1
-        rotation = 90.0, -15.0, 0.0
-    }
-
-    //  ACS propellant tanks.
-
-    MODEL
-    {
-        model = RealScaleBoosters/Parts/Agena/RSBtankSpehereAgena
-        scale = 1.75, 1.75, 1.75
-        position = 1.475, 0.0, 1.475
-        rotation = 0.0, 0.0, 0.0
-    }
-
-    MODEL
-    {
-        model = RealScaleBoosters/Parts/Agena/RSBtankSpehereAgena
-        scale = 1.75, 1.75, 1.75
-        position = 0.75, 0.0, 1.925
-        rotation = 0.0, 0.0, 0.0
-    }
-
-    MODEL
-    {
-        model = RealScaleBoosters/Parts/Agena/RSBtankSpehereAgena
-        scale = 1.75, 1.75, 1.75
-        position = -1.475, 0.0, -1.475
-        rotation = 0.0, 0.0, 0.0
-    }
-
-    MODEL
-    {
-        model = RealScaleBoosters/Parts/Agena/RSBtankSpehereAgena
-        scale = 1.75, 1.75, 1.75
-        position = -0.75, 0.0, -1.925
-        rotation = 0.0, 0.0, 0.0
-    }
-
     @node_stack_top = 0.0, 1.35, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, -1.35, 0.0, 0.0, -1.0, 0.0, 3
 
-    @title = Ariane 5 Vehicle Equipment Bay (VEB)
+    @title = Ariane 5 Interstage Adapter
     @manufacturer = Airbus Defence and Space
-    @description = The EPC/ESC-A interstage adapter and control system for the Ariane 5 launch vehicle family. Includes avionics and RCS thrusters for pitch/roll control of the EPC-E stage after booster separation and for precise injection of the ESC-A upper stage.
+    @description = The EPC-E and ESC-A/ES interstage adapter of the Ariane 5 launch vehicle family.
 
-    @mass = 0.56
+    @mass = 0.72
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
-
-    !MODULE[ModuleSeeThroughObject],*{}
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
         @ejectionForce = 100
-    }
-
-    !MODULE[ModuleRCS*],{}
-
-    //  Two sets of Airbus Safran 400 N thrusters for roll control.
-
-    MODULE
-    {
-        name = ModuleRCS
-        thrusterTransformName = RCSthruster
-        thrusterPower = 0.4
-
-        PROPELLANT
-        {
-            name = Hydrazine
-            ratio = 1.0
-        }
-
-        PROPELLANT
-        {
-            name = Nitrogen
-            ratio = 10.0
-            ignoreForIsp = True
-        }
-
-        atmosphereCurve
-        {
-            key = 0 216
-            key = 1 85
-        }
-    }
-
-    !RESOURCE,*{}
-
-    //  Avionics batteries 33 Wh.
-    //  Supports the EPC-E for the initial duration of the flight (approximately 9 minutes).
-    //  Assumes that the electricity consumption of the EPC-E avionics is 200 W.
-
-    RESOURCE
-    {
-        name = ElectricCharge
-        amount = 120
-        maxAmount = 120
-    }
-
-    //  ESC-A ACS propellant mass 156 Kg (maximum of four tanks, each with a capacity of 85 L).
-
-    RESOURCE
-    {
-        name = Hydrazine
-        amount = 78
-        maxAmount = 156
-    }
-
-    //  ESC-A ACS pressurization gas mass ~0.2 Kg.
-
-    RESOURCE
-    {
-        name = Nitrogen
-        amount = 1600
-        maxAmount = 1600
+        @explosiveNodeID = bottom
     }
 }
 
 //  ==================================================
-//  Ariane 5 EPC (Étage Principal Cryotechnique).
+//  Ariane 5 EPC-E (Étage Principal Cryotechnique).
 
 //  Dimensions: 5.4 m x 24 m
 //  Gross Mass: 187700 Kg
@@ -583,11 +557,12 @@
     @manufacturer = Airbus Defence and Space/Dutch Space
     @description = The evolved cryogenic main stage of the Ariane 5 launch vehicle.
 
+    @mass = 12.9
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -618,6 +593,17 @@
     }
 
     !RESOURCE,*{}
+
+    //  Avionics batteries 33 Wh.
+    //  Supports the EPC-E for the initial duration of it's flight (approximately 9 minutes).
+    //  Assumes that the electricity consumption of the EPC-E avionics is 200 W.
+
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 120
+        maxAmount = 120
+    }
 }
 
 //  ==================================================
@@ -639,8 +625,8 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
@@ -25,8 +25,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -58,8 +58,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -86,8 +86,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @stagingIcon = LIQUID_ENGINE
 
     !MODULE[ModuleDecouple],*{}
@@ -275,8 +275,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -27,8 +27,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -60,8 +60,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -93,8 +93,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -125,8 +125,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -157,8 +157,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -189,8 +189,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -221,8 +221,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -253,8 +253,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -284,8 +284,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -312,8 +312,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -335,8 +335,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -361,15 +361,15 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %vesselIcon = Probe
 
-    //  Two sets of RCS thrusters for three axis control and ullage.
+    //  Two sets of RCS thrusters for three axis control and ullage:
     //  Aerojet Rocketdyne MR-106J (40 N) for attitude control.
     //  Aerojet Rocketdyne MR-106K (27 N) ullage control.
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.428
         !resourceName = NULL
@@ -552,8 +552,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -581,8 +581,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !stageOffset = NULL
     !childStageOffset = NULL
 }
@@ -607,8 +607,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -630,8 +630,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -659,8 +659,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -680,8 +680,8 @@
 
     @mass = 15.075
     @crashTolerance = 12
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @breakingForce = 250
     @breakingTorque = 250
 
@@ -789,8 +789,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Carrack.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Carrack.cfg
@@ -22,8 +22,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -0.75, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -55,8 +55,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -0.5, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -88,8 +88,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -168,8 +168,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleSeeThroughObject],*{}
 
@@ -266,8 +266,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -289,8 +289,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Delta.cfg
@@ -29,8 +29,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -61,8 +61,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -94,8 +94,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -127,8 +127,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -160,8 +160,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -193,8 +193,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -226,8 +226,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -1.0, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -259,8 +259,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -328,8 +328,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -359,8 +359,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -395,8 +395,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -431,8 +431,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -476,14 +476,14 @@
 
     @title = Delta-K Upper Stage
     @manufacturer = McDonnel Douglas
-    @description = The second stage of a Delta II. Contains guidance capability.
+    @description = The Delta II upper stage. Equipped with guidance capability.
 
     @mass = 0.845
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleCommand]
     {
@@ -627,14 +627,14 @@
 
     @title = Delta Cryogenic Upper Stage (DCUS)
     @manufacturer = Boeing Co.
-    @description = The Delta Cryogenic Upper Stage (DCUS) used on the Delta III launch vehicle. Contains guidance capability.
+    @description = The Delta Cryogenic Upper Stage (DCUS) as used on the Delta III launch vehicle. Equipped with guidance capability.
 
     @mass = 2.2
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -751,14 +751,14 @@
 
     @title = Delta Cryogenic Second Stage (DCSS-4)
     @manufacturer = United Launch Alliance (ULA)
-    @description = The 4 meter variant of the Delta Cryogenic Second Stage (DCSS-4) used on the Delta IV Medium 4 and 4+. Contains guidance capability.
+    @description = The 4 meter variant of the Delta Cryogenic Second Stage (DCSS-4) used on the Delta IV Medium 4 and 4+. Equipped with guidance capability.
 
     @mass = 2.42
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -875,14 +875,14 @@
 
     @title = Delta Cryogenic Second Stage (DCSS-5)
     @manufacturer = United Launch Alliance (ULA)
-    @description = The 5 meter variant of the Delta Cryogenic Second Stage (DCSS-5) used on the Delta IV Medium 5+ and Delta IV Heavy. Contains guidance capability.
+    @description = The 5 meter variant of the Delta Cryogenic Second Stage (DCSS-5) used on the Delta IV Medium 5+ and Delta IV Heavy. Equipped with guidance capability.
 
     @mass = 3.06
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1056,8 +1056,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1084,8 +1084,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1112,8 +1112,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 773.15
-    %skinMaxTemp = 873.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1140,8 +1140,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -1168,8 +1168,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @fuelCrossFeed = True
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1233,8 +1233,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @fuelCrossFeed = True
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1298,8 +1298,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -1346,8 +1346,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1410,8 +1410,8 @@
     @crashTolerance = 14
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -3,7 +3,7 @@
 
 //  NTRS - Reusable Agena Study:                        http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
 //  Heroicrelics - LR101 engine:                        http://heroicrelics.org/info/lr-101/lr-101.html
-//  Norbert Brügge -  Atlas propulsion systems:         http://www.b14643.de/Spacerockets_2/United_States_4/Atlas/Propulsion/engines.htm
+//  Norbert Brügge - Atlas propulsion systems:          http://www.b14643.de/Spacerockets_2/United_States_4/Atlas/Propulsion/engines.htm
 //  Norbert Brügge - Vikas engine family:               http://www.b14643.de/Spacerockets_1/India/Vikas/Vikas.htm
 
 //  Orbital ATK - Propulsion Products Catalog:          https://www.orbitalatk.com/flight-systems/propulsion-systems/docs/2016%20OA%20Motor%20Catalog.pdf
@@ -44,7 +44,7 @@
 //  Ariane 5 - Space Launch Report:                     http://spacelaunchreport.com/ariane5.html
 //  ESA - EAP-241 boosters:                             http://www.esa.int/Our_Activities/Launchers/Launch_vehicles/Boosters_EAP
 //  Airbus Safran Launchers - Vulcain 2 brochure:       http://www.space-propulsion.com/brochures/launcher-propulsion/Vulcain2.pdf
-//  Safran Snecma -  HM-7 engine brochure:              https://web.archive.org/web/20130714113757/http://www.snecma.com/IMG/files/fiche_hm7b_ang_2011_modulvoir_file_fr.pdf
+//  Safran Snecma - HM-7 engine brochure:               https://web.archive.org/web/20130714113757/http://www.snecma.com/IMG/files/fiche_hm7b_ang_2011_modulvoir_file_fr.pdf
 
 //  NASA - Saturn V Flight Manual:                      http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
 //  NASA - F-1 engine fact sheet:                       http://history.msfc.nasa.gov/saturn_apollo/documents/F-1_Engine.pdf
@@ -81,8 +81,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     %engineType = AJ10_Adv
 
@@ -120,7 +120,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBengineAJ10-118K]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineAJ10-118K]:AFTER[RealismOverhaulEngines]
 {
     @title = AJ10-118 Series
     @manufacturer = Aerojet Rocketdyne
@@ -138,7 +138,7 @@
 //  P241A EAP (Étages d’Accélération à Poudre)
 
 //  Dimensions: 3.07 x 27 m
-//  Gross Mass: 275500 Kg
+//  Gross Mass: 278420 Kg
 
 //  The gross mass value excludes the mass of the nose
 //  cone (2100 Kg).
@@ -151,12 +151,12 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @mass = 35.9
+    @mass = 37.8
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^=:$: eap
@@ -165,12 +165,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 6709
-        @maxThrust = 6709
-        @heatProduction = 20
-        @useEngineResponseTime = False
-        @engineAccelerationSpeed = 0
-
         @PROPELLANT[SolidFuel]
         {
             @name = HTPB
@@ -178,50 +172,10 @@
 
         @atmosphereCurve
         {
-            @key,0 = 0 271
-            @key,1 = 1 250
+            @key,0 = 0 277
+            @key,1 = 1 253
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 7.3
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleFuelTanks],*{}
-
-    MODULE
-    {
-        name = ModuleFuelTanks
-        type = HTPB
-        volume = 135593
-        basemass = -1
-
-        //  HTPB/AP propellant mixture mass 240000 Kg.
-
-        TANK
-        {
-            name = HTPB
-            amount = 135593
-            maxAmount = 135593
-        }
-    }
-
-    !RESOURCE,*{}
-}
-
-//  ==================================================
-//  P241A EAP (Étages d’Accélération à Poudre)
-
-//  Part configuration.
-//  ==================================================
-
-@PART[RSBengineArianeVSRB]:AFTER[RealismOverhaulEnginesPost]
-{
-    @title = P241A EAP
-    @manufacturer = Avio/Regulus/SABCA
-    @description = A steel casing solid rocket motor used in pairs by the Ariane 5 launch vehicle for the initial phases of the flight.
 }
 
 //  ==================================================
@@ -245,8 +199,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -302,7 +256,7 @@
 //  Part configuration.
 //  ==================================================
 
-@PART[RSBdelta2srm]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBdelta2srm]:AFTER[RealismOverhaulEngines]
 {
     @title = GEM-40 Series
     @manufacturer = Orbital ATK
@@ -330,8 +284,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -387,7 +341,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBdelta3srm]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBdelta3srm]:AFTER[RealismOverhaulEngines]
 {
     @title = GEM-46 LDXL
     @manufacturer = Orbital ATK
@@ -424,8 +378,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -490,7 +444,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBdelta3srmG]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBdelta3srmG]:AFTER[RealismOverhaulEngines]
 {
     @title = GEM-46 LDXL-TVC
     @manufacturer = Orbital ATK
@@ -522,8 +476,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -584,7 +538,7 @@
 //  Part configuration.
 //  ==================================================
 
-@PART[RSBdeltaIVsrm]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBdeltaIVsrm]:AFTER[RealismOverhaulEngines]
 {
     @title = GEM-60 Series
     @manufacturer = Orbital ATK
@@ -609,8 +563,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -674,8 +628,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -741,8 +695,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^=:$: castor orbital atk
@@ -799,7 +753,7 @@
 //  Part configuration.
 //  ==================================================
 
-@PART[RSBengineCastor30]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineCastor30]:AFTER[RealismOverhaulEngines]
 {
     @title = Castor 30
     @manufacturer = Orbital ATK
@@ -824,8 +778,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -887,8 +841,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -939,8 +893,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -991,8 +945,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1049,8 +1003,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 523.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1085,7 +1039,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBengineH1]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineH1]:AFTER[RealismOverhaulEngines]
 {
     @title = H-1 Series
     @description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, optimized for the first-stage main engine role.
@@ -1123,8 +1077,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1159,7 +1113,7 @@
 //  Part configuration.
 //  ==================================================
 
-@PART[RSBengineHM7B]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineHM7B]:AFTER[RealismOverhaulEngines]
 {
     @title = HM-7 Series
     @manufacturer = Snecma S.A.
@@ -1186,8 +1140,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1241,8 +1195,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1289,8 +1243,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1331,7 +1285,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBengineLR101]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineLR101]:AFTER[RealismOverhaulEngines]
 {
     @MODULE[ModuleGimbal]
     {
@@ -1366,8 +1320,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1428,8 +1382,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1470,7 +1424,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBengineRL10A3|RSBengineRL10A42]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineRL10A3|RSBengineRL10A42]:AFTER[RealismOverhaulEngines]
 {
     @title = RL10-A/C Series
     @manufacturer = Aerojet Rocketdyne
@@ -1503,8 +1457,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1549,7 +1503,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBengineRL10B2]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineRL10B2]:AFTER[RealismOverhaulEngines]
 {
     @title = RL10-B/CECE Series
     @manufacturer = Aerojet Rocketdyne
@@ -1593,8 +1547,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1654,8 +1608,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     %engineType = H1
 
@@ -1693,7 +1647,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RSBengineRS27A]:AFTER[RealismOverhaulEnginesPost]
+@PART[RSBengineRS27A]:AFTER[RealismOverhaulEngines]
 {
     @title = RS-27 Series
     @description = Kerolox gas-generator first-stage engine used on the first stages of the Delta 2000, 3000 and II launch vehicle families. Optimized for sustainer operation.
@@ -1726,8 +1680,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    &skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1794,8 +1748,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1863,8 +1817,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1919,8 +1873,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
@@ -1977,8 +1931,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 523.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     %engineType = Agena
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Launch_Clamps.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Launch_Clamps.cfg
@@ -18,7 +18,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 4273.15
-    %skinMaxTemp = 4273.15
+    %skinMaxTemp = 5273.15
     !explosionPotential = NULl
 }
 
@@ -42,7 +42,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 4273.15
-    %skinMaxTemp = 4273.15
+    %skinMaxTemp = 5273.15
     !explosionPotential = NULl
 }
 
@@ -66,7 +66,7 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 4273.15
-    %skinMaxTemp = 4273.15
+    %skinMaxTemp = 5273.15
     !explosionPotential = NULl
 }
 
@@ -90,6 +90,6 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 4273.15
-    %skinMaxTemp = 4273.15
+    %skinMaxTemp = 5273.15
     !explosionPotential = NULl
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_PSLV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_PSLV.cfg
@@ -24,8 +24,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @CoMOffset = -0.6, -1.0, 0.0
 
     @MODULE[ModuleAnchoredDecoupler]
@@ -57,8 +57,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -80,8 +80,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -103,8 +103,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -126,8 +126,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -155,8 +155,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @stagingIcon = LIQUID_ENGINE
 
     !MODULE[ModuleDecouple],*{}
@@ -380,8 +380,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -407,10 +407,10 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.2723
         !resourceName = NULL
@@ -455,8 +455,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -558,8 +558,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -618,7 +618,7 @@
 
     //  270 N bipropellant ACS thrusters for attitude control (exact specifications unknown).
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.2723
         !resourceName = NULL
@@ -669,8 +669,8 @@
 
     @mass = 0.015
     @crashTolerance = 10
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -736,8 +736,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -803,8 +803,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -832,8 +832,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1002,8 +1002,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1167,8 +1167,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1329,8 +1329,8 @@
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_STS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_STS.cfg
@@ -26,8 +26,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -48,8 +48,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @bulkheadProfiles = size2, size5
     %noFuelCrossFeedNode = bottom
 }
@@ -75,8 +75,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -128,8 +128,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @bulkheadProfiles = size1, size5
 
     @MODULE[ModuleDecouple]
@@ -157,8 +157,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @bulkheadProfiles = size1, size5
 
     @MODULE[ModuleDecouple]
@@ -184,8 +184,8 @@
 
     @mass = 1.86
     @crashTolerance = 12
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @fuelCrossFeed = False
 
     //  Each nose cone contains four separation motors with each motor rated for 89.2 kN of vacuum thrust.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -35,8 +35,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -58,8 +58,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -81,8 +81,8 @@
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -104,8 +104,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -127,8 +127,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -150,8 +150,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 }
 
 //  ==================================================
@@ -181,8 +181,8 @@
     @crashTolerance = 10
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 
     @MODULE[ModuleCommand]
@@ -225,8 +225,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 
     @MODULE[ModuleCommand]
@@ -320,8 +320,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -379,8 +379,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -444,8 +444,8 @@
 
     @mass = 0.075
     @crashTolerance = 12
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     //  One SE 7-1 (320 N) thruster for ullage and three TR-204 (667 N) thrusters for attitude control.
 
@@ -546,7 +546,7 @@
     @manufacturer = Thiokol
 
     @crashTolerance = 12
-    @maxTemp = 573.15
+    @maxTemp = 673.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
@@ -613,8 +613,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    @skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    @skinMaxTemp = 773.15
 
     //  Four 155 kN retro motors (inert 104 Kg - gross 226 Kg).
 
@@ -685,8 +685,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     //  Four 163 kN retro motors (inert 50 Kg - gross 170 Kg).
 
@@ -758,8 +758,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -821,8 +821,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -882,8 +882,8 @@
 
     @mass = 0.104
     @crashTolerance = 12
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -956,8 +956,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleDecouple]
     {
@@ -984,8 +984,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     //  Eight 155 kN retro motors (inert 104 Kg - gross 226 Kg).
 
@@ -1056,8 +1056,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 573.15
-    %skinMaxTemp = 673.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -1157,8 +1157,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1218,8 +1218,8 @@
 
     @mass = 0.85
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1240,8 +1240,8 @@
 
     @mass = 0.6
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1262,8 +1262,8 @@
 
     @mass = 0.85
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1284,8 +1284,8 @@
 
     @mass = 0.6
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1305,8 +1305,8 @@
 
     @mass = 0.35
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1327,8 +1327,8 @@
 
     @mass = 2.4
     @crashTolerance = 14
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @breakingForce = 250
     @breakingTorque = 250
 
@@ -1357,8 +1357,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1417,8 +1417,8 @@
 
     @mass = 0.2
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1438,8 +1438,8 @@
 
     @mass = 0.2
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     !explosionPotential = NULL
 }
 
@@ -1462,8 +1462,8 @@
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1525,8 +1525,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1588,8 +1588,8 @@
     @crashTolerance = 6
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -1650,8 +1650,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @bulkheadProfiles = size5, size6
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1685,8 +1685,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @bulkheadProfiles = size6, size10
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1720,8 +1720,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @bulkheadProfiles = size7, size10
 
     !MODULE[ModuleFuelTanks],*{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Structural.cfg
@@ -17,8 +17,8 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
 
     @MODULE[ModuleAnchoredDecoupler]
     {
@@ -45,7 +45,7 @@
 
     @mass = 0.075
     @crashTolerance = 16
-    @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
     @maxLength = 25
 }


### PR DESCRIPTION
**Change Log:**

* Normalize all temperature values to account for the DRE nerfs.
* Fix the RCS thrusters of the Ariane 5 (they are part of the upper stage, not the interstage).
* Fix the inert mass of the first stage.
* Minor updates to the part descriptions.

**Notes:**

* The Ariane 5 interstage should also carry ullage/separation motors but these are not documented very well (if at all...). They also cannot be integrated with thr interstage, since KSP cannot handle two separate modules in one staging action in the staging list (only via action groups). So, the solution for now is to use either the generic RO or the RSB PSLV separation motors.

* Older discussion with @Theysen about the above note: https://github.com/KSP-RO/RealismOverhaul/pull/1757
* EADS Astrium -  Ariane 5 ACS: https://web.archive.org/web/20110719143310/http://cs.astrium.eads.net/sp/spacecraft-propulsion/showcase/ariane5-attitude-control-system.html
* Arianespace - ESC-A: http://www.arianespace.com/?popup=ariane-5-4