### PR TITLE
[Maintenance] Squad antennae updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -31,9 +31,9 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 200000
+        @antennaPower = 1600
         @packetInterval = 1.0
-        @packetSize = 1.28
+        @packetSize = 1.024
         @packetResourceCost = 0.004
     }
 }
@@ -46,7 +46,7 @@
 
 @PART[SurfAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: <color=red>Note that it is not activated by default!</color> Maximum effective range approximately 200 Mm, power consumption 12 Watts, maximum data rate 1.3 Mbit/s.
+    @description ^=:$: <color=orange>Note that it is not activated by default!</color> Maximum effective range approximately 200 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -60,7 +60,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 1.280
+            @PacketSize = 1.024
             @PacketResourceCost = 0.004
         }
     }
@@ -93,9 +93,9 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 800000
+        @antennaPower = 6400
         @packetInterval = 1.0
-        @packetSize = 0.768
+        @packetSize = 0.512
         @packetResourceCost = 0.0005
     }
 }
@@ -108,7 +108,7 @@
 
 @PART[longAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: If you wonder how a 4 Mm antenna can reach the Moon, check the Realism Overhaul FAQ. Maximum effective range approximately 400 Mm, power consumption 1.5 Watts, maximum data rate 768 kbit/s.
+    @description ^=:$: If you wonder how a 4 Mm antenna can reach the Moon, check the Realism Overhaul FAQ. Maximum effective range approximately 400 Mm, power consumption 1.5 Watts, maximum data rate 512 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -124,7 +124,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 0.768
+            @PacketSize = 0.512
             @PacketResourceCost = 0.0005
         }
     }
@@ -160,9 +160,9 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 3400000000
+        @antennaPower = 2.71e9
         @packetInterval = 1.0
-        @packetSize = 2.048
+        @packetSize = 0.512
         @packetResourceCost = 0.005
     }
 }
@@ -175,14 +175,14 @@
 
 @PART[mediumDishAntenna]:AFTER[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 260 Gm, power consumption 15 Watts, maximum data rate 2 Mbit/s.
+    @description ^= :$: Maximum effective range approximately 260 Gm, power consumption 15 Watts, maximum data rate 512 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 5.9e8
+        @Mode1DishRange = 5.93e8
         @EnergyCost = 0.015
         @MaxQ = 6000
         @DishAngle = 10.0
@@ -190,7 +190,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 2.048
+            @PacketSize = 0.512
             @PacketResourceCost = 0.005
         }
     }
@@ -228,9 +228,9 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 5750000000
+        @antennaPower = 4.63e9
         @packetInterval = 1.0
-        @packetSize = 1.28
+        @packetSize = 0.768
         @packetResourceCost = 0.01
     }
 }
@@ -243,14 +243,14 @@
 
 @PART[HighGainAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: Comparatively low bandwidth, on par with standard omnidirectional antennae. Maximum effective range approximately 340 Gm, power consumption 25 Watts, maximum data rate 1.3 Mbit/s.
+    @description ^=:$: Comparatively low bandwidth, on par with standard omnidirectional antennae. Maximum effective range approximately 340 Gm, power consumption 25 Watts, maximum data rate 768 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 1e9
+        @Mode1DishRange = 1.01e9
         @EnergyCost = 0.025
         @MaxQ = 6000
         @DishAngle = 4.0
@@ -258,7 +258,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 1.280
+            @PacketSize = 0.768
             @PacketResourceCost = 0.01
         }
     }
@@ -295,7 +295,7 @@
         @antennaType = DIRECT
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 8000000000
+        @antennaPower = 6.4e9
         @packetInterval = 1.0
         @packetSize = 1.024
         @packetResourceCost = 0.01
@@ -364,9 +364,9 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 16750000000
+        @antennaPower = 40e9
         @packetInterval = 1.0
-        @packetSize = 0.896
+        @packetSize = 2.048
         @packetResourceCost = 0.01
     }
 }
@@ -379,14 +379,14 @@
 
 @PART[RelayAntenna5]:AFTER[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 580 Gm, power consumption 35 Watts, maximum data rate 896 kbit/s.
+    @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 35 Watts, maximum data rate 2 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 3.0e9
+        @Mode1DishRange = 8.77e9
         @EnergyCost = 0.035
         %MaxQ = 6000
         @DishAngle = 2.0
@@ -396,14 +396,14 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 0.896
+            @PacketSize = 2.048
             @PacketResourceCost = 0.01
         }
     }
 }
 
 //  ==================================================
-//  Communotron 88-88.
+//  Communotron 88-88 retractable parabolic antenna.
 
 //  Dimensions: 4.75 m x 2.4 m (extended)
 //  Inert Mass: 55 Kg
@@ -431,15 +431,15 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 63000000000
+        @antennaPower = 2.5e11
         @packetInterval = 1.0
-        @packetSize = 0.768
+        @packetSize = 1.024
         @packetResourceCost = 0.015
     }
 }
 
 //  ==================================================
-//  Communotron 88-88.
+//  Communotron 88-88 retractable parabolic antenna.
 
 //  Ven Stock Revamp compatibility.
 //  ==================================================
@@ -464,21 +464,21 @@
 }
 
 //  ==================================================
-//  Communotron 88-88.
+//  Communotron 88-88 retractable parabolic antenna.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
 @PART[commDish]:AFTER[RemoteTech]
 {
-    @description ^=:$: Maximum effective range approximately 2.5 Tm, power consumption 45 Watts, maximum data rate 768 kbit/s.
+    @description ^=:$: Maximum effective range approximately 2.5 Tm, power consumption 45 Watts, maximum data rate 1 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 3.5e10
+        @Mode1DishRange = 5.5e10
         @EnergyCost = 0.045
         @MaxQ = 6000
         @DishAngle = 0.4
@@ -486,7 +486,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 0.768
+            @PacketSize = 1.024
             @PacketResourceCost = 0.015
         }
     }
@@ -523,9 +523,9 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 4100000000000
+        @antennaPower = 9e12
         @packetInterval = 1.0
-        @packetSize = 0.512
+        @packetSize = 0.768
         @packetResourceCost = 0.015
     }
 }
@@ -538,14 +538,14 @@
 
 @PART[RelayAntenna50]:AFTER[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 20 Tm, power consumption 60 Watts, maximum data rate 512 kbit/s.
+    @description ^= :$: Maximum effective range approximately 15 Tm, power consumption 60 Watts, maximum data rate 768 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 2.65e12
+        @Mode1DishRange = 1.98e12
         @EnergyCost = 0.06
         %MaxQ = 6000
         @DishAngle = 0.75
@@ -555,7 +555,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 0.512
+            @PacketSize = 0.768
             @PacketResourceCost = 0.015
         }
     }
@@ -592,9 +592,9 @@
         @antennaType = RELAY
         @antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 16400000000000
+        @antennaPower = 36e12
         @packetInterval = 1.0
-        @packetSize = 0.384
+        @packetSize = 0.512
         @packetResourceCost = 0.04
     }
 }
@@ -607,14 +607,14 @@
 
 @PART[RelayAntenna100]:AFTER[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 40 Tm, power consumption 80 Watts, maximum data rate 384 kbit/s.
+    @description ^= :$: Maximum effective range approximately 30 Tm, power consumption 80 Watts, maximum data rate 512 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 8.6e12
+        @Mode1DishRange = 7.9e12
         @EnergyCost = 0.08
         %MaxQ = 6000
         @DishAngle = 0.5
@@ -624,7 +624,7 @@
         @TRANSMITTER
         {
             @PacketInterval = 1.0
-            @PacketSize = 0.384
+            @PacketSize = 0.512
             @PacketResourceCost = 0.04
         }
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -30,8 +30,8 @@
     {
         @antennaType = DIRECT
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 1600
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 400
         @packetInterval = 1.0
         @packetSize = 1.024
         @packetResourceCost = 0.004
@@ -92,8 +92,8 @@
     {
         @antennaType = DIRECT
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 6400
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 1600
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.0005
@@ -159,8 +159,8 @@
     {
         @antennaType = DIRECT
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 2.71e9
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 9e8
         @packetInterval = 1.0
         @packetSize = 0.512
         @packetResourceCost = 0.005
@@ -175,14 +175,14 @@
 
 @PART[mediumDishAntenna]:AFTER[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 260 Gm, power consumption 15 Watts, maximum data rate 512 kbit/s.
+    @description ^= :$: Maximum effective range approximately 300 Gm, power consumption 15 Watts, maximum data rate 512 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 5.93e8
+        @Mode1DishRange = 7.9e8
         @EnergyCost = 0.015
         @MaxQ = 6000
         @DishAngle = 10.0
@@ -227,8 +227,8 @@
     {
         @antennaType = DIRECT
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 4.63e9
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 1.23e9
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.01
@@ -243,14 +243,14 @@
 
 @PART[HighGainAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: Comparatively low bandwidth, on par with standard omnidirectional antennae. Maximum effective range approximately 340 Gm, power consumption 25 Watts, maximum data rate 768 kbit/s.
+    @description ^=:$: Comparatively low bandwidth, on par with standard omnidirectional antennae. Maximum effective range approximately 350 Gm, power consumption 25 Watts, maximum data rate 768 kbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 1.01e9
+        @Mode1DishRange = 1.075e9
         @EnergyCost = 0.025
         @MaxQ = 6000
         @DishAngle = 4.0
@@ -294,8 +294,8 @@
     {
         @antennaType = DIRECT
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 6.4e9
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 1.6e9
         @packetInterval = 1.0
         @packetSize = 1.024
         @packetResourceCost = 0.01
@@ -363,8 +363,8 @@
     {
         @antennaType = RELAY
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 40e9
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 10e9
         @packetInterval = 1.0
         @packetSize = 2.048
         @packetResourceCost = 0.01
@@ -430,8 +430,8 @@
     {
         @antennaType = RELAY
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 2.5e11
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 6.3e10
         @packetInterval = 1.0
         @packetSize = 1.024
         @packetResourceCost = 0.015
@@ -522,8 +522,8 @@
     {
         @antennaType = RELAY
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 9e12
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 2.3e12
         @packetInterval = 1.0
         @packetSize = 0.768
         @packetResourceCost = 0.015
@@ -591,7 +591,7 @@
     {
         @antennaType = RELAY
         @antennaCombinable = True
-        %antennaCombinableExponent = 1
+        %antennaCombinableExponent = 2.0
         @antennaPower = 36e12
         @packetInterval = 1.0
         @packetSize = 0.512
@@ -614,7 +614,7 @@
     @MODULE[ModuleRTAntenna]
     {
         @Mode0DishRange = 0
-        @Mode1DishRange = 7.9e12
+        @Mode1DishRange = 9e12
         @EnergyCost = 0.08
         %MaxQ = 6000
         @DishAngle = 0.5


### PR DESCRIPTION
**Change Log:**

* Update all antenna ranges (CommNet and RT) to have better chances to operate as expected (ranges did not cover 100% of the suggested purpose) and be better balanced against both themselves and their RT counterparts.
* Update the data rates for better balancing.
* Fix the incorrect antenna combinable exponent to operate the same as the RT "multiple antenna multiplier" (the ranges of identical antennae are stacked and the overall range doubles).
* Fix the red color of the Communotron 16-S that made it difficult to read.

|              Name               |   Type   |   Link Range | Data Rate  |                          Purpose                          |
|:-------------------------:|:--------:|:--------------:|:------------:|:--------------------------------------------:|
|Communotron 16-S      |  Omni   |      0.2 Gm    | 1024 kbit/s |                               Earth                          |
|Communotron 16         |  Omni   |      0.4 Gm    | 512 kbit/s   |                          Earth/Moon                    |
|DTS-M1                         |   Dish   |      300 Gm   |  512 kbit/s  |                               Venus                         |
|Communotron HG-55   |   Dish   |      350 Gm   |  768 kbit/s  |                           Venus/Mars                    |
|HG-5                              |  Dish   |      400 Gm    |  1024 kbit/s |                   Mercury/Venus/Mars            |
|RA-2                              |   Dish  |     1000 Gm   |  2048 kbit/s |                  Inner Planets/Jupiter              |
|Communotron 88-88    |  Dish   |     2500 Gm   |  1024 kbit/s |            Inner Planets/Jupiter/Saturn         |
|RA-15                            | Dish    |   15000 Gm    | 768 kbit/s   |                 Inner & Outer Planets              |
|RA-100                          |   Dish   |   30000 Gm   |  512 kbit/s  | Inner & Outer Planets/Interstellar Space |

### Data Rates

- Omnis generally have low rates and are supposed to be auxiliary antennas if a dish is also installed. They also fulfill the role of surface-to-obit communications (early tech landers/atmospheric probes).
- Dishes initially start with low rates (early tech, Ranger/Mariner-alike) and they increase till the RA-2 (the antenna in VSR is modeled after the MRO/OSIRIS-REx/Ulysses and other, similar modern missions, all-around antenna). As effective distances increase the data rates decrease again (Pioneer 10/11, Voyager 1/2, Galileo, Cassini), since IRL they require heavy use of error correction techniques.