### PR TITLE
Hg 3 speculative upgrades

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -118,7 +118,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 5 //Improvements to technology in 1980s-90s allow for more ignitions
+			%ignitions = 5 //Improvements to technology in 1980s allow for more ignitions and improved reliability
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -151,7 +151,7 @@
 			
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 2 //Limited emergency relight capability, ala NK-33.
+			%ignitions = 2 //Limited emergency relight capability, ala NK-33. Also improves reliability.
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -204,8 +204,9 @@
 		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.962
-		cycleReliabilityStart = 0.902
-		cycleReliabilityEnd = 0.962
+		cycleReliabilityStart = 0.9468
+		cycleReliabilityEnd = 0.9995
+		techTransfer = HG-3,HG-3-SL:50
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3A-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -216,7 +217,8 @@
 		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.962
-		cycleReliabilityStart = 0.902
-		cycleReliabilityEnd = 0.962
+		cycleReliabilityStart = 0.9468
+		cycleReliabilityEnd = 0.9995
+		techTransfer = HG-3,HG-3-SL:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -9,6 +9,8 @@
 //  Burn Time: 600 s
 //  O/F Ratio: ?? (Assumed 5.5 ala J-2)
 
+//Upgrades (HG-3A, etc.) are purely speculative.
+
 //  Source 1: http://www.astronautix.com/h/hg-3.html
 //  Source 2: http://www.astronautix.com/h/hg-3-sl.html
 //  Source 3: https://history.msfc.nasa.gov/saturn_apollo/propulsion_center.html
@@ -91,6 +93,71 @@
 				amount = 0.500
 			}
 		}
+		CONFIG
+		{
+			name = HG-3A
+			minThrust = 938.469
+			maxThrust = 1400.70
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 451
+				key = 1 280
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 5 //Improvements to technology in 1980s-90s allow for more ignitions
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
+			name = HG-3A-SL
+			minThrust = 929.29
+			maxThrust = 1387.00
+			massMult = 0.973574409
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 450
+				key = 1 360
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 2 //Limited emergency relight capability, ala NK-33.
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
 	}
 	@MODULE[ModuleGimbal]
 	{
@@ -127,5 +194,29 @@
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
 		cycleReliabilityEnd = 0.96
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = HG-3A
+		ratedBurnTime = 600
+		ignitionReliabilityStart = 0.902
+		ignitionReliabilityEnd = 0.962
+		cycleReliabilityStart = 0.902
+		cycleReliabilityEnd = 0.962
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3A-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = HG-3A-SL
+		ratedBurnTime = 600
+		ignitionReliabilityStart = 0.902
+		ignitionReliabilityEnd = 0.962
+		cycleReliabilityStart = 0.902
+		cycleReliabilityEnd = 0.962
 	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3-SL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3-SL.cfg
@@ -10,8 +10,22 @@
 		%powerEffectName = Hydrolox-Lower
 		}
 		
+		//HG-3A-SL, Hydrolox-Lower
+		@CONFIG[HG-3A-SL]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		
 		//HG-3, Hydrolox-Upper
 		@CONFIG[HG-3]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3A, Hydrolox-Upper
+		@CONFIG[HG-3A]
 		{
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3.cfg
@@ -10,8 +10,22 @@
 		%powerEffectName = Hydrolox-Lower
 		}
 		
+		//HG-3A-SL, Hydrolox-Lower
+		@CONFIG[HG-3A-SL]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		
 		//HG-3, Hydrolox-Upper
 		@CONFIG[HG-3]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3A, Hydrolox-Upper
+		@CONFIG[HG-3A]
 		{
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTHG-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTHG-3.cfg
@@ -10,8 +10,21 @@
 		%powerEffectName = Hydrolox-Lower
 		}
 		
+		//HG-3A-SL, Hydrolox-Lower
+		@CONFIG[HG-3A-SL]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		
 		//HG-3, Hydrolox-Upper
 		@CONFIG[HG-3]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3A, Hydrolox-Upper
+		@CONFIG[HG-3A]
 		{
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTHG-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTHG-3.cfg
@@ -15,6 +15,7 @@
 		{
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Lower
+		}
 		
 		//HG-3, Hydrolox-Upper
 		@CONFIG[HG-3]


### PR DESCRIPTION
In the same vein as upgrades to the E-1 engine. Upgrades don't improve thrust or ISP, but do improve reliability based on posited tech improvements during development of RS-25.