### PR TITLE
Fix RD-108 Default Configuration

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -48,7 +48,7 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         origMass = 1.278
-        configuration = RD-108-8D75PS
+        configuration = RD-108-8D75
         modded = false
 
         CONFIG


### PR DESCRIPTION
Set RD-108 to use the same default configuration as RD-107.