### PR TITLE
[Bugfix] RealEngines updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_American.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_American.cfg
@@ -1,41 +1,38 @@
 //  ==================================================
 //  Sources:
-
-//  NASA - Vanguard: A History (chapter 5):         https://history.nasa.gov/SP-4202/chapter5.html
-//  Alternate Wars - Aerojet General Space Engines: http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-//  Designation Systems - Martin Vanguard:          http://www.designation-systems.net/dusrm/app4/vanguard.html
-//  Norbert Brügge - Vanguard SLV:                  http://www.b14643.de/Spacerockets_2/United_States_7/Vanguard/Description/Frame.htm
-//  Norbert Brügge - Thor Able SLV:                 http://www.b14643.de/Spacerockets_2/United_States_4/Thor/Description/Frame.htm
-//  Encyclopedia Astronautica - AJ10-40 engine:     http://www.astronautix.com/a/aj10-40.html
-//  Encyclopedia Astronautica - AJ10-104 engine:    http://www.astronautix.com/a/aj10-104.html
-
-//  NASA - J-2 engine fact sheet:           https://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf
-//  Encyclopedia Astronautica - J-2 engine: http://www.astronautix.com/j/j-2.html
-
-//  NASA - AER: Descent Propulsion System:        https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19730011150.pdf
-//  NASA - Apollo LM Propulsion Systems Overview: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090016298.pdf
-
+//
+//  NASA - Vanguard: A History (chapter 5):          https://history.nasa.gov/SP-4202/chapter5.html
+//  Alternate Wars - Aerojet General Space Engines:  http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+//  Designation Systems - Martin Vanguard:           http://www.designation-systems.net/dusrm/app4/vanguard.html
+//  Norbert Brügge - Vanguard SLV:                   http://www.b14643.de/Spacerockets_2/United_States_7/Vanguard/Description/Frame.htm
+//  Norbert Brügge - Thor Able SLV:                  http://www.b14643.de/Spacerockets_2/United_States_4/Thor/Description/Frame.htm
+//  Encyclopedia Astronautica - AJ10-40 engine:      http://www.astronautix.com/a/aj10-40.html
+//  Encyclopedia Astronautica - AJ10-104 engine:     http://www.astronautix.com/a/aj10-104.html
+//  NASA - J-2 engine fact sheet:                    https://www.nasa.gov/centers/marshall/pdf/499245main_J2_Engine_fs.pdf
+//  Encyclopedia Astronautica - J-2 engine:          http://www.astronautix.com/j/j-2.html
+//  NASA - AER: Descent Propulsion System:           https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19730011150.pdf
+//  NASA - Apollo LM Propulsion Systems Overview:    https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090016298.pdf
 //  SpaceX - Making Humans a Multiplanetary Species: https://web.archive.org/web/20160928040332/http://www.spacex.com/sites/spacex/files/mars_presentation.pdf
-
-//  PWR - RS-25 engine:            https://web.archive.org/web/20120208191620/http://www.pw.utc.com/products/pwr/assets/pwr_SSME.pdf
-//  AJR - RS-25 engine:            https://www.rocket.com/rs-25-engine
-//  ShuttlePressKit - Shuttle MPS: https://web.archive.org/web/20120204133938/http://www.shuttlepresskit.com/scom/216.pdf
-
-//  FAA - DragonFly RLV test environmental impact: http://www.faa.gov/about/office_org/headquarters_offices/ast/media/20140513_DragonFly_DraftEA_Appendices%28reduced%29.pdf
-//  SpaceX - SuperDraco 3D printed engine chamber: http://www.spacex.com/news/2014/07/31/spacex-launches-3d-printed-part-space-creates-printed-engine-chamber-crewed
+//  PWR - RS-25 engine:                              https://web.archive.org/web/20120208191620/http://www.pw.utc.com/products/pwr/assets/pwr_SSME.pdf
+//  AJR - RS-25 engine:                              https://www.rocket.com/rs-25-engine
+//  ShuttlePressKit - Shuttle MPS:                   https://web.archive.org/web/20120204133938/http://www.shuttlepresskit.com/scom/216.pdf
+//  FAA - DragonFly RLV test environmental impact:   http://www.faa.gov/about/office_org/headquarters_offices/ast/media/20140513_DragonFly_DraftEA_Appendices%28reduced%29.pdf
+//  SpaceX - SuperDraco 3D printed engine chamber:   http://www.spacex.com/news/2014/07/31/spacex-launches-3d-printed-part-space-creates-printed-engine-chamber-crewed
 
 //  ==================================================
 //  NAA 75-110-A engine series.
-
+//
 //  Dimensions: 1.78 m x 2.65 m
-//  Gross Mass: 670 Kg
+//  Gross Mass: 670 kg
 //  ==================================================
 
 @PART[A7]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-A-7
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -46,28 +43,28 @@
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = 0.285, -1.39, 0.0
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = -0.285, -1.39, 0.0
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = 0.0, -1.39, 0.285
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = 0.0, -1.39, -0.285
         rotation = 0.0, 0.0, 0.0
     }
@@ -80,8 +77,6 @@
 
     @mass = 0.67
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -127,29 +122,31 @@
     {
         @gimbalTransformName = newThrustTransform
         %gimbalRange = 2.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 }
 
 //  ==================================================
 //  AJ10-37/42/101A/142/118/118D engine series.
-
+//
 //  Dimensions: 0.58 m x 1.3 m
-//  Inert Mass: 80 Kg
-
+//  Inert Mass: 80 kg
+//
 //  * The 37 (Vanguard) and 40 (Able) variants are
 //    practically the same.
 //  ==================================================
 
 @PART[AJ10_37]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-AJ10-37
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -165,8 +162,6 @@
 
     @mass = 0.08
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -210,10 +205,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 4.25
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
     }
 
     !MODULE[ModuleAlternator],*{}
@@ -223,19 +218,21 @@
 
 //  ==================================================
 //  AJ10-104/118E series engine.
-
+//
 //  Dimensions: 0.84 m x 1.9 m
-//  Inert Mass: 90 Kg
-
+//  Inert Mass: 90 kg
+//
 //  * The part model refers to the extended nozzle
 //    variant (7890 lbf).
 //  ==================================================
 
 @PART[AJ10_104]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-AJ10-104
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -251,8 +248,6 @@
 
     @mass = 0.09
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -296,10 +291,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 4.25
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
     }
 
     !MODULE[ModuleAlternator],*{}
@@ -309,16 +304,18 @@
 
 //  ==================================================
 //  AJ10-137 engine.
-
+//
 //  Dimensions: 2.54 m x 3.55 m
-//  Inert Mass: 295 Kg
+//  Inert Mass: 295 kg
 //  ==================================================
 
 @PART[AJ10_137]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-AJ10-137
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -333,66 +330,28 @@
 
     @mass = 0.295
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2, size3
     @tags = AJ10-137 ascent apollo engine launch propuls rocket SPS vac
 
     %engineType = AJ10_137
-
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 97.9
-        @maxThrust = 97.9
-        @heatProduction = 43
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Aerozine50
-            @ratio = 0.5017
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.4983
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 314
-            @key,1 = 1 100
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 4.5
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
-    }
 }
 
 //  ==================================================
 //  AJ10-190 engine.
-
+//
 //  Dimensions: 1.2 m x 2.17 m
-//  Inert Mass: 125 Kg
+//  Inert Mass: 125 kg
 //  ==================================================
 
 @PART[AJ10_190]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-AJ10-190
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -407,59 +366,28 @@
 
     @mass = 0.125
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2
     @tags = AJ10-190 ascent engine launch OMS propuls rocket shuttle STS vac
 
     %engineType = AJ10_190
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = MMH
-            @ratio = 0.4990
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = MON3
-            @ratio = 0.5010
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 316
-            @key,1 = 1 100
-        }
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 6.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
-    }
 }
 
 //  ==================================================
 //  J-2 engine.
-
+//
 //  Dimensions: 2.05 m x 3.61 m
-//  Inert Mass: 1742 Kg
+//  Inert Mass: 1742 kg
 //  ==================================================
 
 @PART[J2]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-J2
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -475,72 +403,28 @@
 
     @mass = 1.742
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2
     @tags = ascent apollo engine J-2 J-2S launch propuls rocket S-II S-IVB saturn vac
 
     %engineType = J2
-
-    @MODULE[ModuleEngines*]
-    {
-        !engineID = NULL
-        @minThrust = 1023.1
-        @maxThrust = 1023.1
-        @heatProduction = 102
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdHydrogen
-            @ratio = 0.7454
-            @DrawGauge = True
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.2546
-            %DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 425
-            @key,1 = 1 283
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 1.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-    }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
 //  APS (LMAE) engine.
-
+//
 //  Dimensions: 0.86 m x 1.3 m
-//  Inert Mass: 82 Kg
+//  Inert Mass: 82 kg
 //  ==================================================
 
 @PART[LMAE]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-LMAE
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -552,62 +436,32 @@
 
     @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1
     @node_stack_bottom = 0.0, -0.89, 0.0, 0.0, -1.0, 0.0, 1
-	@node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
+    @node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 
     @mass = 0.082
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2
     @tags = APS apollo engine launch LEM LM LMAE lunar propuls rocket saturn throttle vac
 
     %engineType = LMAE
-
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 15.6
-        @maxThrust = 15.6
-        @heatProduction = 200
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Aerozine50
-            @ratio = 0.5017
-            @DrawGauge = True
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.4983
-            %DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 311
-            @key,1 = 1 100
-        }
-
-        !thrustCurve,*{}
-    }
 }
 
 //  ==================================================
 //  DPS (LMDE) engine.
-
+//
 //  Dimensions: 1.5 m x 2.4 m
-//  Inert Mass: 158 Kg
+//  Inert Mass: 158 kg
 //  ==================================================
 
 @PART[LMDE]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-LMDE
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -623,74 +477,31 @@
 
     @mass = 0.158
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size1
     @tags = apollo descent engine launch LEM LM LMDE lunar propuls rocket saturn throttle vac
 
     %engineType = LMDE
-
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 4.7
-        @maxThrust = 46.7
-        @heatProduction = 32
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Aerozine50
-            @ratio = 0.5017
-            @DrawGauge = True
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.4983
-            %DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 311
-            @key,1 = 1 100
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 6.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-    }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
 //  Raptor engine (surface variant).
-
+//
 //  Dimensions: 1.3 m x 2.2 m
-//  Inert Mass: 1600 Kg
-
+//  Inert Mass: 1600 kg
+//
 //  * Stats are completely hypothetical. The parts are
 //    tagged as "WIP-RO" for now.
 //  ==================================================
 
 @PART[Raptor_engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-Raptor-ASL
+
     %RSSROConfig = False
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -700,70 +511,29 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.595, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -0.585, 0.0, 0.0, -1.0, 0.0, 2
-    @node_attach = 0.0, 1.595, 0.0, 0.0, 1.0, 0.0
+    @node_stack_top = 0.0, 0.638, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -1.35, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 0.638, 0.0, 0.0, 1.0, 0.0
 
     @mass = 1.6
     @crashTolerance = 10
-    @breakingForce = 250
-    @breakingTorque = 250
-    !linearStrength = NULL
-    !angularStrength = NULL
+    !linearStrength = DELETE
+    !angularStrength = DELETE
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2
     @tags = ascent BFR descent engine ITS launch propuls rocket spacex throttle surf
 
     %engineType = Raptor
-
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 610.0
-        @maxThrust = 3050.0
-        @heatProduction = 282
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdMethane
-            @ratio = 0.4137
-            @DrawGauge = True
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.5863
-            %DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 361
-            @key,1 = 1 334
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 8.0
-    }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
 //  Raptor engine (surface variant).
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[Raptor_engine]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-Raptor-ASL]:FOR[RealismOverhaulEnginesPost]
 {
     @title = Raptor (Surface Variant)
 
@@ -775,19 +545,21 @@
 
 //  ==================================================
 //  Raptor engine (vacuum variant).
-
+//
 //  Dimensions: 2.4 m x 3.95 m
-//  Inert Mass: 1760 Kg
-
+//  Inert Mass: 1760 kg
+//
 //  * Stats are completely hypothetical. The parts are
 //    tagged as "WIP-RO" for now.
 //  ==================================================
 
 @PART[Raptor_Vacuum]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-Raptor-VAC
+
     %RSSROConfig = False
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -797,70 +569,29 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 1.535, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -2.405, 0.0, 0.0, -1.0, 0.0, 3
-    @node_attach = 0.0, 1.535, 0.0, 0.0, 1.0, 0.0
+    @node_stack_top = 0.0, 0.615, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -3.275, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 0.0, 0.615, 0.0, 0.0, 1.0, 0.0
 
     @mass = 1.76
     @crashTolerance = 10
-    @breakingForce = 250
-    @breakingTorque = 250
-    !linearStrength = NULL
-    !angularStrength = NULL
+    !linearStrength = DELETE
+    !angularStrength = DELETE
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2, size3
     @tags = ascent BFR descent engine ITS launch propuls rocket spacex throttle vac
 
     %engineType = Raptor
-
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 700.0
-        @maxThrust = 3500.0
-        @heatProduction = 311
-        %useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = LqdMethane
-            @ratio = 0.4137
-            @DrawGauge = True
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.5863
-            %DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 382
-            @key,1 = 1 280
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRange = 8.0
-    }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
 //  Raptor engine (vacuum variant).
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[Raptor_Vacuum]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-Raptor-VAC]:FOR[RealismOverhaulEnginesPost]
 {
     @title = Raptor (Vacuum Variant)
 
@@ -872,19 +603,21 @@
 
 //  ==================================================
 //  RS-25 engine.
-
+//
 //  Dimensions: 2.44 m x 4.27 m
-//  Inert Mass: 3527 Kg
-
+//  Inert Mass: 3527 kg
+//
 //  * Power levels are calculated based on the 109%
 //    TPL value of RS-25C variant.
 //  ==================================================
 
 @PART[SSME_Engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-SSME
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -900,10 +633,8 @@
 
     @mass = 3.527
     @crashTolerance = 10
-    @breakingForce = 250
-    @breakingTorque = 250
-    !linearStrength = NULL
-    !angularStrength = NULL
+    !linearStrength = DELETE
+    !angularStrength = DELETE
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf, size2, size3
@@ -913,7 +644,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        !engineID = NULL
+        !engineID = DELETE
         @minThrust = 1400.7
         @maxThrust = 2090.6
         @heatProduction = 109
@@ -945,10 +676,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 8.5
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
     }
 
     !MODULE[ModuleAlternator],*{}
@@ -958,21 +689,23 @@
 
 //  ==================================================
 //  SuperDraco engine.
-
+//
 //  Dimensions: 0.8 m x 0.67 m
-//  Inert Mass: 150 Kg
-
+//  Inert Mass: 150 kg
+//
 //  Notes:
-
+//
 //  * The inert mass value includes the mass of the
-//    SuperDraco mounting hardware (approximately 20 Kg).
+//    SuperDraco mounting hardware (approximately 20 kg).
 //  ==================================================
 
 @PART[SuperDrago]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-SuperDraco
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -988,8 +721,6 @@
 
     @mass = 0.15
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     @bulkheadProfiles = srf
@@ -999,36 +730,15 @@
     %engineTypeMult = 2
     %ignoreMass = False
     %massOffset = 0.02
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[MonoPropellant]
-        {
-            @name = MMH
-            @ratio = 0.5629
-        }
-
-        PROPELLANT
-        {
-            name = NTO
-            ratio = 0.4371
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 280
-            @key,1 = 1 235
-        }
-    }
 }
 
 //  ==================================================
 //  SuperDraco engine.
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[SuperDrago]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-SuperDraco]:FOR[RealismOverhaulEnginesPost]
 {
     @title = SuperDraco Dual Engine Block
     @description = The integrated dual SuperDraco engine block used by the Dragon V2 spacecraft for powered landings, trajectory corrections and as a Launch Abort System (LAS).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -1,6 +1,6 @@
 //  ==================================================
 //  Sources:
-
+//
 //  Liquid Propellant Rocket Engines - NK-33/43 engine:    http://www.lpre.de/sntk/NK-33/index.htm
 //  Russian Space Web - NK-33 engine:                      http://www.russianspaceweb.com/nk33.html
 //  Norbert Brügge - Kuznetsov NK rocket engine variants:  http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm
@@ -8,97 +8,81 @@
 //  Encyclopedia Astronautica - NK-43 engine:              http://www.astronautix.com/n/nk-43.html
 //  Encyclopedia Astronautica - RD-58 engine:              http://astronautix.com/r/rd-58.html
 //  Norbert Brügge - Block D upper stage:                  http://www.b14643.de/Spacerockets_1/East_Europe_2/Proton/Gallery/Block-D.htm
-
 //  Encyclopedia Astronautica - RD-103 engine:             http://astronautix.com/r/rd-103.html
 //  Encyclopedia Astronautica - RD-103M engine:            http://astronautix.com/r/rd-103m.html
-
 //  NPO Energomash - RD-107/RD-108 engines:                http://www.npoenergomash.ru/eng/dejatelnost/engines/rd107/
 //  Norbert Brügge - RD-107/RD-108 engine modifications:   http://www.b14643.de/Spacerockets_1/East_Europe_1/Semyorka/Propulsion/history.htm
-
 //  Russian Space Web - RD-0110 engine:                    http://www.russianspaceweb.com/rd0110.html
 //  Encyclopedia Astronautica - RD-0110 engine:            http://www.astronautix.com/r/rd-0110.html
-
 //  Liquid Propellant Rocket Engines - RD-0120 engine:     http://www.lpre.de/kbkha/RD-0120/index.htm
 //  AIAA - RD-0120 design, development and history:        http://lpre.de/resources/articles/AIAA-1995-2540.pdf
 //  Russian Space Web - RD-0120 engine:                    http://russianspaceweb.com/rd0120.html
 //  Encyclopedia Astronautica - RD-0120 engine:            http://astronautix.com/r/rd-0120.html
-
 //  Liquid Propellant Rocket Engines - RD-0124 engine:     http://www.lpre.de/kbkha/RD-0124/index.htm
 //  AIAA - GG and SC Cycle Rocket Engines Turbopumps:      http://rocket-propulsion.info/resources/articles/AIAA-2005-3946.pdf
 //  Russian Space Web - RD-0124 engine:                    http://www.russianspaceweb.com/rd0124.html
 //  Encyclopedia Astronautica - RD-0124 engine:            http://www.astronautix.com/r/rd-0124.html
-
 //  Russian Space Web - RD-0146 engine:                    http://www.russianspaceweb.com/rd0146.html
 //  AIAA - The First Russian LOX-LH2 Expander Cycle LRE:   http://www.lpre.de/resources/articles/AIAA-2006-4904_RD0146.pdf
 //  Encyclopedia Astronautica - RD-0146 engine:            http://www.astronautix.com/r/rd-0146.html
-
 //  Liquid Propellant Rocket Engines - RD-170 engine:      http://www.lpre.de/energomash/RD-170/index.htm
 //  AIAA - RD-170, A Different Approach to LV Propulsion:  http://rocket-propulsion.info/resources/articles/AIAA-1993-2415.pdf
 //  Russian Space Web - RD-170 engine:                     http://www.russianspaceweb.com/rd170.html
 //  Encyclopedia Astronautica - RD-170 engine:             http://www.astronautix.com/r/rd-170.html
-
 //  NPO Energomash - RD-180 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd180/
 //  AIAA - RD-180 Engine Production and Flight Experience: http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3998.pdf
 //  AIAA - RD-180 Engine Development and Characteristics:  http://my.fit.edu/~dkirk/4262/RD180_Presentation.pdf
 //  LPRE - RD-180 engine:                                  http://www.lpre.de/energomash/RD-180/index.htm
 //  Encyclopedia Astronautica - RD-180 engine:             http://www.astronautix.com/r/rd-180.html
-
 //  NPO Energomash - RD-191 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd191/
 //  Russian Space Web - RD-191 engine:                     http://russianspaceweb.com/rd191.html
 //  Encyclopedia Astronautica - RD-191 engine:             http://www.astronautix.com/r/rd-191.html
-
 //  KB Khimavtomatika - RD-0210 engine:                    http://www.kbkha.ru/?p=8&cat=8&prod=33
 //  Liquid Propellant Rocket Engines - RD-0210 engine:     http://www.lpre.de/kbkha/RD-0203/index.htm
 //  Russian Space Web - RD-0210 engine:                    http://www.russianspaceweb.com/rd0210.html
 //  Encyclopedia Astronautica - RD-0210 engine:            http://www.astronautix.com/engines/rd0210.htm
-
 //  KB Khimavtomatika - RD-0213 engine:                    http://www.kbkha.ru/?p=8&cat=8&prod=33
 //  Russian Space Web - RD-0212 engine:                    http://www.russianspaceweb.com/rd0212.html
 //  Russian Space Web - Proton Third Stage:                http://www.russianspaceweb.com/proton_stage3.html
 //  Encyclopedia Astronautica - RD-0212 engine:            http://www.astronautix.com/r/rd-0212.html
 //  Encyclopedia Astronautica - RD-0214 engine:            http://www.astronautix.com/r/rd-0214.html
 //  Russian Space Web - Sunkar launch vehicle:             http://www.russianspaceweb.com/sunkar.html
-
 //  NPO Energomash - RD-253 engine:                        http://www.npoenergomash.ru/eng/dejatelnost/engines/rd253/
 //  Russian Space Web - RD-253 engine:                     http://www.russianspaceweb.com/rd253.html
 //  Encyclopedia Astronautica - RD-253 engine:             http://www.astronautix.com/r/rd-253-11d48.html
-
 //  KB KhIMMASH - KVD-1 & S5.92 Brochure:                  http://www.k204.ru/books/vrd/wiki2/PDF/Himmash.pdf
 //  KB KhIMMASH - S5.92 engine:                            http://kbhmisaeva.ru/main.php?id=53
 //  Encyclopedia Astronautica - S5.92 engine:              http://www.astronautix.com/s/s592.html
-
 //  Norbert Brügge - Isaev Design Bureau KDUs:             http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
 //  Encyclopedia Astronautica - KTDU-35:                   http://www.astronautix.com/k/ktdu-35.html
 //  Encyclopedia Astronautica - KTDU-66:                   http://www.astronautix.com/k/ktdu-66.html
-
 //  Encyclopedia Astronautica - RD-0105 engine:            http://astronautix.com/r/rd-0105.html
 //  Encyclopedia Astronautica - RD-0109 engine:            http://astronautix.com/r/rd-0109.html
-
 //  Norbert Brügge - N-1 NK series engine variants:        http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm
 //  Encyclopedia Astronautica - NK-9 engine:               http://www.astronautix.com/n/nk-9.html
 //  Encyclopedia Astronautica - NK-9V engine:              http://www.astronautix.com/n/nk-9v.html
 //  Encyclopedia Astronautica - NK-21 engine:              http://www.astronautix.com/n/nk-21.html
 //  Encyclopedia Astronautica - NK-31 engine:              http://www.astronautix.com/n/nk-31.html
 //  Encyclopedia Astronautica - NK-39 engine:              http://www.astronautix.com/n/nk-39.html
-
 //  Yuzhnoye Design Office - RD-856 vernier engine:        http://www.yuzhnoye.com/en/technique/rocket-engines/steering/rd-856/
 //  Encyclopedia Astronautica - RD-856 vernier engine:     http://www.astronautix.com/r/rd-856.html
-
 //  LPRE - Isaev Design Bureau propulsion systems:         http://lpre.de/kbhm/index.htm
 //  Norbert Brügge - Russian rocket engines:               http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 
 //  ==================================================
 //  NK-33 engine.
-
+//
 //  Dimensions: 2.7 m x 4 m
-//  Gross Mass: 1240 Kg
+//  Gross Mass: 1240 kg
 //  ==================================================
 
 @PART[NK33engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-NK-33
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -109,13 +93,11 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 1.085, 0.0, 0.0, 1.0, 0.0, 2
-    !node_stack_center = NULL
+    !node_stack_center = DELETE
     @node_stack_bottom = 0.0, -2.265, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 1.24
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -166,16 +148,18 @@
 
 //  ==================================================
 //  NK-43 engine.
-
+//
 //  Dimensions: 2.95 m x 5.4 m
-//  Gross Mass: 1400 Kg
+//  Gross Mass: 1400 kg
 //  ==================================================
 
 @PART[NK43engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-NK-43
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -190,8 +174,6 @@
 
     @mass = 1.4
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -242,16 +224,18 @@
 
 //  ==================================================
 //  RD-58 engine.
-
+//
 //  Dimensions: 2.1 m x 2.3 m
-//  Gross Mass: 300 Kg
+//  Gross Mass: 300 kg
 //  ==================================================
 
 @PART[RD58]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-58
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -267,15 +251,13 @@
 
     @mass = 0.3
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = srf, size2
-    !stackSymmetry = NULL
+    !stackSymmetry = DELETE
     @tags = ascent launch propuls proton RD-58 rocket vac zenit
 
     %engineType = RD58
@@ -311,10 +293,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 7.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 
@@ -325,16 +307,18 @@
 
 //  ==================================================
 //  RD-100 series engine.
-
+//
 //  Dimensions: 1.3 m x 3.05 m
-//  Gross Mass: 870 Kg
+//  Gross Mass: 870 kg
 //  ==================================================
 
 @PART[rd100]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-100
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -345,28 +329,28 @@
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = 0.25, -0.8, 0.0
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = -0.25, -0.8, 0.0
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = 0.0, -0.8, 0.25
         rotation = 0.0, 0.0, 0.0
     }
 
     MODEL
     {
-        model = RealismOverhaul/emptyengine
+        model = RealismOverhaul/Assets/EmptyEngine
         position = 0.0, -0.8, -0.25
         rotation = 0.0, 0.0, 0.0
     }
@@ -380,8 +364,6 @@
 
     @mass = 0.87
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -395,58 +377,29 @@
     @MODULE[ModuleEngines*]
     {
         %thrustVectorTransformName = newThrustTransform
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Ethanol90
-            @ratio = 0.4695
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.5305
-        }
-
-        PROPELLANT
-        {
-            name = HTP
-            ratio = 0.01
-            ignoreForIsp = True
-            DrawGauge = False
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 237
-            @key,1 = 1 203
-        }
     }
 
     @MODULE[ModuleGimbal]
     {
         %gimbalTransformName = newThrustTransform
         %gimbalRange = 2.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
     }
 }
 
 //  ==================================================
 //  RD-107 series engine.
-
+//
 //  Dimensions: 2.6 m x 2.66 m
-//  Gross Mass: 1190 Kg
+//  Gross Mass: 1190 kg
 //  ==================================================
 
 @PART[RD107]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-107
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -461,8 +414,6 @@
 
     @mass = 1.19
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -508,54 +459,42 @@
 
         !thrustCurve,*{}
     }
-
-    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]],*{}
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        @minThrust = 38.0
-        @maxThrust = 38.0
-        @heatProduction = 50
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3531
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6274
-        }
-
-        PROPELLANT
-        {
-            name = HTP
-            ratio = 0.0195
-            DrawGauge = False
-            ignoreForIsp = True
-        }
-
-        @atmosphereCurve
-        {
-            @key = 0 306
-            @key = 1 250
-        }
-
-        !thrustCurve,*{}
-    }
 }
 
 //  ==================================================
 //  RD-107 series engine.
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[RD107]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-107]:FOR[RealismOverhaulEnginesPost]
 {
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        !THRUST_TRANSFORM,*{}
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform
+            overallMultiplier = 1.0
+        }
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform2
+            overallMultiplier = 0.0350
+        }
+    }
+
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]],*{}
+
+    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]],*{}
+
+    // Setup the gimbals for the vernier engines.
+
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
     {
         @gimbalRangeYP = 45.0
@@ -568,16 +507,18 @@
 
 //  ==================================================
 //  RD-108 series engine.
-
+//
 //  Dimensions: 2.8 m x 2.66 m
-//  Gross Mass: 1278 Kg
+//  Gross Mass: 1278 kg
 //  ==================================================
 
 @PART[RD108]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-108
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -592,8 +533,6 @@
 
     @mass = 1.278
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -639,54 +578,40 @@
 
         !thrustCurve,*{}
     }
-
-    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]],*{}
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        @minThrust = 38.0
-        @maxThrust = 38.0
-        @heatProduction = 50
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3531
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6274
-        }
-
-        PROPELLANT
-        {
-            name = HTP
-            ratio = 0.0195
-            DrawGauge = False
-            ignoreForIsp = True
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 308
-            @key,1 = 1 241
-        }
-
-        !thrustCurve,*{}
-    }
 }
 
 //  ==================================================
 //  RD-108 series engine.
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[RD108]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-108]:FOR[RealismOverhaulEnginesPost]
 {
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
+    {
+        !THRUST_TRANSFORM,*{}
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform
+            overallMultiplier = 1.0
+        }
+
+        THRUST_TRANSFORM
+        {
+            name = thrustTransform2
+            overallMultiplier = 0.0370
+        }
+    }
+
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]],*{}
+
+    !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[thrustTransform]],*{}
+
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
     {
         @gimbalRangeYP = 0
@@ -699,16 +624,18 @@
 
 //  ==================================================
 //  RD-0110 engine.
-
+//
 //  Dimensions: 2.45 m x 1.55 m
-//  Gross Mass: 410 Kg
+//  Gross Mass: 410 kg
 //  ==================================================
 
 @PART[RD0110engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0110
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -760,22 +687,20 @@
 
     @node_stack_top = 0.0, 0.643, 0.0, 0.0, 1.0, 0.0, 2
     @node_stack_bottom = 0.0, -0.894, 0.0, 0.0, -1.0, 0.0, 2
-    !node_stack_top1 = NULL
-    !node_stack_top1 = NULL
-    !node_stack_top1 = NULL
-    !node_stack_top1 = NULL
+    !node_stack_top1 = DELETE
+    !node_stack_top1 = DELETE
+    !node_stack_top1 = DELETE
+    !node_stack_top1 = DELETE
 
     @mass = 0.41
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = srf, size0, size2
-    !stackSymmetry = NULL
+    !stackSymmetry = DELETE
     @tags = ascent launch propuls RD-0110 rocket soyuz vac
 
     %engineType = RD0110
@@ -816,57 +741,33 @@
 
 //  ==================================================
 //  RD-0110 engine.
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[RD0110engine]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-0110]:AFTER[RealismOverhaulEngines]
 {
-    //  Vernier engine setup.
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
 
-    MODULE
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        name = ModuleEngines
-        engineID = VernierEngine
-        thrustVectorTransformName = thrustTransform2
-        exhaustDamage = True
-        ignitionThreshold = 0.1
-        minThrust = 6.0
-        maxThrust = 6.0
-        heatProduction = 100
-        EngineType = LiquidFuel
-        ullage = True
-        pressureFed = False
-        ignitions = 1
+        !THRUST_TRANSFORM,*{}
 
-        IGNITOR_RESOURCE
+        THRUST_TRANSFORM
         {
-            name = ElectricCharge
-            amount = 0.02
+            name = thrustTransform
+            overallMultiplier = 1.0
         }
 
-        PROPELLANT
+        THRUST_TRANSFORM
         {
-            name = Kerosene
-            ratio = 0.3853
-            DrawGauge = False
-        }
-
-        PROPELLANT
-        {
-            name = LqdOxygen
-            ratio = 0.6147
-            DrawGauge = False
-        }
-
-        atmosphereCurve
-        {
-            key = 0 330
-            key = 1 165
+            name = thrustTransform2
+            overallMultiplier = 0.0134
         }
     }
 
-    //  Vernier gimbal setup.
+    //  Vernier engines gimbal setup.
 
     !MODULE[ModuleGimbal],*{}
 
@@ -885,16 +786,18 @@
 
 //  ==================================================
 //  RD-0120 engine.
-
+//
 //  Dimensions: 2.93 m x 4.7 m
-//  Gross Mass: 3450 Kg
+//  Gross Mass: 3450 kg
 //  ==================================================
 
 @PART[rd0120]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0120
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -909,8 +812,6 @@
 
     @mass = 3.45
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -952,10 +853,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 11.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 
@@ -966,16 +867,18 @@
 
 //  ==================================================
 //  RD-0124 engine.
-
+//
 //  Dimensions: 2.45 m x 1.55 m
-//  Gross Mass: 500 Kg
+//  Gross Mass: 500 kg
 //  ==================================================
 
 @PART[RD0124engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0124
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -990,8 +893,6 @@
 
     @mass = 0.5
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1051,16 +952,18 @@
 
 //  ==================================================
 //  RD-0124 engine (dual).
-
+//
 //  Dimensions: 3.2 m x 2.0 m
-//  Gross Mass: 960 Kg
+//  Gross Mass: 960 kg
 //  ==================================================
 
 @PART[RD0124Aengine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0124A
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1075,8 +978,6 @@
 
     @mass = 0.96
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1120,21 +1021,21 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 3.5
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 }
 
 //  ==================================================
 //  RD-0124 engine (dual).
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[RD0124Aengine]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-0124A]:AFTER[RealismOverhaulEngines]
 {
     @title = RD-0124A (Dual)
     @manufacturer = NPO Energomash
@@ -1143,16 +1044,18 @@
 
 //  ==================================================
 //  RD-0146 engine.
-
+//
 //  Dimensions: 1.75 m x 2.7 m
-//  Gross Mass: 240 Kg
+//  Gross Mass: 240 kg
 //  ==================================================
 
 @PART[RD0146engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0146
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1167,15 +1070,13 @@
 
     @mass = 0.24
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
     %childStageOffset = 1
     %stagingIcon = LIQUID_ENGINE
     @bulkheadProfiles = srf, size2
-    !stackSymmetry = NULL
+    !stackSymmetry = DELETE
     @tags = angara ascent kvtk launch ppts propuls RD-0146 rocket rus-m vac
 
     %engineType = RD0146
@@ -1211,10 +1112,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 4.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 
@@ -1225,16 +1126,18 @@
 
 //  ==================================================
 //  RD-170 engine.
-
+//
 //  Dimensions: 4.05 m x 3.8 m
-//  Gross Mass: 9750 Kg
+//  Gross Mass: 9750 kg
 //  ==================================================
 
 @PART[RD170engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-170
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1245,13 +1148,11 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 1.505, 0.0, 0.0, 1.0, 0.0, 4
-    !node_stack_center = NULL
+    !node_stack_center = DELETE
     @node_stack_bottom = 0.0, -2.283, 0.0, 0.0, -1.0, 0.0, 4
 
     @mass = 9.75
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1293,10 +1194,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 8.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 
@@ -1307,16 +1208,18 @@
 
 //  ==================================================
 //  RD-180 engine.
-
+//
 //  Dimensions: 3.55 m x 3.8 m
-//  Gross Mass: 5440 Kg
+//  Gross Mass: 5330 kg
 //  ==================================================
 
 @PART[RD180engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-180
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1327,13 +1230,11 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 1.509, 0.0, 0.0, 1.0, 0.0, 3
-    !node_stack_center = NULL
+    !node_stack_center = DELETE
     @node_stack_bottom = 0.0, -2.283, 0.0, 0.0, -1.0, 0.0, 3
 
-    @mass = 5.44
+    @mass = 5.33
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1343,62 +1244,22 @@
     @tags = ascent atlas launch propuls RD-180 rocket rus-m surf
 
     %engineType = RD180
-
-    @MODULE[ModuleEngines*]
-    {
-        @minThrust = 1951.43
-        @maxThrust = 4152.41
-        @heatProduction = 105
-        @useThrustCurve = False
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3384
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6616
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 337
-            @key,1 = 1 311
-        }
-
-        !thrustCurve,*{}
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 8.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
-    }
-
-    !MODULE[ModuleAlternator],*{}
-
-    !RESOURCE,*{}
 }
 
 //  ==================================================
 //  RD-191 engine.
-
+//
 //  Dimensions: 2.7 m x 3.8 m
-//  Gross Mass: 2200 Kg
+//  Gross Mass: 2200 kg
 //  ==================================================
 
 @PART[RD191engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-191
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1409,13 +1270,11 @@
     @rescaleFactor = 1.0
 
     @node_stack_top = 0.0, 1.34244, 0.0, 0.0, 1.0, 0.0, 2
-    !node_stack_center = NULL
+    !node_stack_center = DELETE
     @node_stack_bottom = 0.0, -2.282925, 0.0, 0.0, -1.0, 0.0, 2
 
     @mass = 2.2
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1457,10 +1316,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 8.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         @gimbalResponseSpeed = 16
     }
 
@@ -1471,16 +1330,18 @@
 
 //  ==================================================
 //  RD-0210/0211 engine.
-
+//
 //  Dimensions: 1.47 m x 2.23 m
-//  Gross Mass: 566 Kg
+//  Gross Mass: 566 kg
 //  ==================================================
 
 @PART[RD0210]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0210
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1495,8 +1356,6 @@
 
     @mass = 0.566
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1506,51 +1365,22 @@
     @tags = ascent launch propuls proton RD-0210 RD-0211 rocket vac
 
     %engineType = RD0210
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = UDMH
-            @ratio = 0.4135
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.5865
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 313
-            @key,1 = 1 220
-        }
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 3.25
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        @gimbalResponseSpeed = 16
-    }
 }
 
 //  ==================================================
 //  RD-0212 engine.
-
+//
 //  Dimensions: 1.47 m x 2.9 m
-//  Gross Mass: 910 Kg
+//  Gross Mass: 910 kg
 //  ==================================================
 
 @PART[RD0212]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0212
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL,0
     {
@@ -1589,8 +1419,6 @@
 
     @mass = 0.91
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1600,65 +1428,37 @@
     @tags = ascent launch propuls proton RD-0212 RD-0213 RD-0214 rocket vac
 
     %engineType = RD0212
+}
 
-    //  Main engine.
+//  ==================================================
+//  RD-0212 engine.
+//
+//  Engine configuration.
+//  ==================================================
+
+@PART[RO-RealEngines-RD-0212]:AFTER[RealismOverhaulEngines]
+{
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = MainEngine
+        !THRUST_TRANSFORM,*{}
 
-        @PROPELLANT[LiquidFuel]
+        THRUST_TRANSFORM
         {
-            @name = UDMH
-            @ratio = 0.4192
+            name = thrustTransform
+            overallMultiplier = 1.0
         }
 
-        @PROPELLANT[Oxidizer]
+        THRUST_TRANSFORM
         {
-            @name = NTO
-            @ratio = 0.5808
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 313
-            @key,1 = 1 220
+            name = thrustTransform2
+            overallMultiplier = 0.0528
         }
     }
 
-    //  Vernier engine.
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        %engineID = VernierEngine
-        @minThrust = 30.9
-        @maxThrust = 30.9
-        @heatProduction = 4
-        @useThrustCurve = False
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = UDMH
-            @ratio = 0.4135
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.5865
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 294
-            @key,1 = 1 147
-        }
-
-        !thrustCurve,*{}
-    }
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]],*{}
 
     !MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal1]],*{}
 
@@ -1666,26 +1466,27 @@
 
     @MODULE[ModuleGimbal]:HAS[#gimbalTransformName[gimbal]]
     {
-        @gimbalRangeYP = 0
-        @gimbalRangeYN = 0
-        @gimbalRangeXP = 45.0
-        @gimbalRangeXN = 45.0
-        @gimbalResponseSpeed = 16
+        %gimbalRangeYP = 0
+        %gimbalRangeYN = 0
+        %gimbalRangeXP = 45.0
+        %gimbalRangeXN = 45.0
     }
 }
 
 //  ==================================================
 //  RD-253/275 engine.
-
+//
 //  Dimensions: 3.5 m x 2.8 m
-//  Gross Mass: 1080 Kg
+//  Gross Mass: 1080 kg
 //  ==================================================
 
 @PART[RD275]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-253
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1701,8 +1502,6 @@
 
     @mass = 1.08
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1715,7 +1514,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        !engineID = NULL
+        !engineID = DELETE
         @minThrust = 1627.9
         @maxThrust = 1627.9
         @heatProduction = 200
@@ -1745,10 +1544,10 @@
     @MODULE[ModuleGimbal]
     {
         %gimbalRange = 6.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
     }
 
     !RESOURCE,*{}
@@ -1756,16 +1555,18 @@
 
 //  ==================================================
 //  S5.92 engine.
-
+//
 //  Dimensions: 0.4 m x 0.96 m
-//  Inert Mass: 75 Kg
+//  Inert Mass: 75 kg
 //  ==================================================
 
 @PART[S5_92fversion]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-S5-92
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1789,89 +1590,55 @@
     @tags = ascent fregat launch propuls S.92 rocket soyuz vac zenit
 
     %engineType = S5_92
+}
 
-    //  Main engine.
+//  ==================================================
+//  S5.92 engine.
+//
+//  Engine configuration.
+//  ==================================================
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
-    {
-        %engineID = MainEngine
-
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = UDMH
-            @ratio = 0.4782
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.5218
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 327
-            @key,1 = 1 158
-        }
-    }
-
+@PART[RO-RealEngines-S5-92]:AFTER[RealismOverhaulEngines]
+{
     //  Gas generator exhaust.
-
     //  The thrust values have been set to 1/100 of
     //  the nominal thrust value of the main engine.
     //  True values unknown.
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = GasGenerator
-        @minThrust = 0.2
-        @maxThrust = 0.2
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 50
+        !THRUST_TRANSFORM,*{}
 
-        @PROPELLANT[LiquidFuel]
+        THRUST_TRANSFORM
         {
-            @name = UDMH
-            @ratio = 0.4782
+            name = thrustTransform
+            overallMultiplier = 1.0
         }
 
-        @PROPELLANT[Oxidizer]
+        THRUST_TRANSFORM
         {
-            @name = NTO
-            @ratio = 0.5218
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 327
-            @key,1 = 1 158
+            name = tt2
+            overallMultiplier = 0.01
         }
     }
 
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 5.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-        %gimbalResponseSpeed = 16
-    }
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]],*{}
 }
 
 //  ==================================================
 //  S5.98M engine.
-
+//
 //  Dimensions: 0.425 m x 0.97 m
-//  Inert Mass: 95 Kg
+//  Inert Mass: 95 kg
 //  ==================================================
 
 @PART[S5_98M]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-S5-98
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -1895,45 +1662,26 @@
     @tags = ascent briz launch propuls proton rocket rokot S.98M vac
 
     %engineType = S5_98M
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = UDMH
-            @ratio = 0.4782
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = NTO
-            @ratio = 0.5218
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 370
-            @key,1 = 1 235
-        }
-    }
 }
 
 //  ==================================================
-//  RD-0110 vernier engine.
-
-//  Dimensions: 0.325 m x 0.7 m
-//  Gross Mass: 10 Kg
+//  RD-0110R vernier engine.
+//
+//  Dimensions: 0.375 m x 0.8 m
+//  Gross Mass: 140 kg
 //  ==================================================
 
 @PART[STEERING_MOTOR_RD0110engine]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-0110R
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
-        @scale = 1.0, 1.0, 1.0
+        @scale = 1.155, 1.155, 1.155
     }
 
     @scale = 1.0
@@ -1941,10 +1689,8 @@
 
     @node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 
-    @mass = 0.01
+    @mass = 0.14
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -1953,102 +1699,16 @@
     @bulkheadProfiles = srf, size0
     @tags = ascent launch propuls RD-0110 rocket soyuz vac vern
 
-    %engineType = RD0110Vernier
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3853
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6147
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 330
-            @key,1 = 1 165
-        }
-    }
-}
-
-//  ==================================================
-//  RD-0110 vernier engine.
-
-//  Engine configuration.
-//  ==================================================
-
-@PART[STEERING_MOTOR_RD0110engine]:FOR[RealismOverhaulEnginesPost]
-{
-    //  Fix the wrong gimbal directions.
-
-    @MODULE[ModuleGimbal]
-    {
-        @gimbalRangeXP = 25.0
-        @gimbalRangeXN = 25.0
-        @gimbalRangeYP = 0
-        @gimbalRangeYN = 0
-    }
-}
-
-//  ==================================================
-//  RD-0110R vernier engine.
-
-//  Dimensions: 0.375 m x 0.8 m
-//  Gross Mass: 140 Kg
-//  ==================================================
-
-+PART[STEERING_MOTOR_RD0110engine]:FOR[RealismOverhaul]
-{
-    @name = RO-RealEngines-RD-0110R
-    %RSSROConfig = True
-
-    !mesh = NULL
-
-    @MODEL
-    {
-        @scale = 1.155, 1.155, 1.155
-    }
-
-    @mass = 0.14
-    @tags = ascent launch propuls RD-0110 rocket soyuz vac vern
-
     %engineType = RD0110R
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3853
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6147
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 330
-            @key,1 = 1 165
-        }
-    }
 }
 
 //  ==================================================
 //  RD-0110R vernier engine.
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0110R]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-0110R]:AFTER[RealismOverhaulEngines]
 {
     //  Fix the wrong gimbal directions.
 
@@ -2063,14 +1723,14 @@
 
 //  ==================================================
 //  KTDU-35 propulsion system.
-
+//
 //  Dimensions: 0.88 m x 1.1 m
-//  Gross Mass: 305 Kg
+//  Gross Mass: 305 kg
 //  ==================================================
 
-+PART[S5_92fversion]:FOR[RealismOverhaul]
++PART[RO-RealEngines-S5-92]:FOR[RealismOverhaul]
 {
-    @name = RO-RealEngines-KTDU35
+    @name = RO-RealEngines-KTDU-35
 
     %RSSROConfig = True
 
@@ -2086,61 +1746,25 @@
     @tags = ascent isaev KTDU-35 launch progress propuls rocket S5.35 S5.60 soyuz vac
 
     %engineType = KTDU35
+}
 
-    //  Main engine (S5.60).
+//  ==================================================
+//  KTDU-35 propulsion system.
+//
+//  Engine configuration.
+//  ==================================================
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
-    {
-        %engineID = MainEngine
-        @minThrust = 4.09
-        @maxThrust = 4.09
-        @heatProduction = 1
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 25
-        %stagingEnabled = True
-
-        @PROPELLANT[UDMH]
-        {
-            @ratio = 0.5052
-        }
-
-        @PROPELLANT[NTO]
-        {
-            @name = AK27
-            @ratio = 0.4948
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 278
-            @key,1 = 1 100
-        }
-    }
-
+@PART[RO-RealEngines-KTDU-35]:AFTER[RealismOverhaulEngines]
+{
     //  Backup engine (S5.35).
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
     {
-        %engineID = BackupEngine
+        @engineID = BackupEngine
         @minThrust = 4.03
         @maxThrust = 4.03
         @heatProduction = 1
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 25
         %stagingEnabled = False
-
-        @PROPELLANT[UDMH]
-        {
-            @ratio = 0.5052
-        }
-
-        @PROPELLANT[NTO]
-        {
-            @name = AK27
-            @ratio = 0.4948
-        }
 
         @atmosphereCurve
         {
@@ -2152,14 +1776,14 @@
 
 //  ==================================================
 //  NK-9 engine.
-
+//
 //  Dimensions: 1.1 m x 2.9 m
-//  Gross Mass: 316 Kg
+//  Gross Mass: 316 kg
 //  ==================================================
 
-+PART[NK33engine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
++PART[RO-RealEngines-NK-33]:FOR[RealismOverhaul]
 {
-    @name = RO-RealEngines-NK9
+    @name = RO-RealEngines-NK-9
 
     %RSSROConfig = True
 
@@ -2198,14 +1822,14 @@
 
 //  ==================================================
 //  NK-9V series engine (9V/21/19/31/39).
-
+//
 //  Dimensions: 1.84 m x 3.9 m
-//  Gross Mass: 450 Kg
+//  Gross Mass: 450 kg
 //  ==================================================
 
-+PART[NK43engine]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
++PART[RO-RealEngines-NK-43]:FOR[RealismOverhaul]
 {
-    @name = RO-RealEngines-NK9V
+    @name = RO-RealEngines-NK-9V
 
     %RSSROConfig = True
 
@@ -2245,14 +1869,14 @@
 
 //  ==================================================
 //  RD-0105 series engine.
-
+//
 //  Dimensions: 0.76 m x 1.58 m
-//  Gross Mass: 125 Kg
+//  Gross Mass: 125 kg
 //  ==================================================
 
-+PART[S5_92fversion]:FOR[RealismOverhaul]
++PART[RO-RealEngines-S5-92]:FOR[RealismOverhaul]
 {
-    @name = RO-RealEngines-RD0105
+    @name = RO-RealEngines-RD-0105
 
     %RSSROConfig = True
 
@@ -2269,14 +1893,9 @@
     @tags = ascent launch luna propuls RD-0105 RD-0109 rocket vac voskhod vostok
 
     %engineType = RD0105
-    %useVerniers = True
-    %vernierThrust = 0.5
-
-    //  Main engine.
 
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = MainEngine
         @minThrust = 49.4
         @maxThrust = 49.4
         @heatProduction = 51
@@ -2302,39 +1921,44 @@
             @key,1 = 1 100
         }
     }
+}
 
-    //  Vernier engines.
-    //  The model provides two separate vernier thrust transforms but the Blok-E had four vernier engines.
-    //  So, we double the thrust available from each vernier engine (420 N for each one).
+//  ==================================================
+//  RD-0105 series engine.
+//
+//  Engine configuration.
+//  ==================================================
 
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
+@PART[RO-RealEngines-RD-0105]:AFTER[RealismOverhaulEngines]
+{
+    //  Configure the thrust transforms of 
+    //  the main and vernier engines.
+    //
+    //  The model provides two separate
+    //  vernier thrust transforms but the
+    //  Blok-E had four vernier engines.
+    //  So, we double the thrust available
+    //  from each vernier engine (420 N
+    //  for each one).
+
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
-        %engineID = VenierEngine
-        @minThrust = 0.84
-        @maxThrust = 0.84
-        @heatProduction = 1
-        %ullage = True
-        %pressureFed = False
-        %ignitions = 1
+        !THRUST_TRANSFORM,*{}
 
-        @PROPELLANT[UDMH]
+        THRUST_TRANSFORM
         {
-            @name = Kerosene
-            @ratio = 0.3594
+            name = thrustTransform
+            overallMultiplier = 1.0
         }
 
-        @PROPELLANT[NTO]
+        THRUST_TRANSFORM
         {
-            @name = LqdOxygen
-            @ratio = 0.6406
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 326
-            @key,1 = 1 100
+            name = tt2
+            overallMultiplier = 0.0085
         }
     }
+
+    !MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]],*{}
 
     // Vernier gimbal setup.
 
@@ -2342,10 +1966,10 @@
     {
         @gimbalTransformName = tt2
         @gimbalRange = 7.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
         %gimbalResponseSpeed = 16
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
@@ -1,32 +1,31 @@
 //  ==================================================
 //  Sources:
-
+//
 //  Yuzhnoye Design Office - RD-8 engine:                       http://www.yuzhnoye.com/en/technique/rocket-engines/steering/rd-8
 //  Encyclopedia Astronautica - RD-8 engine:                    http://www.astronautix.com/r/rd-8.html
-
 //  Encyclopedia Astronautica - RD-802 engine:                  http://www.astronautix.com/r/rd-802.html
 //  Yuzhnoye Design Office - Kerolox rocket engine development: http://www.khai.edu/csp/nauchportal/Arhiv/AKTT/2013/AKTT113/Degtyar.pdf
-
 //  NPO Energomash - RD-120 engine:                             http://www.npoenergomash.ru/eng/dejatelnost/engines/rd120/
 //  Moscow Aviation Institute - V.P. Glushko Energomash RPA:    http://www.k204.ru/books/vrd/wiki2/PDF/Emash.pdf
 //  Encyclopedia Astronautica: RD-120 engine:                   http://astronautix.com/r/rd-120.html
-
 //  Norbert Brügge - Ukrainian rocket engines:                  http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
 
 //  ==================================================
 //  RD-8 engine.
-
+//
 //  Dimensions: 0.7 m x 0.95 m
-//  Inert Mass: 95 Kg
-
+//  Inert Mass: 95 kg
+//
 //  * Stats refers to the single chamber variant.
 //  ==================================================
 
 @PART[RD8]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-8
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -40,8 +39,6 @@
 
     @mass = 0.095
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -52,54 +49,32 @@
 
     %engineType = RD8
     %engineTypeMult = 0.25
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3670
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6330
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 342
-            @key,1 = 1 170
-        }
-    }
 }
 
 //  ==================================================
 //  RD-8 engine.
-
+//
 //  Engine configuration.
 //  ==================================================
 
-@PART[RD8]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-8]:AFTER[RealismOverhaulEngines]
 {
     //  Fix the wrong gimbal directions.
 
     @MODULE[ModuleGimbal]
     {
-        !gimbalRange = NULL
-        %gimbalRangeXP = 33.0
-        %gimbalRangeXN = 33.0
-        %gimbalRangeYP = 0
-        %gimbalRangeYN = 0
+        @gimbalRangeXP = 33.0
+        @gimbalRangeXN = 33.0
+        @gimbalRangeYP = 0
+        @gimbalRangeYN = 0
     }
 }
 
 //  ==================================================
 //  RD-805 engine.
-
+//
 //  Dimensions: 0.7 m x 0.95 m
-//  Inert Mass: 40 Kg
+//  Inert Mass: 40 kg
 //  ==================================================
 
 +PART[RD8]:FIRST
@@ -118,7 +93,7 @@
 {
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -132,8 +107,6 @@
 
     @mass = 0.04
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -143,50 +116,22 @@
     @tags = ascent launch propuls RD-805 rocket vernier vac zenit
 
     %engineType = RD805
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3576
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6424
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 344
-            @key,1 = 1 172
-        }
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 8.0
-        !gimbalRangeYP = NULL
-        !gimbalRangeYN = NULL
-        !gimbalRangeXP = NULL
-        !gimbalRangeXN = NULL
-    }
 }
 
 //  ==================================================
 //  RD-120 engine.
-
+//
 //  Dimensions: 3.55 m x 4.7 m
-//  Inert Mass: 1125 Kg
+//  Inert Mass: 1125 kg
 //  ==================================================
 
 @PART[RD120]:FOR[RealismOverhaul]
 {
+    @name = RO-RealEngines-RD-120
+
     %RSSROConfig = True
 
-    !mesh = NULL
+    !mesh = DELETE
 
     @MODEL
     {
@@ -203,8 +148,6 @@
 
     @mass = 1.125
     @crashTolerance = 10
-    %breakingForce = 250
-    %breakingTorque = 250
     @maxTemp = 573.15
     %skinMaxTemp = 673.15
     %stageOffset = 1
@@ -214,43 +157,13 @@
     @tags = ascent launch propuls RD-120 rocket srf vac zenit
 
     %engineType = RD120
-
-    @MODULE[ModuleEngines*]
-    {
-        @PROPELLANT[LiquidFuel]
-        {
-            @name = Kerosene
-            @ratio = 0.3486
-        }
-
-        @PROPELLANT[Oxidizer]
-        {
-            @name = LqdOxygen
-            @ratio = 0.6514
-        }
-
-        @atmosphereCurve
-        {
-            @key,0 = 0 350
-            @key,1 = 1 175
-        }
-    }
-
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 6.0
-        !gimbalRangeYP = 0.0
-        !gimbalRangeYN = 0.0
-        !gimbalRangeXP = 0.0
-        !gimbalRangeXN = 0.0
-    }
 }
 
 //  ==================================================
 //  RD-856 vernier engine.
-
+//
 //  Dimensions: 0.3 m x 0.66 m
-//  Inert Mass: 28 Kg
+//  Inert Mass: 28 kg
 //  ==================================================
 
 +PART[STEERING_MOTOR_RD0110engine]:FOR[RealismOverhaul]
@@ -298,7 +211,7 @@
 //  Engine configuration.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-856]:FOR[RealismOverhaulEnginesPost]
+@PART[RO-RealEngines-RD-856]:AFTER[RealismOverhaulEngines]
 {
     //  Fix the wrong gimbal directions.
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Ukrainian.cfg
@@ -116,6 +116,15 @@
     @tags = ascent launch propuls RD-805 rocket vernier vac zenit
 
     %engineType = RD805
+
+    @MODULE[ModuleGimbal]
+    {
+        %gimbalRange = 8.0
+        !gimbalRangeYP = DELETE
+        !gimbalRangeYN = DELETE
+        !gimbalRangeXP = DELETE
+        !gimbalRangeXN = DELETE
+    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/A7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/A7.cfg
@@ -2,7 +2,7 @@
 //  NAA-75-110 A-Series engine plume setup.
 //  ==================================================
 
-@PART[A7]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-A-7]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -41,24 +41,9 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Alcolox-Lower-A6
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
-    @MODULE[ModuleEngineConfigs]
-    {
-        @CONFIG,*
-        {
-            %powerEffectName = Alcolox-Lower-A6
-        }
-    }
-}
-
-//  ==================================================
-//  NAA-75-110 A-Series engine plume configuration.
-//  ==================================================
-
-@PART[A7]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
-{
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG[A-6]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_104.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_104.cfg
@@ -2,7 +2,7 @@
 //  AJ10-104 engine plume setup.
 //  ==================================================
 
-@PART[AJ10_104]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-104]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Upper
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_137.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_137.cfg
@@ -2,7 +2,7 @@
 //  AJ10-137 engine plume setup.
 //  ==================================================
 
-@PART[AJ10_137]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-137]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,7 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Apollo-SM
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_190.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_190.cfg
@@ -2,7 +2,7 @@
 //  AJ10-190 engine plume setup.
 //  ==================================================
 
-@PART[AJ10_190]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-190]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,7 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Apollo-SM
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_37.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_37.cfg
@@ -2,7 +2,7 @@
 //  AJ10-37 engine plume setup.
 //  ==================================================
 
-@PART[AJ10_37]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-37]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Upper
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/J2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/J2.cfg
@@ -2,7 +2,7 @@
 //  J-2 engine plume setup.
 //  ==================================================
 
-@PART[J2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-J2]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hydrolox-Upper
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/KTDU35.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/KTDU35.cfg
@@ -2,7 +2,7 @@
 //  KTDU-35 propulsion system plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-KTDU35]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-KTDU-35]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -41,20 +41,28 @@
     @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
     {
         %powerEffectName = Hypergolic-Upper
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngines*]:HAS[#engineID[BackupEngine]]
     {
         %powerEffectName = Hypergolic-OMS-Red
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
-    @MODULE[ModuleEngineConfigs]
+    @MODULE[ModuleEngineConfigs]:HAS[#engineID[MainEngine]]
     {
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper
+        }
+    }
+
+    @MODULE[ModuleEngineConfigs]:HAS[#engineID[BackupEngine]]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic-OMS-Red
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMAE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMAE.cfg
@@ -2,7 +2,7 @@
 //  APS (LMAE) engine plume setup.
 //  ==================================================
 
-@PART[LMAE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-LMAE]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-White
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMDE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMDE.cfg
@@ -2,7 +2,7 @@
 //  DPS (LMDE) engine plume setup.
 //  ==================================================
 
-@PART[LMDE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-LMDE]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-White
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK33engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK33engine.cfg
@@ -2,7 +2,7 @@
 //  NK-33 series plume setup.
 //  ==================================================
 
-@PART[NK33engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-33]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK43engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK43engine.cfg
@@ -2,7 +2,7 @@
 //  NK-43 series plume setup.
 //  ==================================================
 
-@PART[NK43engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-43]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
@@ -2,7 +2,7 @@
 //  NK-9 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-NK9]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-9]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,7 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
@@ -2,7 +2,7 @@
 //  NK-9V engine series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-NK9V]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-9V]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,7 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD-856.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD-856.cfg
@@ -24,7 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Vernier
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0105.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0105.cfg
@@ -2,7 +2,7 @@
 //  RD-0105 engine series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD0105]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0105]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -41,13 +41,7 @@
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[tt2]]
-    {
-        %powerEffectName = Kerolox-Vernier
-        !runningEffectName = NULL
+        %runningEffectName = Kerolox-Vernier
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -55,6 +49,7 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
+            %runningEffectName = Kerolox-Vernier
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0110.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0110.cfg
@@ -2,7 +2,7 @@
 //  RD-0110 engine plume setup.
 //  ==================================================
 
-@PART[RD0110engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0110]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -41,17 +41,7 @@
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Kerolox-Vernier
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -59,6 +49,7 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
+            %runningEffectName = Kerolox-Vernier
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
@@ -2,7 +2,7 @@
 //  RD-0124A plume setup.
 //  ==================================================
 
-@PART[RD0124Aengine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0124A]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124engine.cfg
@@ -2,7 +2,7 @@
 //  RD-0124 series plume setup.
 //  ==================================================
 
-@PART[RD0124engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0124]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0146engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0146engine.cfg
@@ -2,7 +2,7 @@
 //  RD-0146 engine plume setup.
 //  ==================================================
 
-@PART[RD0146engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0146]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hydrolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
@@ -2,7 +2,7 @@
 //  RD-0210/0211 engine plume setup.
 //  ==================================================
 
-@PART[RD0210]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0210]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
@@ -2,7 +2,7 @@
 //  RD-0212 engine plume setup.
 //  ==================================================
 
-@PART[RD0212]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0212]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -38,20 +38,10 @@
         emissionMult = 0.5
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Hypergolic-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#engineID[VernierEngine]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Hypergolic-OMS-Red
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -59,6 +49,7 @@
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper
+            %runningEffectName = Hypergolic-OMS-Red
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD107.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD107.cfg
@@ -2,7 +2,7 @@
 //  RD-107 series plume setup.
 //  ==================================================
 
-@PART[RD107]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-107]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -41,17 +41,7 @@
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Kerolox-Vernier
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -59,6 +49,7 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
+            %runningEffectName = Kerolox-Vernier
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
@@ -2,7 +2,7 @@
 //  RD-108 series plume setup.
 //  ==================================================
 
-@PART[RD108]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-108]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -41,17 +41,7 @@
     @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform2]]
-    {
-        //  Workaround for a SmokeScreen bug.
-
-        !powerEffectName = NULL
         %runningEffectName = Kerolox-Vernier
-        !fxOffset = NULL
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -59,6 +49,7 @@
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
+            %runningEffectName = Kerolox-Vernier
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120.cfg
@@ -2,7 +2,7 @@
 //  RD-120 engine plume setup.
 //  ==================================================
 
-@PART[RD120]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-120]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD275.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD275.cfg
@@ -2,7 +2,7 @@
 //  RD-253/275 engine plume setup.
 //  ==================================================
 
-@PART[RD275]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-253]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD58.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD58.cfg
@@ -2,7 +2,7 @@
 //  RD-58 series plume setup.
 //  ==================================================
 
-@PART[RD58]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-58]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
@@ -2,7 +2,7 @@
 //  RD-8 engine plume setup.
 //  ==================================================
 
-@PART[RD8]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-8]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Vernier
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD805.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD805.cfg
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Upper
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_Vacuum.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_Vacuum.cfg
@@ -2,7 +2,7 @@
 //  Raptor engine (vacuum variant) plume setup.
 //  ==================================================
 
-@PART[Raptor_Vacuum]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-Raptor-VAC]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hydrolox-Upper
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_engine.cfg
@@ -2,7 +2,7 @@
 //  Raptor engine (surface variant) plume setup.
 //  ==================================================
 
-@PART[Raptor_engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-Raptor-ASL]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hydrolox-Lower
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
@@ -2,7 +2,7 @@
 //  S5.92 engine plume setup.
 //  ==================================================
 
-@PART[S5_92fversion]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-S5-92]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -38,18 +38,10 @@
         emissionMult = 0.75
     }
 
-    @MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
+    @MODULE[ModuleEngines*]:HAS[#thrustVectorTransformName[thrustTransform]]
     {
         %powerEffectName = Hypergolic-OMS-Red
-        !runningEffectName = NULL
-        !fxOffset = NULL
-    }
-
-    @MODULE[ModuleEngines*]:HAS[#engineID[GasGenerator]]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        %runningEffectName = Hypergolic-OMS-White
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -57,6 +49,7 @@
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-Red
+            %runningEffectName = Hypergolic-OMS-White
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
@@ -2,7 +2,7 @@
 //  S5.98M engine plume setup.
 //  ==================================================
 
-@PART[S5_98M]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-S5-98]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-Red
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SSME_Engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SSME_Engine.cfg
@@ -2,7 +2,7 @@
 //  RS-25 engine plume setup.
 //  ==================================================
 
-@PART[SSME_Engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-SSME]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -23,7 +23,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hydrolox-Lower
-        !runningEffectName = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/STEERING_MOTOR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/STEERING_MOTOR.cfg
@@ -1,8 +1,8 @@
 //  ==================================================
-//  RD-0110 vernier engine plume setup.
+//  RD-0110R vernier engine plume setup.
 //  ==================================================
 
-@PART[STEERING_MOTOR_RD0110engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0110R]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Vernier
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SuperDrago.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SuperDrago.cfg
@@ -2,7 +2,7 @@
 //  SuperDraco engine plume setup.
 //  ==================================================
 
-@PART[SuperDrago]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-SuperDraco]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hypergolic-OMS-Red
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd0120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd0120.cfg
@@ -2,7 +2,7 @@
 //  RD-0120 engine plume setup.
 //  ==================================================
 
-@PART[rd0120]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0120]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Hydrolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd100.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd100.cfg
@@ -2,7 +2,7 @@
 //  RD-103 engine plume setup.
 //  ==================================================
 
-@PART[rd100]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-100]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Alcolox-Lower-A6
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd170engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd170engine.cfg
@@ -2,7 +2,7 @@
 //  RD-170 engine plume setup.
 //  ==================================================
 
-@PART[RD170engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-170]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd180engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd180engine.cfg
@@ -2,7 +2,7 @@
 //  RD-180 engine plume setup.
 //  ==================================================
 
-@PART[RD180engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-180]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd191engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd191engine.cfg
@@ -2,7 +2,7 @@
 //  RD-191 engine plume setup.
 //  ==================================================
 
-@PART[RD191engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-191]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -24,8 +24,7 @@
     @MODULE[ModuleEngines*]
     {
         %powerEffectName = Kerolox-Lower
-        !runningEffectName = NULL
-        !fxOffset = NULL
+        !runningEffectName = DELETE
     }
 
     @MODULE[ModuleEngineConfigs]


### PR DESCRIPTION
**Change Log:**

* Change **all** internal part names to fix compatibility issues with RP-0/1. **WARNING: save & craft-breaking update!**
* Update all engines with integrated tubopump exhausts/vernier engines to use a single engine module in order to fix various TestFlight interop bugs.
* Simplify the RealPlume patches of the A-7 engine.