### PR TITLE
SSTU MUS tank fairings to work with small tank sizes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Tanks.cfg
@@ -161,7 +161,9 @@
 	@MODULE[SSTUNodeFairing],*
 	{
 		%maxTopDiameter = 99.0
+		%minTopDiameter = 0.1
 		%maxBottomDiameter = 99.0
+		%minBottomDiameter = 0.1
 		%topDiameterIncrement = 0.5
 		%bottomDiameterIncrement = 0.5
 	}


### PR DESCRIPTION
Allows MUS fairings to be able to size correctly with very small tanks.  Old min defaults to 0.625, but tanks can go down to 0.1.