### PR TITLE
RCS mass fix and rebalance

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -13,7 +13,10 @@
 		configuration = Nitrogen
 		modded = false
 		
-		origMass = 0.028
+		// The Apollo R-4D thruster was about 3.4 kg - 3.6kg [1, 2], i estimate the quad's mass to be roughly 16 kg
+		// 1. https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+		// 2. https://www.apolloartifacts.com/2013/11/marquardt-r-4d-apollo-spacecraft-attitude-control-engine.html
+		origMass = 0.016
 
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -10,20 +10,27 @@
 //  has *any* useRcsConfig string, so we're doing to do a little dance
 //  to get the initial configs in. We really should have code generating
 //  this.
+
+//  Mass is scaling by about sqrt(thrust):
+//  MR-106E: 22N thruster, mass: ~0.6kg [1]
+//  MR-80B: 3100N thruster, mass: 8.5kg [1]
+//  1. http://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf
 //  ==================================================
 
 @PART[*]:HAS[#useRcsConfig[RCSBlockTriple]]:BEFORE[RealismOverhaulEngines]
 {
 	engineType = RCSGeneric
 	engineTypeMult = 3
-	engineCostMult = 0.7
+	engineTypeMassMult = 0.5774
+	engineTypeCostMult = 0.5774
 }
 
 @PART[*]:HAS[#useRcsConfig[RCSBlockDouble]]:BEFORE[RealismOverhaulEngines]
 {
     engineType = RCSGeneric
 	engineTypeMult = 2
-	engineCostMult = 0.85
+	engineTypeMassMult = 0.7071
+	engineTypeCostMult = 0.7071
 }
 
 @PART[*]:HAS[#useRcsConfig[RCSBlock]]:BEFORE[RealismOverhaulEngines]
@@ -35,53 +42,62 @@
 {
     engineType = RCSGeneric
 	engineTypeMult = 0.5
-	engineCostMult = 1.5
+	engineTypeMassMult = 1.4142
+	engineTypeCostMult = 1.4142
 }
 
 @PART[*]:HAS[#useRcsConfig[RCSBlockQuarter]]:BEFORE[RealismOverhaulEngines]
 {
     engineType = RCSGeneric
 	engineTypeMult = 0.25
-	engineCostMult = 2.0
+	engineTypeMassMult = 2
+	engineTypeCostMult = 2
 }
 
 @PART[*]:HAS[#useRcsConfig[RCSBlockTenth]]:BEFORE[RealismOverhaulEngines]
 {
     engineType = RCSGeneric
 	engineTypeMult = 0.1
-	engineCostMult = 4
+	engineTypeMassMult = 3.1623
+	engineTypeCostMult = 3.1623
 }
 
 @PART[*]:HAS[#useRcsConfig[RCSBlock15x]]:BEFORE[RealismOverhaulEngines]
 {
     engineType = RCSGeneric
 	engineTypeMult = 1.5
-	engineCostMult = 0.9
+	engineTypeMassMult = 0.8165
+	engineTypeCostMult = 0.8165
 }
 @PART[*]:HAS[#useRcsConfig[RCSBlock4x]]:BEFORE[RealismOverhaulEngines]
 {
     engineType = RCSGeneric
 	engineTypeMult = 4
-	engineCostMult = 0.6
+	engineTypeMassMult = 0.5
+	engineTypeCostMult = 0.5
+	
 }
 @PART[*]:HAS[#useRcsConfig[RCSBlock8x]]:BEFORE[RealismOverhaulEngines]
 {
     engineType = RCSGeneric
 	engineTypeMult = 8
-	engineCostMult = 0.4
+	engineTypeMassMult = 0.3536
+	engineTypeCostMult = 0.3536
 }
 
 //  ==================================================
-//  Apply nozzle multiplier to mass (note: cost is from
-//  catalyzer/chamber so not changed)
+//  Apply nozzle multiplier to mass (note: cost is from catalyzer/chamber so not changed)
+//  nozzle-mass scaling taken from AR MRM-106D: 2 nozzle: 1.5 kg, 4 nozzle: 2.7 kg [1]
+//  1. http://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf
 //  ==================================================
 
 @PART[*]:HAS[#RcsNozzles[*]]:FOR[RO-RCS]
 {
 	@MODULE[ModuleEngineConfigs]
 	{
-		@origMass *= 0.125
+		@origMass /= 4.5
 		nozzleCount = #$../RcsNozzles$
+		@nozzleCount += 0.5
 		@origMass *= #$nozzleCount$
 		!nozzleCount = NULL
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RCS.cfg
@@ -13,7 +13,7 @@
 //**********************************************************
 //  4A-V	(4-port, 4-directional Angled)
 //**********************************************************
-@PART[SSTU-SC-GEN-RCS-4A-V]:AFTER[SSTU]
+@PART[SSTU-SC-GEN-RCS-4A-V]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock15x
@@ -51,7 +51,7 @@
 //**********************************************************
 //  4F-T	(4-port, 3-directional)
 //**********************************************************
-@PART[SSTU-SC-GEN-RCS-4F-T]:AFTER[SSTU]
+@PART[SSTU-SC-GEN-RCS-4F-T]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock
@@ -87,7 +87,7 @@
 //**********************************************************
 //  4F-V	(4-port, 4-directional)
 //**********************************************************
-@PART[SSTU-SC-GEN-RCS-4F-V]:AFTER[SSTU]
+@PART[SSTU-SC-GEN-RCS-4F-V]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock15x
@@ -124,7 +124,7 @@
 //**********************************************************
 //  5F-V	(5-port, 5-directional)
 //**********************************************************
-@PART[SSTU-SC-GEN-RCS-5F-V]:AFTER[SSTU]
+@PART[SSTU-SC-GEN-RCS-5F-V]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock
@@ -161,7 +161,7 @@
 //**********************************************************
 //  6A-T	(6-port (2 forward), 3-directional)
 //**********************************************************
-@PART[SSTU-SC-GEN-RCS-6A-T]:AFTER[SSTU]
+@PART[SSTU-SC-GEN-RCS-6A-T]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock
@@ -198,7 +198,7 @@
 //**********************************************************
 //  8A-T	(8-port, 4-directional)
 //**********************************************************
-@PART[SSTU-SC-GEN-RCS-8A-T]:AFTER[SSTU]
+@PART[SSTU-SC-GEN-RCS-8A-T]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -996,8 +996,6 @@
 	
 	%RSSROConfig = True
 	
-	// Scaled to a nozzle diameter of 45 cm, a little larger than the 40 cm of the R-40B [1] because it gets better Isp at later TLs
-	// 1. https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
 	%rescaleFactor = 3.5
 	
 	@title = 2.2/3.6kN Thruster
@@ -1059,14 +1057,24 @@
 {
 	@MODEL
 	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
+		@model = VenStockRevamp/Squad/Parts/Propulsion/OMS-L
+		@scale = 1, 1, 1
 	}
-
-	@node_stack_top = 0.0, -0.03, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -0.256, 0.0, 0.0, -1.0, 0.0, 1
+	
+	%rescaleFactor = 0.41
+	
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -1.235, 0.0, 0.0, -1.0, 0.0, 1
 	!node_stack_top2 = NULL
 
 	!MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}
+}
+
+@PART[RO-2kN-Thruster]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+{
+    // Scaled to a nozzle diameter of 45 cm, a little larger than the 40 cm of the R-40B [1] because it gets better Isp at later TLs
+    // 1. https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+	%rescaleFactor = 0.59
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1062,6 +1062,8 @@
 		@model = VenStockRevamp/Squad/Parts/Propulsion/LV-1B
 	}
 
+	@node_stack_top = 0.0, -0.03, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.256, 0.0, 0.0, -1.0, 0.0, 1
 	!node_stack_top2 = NULL
 
 	!MODULE[ModuleJettison]:HAS[#jettisonName[Size1B]]{}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -935,6 +935,8 @@
 	@manufacturer = Generic
 	@description = Thruster for orbital maneuvers, similar to ones used in the Galileo probe.
 
+	%rescaleFactor = 2.475
+	
 	@mass = 0.015
 	@crashTolerance = 10
 	@maxTemp = 573.15
@@ -994,7 +996,9 @@
 	
 	%RSSROConfig = True
 	
-	@rescaleFactor *= 1.4
+	// Scaled to a nozzle diameter of 45 cm, a little larger than the 40 cm of the R-40B [1] because it gets better Isp at later TLs
+	// 1. https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf
+	%rescaleFactor = 3.5
 	
 	@title = 2.2/3.6kN Thruster
 	@manufacturer = Generic

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -138,8 +138,10 @@
 	MODEL
 	{
 		model = Squad/Parts/Utility/linearRCS/model
-		scale = 2.0, 2.0, 2.0
+		scale:NEEDS[!VenStockRevamp] = 1.28, 1.28, 1.28
+		scale:NEEDS[VenStockRevamp] = 1.41, 1.41, 1.41
 	}
+	%rescaleFactor = 2.0
 	@mass = 0.012
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
@@ -167,13 +169,6 @@
 +PART[linearRcs]:AFTER[RealismOverhaul]
 {
 	@name = RO_FASA_MercuryPodRCS
-	!mesh = DEL
-	!MODEL {}
-	MODEL
-	{
-		model = Squad/Parts/Utility/linearRCS/model
-		scale = 1.0, 1.0, 1.0
-	}
 	%rescaleFactor = 1.0
 	@title = Attitude Jet (138/223 N class)
 	@manufacturer = Generic
@@ -202,14 +197,7 @@
 +PART[linearRcs]:AFTER[RealismOverhaul]
 {
 	@name = RO_FASA_ExplorerRCS
-	!mesh = DEL
-	!MODEL {}
-	MODEL
-	{
-		model = Squad/Parts/Utility/linearRCS/model
-		scale = 0.7, 0.7, 0.7
-	}
-	%rescaleFactor = 1.0
+	%rescaleFactor = 0.707
 	@title = Attitude Jet (69/111 N class)
 	@manufacturer = Generic
 	@description = These small thrusters are for upper stage or small probe orientation.
@@ -233,14 +221,7 @@
 +PART[linearRcs]:AFTER[RealismOverhaul]
 {
 	@name = RO_linearRcs_tenth
-	!mesh = DEL
-	!MODEL {}
-	MODEL
-	{
-		model = Squad/Parts/Utility/linearRCS/model
-		scale = 0.5, 0.5, 0.5
-	}
-	%rescaleFactor = 1.0
+	%rescaleFactor = 0.447
 	@title = Attitude Jet (28/45 N class)
 	@manufacturer = Generic
 	@description = These small thrusters are for upper stage or very small probe orientation.
@@ -365,8 +346,10 @@
 	MODEL
 	{
 		model = Squad/Parts/Utility/rcsBlockRV-105/model
-		scale = 1.4, 1.4, 1.4
+		//match R-4D nozzle diameter of 15 cm
+		scale = 1.875, 1.875, 1.875
 	}
+	%rescaleFactor = 1.0
 	@mass = 0.028
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
@@ -393,16 +376,7 @@
 +PART[RCSBlock]:AFTER[RealismOverhaul]
 {
 	@name = SquadRCSBlockHalf
-	!mesh = DELETE
-	!MODEL {}
-	MODEL
-	{
-		model = Squad/Parts/Utility/rcsBlockRV-105/model
-		scale = 1.0, 1.0, 1.0
-	}
-	@scale = 0.625
-	%rescaleFactor = 1.0
-	@node_attach = 0.045212, -0.00105571, -0.00059382, 1.0, 0.0, 0.0
+	%rescaleFactor = 0.707
 	@TechRequired = stability
 	@entryCost = 1450
 	@title = RCS Quad (138/223 N class)
@@ -419,16 +393,7 @@
 +PART[RCSBlock]:AFTER[RealismOverhaul]
 {
 	@name = RCSBlockQuarter
-	!mesh = DELETE
-	!MODEL {}
-	MODEL
-	{
-		model = Squad/Parts/Utility/rcsBlockRV-105/model
-		scale = 0.7, 0.7, 0.7
-	}
-	@scale = 0.3125
-	%rescaleFactor = 1.0
-	@node_attach = 0.045212, -0.00105571, -0.00059382, 1.0, 0.0, 0.0
+	%rescaleFactor = 0.5
 	@TechRequired = stability
 	@entryCost = 3400
 	@title = RCS Quad (69/111 N class)
@@ -445,16 +410,7 @@
 +PART[RCSBlock]:AFTER[RealismOverhaul]
 {
 	@name = SquadRCSBlockTenth
-	!mesh = DELETE
-	!MODEL {}
-	MODEL
-	{
-		model = Squad/Parts/Utility/rcsBlockRV-105/model
-		scale = 0.44, 0.44, 0.44
-	}
-	@scale = 0.125
-	%rescaleFactor = 1.0
-	@node_attach = 0.045212, -0.00105571, -0.00059382, 1.0, 0.0, 0.0
+	%rescaleFactor = 0.316
 	@TechRequired = stability
 	@entryCost = 1450
 	@title = RCS Quad (28/45 N class)

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
@@ -4,12 +4,12 @@
 
 @PART[RO-2kN-Thruster]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME:NEEDS[!VenStockRevamp]
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.35
-        plumeScale = 0.25
+        plumePosition = 0.0, 0.0, 0.13
+        plumeScale = 0.75
         flarePosition = 0.0, 0.0, 0.0
         flareScale = 0.0
         smokePosition = 0.0, 0.0, 0.0
@@ -19,17 +19,47 @@
         speed = 1.5
     }
 
-    PLUME
+    PLUME:NEEDS[!VenStockRevamp]
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
         plumePosition = 0.0, 0.0, -0.01
-        plumeScale = 0.25
-        flarePosition = 0.0, 0.0, -0.6
-        flareScale = 0.055
+        plumeScale = 0.6
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 0.25
         smokePosition = 0.0, 0.0, 0.0
         localRotation = 0.0, 0.0, 0.0
         emissionMult = 0.75
+        energy = 1.0
+        speed = 1.0
+    }
+	
+	PLUME:NEEDS[VenStockRevamp]
+    {
+        name = Hypergolic-OMS-Red
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.32
+        plumeScale = 0.8
+        flarePosition = 0.0, 0.0, -0.62
+        flareScale = 0.32
+        smokePosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.5
+    }
+
+    PLUME:NEEDS[VenStockRevamp]
+    {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -0.5
+        plumeScale = 0.75
+        flarePosition = 0.0, 0.0, -0.62
+        flareScale = 0.32
+        smokePosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
         energy = 1.0
         speed = 1.0
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/microEngine.cfg
@@ -4,12 +4,12 @@
 
 @PART[microEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME
+    PLUME:NEEDS[!VenStockRevamp]
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.55
-        plumeScale = 0.25
+        plumePosition = 0.0, 0.0, 0.2
+        plumeScale = 0.5
         flarePosition = 0.0, 0.0, -0.85
         flareScale = 0.05
         smokePosition = 0.0, 0.0, 0.0
@@ -19,14 +19,44 @@
         speed = 1.5
     }
 
-    PLUME
+    PLUME:NEEDS[!VenStockRevamp]
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.05
-        plumeScale = 0.1
-        flarePosition = 0.0, 0.0, -0.8
-        flareScale = 0.075
+        plumePosition = 0.0, 0.0, 0.01
+        plumeScale = 0.45
+        flarePosition = 0.0, 0.0, -0.1
+        flareScale = 0.23
+        smokePosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
+    }
+	
+	PLUME:NEEDS[VenStockRevamp]
+    {
+        name = Hypergolic-OMS-Red
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.55
+        plumeScale = 0.6
+        flarePosition = 0.0, 0.0, -0.62
+        flareScale = 0.32
+        smokePosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.5
+    }
+
+    PLUME:NEEDS[VenStockRevamp]
+    {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, -0.2
+        plumeScale = 0.65
+        flarePosition = 0.0, 0.0, -1.0
+        flareScale = 0.25
         smokePosition = 0.0, 0.0, 0.0
         localRotation = 0.0, 0.0, 0.0
         emissionMult = 0.5


### PR DESCRIPTION
PR #1842 broke the rcs mass calculation in an attempt to fix #1769, resulting in single nozzle thrusters having a mass of 1/8 of a quad thruster with the same thrust, for example. The real issue was just poor balancing though, the calculation itself worked as intended before the patch.

Here's my attempt to fix this. Doing some research for balancing, it seems rcs thruster mass scales roughly proportional to sqrt(thrust) instead of linearly with thrust (see [here](https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Bipropellant%20Data%20Sheets.pdf), [here](http://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf) or [here](http://www.space-propulsion.com/brochures/hydrazine-thrusters/hydrazine-thrusters.pdf)), so this is what i did as well. 
I also reduced the mass savings for multi nozzle thrusters, according to one real world example i found [here](http://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf).

These changes result in the following masses (for TL2 thrusters):

Thruster|Mass
---------|-----------------
**28/45 N**|1.7 kg
**138/223 N**|3.8 kg
**138/223 N quad**|11.3 kg
**275/445 N quad**|16 kg
**550/890 N**|7.5 kg
**1.1/1.78 kN**|10.7 kg
**2.2/3.6 kN**|15.1 kg

I also fixed and changed the scaling of the parts slightly (for rcs parts) or not so slightly (for the 1/2 kN thrusters, they were a bit on the small side i think, the latter now got a nozzle diameter of 45 cm, a little larger than the slighly lower I<sub>sp</sub> AR R-40B).

Edit: As siimav suggested i now changed the 1/2 kn thrusters' models to OMS Large if VSR is installed, those look better for a vacuum thruster i think:

![image](https://user-images.githubusercontent.com/11480934/48978254-11964480-f0a9-11e8-899c-3b66f49d16e0.png)
