### PR TITLE
[Bugfix] RSB Ariane 5 interstage adapter

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Ariane.cfg
@@ -500,11 +500,6 @@
 
 //  Dimensions: 5.4 m x 2.7 m
 //  Inert Mass: 720 Kg
-
-//  Notes:
-
-//  * The interstage adapter is part of the ESC-A and
-//    not of the EPC-E (decouples from the bottom).
 //  ==================================================
 
 @PART[RSBdecouplerArianeV]:FOR[RealismOverhaul]
@@ -533,7 +528,6 @@
     @MODULE[ModuleDecouple]
     {
         @ejectionForce = 100
-        @explosiveNodeID = bottom
     }
 }
 


### PR DESCRIPTION
**Change Log:**

* Fix the decouling node of the Ariane 5 interstage adapter (should decouple from the top).