### PR TITLE
Update SSTU_Tanks.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -22,10 +22,15 @@
 	
 	@MODULE[SSTUModularFuelTank]
 	{
+		@currentTankDiameter = 1.0
 		@maxTankDiameter = 99.0
 		@minTankDiameter = 0.1
 		@tankDiameterIncrement = 0.1
-		!UPGRADES,* {}
+		!UPGRADES[SSTU-VCMod-Lightweight] {}
+		!UPGRADES[SSTU-VCMod-SuperLightweight] {}
+		!UPGRADES[SSTU-VCMod-LowBoiloff] {}
+		!UPGRADES[SSTU-VCMod-ZeroBoiloff] {}
+		!UPGRADES[SSTU-VCMod-LightweightZeroBoiloff] {}
 	}
 	@MODULE[SSTUNodeFairing],*
 	{
@@ -43,7 +48,6 @@
 {
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume = 1060
 		%utilizationTweakable = true
 	}
 }
@@ -59,22 +63,6 @@
 	{
 		@startsEnabled = true
 	}
-	@MODULE[SSTUModularFuelTank]
-	{
-		CAP
-		{
-			name = MUS-Upper-Dome
-		}
-	}
-}
-
-//*******************************************************************************
-// Modify the Dome
-//*******************************************************************************
-@SSTU_MODEL[MUS-Upper-Dome]
-{
-	@invertForBottom = true
-	%node = 0, 1.1150, 0, 0, 1, 0, 2
 }
 
 //*******************************************************************************
@@ -89,7 +77,7 @@
 //*******************************************************************************
 // Lander Tank
 //*******************************************************************************
-@PART[SSTU-SC-TANK-MFT-L]:AFTER[SSTU]
+@PART[SSTU-SC-TANK-MFT-LV]:AFTER[SSTU]
 {
 	@title = Modular Lander Fuel Tank
 	@description = These specially shaped tanks are designed to be used for landing craft. Includes variable diameter, length, and paint-scheme as well as multiple options for mounts.
@@ -114,26 +102,61 @@
 }
 
 //*******************************************************************************
+// The section only needs to remain until SSTU updates their ModIntegration/RealFuels/RF.cfg with PR #678
+//*******************************************************************************
+@PART[SSTU-SC-TANK-MUS]:FOR[SSTU]:NEEDS[RealFuels]
+{
+	!MODULE[ModuleKISInventory]{}
+	!MODULE[SSTUResourceBoiloff]{}
+	!MODULE[SSTUVolumeContainer]{}
+	!MODULE[ModuleFuelTanks] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 2000
+		type = Default
+		typeAvailable = Default
+		typeAvailable = Cryogenic
+		typeAvailable = ServiceModule
+		typeAvailable = Fuselage
+		typeAvailable = Balloon
+		typeAvailable = BalloonCryo
+		typeAvailable = Structural
+	}
+}
+
+//*******************************************************************************
 // Modular Upper Stage
 // Removed the ability for it to control infinite mass with Avionics
 //*******************************************************************************
-@PART[SSTU-SC-TANK-MUS-*]:NEEDS[RealFuels&SSTU]:AFTER[SSTU] // FIXME for 1.3
+@PART[SSTU-SC-TANK-MUS]:NEEDS[RealFuels&SSTU]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock
+	@title = Modular Upper Stage Tank
+	@description = The standard upper stage tank that includes selectable mount and nosecone options as well as variable diameter, length, and paint-scheme.  Comes in split and common tank designs and has built in RCS thrusters.
 	@maxTemp = 800
 	%skinMaxTemp = 900
 	@mass = 0.5
-	@MODULE[SSTUCustomUpperStage]
+
+	@MODULE[SSTUModularUpperStage]
 	{
-		@defaultDiameter = 1.5
-		@maxTankHeight = 99.0
+		@currentTankDiameter = 1.0
 		@maxTankDiameter = 99.0
 		@minTankDiameter = 0.1
 		@tankDiameterIncrement = 0.1
-		@tankHeightIncrement = 0.1
-		@defaultRcsThrust = 0.1
-		!UPGRADES,* {}
+		@supportPercent = 0
+		@UPGRADES
+		{
+			UPGRADE
+			{
+				name = SSTU-MUS-A1
+			}
+		}
+	}
+	@MODULE[SSTUSelectableNodes]
+	{
+		@startsEnabled = true
 	}
 	@MODULE[SSTUNodeFairing],*
 	{
@@ -142,22 +165,15 @@
 		%topDiameterIncrement = 0.5
 		%bottomDiameterIncrement = 0.5
 	}
-	!MODULE[ModuleSAS] {}
-	!MODULE[ModuleResourceConverter] {}
-	!MODULE[SSTUVolumeContainer]{}
-	!MODULE[SSTUResourceBoiloff]{}
-	!MODULE[ModuleRCS],* {}
-	MODULE
+	@MODULE[ModuleSAS]
 	{
-		name = ModuleRCS
-		thrusterTransformName = SC-GEN-RCS-4F-T-ThrustTransform
-		resourceFlowMode = STAGE_PRIORITY_FLOW
-		enableRoll = true
-		enableYaw = true
-		enablePitch = true
-		enableX = true
-		enableY = true
-		enableZ = true
+		@SASServiceLevel = 0
+	}
+	@MODULE[ModuleRCSFX]
+	{
+		!resourceName = NULL
+		!thrusterPower = NULL
+		!atmosphereCurve {}
 		atmosphereCurve
 		{
 			key = 0 220
@@ -171,28 +187,21 @@
 			resourceFlowMode = NO_FLOW
 		}
 	}
-	
-	@MODULE[SSTUSelectableNodes]
-	{
-		@startsEnabled = true
-	}
-
-    %MODULE[ModuleSPU]:NEEDS[RemoteTech]
+	!MODULE[ModuleResourceConverter] {}
+	%MODULE[ModuleSPU]:NEEDS[RemoteTech]
 	{
 		%IsRTCommandStation = false
-    }
-
-    %MODULE[ModuleRTAntennaPassive]:NEEDS[RemoteTech]
+	}
+	%MODULE[ModuleRTAntennaPassive]:NEEDS[RemoteTech]
 	{
-        %TechRequired = start
-        %OmniRange = 300000
-        
-        %TRANSMITTER
+		%TechRequired = start
+		%OmniRange = 300000
+		
+		%TRANSMITTER
 		{
-            %PacketInterval = 1.0
-            %PacketSize = 0.1
-            %PacketResourceCost = 15.0
-        }
-    }
-
+			%PacketInterval = 1.0
+			%PacketSize = 0.1
+			%PacketResourceCost = 15.0
+		}
+	}
 }


### PR DESCRIPTION
This should fix the problem with the Modular Standard Fuel Tank as well as update the Modular Upper Stage to work with 1.3.1. 

I noticed that there is a problem with the SSTU/ModIntegration/RealFuels/RF.cfg file.  It's still referencing the old way the MUS was named.  There is a PR on the SSTU github (#678) but until it's released, I needed to add a version of it here so that the MUS would get the correct fuel tank options.