### PR TITLE
[Bugfix] Make the Ranger solar panel RO compatible

### DIFF
--- a/GameData/RealismOverhaul/Parts/Solar/RangerPanel.cfg
+++ b/GameData/RealismOverhaul/Parts/Solar/RangerPanel.cfg
@@ -2,6 +2,7 @@ PART {
     name = RO-rangerSolarPanel
     module = Part
     author = taniwha (Bill Currie)
+    RSSROConfig = True
     rescaleFactor = 0.85
     TechRequired = earlyPower
     entryCost = 12581


### PR DESCRIPTION
**Change Log:**

* Fix the RO compatibility of the Ranger Solar Panel (missing the RSSROConfig = True tag).