### PR TITLE
CO₂ scrubbers

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -89,23 +89,25 @@
 	@description = A life support module that filters Oxygen out of the air. Requires IntakeAir and oxygen atmosphere. Rated for 3 people.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		//inputResources = IntakeAir, 0.035, ElectricCharge, 0.010
 		//outputResources = Oxygen, 0.0073, false
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.010
+			ResourceName = ElectricCharge
+			Ratio = 0.010
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = IntakeAir
-			@Ratio = 0.035
+			ResourceName = IntakeAir
+			Ratio = 0.035
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Oxygen
-			@Ratio = 0.0073
+			ResourceName = Oxygen
+			Ratio = 0.0073
 			@DumpExcess = false
 		}
 	}
@@ -124,36 +126,38 @@
 	@description = A simple CO2 scrubber using lithium peroxide. Absorbs CO2, and releases O2 and lithium carbonate (waste). Requires small electric charge to run air pump. Figure 0.5L of LithiumPeroxide/person/day. Rated for 3 people. Resources for 14days.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		//inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumPeroxide, 0.0000051872
 		//outputResources = Oxygen, 0.0029240301, true, Waste, 0.0000257297, true
 		@converterName = CO2 Scrubber
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.010
+			ResourceName = ElectricCharge
+			Ratio = 0.010
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = CarbonDioxide
-			@Ratio = 0.0058912100
+			ResourceName = CarbonDioxide
+			Ratio = 0.0058912100
 		}
-		@INPUT_RESOURCE,2
+		INPUT_RESOURCE
 		{
-			@ResourceName = LithiumPeroxide
-			@Ratio = 0.0000051872
+			ResourceName = LithiumPeroxide
+			Ratio = 0.0000051872
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Oxygen
-			@Ratio = 0.0029240301
-			@DumpExcess = true
+			ResourceName = Oxygen
+			Ratio = 0.0029240301
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Waste
-			@Ratio = 0.0000257297
-			@DumpExcess = true
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = true
 		}
 	}
 	!RESOURCE[CarbonDioxide]
@@ -173,36 +177,38 @@
 	@description = A simple CO2 scrubber using lithium hydroxide. Absorbs CO2, and releases water (which needs purification before use) and lithium carbonate (waste). Requires small electric charge to run air pump. Figure 0.75L of LithiumHydroxide/person/day. Rated for 3 people. Resources for 14days.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		//inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
 		//outputResources = WasteWater, 0.003341591, true, Waste, 0.0000257297, true
 		@converterName = CO2 Scrubber
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.010
+			ResourceName = ElectricCharge
+			Ratio = 0.010
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = CarbonDioxide
-			@Ratio = 0.0058912100
+			ResourceName = CarbonDioxide
+			Ratio = 0.0058912100
 		}
-		@INPUT_RESOURCE,2
+		INPUT_RESOURCE
 		{
-			@ResourceName = LithiumHydroxide
-			@Ratio = 0.0000085683
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = WasteWater
-			@Ratio = 0.003341591
-			@DumpExcess = true
+			ResourceName = WasteWater
+			Ratio = 0.003341591
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Waste
-			@Ratio = 0.0000257297
-			@DumpExcess = true
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = true
 		}
 	}
 	@RESOURCE[LithiumPeroxide]
@@ -219,42 +225,44 @@
 	@description = A simple CO2 scrubber using potassium superoxide. Absorbs CO2, and releases water (which needs purification before use) and carbon (waste). Requires small electric charge to run air pump. Figure 0.75L of PotassiumSuperoxide/person/day. Rated for 3 people. Resources for 14days.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		//inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, PotassiumSuperoxide, 0.0000086769
 		//outputResources = Oxygen, 0.0043860452, true, Waste, 0.0000348617, true, WasteWater, 0.00000238761, true
 		@converterName = CO2 Scrubber
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.010
+			ResourceName = ElectricCharge
+			Ratio = 0.010
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = CarbonDioxide
-			@Ratio = 0.0058912100
+			ResourceName = CarbonDioxide
+			Ratio = 0.0058912100
 		}
-		@INPUT_RESOURCE,2
+		INPUT_RESOURCE
 		{
-			@ResourceName = PotassiumSuperoxide
-			@Ratio = 0.0000086769
+			ResourceName = PotassiumSuperoxide
+			Ratio = 0.0000086769
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Oxygen
-			@Ratio = 0.0043860452
-			@DumpExcess = true
+			ResourceName = Oxygen
+			Ratio = 0.0043860452
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Waste
-			@Ratio = 0.0000348617
-			@DumpExcess = true
+			ResourceName = Waste
+			Ratio = 0.0000348617
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,2
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = WasteWater
-			@Ratio = 0.00000238761
-			@DumpExcess = true
+			ResourceName = WasteWater
+			Ratio = 0.00000238761
+			DumpExcess = true
 		}
 	}
 	@RESOURCE[LithiumPeroxide]
@@ -278,36 +286,38 @@
 	@description = Using the Bosch reaction, a substantial amount of electricity is used to produce the heat needed to react CO2 and H2 to form carbon (waste) and water vapor. Rated for 3 people.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		//inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 2.5, Hydrogen, 0.0117123855
 		//outputResources = WasteWater, 0.00000955024, true, Waste, 0.0000053866718248, true
 		@converterName = Bosch Reactor
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 2.5
+			ResourceName = ElectricCharge
+			Ratio = 2.5
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = CarbonDioxide
-			@Ratio = 0.0058912100
+			ResourceName = CarbonDioxide
+			Ratio = 0.0058912100
 		}
-		@INPUT_RESOURCE,2
+		INPUT_RESOURCE
 		{
-			@ResourceName = Hydrogen
-			@Ratio = 0.0117123855
+			ResourceName = Hydrogen
+			Ratio = 0.0117123855
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Waste
-			@Ratio = 0.0000053866718248
-			@DumpExcess = true
+			ResourceName = Waste
+			Ratio = 0.0000053866718248
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = WasteWater
-			@Ratio = 0.00000955024
-			@DumpExcess = true
+			ResourceName = WasteWater
+			Ratio = 0.00000955024
+			DumpExcess = true
 		}
 	}
 	!RESOURCE[CarbonDioxide]
@@ -327,36 +337,38 @@
 	@description = Using the Sabatier reaction to reclaim water from carbon dioxide and hydrogen. Produces 1kg LqdMethane/day.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 1.0	// Amount LqdMethane/Day
 		//inputResources = CarbonDioxide, 0.0172683775, ElectricCharge, 0.7, Hydrogen, 0.0647212460
 		//outputResources = LqdMethane, 0.0000271941, true, Water, 0.0000259988, true
 		@converterName = Sabatier Reactor
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.7
+			ResourceName = ElectricCharge
+			Ratio = 0.7
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = CarbonDioxide
-			@Ratio = 0.0172683775
+			ResourceName = CarbonDioxide
+			Ratio = 0.0172683775
 		}
-		@INPUT_RESOURCE,2
+		INPUT_RESOURCE
 		{
-			@ResourceName = Hydrogen
-			@Ratio = 0.0647212460
+			ResourceName = Hydrogen
+			Ratio = 0.0647212460
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = LqdMethane
-			@Ratio = 0.0000271941
-			@DumpExcess = true
+			ResourceName = LqdMethane
+			Ratio = 0.0000271941
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Water
-			@Ratio = 0.0000259988
-			@DumpExcess = true
+			ResourceName = Water
+			Ratio = 0.0000259988
+			DumpExcess = true
 		}
 	}
 	!RESOURCE[CarbonDioxide]
@@ -377,36 +389,38 @@
 	@description = A life support recycling module that uses the Sabatier reaction to reclaim water from carbon dioxide and hydrogen. Produces 2kg LqdMethane/day.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 2.0	// Amount LqdMethane/Day
 		//inputResources = CarbonDioxide, 0.0172683775, ElectricCharge, 0.8, Hydrogen, 0.0647212460
 		//outputResources = LqdMethane, 0.0000271941, true, Water, 0.0000259988, true
 		@converterName = Sabatier Reactor
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.8
+			ResourceName = ElectricCharge
+			Ratio = 0.8
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = CarbonDioxide
-			@Ratio = 0.0172683775
+			ResourceName = CarbonDioxide
+			Ratio = 0.0172683775
 		}
-		@INPUT_RESOURCE,2
+		INPUT_RESOURCE
 		{
-			@ResourceName = Hydrogen
-			@Ratio = 0.0647212460
+			ResourceName = Hydrogen
+			Ratio = 0.0647212460
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = LqdMethane
-			@Ratio = 0.0000271941
-			@DumpExcess = true
+			ResourceName = LqdMethane
+			Ratio = 0.0000271941
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Water
-			@Ratio = 0.0000259988
-			@DumpExcess = true
+			ResourceName = Water
+			Ratio = 0.0000259988
+			DumpExcess = true
 		}
 	}
 	!RESOURCE[CarbonDioxide]
@@ -425,29 +439,31 @@
 	@description = Get the most from your pee. Recycle. Rated for 1 person
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 1.0	// # of people - Figures based on per/person
 		//inputResources = WasteWater, 0.00004059709561, ElectricCharge, 0.1
 		//outputResources = Water, 0.0000383361, false, Waste, 0.00000365912, true
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.1
+			ResourceName = ElectricCharge
+			Ratio = 0.1
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = WasteWater
-			@Ratio = 0.00004059709561
+			ResourceName = WasteWater
+			Ratio = 0.00004059709561
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Waste
-			@Ratio = 0.00000365912
-			@DumpExcess = true
+			ResourceName = Waste
+			Ratio = 0.00000365912
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Water
-			@Ratio = 0.0000383361
+			ResourceName = Water
+			Ratio = 0.0000383361
 			@DumpExcess = false
 		}
 	}
@@ -468,29 +484,31 @@
 	@description = Get the most from your pee. Recycle. Rated for 2 people.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 2.0	// # of people - Figures based on per/person
 		//inputResources = WasteWater, 0.00004059709561, ElectricCharge, 0.3
 		//outputResources = Water, 0.0000383361, false, Waste, 0.00000365912, true
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.3
+			ResourceName = ElectricCharge
+			Ratio = 0.3
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = WasteWater
-			@Ratio = 0.00004059709561
+			ResourceName = WasteWater
+			Ratio = 0.00004059709561
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Waste
-			@Ratio = 0.00000365912
-			@DumpExcess = true
+			ResourceName = Waste
+			Ratio = 0.00000365912
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Water
-			@Ratio = 0.0000383361
+			ResourceName = Water
+			Ratio = 0.0000383361
 			@DumpExcess = false
 		}
 	}
@@ -510,29 +528,31 @@
 	@description = Using electroysis, split water into hydrogen and oxygen. Rated for 2 people.
 	@MODULE[TacGenericConverter]
 	{
+		!INPUT_RESOURCE,* {}
+		!OUTPUT_RESOURCE,* {}
 		conversionRate = 2.0	// # of people - Figures based on per/person
 		//inputResources = Water, 0.0000053129, ElectricCharge, 0.5
 		//outputResources = Hydrogen, 0.0066129570, true, Oxygen, 0.003116887, false
-		@INPUT_RESOURCE,0
+		INPUT_RESOURCE
 		{
-			@ResourceName = ElectricCharge
-			@Ratio = 0.5
+			ResourceName = ElectricCharge
+			Ratio = 0.5
 		}
-		@INPUT_RESOURCE,1
+		INPUT_RESOURCE
 		{
-			@ResourceName = Water
-			@Ratio = 0.0000053129
+			ResourceName = Water
+			Ratio = 0.0000053129
 		}
-		@OUTPUT_RESOURCE,0
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Hydrogen
-			@Ratio = 0.0066129570
-			@DumpExcess = true
+			ResourceName = Hydrogen
+			Ratio = 0.0066129570
+			DumpExcess = true
 		}
-		@OUTPUT_RESOURCE,1
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = Oxygen
-			@Ratio = 0.003116887
+			ResourceName = Oxygen
+			Ratio = 0.003116887
 			@DumpExcess = false
 		}
 	}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -181,7 +181,7 @@
 		!OUTPUT_RESOURCE,* {}
 		conversionRate = 3.0	// # of people - Figures based on per/person
 		//inputResources = CarbonDioxide, 0.0058912100, ElectricCharge, 0.010, LithiumHydroxide, 0.0000085683
-		//outputResources = WasteWater, 0.003341591, true, Waste, 0.0000257297, true
+		//outputResources = WasteWater, 0.0000046828, true, Waste, 0.0000257297, true
 		@converterName = CO2 Scrubber
 		INPUT_RESOURCE
 		{
@@ -201,7 +201,7 @@
 		OUTPUT_RESOURCE
 		{
 			ResourceName = WasteWater
-			Ratio = 0.003341591
+			Ratio = 0.0000046828
 			DumpExcess = true
 		}
 		OUTPUT_RESOURCE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Command.cfg
@@ -251,8 +251,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -550,8 +550,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BahamutoD/Mk2LightningCockpit.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BahamutoD/Mk2LightningCockpit.cfg
@@ -109,8 +109,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Hab.cfg
@@ -470,8 +470,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 
@@ -666,8 +666,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 
@@ -1914,8 +1914,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 
@@ -2270,8 +2270,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CMES-WIP/RO_CMES_Pod.cfg
@@ -315,8 +315,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 
@@ -914,8 +914,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 
@@ -1789,8 +1789,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -318,8 +318,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_MOLScience.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_MOLScience.cfg
@@ -132,8 +132,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/JFJohnny/RO_K2_Command_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/JFJohnny/RO_K2_Command_Pod.cfg
@@ -487,8 +487,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
@@ -131,8 +131,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -305,8 +305,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -474,8 +474,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_ALCOR.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_ALCOR.cfg
@@ -154,8 +154,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
@@ -393,8 +393,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -521,8 +521,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -649,8 +649,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -785,8 +785,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -918,8 +918,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1048,8 +1048,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1171,8 +1171,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1372,8 +1372,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1485,8 +1485,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1598,8 +1598,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1712,8 +1712,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
@@ -213,8 +213,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1250,8 +1250,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_PorkWorks_HabitatPack.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_PorkWorks_HabitatPack.cfg
@@ -117,8 +117,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -270,8 +270,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -404,8 +404,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -543,8 +543,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -677,8 +677,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -818,8 +818,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -956,8 +956,8 @@ MODULE
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -740,8 +740,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -149,8 +149,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -326,8 +326,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -496,8 +496,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -872,8 +872,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -213,8 +213,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -523,8 +523,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -833,8 +833,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1143,8 +1143,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1389,8 +1389,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
@@ -137,8 +137,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -303,8 +303,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -453,8 +453,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -575,8 +575,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -954,8 +954,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1087,8 +1087,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1781,8 +1781,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1941,8 +1941,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -2114,8 +2114,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -2255,8 +2255,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -2448,8 +2448,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares.cfg
@@ -111,8 +111,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
@@ -689,8 +689,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -395,8 +395,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -494,8 +494,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
@@ -141,8 +141,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -299,8 +299,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -434,8 +434,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -950,8 +950,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1081,8 +1081,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Crew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Crew.cfg
@@ -109,8 +109,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -252,8 +252,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -383,8 +383,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
@@ -256,8 +256,8 @@
 
         OUTPUT_RESOURCE
         {
-            ResourceName = Water
-            Ratio = 0.0032924498
+            ResourceName = WasteWater
+            Ratio = 0.0000046828
             DumpExcess = True
         }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/WildBlueIndustries/RO_WildBlueIndustries_Buffalo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/WildBlueIndustries/RO_WildBlueIndustries_Buffalo.cfg
@@ -194,8 +194,8 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 
@@ -1075,8 +1075,8 @@ description = This sturdy chassis is designed to support a variety of components
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Water
-			Ratio = 0.0032924498
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
 			DumpExcess = True
 		}
 


### PR DESCRIPTION
Our MM patches for CO₂ scrubbers using LithiumHydroxide were broken in various ways.
Note that I haven't tested patch 3 (c97b09c), because it's mildly game-breaking: previously any crew cabin with one of these scrubbers would run a water surplus, so you didn't need to take much water with you; now you get much less water (about a tenth of what a 'naut drinks) and it's not potable.
Also, that patch was created with a horrendous `grep`/`tr`/`sed`/`bash` script; hopefully it's correct.