### PR TITLE
SSTU Engine Mass Fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engine_mass_fix
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engine_mass_fix
@@ -1,0 +1,216 @@
+
+@PART[*]:HAS[@MODULE[SSTUModularEngineCluster]]:NEEDS[SSTU]:BEFORE[RealismOverhaul]
+{
+	ignoreMass = True
+}
+
+
+//US UPPER
+//AJ10
+@PART[SSTU-AJ10-CustomEarly]:AFTER[SSTU]
+{
+	@mass = 0.08
+}
+
+@PART[SSTU-AJ10-CustomMid]:AFTER[SSTU]
+{
+	@mass = 0.09
+}
+
+@PART[SSTU-AJ10-CustomAdvanced]:AFTER[SSTU]
+{
+	@mass = 0.10
+}
+
+@PART[SSTU-SC-ENG-AJ10-137]:AFTER[SSTU]
+{
+	@mass = 0.295
+}
+
+@PART[SSTU-SC-ENG-AJ10-190]:AFTER[SSTU]
+{
+	@mass = 0.125
+}
+
+//RL10
+@PART[SSTU-SC-ENG-RL10A-3]:AFTER[SSTU]
+{
+	@mass = 0.136606
+}
+
+@PART[SSTU-SC-ENG-RL10A-4]:AFTER[SSTU]
+{
+	@mass = 0.167
+}
+
+@PART[SSTU-SC-ENG-RL10A-5]:AFTER[SSTU]
+{
+	@mass = 0.143
+}
+
+@PART[SSTU-SC-ENG-RL10B-2]:AFTER[SSTU]
+{
+	@mass = 0.277
+}
+@PART[RO-SSTU-RL10C]:AFTER[SSTU]
+{
+	@mass = 0.191
+}
+
+@PART[SSTU-SC-ENG-Vinci]:AFTER[SSTU]
+{
+	@mass = 0.550
+}
+
+@PART[SSTU-SC-ENG-SuperDraco]:AFTER[SSTU]
+{
+	@mass = 0.065
+}
+
+//AGENA
+@PART[SSTU-SC-ENG-LR81-8048]:AFTER[SSTU]
+{
+	@mass = 0.132
+}
+
+@PART[SSTU-SC-ENG-LR81-8096]:AFTER[SSTU]
+{
+	@mass = 0.132
+}
+
+@PART[SSTU-SC-ENG-J-2]:AFTER[SSTU]
+{
+	@mass = 1.536788
+}
+
+@PART[SSTU-SC-ENG-J-2X]:AFTER[SSTU]
+{
+	@mass = 2.47
+}
+
+@PART[SSTU-SC-ENG-M1-RO]:AFTER[SSTU]
+{
+	@mass = 9.068
+}
+
+@PART[RO-SSTU-M1-SL]:AFTER[SSTU]
+{
+	@mass = 9.068
+}
+
+@PART[SSTU-SC-ENG-F1]:AFTER[SSTU]
+{
+	@mass = 8.19618
+}
+@PART[SSTU-SC-ENG-F1B]:AFTER[SSTU]
+{
+	@mass = 9.656
+}
+@PART[SSTU-SC-ENG-H1]:AFTER[SSTU]
+{
+	@mass = 0.988
+}
+@PART[SSTU-SC-ENG-LMAE]:AFTER[SSTU]
+{
+	@mass = 0.095
+}
+
+@PART[SSTU-SC-ENG-LMDE]:AFTER[SSTU]
+{
+	@mass = 0.158
+}
+
+@PART[SSTU-SC-ENG-RS-25]:AFTER[SSTU]
+{
+	@mass = 1.027026
+}
+
+@PART[SSTU-SC-ENG-RS-68]:AFTER[SSTU]
+{
+	@mass = 6.597
+}
+
+
+//MERLIN
+@PART[SSTU-SC-ENG-Merlin-1A]:AFTER[SSTU]
+{
+	@mass = 0.76
+}
+
+@PART[SSTU-SC-ENG-Merlin-1B]:AFTER[SSTU]
+{
+	@mass = 0.76
+}
+
+@PART[SSTU-SC-ENG-Merlin-1C]:AFTER[SSTU]
+{
+	@mass = 0.630
+}
+
+@PART[SSTU-SC-ENG-Merlin-1D]:AFTER[SSTU]
+{
+	@mass = 00.469984
+}
+
+@PART[SSTU-SC-ENG-Merlin-1BV]:AFTER[SSTU]
+{
+	@mass = 0.912
+}
+
+@PART[SSTU-SC-ENG-Merlin-1CV]:AFTER[SSTU]
+{
+	@mass = 0.76
+}
+
+@PART[SSTU-SC-ENG-Merlin-1DV]:AFTER[SSTU]
+{
+	@mass = 0.489972
+}
+
+//SOVIET ENGINES
+
+@PART[SSTU-SC-ENG-RD-0110]:AFTER[SSTU]
+{
+	@mass = 0.451
+}
+
+@PART[SSTU-SC-ENG-RD-0124]:AFTER[SSTU]
+{
+	@mass = 0.480
+}
+
+@PART[SSTU-SC-ENG-RD-107X]:AFTER[SSTU]
+{
+	@mass = 1.19
+}
+@PART[SSTU-SC-ENG-RD-107A]:AFTER[SSTU]
+{
+	@mass = 1.19
+	%MODULE[ModuleEngineConfigs]
+	{
+		%origMass = 1.19
+	}
+}
+
+@PART[SSTU-SC-ENG-RD-108A]:AFTER[SSTU]
+{
+	@mass = 1.287
+	%MODULE[ModuleEngineConfigs]
+	{
+		%origMass = 1.287
+	}
+}
+@PART[SSTU-SC-ENG-RD-171]:AFTER[SSTU]
+{
+	@mass = 9.5
+}
+
+@PART[SSTU-SC-ENG-RD-180]:AFTER[SSTU]
+{
+	@mass = 5.48
+}
+
+@PART[SSTU-SC-ENG-RD-181]:AFTER[SSTU]
+{
+	@mass = 2.290
+}


### PR DESCRIPTION
Work around for the engine clustering mass bug. Sets the stock mass parameter to the appropriate value and ignores the origMass parameter. As a consequence, engines with multiple variants have a fixed mass. RD-107 and RD-108 engines are excluded, as I personally never cluster these engines and would prefer to preserve the mass switching with upgraded variants.