### PR TITLE
[Bug Fix] RSB Atlas V

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Atlas.cfg
@@ -297,7 +297,7 @@
 //  Atlas V CCB nose cone.
 
 //  Dimensions: 3.81 m x 2.8 m
-//  Inert Mass: 415 Kg
+//  Inert Mass: 425 Kg
 //  ==================================================
 
 @PART[RSBnosecone381]:FOR[RealismOverhaul]
@@ -308,7 +308,7 @@
     @manufacturer = Orbital ATK
     @description = A 3.8 meter aerodynamic nose cone for the Atlas V HLV.
 
-    @mass = 0.415
+    @mass = 0.425
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
@@ -353,6 +353,8 @@
 {
     %RSSROConfig = True
 
+    %node_stack_payload = 0.0, 4.455, 0.0, 0.0, 1.0, 0.0, 2
+
     @title = Common Centaur
     @manufacturer = United Launch Alliance (ULA)
     @description = The second stage of an Atlas V. Contains the necessary avionics, communications and power supply for mission times of up to 6 hours.
@@ -364,10 +366,14 @@
     @maxTemp = 673.15
     %skinMaxTemp = 773.15
     %vesselIcon = Probe
+    !ActivatesEvenIfDisconnected = NULL
+    !stagingIcon = NULL
+
+    !MODULE[ModuleDecouple],*{}
 
     //  Two sets of RCS thrusters for three axis control and ullage:
-    //  Aerojet Rocketdyne MR-106J (40 N) for attitude control.
-    //  Aerojet Rocketdyne MR-106K (27 N) ullage control.
+    //  Eight Aerojet Rocketdyne MR-106J (40 N) for attitude control.
+    //  Four Aerojet Rocketdyne MR-106K (27 N) for ullage control.
 
     @MODULE[ModuleRCS*]
     {
@@ -378,18 +384,18 @@
 
         transformMultipliers
         {
-            trf0  = 0.0935
-            trf1  = 0.0935
-            trf2  = 0.0935
-            trf3  = 0.0935
-            trf4  = 0.0935
-            trf5  = 0.0935
-            trf6  = 0.0935
-            trf7  = 0.0935
-            trf8  = 0.0631
-            trf9  = 0.0631
-            trf10 = 0.0631
-            trf11 = 0.0631
+            trf0  = 0.09346
+            trf1  = 0.09346
+            trf2  = 0.09346
+            trf3  = 0.09346
+            trf4  = 0.09346
+            trf5  = 0.09346
+            trf6  = 0.09346
+            trf7  = 0.09346
+            trf8  = 0.06308
+            trf9  = 0.06308
+            trf10 = 0.06308
+            trf11 = 0.06308
         }
 
         PROPELLANT
@@ -428,7 +434,6 @@
         basemass = -1
 
         //  Centaur fuel and oxidizer mass 20830 Kg.
-
         //  Following masses calculated from a 5.5:1 mixture ratio:
 
         //  Centaur fuel mass 3204.6 Kg.
@@ -615,7 +620,7 @@
 //  Atlas V 500 series aft stub adapter.
 
 //  Dimensions: 3.81 m x 4.1 m
-//  Inert Mass: 1240 Kg
+//  Inert Mass: 1525 Kg
 //  ==================================================
 
 @PART[RSBinterstageAtlasCentaur500]:FOR[RealismOverhaul]
@@ -626,7 +631,7 @@
     @manufacturer = United Launch Alliance (ULA)
     @description = The aft Centaur Interstage Adapter (CIA) for the Atlas V 500 series. Typically used with a 500 series Atlas V fairing base encapsulating the entire Centaur upper stage. Place this interstage first, then snap the 500 series fairing base onto the "gap".
 
-    @mass = 1.24
+    @mass = 1.525
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
@@ -643,7 +648,7 @@
 //  Atlas 500 series aft stub adapter (procedural).
 
 //  Dimensions: 3.81 m x 4.1 m
-//  Inert Mass: 1240 Kg
+//  Inert Mass: 1525 Kg
 //  ==================================================
 
 @PART[RSBfairingAtlas500]FOR[RealismOverhaul]
@@ -655,7 +660,7 @@
     @manufacturer = United Launch Alliance (ULA)
     @description = The procedural fairing version of the aft Centaur Interstage Adapter (CIA) for the Atlas V 500 series. Typically used with a 500 series Atlas V fairing base encapsulating the entire Centaur upper stage. Place this interstage first, then snap the 500 series fairing base onto the "gap".
 
-    @mass = 1.24
+    @mass = 1.525
     @crashTolerance = 16
     @breakingForce = 250
     @breakingTorque = 250
@@ -729,7 +734,7 @@
             @name = HTPB
         }
 
-        atmosphereCurve
+        @atmosphereCurve
         {
             @key,0 = 0 254
             @key,1 = 1 160

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Engines.cfg
@@ -1329,7 +1329,7 @@
     %engineType = RD180
     %engineTypeMult = 1
     %massOffset = 0.5
-    %ignoreMass = True
+    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {


### PR DESCRIPTION
**Change Log:**

* Increased the mass of the Atlas V Heavy variant CCB nose cone to be more in-line with the HLV CCB inert mass.
* Removed a redundant decoupler module from the Common Centaur.
* Added an extra attachment node to the Common Centaur (allows smaller and/or custom decoupler modules/structures to be mounted on the top of the astrionics module).
* Tweaked the RCS thrust multipliers to make the thrust values a bit more accurate.
* Increased the mass of the Atlas V 500 series C-ISA in order to add the missing 285 kg of the Booster ISA.
* Fixed a major bug with the CCB retro motors rendering them unusable.
* Fixed the inert mass of the RD-180 engine to account for the CCB structural adapter and heat shield masses.