### PR TITLE
RN update castor 1 masses

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -112,7 +112,6 @@
 	@node_stack_top = 0.0, 2.961952, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.40132, 0.0, 0.0, 1.0
 	@attachRules = 1,1,1,1,0
-	@mass = 0.535
 	%engineType = Castor-1
 }
 @PART[solidBoosterSmall]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -112,6 +112,7 @@
 	@node_stack_top = 0.0, 2.961952, 0.0, 0.0, 1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, -0.40132, 0.0, 0.0, 1.0
 	@attachRules = 1,1,1,1,0
+	@mass = 0.877 //0.887-0.01 for decoupler
 	%engineType = Castor-1
 }
 @PART[solidBoosterSmall]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
@@ -629,7 +629,7 @@
 		scale = 1.50, 1.50, 1.50
 	}
 	%node_attach = 0.0, 0.0, -0.40, 0.0, 0.0, 1.0, 1
-	@mass = 0.535
+	@mass = 0.877 //0.887-0.01 for decoupler
 	%engineType = Castor-1
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -1,7 +1,7 @@
 @PART[FASADeltaCastorSrb]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.535
+	@mass = 0.877 //0.887-0.01 for decoupler
 	%engineType = Castor-1
 }
 @PART[FASADeltaMB3LFE]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
@@ -4592,7 +4592,7 @@
 	}
 	%scale = 1.0
 	%rescaleFactor = 1.0
-	@mass = 0.886 //0.887-0.001
+	@mass = 0.877 //0.887-0.01
 	%engineType = Castor-1
 }
 
@@ -5161,7 +5161,7 @@
 	%rescaleFactor = 1.0
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
-	@mass = 0.001
+	@mass = 0.01
 	@title = Castor-1 Radial Decoupler
 	@manufacturer = Aerojet
 	@description = Radial decoupler for the castor-1 boosters of the thor-able/delta rocket.


### PR DESCRIPTION
-Fix masses for the rest of the castor 1 srb's to be in line with mine,
which uses data from b14643 instead of astronautix like the rest of
these came from