### PR TITLE
Add basic kerolox plume for S2.253 engine 

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S2.253.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S2.253.cfg
@@ -1,0 +1,37 @@
+//  ==================================================
+//  S2.253 engine plume setup.
+//  ==================================================
+
+@PART[RO-RealEngines-S2.253]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        plumePosition = 0.0, 0.0, 0.1
+        plumeScale = 0.3
+        flarePosition = 0.0, 0.0, 0.1
+        flareScale = 0.3
+        smokePosition = 0.0, 0.0, 0.0
+        smokeScale = 0.3
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 1.0
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = NULL
+    }
+
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}


### PR DESCRIPTION
We have a new engine from the Scud missile (see 5730a6c7f17b55aa1769a61fc5379fe31fb73d57), but it was without a plume.  This adds a basic plume using the kerolox prefab, sized and placed to fit the temporary (RD-10x) model.