### PR TITLE
unpatch DRE part upgrades

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -1974,6 +1974,19 @@
 	}
 }
 
+@PART[Mark1Cockpit]:BEFORE[RealismOverhaul]
+{
+	//undoes DRE stock patches that conflict with RO
+	!MODULE[PartStatsUpgradeModule],* {}
+	@MODULE[ModuleAeroReentry]
+	{
+		!maxOperationalTemp = dummy
+		!skinMaxOperationalTemp = dummy
+		!UPGRADES,* {}
+	}
+}
+
+
 // Resized parts.
 // because why not, and 1.25m is too narrow a diameter for crewed spaceplanes
 +PART[Mark1Cockpit]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -1696,7 +1696,7 @@
 		name = ModuleFuelTanks
 		volume = 100
 		basemass = -1
-		type = Fuselage
+		type = ServiceModule
 		TANK
 		{
 			name = ElectricCharge

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -1696,7 +1696,7 @@
 		name = ModuleFuelTanks
 		volume = 100
 		basemass = -1
-		type = ServiceModule
+		type = Fuselage
 		TANK
 		{
 			name = ElectricCharge


### PR DESCRIPTION
A DRE patch ( GameData/DeadlyReentry/DeadlyReentry-Upgrades.cfg )  lowers the cockpit's heat tolerance to 450/450K, rendering it unsafe at any speed. Same patch would also add a part upgrade which doesn't work on the RP-0 tech tree.

This here cleans up the fallout.

On second thought, maybe it would be better to add a NOT[RealismOverhaul] to the original DRE patch?