### PR TITLE
[Bug Fix] Update the RO engine part patcher

### DIFF
--- a/GameData/RealismOverhaul/RO_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_Engines.cfg
@@ -1,25 +1,26 @@
 //  ==================================================
 //  Catch any engine part modules and place them into
-//  the Engine category.
+//  the "Engine" category.
 
-//  Check if the module implements:
+//  Check if the part module already implements:
 
-//      *   ModuleCommand (MechJeb)
-//      *   Decoupler(s) (coupling as a primary function)
-//      *   Custom part categories (FilterExtensions)
+//  * Command modules (MechJeb)
+//  * Decouplers (coupling as a primary function)
+//  * Custom part categories (FilterExtensions)
+//  * The "leaveCategory" parameter (leaves the part category as is)
 //  ==================================================
 
-@PART[*]:HAS[@MODULE[ModuleEngines*],!MODULE[*Decouple*],!MODULE[ModuleCommand]]:BEFORE[zzzRealismOverhaul]
+@PART[*]:HAS[@MODULE[ModuleEngines*],!MODULE[*Decouple*],!MODULE[ModuleCommand],~leaveCategory[*]]:BEFORE[zzzRealismOverhaul]
 {
-	%category = Engine
+    %category = Engine
 }
 
 //  ==================================================
-//  Make sure that no engine part module has a
+//  Make sure that no engine part module implements a
 //  TweakScale module.
 //  ==================================================
 
 @PART[*]:HAS[@MODULE[TweakScale],@MODULE[ModuleEngines*]]:FOR[zzzRealismOverhaul]
 {
-    !MODULE[TweakScale]{}
+    !MODULE[TweakScale],*{}
 }


### PR DESCRIPTION
**Change Log:**

* Update the engine category patcher to add the **leaveCategory** parameter. This can be used for parts that include engine modules (ModuleEngines/FX/RF) but they are not engines by themselves.
* Make sure that all TweakScale modules will be removed by parts that include engine modules (previously only the first one would be removed).