### PR TITLE
[Bug FIx] Fix some RO global patcher bugs

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -214,7 +214,22 @@
 //  Add Telemachus support to all antenna parts.
 //  ==================================================
 
-@PART[*]:HAS[@MODULE[ModuleRTAntenna*]|@MODULE[ModuleDataTransmitter],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:AFTER[RealismOverhaul]
+@PART[*]:HAS[@MODULE[ModuleDataTransmitter],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = TelemachusDataLink
+	}
+
+	MODULE
+	{
+		name = TelemachusPowerDrain
+		powerConsumptionBase = 0.001
+		powerConsumptionIncrease = 0.001
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntenna*],!MODULE[TelemachusDataLink]]:NEEDS[Telemachus]:AFTER[RealismOverhaul]
 {
 	MODULE
 	{
@@ -233,7 +248,7 @@
 //  Allow decoupler propellant cross - feeding.
 //  ==================================================
 
-@PART[*]:HAS[@MODULE[ModuleAnchoredDecoupler]|@MODULE[ModuleDecouple],!MODULE[ModuleToggleCrossfeed]]:FOR[zzzRealismOverhaul]
+@PART[*]:HAS[@MODULE[Module*Decouple*],!MODULE[ModuleToggleCrossfeed]]:FOR[zzzRealismOverhaul]
 {
     MODULE
     {


### PR DESCRIPTION
**Change Log:**

* Fix the Telemachus and the decoupler cross feed patchers (it is not possible to check for mutiple modules inside a **HAS[]** block - in the case of the cross feed check, just a wildcard check is enough).