### PR TITLE
Fix typo

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
@@ -480,7 +480,7 @@
 		}
 		CONFIG
 		{
-			name = Star48BV
+			name = Star-48BV
 			maxThrust = 78
 			heatProduction = 100
 			PROPELLANT


### PR DESCRIPTION
The CONFIG node is accessed as Star-48BV (and not Star48BV) in RO_SuggestedMods\KK Launchers\RO_KK_ATK.cfg.
This patch changes it to Star-48BV following the convention of the other two nodes in the file.