### PR TITLE
Fix MM patch for J-2T gimbal

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -9,10 +9,11 @@
 	@title = J-2T-200/250K
 	@manufacturer = Rocketdyne
 	@description = Aerospike. Using proven technology from the J-2 and introducing an aerospike nozzle to the developing J-2S machinery. Diameter: [2.5 m].
-	@MODULE[ModuleGimbal],*
+	%MODULE[ModuleGimbal]
 	{
 		%gimbalRange = 7.0
 		%useGimbalResponseSpeed = True
+		%gimbalTransformName = thrustTransform
 		%gimbalResponseSpeed = 16
 	}
 	


### PR DESCRIPTION
The base part (toroidalAerospike from stock) doesn't have a gimbal, so we
 have to % (rather than @) our gimbal config.