### PR TITLE
Thesciencenut nfe rtg fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NFE_RTG_PATCH.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NFE_RTG_PATCH.cfg
@@ -1,0 +1,169 @@
+// Patches RTGs
+@PART[rtg-0625]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///NASA & DOE Advanced Sterling RTG		///page 46 of https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160001769.pdf
+	@mass = 0.031
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.137
+		@HalfLife = 43.103
+		///HalfLife = 8.35
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+@PART[rtg]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///Multi-Hundred-Watt RTG //page 25 of https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160001769.pdf
+	@cost *= 0.5
+	@mass = 0.0377
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.16
+		///HalfLife = 8.35
+		@HalfLife = 31.25
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+@PART[RLA_mmrtg]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///Multi-Mission RTG ///(Unsure where this part actually is)
+	@mass = 0.045
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.122
+		@HalfLife = 10.416
+		///HalfLife = 8.35
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+
+//Ven's Stock Revamp
+@PART[rtgMini]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///SNAP-3 Series RTG
+	@mass = 0.0023		///Pulled mass from original config and adjusted to compensate for removal of plutonium
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.0025
+		@HalfLife = 31.25
+		///HalfLife = 8.35
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+// SXT mod
+@PART[SXTDepolyRTGI]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///GPHS-RTG		///page 31 of https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160001769.pdf
+	@mass = 0.056
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.25
+		@HalfLife = 31.25
+		///HalfLife = 8.35
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+@PART[SXTDepolyRTGII]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///GPHS-RTG Shielded	///page 31 of https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160001769.pdf
+	@mass = 0.056
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.25
+		@HalfLife = 31.25
+		///HalfLife = 8.35
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+@PART[RO-SNAP-19-RTG]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///SNAP-19 Series RTG		///page 4 of https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160001769.pdf
+	@mass = 0.0152
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.04
+		///HalfLife = 8.35
+		@HalfLife = 31.25
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!MODULE[ModuleResourceConverter]{}
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+@PART[RO-SNAP-9-RTG]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///SNAP-9 Series RTG		///Pulled mass from original config and adjusted to compensate for removal of plutonium
+	@mass = 0.012
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.03
+		///HalfLife = 8.35
+		@HalfLife = 31.25
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!MODULE[ModuleResourceConverter]{}
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}
+@PART[RO-MMRTG]:NEEDS[NearFutureElectrical]:FOR[RealismOverhaul]
+{
+///Multi-Mission RTG	///page 11 of ttps://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160001769.pdf
+	@mass = 0.045
+	@cost *= 0.5
+	!MODULE[ModuleGenerator] {}
+    @MODULE[ModuleRadioisotopeGenerator]
+	{
+		///name = ModuleRadioisotopeGenerator
+		@BasePower = 0.11
+		///HalfLife = 8.35
+		@HalfLife = 31.25
+		@EasyMode = true
+	}
+	!MODULE[ModuleResourceConverter]{}	///Removed this due to the fact that it doesn't decay
+	!MODULE[ModuleResourceConverter]{}
+	!RESOURCE[Plutonium-238]{}
+	!RESOURCE[DepletedFuel]{}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -2,7 +2,7 @@
 {
 	%RSSROConfig = True
 	!mesh = DELETE
-	@MODEL
+	MODEL
 	{
 		model = NearFutureElectrical/Parts/RTG/rtg-0625/rtg-0625
 		scale = 0.666667, 0.803949, 0.666667
@@ -139,7 +139,7 @@
 	{
 	}
 	!mesh = DELETE
-	@MODEL
+	MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-375/reactor-375
 		scale = 1.0, 1.0, 1.0
@@ -200,7 +200,7 @@
 	{
 	}
 	!mesh = DELETE
-	@MODEL
+	MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-25/reactor-25
 		scale = 0.8, 1.908027, 0.8
@@ -305,7 +305,7 @@
 {
 	%RSSROConfig = True
 	!mesh = DELETE
-	@MODEL
+	MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-25-2/reactor-25-2
 		scale = 1.84, 4.064981, 1.84
@@ -415,7 +415,7 @@
 	{
 	}
 	!mesh = DELETE
-	@MODEL
+	MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-125/reactor-125
 		scale = 1.12, 1.855994, 1.12
@@ -530,7 +530,7 @@
 	{
 	}
 	!mesh = DELETE
-	@MODEL
+	MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-0625/reactor-0625
 		scale = 0.816, 1.270815, 0.816

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -249,7 +249,7 @@
 	{
 		@maxAmount = 90.9090						///Couldn't find the actual amount of fuel, so estimated a mass of 1000kg
 	}
-	@RESOURCE[EnrichedUranium]						///Technically uses Li-6, but that isn't a used resource
+	@RESOURCE[EnrichedUranium]						///40% and 50% enriched uranium (uranium nitride)
 	{
 		@amount = 90.9090							///Couldn't find the actual amount of fuel, so estimated a mass of 1000kg
 		@maxAmount = 90.9090						///10 year run time at 80% of 200kW
@@ -259,8 +259,8 @@
 	
 	///@OverheatAnimation = Reactor_10kW_Heat		/// Heat animation, plays when above nominal temp
 		@HeatGeneration = 250000					/// Heat to generate (kW*50)
-		@NominalTemperature = 400					/// Above this temp more power output but risky
-		@CriticalTemperature = 2100					/// Above this temp, reactor takes damage
+		@NominalTemperature = 654					/// Above this temp more power output but risky
+		@CriticalTemperature = 2374					/// Above this temp, reactor takes damage
 		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
 													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 	
@@ -275,7 +275,6 @@
 		@OUTPUT_RESOURCE
 		{	
 		///@ResourceName = DepletedUranium 			///Should be DepletedLi-6, but resource currently doesn't exist
-													///uncomment if this resource is added later
 			@ResourceName = DepletedFuel 
 			@Ratio = 0.0000003843607305				///Original Ratio = 
 			@DumpExcess = false
@@ -285,7 +284,7 @@
 	}
 		@MODULE[ModuleCoreHeatNoCatchup]
 	{
-		@CoreTempGoal = 400							///Internal temp goal - we don't transfer till we hit this point
+		@CoreTempGoal = 654							///Internal temp goal - we don't transfer till we hit this point
 		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
 		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
 		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
@@ -296,7 +295,7 @@
 		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
 		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
 		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
-		@CoreShutdownTemp = 2000					///At what core temperature do we shut down all generators on this part?
+		@CoreShutdownTemp = 2174					///At what core temperature do we shut down all generators on this part?
 		@MaxCoolant = 5000							///Maximum amount of radiator capacity we can consume - 50 = 1 small
 	
 	}
@@ -343,17 +342,17 @@
 	///		@key,1 = 500 75
 	///		@key,2 = 1500 5
 	///	}
-		@PowerGeneration = 45000
-		@HeatUsed = 145000
+		@PowerGeneration = 60000
+		@HeatUsed = 200000
 	}
 	@MODULE[FissionReactor]
 	{
 	
 	///@OverheatAnimation = Reactor_10kW_Heat		/// Heat animation, plays when above nominal temp
 	
-		@HeatGeneration = 7250000					/// Heat to generate (kW*50)
-		@NominalTemperature = 520					/// Above this temp more power output but risky
-		@CriticalTemperature = 2200					/// Above this temp, reactor takes damage
+		@HeatGeneration = 10000000					/// Heat to generate (kW*50)
+		@NominalTemperature = 794					/// Above this temp more power output but risky
+		@CriticalTemperature = 2474				/// Above this temp, reactor takes damage
 		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
 													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 	
@@ -378,7 +377,7 @@
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
 	{
-		@CoreTempGoal = 520							///Internal temp goal - we don't transfer till we hit this point
+		@CoreTempGoal = 794							///Internal temp goal - we don't transfer till we hit this point
 		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
 		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
 		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
@@ -389,8 +388,8 @@
 		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
 		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
 		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
-		@CoreShutdownTemp = 2200					///At what core temperature do we shut down all generators on this part?
-		@MaxCoolant = 145000						///Maximum amount of radiator capacity we can consume - 50 = 1 small
+		@CoreShutdownTemp = 2474					///At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 200000						///Maximum amount of radiator capacity we can consume - 50 = 1 small
 	
 	}
 	@RESOURCE[ElectricCharge]
@@ -404,7 +403,7 @@
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 12727.27272727273
+		@amount = 12727.27272727273					///Unknown fuel mass, but 2 years worth of 4.95% enriched uranium (This was my best initial guess)
 		@maxAmount = 12727.27272727273
 	}
 }
@@ -427,7 +426,7 @@
 	@title = TOPAZ-II Nuclear Reactor
 	@description = I. V. Kurchatov Institute of Atomic Energy. Related to the TOPAZ-I, a nuclear fission reactor found in around 30 satellites put into orbit by the Soviet Union.
 	@attachRules = 1,0,1,1,1
-	@mass = 1.061
+	@mass = .320
 	@MODULE[FissionGenerator]
 	{
 		///@UseStagingIcon = true
@@ -460,7 +459,7 @@
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
 	{
-		@CoreTempGoal = 550							///Internal temp goal - we don't transfer till we hit this point
+		@CoreTempGoal = 824							///Internal temp goal - we don't transfer till we hit this point
 		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
 		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
 		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
@@ -471,7 +470,7 @@
 		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
 		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
 		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
-		@CoreShutdownTemp = 1300					///At what core temperature do we shut down all generators on this part?
+		@CoreShutdownTemp = 1574					///At what core temperature do we shut down all generators on this part?
 		@MaxCoolant = 135							///Maximum amount of radiator capacity we can consume - 50 = 1 small
 	
 	}
@@ -482,8 +481,8 @@
 	///@OverheatAnimation = Reactor_50kW_Heat		/// Heat animation, plays when above nominal temp
 	
 		@HeatGeneration = 6750						/// Heat to generate (kW*50)
-		@NominalTemperature = 550					/// Above this temp more power output but risky
-		@CriticalTemperature = 1300					/// Above this temp, reactor takes damage
+		@NominalTemperature = 824					/// Above this temp more power output but risky
+		@CriticalTemperature = 1574				/// Above this temp, reactor takes damage
 		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
 													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 	
@@ -501,7 +500,7 @@
 		///@ResourceName = DepletedUranium 			///Should be DepletedUranium, but resource currently doesn't exist
 													///uncomment if this resource is added later
 			@ResourceName = DepletedFuel 
-			@Ratio = 0.0000000105699306		///Original Ratio = 0.0000000239085
+			@Ratio = 0.0000000105699306				///Original Ratio = 0.0000000239085
 			@DumpExcess = false
 			@FlowMode = NO_FLOW
 		}
@@ -519,7 +518,7 @@
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 1
+		@amount = 1									///12kg of HEU, 3 years of fuel at 135kWt
 		@maxAmount = 1
 	}
 }
@@ -542,7 +541,7 @@
 	@title = NASA SAFE-400 Nuclear Reactor
 	@description = Safe Affordable Fission Engine. Small and lightweight but powerful reactor enabled by new technology.
 	@attachRules = 1,0,1,1,1
-	@mass = 0.656									///http://www.world-nuclear.org/information-library/non-power-nuclear-applications/transport/nuclear-reactors-for-space.aspx
+	@mass = 0.512									///http://www.world-nuclear.org/information-library/non-power-nuclear-applications/transport/nuclear-reactors-for-space.aspx
 	@MODULE[FissionGenerator]
 	{
 		///@UseStagingIcon = true
@@ -580,8 +579,8 @@
 	///@OverheatAnimation = Reactor_10kW_Heat		/// Heat animation, plays when above nominal temp
 	
 		@HeatGeneration = 20000						/// Heat to generate (kW*50)
-		@NominalTemperature = 880					/// Above this temp more power output but risky
-		@CriticalTemperature = 1300					/// Above this temp, reactor takes damage
+		@NominalTemperature = 1154					/// Above this temp more power output but risky
+		@CriticalTemperature = 1574				/// Above this temp, reactor takes damage
 		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
 													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		
@@ -589,8 +588,8 @@
 
 		@INPUT_RESOURCE
 		{
-			@ResourceName = EnrichedUranium
-			@Ratio = 0.00000001931414573820396
+			@ResourceName = EnrichedUranium			///97%HEU
+			@Ratio = 0.0000000374752087
 			@FlowMode = NO_FLOW
 		}
 		@OUTPUT_RESOURCE
@@ -598,7 +597,7 @@
 		
 		///@ResourceName = DepletedUranium 			///Should be DepletedUranium, but resource currently doesn't exist, uncomment this line and comment out line below if this is added
 			@ResourceName = DepletedFuel 
-			@Ratio = 0.00000001931414573820396		///Original Ratio = 
+			@Ratio = 0.0000000374752087				///Original Ratio = 
 			@DumpExcess = false
 			@FlowMode = NO_FLOW
 		}
@@ -607,7 +606,7 @@
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
 	{
-		@CoreTempGoal = 880							///Internal temp goal - we don't transfer till we hit this point
+		@CoreTempGoal = 1154							///Internal temp goal - we don't transfer till we hit this point
 		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
 		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
 		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
@@ -618,7 +617,7 @@
 		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
 		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
 		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
-		@CoreShutdownTemp = 1300					///At what core temperature do we shut down all generators on this part?
+		@CoreShutdownTemp = 1574					///At what core temperature do we shut down all generators on this part?
 		@MaxCoolant = 400							///Maximum amount of radiator capacity we can consume - 50 = 1 small
 	}
 	@RESOURCE[ElectricCharge]
@@ -628,11 +627,11 @@
 	}
 	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 6.9
+		@maxAmount = 11.8181
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 6.9
-		@maxAmount = 6.9
+		@amount = 11.8181
+		@maxAmount = 11.8181						///130kg of fuel, 10 years at 400kWt
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -2,7 +2,7 @@
 {
 	%RSSROConfig = True
 	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
 		model = NearFutureElectrical/Parts/RTG/rtg-0625/rtg-0625
 		scale = 0.666667, 0.803949, 0.666667
@@ -139,7 +139,7 @@
 	{
 	}
 	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-375/reactor-375
 		scale = 1.0, 1.0, 1.0
@@ -153,29 +153,30 @@
 	@mass = 5.4
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 2000
-		@ThermalPower = 4000
-		@ThermalPowerResponseRate = 125
-		@BurnRate = 0.000006
-		@MinPowerPercent = 0.2
-		@CurrentPowerPercent = 0.2
-		@MaxCoreTemperature = 420
-		@MeltdownCoreTemperature = 2100
-		@CoreTemperatureResponseRate = 5
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+	///	@UseStagingIcon = true
+	///	@UseForcedActivation = true
+	///	@PowerGenerationMaximum = 2000
+	///	@ThermalPower = 4000
+	///	@ThermalPowerResponseRate = 125
+	///	@BurnRate = 0.000006
+	///	@MinPowerPercent = 0.2
+	///	@CurrentPowerPercent = 0.2
+	///	@MaxCoreTemperature = 420
+	///	@MeltdownCoreTemperature = 2100
+	///	@CoreTemperatureResponseRate = 5
+	///	@CurrentCoreTemperature = 0
+	///	@PressureCurve
+	///	{
+	///		@key,0 = 0 0
+	///		@key,1 = 1 10
+	///	}
+	///	@VelocityCurve
+	///	{
+	///		@key,0 = 0 10
+	///		@key,1 = 500 75
+	///		@key,2 = 1500 5
+	///	}
+	
 	}
 	@RESOURCE[ElectricCharge]
 	{
@@ -199,7 +200,7 @@
 	{
 	}
 	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-25/reactor-25
 		scale = 0.8, 1.908027, 0.8
@@ -210,32 +211,34 @@
 	@title = USDOE RAPID-L Nuclear Reactor
 	@description = Design based for lunar bases.
 	@attachRules = 1,0,1,1,1
-	@mass = 7.6
+	@mass = 6.6										///subtracted 1000kg to account for fuel mass
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 200
-		@ThermalPower = 5000
-		@ThermalPowerResponseRate = 35
-		@BurnRate = 0.000007
-		@MinPowerPercent = 0.2
-		@CurrentPowerPercent = 0.2
-		@MaxCoreTemperature = 400
-		@MeltdownCoreTemperature = 2100
-		@CoreTemperatureResponseRate = 3
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+	///	@UseStagingIcon = true
+	///	@UseForcedActivation = true
+	///	@PowerGenerationMaximum = 200
+	///	@ThermalPower = 5000
+	///	@ThermalPowerResponseRate = 35
+	///	@BurnRate = 0.000007
+	///	@MinPowerPercent = 0.2
+	///	@CurrentPowerPercent = 0.2
+	///	@MaxCoreTemperature = 400
+	///	@MeltdownCoreTemperature = 2100
+	///	@CoreTemperatureResponseRate = 3
+	///	@CurrentCoreTemperature = 0
+	///	@PressureCurve
+	///	{
+	///		@key,0 = 0 0
+	///		@key,1 = 1 10
+	///	}
+	///	@VelocityCurve
+	///	{
+	///		@key,0 = 0 10
+	///		@key,1 = 500 75
+	///		@key,2 = 1500 5
+	///	}
+		@PowerGeneration = 200
+		@HeatUsed = 5000
 	}
 	@RESOURCE[ElectricCharge]
 	{
@@ -244,19 +247,65 @@
 	}
 	@RESOURCE[DepletedUranium]
 	{
-		@maxAmount = 500
+		@maxAmount = 90.9090						///Couldn't find the actual amount of fuel, so estimated a mass of 1000kg
 	}
-	@RESOURCE[EnrichedUranium]
+	@RESOURCE[EnrichedUranium]						///Technically uses Li-6, but that isn't a used resource
 	{
-		@amount = 500
-		@maxAmount = 500
+		@amount = 90.9090							///Couldn't find the actual amount of fuel, so estimated a mass of 1000kg
+		@maxAmount = 90.9090						///10 year run time at 80% of 200kW
+	}
+	@MODULE[FissionReactor]
+	{
+	
+	///@OverheatAnimation = Reactor_10kW_Heat		/// Heat animation, plays when above nominal temp
+		@HeatGeneration = 250000					/// Heat to generate (kW*50)
+		@NominalTemperature = 400					/// Above this temp more power output but risky
+		@CriticalTemperature = 2100					/// Above this temp, reactor takes damage
+		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
+													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+	
+		@FuelName = EnrichedUranium					/// Base lifetime calculations off this resource
+
+		@INPUT_RESOURCE
+		{
+			@ResourceName = EnrichedUranium
+			@Ratio = 0.0000003843607305
+			@FlowMode = NO_FLOW
+		}
+		@OUTPUT_RESOURCE
+		{	
+		///@ResourceName = DepletedUranium 			///Should be DepletedLi-6, but resource currently doesn't exist
+													///uncomment if this resource is added later
+			@ResourceName = DepletedFuel 
+			@Ratio = 0.0000003843607305				///Original Ratio = 
+			@DumpExcess = false
+			@FlowMode = NO_FLOW
+		}
+	
+	}
+		@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 400							///Internal temp goal - we don't transfer till we hit this point
+		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
+		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
+		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
+		@HeatRadiantMultiplier = 0.05				///If the core is hotter, how much heat radiates?
+		@CoolingRadiantMultiplier = 0				///If the core is colder, how much radiates?
+		@HeatTransferMultiplier = 0					///If the part is hotter, how much heat transfers in?
+		@CoolantTransferMultiplier = 0.01			///If the part is colder, how much of our energy can we transfer?
+		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
+		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
+		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
+		@CoreShutdownTemp = 2000					///At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 5000							///Maximum amount of radiator capacity we can consume - 50 = 1 small
+	
 	}
 }
 @PART[reactor-25-2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-25-2/reactor-25-2
 		scale = 1.84, 4.064981, 1.84
@@ -271,29 +320,78 @@
 	@mass = 450
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 45000
-		@ThermalPower = 145000
-		@ThermalPowerResponseRate = 120
-		@BurnRate = 0.000008
-		@MinPowerPercent = 0.2
-		@CurrentPowerPercent = 0.2
-		@MaxCoreTemperature = 520
-		@MeltdownCoreTemperature = 2200
-		@CoreTemperatureResponseRate = 3
-		@CurrentCoreTemperature = 0
-		@PressureCurve
+	///	@UseStagingIcon = true
+	///	@UseForcedActivation = true
+	///	@PowerGenerationMaximum = 45000
+	///	@ThermalPower = 145000
+	///	@ThermalPowerResponseRate = 120
+	///	@BurnRate = 0.000008
+	///	@MinPowerPercent = 0.2
+	///	@CurrentPowerPercent = 0.2
+	///	@MaxCoreTemperature = 520
+	///	@MeltdownCoreTemperature = 2200
+	///	@CoreTemperatureResponseRate = 3
+	///	@CurrentCoreTemperature = 0
+	///	@PressureCurve
+	///	{
+	///		@key,0 = 0 0
+	///		@key,1 = 1 10
+	///	}
+	///	@VelocityCurve
+	///	{
+	///		@key,0 = 0 10
+	///		@key,1 = 500 75
+	///		@key,2 = 1500 5
+	///	}
+		@PowerGeneration = 45000
+		@HeatUsed = 145000
+	}
+	@MODULE[FissionReactor]
+	{
+	
+	///@OverheatAnimation = Reactor_10kW_Heat		/// Heat animation, plays when above nominal temp
+	
+		@HeatGeneration = 7250000					/// Heat to generate (kW*50)
+		@NominalTemperature = 520					/// Above this temp more power output but risky
+		@CriticalTemperature = 2200					/// Above this temp, reactor takes damage
+		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
+													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+	
+		@FuelName = EnrichedUranium					/// Base lifetime calculations off this resource
+
+		@INPUT_RESOURCE
 		{
-			@key,0 = 0 0
-			@key,1 = 1 10
+			@ResourceName = EnrichedUranium
+			@Ratio = 0.00020178958534690512
+			@FlowMode = NO_FLOW
 		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
+		@OUTPUT_RESOURCE
+		{	
+		///@ResourceName = DepletedUranium 			///Should be DepletedUranium, but resource currently doesn't exist
+													///uncomment if this resource is added later
+			@ResourceName = DepletedFuel 						
+			@Ratio = 	0.00020178958534690512		///Original Ratio = 
+			@DumpExcess = false
+			@FlowMode = NO_FLOW
 		}
+	
+	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 520							///Internal temp goal - we don't transfer till we hit this point
+		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
+		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
+		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
+		@HeatRadiantMultiplier = 0.05				///If the core is hotter, how much heat radiates?
+		@CoolingRadiantMultiplier = 0				///If the core is colder, how much radiates?
+		@HeatTransferMultiplier = 0					///If the part is hotter, how much heat transfers in?
+		@CoolantTransferMultiplier = 0.01			///If the part is colder, how much of our energy can we transfer?
+		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
+		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
+		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
+		@CoreShutdownTemp = 2200					///At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 145000						///Maximum amount of radiator capacity we can consume - 50 = 1 small
+	
 	}
 	@RESOURCE[ElectricCharge]
 	{
@@ -302,12 +400,12 @@
 	}
 	@RESOURCE[DepletedUranium]
 	{
-		@maxAmount = 750
+		@maxAmount = 12727.27272727273
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 750
-		@maxAmount = 750
+		@amount = 12727.27272727273
+		@maxAmount = 12727.27272727273
 	}
 }
 @PART[reactor-125]:FOR[RealismOverhaul]
@@ -317,7 +415,7 @@
 	{
 	}
 	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-125/reactor-125
 		scale = 1.12, 1.855994, 1.12
@@ -332,43 +430,97 @@
 	@mass = 1.061
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 5.5
-		@ThermalPower = 135
-		@ThermalPowerResponseRate = 5.5
-		@BurnRate = 0.000001
-		@MinPowerPercent = 0.1
-		@CurrentPowerPercent = 0.1
-		@MaxCoreTemperature = 550
-		@MeltdownCoreTemperature = 1100
-		@CoreTemperatureResponseRate = 5
-		@CurrentCoreTemperature = 0
-		@PressureCurve
-		{
-			@key,0 = 0 0
-			@key,1 = 1 10
-		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
-		}
+		///@UseStagingIcon = true
+		///@UseForcedActivation = true
+		///@PowerGenerationMaximum = 5.5
+		///@ThermalPower = 135
+		///@ThermalPowerResponseRate = 5.5
+		///@BurnRate = 0.000001
+		///@MinPowerPercent = 0.1
+		///@CurrentPowerPercent = 0.1
+		///@MaxCoreTemperature = 550
+		///@MeltdownCoreTemperature = 1100
+		///@CoreTemperatureResponseRate = 5
+		///@CurrentCoreTemperature = 0
+		///@PressureCurve
+		///{
+		///	@key,0 = 0 0
+		///	@key,1 = 1 10
+		///}
+		///@VelocityCurve
+		///{
+		///	@key,0 = 0 10
+		///	@key,1 = 500 75
+		///	@key,2 = 1500 5
+		///}
+		
+		@PowerGeneration = 5.5
+		@HeatUsed = 135
+		
 	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 550							///Internal temp goal - we don't transfer till we hit this point
+		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
+		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
+		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
+		@HeatRadiantMultiplier = 0.05				///If the core is hotter, how much heat radiates?
+		@CoolingRadiantMultiplier = 0				///If the core is colder, how much radiates?
+		@HeatTransferMultiplier = 0					///If the part is hotter, how much heat transfers in?
+		@CoolantTransferMultiplier = 0.01			///If the part is colder, how much of our energy can we transfer?
+		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
+		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
+		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
+		@CoreShutdownTemp = 1300					///At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 135							///Maximum amount of radiator capacity we can consume - 50 = 1 small
+	
+	}
+	
+	@MODULE[FissionReactor]
+	{
+	
+	///@OverheatAnimation = Reactor_50kW_Heat		/// Heat animation, plays when above nominal temp
+	
+		@HeatGeneration = 6750						/// Heat to generate (kW*50)
+		@NominalTemperature = 550					/// Above this temp more power output but risky
+		@CriticalTemperature = 1300					/// Above this temp, reactor takes damage
+		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
+													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+	
+		@FuelName = EnrichedUranium					/// Base lifetime calculations off this resource
+
+		@INPUT_RESOURCE
+		{
+			@ResourceName = EnrichedUranium
+			@Ratio = 0.0000000105699306
+			@FlowMode = NO_FLOW
+		}
+		@OUTPUT_RESOURCE
+		{	
+		
+		///@ResourceName = DepletedUranium 			///Should be DepletedUranium, but resource currently doesn't exist
+													///uncomment if this resource is added later
+			@ResourceName = DepletedFuel 
+			@Ratio = 0.0000000105699306		///Original Ratio = 0.0000000239085
+			@DumpExcess = false
+			@FlowMode = NO_FLOW
+		}
+	
+	}
+	
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 50400
 		@maxAmount = 50400
 	}
-	@RESOURCE[DepletedUranium]
+	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 100
+		@maxAmount = 1
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 100
-		@maxAmount = 100
+		@amount = 1
+		@maxAmount = 1
 	}
 }
 @PART[reactor-0625]:FOR[RealismOverhaul]
@@ -378,7 +530,7 @@
 	{
 	}
 	!mesh = DELETE
-	MODEL
+	@MODEL
 	{
 		model = NearFutureElectrical/Parts/FissionReactors/reactor-0625/reactor-0625
 		scale = 0.816, 1.270815, 0.816
@@ -390,45 +542,97 @@
 	@title = NASA SAFE-400 Nuclear Reactor
 	@description = Safe Affordable Fission Engine. Small and lightweight but powerful reactor enabled by new technology.
 	@attachRules = 1,0,1,1,1
-	@mass = 0.656
+	@mass = 0.656									///http://www.world-nuclear.org/information-library/non-power-nuclear-applications/transport/nuclear-reactors-for-space.aspx
 	@MODULE[FissionGenerator]
 	{
-		@UseStagingIcon = true
-		@UseForcedActivation = true
-		@PowerGenerationMaximum = 100
-		@ThermalPower = 400
-		@ThermalPowerResponseRate = 2
-		@BurnRate = 0.0000004
-		@MinPowerPercent = 0.4
-		@CurrentPowerPercent = 0.4
-		@MaxCoreTemperature = 310
-		@MeltdownCoreTemperature = 600
-		@CoreTemperatureResponseRate = 5
-		@CurrentCoreTemperature = 0
-		@PressureCurve
+		///@UseStagingIcon = true
+		///@UseForcedActivation = true
+		///@PowerGenerationMaximum = 100
+		///@ThermalPower = 400
+		///@ThermalPowerResponseRate = 2
+		///@BurnRate = 0.0000004
+		///@MinPowerPercent = 0.4
+		///@CurrentPowerPercent = 0.4
+		///@MaxCoreTemperature = 310
+		///@MeltdownCoreTemperature = 600
+		///@CoreTemperatureResponseRate = 5
+		///@CurrentCoreTemperature = 0
+		///@PressureCurve
+		///{
+		///	@key,0 = 0 0
+		///	@key,1 = 1 10
+		///}
+		///@VelocityCurve
+		///{
+		///	@key,0 = 0 10
+		///	@key,1 = 500 75
+		///	@key,2 = 1500 5
+		///}
+		
+		@PowerGeneration = 100
+		@HeatUsed = 400
+		
+
+	}
+	@MODULE[FissionReactor]
+	{
+	
+	///@OverheatAnimation = Reactor_10kW_Heat		/// Heat animation, plays when above nominal temp
+	
+		@HeatGeneration = 20000						/// Heat to generate (kW*50)
+		@NominalTemperature = 880					/// Above this temp more power output but risky
+		@CriticalTemperature = 1300					/// Above this temp, reactor takes damage
+		@CoreDamageRate = 0.01						/// Amount of damage taken by core when over critical temp
+													/// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		
+		@FuelName = EnrichedUranium					/// Base lifetime calculations off this resource
+
+		@INPUT_RESOURCE
 		{
-			@key,0 = 0 0
-			@key,1 = 1 10
+			@ResourceName = EnrichedUranium
+			@Ratio = 0.00000001931414573820396
+			@FlowMode = NO_FLOW
 		}
-		@VelocityCurve
-		{
-			@key,0 = 0 10
-			@key,1 = 500 75
-			@key,2 = 1500 5
+		@OUTPUT_RESOURCE
+		{	
+		
+		///@ResourceName = DepletedUranium 			///Should be DepletedUranium, but resource currently doesn't exist, uncomment this line and comment out line below if this is added
+			@ResourceName = DepletedFuel 
+			@Ratio = 0.00000001931414573820396		///Original Ratio = 
+			@DumpExcess = false
+			@FlowMode = NO_FLOW
 		}
+	
+	
+	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 880							///Internal temp goal - we don't transfer till we hit this point
+		@CoreToPartRatio = 0.1						///Scale back cooling if the part is this % of core temp
+		@CoreTempGoalAdjustment = 0					///Dynamic goal adjustment
+		@CoreEnergyMultiplier = 0.1					///What percentage of our core energy do we transfer to the part
+		@HeatRadiantMultiplier = 0.05				///If the core is hotter, how much heat radiates?
+		@CoolingRadiantMultiplier = 0				///If the core is colder, how much radiates?
+		@HeatTransferMultiplier = 0					///If the part is hotter, how much heat transfers in?
+		@CoolantTransferMultiplier = 0.01			///If the part is colder, how much of our energy can we transfer?
+		@radiatorCoolingFactor = 1					///How much energy we pull from core with an active radiator?  >= 1
+		@radiatorHeatingFactor = 0.01				///How much energy we push to the active radiator
+		@MaxCalculationWarp = 1000					///Based on how dramatic the changes are, this is the max rate of change
+		@CoreShutdownTemp = 1300					///At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 400							///Maximum amount of radiator capacity we can consume - 50 = 1 small
 	}
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 50400
 		@maxAmount = 50400
 	}
-	@RESOURCE[DepletedUranium]
+	@RESOURCE[DepletedFuel]
 	{
-		@maxAmount = 50
+		@maxAmount = 6.9
 	}
 	@RESOURCE[EnrichedUranium]
 	{
-		@amount = 50
-		@maxAmount = 50
+		@amount = 6.9
+		@maxAmount = 6.9
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
@@ -1,10 +1,11 @@
-@PART[inlineCmdPod]:FOR[RealismOverhaul]
+@PART[command-ppd-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!mesh = DELETE
 	MODEL
 	{
-		model = NearFutureSpacecraft/Parts/Command/inlineCmdPod/inlineCmdPod
+		///model = NearFutureSpacecraft/Parts/Command/inlineCmdPod/inlineCmdPod
+		model = NearFutureSpacecraft/Parts/Command/command-pods/inlineCmdPod
 		scale = 1.6, 1.6, 1.6
 	}
 	!MODULE[TweakScale]
@@ -178,21 +179,22 @@
 		}
 	}
 }
-@PART[mk3-9pod]:FOR[RealismOverhaul]
+@PART[command-mk3-9]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	!mesh = DELETE
-	MODEL
-	{
-		model = NearFutureSpacecraft/Parts/Command/mk3-9pod/mk3-9pod
-		scale = 1.6, 1.6, 1.6
-	}
-	@scale = 1.6
-	@node_stack_bottom = 0.0, -0.336, 0.0, 0.0, -1.0, 0.0, 4
-	@node_stack_top = 0.0, 1.577, 0.0, 0.0, 1.0, 0.0, 1
+	///%rescaleFactor = 1.6		///Used rescale instead of regular tweakscale, but realized that this doesn't need to be scaled up.
+	///!MODULE[TweakScale]
+	///{
+	///}
+	///!mesh = DELETE
+	///MODEL
+	///{
+	///	model = NearFutureSpacecraft/Parts/Command/mk3-9pod/mk3-9pod
+	///	scale = 1.6, 1.6, 1.6
+	///}
+	///@scale = 1.6
+	///@node_stack_bottom = 0.0, -0.336, 0.0, 0.0, -1.0, 0.0, 4
+	///@node_stack_top = 0.0, 1.577, 0.0, 0.0, 1.0, 0.0, 1
 	@MODULE[ModuleCommand]
 	{
 		@RESOURCE[ElectricCharge]
@@ -352,7 +354,8 @@
 		}
 	}
 }
-@PART[utilityCabin]:FOR[RealismOverhaul]
+///@PART[utilityCabin]:FOR[RealismOverhaul]
+@PART[utility-pod-25]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -361,7 +364,8 @@
 	!mesh = DELETE
 	MODEL
 	{
-		model = NearFutureSpacecraft/Parts/Command/utilityCabin/utilityCabin
+		///model = NearFutureSpacecraft/Parts/Command/utilityCabin/utilityCabin
+		model = NearFutureSpacecraft/Parts/Utility/utility-pod-25
 		scale = 1.6, 1.6, 1.6
 	}
 	@node_stack_top = 0.0, 1.392, 0.0, 0.0, 1.0, 0.0, 4
@@ -617,7 +621,8 @@
 		}
 	}
 }
-@PART[rcsblock-5way]:FOR[RealismOverhaul]
+///@PART[rcsblock-5way]:FOR[RealismOverhaul]
+@PART[rcsblock-orbital-5way-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.035
@@ -668,7 +673,7 @@
 		type = Default
 	}
 }
-@PART[landingLeg-pod]:FOR[RealismOverhaul]
+@PART[landingleg-pod-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.1


### PR DESCRIPTION
 Fixes decay of RTGs over time

The decay of RTGs over time doesn't appear to be working properly, this fixes that and removes the Resource Converter module and replaces it with NFE's Radioisotope Generator module. 

Decay rate was taken from actual values taking both the decay of the fuel and the thermocouples. 

Note: This patch will only apply if both RO and NFE are installed.