### PR TITLE
Fix SSTU engine cluster masses

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines_GLOBAL.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Engines_GLOBAL.cfg
@@ -12,6 +12,7 @@
 	@MODULE[SSTUModularEngineCluster]
 	{
 		@diameterIncrement = 0.1	// Allow increments of 1 cm
+		%adjustMass = false			// Fix mass calculation for clusters
 	}
 	
 	@MODULE[SSTUNodeFairing]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Misc.cfg
@@ -9,7 +9,6 @@
 	@MODULE[SSTUCustomRadialDecoupler]
 	{
 		@diameter = 1.0
-		%diameterIncrement = 0.1
 		%maxDiameter = 2.0
 		%diameterIncrement = 0.5
 		!UPGRADES,* {}


### PR DESCRIPTION
SSTU's engine clusters calculate their masses wrong. For example, if you change from one engine to two, the mass triples instead of doubles iirc. Fix this by setting adjustMass to false, which i think was made for realfuels compatibility.