### PR TITLE
[Bug Fix] LMDE global config updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
@@ -28,11 +28,26 @@
 {
 	%title = Lunar Module Descent Engine (LMDE)
 	%manufacturer = TRW
-	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability. Diameter: [1.5 m].
+	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability. Diameter: 1.5 m.
 
 	@MODULE[ModuleEngines*]
 	{
-        %EngineType = LiquidFuel
+		@minThrust = 4.67
+		@maxThrust = 43.9
+		%heatProduction = 35
+		@allowShutdown = True
+		%EngineType = LiquidFuel
+		@useEngineResponseSpeed = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
+		@useThrustCurve = False
+		%ullage = True
+		%pressureFed = True
+		%ignitions = 3
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
 	}
 
 	@MODULE[ModuleGimbal]
@@ -47,7 +62,6 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = LMDE-H
-		modded = false
 		origMass = 0.158
 
 		CONFIG
@@ -55,7 +69,7 @@
 			name = LMDE-H
 			minThrust = 4.67
 			maxThrust = 43.9
-			heatProduction = 100
+			heatProduction = 35
 			massMult = 1.0
 			ullage = True
 			pressureFed = True
@@ -93,9 +107,8 @@
 			name = LMDE-J
 			minThrust = 4.67
 			maxThrust = 45.04
-			heatProduction = 100
+			heatProduction = 36
 			massMult = 1.0
-
 			ullage = True
 			pressureFed = True
 			ignitions = 3
@@ -132,9 +145,8 @@
 			name = TR-201
 			minThrust = 43.8
 			maxThrust = 43.8
-			heatProduction = 100
+			heatProduction = 48
 			massMult = 0.7151 //mass is 0.113
-			
 			ullage = True
 			pressureFed = True
 			ignitions = 5 //(6)


### PR DESCRIPTION
**Change Log:**

* Remove the part mass parameter since it breaks the **ignoreMass** global engine config operator.
* Add some default engine module parameters patching.
* Tweak the heat production values.
* Make sure that all alternator modules will be removed from the part config.
* Convert spaces into tabs.