### PR TITLE
[Mod Support] AIES Electrical Parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_SolarPanels.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_SolarPanels.cfg
@@ -10,6 +10,7 @@
 	@scale = 1.0
 	@rescaleFactor = 1.0
 	@node_attach = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0
+	@category = Electrical
 	@title = SNAP-19 RTG
 	@description = SNAP-19 as found on Pioneer and Viking spacecraft. This has a mounting bracket too.
 	@mass = 0.016
@@ -25,6 +26,7 @@
 @PART[solarpaneles1]:FOR[RealismOverhaul] // based on solarpanel5HiTech
 {
 	%RSSROConfig = True
+	@category = Electrical
 	@description = A little over two times bigger than the ST1 plus the latest state of the art technology, the ES1B gives the user that much more capability. 0.455m^2.
 	@mass = 0.0006
 	@MODULE[ModuleDeployableSolarPanel]
@@ -36,6 +38,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.003
+	@category = Electrical
 	@description = Making things bigger only helps if you can make them more compact for launch...so fold things up. 1.8m^2.
 	@MODULE[ModuleDeployableSolarPanel]
     {
@@ -46,6 +49,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.0026
+	@category = Electrical
 	@description = Slightly larger than the ST1 (1.5x) but the newest technology and folding for compact, narrow storage for launch. 0.33m^2.
 	@MODULE[ModuleDeployableSolarPanel]
     {
@@ -56,6 +60,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.0048
+	@category = Electrical
 	@description = The newest technology and folding for compact, narrow storage for launch. 0.8625m^2.
 	@MODULE[ModuleDeployableSolarPanel]
     {
@@ -66,6 +71,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.0096
+	@category = Electrical
 	@description = The newest technology and folding for compact, narrow storage for launch. 1.725m^2.
 	@MODULE[ModuleDeployableSolarPanel]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Utility.cfg
@@ -10,6 +10,7 @@
 @PART[batteryBAEr]:FOR[RealismOverhaul] // AIES BAE-R Battery
 {
 	%RSSROConfig = True
+	@category = Electrical
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 1600


### PR DESCRIPTION
The AIES solar panels, battery and RTG are currently placed in the "Utility" VAB/SPH parts category rather than in the "Electrical" parts category.

As development of the AIES mod is dead and no licensing information is available, added new lines to the RO configs to at least fix the part categories in RO.