### PR TITLE
BDB fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Apollo.cfg
@@ -47,7 +47,7 @@
 // **************************************************************************************
 
 // Active Docking Mechanism
-@PART[bluedog_Apollo_Block2_ActiveDockingMechanism]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_ActiveDockingMechanism]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -78,7 +78,7 @@
 }
 
 // Command Module
-@PART[bluedog_Apollo_Block2_Capsule]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_Capsule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -240,7 +240,7 @@
 }
 
 // Decoupler
-@PART[bluedog_Apollo_Block2_Decoupler]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_Decoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -264,7 +264,7 @@
 }
 
 // Docking Light
-@PART[bluedog_Apollo_Block2_DockingLight]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_DockingLight]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -285,7 +285,7 @@
 }
 
 // Heat Shield
-@PART[bluedog_Apollo_Block2_Heatshield]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_Heatshield]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -347,7 +347,7 @@
 }
 
 // High Gain Antenna
-@PART[bluedog_Apollo_Block2_HGA]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_HGA]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -360,7 +360,7 @@
 	@mass = 0.01
 	@maxTemp = 1973.15
 }
-@PART[bluedog_Apollo_Block2_HGA]:NEEDS[Bluedog_DB|RemoteTech]:AFTER[RemoteTech]
+@PART[bluedog_Apollo_Block2_HGA]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	
@@ -379,7 +379,7 @@
 }
 
 // LES
-@PART[bluedog_Apollo_Block2_LES]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_LES]:FOR[RealismOverhaul]
 {
 	%category = Engine
 	%RSSROConfig = True
@@ -510,7 +510,7 @@
 }
 
 // Parachutes
-@PART[bluedog_Apollo_Block2_Parachute]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_Parachute]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -559,7 +559,7 @@
 }
 
 // Parachute Mount
-@PART[bluedog_Apollo_Block2_ParachuteMount]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_ParachuteMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -580,7 +580,7 @@
 }
 
 // Passive Docking Mechanism
-@PART[bluedog_Apollo_Block2_PassiveDockingMechanism]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_PassiveDockingMechanism]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -613,7 +613,7 @@
 }
 
 // Quad RCS
-@PART[bluedog_Apollo_Block2_RCSquad]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_RCSquad]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%useRcsConfig = RCSBlock
@@ -660,7 +660,7 @@
 }
 
 // AJ10-137 Service Engine
-@PART[bluedog_Apollo_Block2_ServiceEngine]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_ServiceEngine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -712,7 +712,7 @@
 }
 
 // Service Module
-@PART[bluedog_Apollo_Block2_ServiceModule]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block2_ServiceModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -898,7 +898,7 @@
 // **************************************************************************************
 
 // Ascent Cockpit
-@PART[bluedog_LEM_Ascent_Cockpit]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_LEM_Ascent_Cockpit]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.5646
@@ -949,7 +949,7 @@
 		}
 	}	 
 }
-@PART[bluedog_LEM_Ascent_Cockpit]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]:NEEDS[RemoteTech]
+@PART[bluedog_LEM_Ascent_Cockpit]:FOR[RealismOverhaul]:NEEDS[RemoteTech]
 {
 	MODULE
     {
@@ -989,7 +989,7 @@
 }
 
 // LMAE
-@PART[bluedog_LEM_Ascent_Engine]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_LEM_Ascent_Engine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -1038,7 +1038,7 @@
 }
 
 
-@PART[bluedog_LEM_Descent_Engine]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_LEM_Descent_Engine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -1093,7 +1093,7 @@
 }
 
 // Descent Stage
-@PART[bluedog_LEM_Descent_Tanks]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_LEM_Descent_Tanks]:FOR[RealismOverhaul]
 {
 	%category = FuelTank
 	%RSSROConfig = True
@@ -1160,7 +1160,7 @@
 // **************************************************************************************
 
 // Block III+ Capsule
-@PART[bluedog_Apollo_Block3_Capsule]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block3_Capsule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -1325,7 +1325,7 @@
 }
 
 // Block III HGA
-@PART[bluedog_Apollo_Block3_HGA]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block3_HGA]:FOR[RealismOverhaul]
 {
 	%category = Communication
 	%RSSROConfig = True
@@ -1339,7 +1339,7 @@
 	@mass = 0.01
 	@maxTemp = 1973.15
 }
-@PART[bluedog_Apollo_Block3_HGA]:NEEDS[Bluedog_DB|RemotTech]:AFTER[RemoteTech]
+@PART[bluedog_Apollo_Block3_HGA]:NEEDS[RemoteTech]
 {
 	// Changed to be the same as the Communotron 16. Only designed for LEO use.
 	@MODULE[ModuleRTAntenna]
@@ -1358,7 +1358,7 @@
 }
 
 // Apollo Mission Module
-@PART[bluedog_Apollo_Block3_MissionModule]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block3_MissionModule]:FOR[RealismOverhaul]
 {
 	%category = Pods
 	%RSSROConfig = True
@@ -1374,7 +1374,7 @@
 }
 
 // Block III+ Service Engine (LMAE)
-@PART[bluedog_Apollo_Block3_ServiceEngine]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block3_ServiceEngine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -1427,7 +1427,7 @@
     engineType = LMAE
 }
 // Service Module
-@PART[bluedog_Apollo_Block3_ServiceModule]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block3_ServiceModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
@@ -1477,7 +1477,7 @@
 }
 
 // Apollo Block V Solar Panels
-@PART[bluedog_Apollo_Block5_SolarPanels]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Apollo_Block5_SolarPanels]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646


### PR DESCRIPTION
-Remove pointless NEEDS for BDB as these won't work without the parts
installed anyway, and they are causing mm warnings.