### PR TITLE
[Maintenance] SXT X-405 engine updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -332,51 +332,6 @@
 	@bulkheadProfiles = size1
 
 	%engineType = X405
-	%engineTypeMult = 1
-	%ignoreMass = False
-	%massOffset = 0
-	%useVerniers = True
-    %vernierThrust = 1
-
-	//  Main engine.
-
-	@MODULE[ModuleEngines*]
-	{
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Kerosene
-			@ratio = 0.3874
-		}
-
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.6126
-		}
-
-		PROPELLANT
-		{
-			name = HTP
-			ratio = 0.0146
-			ignoreForIsp = True
-			DrawGauge = False
-		}
-
-		@atmosphereCurve
-		{
-			@key,0 = 0 270
-			@key,1 = 1 248
-		}
-	}
-
-	//  Main engine gimbal module.
-
-	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
-	{
-		@gimbalRange = 5.0
-		%useGimbalResponseSpeed = True
-		%gimbalResponseSpeed = 16
-	}
 
 	!MODULE[ModuleRCS],*{}
 }
@@ -389,128 +344,38 @@
 
 @PART[SXTX405]:AFTER[RealismOverhaulEnginesPost]
 {
-	// Turbopump exhausts.
+	//  Configure the thrust transforms of the
+	//  main engine and turbopump exhausts.
 
-	MODULE
+	@MODULE[ModuleEngines*]
 	{
-		name = ModuleEngines
-		engineID = TurbopumpExhaust
-		thrustVectorTransformName = fxPointA
-		exhaustDamage = False
-		ignitionThreshold = 0.1
-		minThrust = 1
-		maxThrust = 1
-		heatProduction = 0
-		EngineType = LiquidFuel
-		ullage = True
-		pressureFed = False
-		ignitions = 1
-
-		IGNITOR_RESOURCE
+		THRUST_TRANSFORM
 		{
-			name = ElectricCharge
-			amount = 0.025
+			name = thrustTransform
+			overallMultiplier = 1.0
 		}
 
-		PROPELLANT
+		THRUST_TRANSFORM
 		{
-			name = Kerosene
-			ratio = 0.3874
-			DrawGauge = False
-		}
-
-		PROPELLANT
-		{
-			name = LqdOxygen
-			ratio = 0.6126
-			DrawGauge = False
-		}
-
-		PROPELLANT
-		{
-			name = HTP
-			ratio = 0.0146
-			ignoreForIsp = True
-			DrawGauge = False
-		}
-
-		atmosphereCurve
-		{
-			key = 0 278
-			key = 1 254
-		}
-	}
-
-	// Turbopump exhausts engine configuration.
-
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		engineID = TurbopumpExhaust
-		isMaster = False
-		configuration = X-405-Exhaust
-
-		CONFIG
-		{
-			name = X-405-Exhaust
-			minThrust = 1
-			maxThrust = 1
-			heatProduction = 0
-			ullage = True
-			pressureFed = False
-			ignitions = 1
-
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.05
-			}
-
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.3874
-				DrawGauge = False
-			}
-
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.6126
-				DrawGauge = False
-			}
-
-			PROPELLANT
-			{
-				name = HTP
-				ratio = 0.02
-				ignoreForIsp = True
-				DrawGauge = False
-			}
-
-			atmosphereCurve
-			{
-				key = 0 270
-				key = 1 248
-			}
+			name = fxPointA
+			overallMultiplier = 0.01
 		}
 	}
 
 	// Setup the gimbals for the turbopump exhausts.
 
-	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet1]]
+	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet?]],*
 	{
 		@gimbalRange = 25.0
 		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
 	}
 
-	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[jet2]]
+	// Remove the extra variants.
+
+	@MODULE[ModuleEngineConfigs]
 	{
-		@gimbalRange = 25.0
-		%useGimbalResponseSpeed = True
-		%gimbalResponseSpeed = 16
+		!CONFIG:HAS[~name[X-405]],*{}
 	}
 }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTX405.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTX405.cfg
@@ -1,62 +1,56 @@
 //  ==================================================
-//  X-405 Vanguard engine plume setup.
+//  X-405 engine plume setup.
 //  ==================================================
 
 @PART[SXTX405]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
-    {
-        %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[fxPointA]]
-    {
-        %powerEffectName = Solid-Sepmotor
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngineConfigs]:HAS[#configuration[X-405]]
-    {
-        @CONFIG,*
-        {
-            %powerEffectName = Kerolox-Lower
-        }
-    }
-
-    @MODULE[ModuleEngineConfigs]:HAS[#configuration[X-405-Exhaust]]
-    {
-        @CONFIG,*
-        {
-            %powerEffectName = Solid-Sepmotor
-        }
-    }
-
-    //  Main engine plume setup.
-
     PLUME
     {
         name = Kerolox-Lower
         transformName = thrustTransform
-        flarePosition = 0,0,-0.1
-        flareScale = 0.325
-        plumePosition = 0,0,0
+        plumePosition = 0.0, 0.0, 0.0
         plumeScale = 0.325
+        flarePosition = 0.0, 0.0, -0.1
+        flareScale = 0.325
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 0.325
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
         energy = 1.0
         speed = 0.75
     }
-
-    //  Turbopump exhaust plume setup.
 
     PLUME
     {
         name = Solid-Sepmotor
         transformName = fxPointA
-        localPosition = 0,0,-0.1
-        fixedScale = 0.2
+        plumePosition = 0.0, 0.0, -0.1
+        plumeScale = 0.2
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 1.0
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 1.0
+        slagPosition = 0.0, 0.0, 0.0
+        slagScale = 1.0
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
         energy = 0.2
         speed = 0.5
+    }
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        %powerEffectName = Kerolox-Lower
+        %runningEffectName = Solid-Sepmotor
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[X-405]
+        {
+            %powerEffectName = Kerolox-Lower
+        }
     }
 }


### PR DESCRIPTION
**Change Log:**

* Update the turbopump exhaust modules to use the newer THRUST_TRANSFORM feature of RF (fixes some TF issues).
* Add a better patch for the turbopump exhaust gimbal modules.
* Remove the X-405H variant (does not make any sense for that part model and also handled by the BDB X-405H engine).
* Update the RealPlume patch for the turbopump exhaust changes.