### PR TITLE
new Vanguard solids

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
@@ -163,6 +163,7 @@
 @PART[science_module]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%rescaleFactor = 0.5  // more suitable for sounding rockets
 	!MODULE[TweakScale]
 	{
 	}


### PR DESCRIPTION
Based on a single but solid-looking source, new configs for the Vanguard third stage:
GCRC: bog-standard star-cut SRB in metal casing
Altair: Fiberglass case, more propellant, better ISP

In it's current form, this isn't as much a pull request as a request for help. The two engines have virtually the same dimensions: I'd prefer if they'd be two engine types on one part, however, I can't figure out how to adjust the propellant load so each has the appropriate amount. This PR heavy-handedly adds a new part, something I'm not happy about.

Besides, I'm not sure about naming. What I really have here are two dumb SRBs, which my source refers to as GCRC and ABL / X-248. 

Besides, I'm not sure about naming. Limited research shows that many online sources use  "Altair" and "X-248" interchangeably, while some claim that the "Altair stage" was based off a X-248 but had 3-axis control. I didn't turn up anything I'd depend on, though, only ever more contradictory data. However, it seems intriguing that most sites cite larger dimensions, more dry mass and a slightly better ISP than my document -- even if most just copy off each other, these figures must have come from somewhere. Thus I wonder if it wouldn't be better to rename the plain SRB to "X-248", and leave "Altair" available for something more advanced.
