### PR TITLE
[BUGFIX | DECQ R7] Fixed core stage vernier setup and plume

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -1167,6 +1167,37 @@
         }
     }
 
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform3]]
+    {
+        @name = ModuleEnginesRF
+        %engineID = CoreVernierEngine
+        @minThrust = 38.0
+        @maxThrust = 38.0
+        @heatProduction = 100
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            @ratio = 0.3531
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.6274
+            %DrawGauge = False
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 308
+            @key,1 = 1 241
+        }
+    }
+
     !MODULE[TRReflection],*{}
 
     MODULE:NEEDS[TextureReplacer]

--- a/GameData/RealismOverhaul/RealPlume_Configs/DECQ/R7_SECOND_STAGE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/DECQ/R7_SECOND_STAGE.cfg
@@ -34,6 +34,21 @@
         flareScale = 1.0
     }
 
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform3
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 0.5
+        speed = 1.0
+        emissionMult = 0.5
+        plumePosition = 0.0, 0.0, -0.2
+        plumeScale = 2.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+    }
+
     @MODULE[ModuleEngines*]:HAS[#engineID[CoreMainEngine]]
     {
         %powerEffectName = Kerolox-Lower


### PR DESCRIPTION
* added missing vernier thrustTransform to config and added the plume accordingly to core stage vernier

@PhineasFreak I have to crosscheck your PR from earlier this year where you consolidated the plume configs for the DECQ files in general, if there are file splits I'll rework this here