### PR TITLE
Match description of Comm 16-S to config value

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -46,7 +46,7 @@
 
 @PART[SurfAntenna]:AFTER[RemoteTech]
 {
-    @description ^=:$: <color=orange>Note that it is not activated by default!</color> Maximum effective range approximately 200 Mm, power consumption 12 Watts, maximum data rate 1 Mbit/s.
+    @description ^=:$: <color=orange>Note that it is not activated by default!</color> Maximum effective range approximately 200 Mm, power consumption 8 Watts, maximum data rate 1 Mbit/s.
 
     !MODULE[ModuleDataTransmitter],*{}
 


### PR DESCRIPTION
The energy consumption was different in the description and in the config. I assumed the config was right.