### PR TITLE
Fix gimbal on BDB LR79

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Juno_II.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Juno_II.cfg
@@ -59,12 +59,6 @@
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 16
 	}
-	!MODULE[ModuleEnginesFX]
-	{
-	}
-	!MODULE[ModuleGimbal],1
-	{
-	}
 }
 
 // Removing non-relevant configs and changing title


### PR DESCRIPTION
Don't delete a non-existent "second" ModuleGimbal, it ends up deleting the first. Also don't delete the non-existent ModuleEnginesFX.

BDB has 2 engines mapped to LR79: juno_engines3d and thorEngine. thorEngine has built-in verniers, so it has 2 ModuleGimbals instead of 1. The RO config strips out the verniers and their gimbal setting. The RO config for juno_engines3d tries to strip out the same verniers, but there aren't any. I don't speak ModuleManager, but it would seem `!MODULE[ModuleGimbal],1` is intended to match "the second one", but that "second of one item" is that one item.