### PR TITLE
Realism Tweaks to Early HG-3 Engines, New Speculative Upgrades

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -9,7 +9,7 @@
 //  Burn Time: 600 s
 //  O/F Ratio: ?? (Assumed 5.5 ala J-2)
 
-//Upgrades (HG-3A, etc.) are purely speculative.
+// Upgrades (HG-3A, etc.) are purely speculative.
 
 //  Source 1: http://www.astronautix.com/h/hg-3.html
 //  Source 2: http://www.astronautix.com/h/hg-3-sl.html
@@ -63,8 +63,8 @@
 		CONFIG
 		{
 			name = HG-3-SL
-			minThrust = 929.29
-			maxThrust = 1387.00
+			minThrust = 925.987
+			maxThrust = 1382.07
 			massMult = 0.973574409
 			heatProduction = 100
 			PROPELLANT
@@ -80,8 +80,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 450
-				key = 1 360
+				key = 0 445
+				key = 1 340
 			}
 			
 			%ullage = True
@@ -96,6 +96,7 @@
 		CONFIG
 		{
 			name = HG-3A
+			description = Speculative upgrade, using lessons learned from experience with HG-3 in service and development of RS-25 to improve reliability.
 			minThrust = 938.469
 			maxThrust = 1400.70
 			heatProduction = 100
@@ -128,8 +129,9 @@
 		CONFIG
 		{
 			name = HG-3A-SL
-			minThrust = 929.29
-			maxThrust = 1387.00
+			description = Sea-level variant of HG-3A upgrade
+			minThrust = 925.987
+			maxThrust = 1382.07
 			massMult = 0.973574409
 			heatProduction = 100
 			PROPELLANT
@@ -145,13 +147,146 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 450
-				key = 1 360
+				key = 0 445
+				key = 1 340
 			}
 			
 			%ullage = True
 			%pressureFed = False
 			%ignitions = 2 //Limited emergency relight capability, ala NK-33. Also improves reliability.
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
+			name = HG-3B
+			description = Further refinement of the HG-3 engine, taking into account developements with the RL-10 and RS-25. Run time and reliability are extended compared to original models, although turbopump throughput is decreased to reduce strain on engine components.
+			minThrust = 938.469
+			maxThrust = 1400.70
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 458
+				key = 1 285
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 5
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
+			name = HG-3B-SL
+			description = Sea-level variant of HG-3B upgrade. Increased specific impulse compared to other sea-level variants prior to B version development results in slightly higher thrust for the same level of turbopump throughput as the HG-3B vacuum engine.
+			minThrust = 926.174
+			maxThrust = 1382.35
+			massMult = 0.973574409
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 452
+				key = 1 352
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 2 //Limited emergency relight capability, ala NK-33.
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
+			name = HG-3B-2
+			description = Modified version of HG-3B, running the turbopumps harder to generate the same level of mass flow as in previous models. This results in improved thrust compared to the normal B model, at the cost of slightly less reliability in comparison.
+			minThrust = 950.035
+			maxThrust = 1422.44
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 458
+				key = 1 285
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 5
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
+			name = HG-3B-SL-2
+			description = Sea-level version of HG-3B-2 upgrade and modification. The improved specific impulse now means that this version produces more vacuum thrust than previous vacuum versions of the engine.
+			minThrust = 940.553
+			maxThrust = 1403.81
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546
+			}
+			atmosphereCurve
+			{
+				key = 0 452
+				key = 1 352
+			}
+			
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 2
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -203,9 +338,9 @@
 		name = HG-3A
 		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.902
-		ignitionReliabilityEnd = 0.962
-		cycleReliabilityStart = 0.9468
-		cycleReliabilityEnd = 0.9995
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.91
+		cycleReliabilityEnd = 0.98
 		techTransfer = HG-3,HG-3-SL:50
 	}
 }
@@ -216,9 +351,61 @@
 		name = HG-3A-SL
 		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.902
-		ignitionReliabilityEnd = 0.962
-		cycleReliabilityStart = 0.9468
-		cycleReliabilityEnd = 0.9995
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.91
+		cycleReliabilityEnd = 0.98
 		techTransfer = HG-3,HG-3-SL:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = HG-3B
+		ratedBurnTime = 750
+		ignitionReliabilityStart = 0.902
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.91488
+		cycleReliabilityEnd = 0.99
+		techTransfer = HG-3A,HG-3A-SL:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = HG-3B-SL
+		ratedBurnTime = 750
+		ignitionReliabilityStart = 0.902
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.91488
+		cycleReliabilityEnd = 0.99
+		techTransfer = HG-3A,HG-3A-SL:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = HG-3B-2
+		ratedBurnTime = 750
+		ignitionReliabilityStart = 0.902
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.90
+		cycleReliabilityEnd = 0.988
+		techTransfer = HG-3A,HG-3A-SL,HG-3B,HG-3B-SL:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B-SL-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = HG-3B-SL-2
+		ratedBurnTime = 750
+		ignitionReliabilityStart = 0.902
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.90
+		cycleReliabilityEnd = 0.988
+		techTransfer = HG-3A,HG-3A-SL,HG-3B,HG-3B-SL:50
 	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3-SL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3-SL.cfg
@@ -30,6 +30,33 @@
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Upper
 		}
+		
+		//HG-3B-SL, Hydrolox-Lower
+		@CONFIG[HG-3B-SL]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		
+		//HG-3B-SL-2, Hydrolox-Lower
+		@CONFIG[HG-3B-SL-2]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		//HG-3B, Hydrolox-Upper
+		@CONFIG[HG-3B]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3B-2, Hydrolox-Upper
+		@CONFIG[HG-3B-2]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
 	}
 	
 	PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3.cfg
@@ -30,6 +30,34 @@
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Upper
 		}
+		
+		//HG-3B, Hydrolox-Upper
+		@CONFIG[HG-3B]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3B-2, Hydrolox-Upper
+		@CONFIG[HG-3B-2]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3B-SL, Hydrolox-Lower
+		@CONFIG[HG-3B-SL]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		
+		//HG-3B-SL-2, Hydrolox-Lower
+		@CONFIG[HG-3B-SL-2]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
 	}
 	
 	PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTHG-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTHG-3.cfg
@@ -30,6 +30,33 @@
 		!runningEffectName = DELETE
 		%powerEffectName = Hydrolox-Upper
 		}
+		//HG-3B-SL, Hydrolox-Lower
+		@CONFIG[HG-3B-SL]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		
+		//HG-3B-SL-2, Hydrolox-Lower
+		@CONFIG[HG-3B-SL-2]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Lower
+		}
+		
+		//HG-3B, Hydrolox-Upper
+		@CONFIG[HG-3B]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
+		
+		//HG-3B-2, Hydrolox-Upper
+		@CONFIG[HG-3B-2]
+		{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+		}
 	}
 	
 	PLUME


### PR DESCRIPTION
This pull request is intended to, primarily, bring the early HG-3-SL and HG-3A-SL more in line with realism based on known information about how sea-level versions of engines such as the J-2S functioned - ie., using the same turbopumps with the same settings with a new nozzle optimized for lower altitude operations. This implies an identical mass flow rate for both versions of the engine, which in turn means that either the thrust of the originally posted sea-level variants was too low, or the specific impulse was too high. As the ISP of the SL variants was already at nearly SSME levels anyways, despite it's earlier development date, I decided that it would likely be more realistic to lower the specific impulse of the engines to bring their mass flow rates back in line with their vacuum counterparts. However, thrust has also been adjusted slightly based on the determined information about the vacuum engines compared to their sea-level counterparts.

This pull request's second realism tweak is to adjust the reliability boost from upgrading to the HG-3A and -3A-SL engines, as prior to this pull request those engines had reliability levels so high that it would be incredibly unlikely that an HG-3A engine would fail even after hundreds of flights with these engines. This has been rebalanced so that the HG-3A and HG-3A-SL are merely significantly more reliable than the HG-3 and HG-3-SL.

Additionally, this pull request also introduces more speculative upgrades for the HG-3 engine, intended to further improve the number of high-thrust, high specific impulse engines available in the early to late '90s portion of the tech tree and later.