### PR TITLE
Add Speculative NK-9 Configurations

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
@@ -19,6 +19,16 @@
 	%title = NK-9
 	%manufacturer = SNTK Kuznetsov
 	%description = Staged combustion kerolox booster engine. Designed by Kuznetsov for the Korolev GR-1 project. Basis for the NK-15 used on the N1, and the NK-33 used today. Diameter: [1.3 m].
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+
+        !IGNITOR_RESOURCE,*{}
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -50,6 +60,106 @@
 				key = 1 286.5	//calculated from sl and vac thrust
 			}
 			massMult = 1.0
+
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = NK-9-1969
+			maxThrust = 421
+			minThrust = 421
+			heatProduction = 205
+			// speculative = fictional
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.35574
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.64426
+			}
+			atmosphereCurve
+			{
+				key = 0 331
+				key = 1 297
+			}
+			massMult = 1.0
+
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = NK-9-1972
+			maxThrust = 436 // (for same TWR as NK-33 - (1766 / 1459) * 360)
+			minThrust = 436
+			heatProduction = 205
+			// speculative = fictional
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.35574
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.64426
+			}
+			atmosphereCurve
+			{
+				key = 0 331
+				key = 1 297
+			}
+			massMult = 1.0
+
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = NK-9-2009
+			maxThrust = 448 // (for same TWR as AJ26-62 - (1815 / (1222 * 1.1937)) * 360)
+			minThrust = 448
+			heatProduction = 205
+			// speculative = fictional
+			// 2.7 O/F mass ratio (Antares UG)
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3400
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6600
+			}
+			atmosphereCurve
+			{
+				key = 0 331.9 // Antares UG
+				key = 1 301.6 // Antares UG
+			}
+			massMult = 1.0
 			
 			ullage = True
 			ignitions = 1
@@ -69,6 +179,7 @@
 	!MODULE[ModuleAlternator] { }
 	!RESOURCE[ElectricCharge] { }
 }
+
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-9]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -82,5 +193,44 @@
 		techTransfer = NK-9V:50
 		
 		reliabilityMidH = 0.65
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-9-1969]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = NK-9-1969
+		ratedBurnTime = 190
+		ignitionReliabilityStart = 0.90
+		ignitionReliabilityEnd = 0.983
+		cycleReliabilityStart = 0.885
+		cycleReliabilityEnd = 0.978
+		techTransfer = NK-9-1972,NK-9V:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-9-1972]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = NK-9-1972
+		ratedBurnTime = 240
+		ignitionReliabilityStart = 0.93
+		ignitionReliabilityEnd = 0.996
+		cycleReliabilityStart = 0.92
+		cycleReliabilityEnd = 0.996
+		techTransfer = NK-9-2009,NK-9V:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-9-2009]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = NK-9-2009
+		ratedBurnTime = 240
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.996
+		cycleReliabilityStart = 0.96
+		cycleReliabilityEnd = 0.996
+		techTransfer = NK-9V:50
 	}
 }


### PR DESCRIPTION
Add NK-9 upgrades in line with NK-15 and NK-33 with respect to TWR and
ISP. It should give players more options for light Soviet launchers.