### PR TITLE
Fix lv1 static solar panel scales

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
@@ -133,7 +133,7 @@
 	@title = ST1 Tiny Solar Panel
 	@description = Small static Level 1 solar panel. 0.05m^2.
 	%RSSROConfig = True
-	%rescaleFactor = 0.2434
+	%rescaleFactor = 0.5443309471123242
 	@mass = 0.000075	// Level 1 static @ 0.0005t/m^2 + 0.001t/m^2 
 	@MODULE[ModuleDeployableSolarPanel]
 	{
@@ -146,7 +146,7 @@
 	@title = ST1 Medium Solar Panel
 	@description = Medium static Level 1 solar panel. 0.125m^2.
 	%RSSROConfig = True
-	%rescaleFactor = 0.608581
+	%rescaleFactor = 0.8606627968957994
 	@mass = 0.0003	// Level 1 static @ 0.0005t/m^2 + 0.001t/m^2 
 	@MODULE[ModuleDeployableSolarPanel]
 	{


### PR DESCRIPTION
The rescale factors for the tiny and medium panels were wrong. Instead of scaling the area by 1/2 and 1/5, the dimensions were scaled by those amounts, resulting in the models ingame having 1/4 and 1/25 the area, Fix this by scaling the dimensions with the square roots.