### PR TITLE
Increase AJ10 mid reliabilities to better match IRL and AJ10 early reliabilities

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
@@ -92,33 +92,38 @@
 	}
 }
 
+# At least 16 successful ignitions (more if there were more than the one restart of the Transit 1B mission[2]) with 1 failed ignition. One flight had insufficient thrust. [1]
+# [1] https://en.wikipedia.org/wiki/List_of_Thor_and_Delta_launches_(1960%E2%80%9369)
+# [2] http://www.astronautix.com/t/thorablestar.html
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-104]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ10-104
 		ratedBurnTime = 300
-		ignitionReliabilityStart = 0.8
-		ignitionReliabilityEnd = 0.88
+		ignitionReliabilityStart = 0.93
+		ignitionReliabilityEnd = 0.97
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.86
-		cycleReliabilityEnd = 0.9
+		cycleReliabilityStart = 0.91
+		cycleReliabilityEnd = 0.95
         techTransfer = AJ10-37,AJ10-42,AJ10-142:50
 	}
 }
 
 # Test Flight data (400 second burn time) taken from here: http://www.astronautix.com/a/aj10-118e.html
+# At least 48 successful ignitions (more if there were restarts) with 0 failures. One flight failed because of a leaky tank. [1]
+# [1] https://en.wikipedia.org/wiki/List_of_Thor_and_Delta_launches_(1960%E2%80%9369)
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118E]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ10-118E
 		ratedBurnTime = 400
-		ignitionReliabilityStart = 0.9375
-		ignitionReliabilityEnd = 0.97
+		ignitionReliabilityStart = 0.96
+		ignitionReliabilityEnd = 0.99
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.93
-		cycleReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.94
+		cycleReliabilityEnd = 0.985
 		techTransfer =  AJ10-37,AJ10-104,AJ10-42,AJ10-142:50
 		reliabilityDataRateMultiplier = 2
 	}


### PR DESCRIPTION
The AJ10 mid reliabilities are too low in my opinion, see #1939. I went through wikipedia launch lists and  propose new values here, open for debate. :)