### PR TITLE
[Maintenance] DECQ R-7 Pack

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -276,12 +276,6 @@
             pressureFed = False
             ignitions = 1
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.25
-            }
-
             PROPELLANT
             {
                 name = HTPB

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -1,19 +1,189 @@
 //  ==================================================
 //  Sources:
 
-//  Soyuz User's Manual - Starsem:     http://www.starsem.com/services/images/soyuz_users_manual_190401.pdf
-//  Soyuz - Norbert Brügge:            http://www.b14643.de/Spacerockets_1/East_Europe_1/Semyorka/Description/Soyuz/Frame.htm
-//  Soyuz FG - Space Launch Report:    http://spacelaunchreport.com/soyuz.html
-//  Soyuz FG/Fregat - Spaceflight 101: http://spaceflight101.com/spacerockets/soyuz-fg-fregat/
-//  Soyuz FG - Spaceflight 101:        http://spaceflight101.com/spacerockets/soyuz-fg/
-//  Soyuz 2-1A - Spaceflight 101:      http://spaceflight101.com/spacerockets/soyuz-2-1a/
-//  Soyuz - Braeunig:                  http://www.braeunig.us/space/specs/r7.htm
-//  R-7 - Don P. Mitchell:             http://mentallandscape.com/S_R7.htm
-//  RD-0110 - Russian Space Web:       http://www.russianspaceweb.com/rd0110.html
-//  RD-107/108 - NPO Energomash:       http://www.lpre.de/energomash/RD-107/index.htm
+//  STARSEM - Soyuz User's Manual:      http://www.starsem.com/services/images/soyuz_users_manual_190401.pdf
+//  Norbert Brügge - Soyuz /-U /-FG:    http://www.b14643.de/Spacerockets_1/East_Europe_1/Semyorka/Description/Soyuz/Frame.htm
+//  Space Launch Report - Soyuz FG:     http://spacelaunchreport.com/soyuz.html
+//  Spaceflight 101 - Soyuz FG/Fregat:  http://spaceflight101.com/spacerockets/soyuz-fg-fregat/
+//  Spaceflight 101 - Soyuz FG:         http://spaceflight101.com/spacerockets/soyuz-fg/
+//  Spaceflight 101 - Soyuz 2-1A:       http://spaceflight101.com/spacerockets/soyuz-2-1a/
+//  Braeunig - Soyuz/Molniya:           http://www.braeunig.us/space/specs/r7.htm
+//  Don P. Mitchell - The R-7 Missile:  http://mentallandscape.com/S_R7.htm
+//  Russian Space Web - RD-0110 engine: http://www.russianspaceweb.com/rd0110.html
+//  KBKhA - RD-0124 engine series:      http://www.kbkha.ru/?p=8&cat=8&prod=51
+//  AIAA - KBKhA open cycle engines:    http://www.rocket-propulsion.info/resources/articles/AIAA-2005-3946.pdf
+//  NPO Energomash - RD-107/108 engine: http://www.lpre.de/energomash/RD-107/index.htm
+//  Russian Space Web - Sputnik Design: http://www.russianspaceweb.com/sputnik_design.html
+//  Don P. Mitchell - Sputnik 1:        http://mentallandscape.com/S_Sputnik1.htm
 
 //  ==================================================
-//  Soyuz TM/TMA/MS launch escape system jettison motor.
+//  Sputnik 1 spacecraft.
+
+//  Dimensions: 0.58 m x 0.58 m
+//  Gross Mass: 83.6 kg
+//  ==================================================
+
+@PART[SPUTNIK_1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 1
+
+    @title = Sputnik 1
+    %manufacturer = Experimental Design Bureau 1 (OKB-1)
+    @description = The first ever artificial satellite to orbit the Earth. Includes a thermometer for reading the internal temperature and a primitive micrometeorite detector.
+
+    @mass = 0.0836
+    @crashTolerance = 10
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    @fuelCrossFeed = False
+    !explosionPotential = NULL
+    @bulkheadProfiles = size1
+    %crewCapacity = 0
+    %vesselType = Probe
+    @tags ^= :$: command control probe satellite sputnik
+    !specPower = NULL
+
+    @MODULE[ModuleCommand]
+    {
+        @hasHibernation = False
+
+        !RESOURCE,*{}
+    }
+
+    !MODULE[ModuleSAS],*{}
+
+    !MODULE[ModuleReactionWheel],*{}
+
+    !MODULE[ModuleDataTransmitter],*:HAS[#antennaType[INTERNAL]]{}
+
+    //  Level 1 telecommunications system.
+
+    @MODULE[ModuleDataTransmitter]:HAS[#antennaType[DIRECT]]
+    {
+        @antennaPower = 125
+        @packetInterval = 1.0
+        @packetSize = 0.128
+        @packetResourceCost = 0.001
+        %antennaCombinable = True
+        %antennaCombinableExponent = 2.0
+    }
+
+    //  Avionics batteries ~500 Wh.
+    //  Supports the telecommunications system for approximately 20 days.
+
+    @RESOURCE[ElectricCharge]
+    {
+        @amount = 1800
+        @maxAmount = 1800
+    }
+}
+
+//  ==================================================
+//  Sputnik 1 spacecraft.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[SPUTNIK_1]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Features an integrated telecommunications system with a maximum effective range of 5 Mm, power consumption 1 Watt, data rate 128 kbit/s.
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleDeployableAntenna],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        ActionMode0Name = Deactivate Tracking Beacon
+        ActionMode1Name = Activate Tracking Beacon
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 50000
+        EnergyCost = 0.001
+        DeployFXModules = 0
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.128
+            PacketResourceCost = 0.001
+        }
+    }
+}
+
+//  ==================================================
+//  Sputnik 1 spacecraft adapter.
+
+//  Dimensions: 2.6 m x 2.59 m
+//  Gross Mass: 450 kg
+//  ==================================================
+
+@PART[SPUTNIK_1_FAIRING]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, 1.736, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.0, 0.0, 0.0, -1.0, 0.0, 2
+
+    @title = Sputnik 1 Adapter
+    %manufacturer = Experimental Design Bureau 1 (OKB-1)
+    @description = The adapter for the Sputnik 1 spacecraft. Includes basic avionics for the R-7 launch vehicle and an aerodynamic cap to protect the satellite.
+
+    @mass = 0.45
+    @crashTolerance = 10
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    @bulkheadProfiles = size1, size2
+    @fuelCrossFeed = False
+    @CoMOffset = 0.0, 0.802, 0.0
+    @tags ^= :$: break decouple separat split stag
+    !specPower = NULL
+
+    !MODULE[ModuleCommand],*{}
+
+    !MODULE[ModuleSAS],*{}
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 5.0
+    }
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  Soyuz TM/TMA/MS emergency rescue system jettison
+//  motor.
 
 //  Dimensions: 0.41 m x 2.5 m
 //  Gross Mass: 310 Kg
@@ -31,7 +201,7 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = Soyuz Launch Escape System Jettison Motor
+    @title = Soyuz Emergency Rescue System Jettison Motor
     %manufacturer = TsSKB-Progress
     @description = A small, multi-nozzle solid motor designed to cleanly separate the Soyuz launch escape system assembly from the fairing during a nominal flight. It can also pull away the entire upper section of the fairing in case of an abort.
 
@@ -40,18 +210,18 @@
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
+    @tags ^= :$: abort booster emergency explo ?les l.e.s malfunc ?rud safe solid surviv
     !specPower = NULL
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @exhaustDamage = True
         @minThrust = 145.0
         @maxThrust = 145.0
-        @heatProduction = 100
+        @heatProduction = 139
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
         %ullage = False
@@ -79,7 +249,7 @@
         volume = 120
         basemass = -1
 
-        //  HTPB propellant mixture 212 Kg.
+        //  HTPB/AP propellant mixture mass ~212 Kg.
 
         TANK
         {
@@ -94,16 +264,23 @@
     MODULE
     {
         name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        configuration = Soyuz-LES-Jettison
-        modded = False
+        configuration = Soyuz-SAS-Jettison
 
         CONFIG
         {
-            name = Soyuz-LES-Jettison
+            name = Soyuz-SAS-Jettison
             minThrust = 145.0
             maxThrust = 145.0
             heatProduction = 100
+            ullage = False
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
 
             PROPELLANT
             {
@@ -124,7 +301,8 @@
 }
 
 //  ==================================================
-//  Soyuz TM/TMA/MS launch escape system abort motor.
+//  Soyuz TM/TMA/MS emergency rescue system abort
+//  motor.
 
 //  Dimensions: 0.74 m x 3.8 m
 //  Gross Mass: 2540 Kg
@@ -145,7 +323,7 @@
     @node_stack_bottom = 0.0, -0.0, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_top = 0.0, 4.312, 0.0, 0.0, 1.0, 0.0, 1
 
-    @title = Soyuz Launch Escape System Abort Motor
+    @title = Soyuz Emergency Rescue System Abort Motor
     %manufacturer = TsSKB-Progress
     @description = The Launch Escape System abort motor assembly for the Soyuz TM/TMA/MS spacecraft. It contains a powerful solid rocket motor with two sets of nozzles, providing very high thrust needed to separate the Orbital and Descent modules from the rocket. Unlike older variants, it fires long enough to allow the main parachute to be deployed.
 
@@ -154,21 +332,19 @@
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     @stagingIcon = SOLID_BOOSTER
-    @bulkheadProfiles = size1, srf
+    @tags ^= :$: abort booster emergency explo ?les l.e.s malfunc ?rud safe solid surviv
     !specPower = NULL
 
     @MODULE[ModuleEngines*],*
     {
-        @name = ModuleEnginesRF
-        %engineID = LES
         @exhaustDamage = True
         @minThrust = 725.0
         @maxThrust = 725.0
-        @heatProduction = 100
+        @heatProduction = 59
         @stagingEnabled = False
         %ullage = False
         %pressureFed = False
@@ -204,7 +380,7 @@
         volume = 900
         basemass = -1
 
-        //  HTPB propellant mixture 1590 Kg.
+        //  HTPB/AP propellant mixture mass ~1590 Kg.
 
         TANK
         {
@@ -219,16 +395,17 @@
     MODULE
     {
         name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        configuration = Soyuz-LES-Abort
-        modded = False
+        configuration = Soyuz-SAS-Abort
 
         CONFIG
         {
-            name = Soyuz-LES-Abort
+            name = Soyuz-SAS-Abort
             minThrust = 725.0
             maxThrust = 725.0
-            heatProduction = 100
+            heatProduction = 59
+            ullage = False
+            pressureFed = False
+            ignitions = 1
 
             PROPELLANT
             {
@@ -271,35 +448,55 @@
 
     @title = Soyuz TM/TMA/MS Fairing (Front)
     %manufacturer = TsSKB-Progress
-    @description = This fairing is designed specifically for the Soyuz TM/TMA/MS spacecraft. It has many provisions to allow the crew to escape disaster in case of an emergency. The most notable element are the grid fins, acting as air brakes to stabilize the shroud. The lower section can also separate, lightening the load for the escape tower. It also includes two small abort motors designed to pull the Orbital and Descent modules away from the shroud after the launch escape system has separated, but before shroud jettison. This segment is equipped with housings for VZOR periscope and docking sensors.
+    @description = This fairing is designed specifically for the Soyuz TM/TMA/MS spacecraft series. It has many provisions to allow the crew to escape in case of an emergency. The most notable element are the grid fins, acting as air brakes to stabilize the shroud. The lower section can also separate, lightening the load for the escape tower. It also includes two small abort motors designed to pull the Orbital and Descent modules away from the shroud after the launch escape system has separated, but before shroud jettison. This segment is equipped with housings for VZOR periscope and docking sensors.
 
     @mass = 0.68
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     @stagingIcon = FUEL_TANK
-    %CoMOffset = 0.0, 5.56, 0.0
+    %CoMOffset = 0.0, 2.0, 0.0
+    @tags = aero )cap cargo cone contain drag fairing hollow inter nose payload protect R7 rocket shroud soyuz stage (stor transport
     !specPower = NULL
 
-    @MODULE[ModuleAnimateGeneric]
+    @MODULE[ModuleAnimateGeneric]:HAS[#animationName[ANIM]]
     {
         %isOneShot = False
         %disableAfterPlaying = True
     }
 
-    !MODULE[ModuleEngines*],*:HAS[~thrustVectorTransformName[thrustTransform3]]{}
+    //  Fairing separation solid rocket motor.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        @thrustVectorTransformName = thrustTransform2
+        @exhaustDamage = True
+        @minThrust = 5.0
+        @maxThrust = 5.0
+        @heatProduction = 1
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        %stagingEnabled = True
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 230
+        }
+    }
+
+    //  Secondary launch escape system (SAS) solid rocket motors.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform3]]
     {
-        @name = ModuleEnginesRF
         @exhaustDamage = True
         @minThrust = 10.0
         @maxThrust = 10.0
-        @heatProduction = 100
+        @heatProduction = 10
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
         @stagingEnabled = False
@@ -325,26 +522,25 @@
         %stagingDisableText = Fairing Staged
     }
 
-    !MODULE[ModuleFuelTanks],*{}
+    !RESOURCE,*{}
 
-    MODULE
+    //  HTPB/AP propellant mixture mass ~18 Kg.
+
+    RESOURCE
     {
-        name = ModuleFuelTanks
-        type = HTPB
-        volume = 10
-        basemass = -1
-
-        //  HTPB propellant mixture ~18 Kg.
-
-        TANK
-        {
-            name = HTPB
-            amount = 10
-            maxAmount = 10
-        }
+        name = HTPB
+        amount = 10
+        maxAmount = 10
     }
 
-    !RESOURCE,*{}
+    //  Generic solid propellant mixture mass ~1.8 kg.
+
+    RESOURCE
+    {
+        name = SolidFuel
+        amount = 1
+        maxAmount = 1
+    }
 }
 
 //  ==================================================
@@ -377,11 +573,12 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     @stagingIcon = FUEL_TANK
-    %CoMOffset = 0.0, 5.56, 0.0
+    %CoMOffset = 0.0, 2.0, 0.0
+    @tags = aero )cap cargo cone contain drag fairing hollow inter nose payload protect R7 rocket shroud soyuz stage (stor transport
     !specPower = NULL
 
     @MODULE[ModuleAnimateGeneric]
@@ -390,15 +587,34 @@
         %disableAfterPlaying = True
     }
 
-    !MODULE[ModuleEngines*],*:HAS[~thrustVectorTransformName[thrustTransform3]]{}
+    //  Fairing separation solid rocket motor.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        @thrustVectorTransformName = thrustTransform2
+        @exhaustDamage = True
+        @minThrust = 5.0
+        @maxThrust = 5.0
+        @heatProduction = 1
+        @useEngineResponseTime = False
+        @engineAccelerationSpeed = 0
+        %stagingEnabled = True
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 250
+            @key,1 = 1 230
+        }
+    }
+
+    //  Secondary launch escape system (SAS) solid rocket motors.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform3]]
     {
-        @name = ModuleEnginesRF
         @exhaustDamage = True
         @minThrust = 10.0
         @maxThrust = 10.0
-        @heatProduction = 100
+        @heatProduction = 10
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
         @stagingEnabled = False
@@ -424,30 +640,30 @@
         %stagingDisableText = Fairing Staged
     }
 
-    !MODULE[ModuleFuelTanks],*{}
+    !RESOURCE,*{}
 
-    MODULE
+    //  HTPB/AP propellant mixture mass ~18 Kg.
+
+    RESOURCE
     {
-        name = ModuleFuelTanks
-        type = HTPB
-        volume = 10
-        basemass = -1
-
-        //  HTPB propellant mixture ~18 Kg.
-
-        TANK
-        {
-            name = HTPB
-            amount = 10
-            maxAmount = 10
-        }
+        name = HTPB
+        amount = 10
+        maxAmount = 10
     }
 
-    !RESOURCE,*{}
+    //  Generic solid propellant mixture mass ~1.8 kg.
+
+    RESOURCE
+    {
+        name = SolidFuel
+        amount = 1
+        maxAmount = 1
+        isTweakable = False
+    }
 }
 
 //  ==================================================
-//  Soyuz-U Progress payload fairing.
+//  Progress payload fairing.
 
 //  Dimensions: 3.0 m x 11.3 m
 //  Inert Mass: 700 Kg (per halve)
@@ -465,7 +681,7 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @title = Soyuz-U Progress Payload Fairing
+    @title = Progress Payload Fairing
     %manufacturer = TsSKB-Progress
     @description = A payload fairing designed specifically for the Progress resupply spacecraft.
 
@@ -474,12 +690,13 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     @stagingIcon = FUEL_TANK
     %fuelCrossFeed = False
     %stackSymmetry = 1
+    @tags ^= :$: aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport
     !specPower = NULL
 
     @MODULE[ModuleDecouple]
@@ -493,7 +710,7 @@
 }
 
 //  ==================================================
-//  Soyuz ST payload fairing.
+//  Soyuz ST-A/ST-B payload fairing.
 
 //  Dimensions: 4.1 m x 11.8 m
 //  Inert Mass: 900 Kg (per halve)
@@ -520,12 +737,13 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = FUEL_TANK
     %fuelCrossFeed = False
     %stackSymmetry = 1
+    @tags ^= :$: aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport
     !specPower = NULL
 
     @MODULE[ModuleDecouple]
@@ -539,7 +757,7 @@
 }
 
 //  ==================================================
-//  Soyuz/Progress payload adapter.
+//  Soyuz & Progress payload adapter.
 
 //  Dimensions: 3 m x 1.2 m
 //  Inert Mass: 150 Kg
@@ -565,11 +783,13 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = DECOUPLER_HOR
+    %stackSymmetry = 1
+    @tags ^= :$: break decouple separat split stag
     !specPower = NULL
     !meshes = NULL
 
@@ -606,11 +826,12 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = DECOUPLER_HOR
+    @tags ^= :$: break decouple separat split stag
     !specPower = NULL
 
     @MODULE[ModuleDecouple]
@@ -620,7 +841,7 @@
 }
 
 //  ==================================================
-//  Soyuz Block I.
+//  R-7 Block I stage.
 
 //  Dimensions: 2.5 m x 6 m
 //  Gross Mass: 23570 Kg
@@ -651,17 +872,46 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = SOLID_BOOSTER
     %fuelCrossFeed = True
+    %crewCapacity = 0
+    %vesselType = Probe
+    @tags ^= :$: command control (core fly fueltank liquid oxidizer probe propellant rocket sas space stab steer
+
+    !MODULE[ModuleCommand],*{}
+
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+        hasHibernation = False
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.2
+        }
+    }
+
+    !MODULE[ModuleSAS],*{}
+
+    MODULE
+    {
+        name = ModuleSAS
+        SASServiceLevel = 3
+        standalone = True
+    }
+
+    //  Simulates the LOX valve that opens after payload separation.
 
     @MODULE[ModuleEngines*]
     {
-        @minThrust = 0.35
-        @maxThrust = 0.35
+        @minThrust = 0.7
+        @maxThrust = 0.7
         @heatProduction = 0
         @useEngineResponseTime = False
         @engineAccelerationSpeed = 0
@@ -683,6 +933,24 @@
         }
     }
 
+    !MODULE[ModuleDataTransmitter],*{}
+
+    //  Level 2 telecommunications system.
+
+    MODULE
+    {
+        name = ModuleDataTransmitter
+        antennaType = DIRECT
+        antennaPower = 50
+        antennaCombinable = True
+        antennaCombinableExponent = 2.0
+        packetInterval = 1.0
+        packetSize = 0.256
+        requiredResource = ElectricCharge
+        packetResourceCost = 0.025
+        DeployFxModules = 0
+    }
+
     !MODULE[ModuleFuelTanks],*{}
 
     MODULE
@@ -692,7 +960,7 @@
         volume = 22430
         basemass = -1
 
-        //  RD-0110 fuel 7077 Kg.
+        //  RD-0110 fuel mass ~7077 Kg.
 
         TANK
         {
@@ -701,7 +969,7 @@
             maxAmount = 8630
         }
 
-        //  RD-0110 oxidizer 15747 Kg.
+        //  RD-0110 oxidizer mass ~15747 Kg.
 
         TANK
         {
@@ -713,7 +981,7 @@
 
     !RESOURCE,*{}
 
-    //  Avionics batteries 1.95 kWh.
+    //  Avionics batteries ~1.95 kWh.
     //  Supports the Block I stage and it's payload for the duration of it's flight (approximately 15 minutes).
 
     RESOURCE
@@ -725,44 +993,15 @@
 }
 
 //  ==================================================
-//  Soyuz Block I.
-
-//  Workaround for a Realism Overhaul patching limitation.
-//  ==================================================
-
-@PART[R7_BLOCK_I]:BEFORE[RealismOverhaul]
-{
-    %crewCapacity = 0
-    %vesselType = Probe
-
-    MODULE
-    {
-        name = ModuleCommand
-        minimumCrew = 0
-
-        RESOURCE
-        {
-            name = ElectricCharge
-            rate = 0.2
-        }
-    }
-
-    MODULE
-    {
-        name = ModuleSAS
-        SASServiceLevel = 3
-        standalone = True
-    }
-}
-
-//  ==================================================
-//  Soyuz Block I.
+//  R-7 Block I stage.
 
 //  Remote Tech compatibility.
 //  ==================================================
 
-@PART[R7_BLOCK_I]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
+@PART[R7_BLOCK_I]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
 {
+    @description ^= :$: Features an integrated telecommunications system with a maximum effective range of 10 Mm, power consumption 25 Watts, data rate 256 kbit/s.
+
     @MODULE[ModuleCommand]
     {
         @RESOURCE[ElectricCharge]
@@ -787,15 +1026,17 @@
     MODULE
     {
         name = ModuleRTAntenna
+        ActionMode0Name = Deactivate Telemetry System
+        ActionMode1Name = Activate Telemetry System
         IsRTActive = True
         Mode0OmniRange = 0
-        Mode1OmniRange = 100000
+        Mode1OmniRange = 10000000
         EnergyCost = 0.025
 
         TRANSMITTER
         {
             PacketInterval = 1.0
-            PacketSize = 0.128
+            PacketSize = 0.256
             PacketResourceCost = 0.01385
         }
     }
@@ -823,7 +1064,8 @@
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.791, 0, 0.0, 1.0, 0.0, 2
+    @node_stack_top = 0.0, 0.805, 0.0, 0.0, 1.0, 0.0, 2
+    %node_stack_bottom = 0.0, -0.784, 0.0, 0.0, -1.0, 0.0, 2
 
     @category = Engine
 
@@ -832,22 +1074,19 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
+    @tags = progress propuls R7 RD-0124 rocket soyuz
 
     %engineType = RD0124
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 294.3
         @maxThrust = 294.3
-        @heatProduction = 100
+        @heatProduction = 90
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -872,22 +1111,9 @@
         }
     }
 
-    //  Fix a NullRef bug (caused by a missing bottom attachment node).
-
-    @MODULE[ModuleJettison],*
+    @MODULE[ModuleAnimateThrottle]
     {
-        @bottomNodeName = top
-    }
-
-    !MODULE[ModuleAnimateHeat],*{}
-
-    MODULE
-    {
-        name = FXModuleAnimateThrottle
-        animationName = rd0124_heat
-        responseSpeed = 0.005
-        dependOnEngineState = True
-        dependOnThrottle = True
+        @name = FXModuleAnimateThrottle
     }
 }
 
@@ -915,22 +1141,19 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
+    @tags ^= :$: propuls RD-0110 rocket
 
     %engineType = RD0110
-    %engineTypeMult = 1
-    %massOffset = 0
-    %ignoreMass = False
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        @name = ModuleEnginesRF
         %engineID = MainEngine
-        @minThrust = 269.69
-        @maxThrust = 298
-        @heatProduction = 100
+        @minThrust = 269.7
+        @maxThrust = 298.0
+        @heatProduction = 88
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -957,11 +1180,10 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
     {
-        @name = ModuleEnginesRF
         %engineID = VernierEngine
         @minThrust = 6.0
         @maxThrust = 6.0
-        @heatProduction = 100
+        @heatProduction = 10
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -985,24 +1207,6 @@
             @key,1 = 1 141
         }
     }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 45.0
-        @useGimbalResponseSpeed = True
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAnimateHeat],*{}
-
-    MODULE
-    {
-        name = FXModuleAnimateThrottle
-        animationName = 3EMM
-        responseSpeed = 0.005
-        dependOnEngineState = True
-        dependOnThrottle = True
-    }
 }
 
 //  ==================================================
@@ -1011,7 +1215,7 @@
 //  Engine compatibility.
 //  ==================================================
 
-@PART[RD_0110]:AFTER[RealismOverhaulEnginesPost]
+@PART[RD_0110]:AFTER[RealismOverhaulEngines]
 {
     @MODULE[ModuleGimbal]
     {
@@ -1022,7 +1226,7 @@
 }
 
 //  ==================================================
-//  Soyuz truss interstage adapter.
+//  R-7 Block A stage truss interstage adapter.
 
 //  Dimensions: 2.6 m x 1.6 m
 //  Inert Mass: 400 Kg
@@ -1040,6 +1244,9 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
+    @node_stack_top = 0.0, 0.489, 0.0, 0.0, 1.0, 0.0, 2, 1, 1
+    @node_stack_bottom = 0.0, -1.086, 0.0, 0.0, -1.0, 0.0, 2, 1, 1
+
     @title = Soyuz FG/U/ST Truss Interstage Adapter
     %manufacturer = TsSKB-Progress
 
@@ -1048,9 +1255,11 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 673.15
-    %skinMaxTemp = 673.15
+    %skinMaxTemp = 773.15
     %stageOffset = 1
     %childStageOffset = 1
+    @bulkheadProfiles = size2
+    @tags ^= :$: break decouple separat split stag
     !specPower = NULL
 
     @MODULE[ModuleDecouple]
@@ -1060,7 +1269,7 @@
 }
 
 //  ==================================================
-//  Soyuz core booster.
+//  R-7 Block A stage.
 
 //  Dimensions: 2.5 m x 27 m
 //  Gross Mass: 99500 Kg
@@ -1086,10 +1295,13 @@
     @breakingForce = 250
     @breakingTorque = 250
     @maxTemp = 573.15
-    %skinMaxTemp = 573.15
+    %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %fuelCrossFeed = True
+    %crewCapacity = 0
+    %vesselType = Probe
+    @tags ^= :$: command control (core fly fueltank liquid oxidizer probe propellant propuls RD-108 RD-118 rocket sas space stab steer
     !specPower = NULL
 
     %engineType = RD108-118
@@ -1097,13 +1309,38 @@
     %massOffset = 4.82
     %ignoreMass = True
 
+    !MODULE[ModuleCommand],*{}
+
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+        hasHibernation = False
+
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.5
+        }
+    }
+
+    !MODULE[ModuleSAS],*{}
+
+    MODULE
+    {
+        name = ModuleSAS
+        SASServiceLevel = 1
+        standalone = True
+    }
+
+    //  Main engine.
+
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        @name = ModuleEnginesRF
         %engineID = CoreMainEngine
         @minThrust = 918.3
         @maxThrust = 918.3
-        @heatProduction = 100
+        @heatProduction = 90
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -1136,13 +1373,14 @@
         }
     }
 
+    //  Y axis vernier engines.
+
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
     {
-        @name = ModuleEnginesRF
         %engineID = CoreVernierEngine
-        @minThrust = 38.0
-        @maxThrust = 38.0
-        @heatProduction = 100
+        @minThrust = 34.0
+        @maxThrust = 34.0
+        @heatProduction = 10
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -1151,6 +1389,7 @@
         {
             @name = Kerosene
             @ratio = 0.3531
+            %DrawGauge = True
         }
 
         @PROPELLANT[Oxidizer]
@@ -1160,20 +1399,29 @@
             %DrawGauge = False
         }
 
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
+        }
+
         @atmosphereCurve
         {
-            @key,0 = 0 308
+            @key,0 = 0 313
             @key,1 = 1 241
         }
     }
+
+    //  X axis vernier engines.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform3]]
     {
-        @name = ModuleEnginesRF
         %engineID = CoreVernierEngine
-        @minThrust = 38.0
-        @maxThrust = 38.0
-        @heatProduction = 100
+        @minThrust = 34.0
+        @maxThrust = 34.0
+        @heatProduction = 10
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -1182,6 +1430,7 @@
         {
             @name = Kerosene
             @ratio = 0.3531
+            %DrawGauge = False
         }
 
         @PROPELLANT[Oxidizer]
@@ -1191,31 +1440,37 @@
             %DrawGauge = False
         }
 
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
+        }
+
         @atmosphereCurve
         {
-            @key,0 = 0 308
+            @key,0 = 0 313
             @key,1 = 1 241
         }
     }
 
-    !MODULE[TRReflection],*{}
+    !MODULE[ModuleDataTransmitter],*{}
 
-    MODULE:NEEDS[TextureReplacer]
-    {
-        name = TRReflection
-        shader = Reflective/Bumped Diffuse
-        colour = 0.5 0.5 0.5
-        interval = 2.0
-        meshes = Box40_006_005
-    }
+    //  Level 1 telecommunications system.
 
-    MODULE:NEEDS[TextureReplacer]
+    MODULE
     {
-        name = TRReflection
-        shader = Reflective/Bumped Diffuse
-        colour = 0.5 0.5 0.5
-        interval = 2.0
-        meshes = Cylinder_020
+        name = ModuleDataTransmitter
+        antennaType = DIRECT
+        antennaPower = 125
+        antennaCombinable = True
+        antennaCombinableExponent = 2.0
+        packetInterval = 1.0
+        packetSize = 0.256
+        requiredResource = ElectricCharge
+        packetResourceCost = 0.025
+        DeployFxModules = 0
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1227,7 +1482,7 @@
         volume = 90280
         basemass = -1
 
-        //  RD-108 fuel 25640 Kg.
+        //  RD-108 fuel mass ~25640 Kg.
 
         TANK
         {
@@ -1236,7 +1491,7 @@
             maxAmount = 31270
         }
 
-        //  RD-108 oxidizer 65360 Kg.
+        //  RD-108 oxidizer mass ~65360 Kg.
 
         TANK
         {
@@ -1245,7 +1500,7 @@
             maxAmount = 57280
         }
 
-        //  RD-108 turbopump fuel 2475 Kg.
+        //  RD-108 turbopump fuel mass ~2475 Kg.
 
         TANK
         {
@@ -1257,19 +1512,19 @@
 
     !RESOURCE,*{}
 
-    //  Avionics batteries 650 Wh.
+    //  Avionics batteries ~1.95 kWh.
     //  Supports the core booster for the duration of it's flight (approximately 5 minutes).
 
     RESOURCE
     {
         name = ElectricCharge
-        amount = 180
-        maxAmount = 180
+        amount = 540
+        maxAmount = 540
     }
 }
 
 //  ==================================================
-//  Soyuz core booster.
+//  R-7 Block A stage.
 
 //  Engine compatibility.
 //  ==================================================
@@ -1278,18 +1533,211 @@
 {
     @title = Soyuz FG/U/ST Core Stage
     @manufacturer = TsSKB-Progress
-    @description = The Block A is one of the few parts that still remain mostly unchanged from the original R7 design. A very reliable element, powered by a single RD-108 engine with four verniers for attitude control. It is ignited on the ground along with the strap - on boosters.
+    @description = The Block A is one of the few parts that still remain mostly unchanged from the original R-7 launch vehicle design. A very reliable element, powered by a single RD-108 engine with four verniers for attitude control. It is ignited on the ground, along with the Blocks B,V,G and D.
 
-    @MODULE[ModuleGimbal]
+    //  Main engine setup.
+
+    @MODULE[ModuleEngineConfigs]
     {
-        @gimbalRange = 45.0
+        %isMaster = True
+        %engineID = CoreMainEngine
+
+        @CONFIG[*]:HAS[@PROPELLANT[Kerosene]]
+        {
+            OtherModules
+            {
+                CoreVernierEngine = RD-108-118-Verniers-RG1
+            }
+        }
+
+        @CONFIG[*]:HAS[@PROPELLANT[Syntin]]
+        {
+            OtherModules
+            {
+                CoreVernierEngine = RD-108-118-Verniers-Syntin
+            }
+        }
+    }
+
+    //  Vernier engine setup.
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        configuration = RD-108-118-Verniers-RG1
+        isMaster = False
+        engineID = CoreVernierEngine
+
+        CONFIG
+        {
+            name = RD-108-118-Verniers-RG1
+            minThrust = 34.0
+            maxThrust = 34.0
+            heatProduction = 10
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.025
+            }
+
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.3680
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6320
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.0195
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 313
+                key = 1 250
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-108-118-Verniers-Syntin
+            minThrust = 34.0
+            maxThrust = 34.0
+            heatProduction = 10
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.025
+            }
+
+            PROPELLANT
+            {
+                name = Syntin
+                ratio = 0.3594
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6406
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.0195
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 313
+                key = 1 250
+            }
+        }
+    }
+
+    //  Y axis vernier engine gimbal setup.
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
+    {
+        !gimbalRange,* = NULL
+        %gimbalRangeYP = 45.0
+        %gimbalRangeYN = 45.0
+        %gimbalRangeXP = 0
+        %gimbalRangeXN = 0
+        @useGimbalResponseSpeed = True
+        @gimbalResponseSpeed = 16
+    }
+
+    //  X axis vernier engine gimbal setup.
+
+    @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal2]]
+    {
+        !gimbalRange,* = NULL
+        %gimbalRangeYP = 0
+        %gimbalRangeYN = 0
+        %gimbalRangeXP = 45.0
+        %gimbalRangeXN = 45.0
         @useGimbalResponseSpeed = True
         @gimbalResponseSpeed = 16
     }
 }
 
 //  ==================================================
-//  Soyuz strap - on booster decoupler.
+//  R-7 Block A stage.
+
+//  Remote Tech compatibility.
+//  ==================================================
+
+@PART[R7_SECOND_STAGE]:FOR[RealismOverhaulRT]:NEEDS[RemoteTech]
+{
+    @description ^= :$: Features an integrated telemetry system with a maximum effective range of 5 Mm, power consumption 25 Watts, data rate 256 kbit/s.
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate -= 0.025
+        }
+    }
+
+    !MODULE[ModuleDataTransmitter],*{}
+
+    !MODULE[ModuleSPU*],*{}
+
+    !MODULE[ModuleRTAntenna*],*{}
+
+    MODULE
+    {
+        name = ModuleSPU
+        IsRTCommandStation = False
+        RTCommandMinCrew = 0
+    }
+
+    MODULE
+    {
+        name = ModuleRTAntenna
+        ActionMode0Name = Deactivate Telemetry System
+        ActionMode1Name = Activate Telemetry System
+        IsRTActive = True
+        Mode0OmniRange = 0
+        Mode1OmniRange = 50000
+        EnergyCost = 0.025
+
+        TRANSMITTER
+        {
+            PacketInterval = 1.0
+            PacketSize = 0.256
+            PacketResourceCost = 0.01385
+        }
+    }
+}
+
+//  ==================================================
+//  R-7 Block B,V,G,D decoupler.
 
 //  Dimensions: N/A
 //  Inert Mass: 200 Kg
@@ -1304,6 +1752,9 @@
         @scale = 1.0, 1.0, 1.0
     }
 
+    @node_stack_top = 0.127, -4.85, -0.0, 0.0, -1.0, 0.0, 1
+    @node_stack_top2 = 0.09, -6.9, -0.0, 0.0, -1.0, 0.0, 1
+
     @scale = 1.0
     @rescaleFactor = 1.0
 
@@ -1314,8 +1765,9 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    @tags ^= :$: break decouple separat split stag
 
     @MODULE[ModuleDecouple]
     {
@@ -1324,7 +1776,7 @@
 }
 
 //  ==================================================
-//  Soyuz strap - on booster top oxidizer valve.
+//  R-7 Block B,V,G,D stage top oxidizer valve.
 
 //  Dimensions: 0.63 m x 1.6 m
 //  Gross Mass: 50 Kg
@@ -1350,17 +1802,19 @@
     @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     @bulkheadProfiles = size1
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = SOLID_BOOSTER
+    @tags ^= :$: motor rocket separat thruster valve
     !specPower = NULL
+
+    //  Simulates the LOX valve that opens upon booster separation.
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 22.5
         @maxThrust = 22.5
         @throttleLocked = True
@@ -1387,7 +1841,7 @@
 }
 
 //  ==================================================
-//  Soyuz strap - on booster bottom oxidizer valve.
+//  R-7 Block B,V,G,D stage bottom oxidizer valve.
 
 //  Dimensions: 0.3 m x 0.1 m
 //  Gross Mass: 20 Kg
@@ -1413,18 +1867,20 @@
     @crashTolerance = 12
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 473.15
-    %skinMaxTemp = 473.15
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
     @bulkheadProfiles = size1
     %stackSymmetry = 3
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = SOLID_BOOSTER
+    @tags ^= :$: motor rocket separat thruster valve
     !specPower = NULL
+
+    //  Simulates the LOX valve that opens upon booster separation.
 
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         @minThrust = 10.0
         @maxThrust = 10.0
         @throttleLocked = True
@@ -1451,7 +1907,7 @@
 }
 
 //  ==================================================
-//  Soyuz strap - on booster.
+//  R-7 Block B,V,G,D stage.
 
 //  Dimensions: 2.5 m x 18 m
 //  Gross Mass: 44100 Kg
@@ -1482,6 +1938,7 @@
     %childStageOffset = 1
     %fuelCrossFeed = True
     %CoMOffset = 0.0, -6.0, 0.0
+    @tags ^= :$: fueltank liquid oxidizer propellant propuls RD-107 RD-117 rocket
     !specPower = NULL
 
     %engineType = RD107-117
@@ -1491,11 +1948,10 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        @name = ModuleEnginesRF
         %engineID = BoosterMainEngine
         @minThrust = 972.3
         @maxThrust = 972.3
-        @heatProduction = 100
+        @heatProduction = 138
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -1530,11 +1986,10 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
     {
-        @name = ModuleEnginesRF
         %engineID = BoosterVernierEngine
-        @minThrust = 38.0
-        @maxThrust = 38.0
-        @heatProduction = 100
+        @minThrust = 34.0
+        @maxThrust = 34.0
+        @heatProduction = 10
         %ullage = True
         %pressureFed = False
         %ignitions = 1
@@ -1552,27 +2007,19 @@
             %DrawGauge = False
         }
 
+        PROPELLANT
+        {
+            name = HTP
+            ratio = 0.0195
+            DrawGauge = False
+            ignoreForIsp = True
+        }
+
         @atmosphereCurve
         {
-            @key,0 = 0 308
+            @key,0 = 0 313
             @key,1 = 1 250
         }
-    }
-
-    @MODULE[ModuleLiftingSurface]
-    {
-        @deflectionLiftCoeff = 0.292
-    }
-
-    !MODULE[TRReflection],*{}
-
-    MODULE:NEEDS[TextureReplacer]
-    {
-        name = TRReflection
-        shader = Reflective/Bumped Diffuse
-        colour = 0.5 0.5 0.5
-        interval = 2.0
-        meshes = Cylinder_002
     }
 
     !MODULE[ModuleFuelTanks],*{}
@@ -1584,7 +2031,7 @@
         volume = 38920
         basemass = -1
 
-        //  RD-107 fuel 11045 Kg.
+        //  RD-107 fuel mass ~11045 Kg.
 
         TANK
         {
@@ -1593,7 +2040,7 @@
             maxAmount = 13470
         }
 
-        //  RD-107 oxidizer 28182 Kg.
+        //  RD-107 oxidizer mass ~28182 Kg.
 
         TANK
         {
@@ -1602,7 +2049,7 @@
             maxAmount = 24700
         }
 
-        //  RD-107 turbopump fuel 1073 Kg.
+        //  RD-107 turbopump fuel mass ~1073 Kg.
 
         TANK
         {
@@ -1616,16 +2063,142 @@
 }
 
 //  ==================================================
-//  Soyuz strap - on booster.
+//  R-7 Block B,V,G,D stage.
 
 //  Engine compatibility.
 //  ==================================================
 
-@PART[R7_FIRST_STAGE]:AFTER[RealismOverhaulEnginesPost]
+@PART[R7_FIRST_STAGE]:AFTER[RealismOverhaulEngines]
 {
     @title = Soyuz FG/U/ST Booster
     @manufacturer = TsSKB-Progress
-    @description = One of the oldest parts of the R7 launch vehicle series, the strap - on booster was designed to support the core stage both in flight and on the ground. The individual boosters are designated as Blocks B,V,G and D and each one is powered by the RD-107 engine. It is ignited on the ground along with the second (core booster) stage.
+    @description = One of the oldest parts of the R-7 launch vehicle series, designed to support the core stage both in flight and on the ground. The individual boosters are designated as Blocks B,V,G and D and each one is powered by the RD-107 engine. It is ignited on the ground along with the Block A stage.
+
+    //  Main engine setup.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        %isMaster = True
+        %engineID = BoosterMainEngine
+
+        @CONFIG[*]:HAS[@PROPELLANT[Kerosene]]
+        {
+            OtherModules
+            {
+                BoosterVernierEngine = RD-107-117-Verniers-RG1
+            }
+        }
+
+        @CONFIG[*]:HAS[@PROPELLANT[Syntin]]
+        {
+            OtherModules
+            {
+                BoosterVernierEngine = RD-107-117-Verniers-Syntin
+            }
+        }
+    }
+
+    //  Vernier engine setup.
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        configuration = RD-107-117-Verniers-RG1
+        isMaster = False
+        engineID = BoosterVernierEngine
+
+        CONFIG
+        {
+            name = RD-107-117-Verniers-RG1
+            minThrust = 34.0
+            maxThrust = 34.0
+            heatProduction = 10
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.025
+            }
+
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.3603
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6397
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.0195
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 313
+                key = 1 250
+            }
+        }
+
+        CONFIG
+        {
+            name = RD-107-117-Verniers-Syntin
+            minThrust = 34.0
+            maxThrust = 34.0
+            heatProduction = 10
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.025
+            }
+
+            PROPELLANT
+            {
+                name = Syntin
+                ratio = 0.3518
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.6482
+                DrawGauge = False
+            }
+
+            PROPELLANT
+            {
+                name = HTP
+                ratio = 0.0195
+                DrawGauge = False
+                ignoreForIsp = True
+            }
+
+            atmosphereCurve
+            {
+                key = 0 313
+                key = 1 250
+            }
+        }
+    }
+
+    //  Vernier engines gimbal setup.
 
     @MODULE[ModuleGimbal]
     {
@@ -1635,4 +2208,38 @@
         @gimbalRangeXP = 45.0
         @gimbalRangeXN = 45.0
     }
+}
+
+//  ==================================================
+//  R-7 launch pad.
+
+//  Dimensions: 23 m x 20.6 m
+//  Inert Mass: 1000000 kg
+//  ==================================================
+
+@PART[TOWER_SOYUZ]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %scale = 1.0
+    @rescaleFactor = 1.0
+
+    @node_stack_top = 0.0, -4.975, 0.0, 0.0, 1.0, 0.0, 9
+
+    @title = R-7 Launch Gantry
+    @manufacturer = Roskosmos
+    @description = The launch pad for the R-7 series of launch vehicles.
+
+    @mass = 1000.0
+    @crashTolerance = 100
+    @breakingForce = 2500
+    @breakingTorque = 2500
+    @maxTemp = 5773.15
+    %skinMaxTemp = 6773.15
+    @fuelCrossFeed = True
+    !explosionPotential = NULL
+    @stageOffset = 1
+    @childStageOffset = 1
+    @bulkheadProfiles = size9
+    @tags = clam hold )pad rocket stabil tower
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -186,7 +186,7 @@
 //  motor.
 
 //  Dimensions: 0.41 m x 2.5 m
-//  Gross Mass: 310 Kg
+//  Gross Mass: 310 kg
 //  ==================================================
 
 @PART[EAS_top]:FOR[RealismOverhaul]
@@ -249,7 +249,7 @@
         volume = 120
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass ~212 Kg.
+        //  HTPB/AP propellant mixture mass ~212 kg.
 
         TANK
         {
@@ -305,7 +305,7 @@
 //  motor.
 
 //  Dimensions: 0.74 m x 3.8 m
-//  Gross Mass: 2540 Kg
+//  Gross Mass: 2540 kg
 //  ==================================================
 
 @PART[EAS]:FOR[RealismOverhaul]
@@ -380,7 +380,7 @@
         volume = 900
         basemass = -1
 
-        //  HTPB/AP propellant mixture mass ~1590 Kg.
+        //  HTPB/AP propellant mixture mass ~1590 kg.
 
         TANK
         {
@@ -429,7 +429,7 @@
 //  Soyuz TM/TMA/MS payload fairing (front).
 
 //  Dimensions: 3 m x 8.7 m
-//  Inert Mass: 700 Kg
+//  Inert Mass: 700 kg
 //  ==================================================
 
 @PART[SOYUZ_FG1]:FOR[RealismOverhaul]
@@ -524,7 +524,7 @@
 
     !RESOURCE,*{}
 
-    //  HTPB/AP propellant mixture mass ~18 Kg.
+    //  HTPB/AP propellant mixture mass ~18 kg.
 
     RESOURCE
     {
@@ -547,7 +547,7 @@
 //  Soyuz TM/TMA/MS payload fairing (back).
 
 //  Dimensions: 3 m x 8.7 m
-//  Inert Mass: 700 Kg
+//  Inert Mass: 700 kg
 //  ==================================================
 
 @PART[SOYUZ_FG2]:FOR[RealismOverhaul]
@@ -642,7 +642,7 @@
 
     !RESOURCE,*{}
 
-    //  HTPB/AP propellant mixture mass ~18 Kg.
+    //  HTPB/AP propellant mixture mass ~18 kg.
 
     RESOURCE
     {
@@ -666,7 +666,7 @@
 //  Progress payload fairing.
 
 //  Dimensions: 3.0 m x 11.3 m
-//  Inert Mass: 700 Kg (per halve)
+//  Inert Mass: 700 kg (per halve)
 //  ==================================================
 
 @PART[PROGRESS_FG1]:FOR[RealismOverhaul]
@@ -713,7 +713,7 @@
 //  Soyuz ST-A/ST-B payload fairing.
 
 //  Dimensions: 4.1 m x 11.8 m
-//  Inert Mass: 900 Kg (per halve)
+//  Inert Mass: 900 kg (per halve)
 //  ==================================================
 
 @PART[SOYUZ_F_2]:FOR[RealismOverhaul]
@@ -760,7 +760,7 @@
 //  Soyuz & Progress payload adapter.
 
 //  Dimensions: 3 m x 1.2 m
-//  Inert Mass: 150 Kg
+//  Inert Mass: 150 kg
 //  ==================================================
 
 @PART[ADAPTER_BLOCK_I]:FOR[RealismOverhaul]
@@ -803,7 +803,7 @@
 //  Soyuz ST payload adapter.
 
 //  Dimensions: 4.1 m x 1.1 m
-//  Inert Mass: 200 Kg
+//  Inert Mass: 200 kg
 //  ==================================================
 
 @PART[ADAPTER_BLOCK_I2]:FOR[RealismOverhaul]
@@ -844,11 +844,11 @@
 //  R-7 Block I stage.
 
 //  Dimensions: 2.5 m x 6 m
-//  Gross Mass: 23570 Kg
+//  Gross Mass: 23570 kg
 
 //  Inert mass does not include the mass of the
-//  payload adapters (150 Kg or 200 Kg) or the engine
-//  (450 Kg).
+//  payload adapters (150 kg or 200 kg) or the engine
+//  (450 kg).
 //  ==================================================
 
 @PART[R7_BLOCK_I]:FOR[RealismOverhaul]
@@ -960,7 +960,7 @@
         volume = 22430
         basemass = -1
 
-        //  RD-0110 fuel mass ~7077 Kg.
+        //  RD-0110 fuel mass ~7077 kg.
 
         TANK
         {
@@ -969,7 +969,7 @@
             maxAmount = 8630
         }
 
-        //  RD-0110 oxidizer mass ~15747 Kg.
+        //  RD-0110 oxidizer mass ~15747 kg.
 
         TANK
         {
@@ -1046,7 +1046,7 @@
 //  RD-0124 engine.
 
 //  Dimensions: 2.4 m x 1.55 m
-//  Inert Mass: 480 Kg
+//  Inert Mass: 480 kg
 //  ==================================================
 
 @PART[RD0124]:FOR[RealismOverhaul]
@@ -1121,7 +1121,7 @@
 //  RD-0110 engine.
 
 //  Dimensions: 2.4 m x 1.5 m
-//  Inert Mass: 451 Kg
+//  Inert Mass: 451 kg
 //  ==================================================
 
 @PART[RD_0110]:FOR[RealismOverhaul]
@@ -1229,7 +1229,7 @@
 //  R-7 Block A stage truss interstage adapter.
 
 //  Dimensions: 2.6 m x 1.6 m
-//  Inert Mass: 400 Kg
+//  Inert Mass: 400 kg
 //  ==================================================
 
 @PART[DECOUPLER]:FOR[RealismOverhaul]
@@ -1272,10 +1272,10 @@
 //  R-7 Block A stage.
 
 //  Dimensions: 2.5 m x 27 m
-//  Gross Mass: 99500 Kg
+//  Gross Mass: 99500 kg
 
 //  Inert mass does not include the mass of the truss
-//  interstage adapter (400 Kg).
+//  interstage adapter (400 kg).
 //  ==================================================
 
 @PART[R7_SECOND_STAGE]:FOR[RealismOverhaul]
@@ -1482,7 +1482,7 @@
         volume = 90280
         basemass = -1
 
-        //  RD-108 fuel mass ~25640 Kg.
+        //  RD-108 fuel mass ~25640 kg.
 
         TANK
         {
@@ -1491,7 +1491,7 @@
             maxAmount = 31270
         }
 
-        //  RD-108 oxidizer mass ~65360 Kg.
+        //  RD-108 oxidizer mass ~65360 kg.
 
         TANK
         {
@@ -1500,7 +1500,7 @@
             maxAmount = 57280
         }
 
-        //  RD-108 turbopump fuel mass ~2475 Kg.
+        //  RD-108 turbopump fuel mass ~2475 kg.
 
         TANK
         {
@@ -1740,7 +1740,7 @@
 //  R-7 Block B,V,G,D decoupler.
 
 //  Dimensions: N/A
-//  Inert Mass: 200 Kg
+//  Inert Mass: 200 kg
 //  ==================================================
 
 @PART[R7_FIRST_STAGE_DECOUPLER]:FOR[RealismOverhaul]
@@ -1779,7 +1779,7 @@
 //  R-7 Block B,V,G,D stage top oxidizer valve.
 
 //  Dimensions: 0.63 m x 1.6 m
-//  Gross Mass: 50 Kg
+//  Gross Mass: 50 kg
 //  ==================================================
 
 @PART[R7_FS_TOP]:FOR[RealismOverhaul]
@@ -1844,7 +1844,7 @@
 //  R-7 Block B,V,G,D stage bottom oxidizer valve.
 
 //  Dimensions: 0.3 m x 0.1 m
-//  Gross Mass: 20 Kg
+//  Gross Mass: 20 kg
 //  ==================================================
 
 @PART[R7_RETRO_MOTOR]:FOR[RealismOverhaul]
@@ -1910,10 +1910,10 @@
 //  R-7 Block B,V,G,D stage.
 
 //  Dimensions: 2.5 m x 18 m
-//  Gross Mass: 44100 Kg
+//  Gross Mass: 44100 kg
 
 //  Inert mass does not include the mass of the radial
-//  decoupler (200 Kg).
+//  decoupler (200 kg).
 //  ==================================================
 
 @PART[R7_FIRST_STAGE]:FOR[RealismOverhaul]
@@ -2031,7 +2031,7 @@
         volume = 38920
         basemass = -1
 
-        //  RD-107 fuel mass ~11045 Kg.
+        //  RD-107 fuel mass ~11045 kg.
 
         TANK
         {
@@ -2040,7 +2040,7 @@
             maxAmount = 13470
         }
 
-        //  RD-107 oxidizer mass ~28182 Kg.
+        //  RD-107 oxidizer mass ~28182 kg.
 
         TANK
         {
@@ -2049,7 +2049,7 @@
             maxAmount = 24700
         }
 
-        //  RD-107 turbopump fuel mass ~1073 Kg.
+        //  RD-107 turbopump fuel mass ~1073 kg.
 
         TANK
         {


### PR DESCRIPTION
**Change Log:**

* Added RO configs for the missing parts (Sputnik 1 and launch gantry).
* Fixed the separation issues of the Soyuz FG fairings.
* Added a missing bottom attachment node to the RD-0124 engine (this also fixes an old bug).
* Fixed the attachment node sizes of the interstage truss adapter.
* Added command capabilities and increased the carried battery size of the R-7 core for compatibility for the Sputnik launch vehicle configuration.
* Reduced a bit the thrust and increased the VAC Isp of the RD-107/RD-108 verniers (sources define thrust values anywhere between 24 kN - probably an ASL value - to 34 kN and VAC Isp of 313 s).
*  Fixed some major bugs regarding the Syntin variants of the RD-107/RD-108 engines (previously it was impossible to use them since the vernier engines lacked compatible engine module configs).
* Added support for the stock CommNet system.
* Tweaked the heat production values of the engines.
* Added some extra part tags.
* Tweaked the part temperature values to be in-line with the other parts.

**Notes:**

One unfortunate note of the new DECQ R-7 core model is that for some reason the RD-108 vernier engines got separated from each other, resulting in one engine module for the X axis and one for the Y (i really wonder why this change was made, it makes no actual sense).

This is not much by itself until someone tries to use the Syntin variants of the RD-108 engine: due to a (probable) bug within RealFuels one vernier pair gets the correct propellant combination but the other does not (remains at KeroLOX). The result: a stage that is impossible to control after booster separation, since ony one pair of verniers work.

I hope that someone can confirm that this is a bug caused by the RO configs and not RF!

**This pack also requires some updates to it's RealPlume configs. Until PR https://github.com/KSP-RO/RealismOverhaul/pull/1935 can be merged then this PR should not be merged into master.**