### PR TITLE
RN fix craft files

### DIFF
--- a/Ships/VAB/RO RN Almaz 2-3-5.craft
+++ b/Ships/VAB/RO RN Almaz 2-3-5.craft
@@ -1,5 +1,5 @@
 ship = RO RN Almaz 2-3-5
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Almaz-2/3/5 for RO¨AG1 - Open solar panels and antennae
 type = VAB
 size = 7.47747946,56.0153999,6.93230247

--- a/Ships/VAB/RO RN Cassini Huygens.craft
+++ b/Ships/VAB/RO RN Cassini Huygens.craft
@@ -1,5 +1,5 @@
 ship = RO RN Cassini Huygens
-version = 1.3.1
+version = 1.1.3
 description = RN Cassini for RSS/RO¨AG1 - Deploy Cassini Antenna¨AG2 - Deploy Huygens parachute and cords¨AG3 - Deploy Huygens antennae
 type = VAB
 size = 10.7029762,59.2781906,8.68759441

--- a/Ships/VAB/RO RN Cygnus Extended.craft
+++ b/Ships/VAB/RO RN Cygnus Extended.craft
@@ -1,5 +1,5 @@
 ship = RO RN Cygnus Extended
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Cygnus Extended for RO¨AG1 - Open solar panels
 type = VAB
 size = 3.99580383,42.4831772,4.10673475

--- a/Ships/VAB/RO RN Cygnus.craft
+++ b/Ships/VAB/RO RN Cygnus.craft
@@ -1,5 +1,5 @@
 ship = RO RN Cygnus
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Cygnus for RO¨AG1 - Open solar panels
 type = VAB
 size = 3.99580383,40.49226,4.10673475

--- a/Ships/VAB/RO RN Explorer 6.craft
+++ b/Ships/VAB/RO RN Explorer 6.craft
@@ -1,5 +1,5 @@
 ship = RO RN Explorer 6
-version = 1.2.2
+version = 1.1.3
 description = RN RO Explorer 6¨Thor-Able II launcher¨AG1 - Deploy Solar Panels
 type = VAB
 size = 3.46797252,28.2769279,3.46797156

--- a/Ships/VAB/RO RN KK Aqua.craft
+++ b/Ships/VAB/RO RN KK Aqua.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK Aqua
-version = 1.3.1
+version = 1.1.3
 description = RN Aqua for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 5.24619198,40.2060852,5.18432236

--- a/Ships/VAB/RO RN KK Aura.craft
+++ b/Ships/VAB/RO RN KK Aura.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK Aura
-version = 1.3.1
+version = 1.1.3
 description = RN Aura for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 5.24619102,39.6596451,5.18432236

--- a/Ships/VAB/RO RN KK Dawn.craft
+++ b/Ships/VAB/RO RN KK Dawn.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK Dawn
-version = 1.3.1
+version = 1.1.3
 description = RN Dawn for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 5.68717003,39.3680725,5.6727705

--- a/Ships/VAB/RO RN KK Deep Impact.craft
+++ b/Ships/VAB/RO RN KK Deep Impact.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK Deep Impact
-version = 1.3.1
+version = 1.1.3
 description = RN Deep Impact for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 5.24618864,39.8594818,5.18432331

--- a/Ships/VAB/RO RN KK Deep Space 1.craft
+++ b/Ships/VAB/RO RN KK Deep Space 1.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK Deep Space 1
-version = 1.3.1
+version = 1.1.3
 description = RN Deep Space 1 for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 4.70955133,39.4981384,4.22047043

--- a/Ships/VAB/RO RN KK MESSENGER.craft
+++ b/Ships/VAB/RO RN KK MESSENGER.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK MESSENGER
-version = 1.3.1
+version = 1.1.3
 description = RN MESSENGER for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 5.68717194,39.9054489,5.6727705

--- a/Ships/VAB/RO RN KK NEAR Shoemaker.craft
+++ b/Ships/VAB/RO RN KK NEAR Shoemaker.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK NEAR Shoemaker
-version = 1.3.1
+version = 1.1.3
 description = RN NEAR for RSS/RO¨AG1 - Deploy Solar Panels
 type = VAB
 size = 5.24618864,38.8956451,5.18432474

--- a/Ships/VAB/RO RN KK Stardust.craft
+++ b/Ships/VAB/RO RN KK Stardust.craft
@@ -1,5 +1,5 @@
 ship = RO RN KK Stardust
-version = 1.3.1
+version = 1.1.3
 description = RN Stardust for RSS/RO¨AG1 - Deploy Solar Panels¨AG2 - Deploy Gel Collector
 type = VAB
 size = 4.71281242,38.8956375,3.94674563

--- a/Ships/VAB/RO RN Luna 13.craft
+++ b/Ships/VAB/RO RN Luna 13.craft
@@ -1,5 +1,5 @@
 ship = RO RN Luna 13
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Luna-13 for RO¨AG1 - Decouple ALS and airbag cover¨AG2 - Inflate airbag¨AG3 - Open als petals¨AG9 - Shutdown main engine¨AG10 - Extend ground sensors
 type = VAB
 size = 10.2001028,44.823761,10.2001114

--- a/Ships/VAB/RO RN Luna 9.craft
+++ b/Ships/VAB/RO RN Luna 9.craft
@@ -1,5 +1,5 @@
 ship = RO RN Luna 9
-version = 1.2.2
+version = 1.1.3
 description = Raidernick's Luna-9 for RO¨AG1 - Decouple ALS and airbag cover¨AG2 - Inflate airbag¨AG3 - Open als petals¨AG9 - Shutdown main engine¨AG10 - Extend ground sensors
 type = VAB
 size = 10.2001038,44.3766479,10.2001114

--- a/Ships/VAB/RO RN Molniya 1.craft
+++ b/Ships/VAB/RO RN Molniya 1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Molniya 1
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Molniya-1 for RO¨AG1 - Deploy probe solar panels
 type = VAB
 size = 10.2001009,44.3766403,10.2001133

--- a/Ships/VAB/RO RN Pioneer 0-1-2.craft
+++ b/Ships/VAB/RO RN Pioneer 0-1-2.craft
@@ -1,5 +1,5 @@
 ship = RO RN Pioneer 0-1-2
-version = 1.3.1
+version = 1.1.3
 description = RN RO Pioneer 0/1/2¨Thor-Able I rocket¨AG1 - Activate Engine Pair 1¨AG2 - Activate Engine Pair 2¨AG3 - Activate Engine Pair 3¨AG4 - Activate Engine Pair 4
 type = VAB
 size = 3.4679718,27.9732933,3.46797156

--- a/Ships/VAB/RO RN Pioneer 3-4.craft
+++ b/Ships/VAB/RO RN Pioneer 3-4.craft
@@ -1,5 +1,5 @@
 ship = RO RN Pioneer 3-4
-version = 1.2.2
+version = 1.1.3
 description = RN RO Pioneer 3-4¨Juno II launcher
 type = VAB
 size = 3.06317377,23.3383369,2.80029154

--- a/Ships/VAB/RO RN Pioneer 5.craft
+++ b/Ships/VAB/RO RN Pioneer 5.craft
@@ -1,5 +1,5 @@
 ship = RO RN Pioneer 5
-version = 1.2.2
+version = 1.1.3
 description = RN RO Pioneer 5 ¨Thor-Delta launcher¨AG1 - Deploy Solar Panels
 type = VAB
 size = 3.46797204,28.2769279,3.46797132

--- a/Ships/VAB/RO RN Pioneer 6.craft
+++ b/Ships/VAB/RO RN Pioneer 6.craft
@@ -1,5 +1,5 @@
 ship = RO RN Pioneer 6
-version = 1.3.1
+version = 1.1.3
 description = RN RO Pioneer 6¨Delta E launcher¨AG1 - Deploy Antennae
 type = VAB
 size = 4.10471153,29.3975143,3.5547843

--- a/Ships/VAB/RO RN Pioneer 7-8-9.craft
+++ b/Ships/VAB/RO RN Pioneer 7-8-9.craft
@@ -1,5 +1,5 @@
 ship = RO RN Pioneer 7-8-9
-version = 1.3.1
+version = 1.1.3
 description = RN RO Pioneer 7-8-9¨Delta E1 launcher¨AG1 - Deploy Antennae
 type = VAB
 size = 4.10470295,29.3975143,3.55477715

--- a/Ships/VAB/RO RN Progress 7K-TG.craft
+++ b/Ships/VAB/RO RN Progress 7K-TG.craft
@@ -1,5 +1,5 @@
 ship = RO RN Progress 7K-TG
-version = 1.2.2
+version = 1.1.3
 description = Raidernick's Progress-7KTG for RO¨AG1 - Deploy antennae
 type = VAB
 size = 10.2017221,47.2491608,10.2017174

--- a/Ships/VAB/RO RN Salyut 1.craft
+++ b/Ships/VAB/RO RN Salyut 1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Salyut 1
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Salyut-1 for RO¨AG1 - Open solar panels and antennae
 type = VAB
 size = 7.47747946,56.9667511,6.93230152

--- a/Ships/VAB/RO RN Salyut 4.craft
+++ b/Ships/VAB/RO RN Salyut 4.craft
@@ -1,5 +1,5 @@
 ship = RO RN Salyut 4
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Salyut-4 for RO¨AG1 - Open solar panels and antennae
 type = VAB
 size = 7.47747946,57.2240829,6.93230152

--- a/Ships/VAB/RO RN Salyut 6.craft
+++ b/Ships/VAB/RO RN Salyut 6.craft
@@ -1,5 +1,5 @@
 ship = RO RN Salyut 6
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Salyut-6 for RO¨AG1 - Open solar panels and antennae
 type = VAB
 size = 7.47747946,57.6575012,6.93230152

--- a/Ships/VAB/RO RN Salyut 7.craft
+++ b/Ships/VAB/RO RN Salyut 7.craft
@@ -1,5 +1,5 @@
 ship = RO RN Salyut 7
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Salyut-7 for RO¨AG1 - Open solar panels and antennae
 type = VAB
 size = 7.47747946,57.6575012,6.93230104

--- a/Ships/VAB/RO RN Skylab.craft
+++ b/Ships/VAB/RO RN Skylab.craft
@@ -1,5 +1,5 @@
 ship = RO RN Skylab
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Skylab for RO¨**NOTE**: Do NOT decouple the micro meteorite shields or left solar panel if you want to use the "intended" version of the station rather than the realistic "broken" version.¨¨AG1 - Deploy station, telescope and small solar panels¨AG2 - Deploy large solar panels¨AG3 - Deploy primary parasol¨AG4 - Deploy Secondary Parasol
 type = VAB
 size = 7.15855789,35.1111832,6.92521095

--- a/Ships/VAB/RO RN Soyuz 7K-OK-A.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-OK-A.craft
@@ -1,5 +1,5 @@
 ship = RO RN Soyuz 7K-OK-A
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Soyuz-7KOKA for RO¨AG1 - Deploy antennae¨AG2 - Toggle "burn" state on descent module¨AG9 - Deploy parachute and decouple heatshield¨AG10 - Decouple orbital module only, for use during abort only
 type = VAB
 size = 10.200263,50.2752228,10.2002764

--- a/Ships/VAB/RO RN Soyuz 7K-OK-P.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-OK-P.craft
@@ -1,5 +1,5 @@
 ship = RO RN Soyuz 7K-OK-P
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Soyuz-7KOKP for RO¨AG1 - Deploy antennae¨AG2 - Toggle "burn" state on descent module¨AG9 - Deploy parachute and decouple heatshield¨AG10 - Decouple orbital module only, for use during abort only
 type = VAB
 size = 10.200263,50.2751312,10.200285

--- a/Ships/VAB/RO RN Soyuz 7K-T-AF.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-T-AF.craft
@@ -1,5 +1,5 @@
 ship = RO RN Soyuz 7K-T-AF
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Soyuz-7KTAF for RO¨AG1 - Deploy antennae¨AG2 - Toggle "burn" state on descent module¨AG9 - Deploy parachute and decouple heatshield¨AG10 - Decouple orbital module only, for use during abort only
 type = VAB
 size = 10.200263,50.2754059,10.2002916

--- a/Ships/VAB/RO RN Soyuz 7K-T.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-T.craft
@@ -1,5 +1,5 @@
 ship = RO RN Soyuz 7K-T
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Soyuz-7KT for RO¨AG1 - Deploy antennae¨AG2 - Toggle "burn" state on descent module¨AG9 - Deploy parachute and decouple heatshield¨AG10 - Decouple orbital module only, for use during abort only
 type = VAB
 size = 10.2002659,49.6195755,10.200284

--- a/Ships/VAB/RO RN Soyuz ASTP.craft
+++ b/Ships/VAB/RO RN Soyuz ASTP.craft
@@ -1,5 +1,5 @@
 ship = RO RN Soyuz ASTP
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Soyuz-ASTP for RO¨AG1 - Deploy antennae¨AG2 - Toggle "burn" state on descent module¨AG9 - Deploy parachute and decouple heatshield¨AG10 - Decouple orbital module only, for use during abort only
 type = VAB
 size = 10.2002668,49.9299469,10.2002754

--- a/Ships/VAB/RO RN TKS.craft
+++ b/Ships/VAB/RO RN TKS.craft
@@ -1,5 +1,5 @@
 ship = RO RN TKS
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's TKS for RO¨AG1 - Deploy antennae¨AG3 - Decouple rcs and les tower, use ONLY during an abort¨AG9 - Deploy parachute¨AG10 - Activate retro motor
 type = VAB
 size = 7.47747946,59.0311584,6.93230247

--- a/Ships/VAB/RO RN Tiros-1.craft
+++ b/Ships/VAB/RO RN Tiros-1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Tiros-1
-version = 1.2.2
+version = 1.1.3
 description = RN RO Tiros-1¨Thor-Able II launcher¨AG1 - Deploy Weights
 type = VAB
 size = 3.46797252,28.2769241,3.46797132

--- a/Ships/VAB/RO RN Transit 2a - Grab 1.craft
+++ b/Ships/VAB/RO RN Transit 2a - Grab 1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Transit 2a - Grab 1
-version = 1.2.2
+version = 1.1.3
 description = RN RO Transit 2a/Grab 1¨Thor-Able Star launcher
 type = VAB
 size = 3.46796894,25.4980621,3.4679687

--- a/Ships/VAB/RO RN Voskhod 1.craft
+++ b/Ships/VAB/RO RN Voskhod 1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Voskhod 1
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Voskhod-1 for RO¨AG1 - Deploy antennae¨AG10 - Activate backup retro module
 type = VAB
 size = 10.2053576,43.5127525,10.205368

--- a/Ships/VAB/RO RN Voskhod 2.craft
+++ b/Ships/VAB/RO RN Voskhod 2.craft
@@ -1,5 +1,5 @@
 ship = RO RN Voskhod 2
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Voskhod-2 for RO¨AG1 - Deploy antennae¨AG9 - Inflate/Deflate airlock¨AG10 - Activate backup retro module
 type = VAB
 size = 10.2053547,43.9750214,10.2053661

--- a/Ships/VAB/RO RN Vostok 1.craft
+++ b/Ships/VAB/RO RN Vostok 1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Vostok 1
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Vostok-1 for RO¨AG1 - Deploy antennae
 type = VAB
 size = 10.2061214,37.9652481,10.2061119

--- a/Ships/VAB/RO RN Zond 7K-L1.craft
+++ b/Ships/VAB/RO RN Zond 7K-L1.craft
@@ -1,5 +1,5 @@
 ship = RO RN Zond 7K-L1
-version = 1.3.1
+version = 1.1.3
 description = Raidernick's Zond-7KL1 for RO¨AG1 - Deploy antennae¨AG2 - Toggle "burn" state on descent module¨AG9 - Deploy parachute and decouple heatshield¨AG10 - Decouple top avionics package only, for use during abort only
 type = VAB
 size = 7.47747946,57.3028946,6.93230152

--- a/Subassemblies/KK Atlas V 401.craft
+++ b/Subassemblies/KK Atlas V 401.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 401
-version = 1.2.2
+version = 1.1.3
 description = LEO - 9,797 kg and GTO - 4,750 kg. Use 400 series fairings.
 type = None
 size = 4.11850214,45.2000504,4.07266998

--- a/Subassemblies/KK Atlas V 402.craft
+++ b/Subassemblies/KK Atlas V 402.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 402
-version = 1.2.2
+version = 1.1.3
 description = LEO - 12,500 kg. Use 400 series fairings.
 type = None
 size = 4.11850214,45.2000504,4.07266998

--- a/Subassemblies/KK Atlas V 411.craft
+++ b/Subassemblies/KK Atlas V 411.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 411
-version = 1.2.2
+version = 1.1.3
 description = LEO - 12,150 kg and GTO - 5,950 kg. Use 400 series fairings.
 type = None
 size = 4.11850214,45.4484406,5.69157791

--- a/Subassemblies/KK Atlas V 412.craft
+++ b/Subassemblies/KK Atlas V 412.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 412
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown kg. Use 400 series fairings.
 type = None
 size = 4.11850214,45.4484406,5.69157791

--- a/Subassemblies/KK Atlas V 421.craft
+++ b/Subassemblies/KK Atlas V 421.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 421
-version = 1.2.2
+version = 1.1.3
 description = LEO - 14,067 kg and GTO - 6,890 kg. Use 400 series fairings.
 type = None
 size = 4.11850262,45.4484406,7.36008453

--- a/Subassemblies/KK Atlas V 422.craft
+++ b/Subassemblies/KK Atlas V 422.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 422
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown kg. Use 400 series fairings.
 type = None
 size = 4.11850262,45.4484406,7.36008453

--- a/Subassemblies/KK Atlas V 431.craft
+++ b/Subassemblies/KK Atlas V 431.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 431
-version = 1.2.2
+version = 1.1.3
 description = LEO - 15,718 kg and GTO - 7,700 kg. Use 400 series fairings.
 type = None
 size = 4.11850262,45.4662857,7.36008453

--- a/Subassemblies/KK Atlas V 432.craft
+++ b/Subassemblies/KK Atlas V 432.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 432
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown kg. Use 400 series fairings.
 type = None
 size = 4.11850166,45.4662781,7.36008453

--- a/Subassemblies/KK Atlas V 501.craft
+++ b/Subassemblies/KK Atlas V 501.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 501
-version = 1.2.2
+version = 1.1.3
 description = LEO - 8,123 kg and GTO - 3,775 kg. Use 500 series fairings.
 type = None
 size = 5.29435444,45.4029999,5.2943573

--- a/Subassemblies/KK Atlas V 502.craft
+++ b/Subassemblies/KK Atlas V 502.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 502
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown. Use 500 series fairings.
 type = None
 size = 5.29435396,45.4029999,5.29435349

--- a/Subassemblies/KK Atlas V 511.craft
+++ b/Subassemblies/KK Atlas V 511.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 511
-version = 1.2.2
+version = 1.1.3
 description = LEO - 10,986 kg and GTO - 5,250 kg. Use 500 series fairings.
 type = None
 size = 5.29435349,45.6513901,6.30242157

--- a/Subassemblies/KK Atlas V 512.craft
+++ b/Subassemblies/KK Atlas V 512.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 512
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown. Use 500 series fairings.
 type = None
 size = 5.29435444,45.6513901,6.30241966

--- a/Subassemblies/KK Atlas V 521.craft
+++ b/Subassemblies/KK Atlas V 521.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 521
-version = 1.2.2
+version = 1.1.3
 description = LEO - 13,490 kg and GTO - 6,475 kg. Use 500 series fairings.
 type = None
 size = 5.29435444,45.6513901,7.36008453

--- a/Subassemblies/KK Atlas V 522.craft
+++ b/Subassemblies/KK Atlas V 522.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 522
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown. Use 500 series fairings.
 type = None
 size = 5.29435396,45.6513901,7.36008453

--- a/Subassemblies/KK Atlas V 531.craft
+++ b/Subassemblies/KK Atlas V 531.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 531
-version = 1.2.2
+version = 1.1.3
 description = LEO - 15,575 kg and GTO - 7,475 kg. Use 500 series fairings.
 type = None
 size = 5.29435396,45.6692352,7.36008453

--- a/Subassemblies/KK Atlas V 532.craft
+++ b/Subassemblies/KK Atlas V 532.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 532
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown. Use 500 series fairings.
 type = None
 size = 5.29435396,45.6692467,7.36009216

--- a/Subassemblies/KK Atlas V 541.craft
+++ b/Subassemblies/KK Atlas V 541.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 541
-version = 1.2.2
+version = 1.1.3
 description = LEO - 17,443 kg and GTO - 8,290 kg. Use 500 series fairings.
 type = None
 size = 5.40702868,45.6692352,7.36008453

--- a/Subassemblies/KK Atlas V 542.craft
+++ b/Subassemblies/KK Atlas V 542.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 542
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown. Use 500 series fairings.
 type = None
 size = 5.4070282,45.6692276,7.36008263

--- a/Subassemblies/KK Atlas V 551.craft
+++ b/Subassemblies/KK Atlas V 551.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 551
-version = 1.2.2
+version = 1.1.3
 description = LEO - 18,814 kg and GTO - 8,900 kg. Use 500 series fairings.
 type = None
 size = 5.51838255,45.6692352,7.36008453

--- a/Subassemblies/KK Atlas V 552.craft
+++ b/Subassemblies/KK Atlas V 552.craft
@@ -1,5 +1,5 @@
 ship = Atlas V 552
-version = 1.2.2
+version = 1.1.3
 description = LEO - unknown. Use 500 series fairings.
 type = None
 size = 5.51838207,45.6692352,7.36008453

--- a/Subassemblies/KK Delta IV Heavy.craft
+++ b/Subassemblies/KK Delta IV Heavy.craft
@@ -1,5 +1,5 @@
 ship = Delta IV Heavy
-version = 1.2.2
+version = 1.1.3
 description = LEO - 25,980 kg and GTO - 14,220 kg. RS-68A
 type = None
 size = 16.0653839,52.0665092,7.03615665

--- a/Subassemblies/KK Delta IV Medium+ 4,2.craft
+++ b/Subassemblies/KK Delta IV Medium+ 4,2.craft
@@ -1,5 +1,5 @@
 ship = Delta IV Medium+ 4,2
-version = 1.2.2
+version = 1.1.3
 description = LEO - 12,000 kg and GTO - 6,390 kg. RS-68A
 type = None
 size = 8.93518829,50.9269753,5.70554256

--- a/Subassemblies/KK Delta IV Medium+ 5,2.craft
+++ b/Subassemblies/KK Delta IV Medium+ 5,2.craft
@@ -1,5 +1,5 @@
 ship = Delta IV Medium+ 5,2
-version = 1.2.2
+version = 1.1.3
 description = LEO - 10,220 kg and GTO - 5,490 kg. RS-68A
 type = None
 size = 8.93584251,52.0478058,7.03615761

--- a/Subassemblies/KK Delta IV Medium+ 5,4.craft
+++ b/Subassemblies/KK Delta IV Medium+ 5,4.craft
@@ -1,5 +1,5 @@
 ship = Delta IV Medium+ 5,4
-version = 1.2.2
+version = 1.1.3
 description = LEO - 12,820 kg and GTO - 7,300 kg. RS-68A
 type = None
 size = 9.06464767,52.0478058,7.03615713

--- a/Subassemblies/KK Delta IV Medium.craft
+++ b/Subassemblies/KK Delta IV Medium.craft
@@ -1,5 +1,5 @@
 ship = Delta IV Medium
-version = 1.2.2
+version = 1.1.3
 description = LEO - 8,510 kg and GTO - 4,440 kg. RS-68A
 type = None
 size = 5.18062019,50.9269753,5.70554256

--- a/Subassemblies/RN Delta 0900.craft
+++ b/Subassemblies/RN Delta 0900.craft
@@ -1,5 +1,5 @@
 ship = Delta 0900
-version = 1.3.1
+version = 1.1.3
 description = MEO - 800 kg.
 type = None
 size = 4.34811783,34.105835,4.32078552

--- a/Subassemblies/RN Delta A.craft
+++ b/Subassemblies/RN Delta A.craft
@@ -1,5 +1,5 @@
 ship = Delta A
-version = 1.2.2
+version = 1.1.3
 description = LEO - 320 kg.
 type = None
 size = 3.46744347,27.123642,3.4674437

--- a/Subassemblies/RN Delta B.craft
+++ b/Subassemblies/RN Delta B.craft
@@ -1,5 +1,5 @@
 ship = Delta B
-version = 1.2.2
+version = 1.1.3
 description = LEO - 375 kg.
 type = None
 size = 3.46744347,28.0053825,3.4674437

--- a/Subassemblies/RN Delta C.craft
+++ b/Subassemblies/RN Delta C.craft
@@ -1,5 +1,5 @@
 ship = Delta C
-version = 1.2.2
+version = 1.1.3
 description = GTO - 410 kg.
 type = None
 size = 3.46744347,27.8653831,3.4674437

--- a/Subassemblies/RN Delta C1.craft
+++ b/Subassemblies/RN Delta C1.craft
@@ -1,5 +1,5 @@
 ship = Delta C1
-version = 1.2.2
+version = 1.1.3
 description = LEO - 600 kg.
 type = None
 size = 3.46744347,28.0053825,3.46744347

--- a/Subassemblies/RN Delta D.craft
+++ b/Subassemblies/RN Delta D.craft
@@ -1,5 +1,5 @@
 ship = Delta D
-version = 1.3.1
+version = 1.1.3
 description = GTO - 104 kg.
 type = None
 size = 4.104702,27.865387,3.55477762

--- a/Subassemblies/RN Delta E.craft
+++ b/Subassemblies/RN Delta E.craft
@@ -1,5 +1,5 @@
 ship = Delta E
-version = 1.3.1
+version = 1.1.3
 description = LEO - 735 kg.
 type = None
 size = 4.10471201,25.6653748,3.55478454

--- a/Subassemblies/RN Delta E1.craft
+++ b/Subassemblies/RN Delta E1.craft
@@ -1,5 +1,5 @@
 ship = Delta E1
-version = 1.3.1
+version = 1.1.3
 description = GTO - 205 kg.
 type = None
 size = 4.10470295,25.8053741,3.55477715

--- a/Subassemblies/RN Delta G.craft
+++ b/Subassemblies/RN Delta G.craft
@@ -1,5 +1,5 @@
 ship = Delta G
-version = 1.3.1
+version = 1.1.3
 description = LEO - 650 kg.
 type = None
 size = 4.104702,23.8979416,3.55477762

--- a/Subassemblies/RN Delta J.craft
+++ b/Subassemblies/RN Delta J.craft
@@ -1,5 +1,5 @@
 ship = Delta J
-version = 1.3.1
+version = 1.1.3
 description = LTO - 250 kg.
 type = None
 size = 4.104702,25.2914848,3.55477762

--- a/Subassemblies/RN Delta L.craft
+++ b/Subassemblies/RN Delta L.craft
@@ -1,5 +1,5 @@
 ship = Delta L
-version = 1.3.1
+version = 1.1.3
 description = GTO - 356 kg.
 type = None
 size = 4.10818005,34.105835,3.55778885

--- a/Subassemblies/RN Delta M.craft
+++ b/Subassemblies/RN Delta M.craft
@@ -1,5 +1,5 @@
 ship = Delta M
-version = 1.3.1
+version = 1.1.3
 description = GTO - 356 kg.
 type = None
 size = 4.108181,34.105835,3.55778885

--- a/Subassemblies/RN Delta M6.craft
+++ b/Subassemblies/RN Delta M6.craft
@@ -1,5 +1,5 @@
 ship = Delta M6
-version = 1.3.1
+version = 1.1.3
 description = GTO - 454 kg.
 type = None
 size = 4.22119713,34.1058426,4.25098658

--- a/Subassemblies/RN Delta N.craft
+++ b/Subassemblies/RN Delta N.craft
@@ -1,5 +1,5 @@
 ship = Delta N
-version = 1.3.1
+version = 1.1.3
 description = LEO - 900 kg.
 type = None
 size = 4.10817909,34.105835,3.55778909

--- a/Subassemblies/RN Delta N6.craft
+++ b/Subassemblies/RN Delta N6.craft
@@ -1,5 +1,5 @@
 ship = Delta N6
-version = 1.3.1
+version = 1.1.3
 description = LEO - 1600 kg.
 type = None
 size = 4.22119713,34.1058426,4.25098658

--- a/Subassemblies/RN Dnepr 1 (5.25m Fairing).craft
+++ b/Subassemblies/RN Dnepr 1 (5.25m Fairing).craft
@@ -1,5 +1,5 @@
 ship = Dnepr 1 (5.25m Fairing)
-version = 1.2.2
+version = 1.1.3
 description = LEO Yasny - 3,200 kg and LEO Baikonur - 3,600 kg.
 type = None
 size = 4.32108498,35.2465286,4.32108498

--- a/Subassemblies/RN Dnepr 1 (5.25m) DU-802.craft
+++ b/Subassemblies/RN Dnepr 1 (5.25m) DU-802.craft
@@ -1,5 +1,5 @@
 ship = Dnepr 1 (5.25m) DU-802
-version = 1.3.1
+version = 1.1.3
 description = GEO - 300kg (unconfirmed). 5.25m fairing.
 type = None
 size = 4.32108498,34.246521,4.32108402

--- a/Subassemblies/RN Dnepr 1 (7.45m Fairing).craft
+++ b/Subassemblies/RN Dnepr 1 (7.45m Fairing).craft
@@ -1,5 +1,5 @@
 ship = Dnepr 1 (7.45m Fairing)
-version = 1.2.2
+version = 1.1.3
 description = LEO Yasny - 3,200 kg and LEO Baikonur - 3,600 kg.
 type = None
 size = 4.32108402,37.4478683,4.32108307

--- a/Subassemblies/RN Dnepr 1 (7.45m) DU-802.craft
+++ b/Subassemblies/RN Dnepr 1 (7.45m) DU-802.craft
@@ -1,5 +1,5 @@
 ship = Dnepr 1 (7.45m) DU-802
-version = 1.3.1
+version = 1.1.3
 description = GEO - 300kg (unconfirmed). 7.45m fairing.
 type = None
 size = 4.32108498,36.4478607,4.32108402

--- a/Subassemblies/RN Juno II.craft
+++ b/Subassemblies/RN Juno II.craft
@@ -1,5 +1,5 @@
 ship = Juno II
-version = 1.2.2
+version = 1.1.3
 description = Juno II launcher. Based on Jupiter missile.
 type = None
 size = 3.06317377,23.3383369,2.80029154

--- a/Subassemblies/RN Kosmos-3.craft
+++ b/Subassemblies/RN Kosmos-3.craft
@@ -1,5 +1,5 @@
 ship = Kosmos-3
-version = 1.3.1
+version = 1.1.3
 description = LEO - 1,250 kg.
 type = None
 size = 3.39634609,32.4499512,3.39634562

--- a/Subassemblies/RN Kosmos-3M.craft
+++ b/Subassemblies/RN Kosmos-3M.craft
@@ -1,5 +1,5 @@
 ship = Kosmos-3M
-version = 1.3.1
+version = 1.1.3
 description = SSO - 850 kg.
 type = None
 size = 3.39634609,32.4499588,3.39634585

--- a/Subassemblies/RN Proton-K.craft
+++ b/Subassemblies/RN Proton-K.craft
@@ -1,5 +1,5 @@
 ship = Proton-K
-version = 1.3.1
+version = 1.1.3
 description = Proton-K launcher for RO RSS
 type = None
 size = 7.47747946,40.88134,6.93230534

--- a/Subassemblies/RN R-36MUTTkh.craft
+++ b/Subassemblies/RN R-36MUTTkh.craft
@@ -1,5 +1,5 @@
 ship = R-36MUTTkh
-version = 1.2.2
+version = 1.1.3
 description = Mod 4  10x 0.55Mt MIRV 8.8t(includes 3rd stage) to 16000km  in
 type = None
 size = 4.32108498,35.2465286,4.32108307

--- a/Subassemblies/RN Thor-Able I.craft
+++ b/Subassemblies/RN Thor-Able I.craft
@@ -1,5 +1,5 @@
 ship = Thor-Able I
-version = 1.2.2
+version = 1.1.3
 description = USAF Thor-Able I launcher.
 type = None
 size = 3.4679718,26.7511826,3.46797132

--- a/Subassemblies/RN Thor-Able II.craft
+++ b/Subassemblies/RN Thor-Able II.craft
@@ -1,5 +1,5 @@
 ship = Thor-Able II
-version = 1.2.2
+version = 1.1.3
 description = USAF Thor-Able II launcher.
 type = None
 size = 3.46797276,27.1236458,3.4679718

--- a/Subassemblies/RN Thor-Able Star Thor-Epsilon.craft
+++ b/Subassemblies/RN Thor-Able Star Thor-Epsilon.craft
@@ -1,5 +1,5 @@
 ship = Thor-Able Star Thor-Epsilon
-version = 1.2.2
+version = 1.1.3
 description = USAF Thor-Able Star, NASA Thor-Epsilon launcher.
 type = None
 size = 3.46796799,23.3823586,3.46796918

--- a/Subassemblies/RN Thor-Burner I.craft
+++ b/Subassemblies/RN Thor-Burner I.craft
@@ -1,5 +1,5 @@
 ship = Thor-Burner I
-version = 1.2.2
+version = 1.1.3
 description = USAF Thor-Burner I launcher.
 type = None
 size = 3.4679718,20.5695343,3.46797156

--- a/Subassemblies/RN Thor-Delta.craft
+++ b/Subassemblies/RN Thor-Delta.craft
@@ -1,5 +1,5 @@
 ship = Thor-Delta
-version = 1.2.2
+version = 1.1.3
 description = USAF Thor-Delta launcher
 type = None
 size = 3.4679718,27.1236458,3.46797132


### PR DESCRIPTION
-Make it so craft files can be loaded from ksp 1.1.3 onwards, as they
all work perfectly fine back until at least that point.