### PR TITLE
[Bluedog_DB] Updates to Atlas Engines and Centaur Engines

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Atlas.cfg
@@ -36,3 +36,40 @@
 	
 	engineType = LR101
 }
+
+// Provisional Atlas Stack Configs
+
+// Booster Skirt / Fairing / Mass = 1.61
+@PART[bluedog_Atlas_BoosterSkirt]:FOR[RealismOverhaul]
+{
+
+	%RSSROConfig = True
+	@rescaleFactor = 1.6267
+	
+	@title = Atlas Booster Skirt
+	%manufacturer = Rocketdyne
+	@description = Part of the MA-2/3/5 Propulsion Unit, this is a decoupler/fairing for the booster engines of Atlas. Place this on top of the main engines, then add the boosters.
+	@mass = 1.61
+	
+	!MODULE[ModuleEngines*],*{}
+
+	!RESOURCE,*{}
+}
+
+
+// Engine Attachment
+@PART[bluedog_Atlas_SustainerAdapterTank]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.6267
+
+	@title = Atlas Booster Skirt
+	%manufacturer = Rocketdyne
+	@description = Part of the MA-2/3/5 Propulsion Unit for attaching the LR105 Sustainer engine to it.
+	@mass = 0.384
+
+	!MODULE[ModuleEngines*],*{}
+
+	!RESOURCE,*{}
+
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Centaur.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Centaur.cfg
@@ -1,11 +1,13 @@
-// RL-10
+// RL-10A/C
 
-@PART[bluedog_rl10]:FOR[RealismOverhaul]
+@PART[bluedog_Centaur_RL10]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	
 	%attachRules = 1,0,1,0,0
 	
+	@rescaleFactor = 1.95
+
 	%mass = 0.167
     @crashTolerance = 10
 	@maxTemp = 873.15
@@ -40,5 +42,122 @@
 			@name = LqdOxygen
 			@ratio = 0.237
 		}
+	}
+}
+
+
+// RL-10A/C Engine configuration
+
+@PART[bluedog_Centaur_RL10]:AFTER[RealismOverhaulEngines]
+{
+    @title = RL10-A/C Series
+    @manufacturer = Aerojet Rocketdyne
+    @description = Hydrolox restartable expander-cycle vacuum engine. Initially developed by Pratt & Whitney designated as XLR115 and with a vacuum specific impulse of 422 seconds and rated thrust of only 66 kN. Later, the management transferred to the Marshall Space Flight Center and the engine was renamed into RL10. Since then, it has been upgraded many times, now achieving a specific impulse of up to 465 seconds and over 100 kN of thrust. Used by the workhorse Atlas Centaur high energy upper stage, the Saturn I upper stage and the Delta IV Cryogenic Second Stage (DCSS). Includes the A and C variants.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RL10A-1
+
+        !CONFIG,*:HAS[~name[RL10A-1],~name[RL10A-3-1],~name[RL10A-3-3],~name[RL10A-3-3A],~name[RL10A-4],~name[RL10A-4-1/2],~name[RL10A-5],~name[RL10C-1]]{}
+    }
+}
+
+
+// RL10-B2
+
+@PART[bluedog_Centaur_RL10B2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    @scale = 1.0
+
+    @rescaleFactor = 1.95
+
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+
+    %engineType = RL10
+
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 110.1
+        @maxThrust = 110.1
+        @heatProduction = 76
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = LqdHydrogen
+            @ratio = 0.7335
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = LqdOxygen
+            @ratio = 0.2665
+        }
+    }
+
+    !RESOURCE,*{}
+}
+
+
+// RL10B-2 / CECE Engine Configuration
+
+@PART[bluedog_Centaur_RL10B2]:AFTER[RealismOverhaulEngines]
+{
+    @title = RL10-B/CECE Series
+    @manufacturer = Aerojet Rocketdyne
+    @description = Hydrolox restartable expander-cycle vacuum engine. Initially developed by Pratt & Whitney designated as XLR115 and with a vacuum specific impulse of 422 seconds and rated thrust of only 66 kN. Later, the management transferred to the Marshall Space Flight Center and the engine was renamed into RL10. Since then, it has been upgraded many times, now achieving a specific impulse of up to 465 seconds and over 100 kN of thrust. Used by the workhorse Atlas Centaur high energy upper stage, the Saturn I upper stage and the Delta IV Cryogenic Second Stage (DCSS). Includes the B and CECE variants.
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @configuration = RL10B-2
+
+        !CONFIG,*:HAS[~name[RL10B-2],~name[CECE-Base],~name[CECE-High],~name[CECE-Methane]]{}
+    }
+}
+
+
+// RL10A4-1/-2 
+
+@PART[bluedog_Centaur_RL10A41]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+
+    @rescaleFactor = 1.95
+
+    @crashTolerance = 10
+    @breakingForce = 250
+    @breakingTorque = 250
+    @maxTemp = 673.15
+    %skinMaxTemp = 773.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+
+    %engineType = RL10
+}
+@PART[bluedog_Centaur_RL10A41]:AFTER[RealismOverhaulEngines]
+{
+	@title = RL10A-4 Series Vacuum Engine (Extendable Nozzle)
+	
+	@MODULE[ModuleEngineConfigs] 
+	{
+		!CONFIG[RL10A-1] {}
+		!CONFIG[RL10A-3-1] {}		
+		!CONFIG[RL10A-3-3] {}
+		!CONFIG[RL10A-3-3A] {}
+		!CONFIG[RL10A-5] {}
+		!CONFIG[RL10B-2] {}
+		!CONFIG[RL10C-1] {}
+		!CONFIG[CECE-Base] {}
+		!CONFIG[CECE-High] {}
+		!CONFIG[CECE-Methane] {}
 	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_LR101.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_LR101.cfg
@@ -1,0 +1,22 @@
+@PART[bluedog_Atlas_LR101_Radial]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%powerEffectName = Kerolox-Vernier
+	}
+	@MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesRF
+    }
+    PLUME
+    {
+        name = Kerolox-Vernier
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        fixedScale = 0.7
+        energy = 1
+        speed = 1.5
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_LR105.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_LR105.cfg
@@ -1,0 +1,22 @@
+@PART[bluedog_Atlas_LR105]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%powerEffectName = Kerolox-Lower
+	}
+	@MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesRF
+    }
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.2
+        fixedScale = 0.7
+        energy = 1
+        speed = 1
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_LR89.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_LR89.cfg
@@ -1,0 +1,22 @@
+@PART[bluedog_Atlas_LR89]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		%powerEffectName = Kerolox-Lower
+	}
+	@MODULE[ModuleEngineConfigs]
+    {
+		%type = ModuleEnginesRF
+    }
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.2
+        fixedScale = 0.7
+        energy = 1
+        speed = 1.3
+    }
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_RL10.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Bluedog_DB/BDB_RL10.cfg
@@ -1,0 +1,142 @@
+// Plume Config
+@PART[bluedog_Centaur_RL10]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.8
+        fixedScale = 1
+        energy = 1.0
+        speed = 1.25
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hydrolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+
+
+// Flare Config
+@PART[bluedog_Centaur_RL10]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.75
+                @fixedScale = 1.5
+            }
+        }
+    }
+}
+
+
+// Plume Config
+@PART[bluedog_Centaur_RL10A41]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.9
+        fixedScale = 1.5
+        energy = 1.0
+        speed = 1.25
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hydrolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+
+
+// Flare Config
+@PART[bluedog_Centaur_RL10A41]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 0.8
+                @fixedScale = 1.6
+            }
+        }
+    }
+}
+
+
+// Plume Config
+@PART[bluedog_Centaur_RL10B2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = thrustTransform
+        localRotation = 0.0, 0.0, 0.0
+        localPosition = 0.0, 0.0, 0.9
+        fixedScale = 2.0
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Hydrolox-Upper
+        !runningEffectName = NULL
+        !fxOffset = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+
+
+// Flare Config
+@PART[bluedog_Centaur_RL10B2]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Upper
+        {
+            @MODEL_MULTI_SHURIKEN_PERSIST[flare]
+            {
+                @localPosition = 0.0, 0.0, 1
+                @fixedScale = 2.2
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Added RealPlume configs to the new Atlas engine models (LR89, LR105, LR101)
* Configured the bottom structures of the Atlas parts for use with RealismOverhaul
* Added engine configs to the new Centaur engines (RL10A/C, RL10A-4-1/2, RL-10B2/CECE)
* Added RealPlume configs to the RL10 engines
