### PR TITLE
[Maintenance] Coatl Aerospace 0.17 updates & fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Command.cfg
@@ -11,7 +11,7 @@
 //  Surveyor lander probe core.
 
 //  Dimensions: 4.26 m x 1.45 m (extended)
-//  Gross Mass: 240 Kg
+//  Gross Mass: 240 kg
 //  ==================================================
 
 @PART[ca_landv_core]:FOR[RealismOverhaul]
@@ -70,8 +70,8 @@
         volume = 100
         basemass = -1
 
-        //  Avionics batteries 4.4 kWh.
-        //  Includes the average capacity of the auxiliary battery (600 Wh, single - use).
+        //  Avionics batteries ~4.4 kWh.
+        //  Includes the average capacity of the auxiliary battery (~600 Wh, single - use).
 
         TANK
         {
@@ -80,7 +80,7 @@
             maxAmount = 15840
         }
 
-        //  Vernier engine fuel mass ~32.9 Kg.
+        //  Vernier engine fuel mass ~32.9 kg.
 
         TANK
         {
@@ -89,7 +89,7 @@
             maxAmount = 38
         }
 
-        //  Vernier engine oxidizer mass ~49.2 Kg.
+        //  Vernier engine oxidizer mass ~49.2 kg.
 
         TANK
         {
@@ -98,7 +98,7 @@
             maxAmount = 35
         }
 
-        //  ACS propellant mass ~2.04 Kg.
+        //  ACS propellant mass ~2.04 kg.
 
         TANK
         {
@@ -115,7 +115,7 @@
 //  Surveyor orbiter probe core.
 
 //  Dimensions: - m x - m
-//  Gross Mass: - Kg
+//  Gross Mass: - kg
 //  ==================================================
 
 @PART[ca_landv_orbiter_core]:FOR[RealismOverhaul]
@@ -174,7 +174,7 @@
         volume = 200
         basemass = -1
 
-        //  Avionics batteries 3.8 kWh.
+        //  Avionics batteries ~3.8 kWh.
 
         TANK
         {
@@ -195,7 +195,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_landv_core|ca_landv_orbiter_core]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_landv_core|ca_landv_orbiter_core]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     !MODULE[ModuleDataTransmitter],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -50,9 +50,9 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 500000
+        @antennaPower = 6400
         @packetInterval = 1.0
-        @packetSize = 0.512
+        @packetSize = 2.048
         @packetResourceCost = 0.015
     }
 }
@@ -65,7 +65,7 @@
 
 @PART[ca_landv_hga]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range approximately 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+    @description ^= :$: Effective range approximately 400 Mm, power consumption 10 Watts, maximum data rate 2 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -83,7 +83,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 750000
+        Mode1DishRange = 400000
         DishAngle = 5.0
         EnergyCost = 0.01
         DeployFxModules = 0
@@ -92,7 +92,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.512
+            PacketSize = 2.048
             PacketResourceCost = 0.005
         }
     }
@@ -120,9 +120,9 @@
     @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
     @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
 
-    @title = Surveyor Omni Antenna
+    @title = Surveyor Low Gain Antenna (LGA)
     @manufacturer = Hughes Aircraft Company
-    @description = The omnidirectional low gain antenna for the Surveyor Lander and Orbiter. Can serve as a backup for the main planar antenna.
+    @description = The omnidirectional low gain antenna for the Surveyor Lander and Orbiter. Two of them can serve as a backup for the main planar antenna.
 
     @mass = 0.005
     @crashTolerance = 8
@@ -138,10 +138,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 101250
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 1600
         @packetInterval = 1.0
-        @packetSize = 0.128
+        @packetSize = 1.024
         @packetResourceCost = 0.015
     }
 }
@@ -154,7 +154,7 @@
 
 @PART[ca_landv_omni]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range approximately 225 Mm, power consumption 10 Watts, maximum data rate 128 kbit/sec.
+    @description ^= :$: Effective range approximately 200 Mm, power consumption 10 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -172,7 +172,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 2250000
+        Mode1OmniRange = 2000000
         EnergyCost = 0.01
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -180,7 +180,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.128
+            PacketSize = 1.024
             PacketResourceCost = 0.005
         }
     }
@@ -225,9 +225,9 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 500000
+        @antennaPower = 6400
         @packetInterval = 1.0
-        @packetSize = 0.512
+        @packetSize = 2.048
         @packetResourceCost = 0.015
     }
 }
@@ -240,7 +240,7 @@
 
 @PART[ca_landv_orbiter_HGA]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Effective range approximately 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+    @description ^= :$: Effective range approximately 500 Mm, power consumption 10 Watts, maximum data rate 2 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -258,7 +258,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 750000
+        Mode1DishRange = 400000
         DishAngle = 5.0
         EnergyCost = 0.01
         DeployFxModules = 0
@@ -267,7 +267,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.512
+            PacketSize = 2.048
             PacketResourceCost = 0.005
         }
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Communication.cfg
@@ -8,7 +8,7 @@
 //  Surveyor lander solar array & high gain antenna.
 
 //  Dimensions: 1 m x 1.5 m (extended)
-//  Inert Mass: 20 Kg
+//  Inert Mass: 20 kg
 //  ==================================================
 
 @PART[ca_landv_hga]:FOR[RealismOverhaul]
@@ -50,10 +50,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 750000
+        @antennaPower = 500000
         @packetInterval = 1.0
         @packetSize = 0.512
-        @packetResourceCost = 0.005
+        @packetResourceCost = 0.015
     }
 }
 
@@ -63,7 +63,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_landv_hga]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_landv_hga]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Effective range approximately 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
 
@@ -102,7 +102,7 @@
 //  Surveyor lander & orbiter low gain antenna.
 
 //  Dimensions: 0.04 m x 1.45 m (extended)
-//  Inert Mass: 5 Kg
+//  Inert Mass: 5 kg
 //  ==================================================
 
 @PART[ca_landv_omni]:FOR[RealismOverhaul]
@@ -139,10 +139,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 2250000
+        @antennaPower = 101250
         @packetInterval = 1.0
         @packetSize = 0.128
-        @packetResourceCost = 0.005
+        @packetResourceCost = 0.015
     }
 }
 
@@ -152,7 +152,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_landv_omni]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_landv_omni]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Effective range approximately 225 Mm, power consumption 10 Watts, maximum data rate 128 kbit/sec.
 
@@ -190,7 +190,7 @@
 //  Surveyor orbiter high gain antenna.
 
 //  Dimensions: 1.2 m x 1.3 m (extended)
-//  Inert Mass: 12 Kg
+//  Inert Mass: 12 kg
 //  ==================================================
 
 @PART[ca_landv_orbiter_HGA]:FOR[RealismOverhaul]
@@ -238,7 +238,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_landv_orbiter_HGA]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_landv_orbiter_HGA]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Effective range approximately 500 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Electrical.cfg
@@ -7,7 +7,7 @@
 //  Surveyor lander & orbiter battery pack.
 
 //  Dimensions: 0.215 m x 0.3 m
-//  Gross Mass: 50 Kg
+//  Gross Mass: 50 kg
 //  ==================================================
 
 @PART[ca_landv_battery]:FOR[RealismOverhaul]
@@ -46,7 +46,7 @@
 //  Surveyor orbiter solar array.
 
 //  Dimensions: 1.03 m x 1.45 m (extended)
-//  Inert Mass: 6 Kg
+//  Inert Mass: 6 kg
 //  ==================================================
 
 @PART[ca_landv_sp]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -11,7 +11,7 @@
 //  TD-339 engine.
 
 //  Dimensions: 0.14 m x 0.33 m
-//  Inert Mass: 2.5 Kg
+//  Inert Mass: 2.5 kg
 //  ==================================================
 
 @PART[ca_landv_vernier]:FOR[RealismOverhaul]
@@ -83,10 +83,10 @@
 //  STAR 37 SRM.
 
 //  Dimensions: 0.94 m x 1.47 m
-//  Gross Mass: 625 Kg
+//  Gross Mass: 625 kg
 //  ==================================================
 
-@PART[ca_landv_srm]:FOR[RealismOverhal]
+@PART[ca_landv_srm]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Science.cfg
@@ -7,7 +7,7 @@
 //  Surveyor camera.
 
 //  Dimensions: 0.1 m x 0.425 m
-//  Gross Mass: 5 Kg
+//  Gross Mass: 5 kg
 //  ==================================================
 
 @PART[ca_landv_cam_s1]:FOR[RealismOverhaul]
@@ -40,7 +40,7 @@
 //  Surveyor soil scoop.
 
 //  Dimensions: 0.15 m x 0.35 m
-//  Inert Mass: 5 Kg
+//  Inert Mass: 5 kg
 //  ==================================================
 
 @PART[ca_landv_soilScoop]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -22,7 +22,7 @@
 //  Conic helical omnidirectional antenna.
 
 //  Dimensions: 0.2 m x 1.1 m
-//  Inert Mass: 3 Kg
+//  Inert Mass: 3 kg
 //  ==================================================
 
 @PART[antenna_cone_toggle]:FOR[RealismOverhaul]
@@ -55,10 +55,10 @@
         @antennaType = RELAY
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 12500000
+        @antennaPower = 11250
         @packetInterval = 1.0
         @packetSize = 3.84
-        @packetResourceCost = 0.005
+        @packetResourceCost = 0.01
         @antennaCombinable = True
     }
 }
@@ -69,7 +69,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[antenna_cone_toggle]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[antenna_cone_toggle]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 75 Mm, power consumption 5 Watts, maximum data rate 3.8 Mbit/sec.
 
@@ -107,7 +107,7 @@
 //  GPS antenna.
 
 //  Dimensions: 0.55 m x 0.2 m
-//  Inert Mass: 8 Kg
+//  Inert Mass: 8 kg
 //  ==================================================
 
 @PART[ca_ant_gps]:FOR[RealismOverhaul]
@@ -138,10 +138,10 @@
         @antennaType = RELAY
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 1200000
+        @antennaPower = 1800
         @packetInterval = 1.0
-        @packetSize = 4.48
-        @packetResourceCost = 0.005
+        @packetSize = 2.048
+        @packetResourceCost = 0.025
     }
 }
 
@@ -151,7 +151,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_ant_gps]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_ant_gps]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 30 Mm, power consumption 10 Watts, maximum data rate 4.5 Mbit/sec.
 
@@ -189,7 +189,7 @@
 //  Ground plane telemetry antenna.
 
 //  Dimensions: 0.04 m x 1.75 m (extended)
-//  Inert Mass: 3 Kg
+//  Inert Mass: 3 kg
 //  ==================================================
 
 @PART[antenna_tv]:FOR[RealismOverhaul]
@@ -225,10 +225,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 100000
+        @antennaPower = 200
         @packetInterval = 1.0
         @packetSize = 6.144
-        @packetResourceCost = 0.004
+        @packetResourceCost = 0.012
     }
 }
 
@@ -238,7 +238,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[antenna_tv]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[antenna_tv]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 10 Mm, power consumption 8 Watts, maximum data rate 6.1 Mbit/sec.
 
@@ -277,7 +277,7 @@
 //  Whip omnidirectional antenna.
 
 //  Dimensions: 0.075 m x 0.7 m
-//  Inert Mass: 3 Kg
+//  Inert Mass: 3 kg
 //  ==================================================
 
 @PART[antenna_quetzal]:FOR[RealismOverhaul]
@@ -311,10 +311,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 1500000
+        @antennaPower = 45000
         @packetInterval = 1.0
         @packetSize = 1.024
-        @packetResourceCost = 0.006
+        @packetResourceCost = 0.018
         @antennaCombinable = True
     }
 }
@@ -325,7 +325,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[antenna_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[antenna_quetzal]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 150 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/sec.
 
@@ -363,7 +363,7 @@
 //  Medium folding parabolic antenna.
 
 //  Dimensions: 1.1 m x 0.15 m (retracted)
-//  Inert Mass: 20 Kg
+//  Inert Mass: 20 kg
 //  ==================================================
 
 @PART[dish_deploy_S]:FOR[RealismOverhaul]
@@ -396,10 +396,10 @@
         @antennaType = RELAY
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 450000000
+        @antennaPower = 1250000000
         @packetInterval = 1.0
         @packetSize = 2.56
-        @packetResourceCost = 0.0175
+        @packetResourceCost = 52.5
 
         !UPGRADES,*{}
     }
@@ -411,7 +411,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_deploy_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_deploy_S]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 25 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
 
@@ -451,7 +451,7 @@
 //  Mariner Mars parabolic antenna.
 
 //  Dimensions: 1.16 m x 0.5 m (extended)
-//  Inert Mass: 35 Kg
+//  Inert Mass: 35 kg
 //  ==================================================
 
 @PART[dish_deploy_S2]:FOR[RealismOverhaul]
@@ -486,10 +486,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 5750000000
+        @antennaPower = 231200000000
         @packetInterval = 1.0
-        @packetSize = 1.28
-        @packetResourceCost = 0.01
+        @packetSize = 0.512
+        @packetResourceCost = 0.03
 
         !UPGRADES,*{}
     }
@@ -501,7 +501,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_deploy_S2]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_deploy_S2]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 340 Gm, power consumption 20 Watts, maximum data rate 1.62 Mbit/sec, gain 27 dBi.
 
@@ -521,7 +521,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 1E9
+        Mode1DishRange = 1E6
         EnergyCost = 0.02
         DishAngle = 5.25
         MaxQ = 6000
@@ -531,7 +531,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 1.28
+            PacketSize = 1.62
             PacketResourceCost = 0.01
         }
     }
@@ -541,7 +541,7 @@
 //  Juno parabolic antenna.
 
 //  Dimensions: 2.5 m x 0.85 m
-//  Inert Mass: 35 Kg
+//  Inert Mass: 35 kg
 
 //  * The mass includes some extra hardware required
 //    by the antenna system (waveguides, mounting,
@@ -596,7 +596,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_hera]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_hera]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 25 Watts, maximum data rate 2 Mbit/sec, gain 43 dBi.
 
@@ -635,7 +635,7 @@
 //  Voyager 1 & 2 parabolic antenna.
 
 //  Dimensions: 3.66 m x 1.45 m
-//  Inert Mass: 53 Kg
+//  Inert Mass: 53 kg
 //  ==================================================
 
 @PART[dish_L]:FOR[RealismOverhaul]
@@ -673,10 +673,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 9000000000000
+        @antennaPower = 1800000000000000
         @packetInterval = 1.0
         @packetSize = 0.384
-        @packetResourceCost = 0.0236
+        @packetResourceCost = 0.05
 
         !UPGRADES,*{}
     }
@@ -688,7 +688,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_L]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_L]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 30 Tm, power consumption 24 Watts, maximum data rate 380 kbit/sec, gain 48 dBi.
 
@@ -727,7 +727,7 @@
 //  Pioneer 10 & 11 parabolic antenna.
 
 //  Dimensions: 2.77 m x 1.3 m
-//  Inert Mass: 40 Kg
+//  Inert Mass: 40 kg
 //  ==================================================
 
 @PART[dish_quetzal]:FOR[RealismOverhaul]
@@ -764,10 +764,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 2250000000000
+        @antennaPower = 450000000000000
         @packetInterval = 1.0
         @packetSize = 0.256
-        @packetResourceCost = 0.008
+        @packetResourceCost = 0.024
 
         !UPGRADES,*{}
     }
@@ -798,7 +798,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_quetzal]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_quetzal]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 15 Tm, power consumption 16 Watts, maximum data rate 0.25 Mbit/sec, gain 34 dBi.
 
@@ -837,7 +837,7 @@
 //  Ulysses parabolic antenna.
 
 //  Dimensions: 1.65 m x 1.2 m
-//  Inert Mass: 25 Kg
+//  Inert Mass: 25 kg
 //  =================================================
 
 @PART[dish_S]:FOR[RealismOverhaul]
@@ -874,10 +874,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 10000000000
+        @antennaPower = 2000000000000
         @packetInterval = 1.0
         @packetSize = 0.768
-        @packetResourceCost = 0.005
+        @packetResourceCost = 0.025
 
         !UPGRADES,*{}
     }
@@ -889,7 +889,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_S]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_S]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 20 Watts, maximum data rate 0.77 Mbit/sec, gain 41 dBi.
 
@@ -928,7 +928,7 @@
 //  MAVEN parabolic antenna.
 
 //  Dimensions: 2 m x 0.8 m
-//  Inert Mass: 32 Kg
+//  Inert Mass: 32 kg
 //  ==================================================
 
 @PART[dish_tatsujin]:FOR[RealismOverhaul]
@@ -964,10 +964,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 255000000000
+        @antennaPower = 50000000000000
         @packetInterval = 1.0
         @packetSize = 0.512
-        @packetResourceCost = 0.01
+        @packetResourceCost = 0.04
     }
 }
 
@@ -977,7 +977,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_tatsujin]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_tatsujin]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 500 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 40 dBi.
 
@@ -1016,7 +1016,7 @@
 //  4MV spacecraft bus omnidirectional antenna.
 
 //  Dimensions: 1.425 m x 1.8 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_vor_comm]:FOR[RealismOverhaul]
@@ -1056,10 +1056,10 @@
         @antennaType = RELAY
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 50000000
+        @antennaPower = 45000
         @packetInterval = 1.0
         @packetSize = 0.512
-        @packetResourceCost = 0.01
+        @packetResourceCost = 0.04
     }
 }
 
@@ -1069,7 +1069,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_vor_comm]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_vor_comm]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 150 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
 
@@ -1107,7 +1107,7 @@
 //  4MV-1 spacecraft bus parabolic antenna.
 
 //  Dimensions: 1.6 m x 0.7 m
-//  Inert Mass: 20 Kg
+//  Inert Mass: 20 kg
 //  ==================================================
 
 @PART[ca_vor_dish]:FOR[RealismOverhaul]
@@ -1142,10 +1142,10 @@
         @antennaType = DIRECT
         %antennaCombinable = True
         %antennaCombinableExponent = 1
-        @antennaPower = 7250000000
+        @antennaPower = 288800000000
         @packetInterval = 1.0
-        @packetSize = 0.512
-        @packetResourceCost = 0.04
+        @packetSize = 1.024
+        @packetResourceCost = 0.025
 
         !UPGRADES,*{}
     }
@@ -1157,7 +1157,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_vor_dish]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_vor_dish]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 380 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 30 dBi.
 
@@ -1196,7 +1196,7 @@
 //  Cassini parabolic antenna.
 
 //  Dimensions: 4 m x 2.03 m
-//  Inert Mass: 110 Kg
+//  Inert Mass: 110 kg
 
 //  This part includes both a targetable and an omni
 //  antenna in order to communicate with Mission
@@ -1257,7 +1257,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[mer_dish]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[mer_dish]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 1.5 Tm, power consumption 30 Watts, maximum data rate 1 Mbit/sec, gain 47 dBi.
 
@@ -1314,7 +1314,7 @@
 //  STEREO parabolic antenna.
 
 //  Dimensions: 1.2 m x 1.1 m (extended)
-//  Inert Mass: 35 Kg
+//  Inert Mass: 35 kg
 //  ==================================================
 
 @PART[dish_xihe]:FOR[RealismOverhaul]
@@ -1361,7 +1361,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[dish_xihe]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[dish_xihe]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Maximum effective range approximately 380 Gm, power consumption 30 Watts, maximum data rate 5 Mbit/sec, gain 38 dBi.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Antenna.cfg
@@ -39,7 +39,7 @@
 
     @title = CA-A02 Helical Omnidirectional Antenna
     @manufacturer = Generic
-    @description = A low gain omnidirectional antenna for short range, high bandwidth communications.
+    @description = A low gain omnidirectional antenna for Lunar range communications.
 
     @mass = 0.003
     @crashTolerance = 8
@@ -54,10 +54,10 @@
     {
         @antennaType = RELAY
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 11250
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 6400
         @packetInterval = 1.0
-        @packetSize = 3.84
+        @packetSize = 0.512
         @packetResourceCost = 0.01
         @antennaCombinable = True
     }
@@ -71,7 +71,7 @@
 
 @PART[antenna_cone_toggle]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 75 Mm, power consumption 5 Watts, maximum data rate 3.8 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 400 Mm, power consumption 5 Watts, maximum data rate 512 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -89,7 +89,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 7.5E5
+        Mode1OmniRange = 4000000
         EnergyCost = 0.005
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -97,7 +97,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 3.84
+            PacketSize = 0.512
             PacketResourceCost = 0.005
         }
     }
@@ -124,7 +124,7 @@
 
     @title = CA-GPS Omnidirectional Antenna
     @manufacturer = Generic
-    @description = This antenna provides access to the KerbNet (GPS) system for very detailed tracking of the spacecraft's position. It can be used as a omnidirectional antenna but it is not very efficient in that role.
+    @description = This antenna provides access to the Global Positioning System (GPS) system for very detailed tracking of the spacecraft's position. It can be used as a omnidirectional antenna but it is not very efficient in that role.
 
     @mass = 0.008
     @crashTolerance = 8
@@ -137,8 +137,8 @@
     {
         @antennaType = RELAY
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 1800
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 400
         @packetInterval = 1.0
         @packetSize = 2.048
         @packetResourceCost = 0.025
@@ -153,7 +153,7 @@
 
 @PART[ca_ant_gps]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 30 Mm, power consumption 10 Watts, maximum data rate 4.5 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 100 Mm, power consumption 10 Watts, maximum data rate 2 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -171,7 +171,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 3E5
+        Mode1OmniRange = 1000000
         EnergyCost = 0.01
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -179,7 +179,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 4.48
+            PacketSize = 2.048
             PacketResourceCost = 0.005
         }
     }
@@ -224,10 +224,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 200
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 1600
         @packetInterval = 1.0
-        @packetSize = 6.144
+        @packetSize = 1.024
         @packetResourceCost = 0.012
     }
 }
@@ -240,7 +240,7 @@
 
 @PART[antenna_tv]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 10 Mm, power consumption 8 Watts, maximum data rate 6.1 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 200 Mm, power consumption 8 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -258,7 +258,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 1E5
+        Mode1OmniRange = 2000000
         EnergyCost = 0.008
         MaxQ = 6000
         DeployFxModules = 0
@@ -267,7 +267,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 6.144
+            PacketSize = 1.024
             PacketResourceCost = 0.004
         }
     }
@@ -310,10 +310,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 45000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 6400
         @packetInterval = 1.0
-        @packetSize = 1.024
+        @packetSize = 0.512
         @packetResourceCost = 0.018
         @antennaCombinable = True
     }
@@ -327,7 +327,7 @@
 
 @PART[antenna_quetzal]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 150 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/sec.
+    @description ^= :$: Maximum effective range approximately 400 Mm, power consumption 12 Watts, maximum data rate 512 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -345,7 +345,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 1.5E6
+        Mode1OmniRange = 4000000
         EnergyCost = 0.012
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -353,7 +353,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 1.024
+            PacketSize = 0.512
             PacketResourceCost = 0.006
         }
     }
@@ -395,10 +395,10 @@
     {
         @antennaType = RELAY
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 1250000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 102400
         @packetInterval = 1.0
-        @packetSize = 2.56
+        @packetSize = 1.024
         @packetResourceCost = 52.5
 
         !UPGRADES,*{}
@@ -413,7 +413,7 @@
 
 @PART[dish_deploy_S]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 25 Gm, power consumption 35 Watts, maximum data rate 2.5 Mbit/sec, gain 25 dBi.
+    @description ^= :$: Maximum effective range approximately 1.6 Gm, power consumption 35 Watts, maximum data rate 1024 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -431,7 +431,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 5E7
+        Mode1DishRange = 1.6E6
         EnergyCost = 0.035
         DishAngle = 10.0
         MaxQ = 6000
@@ -441,7 +441,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 2.56
+            PacketSize = 1.024
             PacketResourceCost = 0.0175
         }
     }
@@ -466,9 +466,9 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = Mariner Mars HGA
+    @title = Mariner Mars High Gain Antenna (HGA)
     @manufacturer = Generic
-    @description = A high gain parabolic antenna used on the early Mariner Mars series of spacecrafts.
+    @description = A high gain parabolic antenna used on the early Mariner Mars spacecraft series.
 
     @mass = 0.035
     @crashTolerance = 12
@@ -485,10 +485,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 231200000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 4.9E6
         @packetInterval = 1.0
-        @packetSize = 0.512
+        @packetSize = 0.768
         @packetResourceCost = 0.03
 
         !UPGRADES,*{}
@@ -503,7 +503,7 @@
 
 @PART[dish_deploy_S2]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 340 Gm, power consumption 20 Watts, maximum data rate 1.62 Mbit/sec, gain 27 dBi.
+    @description ^= :$: Maximum effective range approximately 350 Gm, power consumption 20 Watts, maximum data rate 768 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -521,7 +521,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 1E6
+        Mode1DishRange = 1.075E9
         EnergyCost = 0.02
         DishAngle = 5.25
         MaxQ = 6000
@@ -531,7 +531,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 1.62
+            PacketSize = 0.768
             PacketResourceCost = 0.01
         }
     }
@@ -572,7 +572,7 @@
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 873.15
-    %skinMaxTemo = 873.15
+    %skinMaxTemp = 873.15
     %fuelCrossFeed = False
 
     //  Required electricity assumes only the basic telecommunications
@@ -582,8 +582,8 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 2000000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 40E9
         @packetInterval = 1.0
         @packetSize = 2.048
         @packetResourceCost = 0.043
@@ -598,7 +598,7 @@
 
 @PART[dish_hera]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 25 Watts, maximum data rate 2 Mbit/sec, gain 43 dBi.
+    @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 25 Watts, maximum data rate 2 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -616,7 +616,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 8.75E9
+        Mode1DishRange = 8.77E9
         EnergyCost = 0.043
         DishAngle = 0.5
         DeployFxModules = 0
@@ -672,10 +672,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 1800000000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 36E12
         @packetInterval = 1.0
-        @packetSize = 0.384
+        @packetSize = 0.512
         @packetResourceCost = 0.05
 
         !UPGRADES,*{}
@@ -690,7 +690,7 @@
 
 @PART[dish_L]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 30 Tm, power consumption 24 Watts, maximum data rate 380 kbit/sec, gain 48 dBi.
+    @description ^= :$: Maximum effective range approximately 30 Tm, power consumption 24 Watts, maximum data rate 512 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -708,7 +708,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 5.5E12
+        Mode1DishRange = 7.9E12
         EnergyCost = 0.02415
         DishAngle = 0.6
         DeployFxModules = 0
@@ -717,7 +717,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.384
+            PacketSize = 0.512
             PacketResourceCost = 0.0236
         }
     }
@@ -763,10 +763,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 450000000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 9E12
         @packetInterval = 1.0
-        @packetSize = 0.256
+        @packetSize = 0.768
         @packetResourceCost = 0.024
 
         !UPGRADES,*{}
@@ -800,7 +800,7 @@
 
 @PART[dish_quetzal]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 15 Tm, power consumption 16 Watts, maximum data rate 0.25 Mbit/sec, gain 34 dBi.
+    @description ^= :$: Maximum effective range approximately 15 Tm, power consumption 16 Watts, maximum data rate 768 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -818,7 +818,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 1.75E12
+        Mode1DishRange = 2E12
         EnergyCost = 0.016
         DishAngle = 3.5
         DeployFxModules = 0
@@ -827,7 +827,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.256
+            PacketSize = 0.768
             PacketResourceCost = 0.008
         }
     }
@@ -873,10 +873,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 2000000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 40E9
         @packetInterval = 1.0
-        @packetSize = 0.768
+        @packetSize = 2.048
         @packetResourceCost = 0.025
 
         !UPGRADES,*{}
@@ -891,7 +891,7 @@
 
 @PART[dish_S]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 20 Watts, maximum data rate 0.77 Mbit/sec, gain 41 dBi.
+    @description ^= :$: Maximum effective range approximately 1 Tm, power consumption 20 Watts, maximum data rate 2 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -909,7 +909,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 8.75E9
+        Mode1DishRange = 8.77E9
         EnergyCost = 0.02
         DishAngle = 1.45
         DeployFxModules = 0
@@ -918,7 +918,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.768
+            PacketSize = 2.048
             PacketResourceCost = 0.005
         }
     }
@@ -963,10 +963,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 50000000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 6.4E9
         @packetInterval = 1.0
-        @packetSize = 0.512
+        @packetSize = 1.024
         @packetResourceCost = 0.04
     }
 }
@@ -979,7 +979,7 @@
 
 @PART[dish_tatsujin]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 500 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 40 dBi.
+    @description ^= :$: Maximum effective range approximately 400 Gm, power consumption 30 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -997,7 +997,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 2.175E9
+        Mode1DishRange = 1.4E9
         EnergyCost = 0.03
         DishAngle = 1.2
         DeployFxModules = 0
@@ -1006,7 +1006,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.512
+            PacketSize = 1.024
             PacketResourceCost = 0.01
         }
     }
@@ -1055,10 +1055,10 @@
     {
         @antennaType = RELAY
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 45000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 25600
         @packetInterval = 1.0
-        @packetSize = 0.512
+        @packetSize = 1.024
         @packetResourceCost = 0.04
     }
 }
@@ -1071,7 +1071,7 @@
 
 @PART[ca_vor_comm]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 150 Mm, power consumption 10 Watts, maximum data rate 512 kbit/sec.
+    @description ^= :$: Maximum effective range approximately 800 Mm, power consumption 10 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -1089,7 +1089,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 1.5E6
+        Mode1OmniRange = 8000000
         EnergyCost = 0.03
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -1097,7 +1097,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.512
+            PacketSize = 1.024
             PacketResourceCost = 0.01
         }
     }
@@ -1141,10 +1141,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 288800000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 4.9E6
         @packetInterval = 1.0
-        @packetSize = 1.024
+        @packetSize = 0.768
         @packetResourceCost = 0.025
 
         !UPGRADES,*{}
@@ -1159,7 +1159,7 @@
 
 @PART[ca_vor_dish]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 380 Gm, power consumption 30 Watts, maximum data rate 0.5 Mbit/sec, gain 30 dBi.
+    @description ^= :$: Maximum effective range approximately 350 Gm, power consumption 30 Watts, maximum data rate 768 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -1177,7 +1177,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 1.261E10
+        Mode1DishRange = 1.075E9
         EnergyCost = 0.03
         DishAngle = 1.2
         DeployFxModules = 0
@@ -1186,7 +1186,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.512
+            PacketSize = 0.768
             PacketResourceCost = 0.01
         }
     }
@@ -1241,8 +1241,8 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 100000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 250E9
         @packetInterval = 1.0
         @packetSize = 1.024
         @packetResourceCost = 0.07
@@ -1259,7 +1259,7 @@
 
 @PART[mer_dish]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 1.5 Tm, power consumption 30 Watts, maximum data rate 1 Mbit/sec, gain 47 dBi.
+    @description ^= :$: Maximum effective range approximately 2.5 Tm, power consumption 30 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -1277,7 +1277,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 2E10
+        Mode1DishRange = 55E9
         EnergyCost = 0.03
         DishAngle = 0.5
         DeployFxModules = 0
@@ -1296,7 +1296,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0OmniRange = 0
-        Mode1OmniRange = 1E7
+        Mode1OmniRange = 8000000
         EnergyCost = 0.005
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -1304,7 +1304,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 3.84
+            PacketSize = 1.024
             PacketResourceCost = 0.005
         }
     }
@@ -1344,10 +1344,10 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 100000000000
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 6.4E9
         @packetInterval = 1.0
-        @packetSize = 5.120
+        @packetSize = 1.024
         @packetResourceCost = 0.07
         @DeployFxModules = 0
 
@@ -1363,7 +1363,7 @@
 
 @PART[dish_xihe]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Maximum effective range approximately 380 Gm, power consumption 30 Watts, maximum data rate 5 Mbit/sec, gain 38 dBi.
+    @description ^= :$: Maximum effective range approximately 400 Gm, power consumption 30 Watts, maximum data rate 1 Mbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -1381,7 +1381,7 @@
         name = ModuleRTAntenna
         IsRTActive = False
         Mode0DishRange = 0
-        Mode1DishRange = 1.261E10
+        Mode1DishRange = 1.4E9
         EnergyCost = 0.03
         DishAngle = 0.5
         DeployFxModules = 0
@@ -1390,8 +1390,185 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 5.120
+            PacketSize = 1.024
             PacketResourceCost = 0.04
+        }
+    }
+}
+
+//  ==================================================
+//  Mariner Mars & Venus high gain antenna.
+
+//  Dimensions: 1.25 m x 0.8 m
+//  Inert Mass: 25 kg
+//  ==================================================
+
+@PART[ca_argo-mk2-hga]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.74, 1.74, 1.74
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+    @node_stack_mast = 0.0, 0.0, 0.189, 0.0, 1.0, 0.0, 0
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = Mariner Mars & Venus High Gain Antenna (HGA)
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = The main parabolic antenna of the early Mariner-Mars and Mariner-Venus spacecraft series. Includes attachment points for the low gain antenna.
+
+    @mass = 0.025
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    @bulkheadProfiles = srf
+    @tags ^= :$: communications
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 4.9E6
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 2.0
+        @packetInterval = 1.0
+        @packetSize = 0.768
+        @packetResourceCost = 1.0
+    }
+}
+
+//  ==================================================
+//  Mariner Mars & Venus high gain antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_argo-mk2-hga]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Maximum effective range approximately 350 Gm, power consumption 20 Watts, maximum data rate 768 kbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0DishRange = 0
+        Mode1DishRange = 1.075E9
+        EnergyCost = 0.02
+        DishAngle = 0.5
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.768
+            PacketResourceCost = 0.02
+        }
+    }
+}
+
+//  ==================================================
+//  Mariner Mars & Venus low gain antenna.
+
+//  Dimensions: 0.085 m x 2.2 m
+//  Inert Mass: 8 kg
+//  ==================================================
+
+@PART[ca_argo-mk2-mast]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.64, 1.64, 1.64
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = Mariner Mars & Venus Low Gain Antenna (LGA)
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = The low gain antenna of the early Mariner Mars and Venus spacecraft series. Apart from the antenna it also houses a magnetometer and a Geiger Counter.
+
+    @mass = 0.008
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    @bulkheadProfiles = srf
+    @tags ^= :$: communications
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaPower = 1600
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        @antennaCombinableExponent = 2.0
+        @packetInterval = 1.0
+        @packetSize = 1.024
+        @packetResourceCost = 0.02
+    }
+}
+
+//  ==================================================
+//  Mariner Mars & Venus low gain antenna.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_argo-mk2-mast]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Maximum effective range approximately 200 Mm, power consumption 10 Watts, maximum data rate 1 Mbit/sec.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPUPassive
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = False
+        Mode0OmniRange = 0
+        Mode1OmniRange = 2000000
+        EnergyCost = 0.01
+        DishAngle = 0.5
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.01
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -22,6 +22,7 @@
 //  JHUAPL - STEREO spacecraft GNC system:         http://www.jhuapl.edu/techdigest/TD/td2802/Hunt.pdf
 //  JHUAPL - Spacecraft packaging:                 http://www.jhuapl.edu/techdigest/TD/td2801/Schaefer.pdf
 //  AJR - Propulsion systems data sheets:          https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Propulsion%20System%20Data%20Sheets.pdf
+//  ESA - IUE spacecraft:                          http://sci.esa.int/iue/31301-spacecraft
 
 //  ==================================================
 //  Removed extra parts.
@@ -33,7 +34,7 @@
 //  Juno spacecraft bus.
 
 //  Dimensions: 3.5 m x 2.5 m
-//  Gross Mass: 3185 Kg
+//  Gross Mass: 3185 kg
 //  ==================================================
 
 @PART[ca_hera]:FOR[RealismOverhaul]
@@ -68,7 +69,7 @@
     %breakingTorque = 250
     @crashTolerance = 10
     @maxTemp = 873.15
-    %skinMaxTemo = 873.15
+    %skinMaxTemp = 873.15
     !explosionPotential = NULL
     %fuelCrossFeed = True
     @bulkheadProfiles = size2
@@ -93,7 +94,7 @@
 
     !MODULE[ModuleReactionWheel],*{}
 
-    //  Twelve MR-111C thrusters for three-axis attitude control.
+    //  Twelve MR-111C thrusters (~4.45 N) for three-axis attitude control.
 
     @MODULE[ModuleRCS]
     {
@@ -124,7 +125,7 @@
         volume = 1900
         basemass = -1
 
-        //  Astrionics batteries 550 Wh.
+        //  Astrionics batteries ~550 Wh.
 
         TANK
         {
@@ -133,7 +134,7 @@
             maxAmount = 1528
         }
 
-        //  Engine and ACS fuel mass ~1280 Kg.
+        //  Engine and ACS fuel mass ~1280 kg.
 
         TANK
         {
@@ -142,7 +143,7 @@
             maxAmount = 1275
         }
 
-        //  Engine and ACS oxidizer mass ~752 Kg.
+        //  Engine and ACS oxidizer mass ~752 kg.
 
         TANK
         {
@@ -159,7 +160,7 @@
 //  SSTL-150 satellite bus.
 
 //  Dimensions: 0.7 m x 0.91 m
-//  Gross Mass: 100 Kg
+//  Gross Mass: 100 kg
 //  ==================================================
 
 @PART[barquetta]:FOR[RealismOverhaul]
@@ -251,8 +252,8 @@
         volume = 20
         basemass = -1
 
-        //  Integrated batteries 150 Ah.
-        //  Ten times the actual capacity of SSTL-150 (15 Ah).
+        //  Integrated batteries ~150 Ah.
+        //  Ten times the actual capacity of SSTL-150 (~15 Ah).
 
         TANK
         {
@@ -271,7 +272,7 @@
 //  Voyager 1 & 2 spacecraft bus.
 
 //  Dimensions: 1.78 m x 0.8 m
-//  Gross Mass: 510 Kg
+//  Gross Mass: 510 kg
 //  ==================================================
 
 @PART[torekka]:FOR[RealismOverhaul]
@@ -346,7 +347,7 @@
             maxAmount = 15840
         }
 
-        //  ACS & TCM propellant 104 Kg.
+        //  ACS & TCM propellant ~104 kg.
 
         TANK
         {
@@ -365,10 +366,10 @@
 //  Pioneer 10 & 11 spacecraft bus.
 
 //  Dimensions: 1.45 m x 0.6 m
-//  Gross Mass: 140 Kg
+//  Gross Mass: 140 kg
 
 //  * The inert mass does not include the mass of the
-//    Pioneer Science Package (15 Kg).
+//    Pioneer Science Package (15 kg).
 //  ==================================================
 
 @PART[quetzal]:FOR[RealismOverhaul]
@@ -432,7 +433,7 @@
         volume = 40
         basemass = -1
 
-        //  Integrated battery 40 Wh.
+        //  Integrated battery ~40 Wh.
 
         TANK
         {
@@ -441,7 +442,7 @@
             maxAmount = 144
         }
 
-        //  ACS & TCM propellant 36 Kg.
+        //  ACS & TCM propellant ~36 kg.
 
         TANK
         {
@@ -460,7 +461,7 @@
 //  LM-DS Generic spacecraft bus.
 
 //  Dimensions: 2.4 m x 2.1 m
-//  Gross Mass: 800 Kg
+//  Gross Mass: 800 kg
 //  ==================================================
 
 @PART[tatsujin]:FOR[RealismOverhaul]
@@ -551,7 +552,7 @@
         volume = 1700
         basemass = -1
 
-        //  Avionics batteries 1600 Wh (base config).
+        //  Avionics batteries ~1600 Wh (base config).
 
         TANK
         {
@@ -570,7 +571,7 @@
 //  Venera lander bus.
 
 //  Dimensions: 1.65 m x 1.5 m
-//  Gross Mass: 660 Kg
+//  Gross Mass: 660 kg
 //  ==================================================
 
 @PART[ca_fom_lander]:FOR[RealismOverhaul]
@@ -640,7 +641,7 @@
         volume = 250
         basemass = -1
 
-        //  Batteries 500 Wh.
+        //  Batteries ~500 Wh.
         //  Supports the lander bus for a duration of at least 3 hours (descent: 1 hour, surface operations: >2 hours).
 
         TANK
@@ -660,7 +661,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_fom_lander]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_fom_lander]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     @description ^= :$: Integrated communications antenna with a maximum effective range of 750 km, power consumption 30 Watts and a maximum data rate of 256 kbit/sec.
 
@@ -700,7 +701,7 @@
 //  4MV spacecraft bus GNC system.
 
 //  Dimensions: 2.35 m x 1.15 m
-//  Gross Mass: 840 Kg
+//  Gross Mass: 840 kg
 //  ==================================================
 
 @PART[ca_vor_core]:FOR[RealismOverhaul]
@@ -776,7 +777,7 @@
 //  Huygens atmospheric lander.
 
 //  Dimensions: 1.3 m x - m
-//  Gross Mass: 215 Kg
+//  Gross Mass: 215 kg
 //  ==================================================
 
 @PART[ca_draco]:FOR[RealismOverhaul]
@@ -844,7 +845,7 @@
         volume = 100
         basemass = -1
 
-        //  Avionics batteries 1600 Wh.
+        //  Avionics batteries ~1600 Wh.
 
         TANK
         {
@@ -901,7 +902,7 @@
 //  Cassini spacecraft GNC system.
 
 //  Dimensions: 2.3 m x 0.55 m
-//  Gross Mass: 300 Kg
+//  Gross Mass: 300 kg
 //  ==================================================
 
 @PART[meridiani]:FOR[RealismOverhaul]
@@ -962,7 +963,7 @@
         volume = 25
         basemass = -1
 
-        //  Astrionics batteries.
+        //  Astrionics batteries ~4400 Wh.
 
         TANK
         {
@@ -979,7 +980,7 @@
 //  STEREO spacecraft bus.
 
 //  Dimensions: 1.2 m x 1.1 m
-//  Gross Mass: 280 Kg
+//  Gross Mass: 280 kg
 //  ==================================================
 
 @PART[xihe]:FOR[RealismOverhaul]
@@ -1085,7 +1086,7 @@
         volume = 70
         basemass = -1
 
-        //  Astrionics batteries 590 Wh.
+        //  Astrionics batteries ~590 Wh.
 
         TANK
         {
@@ -1094,7 +1095,7 @@
             maxAmount = 2120
         }
 
-        //  ACS and TCM propellant mass ~63 Kg.
+        //  ACS and TCM propellant mass ~63 kg.
 
         TANK
         {
@@ -1108,12 +1109,178 @@
 }
 
 //  ==================================================
+//  IUE spacecraft bus.
+
+//  Dimensions: 1.45 m x 4.22 m
+//  Gross Mass: - kg
+//  ==================================================
+
+@PART[ca_explorer]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.843, 0.0, 0.0, -1.0, 0.0, 0
+    @node_stack_engine = 0.0, -0.311, 0.0, 0.0, -1.0, 0.0, 0
+    //node_stack_top = 0.0, 0.367, 0.0, 0.0, 1.0, 0.0, 0
+
+    @title = IUE Spacecraft Bus
+    @manufacturer = NASA
+    @description = The spacecraft bus of the International Ultraviolet Explorer (IUE) spacecraft. Includes batteries, a hydrazine attitude control system (ACS) and a short-range telecommunications system.
+
+    @mass = 0.4
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    !explosionPotential = NULL
+    @bulkheadProfiles = size0
+    @tags = coatl ca explorer telescope iue imager research ultraviolet command control (core gyro probe react sas satellite space stab steer torque
+
+    @MODULE[ModuleCommand]
+    {
+        @hasHibernation = False
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2
+        }
+    }
+
+    @MODULE[ModuleRCS*]
+    {
+        @stagingEnabled = True
+        @thrusterPower = 0.022
+        !resourceName = NULL
+
+        PROPELLANT
+        {
+            name = Hydrazine
+            ratio = 1.0
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 245
+            @key,1 = 1 100
+        }
+    }
+
+    @MODULE[ModuleReactionWheel]
+    {
+        @PitchTorque = 1.0
+        @YawTorque = 1.0
+        @RollTorque = 1.0
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 1.0
+        }
+    }
+
+    @MODULE[ModuleSAS]
+    {
+        !UPGRADES,*{}
+    }
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        %antennaCombinable = True
+        %antennaCombinableExponent = 1
+        @antennaPower = 11250
+        @packetInterval = 1.0
+        @packetSize = 1.024
+        @packetResourceCost = 0.012
+        @antennaCombinable = True
+    }
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 50
+        basemass = -1
+
+        //  Avionics batteries ~336 Wh.
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 1210
+            maxAmount = 1210
+        }
+
+        //  ACS propellant mass ~27.3 kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 23.8
+            maxAmount = 23.8
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  IUE spacecraft bus.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[ca_explorer]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 7.5E5
+        EnergyCost = 0.006
+        DeployFxModules = 0
+        ProgressFxModules = 1
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 1.024
+            PacketResourceCost = 0.006
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+}
+
+//  ==================================================
 //  Probes+ probe cores.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_hera|barquetta|torekka|quetzal|tatsujin|meridiani|xihe]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_hera|barquetta|torekka|quetzal|tatsujin|meridiani|xihe]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     !MODULE[ModuleDataTransmitter],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -1,28 +1,37 @@
 //  ==================================================
 //  Sources:
 
-//  JPL - Juno launch press kit:                   https://www.jpl.nasa.gov/news/press_kits/JunoLaunch.pdf
-//  AJR - AJR Propulsion Role in Juno Mission:     https://www.rocket.com/article/aerojet-rocketdyne-propulsion-plays-critical-role-juno-mission-study-jupiter
-//  AJR - Monopropellant Rocket Engine Assemblies: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf
-//  NSSDCA - Voyager 1:                            http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
-//  NTRS - Voyager Backgrounder:                   http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
-//  The Voyager Spacecraft:                        http://www.stickings90.webspace.virginmedia.com/voyager.pdf
-//  NSSDCA - Pioneer 11:                           http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
-//  NASA - Pioneer Odyssey (Chapter 3):            http://history.nasa.gov/SP-349/ch3.htm
-//  SSTL-150 Satellite Platform:                   http://www.sst-us.com/getfile/58b2f67f-44a0-43b3-9922-7ec572838f58
-//  NASA - MRO spacecraft parts:                   http://mars.nasa.gov/mro/mission/spacecraft/parts
-//  MAVEN spacecraft overview:                     http://lasp.colorado.edu/home/maven/about/spacecraft
-//  MAVEN spacecraft press kit:                    http://lasp.colorado.edu/home/maven/files/2011/02/MAVEN_PressKit_Final.pdf
-//  Russian Space Web - Venera 75:                 http://www.russianspaceweb.com/venera75.html
-//  NASA - The Soviet Robotic Exploration Program: https://www.nasa.gov/pdf/643333main_huntress_presentation.pdf
-//  Encyclopedia of Science - Venera Program:      http://www.daviddarling.info/encyclopedia/V/Venera.html
-//  NSSDCA - Huygens probe:                        https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1997-061C
-//  NSSDCA - Cassini spacecraft:                   https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1997-061A
-//  NASA - STEREO spacecraft:                      https://stereo.gsfc.nasa.gov/spacecraft.shtml
-//  JHUAPL - STEREO spacecraft GNC system:         http://www.jhuapl.edu/techdigest/TD/td2802/Hunt.pdf
-//  JHUAPL - Spacecraft packaging:                 http://www.jhuapl.edu/techdigest/TD/td2801/Schaefer.pdf
-//  AJR - Propulsion systems data sheets:          https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Propulsion%20System%20Data%20Sheets.pdf
-//  ESA - IUE spacecraft:                          http://sci.esa.int/iue/31301-spacecraft
+//  JPL - Juno launch press kit:                       https://www.jpl.nasa.gov/news/press_kits/JunoLaunch.pdf
+//  AJR - AJR Propulsion Role in Juno Mission:         https://www.rocket.com/article/aerojet-rocketdyne-propulsion-plays-critical-role-juno-mission-study-jupiter
+//  AJR - Monopropellant Rocket Engine Assemblies:     https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf
+//  NSSDCA - Voyager 1:                                http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-084A
+//  NTRS - Voyager Backgrounder:                       http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19810001583.pdf
+//  The Voyager Spacecraft:                            http://www.stickings90.webspace.virginmedia.com/voyager.pdf
+//  NSSDCA - Pioneer 11:                               http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1973-019A
+//  NASA - Pioneer Odyssey (Chapter 3):                http://history.nasa.gov/SP-349/ch3.htm
+//  SSTL-150 Satellite Platform:                       http://www.sst-us.com/getfile/58b2f67f-44a0-43b3-9922-7ec572838f58
+//  NASA - MRO spacecraft parts:                       http://mars.nasa.gov/mro/mission/spacecraft/parts
+//  MAVEN spacecraft overview:                         http://lasp.colorado.edu/home/maven/about/spacecraft
+//  MAVEN spacecraft press kit:                        http://lasp.colorado.edu/home/maven/files/2011/02/MAVEN_PressKit_Final.pdf
+//  Russian Space Web - Venera 75:                     http://www.russianspaceweb.com/venera75.html
+//  NASA - The Soviet Robotic Exploration Program:     https://www.nasa.gov/pdf/643333main_huntress_presentation.pdf
+//  Encyclopedia of Science - Venera Program:          http://www.daviddarling.info/encyclopedia/V/Venera.html
+//  NSSDCA - Huygens probe:                            https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1997-061C
+//  NSSDCA - Cassini spacecraft:                       https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1997-061A
+//  NASA - STEREO spacecraft:                          https://stereo.gsfc.nasa.gov/spacecraft.shtml
+//  JHUAPL - STEREO spacecraft GNC system:             http://www.jhuapl.edu/techdigest/TD/td2802/Hunt.pdf
+//  JHUAPL - Spacecraft packaging:                     http://www.jhuapl.edu/techdigest/TD/td2801/Schaefer.pdf
+//  AJR - Propulsion systems data sheets:              https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Propulsion%20System%20Data%20Sheets.pdf
+//  ESA - IUE spacecraft:                              http://sci.esa.int/iue/31301-spacecraft
+//  INTA - IUE Spacecraft Operations Final Report:     https://web.archive.org/web/20110906124634/http://sdc.laeff.inta.es/ines/docs/report.pdf
+//  STSCI - The IUE Spacecraft:                        https://archive.stsci.edu/iue/spacecraft.html
+//  NSSDCA - Mariner 4 spacecraft:                     https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1964-077A
+//  NSSDCA - Mariner 5 spacecraft:                     https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1967-060A
+//  NTRS - Mariner Mars 1964 Mechanical Configuration: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660027080.pdf
+//  NTRS - Mariner Mars 1969 Press Kit:                https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19690007929.pdf
+//  NTRS - Mariner Venus 1967 Final Project Report:    https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720013159.pdf
+//  NTRS - Mariner Mars 1971 Attitude Control System:  https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19750002096.pdf
+//  NTRS - To Mars: The Odyssey of Mariner 4:          https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650018349.pdf
 
 //  ==================================================
 //  Removed extra parts.
@@ -625,8 +634,10 @@
 
     @MODULE[ModuleDataTransmitter]
     {
-        @antennaPower = 5500000
+        @antennaPower = 2205000
         !optimumRange = NULL
+        %antennaCombinable = True
+        %antennaCombinableExponent = 2.0
         @packetInterval = 1.0
         @packetSize = 0.256
         @packetResourceCost = 0.04
@@ -663,7 +674,7 @@
 
 @PART[ca_fom_lander]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
-    @description ^= :$: Integrated communications antenna with a maximum effective range of 750 km, power consumption 30 Watts and a maximum data rate of 256 kbit/sec.
+    @description ^= :$: Integrated communications antenna with a maximum effective range of 2 Mm, power consumption 30 Watts and a maximum data rate of 256 kbit/sec.
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -683,7 +694,7 @@
         name = ModuleRTAntenna
         IsRTActive = True
         Mode0OmniRange = 0
-        Mode1OmniRange = 750000
+        Mode1OmniRange = 2000000
         EnergyCost = 0.03
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -776,7 +787,7 @@
 //  ==================================================
 //  Huygens atmospheric lander.
 
-//  Dimensions: 1.3 m x - m
+//  Dimensions: 1.3 m x 0.57 m
 //  Gross Mass: 215 kg
 //  ==================================================
 
@@ -1111,39 +1122,38 @@
 //  ==================================================
 //  IUE spacecraft bus.
 
-//  Dimensions: 1.45 m x 4.22 m
-//  Gross Mass: - kg
+//  Dimensions: 1.45 m x 3.85 m
+//  Gross Mass: 414 kg
 //  ==================================================
 
 @PART[ca_explorer]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = False
+    %RSSROConfig = True
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.0
+        %scale = 1.505, 1.605, 1.505
     }
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_bottom = 0.0, -0.843, 0.0, 0.0, -1.0, 0.0, 0
-    @node_stack_engine = 0.0, -0.311, 0.0, 0.0, -1.0, 0.0, 0
-    //node_stack_top = 0.0, 0.367, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_engine = 0.0, -0.55, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -1.35, 0.0, 0.0, -1.0, 0.0, 1
 
     @title = IUE Spacecraft Bus
     @manufacturer = NASA
     @description = The spacecraft bus of the International Ultraviolet Explorer (IUE) spacecraft. Includes batteries, a hydrazine attitude control system (ACS) and a short-range telecommunications system.
 
-    @mass = 0.4
+    @mass = 0.39
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     !explosionPotential = NULL
-    @bulkheadProfiles = size0
-    @tags = coatl ca explorer telescope iue imager research ultraviolet command control (core gyro probe react sas satellite space stab steer torque
+    @bulkheadProfiles = size1
+    @tags ^= :$: astrionics avionics international
 
     @MODULE[ModuleCommand]
     {
@@ -1151,9 +1161,14 @@
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.2
+            @rate = 0.21
         }
     }
+
+    //  Eight 0.89 N thrusters for fine attitude control and four 22.24 N thrusters for coarse attitude control.
+
+    //  5 lbf: angled thrusters.
+    //  0.2 lbf: rest of the thrusters.
 
     @MODULE[ModuleRCS*]
     {
@@ -1174,15 +1189,17 @@
         }
     }
 
+    //  Assuming 0.18 Nm for each of the reaction wheels.
+
     @MODULE[ModuleReactionWheel]
     {
-        @PitchTorque = 1.0
-        @YawTorque = 1.0
-        @RollTorque = 1.0
+        @PitchTorque = 0.00018
+        @YawTorque = 0.00018
+        @RollTorque = 0.00018
 
         @RESOURCE[ElectricCharge]
         {
-            @rate = 1.0
+            @rate = 0.018
         }
     }
 
@@ -1195,12 +1212,11 @@
     {
         @antennaType = DIRECT
         %antennaCombinable = True
-        %antennaCombinableExponent = 1
-        @antennaPower = 11250
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 160
         @packetInterval = 1.0
-        @packetSize = 1.024
+        @packetSize = 0.256
         @packetResourceCost = 0.012
-        @antennaCombinable = True
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1212,7 +1228,7 @@
         volume = 50
         basemass = -1
 
-        //  Avionics batteries ~336 Wh.
+        //  Two batteries ~336 Wh (28 V @ 6 Ah each).
 
         TANK
         {
@@ -1242,6 +1258,8 @@
 
 @PART[ca_explorer]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Maximum effective range approximately 100 Mm, power consumption 6 Watts, maximum data rate 256 kbit/sec.
+
     !MODULE[ModuleDataTransmitter],*{}
 
     !MODULE[ModuleRTAntenna*],*{}
@@ -1253,7 +1271,7 @@
         name = ModuleRTAntenna
         IsRTActive = True
         Mode0OmniRange = 0
-        Mode1OmniRange = 7.5E5
+        Mode1OmniRange = 1000000
         EnergyCost = 0.006
         DeployFxModules = 0
         ProgressFxModules = 1
@@ -1261,7 +1279,7 @@
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 1.024
+            PacketSize = 0.256
             PacketResourceCost = 0.006
         }
     }
@@ -1275,12 +1293,111 @@
 }
 
 //  ==================================================
+//  Mariner Mars & Venus spacecraft bus.
+
+//  Dimensions: 1.25 m x 0.5 m
+//  Gross Mass: 167 kg
+//  ==================================================
+
+@PART[ca_argo-mk2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.74, 1.74, 1.74
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.255, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.245, 0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_cam = 0.0, -0.085, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = Mariner Mars & Venus Spacecraft Bus
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = The Mariner spacecraft bus as used in the Mariner-Mars and Mariner-Venus missions.
+
+    @mass = 0.155
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    !explosionPotential = NULL
+    @bulkheadProfiles = size1
+    @tags ^= :$: astrionics avionics
+
+    @MODULE[ModuleCommand]
+    {
+        @hasHibernation = False
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2
+        }
+    }
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    @MODULE[ModuleSAS]
+    {
+        @SASServiceLevel = 1
+
+        !UPGRADES,*{}
+    }
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleFuelTanks],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 50
+        basemass = -1
+
+        // One 1.2 kWh battery (28 V @ 43 Ah).
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 4320
+            maxAmount = 4320
+        }
+
+        // Main propulsion system propellant mass ~9.75 kg.
+
+        TANK
+        {
+            name = Hydrazine
+            amount = 9.8
+            maxAmount = 9.8
+        }
+
+        // ACS propellant mass ~2.4 kg.
+
+        TANK
+        {
+            name = Nitrogen
+            amount = 1920
+            maxAmount = 1920
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+
+//  ==================================================
 //  Probes+ probe cores.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_hera|barquetta|torekka|quetzal|tatsujin|meridiani|xihe]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
+@PART[ca_hera|barquetta|torekka|quetzal|tatsujin|meridiani|xihe|ca_argo-mk2]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     !MODULE[ModuleDataTransmitter],*{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -7,7 +7,7 @@
 //  RW-4A radial reaction wheel assembly.
 
 //  Dimensions: 0.5 m x 0.25 m
-//  Inert Mass: 12 Kg
+//  Inert Mass: 12 kg
 
 //  * The maximum torque value has been increased by
 //    a factor of 10 for game play purposes (should be
@@ -50,7 +50,7 @@
 //  RW-2A radial reaction wheel assembly.
 
 //  Dimensions: 0.4 m x 0.175 m
-//  Inert Mass: 6 Kg
+//  Inert Mass: 6 kg
 
 //  * The maximum torque value has been increased by
 //    a factor of 10 for game play purposes (should be
@@ -96,7 +96,7 @@
 //  RW4 radial reaction wheel.
 
 //  Dimensions: 0.35 m x 0.075 m
-//  Inert Mass: 2.5 Kg
+//  Inert Mass: 2.5 kg
 
 //  * The maximum torque value has been increased by
 //    a factor of 10 for game play purposes (should be
@@ -139,7 +139,7 @@
 //  RW1 radial reaction wheel.
 
 //  Dimensions: 0.2 m x 0.05 m
-//  Inert Mass: 1.6 Kg
+//  Inert Mass: 1.6 kg
 
 //  * The maximum torque value has been increased by
 //    a factor of 10 for game play purposes (should be
@@ -182,7 +182,7 @@
 //  CA-AACS Attitude Control System.
 
 //  Dimensions: 0.5 m x 0.3 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_aacs]:FOR[RealismOverhaul]
@@ -200,7 +200,7 @@
     %fuelCrossFeed = False
     @tags ^= :$: star tracker
 
-    //  Avionics batteries 15 Wh.
+    //  Avionics batteries ~15 Wh.
     //  Generic power source & sink.
 
     @RESOURCE[ElectricCharge]
@@ -214,7 +214,7 @@
 //  CA-ACS Star tracker.
 
 //  Dimensions: 0.2 m x 0.25 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_startrack]:FOR[RealismOverhaul]
@@ -237,7 +237,7 @@
 //  CAE-RM01 generic RCS thruster block.
 
 //  Dimensions: 0.4 m x 0.39 m
-//  Inert Mass: 8 Kg
+//  Inert Mass: 8 kg
 //  ==================================================
 
 @PART[ca_RM01]:FOR[RealismOverhaul]
@@ -292,7 +292,7 @@
 //  CAE-RM02 generic RCS thruster block.
 
 //  Dimensions: 0.49 m x 0.29 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_RM02]:FOR[RealismOverhaul]
@@ -347,7 +347,7 @@
 //  CAE-RM03 generic RCS thruster block.
 
 //  Dimensions: 0.7 m x 0.125 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_RM03]:FOR[RealismOverhaul]
@@ -408,7 +408,7 @@
 //  CAE-RM04 generic RCS thruster block.
 
 //  Dimensions: 0.7 m x 0.125 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_RM04]:FOR[RealismOverhaul]
@@ -463,7 +463,7 @@
 //  CA-RS01 generic RCS thruster port.
 
 //  Dimensions: 0.15 m x 0.075 m
-//  Inert Mass: 1.5 Kg
+//  Inert Mass: 1.5 kg
 //  ==================================================
 
 @PART[ca_rs01]:FOR[RealismOverhaul]
@@ -518,7 +518,7 @@
 //  CA-RS04 generic RCS thruster block.
 
 //  Dimensions: 0.2 m x 0.07 m
-//  Inert Mass: 7 Kg
+//  Inert Mass: 7 kg
 //  ==================================================
 
 @PART[ca_rs04]:FOR[RealismOverhaul]
@@ -574,7 +574,7 @@
 //  combination.
 
 //  Dimensions: 0.6 m x 0.5 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_rst]:FOR[RealismOverhaul]
@@ -655,7 +655,7 @@
 //  Cassini Equipment Unit.
 
 //  Dimensions: 1.35 m x 0.48 m
-//  Gross Mass: 175 Kg
+//  Gross Mass: 175 kg
 //  ==================================================
 
 @PART[ca_mer_leu]:FOR[RealismOverhaul]
@@ -693,7 +693,7 @@
     %fuelCrossFeed = True
     @bulkheadProfiles = srf, size1
 
-    //  Main Reaction Wheel Assemblies (RWAs) (34 Nms for each of the axis).
+    //  Main Reaction Wheel Assemblies (RWAs) (~34 Nms for each axis).
 
     @MODULE[ModuleReactionWheel]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Coupling.cfg
@@ -7,7 +7,7 @@
 //  Huygens aeroshell.
 
 //  Dimensions: 1.75 m x 0.675 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_draco_as]:FOR[RealismOverhaul]
@@ -48,7 +48,7 @@
 //  Huygens generic decoupler.
 
 //  Dimensions: 1.85 m x 0.8 m
-//  Inert Mass: 10 Kg
+//  Inert Mass: 10 kg
 //  ==================================================
 
 @PART[mer_ringDecoupler]:FOR[RealismOverhaul]
@@ -89,7 +89,7 @@
 //  Venera reentry module decoupler.
 
 //  Dimensions: 1.6 m x 0.2 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_vor_sep1]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -28,6 +28,19 @@
 //  ESA - Mars Express Bus: Simplified User Manual:              http://sci.esa.int/marsexpress/docs/mex_user_manual.pdf
 //  ESA - Mars Express Spacecraft Performance:                   http://sci2.esa.int/marsexpress/docs/mex2scpf.pdf
 //  NASA - STEREO spacecraft:                                    https://stereo.gsfc.nasa.gov/spacecraft.shtml
+//  ESA - IUE spacecraft:                                        http://sci.esa.int/iue/31301-spacecraft
+//  INTA - IUE Spacecraft Operations Final Report:               https://web.archive.org/web/20110906124634/http://sdc.laeff.inta.es/ines/docs/report.pdf
+//  STSCI - The IUE Spacecraft:                                  https://archive.stsci.edu/iue/spacecraft.html
+//  NSSDCA - Mariner 4 spacecraft:                               https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1964-077A
+//  NSSDCA - Mariner 5 spacecraft:                               https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1967-060A
+//  NTRS - Mariner Mars 1964 Mechanical Configuration:           https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660027080.pdf
+//  NTRS - Mariner Mars 1971 Attitude Control System:            https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19750002096.pdf
+
+//  ==================================================
+//  Removed extra parts.
+//  ==================================================
+
+!PART[ca_rtg8200]:FOR[RealismOverhaul]{}
 
 //  ==================================================
 //  Battery (1500 Wh).
@@ -563,9 +576,9 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: Express Venus
+    @tags ^= :$: express venus wing
 
-    //  Level 2 solar array (~140 W/m2).
+    //  Level 3 solar array (~140 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
@@ -607,9 +620,9 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: Express Mars
+    @tags ^= :$: express mars wing
 
-    //  Level 2 solar array (~140 W/m2).
+    //  Level 3 solar array (~140 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
@@ -651,6 +664,7 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
+    @tags ^= :$: panel wing
 
     //  Level 5 solar array (~230 W/m2).
 
@@ -692,6 +706,7 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
+    @tags ^= :$: panel wing
 
     //  Level 5 solar array (~230 W/m2).
 
@@ -702,10 +717,10 @@
 }
 
 //  ==================================================
-//  Mariner 10 solar array.
+//  Generic Mariner-Mars solar array (standard).
 
 //  Dimensions: 1 m x 2.7 m (extended)
-//  Inert Mass: 10 kg
+//  Inert Mass: 12 kg
 //  ==================================================
 
 @PART[sp_mariner_a]:FOR[RealismOverhaul]
@@ -720,33 +735,33 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @manufacturer = Boeing Co.
-    @description = A solar array wing, similar to the one used by the Mariner Venus spacecrafts, featuring increased power generation efficiency. 2.43 m2.
+    @manufacturer = Generic
+    @description = A solar array wing (SAW), similar to the one used by the Mariner-Mars spacecraft series. 2.34 m2.
 
-    @mass = 0.01
+    @mass = 0.012
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: mariner panel photovoltaic
+    @tags ^= :$: mariner panel photovoltaic wing
 
-    //  Level 1 solar array (~103 W/m2).
+    //  Level 2 solar array (~85 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
-        @chargeRate = 0.25
+        @chargeRate = 0.2
 
         !UPGRADES,*{}
     }
 }
 
 //  ==================================================
-//  Mariner 4 solar array.
+//  Generic Mariner-Mars solar array (with vanes).
 
 //  Dimensions: 1 m x 3 m (extended)
-//  Inert Mass: 12 kg
+//  Inert Mass: 14 kg
 //  ==================================================
 
 @PART[sp_mariner_b]:FOR[RealismOverhaul]
@@ -761,17 +776,19 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @manufacturer = Boeing Co.
-    @description = A solar array wing, similar to the one used by the Mariner Mars spacecrafts. Includes Solar Pressure Vanes for finer attitude control. 2.34 m2.
+    @manufacturer = Generic
+    @description = A solar array wing (SAW), similar to the one used by the Mariner-Mars spacecraft series. Includes solar wind vanes for passive attitude control. 2.34 m2.
 
-    @mass = 0.012
+    @mass = 0.014
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: mariner panel photovoltaic
+    @tags ^= :$: mariner panel photovoltaic wing
+
+    //  Simulates the solar wind vanes.
 
     @MODULE[ModuleReactionWheel]
     {
@@ -779,17 +796,14 @@
         @YawTorque = 0
         @RollTorque = 0
 
-        @RESOURCE[ElectricCharge]
-        {
-            @rate = 0.0025
-        }
+        !RESOURCE,*{}
     }
 
-    //  Level 1 solar array (~90 W/m2).
+    //  Level 2 solar array (~85 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
-        @chargeRate = 0.21
+        @chargeRate = 0.2
 
         !UPGRADES,*{}
     }
@@ -827,7 +841,7 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: Mars MAVEN
+    @tags ^= :$: Mars MAVEN wing
 
     //  Level 5 solar array (~334 W/m2).
 
@@ -869,7 +883,7 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: mars odyssey panel photovoltaic
+    @tags ^= :$: mars odyssey panel photovoltaic wing
 
     //  Level 5 solar array (~255 W/m2).
 
@@ -952,7 +966,7 @@
     %fuelCrossFeed = False
     @tags ^= :$: panel
 
-    //  Level 1 solar array (~100 W/m2).
+    //  Level 2 solar array (~100 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
@@ -983,7 +997,7 @@
 
     @title = 4MV Spacecraft Bus SAW & TCS (Standard)
     @manufacturer = NPO Lavochkin
-    @description = The main solar array of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability 2 kWh. 5.25 m2.
+    @description = The main solar array wings of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability 2 kWh. 5.25 m2.
 
     @mass = 0.12
     @crashTolerance = 10
@@ -993,9 +1007,9 @@
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.63405
-    @tags ^= :$: panel photovoltaic radiator
+    @tags ^= :$: panel photovoltaic radiator wing
 
-    //  Level 1 solar array (~105 W/m2).
+    //  Level 2 solar array (~105 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
@@ -1053,7 +1067,7 @@
     @radiatorHeadroom = 0.63405
     @tags ^= :$: panel photovoltaic radiator
 
-    //  Level 1 solar array (~102 W/m2).
+    //  Level 2 solar array (~102 W/m2).
 
     @MODULE[ModuleDeployableSolarPanel]
     {
@@ -1106,7 +1120,7 @@
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: panel
+    @tags ^= :$: panel wing
 
     //  Level 3 solar array (~162 W/m2).
 
@@ -1122,43 +1136,131 @@
 //  International Ultraviolet Explorer (IUE) solar
 //  array wing (SAW).
 
-//  Dimensions: - m x - m
-//  Inert Mass: - kg
+//  Dimensions: 1.91 m x 0.7 m
+//  Inert Mass: 9.1 kg
 //  ==================================================
 
 @PART[ca_explorer_solar]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = False
+    %RSSROConfig = True
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.0
+        %scale = 1.535, 1.465, 1.465
     }
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
-
     @title = IUE Solar Array Wing (SAW)
-    @manufacturer = ESA
-    @description = A solar array wing built for the International Ultraviolet Explorer (IUE) spacecraft. The 3-in-1 design has the benefit of increasing the angles at which the panels receives power, requiring only coarse pointing to the Sun.
+    @manufacturer = European Space Agency (ESA)
+    @description = A solar array wing built for the International Ultraviolet Explorer (IUE) spacecraft. The 3-in-1 design has the benefit of increasing the angles at which the panels receives power, requiring only coarse pointing to the Sun. 2 m2.
 
-    @mass = 1.0
+    @mass = 0.0091
     @crashTolerance = 10
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
-    @tags ^= :$: panel
+    @tags ^= :$: panel wing
 
-    //  Level - solar array (~- W/m2).
+    //  Level 2 solar array (~106 W/m2).
+
+    //  Power output is divided by three since this solar array is composed by
+    //  three separate suncatcher transforms.
 
     @MODULE[ModuleDeployableSolarPanel],*
     {
-        @chargeRate = 0.212
+        @chargeRate = 0.07085
 
         !UPGRADES,*{}
+    }
+}
+
+//  ==================================================
+//  Mariner Mars solar array.
+
+//  Dimensions: 0.9 m x 2.6 m (extended)
+//  Inert Mass: 9.5 kg
+//  ==================================================
+
+@PART[ca_argo-mk2-solar]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 2.01, 2.01, 1.64
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @title = Mariner Mars Solar Array Wing (SAW)
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = This solar array wing was designed for the early Mariner-Mars spacecraft series. Features an integrated cold gas attitude control system for active attitude control and includes solar wind vanes for passive stability. The spring loaded deployment mechanism prevents the panel from being retracted once deployed. 1.58 m2.
+
+    @mass = 0.0095
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    %fuelCrossFeed = False
+    @bulkheadProfiles = srf
+    @tags ^= :$: panel wing
+
+    //  Level 2 solar array (~111 W/m2).
+
+    @MODULE[ModuleDeployableSolarPanel]
+    {
+        @chargeRate = 0.175
+
+        !UPGRADES,*{}
+    }
+
+    //  Simulates the solar pressure vanes at the tip of the solar array wing (only
+    //  in the Y axis, since the vanes only move up and down). Assumes a Venus-alike
+    //  distance from the Sun, a vane surface area of 0.65 m2 (similar to the Mariner
+    //  4 vanes) and a game-play multiplier of 10 (KSP does not handle well very
+    //  small numbers).
+
+    @MODULE[ModuleReactionWheel]
+    {
+        @PitchTorque = 0.000113
+        @YawTorque = 0
+        @RollTorque = 0
+
+        !RESOURCE,*{}
+    }
+
+    //  Pitch, yaw and roll cold gas attitude control thrusters (two 0.033 N thrusters
+    //  for pitch/yaw and one 0.074 N for roll).
+
+    @MODULE[ModuleRCS*]
+    {
+        @thrusterPower = 0.14
+        !resourceName = NULL
+        !resourceFlowMode = NULL
+
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 1.0
+        }
+
+        transformMultipliers
+        {
+            trf0 = 0.528571
+            trf1 = 0.235714
+            trf2 = 0.235714
+        }
+
+        @atmosphereCurve
+        {
+            @key = 0 250
+            @key = 1 100
+        }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -33,7 +33,7 @@
 //  Battery (1500 Wh).
 
 //  Dimensions: 0.45 m x 0.3 m
-//  Gross Mass: 20 Kg
+//  Gross Mass: 20 kg
 //  ==================================================
 
 @PART[ca_battery_l]:FOR[RealismOverhaul]
@@ -67,7 +67,7 @@
 //  Battery (800 Wh).
 
 //  Dimensions: 0.3 m x 0.175 m
-//  Gross Mass: 10 Kg
+//  Gross Mass: 10 kg
 //  ==================================================
 
 @PART[ca_battery_m]:FOR[RealismOverhaul]
@@ -98,7 +98,7 @@
 //  Battery (440 Wh).
 
 //  Dimensions: 0.15 m x 0.065 m
-//  Gross Mass: 5 Kg
+//  Gross Mass: 5 kg
 //  ==================================================
 
 @PART[ca_battery_s]:FOR[RealismOverhaul]
@@ -129,7 +129,7 @@
 //  Pioneer 10/11 SNAP-19 RTG.
 
 //  Dimensions: 3 m x 0.4 m (extended)
-//  Gross Mass: 30 Kg
+//  Gross Mass: 30 kg
 
 //  * The Pioneer RTG boom includes two SNAP-19 RTG
 //    modules (nominal power output for a single module
@@ -236,7 +236,7 @@
 //  Voyager MHW-RTG.
 
 //  Dimensions: 3.7 m x 0.45 m (extended)
-//  Gross Mass: 120 Kg
+//  Gross Mass: 120 kg
 
 //  * The Voyager RTG boom includes three MHW-RTG
 //    modules (nominal power output for a single module
@@ -346,7 +346,7 @@
 //  Ulysses/New Horizons GPHS-RTG
 
 //  Dimensions: 0.42 m x 1.15 m
-//  Gross Mass: 56.4 Kg
+//  Gross Mass: 56.4 kg
 
 //  * The gross mass is an average value between the RTG
 //    masses of the Cassini, the Galileo, the New Horizons
@@ -441,7 +441,7 @@
 //  GPHS-RTG.
 
 //  Dimensions: 0.42 m x 1.15 m
-//  Gross Mass: 56.4 Kg
+//  Gross Mass: 56.4 kg
 
 //  * The gross mass is an average value between the RTG
 //    masses of the Cassini, the Galileo, the New Horizons
@@ -535,7 +535,7 @@
 //  Venus Express solar array.
 
 //  Dimensions: 1.8 m x 4.6 m (extended)
-//  Inert Mass: 21 Kg
+//  Inert Mass: 21 kg
 //  ==================================================
 
 @PART[sp_express_a]:FOR[RealismOverhaul]
@@ -579,7 +579,7 @@
 //  Mars Express solar array.
 
 //  Dimensions: 1.8 m x 6.8 m (extended)
-//  Inert Mass: 45 Kg
+//  Inert Mass: 45 kg
 //  ==================================================
 
 @PART[sp_express_b]:FOR[RealismOverhaul]
@@ -623,7 +623,7 @@
 //  Juno solar array (standard).
 
 //  Dimensions: 2.7 m x 8.9 m
-//  Inert Mass: 120 Kg
+//  Inert Mass: 120 kg
 //  ==================================================
 
 @PART[sp_juno]:FOR[RealismOverhaul]
@@ -664,7 +664,7 @@
 //  Juno solar array (with magnetometer).
 
 //  Dimensions: 2.7 m x 11.8 m
-//  Inert Mass: 105 Kg
+//  Inert Mass: 105 kg
 //  ==================================================
 
 @PART[sp_juno_mag]:FOR[RealismOverhaul]
@@ -705,7 +705,7 @@
 //  Mariner 10 solar array.
 
 //  Dimensions: 1 m x 2.7 m (extended)
-//  Inert Mass: 10 Kg
+//  Inert Mass: 10 kg
 //  ==================================================
 
 @PART[sp_mariner_a]:FOR[RealismOverhaul]
@@ -746,7 +746,7 @@
 //  Mariner 4 solar array.
 
 //  Dimensions: 1 m x 3 m (extended)
-//  Inert Mass: 12 Kg
+//  Inert Mass: 12 kg
 //  ==================================================
 
 @PART[sp_mariner_b]:FOR[RealismOverhaul]
@@ -799,7 +799,7 @@
 //  MAVEN solar array.
 
 //  Dimensions: 2.45 m x 5.3 m (extended)
-//  Inert Mass: 60 Kg
+//  Inert Mass: 60 kg
 //  ==================================================
 
 @PART[sp_maven]:FOR[RealismOverhaul]
@@ -843,7 +843,7 @@
 //  Mars Odyssey solar array.
 
 //  Dimensions: 1.5 m x 5.7 m (extended)
-//  Inert Mass: 35 Kg
+//  Inert Mass: 35 kg
 //  ==================================================
 
 @PART[sp_odyssey_a]:FOR[RealismOverhaul]
@@ -885,7 +885,7 @@
 //  CA-E200B Solar Array.
 
 //  Dimensions: 5.6 m x 1.25 m (extended)
-//  Inert Mass: 40 Kg
+//  Inert Mass: 40 kg
 //  ==================================================
 
 @PART[sp_odyssey_b]:FOR[RealismOverhaul]
@@ -926,7 +926,7 @@
 //  Venera lander bus solar array.
 
 //  Dimensions: 0.9 m x 0.2 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_fom_sp]:FOR[RealismOverhaul]
@@ -964,7 +964,7 @@
 //  Venera solar array & radiator.
 
 //  Dimensions: 6.7 m x 1.7 m (extended)
-//  Inert Mass: 120 Kg
+//  Inert Mass: 120 kg
 //  ==================================================
 
 @PART[ca_vor_sp]:FOR[RealismOverhaul]
@@ -986,7 +986,9 @@
     @description = The main solar array of the 4MV spacecraft bus. This is the Venus configuration with smaller arrays and a large active radiator for the cooling system. Heat rejection capability 2 kWh. 5.25 m2.
 
     @mass = 0.12
-    @crashTolerance = 8
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
@@ -1020,7 +1022,7 @@
 //  4MV spacecraft bus solar array & radiator.
 
 //  Dimensions: 5 m x 1.7 m (extended)
-//  Inert Mass: 100 Kg
+//  Inert Mass: 100 kg
 //  ==================================================
 
 @PART[ca_vor_sp2]:FOR[RealismOverhaul]
@@ -1042,7 +1044,9 @@
     @description = This is an alternate assembly of the 4MV spacecraft bus solar array and thermal control system, featuring only two solar array wings but with the same radiator assembly. Heat rejection capability 2 kWh. 2.7 m2.
 
     @mass = 0.1
-    @crashTolerance = 8
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
@@ -1076,7 +1080,7 @@
 //  STEREO solar array wing (SAW).
 
 //  Dimensions: 2.65 m x 0.7 m
-//  Inert Mass: 40 Kg
+//  Inert Mass: 40 kg
 //  ==================================================
 
 @PART[sp_stereo]:FOR[RealismOverhaul]
@@ -1097,6 +1101,8 @@
 
     @mass = 0.04
     @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
     @maxTemp = 873.15
     %skinMaxTemp = 873.15
     %fuelCrossFeed = False
@@ -1107,6 +1113,51 @@
     @MODULE[ModuleDeployableSolarPanel]
     {
         @chargeRate = 0.3
+
+        !UPGRADES,*{}
+    }
+}
+
+//  ==================================================
+//  International Ultraviolet Explorer (IUE) solar
+//  array wing (SAW).
+
+//  Dimensions: - m x - m
+//  Inert Mass: - kg
+//  ==================================================
+
+@PART[ca_explorer_solar]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = False
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
+
+    @title = IUE Solar Array Wing (SAW)
+    @manufacturer = ESA
+    @description = A solar array wing built for the International Ultraviolet Explorer (IUE) spacecraft. The 3-in-1 design has the benefit of increasing the angles at which the panels receives power, requiring only coarse pointing to the Sun.
+
+    @mass = 1.0
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    %fuelCrossFeed = False
+    @tags ^= :$: panel
+
+    //  Level - solar array (~- W/m2).
+
+    @MODULE[ModuleDeployableSolarPanel],*
+    {
+        @chargeRate = 0.212
 
         !UPGRADES,*{}
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -27,7 +27,7 @@
 //  Cassini R-4D-11 main engine assembly.
 
 //  Dimensions: 1.2 m x 1.2 m
-//  Gross Mass: 25 Kg
+//  Gross Mass: 25 kg
 //  ==================================================
 
 @PART[mer_engine]:FOR[RealismOverhaul]
@@ -59,7 +59,7 @@
     %ignoreMass = False
     %massOffset = 0.0175
 
-    //  Two Aerojet Rocketdyne R-4D-11 engines (490 N each).
+    //  Two Aerojet Rocketdyne R-4D-11 engines (~490 N each).
 
     @MODULE[ModuleEngines*]
     {
@@ -115,7 +115,7 @@
 //  Cassini Propulsion Module.
 
 //  Dimensions: 3.6 m x 3.4 m
-//  Gross Mass: 4370 Kg
+//  Gross Mass: 4370 kg
 //  ==================================================
 
 @PART[ca_mer_ft]:FOR[RealismOverhaul]
@@ -148,7 +148,7 @@
     @bulkheadProfiles = srf, size1, size2
     @tags ^= :$: propulsion
 
-    //  Attitude Control System (ACS) MR-103H thrusters (1 N each).
+    //  Attitude Control System (ACS) MR-103H thrusters (~1 N each).
 
     @MODULE[ModuleRCS*]
     {
@@ -168,7 +168,7 @@
         }
     }
 
-    //  Articulated Reaction Wheel Assembly (ARWA) (34 Nms).
+    //  Articulated Reaction Wheel Assembly (ARWA) (~34 Nms).
 
     @MODULE[ModuleReactionWheel]
     {
@@ -193,7 +193,7 @@
         volume = 2750
         basemass = -1
 
-        //  R-4D-11 fuel mass ~1132 Kg.
+        //  R-4D-11 fuel mass ~1132 kg.
 
         TANK
         {
@@ -202,7 +202,7 @@
             maxAmount = 1307
         }
 
-        //  R-4D-11 oxidizer mass ~1867 Kg.
+        //  R-4D-11 oxidizer mass ~1867 kg.
 
         TANK
         {
@@ -211,7 +211,7 @@
             maxAmount = 1312
         }
 
-        //  ACS propellant mass ~132 Kg.
+        //  ACS propellant mass ~132 kg.
 
         TANK
         {
@@ -228,7 +228,7 @@
 //  Generic 0.5 kN mono/bipropellant rocket engine.
 
 //  Dimensions: 0.29 m x 0.25 m
-//  Inert Mass: 8 Kg
+//  Inert Mass: 8 kg
 
 //  * Similar to the main engine that was used on the
 //    Mariner Mars series of spacecrafts.
@@ -313,10 +313,10 @@
 //  R-40 series bipropellant rocket engine.
 
 //  Dimensions: 0.4 m x 0.9 m
-//  Inert Mass: 20 Kg
+//  Inert Mass: 20 kg
 
 //  * The inert mass value includes the mass of the
-//    mounting structure (10 Kg).
+//    mounting structure (10 kg).
 //  ==================================================
 
 @PART[ca_lahar]:FOR[RealismOverhaul]
@@ -379,7 +379,7 @@
 //  Fregat-M upper stage.
 
 //  Dimensions: 3.35 m x 1.5 m
-//  Gross Mass: 6235 Kg
+//  Gross Mass: 6235 kg
 //  ==================================================
 
 @PART[ca_linkor]:FOR[RealismOverhaul]
@@ -489,7 +489,7 @@
         volume = 5450
         basemass = -1
 
-        //  Avionics batteries 7200 Wh.
+        //  Avionics batteries ~7200 Wh.
         //  Supports the Fregat for the duration of it's flight (approximately 48 hours).
 
         TANK
@@ -499,7 +499,7 @@
             maxAmount = 25920
         }
 
-        //  S5.92 engine fuel ~1783 Kg.
+        //  S5.92 engine fuel ~1783 kg.
 
         TANK
         {
@@ -508,7 +508,7 @@
             maxAmount = 2255
         }
 
-        //  S5.92 engine oxidizer ~3565 Kg.
+        //  S5.92 engine oxidizer ~3565 kg.
 
         TANK
         {
@@ -517,7 +517,7 @@
             maxAmount = 2460
         }
 
-        //  ACS propellant 65 Kg (85 Kg max).
+        //  ACS propellant 65 kg (85 kg max).
 
         TANK
         {
@@ -536,7 +536,7 @@
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[ca_linkor]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[ca_linkor]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
     !MODULE[ModuleSPU*],*{}
 
@@ -580,7 +580,7 @@
 //  Part configuration.
 //  ==================================================
 
-@PART[ca_linkor]:AFTER[RealismOverhaulEnginesPost]
+@PART[ca_linkor]:AFTER[RealismOverhaulEngines]
 {
     @title = Fregat-M Upper Stage
     @manufacturer = NPO Lavochkin
@@ -591,7 +591,7 @@
 //  CA-LT80 pressurized propellant tank (inline).
 
 //  Dimensions: 1.5 m x 1.75 m
-//  Inert Mass: 45 Kg
+//  Inert Mass: 45 kg
 //  ==================================================
 
 @PART[ca_tank_lfo_m]:FOR[RealismOverhaul]
@@ -642,7 +642,7 @@
 //  CA-MT170 pressurized propellant tank (inline).
 
 //  Dimensions: 1.3 m x 1.9 m
-//  Inert Mass: 65 Kg
+//  Inert Mass: 65 kg
 //  ==================================================
 
 @PART[ca_tank_mp_m]:FOR[RealismOverhaul]
@@ -693,7 +693,7 @@
 //  Generic pressurized propellant tank (radial cylindrical).
 
 //  Dimensions: 0.425 m x 0.8 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 //  ==================================================
 
 @PART[ca_tank_mp_s]:FOR[RealismOverhaul]
@@ -740,10 +740,10 @@
 //  cluster.
 
 //  Dimensions: 1.5 m x 0.75 m
-//  Inert Mass: 20 Kg
+//  Inert Mass: 20 kg
 
 //  * The inert mass value includes the mass of the
-//    mounting structure (7 Kg).
+//    mounting structure (7 kg).
 //  ==================================================
 
 @PART[ca_trident]:FOR[RealismOverhaul]
@@ -901,14 +901,67 @@
 }
 
 //  ==================================================
+//  STAR 24C solid rocket motor.
+
+//  Dimensions: 0.62 m x 1.07 m
+//  Gross Mass: 239 kg
+//  ==================================================
+
+@PART[ca_stella24C]:FOR[RealismOverhaul]
+{
+    %RSSROConfig  = False
+
+    @MODEL
+    {
+        %scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 0.167, 0.0, 0.0, 1.0, 0.0, 0
+    @node_stack_bottom = 0.0, -0.431, 0.0, 0.0, -1.0, 0.0, 0
+
+    @mass = 0.02
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    @bulkheadProfiles = size0
+    @tags ^= :$: star solid
+
+    %engineType = Star-24C
+
+    @MODULE[ModuleEngines*]
+    {
+        @PROPELLANT[SolidFuel]
+        {
+            @name = HTPB
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 282
+            @key,1 = 1 141
+        }
+    }
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 1.0
+    }
+}
+
+//  ==================================================
 //  Voyager 1 & 2 propulsion module.
 
 //  Dimensions: 1.7 m x 1.73 m
-//  Gross Mass: 1145 Kg
+//  Gross Mass: 1145 kg
 
 //  * The gross mass value includes the inert mass of
 //    the ACS thrusters and the auxiliary structural
-//    parts (23 Kg).
+//    parts (23 kg).
 //  ==================================================
 
 @PART[ca_torekkaPM]:FOR[RealismOverhaul]
@@ -941,7 +994,7 @@
     %ignoreMass = False
     %massOffset = 0.023
 
-    //  MR-106E ACS thrusters for roll control.
+    //  MR-106E ACS thrusters for roll control (~22.5 N).
 
     @MODULE[ModuleRCS*]:HAS[#thrusterTransformName[RCS_transform]]
     {
@@ -961,7 +1014,7 @@
         }
     }
 
-    //  MR-104A ACS thrusters for yaw and pitch control and
+    //  MR-104A ACS thrusters (~445 N) for yaw and pitch control and
     //  as vernier thrusters (injection velocity trimming).
 
     @MODULE[ModuleRCS*]:HAS[#thrusterTransformName[RCS_transformL]]
@@ -1010,16 +1063,16 @@
     {
         name = ModuleFuelTanks
         type = HTPB
-        volume = 586.851
+        volume = 586.85
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass ~1038 Kg.
+        //  HTPB/AP propellant mixture mass ~1038 kg.
 
         TANK
         {
             name = HTPB
-            amount = 586.851
-            maxAmount = 586.851
+            amount = 586.85
+            maxAmount = 586.85
         }
     }
 
@@ -1032,7 +1085,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[ca_torekkaPM]:AFTER[RealismOverhaulEnginesPost]
+@PART[ca_torekkaPM]:AFTER[RealismOverhaulEngines]
 {
     @title = Voyager Propulsion Module
     @manufacturer = Jet Propulsion Laboratory (JPL)
@@ -1043,7 +1096,7 @@
 //  KTDU-425A engine.
 
 //  Dimensions: 0.7 m x 0.7 m
-//  Inert Mass: 70 Kg
+//  Inert Mass: 70 kg
 
 //  * Stats similar to the S5.92 engine.
 //  ==================================================
@@ -1105,7 +1158,7 @@
 //  Generic pressurized propellant tank (radial spherical).
 
 //  Dimensions: 0.27 m x 0.27 m
-//  Inert Mass: 5 Kg
+//  Inert Mass: 5 kg
 //  ==================================================
 
 @PART[ca_vor_mptank]:FOR[RealismOverhaul]
@@ -1149,7 +1202,7 @@
 //  4MV-1/2 spacecraft bus propulsion system storage tank.
 
 //  Dimensions: 1.6 m x 1.8 m
-//  Inert Mass: 300 Kg
+//  Inert Mass: 300 kg
 
 //  * The actual part diameter should be 1.1 m instead
 //    of 1.6 m. The diameter was preserved due to the

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -24,6 +24,12 @@
 //  AIAA - DESIGN AND MANUFACTURE OF A FUEL TANK ASSEMBLY: http://www.psi-pci.com/Technical_Paper_Library/AIAA%202003-4606%20Star2%20fuel.pdf
 
 //  ==================================================
+//  Removed extra parts.
+//  ==================================================
+
+!PART[ca_jib-mk2]:FOR[RealismOverhaul]{}
+
+//  ==================================================
 //  Cassini R-4D-11 main engine assembly.
 
 //  Dimensions: 1.2 m x 1.2 m
@@ -63,8 +69,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        //thrustVectorTransformName = thrustTransform
-
         @PROPELLANT[LiquidFuel]
         {
             @name = MMH
@@ -231,7 +235,7 @@
 //  Inert Mass: 8 kg
 
 //  * Similar to the main engine that was used on the
-//    Mariner Mars series of spacecrafts.
+//    Mariner Mars and Venus series of spacecrafts.
 //  * The gimbal range value of the jet vanes is
 //    completely hypothetical.
 //  ==================================================
@@ -904,16 +908,16 @@
 //  STAR 24C solid rocket motor.
 
 //  Dimensions: 0.62 m x 1.07 m
-//  Gross Mass: 239 kg
+//  Gross Mass: 240 kg
 //  ==================================================
 
 @PART[ca_stella24C]:FOR[RealismOverhaul]
 {
-    %RSSROConfig  = False
+    %RSSROConfig = True
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.0
+        %scale = 1.61, 1.61, 1.61
     }
 
     @scale = 1.0
@@ -947,10 +951,7 @@
         }
     }
 
-    @MODULE[ModuleDecouple]
-    {
-        @ejectionForce = 1.0
-    }
+    !MODULE[ModuleDecouple],*{}
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -29,7 +29,7 @@
 //  Cassini Dual Technique Magnetometer.
 
 //  Dimensions: 0.425 m x 0.95 m (retracted)
-//  Inert Mass: 3 Kg
+//  Inert Mass: 3 kg
 //  ==================================================
 
 @PART[mer_mag]:FOR[RealismOverhaul]
@@ -62,15 +62,15 @@
 //  Cassini optical remote sensing package.
 
 //  Dimensions: 0.95 m x 1.85 m
-//  Inert Mass: 150 Kg
+//  Inert Mass: 150 kg
 
 //  * The Cassini ORSP consists of the following
 //    instruments:
 
-//  * Composite Infrared Spectrometer (CIRS) (40 Kg)
-//  * Imaging Science Subsystem (ISS) (58 Kg)
-//  * Ultraviolet Imaging Spectrograph (UVIS) (15 Kg)
-//  * Visible and Infrared Mapping Spectrometer (VIMS) (37 Kg)
+//  * Composite Infrared Spectrometer (CIRS) (40 kg)
+//  * Imaging Science Subsystem (ISS) (58 kg)
+//  * Ultraviolet Imaging Spectrograph (UVIS) (15 kg)
+//  * Visible and Infrared Mapping Spectrometer (VIMS) (37 kg)
 //  ==================================================
 
 @PART[mer_rsp]:FOR[RealismOverhaul]
@@ -105,11 +105,11 @@
 //  MetOp scatterometer.
 
 //  Dimensions: 1.7 m x 3.8 m (retracted)
-//  Inert Mass: 460 Kg
+//  Inert Mass: 460 kg
 
 //  * The inert mass value is the average between the
-//    original MetOp ASCAT instrument (420 Kg) and the
-//    MetOp-SG (500 Kg).
+//    original MetOp ASCAT instrument (420 kg) and the
+//    MetOp-SG (500 kg).
 //  ==================================================
 
 @PART[ca_H2RS]:FOR[RealismOverhaul]
@@ -145,7 +145,7 @@
 //  Mars Global Surveyor laser altimeter (MOLA).
 
 //  Dimensions: 0.7 m x 0.47 m
-//  Inert Mass: 26 Kg
+//  Inert Mass: 26 kg
 //  ==================================================
 
 @PART[ca_HOLA]:FOR[RealismOverhaul]
@@ -178,7 +178,7 @@
 //  Multi-spectral Imager.
 
 //  Dimensions: 0.7 m x 0.27 m
-//  Inert Mass: 15 Kg
+//  Inert Mass: 15 kg
 
 //  * This instrument is a combination of the ALICE and
 //    RALPH instruments carried by New Horizons.
@@ -214,7 +214,7 @@
 //  Accelerometer.
 
 //  Dimensions: 0.15 m x 0.175 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_accelerometer]:FOR[RealismOverhaul]
@@ -244,7 +244,7 @@
 //  Barometer.
 
 //  Dimensions: 0.15 m x 0.175 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_barometer]:FOR[RealismOverhaul]
@@ -274,7 +274,7 @@
 //  Dust Particle Collector.
 
 //  Dimensions: 1.15 m x 0.51 m
-//  Inert Mass: 150 Kg
+//  Inert Mass: 150 kg
 //  ==================================================
 
 @PART[ca_DUSTC]:FOR[RealismOverhaul]
@@ -308,7 +308,7 @@
 //  Cosmic Dust Counter.
 
 //  Dimensions: 0.5 m x 0.6 m
-//  Inert Mass: 17 Kg
+//  Inert Mass: 17 kg
 //  ==================================================
 
 @PART[ca_DUSTX]:FOR[RealismOverhaul]
@@ -341,7 +341,7 @@
 //  Electrostatic Analyzer.
 
 //  Dimensions: 0.11 m x 0.65 m
-//  Inert Mass: 5 Kg
+//  Inert Mass: 5 kg
 //  ==================================================
 
 @PART[ca_ELIX]:FOR[RealismOverhaul]
@@ -375,7 +375,7 @@
 //  Gravity gradiometer.
 
 //  Dimensions: 0.15 m x 0.3 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_gravioli]:FOR[RealismOverhaul]
@@ -408,7 +408,7 @@
 //  Gamma Ray Spectrometer.
 
 //  Dimensions: 6.2 m x 0.45 m (extended)
-//  Inert Mass: 30 Kg
+//  Inert Mass: 30 kg
 //  ==================================================
 
 @PART[ca_GRS]:FOR[RealismOverhaul]
@@ -441,7 +441,7 @@
 //  Infrared Spectrometer.
 
 //  Dimensions: 0.5 m x 0.4 m
-//  Inert Mass: 11 Kg
+//  Inert Mass: 11 kg
 //  ==================================================
 
 @PART[ca_KLIR]:FOR[RealismOverhaul]
@@ -476,7 +476,7 @@
 //  Ultraviolet Spectrometer.
 
 //  Dimensions: 0.5 m x 1.45 m (extended)
-//  Inert Mass: 27 Kg
+//  Inert Mass: 27 kg
 //  ==================================================
 
 @PART[ca_LUV]:FOR[RealismOverhaul]
@@ -521,7 +521,7 @@
 //  Cassini Radio and Plasma Wave Science (RPWS).
 
 //  Dimensions: 0.6 m x 10 m (extended)
-//  Inert Mass: 6.8 Kg
+//  Inert Mass: 6.8 kg
 //  ==================================================
 
 @PART[ca_RPWS]:FOR[RealismOverhaul]
@@ -554,7 +554,7 @@
 //  STEREO Radio and Plasma Wave Science (RPWS).
 
 //  Dimensions: - m x 6 m (extended)
-//  Inert Mass: 11 Kg
+//  Inert Mass: 11 kg
 //  ==================================================
 
 @PART[ca_RPWS_STEREO]:FOR[RealismOverhaul]
@@ -586,7 +586,7 @@
 //  Voyager 1 & 2 Science Boom.
 
 //  Dimensions: 3.8 m x 1.4 m (extended)
-//  Inert Mass: 103 Kg
+//  Inert Mass: 103 kg
 //  ==================================================
 
 @PART[ca_sciBoom]:FOR[RealismOverhaul]
@@ -620,7 +620,7 @@
 //  STEREO boom instrument suit.
 
 //  Dimensions: 0.2 m x 4.5 m
-//  Inert Mass: 12 Kg
+//  Inert Mass: 12 kg
 //  ==================================================
 
 @PART[ca_stereoBoom]:FOR[RealismOverhaul]
@@ -653,7 +653,7 @@
 //  Solar Wind Analyzer.
 
 //  Dimensions: 0.16 m x 0.22 m
-//  Inert Mass: 3 Kg
+//  Inert Mass: 3 kg
 //  ==================================================
 
 @PART[ca_SWIS]:FOR[RealismOverhaul]
@@ -686,7 +686,7 @@
 //  Optical Telescope.
 
 //  Dimensions: 0.6 m
-//  Inert Mass: 65 Kg
+//  Inert Mass: 65 kg
 //  ==================================================
 
 @PART[ca_telescope_a]:FOR[RealismOverhaul]
@@ -719,7 +719,7 @@
 //  Thermometer.
 
 //  Dimensions: 0.1 m x 0.2 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_thermometer]:FOR[RealismOverhaul]
@@ -752,7 +752,7 @@
 //  Pioneer 10 & 11 Triaxial Helium Vector Magnetometer.
 
 //  Dimensions: 0.7 m x 6.6 m (extended)
-//  Inert Mass: 5 Kg
+//  Inert Mass: 5 kg
 //  ==================================================
 
 @PART[ca_magneto2]:FOR[RealismOverhaul]
@@ -792,7 +792,7 @@
 //  Vega camera & spectrometer platform.
 
 //  Dimensions: 1.4 m x 0.8 m
-//  Inert Mass: 80 Kg
+//  Inert Mass: 80 kg
 //  ==================================================
 
 @PART[ca_vor_camera]:FOR[RealismOverhaul]
@@ -831,7 +831,7 @@
 //  Venera magnetometer.
 
 //  Dimensions: 0.3 m x 4 m (extended)
-//  Inert Mass: 10 Kg
+//  Inert Mass: 10 kg
 //  ==================================================
 
 @PART[ca_vor_mag]:FOR[RealismOverhaul]
@@ -872,7 +872,7 @@
 //  Venera Synthetic Aperture Radar (SAR) assembly.
 
 //  Dimensions: 3.5 m x 2.5 m
-//  Inert Mass: 1380 Kg
+//  Inert Mass: 1380 kg
 //  ==================================================
 
 @PART[ca_vor_sar]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Science.cfg
@@ -24,6 +24,7 @@
 //  NASA - Pioneer 10/11 Odyssey (Chapter 4):                      http://history.nasa.gov/SP-349/ch4.htm
 //  NASA - STEREO SWAVES instrument:                               https://swaves.gsfc.nasa.gov/swaves_instr.html
 //  UCLA/SSL - STEREO IMPACT instrument suite:                     http://sprg.ssl.berkeley.edu/impact/instruments.html
+//  NTRS - To Mars: The Odyssey of Mariner 4:                      https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19650018349.pdf
 
 //  ==================================================
 //  Cassini Dual Technique Magnetometer.
@@ -905,4 +906,41 @@
     !MODULE[ModuleDeployableAntenna],*{}
 
     !MODULE[ModuleDataTransmitter],*{}
+}
+
+//  ==================================================
+//  Mariner Mars scan platform.
+
+//  Dimensions: 0.45 m x 0.27 m
+//  Inert Mass: 8.6 kg
+//  ==================================================
+
+@PART[ca_argo-mk2-cam]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        %scale = 1.64, 1.64, 1.64
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0
+
+    @title = Mariner Mars Scan Platform
+    @manufacturer = Jet Propulsion Laboratory (JPL)
+    @description = The Mariner-Mars Scan Platform is an integrated suit of two television cameras, an infrared radiometer, an infrared spectrometer and two star trackers. The assembly features a two-degree-of-freedom mechanism that allows the instrument suite move depending on the encounter parameters of each mission.
+
+    @mass = 0.0086
+    @crashTolerance = 8
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 873.15
+    %skinMaxTemp = 873.15
+    %fuelCrossFeed = False
+    @bulkheadProfiles = srf, size1
+    @tags ^= :$: scan platform
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Structural.cfg
@@ -2,7 +2,7 @@
 //  Voyager SRM mounting truss adapter.
 
 //  Dimensions: 1.7 m x 0.8 m
-//  Inert Mass: 10 Kg
+//  Inert Mass: 10 kg
 //  ==================================================
 
 @PART[ca_torekka_truss]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -12,7 +12,7 @@
 //  Huygens heat shield.
 
 //  Dimensions: 2.7 m x 0.64 m
-//  Gross Mass: 76 Kg
+//  Gross Mass: 76 kg
 //  ==================================================
 
 @PART[ca_draco_hs]:FOR[RealismOverhaul]
@@ -86,7 +86,7 @@
 //  Thermal control system (small).
 
 //  Dimensions: 0.45 m x 0.4 m
-//  Inert Mass: 1 Kg
+//  Inert Mass: 1 kg
 //  ==================================================
 
 @PART[ca_louver_s]:FOR[RealismOverhaul]
@@ -132,7 +132,7 @@
 //  Thermal control system (medium).
 
 //  Dimensions: 0.3 m x 0.725 m
-//  Inert Mass: 1.25 Kg
+//  Inert Mass: 1.25 kg
 //  ==================================================
 
 @PART[ca_louver_s2]:FOR[RealismOverhaul]
@@ -178,7 +178,7 @@
 //  Thermal control system (large).
 
 //  Dimensions: 0.5 m x 0.725 m
-//  Inert Mass: 2 Kg
+//  Inert Mass: 2 kg
 //  ==================================================
 
 @PART[ca_louver_m]:FOR[RealismOverhaul]
@@ -224,7 +224,7 @@
 //  Venera heat shield.
 
 //  Dimensions: 2.4 m x 1.5 m (with the shroud)
-//  Gross Mass: 750 Kg
+//  Gross Mass: 750 kg
 
 //  * Stats similar to the lunar-rated heat shields.
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Utility.cfg
@@ -10,7 +10,7 @@
 //  Huygens drogue parachute.
 
 //  Dimensions: 0.3 m x 0.105 m
-//  Gross Mass: 5 Kg
+//  Gross Mass: 5 kg
 //  ==================================================
 
 @PART[ca_draco_drogue]:FOR[RealismOverhaul]
@@ -80,7 +80,7 @@
 //  RealChute compatibility.
 //  ==================================================
 
-@PART[ca_draco_drogue]:FOR[RealismOverhaul]:NEEDS[RealChute]
+@PART[ca_draco_drogue]:FOR[RealismOverhaulRC]:NEEDS[RealChute]
 {
     !sound_parachute_* = NULL
 
@@ -169,7 +169,7 @@
 //  Huygens main parachute.
 
 //  Dimensions: 0.3 m x 0.105 m
-//  Gross Mass: 7 Kg
+//  Gross Mass: 7 kg
 //  ==================================================
 
 @PART[ca_draco_parachute]:FOR[RealismOverhaul]
@@ -238,7 +238,7 @@
 //  RealChute compatibility.
 //  ==================================================
 
-@PART[ca_draco_parachute]:FOR[RealismOverhaul]:NEEDS[RealChute]
+@PART[ca_draco_parachute]:FOR[RealismOverhaulRC]:NEEDS[RealChute]
 {
     !sound_parachute_* = NULL
 
@@ -327,7 +327,7 @@
 //  Pioneer 10 & 11 Science Package.
 
 //  Dimensions: 1.25 m x 0.6 m
-//  Inert Mass: 10 Kg
+//  Inert Mass: 10 kg
 //  ==================================================
 
 @PART[ca_ESM]:FOR[RealismOverhaul]
@@ -379,7 +379,7 @@
 //  LM900 satellite bus.
 
 //  Dimensions: 1.6 m x 1 m
-//  Gross Mass: 530 Kg
+//  Gross Mass: 530 kg
 
 //  * This is a re-purposed part, originally used as a
 //    service module for the "Quetzal" probe core.
@@ -462,7 +462,7 @@
         volume = 75
         basemass = -1
 
-        //  Integrated battery 50 Wh.
+        //  Integrated battery ~50 Wh.
 
         TANK
         {
@@ -471,7 +471,7 @@
             maxAmount = 180
         }
 
-        //  ACS & TCM propellant 40 Kg.
+        //  ACS & TCM propellant ~40 kg.
 
         TANK
         {
@@ -503,7 +503,7 @@
 //  Venera drogue parachute.
 
 //  Dimensions: 2.4 m x 0.85 m (with the shroud)
-//  Gross Mass: 150 Kg
+//  Gross Mass: 150 kg
 
 //  * The inert mass value assumes that the shroud is
 //    not massless and part of the aeroshell structure.
@@ -587,7 +587,7 @@
 //  RealChute compatibility.
 //  ==================================================
 
-@PART[ca_fom_drogue]:FOR[RealismOverhaul]:NEEDS[RealChute]
+@PART[ca_fom_drogue]:FOR[RealismOverhaulRC]:NEEDS[RealChute]
 {
     !sound_parachute_* = NULL
 
@@ -677,7 +677,7 @@
 //  Venera main parachute.
 
 //  Dimensions: 2.4 m x 0.85 m (with the shroud)
-//  Gross Mass: 150 Kg
+//  Gross Mass: 150 kg
 
 //  * The inert mass value assumes that the shroud is
 //    not massless and part of the aeroshell structure.
@@ -761,7 +761,7 @@
 //  RealChute compatibility.
 //  ==================================================
 
-@PART[ca_fom_parachute]:FOR[RealismOverhaul]:NEEDS[RealChute]
+@PART[ca_fom_parachute]:FOR[RealismOverhaulRC]:NEEDS[RealChute]
 {
     !sound_parachute_* = NULL
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_GroundOps.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_GroundOps.cfg
@@ -14,11 +14,14 @@
         plumeScale = 0.15
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
         localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
+        emissionMult = 0.5
         energy = 1.0
         speed = 1.0
-        emissionMult = 0.5
     }
 
     @MODULE[ModuleEngines*]
@@ -38,7 +41,7 @@
 }
 
 //  ==================================================
-//  STAR 37 SRM plume setup.
+//  STAR-37E SRM plume setup.
 //  ==================================================
 
 @PART[ca_landv_srm]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -53,11 +56,14 @@
         plumeScale = 0.9
         flarePosition = 0.0, 0.0, 0.4
         flareScale = 0.475
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
         localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
+        emissionMult = 0.5
         energy = 1.0
         speed = 1.0
-        emissionMult = 0.5
     }
 
     @MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CoatlAerospace/RP_CA_ProbesPlus.cfg
@@ -1,4 +1,46 @@
 //  ==================================================
+//  Cassini R-4D-11 main engine assembly plume setup.
+//  ==================================================
+
+@PART[mer_engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    !PLUME,*{}
+
+    PLUME
+    {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.2
+        plumeScale = 0.1
+        flarePosition = 0.0, 0.0, -0.35
+        flareScale = 0.1
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hypergolic-OMS-White
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}
+
+//  ==================================================
 //  CA-RST generic engine & RCS thruster port combination
 //  plume setup.
 //  ==================================================
@@ -11,30 +53,36 @@
     {
         name = Hypergolic-OMS-Red
         transformName = Thrust_transform
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 0.75
-        speed = 1.0
-        emissionMult = 0.5
         plumePosition = 0.0, 0.0, 0.14
         plumeScale = 0.4
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 0.75
+        speed = 1.0
     }
 
     PLUME
     {
         name = Hypergolic-OMS-White
         transformName = Thrust_transform
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
         plumePosition = 0.0, 0.0, 0.0
         plumeScale = 0.25
         flarePosition = 0.0, 0.0, -0.075
         flareScale = 0.125
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -97,30 +145,36 @@
     {
         name = Hypergolic-OMS-Red
         transformName = Thrust_transform
-        localRotation = 0.0, 0.0, 0.0
-        localPosition = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 0.5
-        speed = 1.0
         plumePosition = 0.0, 0.0, 0.35
         plumeScale = 0.35
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
     }
 
     PLUME
     {
         name = Hypergolic-OMS-White
         transformName = Thrust_transform
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.0
-        speed = 1.0
-        emissionMult = 0.5
         plumePosition = 0.0, 0.0, 0.05
         plumeScale = 0.125
         flarePosition = 0.0, 0.0, -0.45
         flareScale = 0.075
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -182,15 +236,18 @@
     {
         name = Hypergolic-OMS-Red
         transformName = Thrust_transform
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.25
-        speed = 1.0
-        emissionMult = 0.5
         plumePosition = 0.0, 0.0, 0.575
         plumeScale = 0.5
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.25
+        speed = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -221,15 +278,18 @@
     {
         name = Hypergolic-OMS-Red
         transformName = thrust_Transform
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.25
-        speed = 1.0
-        emissionMult = 0.5
         plumePosition = 0.0, 0.0, 0.4
         plumeScale = 1.0
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.25
+        speed = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -260,15 +320,18 @@
     {
         name = Hypergolic-OMS-Red
         transformName = Thrust_transform
-        localRotation = 0.0, 0.0, 0.0
-        fixedScale = 1.0
-        energy = 1.25
-        speed = 1.0
-        emissionMult = 0.5
         plumePosition = 0.0, 0.0, 0.45
         plumeScale = 0.5
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.25
+        speed = 1.0
     }
 
     @MODULE[ModuleEngines*]
@@ -283,6 +346,48 @@
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-Red
+        }
+    }
+}
+
+//  ==================================================
+//  STAR-24C plume setup.
+//  ==================================================
+
+@PART[ca_stella24C]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    !PLUME,*{}
+
+    PLUME
+    {
+        name = Solid-Vacuum
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.45
+        plumeScale = 0.25
+        flarePosition = 0.0, 0.0, 0.3
+        flareScale = 0.25
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Vacuum
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Vacuum
         }
     }
 }
@@ -303,6 +408,10 @@
         plumeScale = 1.0
         flarePosition = 0.0, 0.0, 0.55
         flareScale = 0.4
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         emissionMult = 0.5
         energy = 1.0
@@ -341,6 +450,10 @@
         plumeScale = 0.35
         flarePosition = 0.0, 0.0, 0.375
         flareScale = 0.35
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
         localRotation = 0.0, 0.0, 0.0
         emissionMult = 0.5
         energy = 1.0


### PR DESCRIPTION
**Change log:**

* Added RO and RealPlume support for all new parts introduced in the late 0.16.1 dev and 0.17 beta updates (IUS, Mariner Mars & Venus).
* Rebalanced all antennae to follow a much better progression curve (reference: https://github.com/KSP-RO/RealismOverhaul/pull/1916).
* Fixed the CommNet exponent value so that it will operate like the RemoteTech multiple antenna multiplier.
* Fixed the range of the Venera Lander so that it will operate as expected with the new antenna rebalances.
* Updated the generic Mariner-Mars & Mariner-Venus solar array stats to better match against the newly introduced (and proper) Mariner-Mars solar array.
* Removed the electricity requirement of the Mariner-Mars solar wind vanes (simulated by reaction wheels - too low of a power consumption IRL to be considered valid in KSP).
* Added the missing Cassini R-4D-11 main engine assembly RealPlume config.
* Separated the Real Chute and RemoteTech passes into custom RO ones (applied after the standard RO part pass).
* Fixed the incorrect "skinMaxTemp" parameter on the Juno Spacecraft Bus.
* Updated the tags of various solar array wings.
* Fixed the wrong capitalization of the "kg" unit.