### PR TITLE
[Bug Fix] LMAE global config updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -23,14 +23,14 @@
 
 @PART[*]:HAS[#engineType[LMAE]]:FOR[RealismOverhaulEngines]
 {
-    %title = Lunar Module Ascent Engine (LMAE)
-    %manufacturer = Bell
-    %description = Pressure-fed engine used for the ascent module of the Apollo lunar lander. Diameter: [0.86 m].
+	%title = Lunar Module Ascent Engine (LMAE)
+	%manufacturer = Bell
+	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander. Diameter: [0.86 m].
 
-    @MODULE[ModuleEngines*]
-    {
-        %EngineType = LiquidFuel
-    }
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
 
 	!MODULE[ModuleGimbal],*{}
 
@@ -41,7 +41,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = LMAE
-        origMass = 0.095
+		origMass = 0.095
 
 		CONFIG
 		{
@@ -49,17 +49,16 @@
 			minThrust = 15.57
 			maxThrust = 15.57
 			heatProduction = 100
-            massMult = 1.0
+			massMult = 1.0
+			ullage = True
+			pressureFed = True
+			ignitions = 10
 
-            ullage = True
-            pressureFed = True
-            ignitions = 10
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.1
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
 
 			PROPELLANT
 			{
@@ -72,7 +71,7 @@
 			{
 				name = NTO
 				ratio = 0.4983
-                DrawGauge = False
+				DrawGauge = False
 			}
 
 			atmosphereCurve
@@ -83,7 +82,7 @@
 		}
 	}
 
-    !MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleAlternator],*{}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -16,9 +16,6 @@
 //      AIES
 //      FASA
 //      Squad
-
-//  FIXME: Number of ignitions (10 instead of 2).
-//  FIXME: Inert mass (NASA references indicate a value of 210 pounds)
 //  ==================================================
 
 @PART[*]:HAS[#engineType[LMAE]]:FOR[RealismOverhaulEngines]
@@ -29,7 +26,22 @@
 
 	@MODULE[ModuleEngines*]
 	{
+		@minThrust = 15.57
+		@maxThrust = 15.57
+		%heatProduction = 20
+		@allowShutdown = True
 		%EngineType = LiquidFuel
+		@useEngineResponseSpeed = False
+		@engineAccelerationSpeed = 0
+		@engineDecelerationSpeed = 0
+		@useThrustCurve = False
+		%ullage = True
+		%pressureFed = True
+		%ignitions = 10
+
+		!IGNITOR_RESOURCE,*{}
+
+		!thrustCurve,*{}
 	}
 
 	!MODULE[ModuleGimbal],*{}
@@ -48,7 +60,7 @@
 			name = LMAE
 			minThrust = 15.57
 			maxThrust = 15.57
-			heatProduction = 100
+			heatProduction = 20
 			massMult = 1.0
 			ullage = True
 			pressureFed = True

--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -1,6 +1,7 @@
 //  ==================================================
 //  Lunar Module Ascent Engine (LMAE)
 
+//  Gross Mass: 95 kg
 //  Throttle Range: N/A
 //  Burn Time: 465 s
 //  O/F Ratio: 1.6
@@ -22,8 +23,7 @@
 
 @PART[*]:HAS[#engineType[LMAE]]:FOR[RealismOverhaulEngines]
 {
-    @mass = 0.095
-    %title = Lunar Module Ascent Engine
+    %title = Lunar Module Ascent Engine (LMAE)
     %manufacturer = Bell
     %description = Pressure-fed engine used for the ascent module of the Apollo lunar lander. Diameter: [0.86 m].
 
@@ -32,7 +32,9 @@
         %EngineType = LiquidFuel
     }
 
-    !MODULE[ModuleGimbal]{}
+	!MODULE[ModuleGimbal],*{}
+
+	!MODULE[ModuleEngineConfigs],*{}
 
 	MODULE
 	{
@@ -40,7 +42,6 @@
 		type = ModuleEngines
 		configuration = LMAE
         origMass = 0.095
-		modded = false
 
 		CONFIG
 		{
@@ -82,7 +83,7 @@
 		}
 	}
 
-    !MODULE[ModuleAlternator]{}
+    !MODULE[ModuleAlternator],*{}
 
     !RESOURCE,*{}
 }


### PR DESCRIPTION
**Change Log:**

* Remove the part mass parameter since it breaks the **ignoreMass** global engine config operator.
* Add some default engine module parameters patching.
* Tweak the heat production values.
* Make sure that no previous engine module configs exist before applying ours.
* Make sure that all alternator and gimbal modules will be removed from the part config.
* Convert spaces into tabs.