### PR TITLE
Added TestFlight config to AJ10_Adv

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -25,10 +25,6 @@
 
 @PART[*]:HAS[#engineType[AJ10_Adv]]:FOR[RealismOverhaulEngines]
 {
-    %title = AJ10 Series (Advanced)
-    %manufacturer = Aerojet Rocketdyne
-    %description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents advanced era AJ10s with a nozzle extension and restart capability. Used on Transtage as AJ10-138; similar models but back with the -118 designation were used on the Delta F and Delta K upper stages.
-
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -60,10 +56,9 @@
 				key = 0 311
 				key = 1 100
 			}
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 0
-			!IGNITOR_RESOURCE,* {}
+			ullage = True
+			pressureFed = True
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -95,10 +90,9 @@
                 		DrawGauge = False
 			}
 
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 0
-			!IGNITOR_RESOURCE,* {}
+			ullage = True
+			pressureFed = True
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -137,10 +131,9 @@
                 		DrawGauge = False
 			}
 
-			%ullage = True
-			%pressureFed = True
-			%ignitions = 0
-			!IGNITOR_RESOURCE,* {}
+			ullage = True
+			pressureFed = True
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -163,10 +156,6 @@
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 8
 	}
-
-    !MODULE[ModuleAlternator]{}
-
-    !RESOURCE,*{}
 }
 
 

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -25,6 +25,10 @@
 
 @PART[*]:HAS[#engineType[AJ10_Adv]]:FOR[RealismOverhaulEngines]
 {
+    %title = AJ10 Series (Advanced)
+    %manufacturer = Aerojet Rocketdyne
+    %description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents advanced era AJ10s with a nozzle extension and restart capability. Used on Transtage as AJ10-138; similar models but back with the -118 designation were used on the Delta F and Delta K upper stages.
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -156,6 +160,10 @@
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 8
 	}
+	
+    	!MODULE[ModuleAlternator]{}
+
+    	!RESOURCE,*{}
 }
 
 

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -19,7 +19,8 @@
 
 //  Real Scale Boosters
 //  SXT
-//	BDB
+//  BDB
+//  SSTU
 //  ==================================================
 
 @PART[*]:HAS[#engineType[AJ10_Adv]]:FOR[RealismOverhaulEngines]
@@ -61,7 +62,7 @@
 			}
 			%ullage = True
 			%pressureFed = True
-			%ignitions = 4
+			%ignitions = 0
 			!IGNITOR_RESOURCE,* {}
 			IGNITOR_RESOURCE
 			{
@@ -76,28 +77,28 @@
 		CONFIG
 		{
 			name = AJ10-118F
-			minThrust = 42.3
-			maxThrust = 42.3
+			minThrust = 41.4
+			maxThrust = 41.4
 			heatProduction = 100
 
 			PROPELLANT
 			{
-				name = Aerozine50
-				ratio = 0.4654
+				name = UDMH
+				ratio = 0.406
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name = NTO
-				ratio = 0.5346
-                DrawGauge = False
+				name = IWFNA
+				ratio = 0.594
+                		DrawGauge = False
 			}
 
-			ullage = True
-			pressureFed = True
-			ignitions = 0
-
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 0
+			!IGNITOR_RESOURCE,* {}
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -106,7 +107,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 315
+				key = 0 306
 				key = 1 215
 			}
 
@@ -133,13 +134,13 @@
 			{
 				name = NTO
 				ratio = 0.5346
-                DrawGauge = False
+                		DrawGauge = False
 			}
 
-			ullage = True
-			pressureFed = True
-			ignitions = 0
-
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 0
+			!IGNITOR_RESOURCE,* {}
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -148,7 +149,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 319.2
+				key = 0 321
 				key = 1 215
 			}
 
@@ -167,3 +168,53 @@
 
     !RESOURCE,*{}
 }
+
+
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-138]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = AJ10-138
+		ratedBurnTime = 440
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.995
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.96
+		cycleReliabilityEnd = 0.99
+        techTransfer = AJ10-104,AJ10-118E:50
+	}
+}
+
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = AJ10-118F
+		ratedBurnTime = 440
+		ignitionReliabilityStart = 0.975
+		ignitionReliabilityEnd = 0.997
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.995
+        techTransfer = AJ10-104,AJ10-118E,AJ10-138:50
+	}
+}
+
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118F]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = AJ10-118K
+		ratedBurnTime = 500
+		ignitionReliabilityStart = 0.975
+		ignitionReliabilityEnd = 0.997
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.995
+        techTransfer = AJ10-118E,AJ10-138,AJ10-118F:50
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -56,6 +56,7 @@
 			{
 				name = NTO
 				ratio = 0.67
+				DrawGauge = False
 			}
 			atmosphereCurve
 			{
@@ -84,15 +85,15 @@
 
 			PROPELLANT
 			{
-				name = UDMH
-				ratio = 0.406
+				name = Aerozine50
+				ratio = 0.33
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name = IWFNA
-				ratio = 0.594
+				name = NTO
+				ratio = 0.67
                 		DrawGauge = False
 			}
 
@@ -148,7 +149,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 321
+				key = 0 320
 				key = 1 215
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -14,6 +14,8 @@
 //  Aerojet Rocketdyne - AJ10-118K:           https://www.rocket.com/delta-ii-stage-2-engine
 //  Norbert Brügge - US Space Rocket Engines: http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
 //  Spaceflight 101 - Delta II 7920:          http://spaceflight101.com/spacerockets/delta-ii-7920/
+//  Encyclopedia Astronautica - AJ10-118F:    http://www.astronautix.com/a/aj10-118f.html
+//  Encyclopedia Astronautica - AJ10-138:     http://www.astronautix.com/a/aj10-138.html
 
 //  Used by:
 
@@ -47,13 +49,13 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.446
+				ratio = 0.33
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.554
+				ratio = 0.67
 			}
 			atmosphereCurve
 			{
@@ -124,14 +126,14 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4654
+				ratio = 0.345
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5346
+				ratio = 0.655
                 		DrawGauge = False
 			}
 
@@ -184,7 +186,7 @@
 }
 
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118F]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
@@ -200,7 +202,7 @@
 }
 
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118F]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-118K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{


### PR DESCRIPTION
I've added TestFlight configs for the AJ10_Adv variants and edited some of their specs (fuel and oxidizer of the 118F).