### PR TITLE
[Bugfix] DECQ R-7 vernier engines

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -46,12 +46,12 @@
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @fuelCrossFeed = False
-    !explosionPotential = NULL
+    !explosionPotential = DELETE
     @bulkheadProfiles = size1
     %crewCapacity = 0
     %vesselType = Probe
     @tags ^= :$: command control probe satellite sputnik
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleCommand]
     {
@@ -167,7 +167,7 @@
     @fuelCrossFeed = False
     @CoMOffset = 0.0, 0.802, 0.0
     @tags ^= :$: break decouple separat split stag
-    !specPower = NULL
+    !specPower = DELETE
 
     !MODULE[ModuleCommand],*{}
 
@@ -214,7 +214,7 @@
     %stageOffset = 1
     %childStageOffset = 1
     @tags ^= :$: abort booster emergency explo ?les l.e.s malfunc ?rud safe solid surviv
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleEngines*]
     {
@@ -331,7 +331,7 @@
     %childStageOffset = 1
     @stagingIcon = SOLID_BOOSTER
     @tags ^= :$: abort booster emergency explo ?les l.e.s malfunc ?rud safe solid surviv
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleEngines*],*
     {
@@ -455,7 +455,7 @@
     @stagingIcon = FUEL_TANK
     %CoMOffset = 0.0, 2.0, 0.0
     @tags = aero )cap cargo cone contain drag fairing hollow inter nose payload protect R7 rocket shroud soyuz stage (stor transport
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleAnimateGeneric]:HAS[#animationName[ANIM]]
     {
@@ -573,7 +573,7 @@
     @stagingIcon = FUEL_TANK
     %CoMOffset = 0.0, 2.0, 0.0
     @tags = aero )cap cargo cone contain drag fairing hollow inter nose payload protect R7 rocket shroud soyuz stage (stor transport
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleAnimateGeneric]
     {
@@ -691,7 +691,7 @@
     %fuelCrossFeed = False
     %stackSymmetry = 1
     @tags ^= :$: aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleDecouple]
     {
@@ -738,7 +738,7 @@
     %fuelCrossFeed = False
     %stackSymmetry = 1
     @tags ^= :$: aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleDecouple]
     {
@@ -784,8 +784,8 @@
     %stagingIcon = DECOUPLER_HOR
     %stackSymmetry = 1
     @tags ^= :$: break decouple separat split stag
-    !specPower = NULL
-    !meshes = NULL
+    !specPower = DELETE
+    !meshes = DELETE
 
     @MODULE[ModuleDecouple]
     {
@@ -826,7 +826,7 @@
     %childStageOffset = 1
     %stagingIcon = DECOUPLER_HOR
     @tags ^= :$: break decouple separat split stag
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleDecouple]
     {
@@ -1047,7 +1047,7 @@
 {
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     MODEL
     {
@@ -1144,7 +1144,6 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = MainEngine
         @minThrust = 269.7
         @maxThrust = 298.0
         @heatProduction = 88
@@ -1172,35 +1171,7 @@
         }
     }
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        %engineID = VernierEngine
-        @minThrust = 6.0
-        @maxThrust = 6.0
-        @heatProduction = 10
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3853
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6147
-            %DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 326
-            @key,1 = 1 141
-        }
-    }
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]],*{}
 }
 
 //  ==================================================
@@ -1211,6 +1182,28 @@
 
 @PART[RD_0110]:AFTER[RealismOverhaulEngines]
 {
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        !THRUST_TRANSFORM,*{}
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform
+            overallMultiplier = 1.0
+        }
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform2
+            overallMultiplier = 0.0134
+        }
+    }
+
+    // Setup the gimbals for the vernier engines.
+
     @MODULE[ModuleGimbal]
     {
         @gimbalRange = 45.0
@@ -1254,7 +1247,7 @@
     %childStageOffset = 1
     @bulkheadProfiles = size2
     @tags ^= :$: break decouple separat split stag
-    !specPower = NULL
+    !specPower = DELETE
 
     @MODULE[ModuleDecouple]
     {
@@ -1296,7 +1289,7 @@
     %crewCapacity = 0
     %vesselType = Probe
     @tags ^= :$: command control (core fly fueltank liquid oxidizer probe propellant propuls RD-108 RD-118 rocket sas space stab steer
-    !specPower = NULL
+    !specPower = DELETE
 
     %engineType = RD108-118
     %engineTypeMult = 1
@@ -1331,7 +1324,6 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = CoreMainEngine
         @minThrust = 918.3
         @maxThrust = 918.3
         @heatProduction = 90
@@ -1367,87 +1359,9 @@
         }
     }
 
-    //  Y axis vernier engines.
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]],*{}
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        %engineID = CoreVernierEngine
-        @minThrust = 34.0
-        @maxThrust = 34.0
-        @heatProduction = 10
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3531
-            %DrawGauge = True
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6274
-            %DrawGauge = False
-        }
-
-        PROPELLANT
-        {
-            name = HTP
-            ratio = 0.0195
-            DrawGauge = False
-            ignoreForIsp = True
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 313
-            @key,1 = 1 241
-        }
-    }
-
-    //  X axis vernier engines.
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform3]]
-    {
-        %engineID = CoreVernierEngine
-        @minThrust = 34.0
-        @maxThrust = 34.0
-        @heatProduction = 10
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3531
-            %DrawGauge = False
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6274
-            %DrawGauge = False
-        }
-
-        PROPELLANT
-        {
-            name = HTP
-            ratio = 0.0195
-            DrawGauge = False
-            ignoreForIsp = True
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 313
-            @key,1 = 1 241
-        }
-    }
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform3]],*{}
 
     !MODULE[ModuleDataTransmitter],*{}
 
@@ -1529,135 +1443,40 @@
     @manufacturer = TsSKB-Progress
     @description = The Block A is one of the few parts that still remain mostly unchanged from the original R-7 launch vehicle design. A very reliable element, powered by a single RD-108 engine with four verniers for attitude control. It is ignited on the ground, along with the Blocks B,V,G and D.
 
-    //  Main engine setup.
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
 
-    @MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %isMaster = True
-        %engineID = CoreMainEngine
+        !THRUST_TRANSFORM,*{}
 
-        @CONFIG[*]:HAS[@PROPELLANT[Kerosene]]
+        THRUST_TRANSFORM
         {
-            OtherModules
-            {
-                CoreVernierEngine = RD-108-118-Verniers-RG1
-            }
+            name = thrustTransform
+            overallMultiplier = 1.0
         }
 
-        @CONFIG[*]:HAS[@PROPELLANT[Syntin]]
+        //  Two separate vernier engine sets
+        //  so half the thrust for each one.
+
+        THRUST_TRANSFORM
         {
-            OtherModules
-            {
-                CoreVernierEngine = RD-108-118-Verniers-Syntin
-            }
+            name = thrustTransform2
+            overallMultiplier = 0.0185
+        }
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform3
+            overallMultiplier = 0.0185
         }
     }
 
-    //  Vernier engine setup.
-
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        configuration = RD-108-118-Verniers-RG1
-        isMaster = False
-        engineID = CoreVernierEngine
-
-        CONFIG
-        {
-            name = RD-108-118-Verniers-RG1
-            minThrust = 34.0
-            maxThrust = 34.0
-            heatProduction = 10
-            ullage = True
-            pressureFed = False
-            ignitions = 1
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.025
-            }
-
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3680
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6320
-                DrawGauge = False
-            }
-
-            PROPELLANT
-            {
-                name = HTP
-                ratio = 0.0195
-                DrawGauge = False
-                ignoreForIsp = True
-            }
-
-            atmosphereCurve
-            {
-                key = 0 313
-                key = 1 250
-            }
-        }
-
-        CONFIG
-        {
-            name = RD-108-118-Verniers-Syntin
-            minThrust = 34.0
-            maxThrust = 34.0
-            heatProduction = 10
-            ullage = True
-            pressureFed = False
-            ignitions = 1
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.025
-            }
-
-            PROPELLANT
-            {
-                name = Syntin
-                ratio = 0.3594
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6406
-                DrawGauge = False
-            }
-
-            PROPELLANT
-            {
-                name = HTP
-                ratio = 0.0195
-                DrawGauge = False
-                ignoreForIsp = True
-            }
-
-            atmosphereCurve
-            {
-                key = 0 313
-                key = 1 250
-            }
-        }
-    }
-
-    //  Y axis vernier engine gimbal setup.
+    //  Y axis vernier engines gimbal setup.
 
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
     {
-        !gimbalRange,* = NULL
+        !gimbalRange,* = DELETE
         %gimbalRangeYP = 45.0
         %gimbalRangeYN = 45.0
         %gimbalRangeXP = 0
@@ -1666,11 +1485,11 @@
         @gimbalResponseSpeed = 16
     }
 
-    //  X axis vernier engine gimbal setup.
+    //  X axis vernier engines gimbal setup.
 
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal2]]
     {
-        !gimbalRange,* = NULL
+        !gimbalRange,* = DELETE
         %gimbalRangeYP = 0
         %gimbalRangeYN = 0
         %gimbalRangeXP = 45.0
@@ -1803,7 +1622,7 @@
     %childStageOffset = 1
     %stagingIcon = SOLID_BOOSTER
     @tags ^= :$: motor rocket separat thruster valve
-    !specPower = NULL
+    !specPower = DELETE
 
     //  Simulates the LOX valve that opens upon booster separation.
 
@@ -1869,7 +1688,7 @@
     %childStageOffset = 1
     %stagingIcon = SOLID_BOOSTER
     @tags ^= :$: motor rocket separat thruster valve
-    !specPower = NULL
+    !specPower = DELETE
 
     //  Simulates the LOX valve that opens upon booster separation.
 
@@ -1933,7 +1752,7 @@
     %fuelCrossFeed = True
     %CoMOffset = 0.0, -6.0, 0.0
     @tags ^= :$: fueltank liquid oxidizer propellant propuls RD-107 RD-117 rocket
-    !specPower = NULL
+    !specPower = DELETE
 
     %engineType = RD107-117
     %engineTypeMult = 1
@@ -1942,7 +1761,6 @@
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = BoosterMainEngine
         @minThrust = 972.3
         @maxThrust = 972.3
         @heatProduction = 138
@@ -1978,43 +1796,7 @@
         }
     }
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        %engineID = BoosterVernierEngine
-        @minThrust = 34.0
-        @maxThrust = 34.0
-        @heatProduction = 10
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3531
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6274
-            %DrawGauge = False
-        }
-
-        PROPELLANT
-        {
-            name = HTP
-            ratio = 0.0195
-            DrawGauge = False
-            ignoreForIsp = True
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 313
-            @key,1 = 1 250
-        }
-    }
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]],*{}
 
     !MODULE[ModuleFuelTanks],*{}
 
@@ -2068,127 +1850,23 @@
     @manufacturer = TsSKB-Progress
     @description = One of the oldest parts of the R-7 launch vehicle series, designed to support the core stage both in flight and on the ground. The individual boosters are designated as Blocks B,V,G and D and each one is powered by the RD-107 engine. It is ignited on the ground along with the Block A stage.
 
-    //  Main engine setup.
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
 
-    @MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %isMaster = True
-        %engineID = BoosterMainEngine
+        !THRUST_TRANSFORM,*{}
 
-        @CONFIG[*]:HAS[@PROPELLANT[Kerosene]]
+        THRUST_TRANSFORM
         {
-            OtherModules
-            {
-                BoosterVernierEngine = RD-107-117-Verniers-RG1
-            }
+            name = thrustTransform
+            overallMultiplier = 1.0
         }
 
-        @CONFIG[*]:HAS[@PROPELLANT[Syntin]]
+        THRUST_TRANSFORM
         {
-            OtherModules
-            {
-                BoosterVernierEngine = RD-107-117-Verniers-Syntin
-            }
-        }
-    }
-
-    //  Vernier engine setup.
-
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        configuration = RD-107-117-Verniers-RG1
-        isMaster = False
-        engineID = BoosterVernierEngine
-
-        CONFIG
-        {
-            name = RD-107-117-Verniers-RG1
-            minThrust = 34.0
-            maxThrust = 34.0
-            heatProduction = 10
-            ullage = True
-            pressureFed = False
-            ignitions = 1
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.025
-            }
-
-            PROPELLANT
-            {
-                name = Kerosene
-                ratio = 0.3603
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6397
-                DrawGauge = False
-            }
-
-            PROPELLANT
-            {
-                name = HTP
-                ratio = 0.0195
-                DrawGauge = False
-                ignoreForIsp = True
-            }
-
-            atmosphereCurve
-            {
-                key = 0 313
-                key = 1 250
-            }
-        }
-
-        CONFIG
-        {
-            name = RD-107-117-Verniers-Syntin
-            minThrust = 34.0
-            maxThrust = 34.0
-            heatProduction = 10
-            ullage = True
-            pressureFed = False
-            ignitions = 1
-
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.025
-            }
-
-            PROPELLANT
-            {
-                name = Syntin
-                ratio = 0.3518
-                DrawGauge = True
-            }
-
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.6482
-                DrawGauge = False
-            }
-
-            PROPELLANT
-            {
-                name = HTP
-                ratio = 0.0195
-                DrawGauge = False
-                ignoreForIsp = True
-            }
-
-            atmosphereCurve
-            {
-                key = 0 313
-                key = 1 250
-            }
+            name = thrustTransform2
+            overallMultiplier = 0.0350
         }
     }
 
@@ -2196,7 +1874,7 @@
 
     @MODULE[ModuleGimbal]
     {
-        !gimbalRange = NULL
+        !gimbalRange = DELETE
         @gimbalRangeYP = 0
         @gimbalRangeYN = 0
         @gimbalRangeXP = 45.0
@@ -2231,7 +1909,7 @@
     @maxTemp = 5773.15
     %skinMaxTemp = 6773.15
     @fuelCrossFeed = True
-    !explosionPotential = NULL
+    !explosionPotential = DELETE
     @stageOffset = 1
     @childStageOffset = 1
     @bulkheadProfiles = size9

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -1182,7 +1182,7 @@
 
 @PART[RD_0110]:AFTER[RealismOverhaulEngines]
 {
-    //  Configure the thrust transforms of 
+    //  Configure the thrust transforms of
     //  the main and vernier engines.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
@@ -1443,7 +1443,7 @@
     @manufacturer = TsSKB-Progress
     @description = The Block A is one of the few parts that still remain mostly unchanged from the original R-7 launch vehicle design. A very reliable element, powered by a single RD-108 engine with four verniers for attitude control. It is ignited on the ground, along with the Blocks B,V,G and D.
 
-    //  Configure the thrust transforms of 
+    //  Configure the thrust transforms of
     //  the main and vernier engines.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
@@ -1850,7 +1850,7 @@
     @manufacturer = TsSKB-Progress
     @description = One of the oldest parts of the R-7 launch vehicle series, designed to support the core stage both in flight and on the ground. The individual boosters are designated as Blocks B,V,G and D and each one is powered by the RD-107 engine. It is ignited on the ground along with the Block A stage.
 
-    //  Configure the thrust transforms of 
+    //  Configure the thrust transforms of
     //  the main and vernier engines.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]

--- a/GameData/RealismOverhaul/RealPlume_Configs/DECQ/RP_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/DECQ/RP_DECQ_R7.cfg
@@ -252,6 +252,8 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
+            %runningEffectName = Kerolox-Vernier
+            %directThrottleEffectName = Kerolox-Vernier
         }
     }
 }
@@ -303,6 +305,7 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
+            %runningEffectName = Kerolox-Vernier
         }
     }
 }
@@ -354,6 +357,7 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
+            %runningEffectName = Kerolox-Vernier
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/DECQ/RP_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/DECQ/RP_DECQ_R7.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  Soyuz LES abort motor plume configuration.
+//  Soyuz LES abort motor plume setup.
 //  ==================================================
 
 @PART[EAS]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -22,7 +22,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Solid-Sepmotor
-        !fxOffset = NULL
+        %runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -58,7 +58,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Solid-Sepmotor
-        !fxOffset = NULL
+        %runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -71,7 +71,7 @@
 }
 
 //  ==================================================
-//  Soyuz fairing abort motors plume configuration.
+//  Soyuz fairing abort motors plume setup.
 //  ==================================================
 
 @PART[SOYUZ_FG1|SOYUZ_FG2]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -94,7 +94,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Solid-Sepmotor
-        !fxOffset = NULL
+        %runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -107,7 +107,7 @@
 }
 
 //  ==================================================
-//  Soyuz Block I LOX valve plume configuration.
+//  Soyuz Block I LOX valve plume setup.
 //  ==================================================
 
 @PART[R7_BLOCK_I]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -130,12 +130,12 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-White
-        !fxOffset = NULL
+        %runningEffectName = DELETE
     }
 }
 
 //  ==================================================
-//  Soyuz strap - on booster top LOX valve plume configuration.
+//  Soyuz Block B,V,G,E top LOX valve plume setup.
 //  ==================================================
 
 @PART[R7_FS_TOP]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -158,12 +158,12 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-White
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 }
 
 //  ==================================================
-//  Soyuz strap - on booster bottom LOX valve plume configuration.
+//  Soyuz Block B,V,G,E bottom LOX valve plume setup.
 //  ==================================================
 
 @PART[R7_RETRO_MOTOR]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -186,12 +186,12 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-White
-        !fxOffset = NULL
+        %runningEffectName = DELETE
     }
 }
 
 //  ==================================================
-//  RD-107 engine plume configuration.
+//  RD-107 engine plume setup.
 //  ==================================================
 
 @PART[R7_FIRST_STAGE]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -241,19 +241,10 @@
         flareScale = 1.0
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[BoosterMainEngine]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Lower
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#engineID[BoosterVernierEngine]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Kerolox-Vernier
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -266,7 +257,7 @@
 }
 
 //  ==================================================
-//  RD-108 engine plume configuration.
+//  RD-108 engine plume setup.
 //  ==================================================
 
 @PART[R7_SECOND_STAGE]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -301,19 +292,10 @@
         flareScale = 1.0
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[CoreMainEngine]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Lower
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#engineID[CoreVernierEngine]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Kerolox-Vernier
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -326,7 +308,7 @@
 }
 
 //  ==================================================
-//  RD-0110 engine plume configuration.
+//  RD-0110 engine plume setup.
 //  ==================================================
 
 @PART[RD_0110]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -361,19 +343,10 @@
         flareScale = 0.5
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Upper
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#engineID[VernierEngine]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Kerolox-Vernier
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -386,7 +359,7 @@
 }
 
 //  ==================================================
-//  RD-0124 engine plume configuration.
+//  RD-0124 engine plume setup.
 //  ==================================================
 
 @PART[RD0124]:FOR[RealPlume]:NEEDS[SmokeScreen]
@@ -409,8 +382,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]


### PR DESCRIPTION
**Change Log:**

* Fix the TestFlight integration of the RD-0110, RD-108 and RD-107 vernier engines (they will now fail if the main engine fails).
* Fix the propellant switching between RG-1 and Syntin breaking the RD-108 and RD-107 vernier engines.

**Notes:**

* The vernier plume config for the RD-108 engine will not work correctly due to a patching issue within RealPlume.