### PR TITLE
[Bugfix] LMAE/LMDE/LR89 engine masses

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -23,7 +23,6 @@
 	%title = Lunar Module Ascent Engine (LMAE)
 	%manufacturer = Bell / Rocketdyne
 	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander. Diameter: [0.86 m].
-  @mass = 0.0816
 
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
@@ -30,8 +30,6 @@
 	%title = Lunar Module Descent Engine (LMDE)
 	%manufacturer = TRW
 	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability. Diameter: 1.5 m.
-  
-  @mass = 0.179
 
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -30,8 +30,6 @@
     %title = LR89 Series
     %manufacturer = Rocketdyne
     %description = Kerolox gas-generator engine that served as booster for Atlas (as -89, MA-x sysem) and main engine for Thor/Thor-Delta/Delta and Jupiter/Juno II rockets (as -79, MB-x system). Late model LR89s were upgraded with RS-27 components for higher efficiency, whereas the RS-27 itself was used on Delta by that point. LR89 configs are comparable to similar-era -79 configs, since they were the same engine underneath.
-    
-    @mass = 0.720
 
     @MODULE[ModuleEngines*]
     {


### PR DESCRIPTION
**Change Log:**

* Fix the incorrect mass definitions of the LMAE, LMDE and LR89 global engine configs (introduced by https://github.com/KSP-RO/RealismOverhaul/commit/117754e48dfb8d6b9ffff28e1ea6bf7ca9680ed3 - breaks the custom mass overrides of specific parts like the DECQ and SXT Lunar Modules).