### PR TITLE
Create the S2.253 engine used in R-11 Scud

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -367,11 +367,11 @@
     {
         name = RD-103
         ratedBurnTime = 130
-        ignitionReliabilityStart = 0.8
-        ignitionReliabilityEnd = 0.9
+        ignitionReliabilityStart = 0.9
+        ignitionReliabilityEnd = 0.98
         ignitionDynPresFailMultiplier = 2.0
         cycleReliabilityStart = 0.85
-        cycleReliabilityEnd = 0.93
+        cycleReliabilityEnd = 0.95
         techTransfer = RD-102:50
         reliabilityDataRateMultiplier = 1
     }
@@ -383,8 +383,8 @@
     {
         name = RD-103M
         ratedBurnTime = 140
-        ignitionReliabilityStart = 0.85
-        ignitionReliabilityEnd = 0.93
+        ignitionReliabilityStart = 0.9
+        ignitionReliabilityEnd = 0.98
         ignitionDynPresFailMultiplier = 2.0
         cycleReliabilityStart = 0.87
         cycleReliabilityEnd = 0.96

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -1,0 +1,110 @@
+//  
+//
+
+@PART[*]:HAS[#engineType[S2.253]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = S2.253 Engine
+    %manufacturer = 
+    %description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile, based on the Wasserfall engine using Kerosene and Nitric Acid as propellants.  Diameter: 0.88 m.
+
+    @MODULE[ModuleEngines,*]
+    {
+        %minThrust = 93.3
+        %maxThrust = 93.3
+        %heatProduction = 35
+        %EngineType = LiquidFuel
+        @useEngineResponseSpeed = False
+        %useThrustCurve = False
+        %ullage = True
+        %pressureFed = False
+        %ignitions = 1
+
+        !IGNITOR_RESOURCE,*{}
+
+        !thrustCurve,*{}
+    }
+
+    @MODULE[ModuleGimbal],*
+    {
+        @gimbalRange = 2.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = S2.253
+        origMass = 0.3
+
+        CONFIG
+        {
+            name = S2.253
+            minThrust = 93.3
+            maxThrust = 93.3
+            heatProduction = 35
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 1
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            PROPELLANT // 3.07 mixture ratio
+            {
+                name = Kerosene
+                ratio = 0.373
+                DrawGauge = True
+            }
+
+            PROPELLANT
+            {
+                name = AK20
+                ratio = 0.627
+                DrawGauge = False
+            }
+
+            atmosphereCurve
+            {
+                key = 0 251
+                key = 1 219
+            }
+        }
+
+       
+    }
+
+
+    !MODULE[ModuleAlternator],*{}
+
+    !RESOURCE,*{}
+}
+
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S2.253]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = S2.253
+        ratedBurnTime = 95
+        ignitionReliabilityStart = 0.9
+        ignitionReliabilityEnd = 0.98
+        ignitionDynPresFailMultiplier = 1.5
+        cycleReliabilityStart = 0.85
+        cycleReliabilityEnd = 0.95
+        reliabilityDataRateMultiplier = 1
+        techTransfer = RD-100:20
+    }
+}
+

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_Russian.cfg
@@ -436,6 +436,113 @@
 }
 
 //  ==================================================
+//  S2.253 series engine.
+
+//  Dimensions: 0.88 m x 1.66 m
+//  Gross Mass: XXX Kg
+//  ==================================================
+
++PART[rd100]:FOR[RealismOverhaul]
+{
+    @name = RO-RealEngines-S2.253
+
+    %RSSROConfig = True
+
+    !mesh = NULL
+
+    @MODEL
+    {
+        @scale = 1.0, 1.0, 1.0
+    }
+
+    //  Modeling the jet vanes as four thrust transforms.
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.25, -0.8, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = -0.25, -0.8, 0.0
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.0, -0.8, 0.25
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    MODEL
+    {
+        model = RealismOverhaul/emptyengine
+        position = 0.0, -0.8, -0.25
+        rotation = 0.0, 0.0, 0.0
+    }
+
+    @scale = 1.0
+    @rescaleFactor = 0.53
+
+    @node_stack_top = 0.0, 2.23, 0.0, 0.0, 1.0, 0.0, 1
+    @node_stack_bottom = 0.0, -0.78, 0.0, 0.0, -1.0, 0.0, 1
+    @node_attach = 0.0, 2.23, 0.0, 0.0, 1.0, 0.0
+
+    @mass = 0.3
+    @crashTolerance = 10
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 573.15
+    %skinMaxTemp = 673.15
+    %stageOffset = 1
+    %childStageOffset = 1
+    %stagingIcon = LIQUID_ENGINE
+    @bulkheadProfiles = srf, size1
+    @tags = ascent irbm launch propuls R-11 rocket surf vertikal
+
+    %engineType = S2.253
+
+    @MODULE[ModuleEngines*]
+    {
+        %thrustVectorTransformName = newThrustTransform
+
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = Kerosene
+            ratio = 0.373
+        }
+
+        @PROPELLANT[Oxidizer]
+        {
+            @name = AK20
+            ratio = 0.627
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 251
+            @key,1 = 1 219
+        }
+    }
+
+    @MODULE[ModuleGimbal]
+    {
+        %gimbalTransformName = newThrustTransform
+        %gimbalRange = 2.0
+        !gimbalRangeYP = NULL
+        !gimbalRangeYN = NULL
+        !gimbalRangeXP = NULL
+        !gimbalRangeXN = NULL
+        @gimbalResponseSpeed = 16
+    }
+}
+
+
+//  ==================================================
 //  RD-107 series engine.
 
 //  Dimensions: 2.6 m x 2.66 m


### PR DESCRIPTION
This creates the R11 Scud missile engine, using the information we were able to gather from different sources.
Mass was estimated based on the missile dry mass and making the TWR lower than RD-100
Reliability was also based on the RD-100 series