### PR TITLE
[Maintenance] RSB Saturn updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -210,7 +210,7 @@
 //  Saturn V Instrument Unit.
 
 //  Dimensions: 6.6 m x 0.9 m
-//  Inert Mass: 2000 Kg
+//  Inert Mass: 1950 Kg
 //  ==================================================
 
 @PART[RSBprobeSaturn]:FOR[RealismOverhaul]
@@ -221,7 +221,7 @@
     @manufacturer = Bendix Corporation & IBM
     @description = The instrumentation and guidance unit for the Saturn V launch vehicle.
 
-    @mass = 2.0
+    @mass = 1.95
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
@@ -287,7 +287,7 @@
         Mode1OmniRange = 1000000
         EnergyCost = 0.025
 
-        TRANSITTER
+        TRANSMITTER
         {
             PacketInterval = 1.0
             PacketSize = 0.128
@@ -426,7 +426,7 @@
 //  ==================================================
 //  Saturn APS unit.
 
-//  Dimensions: 0.7 m x 1.4 m
+//  Dimensions: 0.9 m x 1.8 m
 //  Gross Mass: 135 Kg
 //  ==================================================
 
@@ -436,7 +436,7 @@
 
     @MODEL
     {
-        @scale = 1.5, 1.5, 1.5
+        @scale = 1.93, 1.93, 1.93
     }
 
     @title = Saturn Auxiliary Propulsion System (APS)
@@ -547,7 +547,7 @@
 
     @crashTolerance = 12
     @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
 
@@ -934,7 +934,7 @@
 //  Saturn V S-IC/S-II interstage adapter.
 
 //  Dimensions: 10 m x 6 m
-//  Inert Mass: 4900 Kg
+//  Inert Mass: 4330 Kg
 //  ==================================================
 
 @PART[RSBdecouplerSaturnSII]:FOR[RealismOverhaul]
@@ -952,7 +952,7 @@
     @title = Saturn V S-IC Interstage Adapter
     @manufacturer = North American Aviation
 
-    @mass = 4.9
+    @mass = 4.33
     @crashTolerance = 14
     @breakingForce = 250
     @breakingTorque = 250
@@ -1065,8 +1065,8 @@
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 2697.6
-        @maxThrust = 2697.6
+        @minThrust = 1344
+        @maxThrust = 1344
         @heatProduction = 120
         %ullage = False
         %pressureFed = False

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -20,7 +20,7 @@
 //  Saturn Multibody nose cone.
 
 //  Dimensions: 6.6 m x 4.5 m
-//  Inert Mass: 1050 Kg
+//  Inert Mass: 1050 kg
 //  ==================================================
 
 @PART[RSBnosecone6m2]:FOR[RealismOverhaul]
@@ -43,7 +43,7 @@
 //  Saturn IB nose cone.
 
 //  Dimensions: 6.6 m x 6.7 m
-//  Inert Mass: 1500 Kg
+//  Inert Mass: 1500 kg
 //  ==================================================
 
 @PART[RSBnosecone6m]:FOR[RealismOverhaul]
@@ -66,7 +66,7 @@
 //  Saturn V nose cone.
 
 //  Dimensions: 10 m x 8.3 m
-//  Inert Mass: 3100 Kg
+//  Inert Mass: 3100 kg
 //  ==================================================
 
 @PART[RSBnosecone10m]:FOR[RealismOverhaul]
@@ -89,7 +89,7 @@
 //  Saturn I payload fairing base.
 
 //  Dimensions: 3.9 m x 0.8 m
-//  Inert Mass: 500 Kg
+//  Inert Mass: 500 kg
 //  ==================================================
 
 @PART[RSBfairingSaturn4m]:FOR[RealismOverhaul]
@@ -112,7 +112,7 @@
 //  Saturn V payload fairing base (6.6 meters).
 
 //  Dimensions: 6.6 m x 1.2 m
-//  Inert Mass: 1970 Kg
+//  Inert Mass: 1970 kg
 //  ==================================================
 
 @PART[RSBfairingSaturn6m]:FOR[RealismOverhaul]
@@ -135,7 +135,7 @@
 //  Saturn V payload fairing base (10 meters).
 
 //  Dimensions: 10 m x 1.8 m
-//  Inert Mass: 6180 Kg
+//  Inert Mass: 6180 kg
 //  ==================================================
 
 @PART[RSBfairingSaturn10m]:FOR[RealismOverhaul]
@@ -158,7 +158,7 @@
 //  Saturn I Instrument Unit.
 
 //  Dimensions: 3.9 m x 0.86 m
-//  Inert Mass: 1180 Kg
+//  Inert Mass: 1180 kg
 //  ==================================================
 
 @PART[RSBprobeSaturn2]:FOR[RealismOverhaul]
@@ -210,7 +210,7 @@
 //  Saturn V Instrument Unit.
 
 //  Dimensions: 6.6 m x 0.9 m
-//  Inert Mass: 1950 Kg
+//  Inert Mass: 1950 kg
 //  ==================================================
 
 @PART[RSBprobeSaturn]:FOR[RealismOverhaul]
@@ -300,7 +300,7 @@
 //  Saturn I S-IV stage propellant tank.
 
 //  Dimensions: 3.9 m x 9 m
-//  Gross Mass: 49930 Kg
+//  Gross Mass: 49930 kg
 
 //  Inert mass includes that of other equipment (mostly the
 //  required Helium for propellant pressurization).
@@ -332,7 +332,7 @@
         volume = 134315
         basemass = -1
 
-        //  S-IV fuel mass 7143 Kg.
+        //  S-IV fuel mass 7143 kg.
 
         TANK
         {
@@ -341,7 +341,7 @@
             maxAmount = 100820
         }
 
-        //  S-IV oxidizer mass 38216 Kg.
+        //  S-IV oxidizer mass 38216 kg.
 
         TANK
         {
@@ -358,14 +358,15 @@
 //  Saturn S-IVB propellant tank.
 
 //  Dimensions: 6.6 m x 14.8 m
-//  Gross Mass: 116600 Kg
+//  Gross Mass: 116600 kg
 
-//  Inert mass includes that of other equipment (mostly the APS
-//  units and the required Helium for propellant pressurization
-//  and J-2 engine start).
+//  Inert mass includes that of other equipment, such
+//  as the the required helium tanks for propellant
+//  pressurization and J-2 turbopump startup.
 
-//  Individual propellant masses are calculated based on an O/F
-//  engine ratio of 5.5 (since we lack PU systems).
+//  Individual propellant masses are calculated based
+//  on an O/F engine ratio of 5.5, since we lack PU
+//  systems.
 //  ==================================================
 
 @PART[RSBtankSaturnSIVB]:FOR[RealismOverhaul]
@@ -391,7 +392,7 @@
         volume = 312280
         basemass = -1
 
-        //  S-IVB fuel mass 16490 Kg.
+        //  S-IVB fuel mass 16490 kg.
 
         TANK
         {
@@ -400,7 +401,7 @@
             maxAmount = 232780
         }
 
-        //  S-IVB oxidizer mass 90710 Kg.
+        //  S-IVB oxidizer mass 90710 kg.
 
         TANK
         {
@@ -413,7 +414,7 @@
     !RESOURCE,*{}
 
     //  Avionics batteries 548 Wh.
-    //  Supports the S-IVC for flights up to 3.5 hours in duration (including the battery capacity of the IU).
+    //  Supports the S-IVC for flights up to 3.5 hours in duration (including the battery capacity of the Instrument Unit).
 
     RESOURCE
     {
@@ -427,7 +428,7 @@
 //  Saturn APS unit.
 
 //  Dimensions: 0.9 m x 1.8 m
-//  Gross Mass: 135 Kg
+//  Gross Mass: 135 kg
 //  ==================================================
 
 @PART[RSBsaturnAPS]:FOR[RealismOverhaul]
@@ -499,7 +500,7 @@
         volume = 54
         basemass = -1
 
-        //  APS fuel mass 23 Kg.
+        //  APS fuel mass 23 kg.
 
         TANK
         {
@@ -508,7 +509,7 @@
             maxAmount = 26
         }
 
-        //  APS oxidizer mass 36 Kg.
+        //  APS oxidizer mass 36 kg.
 
         TANK
         {
@@ -517,13 +518,13 @@
             maxAmount = 25
         }
 
-        //  APS pressurization gas mass ~0.09 Kg.
+        //  APS pressurization gas mass ~0.09 kg.
 
         TANK
         {
             name = Helium
-            amount = 510
-            maxAmount = 510
+            amount = 600
+            maxAmount = 600
         }
     }
 
@@ -534,7 +535,7 @@
 //  Saturn S-IVB ullage motor.
 
 //  Dimensions: 0.35 m x 0.9 m
-//  Gross Mass: 60 Kg
+//  Gross Mass: 60 kg
 //  ==================================================
 
 @PART[RSBullageSaturnSIVB]:FOR[RealismOverhaul]
@@ -581,7 +582,7 @@
         volume = 15.25
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass 27 Kg.
+        //  HTPB/AP propellant mixture mass 27 kg.
 
         TANK
         {
@@ -598,7 +599,7 @@
 //  Saturn V S-II/S-IVB interstage adapter.
 
 //  Dimensions: 10 m x 6 m
-//  Gross Mass: 4550 Kg
+//  Gross Mass: 4550 kg
 //  ==================================================
 
 @PART[RSBdecouplerSaturnSIVB]:FOR[RealismOverhaul]
@@ -616,7 +617,7 @@
     @maxTemp = 673.15
     @skinMaxTemp = 773.15
 
-    //  Four 155 kN retro motors (inert 104 Kg - gross 226 Kg).
+    //  Four 155 kN retro motors (inert 104 kg - gross 226 kg).
 
     @MODULE[ModuleEngines*]
     {
@@ -653,7 +654,7 @@
         volume = 275.6
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass 488 Kg.
+        //  HTPB/AP propellant mixture mass 488 kg.
 
         TANK
         {
@@ -670,7 +671,7 @@
 //  Saturn IB interstage adapter.
 
 //  Dimensions: 6.6 m x 5.7 m
-//  Gross Mass: 3080 Kg
+//  Gross Mass: 3080 kg
 //  ==================================================
 
 @PART[RSBdecouplerSaturnSIVB2]:FOR[RealismOverhaul]
@@ -688,7 +689,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 773.15
 
-    //  Four 163 kN retro motors (inert 50 Kg - gross 170 Kg).
+    //  Four 163 kN retro motors (inert 50 kg - gross 170 kg).
 
     @MODULE[ModuleEngines*]
     {
@@ -725,7 +726,7 @@
         volume = 271.75
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass 482 Kg.
+        //  HTPB/AP propellant mixture mass 482 kg.
 
         TANK
         {
@@ -742,10 +743,15 @@
 //  Saturn V S-II propellant tank.
 
 //  Dimensions: 10 m x 21.3 m
-//  Gross Mass: 476500 Kg
+//  Gross Mass: 476500 kg
 
-//  Inert mass includes that of other equipment (mostly the helium
-//  tanks for propellant pressurization and J-2 turbopump start).
+//  Inert mass includes that of other equipment, such
+//  as the helium tanks for propellant pressurization
+//  and J-2 turbopump start.
+
+//  Individual propellant masses are calculated based
+//  on an O/F engine ratio of 5.5, since we lack PU
+//  systems.
 //  ==================================================
 
 @PART[RSBtankSaturnSII]:FOR[RealismOverhaul]
@@ -770,7 +776,7 @@
         volume = 1349810
         basemass = -1
 
-        //  S-II fuel mass 72200 Kg.
+        //  S-II fuel mass 72200 kg.
 
         TANK
         {
@@ -779,7 +785,7 @@
             maxAmount = 1018890
         }
 
-        //  S-II oxidizer mass 377600 Kg.
+        //  S-II oxidizer mass 377600 kg.
 
         TANK
         {
@@ -806,7 +812,7 @@
 //  Saturn C-8 S-II propellant tank.
 
 //  Dimensions: 10 m x 38 m
-//  Gross Mass: 756560 Kg
+//  Gross Mass: 756560 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSII8]:FOR[RealismOverhaul]
@@ -833,7 +839,7 @@
         volume = 2060440
         basemass = -1
 
-        //  S-II-8 fuel mass 108818 Kg.
+        //  S-II-8 fuel mass 108818 kg.
 
         TANK
         {
@@ -842,7 +848,7 @@
             maxAmount = 1535900
         }
 
-        //  S-II-8 oxidizer mass 598501 Kg.
+        //  S-II-8 oxidizer mass 598501 kg.
 
         TANK
         {
@@ -869,7 +875,7 @@
 //  Saturn V S-II ullage motor.
 
 //  Dimensions: 0.4 m x 2.3 m
-//  Mass: 256 Kg
+//  Mass: 256 kg
 //  ==================================================
 
 @PART[RSBullageSaturnSII]:FOR[RealismOverhaul]
@@ -917,7 +923,7 @@
         volume = 85.87
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass 152 Kg.
+        //  HTPB/AP propellant mixture mass 152 kg.
 
         TANK
         {
@@ -934,7 +940,7 @@
 //  Saturn V S-IC/S-II interstage adapter.
 
 //  Dimensions: 10 m x 6 m
-//  Inert Mass: 4330 Kg
+//  Inert Mass: 4330 kg
 //  ==================================================
 
 @PART[RSBdecouplerSaturnSII]:FOR[RealismOverhaul]
@@ -969,7 +975,7 @@
 //  Saturn C-8 S-IC-8/S-II-8 interstage adapter.
 
 //  Dimensions: 12.2 m x 6 m
-//  Inert Mass: 6180 Kg
+//  Inert Mass: 6180 kg
 //  ==================================================
 
 @PART[RSBdecouplerSaturnSII8]:FOR[RealismOverhaul]
@@ -987,7 +993,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 773.15
 
-    //  Eight 155 kN retro motors (inert 104 Kg - gross 226 Kg).
+    //  Eight 155 kN retro motors (inert 104 kg - gross 226 kg).
 
     @MODULE[ModuleEngines*]
     {
@@ -1019,7 +1025,7 @@
         volume = 551.41
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass 976 Kg.
+        //  HTPB/AP propellant mixture mass 976 kg.
 
         TANK
         {
@@ -1041,7 +1047,7 @@
 //  Saturn V S-IC propellant tank.
 
 //  Dimensions: 10 m x 38 m
-//  Gross Mass: 2240000 Kg
+//  Gross Mass: 2240000 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSIC]:FOR[RealismOverhaul]
@@ -1061,7 +1067,7 @@
     %stageOffset = 1
     %childStageOffset = 1
 
-    //  Four 336 kN retro motors (inert 104 Kg - gross 230 Kg).
+    //  Four 336 kN retro motors (inert 104 kg - gross 230 kg).
 
     @MODULE[ModuleEngines*]
     {
@@ -1098,7 +1104,7 @@
         volume = 2104785
         basemass = -1
 
-        //  S-IC fuel mass 647500 Kg.
+        //  S-IC fuel mass 647500 kg.
 
         TANK
         {
@@ -1107,7 +1113,7 @@
             maxAmount = 789585
         }
 
-        //  S-IC oxidizer mass 1500640 Kg.
+        //  S-IC oxidizer mass 1500640 kg.
 
         TANK
         {
@@ -1119,7 +1125,7 @@
 
     !RESOURCE,*{}
 
-    //  HTPB/AP propellant mixture mass 152 Kg.
+    //  HTPB/AP propellant mixture mass 152 kg.
 
     RESOURCE
     {
@@ -1143,7 +1149,7 @@
 //  Saturn C-8 S-IC-8 propellant tank.
 
 //  Dimensions: 12.2 m x 46 m
-//  Gross Mass: 3560380 Kg
+//  Gross Mass: 3560380 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSIC8]:FOR[RealismOverhaul]
@@ -1169,7 +1175,7 @@
         volume = 3381808
         basemass = -1
 
-        //  S-IC-8 fuel mass 1053852 Kg.
+        //  S-IC-8 fuel mass 1053852 kg.
 
         TANK
         {
@@ -1178,7 +1184,7 @@
             maxAmount = 1285186
         }
 
-        //  S-IC-8 oxidizer mass 2392245 Kg.
+        //  S-IC-8 oxidizer mass 2392245 kg.
 
         TANK
         {
@@ -1205,7 +1211,7 @@
 //  Saturn I fin (large - black).
 
 //  Dimensions: 5.2 m x 4.5 m
-//  Inert Mass: 850 Kg
+//  Inert Mass: 850 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIblackL]:FOR[RealismOverhaul]
@@ -1227,7 +1233,7 @@
 //  Saturn I fin (small - black).
 
 //  Dimensions: 3.5 m x 4.5 m
-//  Inert Mass: 600 Kg
+//  Inert Mass: 600 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIblackS]:FOR[RealismOverhaul]
@@ -1249,7 +1255,7 @@
 //  Saturn I fin (large - white).
 
 //  Dimensions: 5.2 m x 4.5 m
-//  Inert Mass: 850 Kg
+//  Inert Mass: 850 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIwhiteL]:FOR[RealismOverhaul]
@@ -1271,7 +1277,7 @@
 //  Saturn I fin (small - white).
 
 //  Dimensions: 3.5 m x 4.5 m
-//  Inert Mass: 600 Kg
+//  Inert Mass: 600 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIwhiteS]:FOR[RealismOverhaul]
@@ -1293,7 +1299,7 @@
 //  Saturn V fin.
 
 //  Dimensions: 4 m x 3.5 m
-//  Inert Mass: 350 Kg
+//  Inert Mass: 350 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIC]:FOR[RealismOverhaul]
@@ -1314,7 +1320,7 @@
 //  Saturn I interstage adapter.
 
 //  Dimensions: 5.6 m x 4.8 m
-//  Inert Mass: 2400 Kg
+//  Inert Mass: 2400 kg
 //  ==================================================
 
 @PART[RSBdecouplerSaturnSIV]:FOR[RealismOverhaul]
@@ -1342,7 +1348,7 @@
 //  Saturn S-I/IB propellant tank.
 
 //  Dimensions: 6.6 m x 23 m
-//  Gross Mass: 446100 Kg
+//  Gross Mass: 446100 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSIB]:FOR[RealismOverhaul]
@@ -1369,7 +1375,7 @@
         volume = 405830
         basemass = -1
 
-        //  S-IB fuel 127863 Kg.
+        //  S-IB fuel 127863 kg.
 
         TANK
         {
@@ -1378,7 +1384,7 @@
             maxAmount = 155930
         }
 
-        //  S-IB oxidizer 285136 Kg.
+        //  S-IB oxidizer 285136 kg.
 
         TANK
         {
@@ -1405,7 +1411,7 @@
 //  Saturn IB fin (black).
 
 //  Dimensions: 3 m x 2.5 m
-//  Mass: 200 Kg
+//  Inert Mass: 200 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIBblack]:FOR[RealismOverhaul]
@@ -1426,7 +1432,7 @@
 //  Saturn IB fin (white).
 
 //  Dimensions: 3 m x 2.5 m
-//  Mass: 200 Kg
+//  Inert Mass: 200 kg
 //  ==================================================
 
 @PART[RSBfinSaturnSIBwhite]:FOR[RealismOverhaul]
@@ -1447,7 +1453,7 @@
 //  Saturn IC S-IE propellant tank.
 
 //  Dimensions: 6.6 m x 19 m
-//  Gross Mass: 422800 Kg
+//  Gross Mass: 422800 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSIE]:FOR[RealismOverhaul]
@@ -1474,7 +1480,7 @@
         volume = 399405
         basemass = -1
 
-        //  S-IE fuel mass 124464 Kg.
+        //  S-IE fuel mass 124464 kg.
 
         TANK
         {
@@ -1483,7 +1489,7 @@
             maxAmount = 151785
         }
 
-        //  S-IE oxidizer mass 282534 Kg.
+        //  S-IE oxidizer mass 282534 kg.
 
         TANK
         {
@@ -1510,7 +1516,7 @@
 //  Saturn Multibody S-IF propellant tank.
 
 //  Dimensions: 6.6 m x 25 m
-//  Gross Mass: 526300 Kg
+//  Gross Mass: 526300 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSIF]:FOR[RealismOverhaul]
@@ -1537,7 +1543,7 @@
         volume = 495330
         basemass = -1
 
-        //  S-1F fuel mass 154335 Kg.
+        //  S-1F fuel mass 154335 kg.
 
         TANK
         {
@@ -1546,7 +1552,7 @@
             maxAmount = 188240
         }
 
-        //  S-1F oxidizer mass 350386 Kg.
+        //  S-1F oxidizer mass 350386 kg.
 
         TANK
         {
@@ -1573,7 +1579,7 @@
 //  Saturn Multibody S-IVC propellant tank.
 
 //  Dimensions: 6.6 m x 18 m
-//  Gross Mass: 254780 Kg
+//  Gross Mass: 254780 kg
 //  ==================================================
 
 @PART[RSBtankSaturnSIVC]:FOR[RealismOverhaul]
@@ -1600,7 +1606,7 @@
         volume = 668590
         basemass = -1
 
-        //  S-IVC fuel mass 35310 Kg.
+        //  S-IVC fuel mass 35310 kg.
 
         TANK
         {
@@ -1609,7 +1615,7 @@
             maxAmount = 498380
         }
 
-        //  S-IVC oxidizer mass 194206 Kg.
+        //  S-IVC oxidizer mass 194206 kg.
 
         TANK
         {
@@ -1622,7 +1628,7 @@
     !RESOURCE,*{}
 
     //  Avionics batteries 548 Wh.
-    //  Supports the S-IVC for flights up to 3.5 hours in duration (including the battery capacity of the IU).
+    //  Supports the S-IVC for flights up to 3.5 hours in duration (including the battery capacity of the Instrument Unit).
 
     RESOURCE
     {
@@ -1636,7 +1642,7 @@
 //  Generic propellant tank adapter (6.6:5).
 
 //  Dimensions: 6.6 m x 4.7 m
-//  Mass: 2000 Kg
+//  Inert Mass: 2000 kg
 //  ==================================================
 
 @PART[RSBtankSaturn6m5m]:FOR[RealismOverhaul]
@@ -1644,7 +1650,7 @@
     %RSSROConfig = True
 
     @manufacturer = Generic
-    @description = A general purpose conical propellant tank.
+    @description = A general purpose propellant tank.
 
     @mass = 2.0
     @crashTolerance = 12
@@ -1671,7 +1677,7 @@
 //  Generic propellant tank adapter (10:6.6).
 
 //  Dimensions: 10 m x 6 m
-//  Inert Mass: 5300 Kg
+//  Inert Mass: 5300 kg
 //  ==================================================
 
 @PART[RSBtankSaturn10m6m]:FOR[RealismOverhaul]
@@ -1679,7 +1685,7 @@
     %RSSROConfig = True
 
     @manufacturer = Generic
-    @description = A general purpose conical propellant tank.
+    @description = A general purpose propellant tank.
 
     @mass = 5.3
     @crashTolerance = 12
@@ -1706,7 +1712,7 @@
 //  Generic propellant tank adapter (10:7.5).
 
 //  Dimensions: 10 m x 6 m
-//  Mass: 5800 Kg
+//  Mass: 5800 kg
 //  ==================================================
 
 @PART[RSBtankSaturn10m7m]:FOR[RealismOverhaul]
@@ -1714,7 +1720,7 @@
     %RSSROConfig = True
 
     @manufacturer = Generic
-    @description = A general purpose conical propellant tank.
+    @description = A general purpose propellant tank.
 
     @mass = 5.8
     @crashTolerance = 12

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Saturn.cfg
@@ -1712,7 +1712,7 @@
 //  Generic propellant tank adapter (10:7.5).
 
 //  Dimensions: 10 m x 6 m
-//  Mass: 5800 kg
+//  Inert Mass: 5800 kg
 //  ==================================================
 
 @PART[RSBtankSaturn10m7m]:FOR[RealismOverhaul]


### PR DESCRIPTION
Some changes backported from the DECQ Apollo-Saturn pack via newer research.

**Change Log:**

* Tweak the dry mass of the Instrument Unit from 2000 to 1950 kg.
* Fix a game-breaking typo within the RemoteTech TRANSMITTER node of the Instrument Unit.
* Increase the size of the S-IVB APS unit (was too small compared to IRL).
* Tweak the dry mass of the S-IC/S-II interstage adapter from 4900 to 4330 kg.
* Fix the incorrect thrust values of the S-IC retromotors.
* Fix the incorrect "kg" unit (lowercase "k" instead of uppercase "K").
* Other documentation updates/fixes.