### PR TITLE
Update RO_RN_USProbes.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
@@ -425,7 +425,7 @@
 	MODULE
 	{
 		name = ModuleRTAntennaPassive
-		Mode1OmniRange = 1E+12
+		OmniRange = 1E+12
 		TRANSMITTER
 		{
 			PacketInterval = 0.9


### PR DESCRIPTION
fix a wrong module definition that also prevented cache creation with RealismExpansion