### PR TITLE
ModuleRCS fixes for 1.6

### DIFF
--- a/GameData/RealismOverhaul/RO_RCS_Fixes.cfg
+++ b/GameData/RealismOverhaul/RO_RCS_Fixes.cfg
@@ -1,3 +1,42 @@
+@PART[*]:HAS[@MODULE[ModuleRCS]]:AFTER[zzzRealismOverhaul]
+{
+	@MODULE[ModuleRCS]
+	{
+		@name = ModuleRCSFX
+	}
+	!EFFECTS {}
+	%EFFECTS
+	{
+		%running
+		{
+			AUDIO_MULTI
+			{
+				channel = Ship
+				transformName = RCSthruster
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.1 0.0
+				volume = 0.5 0.025
+				volume = 1.0 0.1
+				pitch = 0.0 0.75
+				pitch = 1.0 1.5
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/Monoprop_small
+				transformName = RCSthruster
+				emission = 0.0 0.0
+				emission = 0.1 0.0
+				emission = 1.0 1.0
+				speed = 0.0 0.8
+				speed = 1.0 1.0
+				localRotation = -90, 0, 0
+			}
+		}
+	}
+}
+
 @PART[*]:HAS[@MODULE[ModuleRCSFX],@MODULE[ModuleEngines*]]:FOR[zzRealPlume]
 {
 	%EFFECTS

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_RCSThruster.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_RCSThruster.cfg
@@ -9,7 +9,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.20625
@@ -73,7 +73,7 @@
 	{
 	}
 	@mass = 0.008
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.20625
@@ -142,7 +142,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		thrusterPower = 0.014

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BlacklegIndustries/RO_Blackind_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BlacklegIndustries/RO_Blackind_Control.cfg
@@ -34,7 +34,7 @@
 		%fuelCrossFeed    = true
 		%bulkheadProfiles = srf
 
-		@MODULE[ModuleRCS]
+		@MODULE[ModuleRCS*]
 		{
 			@name		   = ModuleRCS
 			@thrusterPower = 0.022

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_AresV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_AresV.cfg
@@ -318,7 +318,7 @@
 			maxAmount = 117.4
 		}
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterTransformName = RCSthruster

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_N1.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_N1.cfg
@@ -560,7 +560,7 @@
 	
 	!MODULE[ModuleEngines] {}
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 8.305 // 33.22 div 4, 4 base jets
@@ -828,7 +828,7 @@
 		maxAmount = 25
 	}
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -1043,7 +1043,7 @@
 	!RESOURCE[MonoPropellant]
 	{ }
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		// filler values for fuel mix, could also be HTP, need an information source to confirm
 		@name = ModuleRCS
@@ -1838,7 +1838,7 @@
 		}
 	}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 10.0275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Orion.cfg
@@ -385,7 +385,7 @@
 			}
 		}
 		
-		@MODULE[ModuleRCS]
+		@MODULE[ModuleRCS*]
 		{
 			@thrusterPower	  = 0.4136846
 			!resourceName	  = NULL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_Soyuz.cfg
@@ -203,7 +203,7 @@ MODULE
   %RSSROConfig = True
   @rescaleFactor = 1.28
   @mass = 0.875
-  !MODULE[ModuleRCS]
+  !MODULE[ModuleRCS*]
   { }	
   !RESOURCE[Food]
   { }
@@ -271,7 +271,7 @@ MODULE
 {
   %RSSROConfig = True
   @rescaleFactor = 1.28
-  !MODULE[ModuleRCS]
+  !MODULE[ModuleRCS*]
   { }
   MODULE
   {
@@ -340,7 +340,7 @@ MODULE
       maxAmount = 258.824995657921
     }
   }
-  !MODULE[ModuleRCS]
+  !MODULE[ModuleRCS*]
   { }
   MODULE
   {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/CSS_Mike_NZ.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/CSS_Mike_NZ.cfg
@@ -348,7 +348,7 @@
 	  maxAmount = 9289
 	  }
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	!MODULE[ModuleRCSFX]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
@@ -716,7 +716,7 @@
 	@maxTemp = 2800
 	%dragCoeff = 1
 	%deflectionLiftCoeff = 0
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	MODULE
@@ -847,7 +847,7 @@
 	@minimum_drag = 0.02
 	@maxTemp = 1973.15
 	
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg
@@ -105,7 +105,7 @@
 
     //  Twelve MR-111C thrusters (~4.45 N) for three-axis attitude control.
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.00445
         !resourceName = NULL
@@ -517,7 +517,7 @@
         }
     }
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @thrusterPower = 0.0255
         !resourceName = NULL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
@@ -54,7 +54,7 @@
 		}
 	}
 	
-	MODULE[ModuleRCS]
+	MODULE[ModuleRCS*]
 	{
 		//8x490N thruster per axis = 
 		@thrusterPower = 3.92
@@ -172,7 +172,7 @@
 	}
 	
 	//RCS source: http://ir.aerojetrocketdyne.com/releaseDetail.cfm?releaseid=742943
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		//3x711kn  per each side = 2.133 KN
 		@thrusterPower = 2.133
@@ -325,7 +325,7 @@
 	}
 	
 	//RCS source: http://ir.aerojetrocketdyne.com/releaseDetail.cfm?releaseid=742943
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		//3x711kn  per each side = 2.133 KN
 		@thrusterPower = 2.133
@@ -727,7 +727,7 @@
 	
 	%fuelCrossFeed = True
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_TANKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_TANKS.cfg
@@ -115,7 +115,7 @@
 		}
 	}
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@resourceName = Hydrazine
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
@@ -101,7 +101,7 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	@RESOURCE[ElectricCharge] //(1)

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -299,7 +299,7 @@
 	@description = This is the lower half of the Big Gemini re-entry module, the passenger compartment.  This version is made of new lightweight materials and painted white for rescue operations.  It has less cargo space but can support up to 12 person crew, including the flight compartment.
 	@mass = 1.720876
 	@CrewCapacity = 10
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	!RESOURCE[ElectricCharge]
@@ -488,7 +488,7 @@
 	@title = Big Gemini Retro Module
 	@description = The Big Gemini Retro Module that contains 4x solid rockets to de-orbit Big Gemini. Decouples before re-entry.  Provides approximately 106dV for re-entry burn.
 	@mass = 1.0978748
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	@MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Titan.cfg
@@ -122,7 +122,7 @@
 	@node_stack_bottom = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
 	@title = FASA Fuel Tank
 	@description = A generic fuel tank.
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}	
 	!RESOURCE[LiquidFuel]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_RCS.cfg
@@ -6,7 +6,7 @@
 	{
 	}
 	@mass = 0.028
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -35,7 +35,7 @@
 	{
 	}
 	@mass = 0.028
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -63,7 +63,7 @@
 	{
 	}
 	@mass = 0.0336
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_LazTek_Historic.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_LazTek_Historic.cfg
@@ -102,7 +102,7 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.4

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_Laztek_Launch.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_Laztek_Launch.cfg
@@ -40,7 +40,7 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.400
@@ -510,7 +510,7 @@
 	!MODULE[ModuleReactionWheel]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.400

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_ATV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_ATV.cfg
@@ -253,7 +253,7 @@
 	@mass = 0.013
 	@title = ATV RCS front
 	@description = A pair of EADS Astrium 216N thrusters. Place four units on the front plate of the ATV, facing away from the docking port.
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.432
@@ -291,7 +291,7 @@
 	@mass = 0.028
 	@title = ATV RCS aft
 	@description = Intended to represent the ATVs aft RCS thrusters. Place four near the aft end of ATVs sides.
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.216

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Atlas.cfg
@@ -79,7 +79,7 @@
 			@rate = 0.25
           		}
         	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
          	{
           		@thrusterPower = 0.05
 		@resourceName = Hydrazine 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Liquidhype/RO_LqdH_Ariane6.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Liquidhype/RO_LqdH_Ariane6.cfg
@@ -115,7 +115,7 @@
 	{
 		@gimbalRange = 6
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	!MODULE[ModuleAlternator]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Liquidhype/RO_LqdH_Vega.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Liquidhype/RO_LqdH_Vega.cfg
@@ -883,7 +883,7 @@
 			maxAmount = 252.6
 		}
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	!MODULE[ModuleAlternator]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/MandatoryRCSPartPack/RCS_025TBlocks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/MandatoryRCSPartPack/RCS_025TBlocks.cfg
@@ -19,7 +19,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @thrusterPower = 0.069
@@ -61,7 +61,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @thrusterPower = 0.069
@@ -103,7 +103,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @resourceFlowMode = STACK_PRIORITY_SEARCH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/MandatoryRCSPartPack/RCS_RV105Variants.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/MandatoryRCSPartPack/RCS_RV105Variants.cfg
@@ -18,7 +18,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @thrusterPower = 0.275
@@ -59,7 +59,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @thrusterPower = 0.275
@@ -100,7 +100,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @thrusterPower = 0.275
@@ -141,7 +141,7 @@
 
     !MODULE[TweakScale] {}
 
-    @MODULE[ModuleRCS]
+    @MODULE[ModuleRCS*]
     {
         @name = ModuleRCS
         @thrusterPower = 0.275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_RCS.cfg
@@ -7,7 +7,7 @@
 	{
 	}
 	@mass = 0.00379
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -38,7 +38,7 @@
 	{
 	}
 	@mass = 0.02016
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -69,7 +69,7 @@
 	{
 	}
 	@mass = 0.01258
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@resourceFlowMode = STACK_PRIORITY_SEARCH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
@@ -621,7 +621,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.035
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/OLDD/RO_OLDD_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/OLDD/RO_OLDD_ApolloCSM.cfg
@@ -382,7 +382,7 @@
 	breakingForce = 250
 	breakingTorque = 250
 	@maxTemp = 1073.15
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	MODULE
@@ -726,7 +726,7 @@
 	breakingForce = 250
 	breakingTorque = 250
 	@maxTemp = 1073.15
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/OLDD/RO_OLDD_LEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/OLDD/RO_OLDD_LEM.cfg
@@ -671,7 +671,7 @@
 	breakingForce = 250
 	breakingTorque = 250
 	@maxTemp = 1073.15
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Control.cfg
@@ -9,7 +9,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -80,7 +80,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -197,7 +197,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -268,7 +268,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -338,7 +338,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -409,7 +409,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		thrusterPower = 0.06875
@@ -482,7 +482,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		thrusterPower = 0.06875
@@ -553,7 +553,7 @@
 	@breakingForce = 250
 	@breakingTorque = 250
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		thrusterPower = 0.06875

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
@@ -120,7 +120,7 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS translation thruster.
 	@mass = 0.05
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -147,7 +147,7 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS translation thruster.
 	@mass = 0.05
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -175,7 +175,7 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS thruster block.
 	@mass = 0.0625
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.4125
@@ -203,7 +203,7 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS thruster block.
 	@mass = 0.075
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.4125
@@ -231,7 +231,7 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Heavy aerodynamic RCS thruster block.
 	@mass = 0.1125
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.825
@@ -259,7 +259,7 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Heavy aerodynamic RCS thruster block.
 	@mass = 0.1125
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.825
@@ -823,7 +823,7 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 
@@ -954,7 +954,7 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	!MODULE[ModuleFuelTanks] {}
@@ -1194,7 +1194,7 @@
 	{
 	}
 	@mass = 0.313 //1 thruster only
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 8.125
@@ -1223,7 +1223,7 @@
 	{
 	}
 	@mass = 0.625 // 2 thrusters only
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 8.125
@@ -1277,7 +1277,7 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_Horizon_Aeronautics_Zenit.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_Horizon_Aeronautics_Zenit.cfg
@@ -429,7 +429,7 @@
 		amount = 20000
 		maxAmount = 20000
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
@@ -410,7 +410,7 @@
 	@manufacturer = RKK Energia
 	@description = Russian RCS Thruster Block. These were used on the Zvezda module of the ISS in pairs of 2x4.
 	@maxTemp = 1073.15
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.13
 		!resourceName = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Apollo.cfg
@@ -275,7 +275,7 @@
 
 	!MODULE[ModuleReactionWheel]{}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.4136846
 		!resourceFlowMode = DELETE
@@ -507,7 +507,7 @@
 
 	!MODULE[ModuleReactionWheel]{}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.4136846
 		!resourceFlowMode = DELETE
@@ -733,7 +733,7 @@
 	%engineType = AJ10_137
 	%ignoreMass = true
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.4448222
 		!resourceName = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_Orion.cfg
@@ -288,7 +288,7 @@
 	
 	!MODULE[ModuleReactionWheel]{}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.712
 		!resourceFlowMode = DELETE
@@ -511,7 +511,7 @@
 	
 	!MODULE[ModuleReactionWheel]{}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.712
 		!resourceFlowMode = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_RCS.cfg
@@ -29,7 +29,7 @@
 	@mass = 0.036
 	@PhysicsSignificance = 0
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.412
@@ -66,7 +66,7 @@
 	@mass = 0.036
 	@PhysicsSignificance = 0
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -103,7 +103,7 @@
 	@mass = 0.036
 	@PhysicsSignificance = 0
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.412
@@ -140,7 +140,7 @@
 	@mass = 0.032
 	@PhysicsSignificance = 0
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -177,7 +177,7 @@
 	@mass = 0.035
 	@PhysicsSignificance = 0
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -214,7 +214,7 @@
 	@mass = 0.04
 	@PhysicsSignificance = 0
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_RCS.cfg
@@ -10,7 +10,7 @@
 	@title = RCS Quad, Extensible (138/223 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad on an extensible boom. Use this for attitude control or translation/ullage for small stages and spacecraft.
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.1375
@@ -43,7 +43,7 @@
 	@title = Attitude Jet 3x (1.24/2 kN class)
 	@manufacturer = Generic
 	@description = A generic RCS thruster array. Use this for attitude control or translation/ullage for very large stages. Note that the thrust per nozzle is only one-third the thrust class; three nozzles fire in the same direction giving the class rating.
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.4125

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Aero.cfg
@@ -21,7 +21,7 @@
 		@type = RealismOverhaulStackHollow_Adapter_Halved
 	}
 }
-@PART[rocketNoseCone]:FOR[RealismOverhaul]
+@PART[rocketNoseCone|rocketNoseCone_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@description = A large nosecone for covering up exposed areas of big rockets. Enhanced to fit stock solid rocket motors too. Capable of some fuel carriage as well.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -579,7 +579,302 @@
 		playAnimationOnEditorSpawn = false
 	}
 }
+@PART[mk1-3pod]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	!mesh = DELETE
+	!MODEL,* {}
+	MODEL
+	{
+		model = Squad/Parts/Command/Mk1-3Pod/Mk1-3
+		scale = 1.722222, 1.722222, 1.722222
+		position = 0.0, 0.0, 0.0
+	}
+	MODEL:NEEDS[SDHI]
+	{
+   		model = SDHI/Service Module System/Parts/SDHI_2.5_ServiceModule/SM_UmbilicalSocket
+   		scale = 1.722222, 1.722222, 1.722222
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 0.17329858875, -0.41440966875, -1.97732613375
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -0.17329858875, -0.41440966875, -1.97732613375
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -1.97732613375, -0.41440966875, -0.17329858875
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 1.97732613375, -0.41440966875, 0.17329858875
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -1.97732613375, -0.41440966875, 0.17329858875
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 1.975797661725, -0.41440966875, -0.17329858875
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -1.46927064375, -0.41440966875, -1.23246511875
+		rotation = 0, 30, 90
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -1.8083331, -0.41440966875, -0.658749915
+		rotation = 270, 30, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 1.46927064375, -0.41440966875, -1.23246511875
+		rotation = 0, 330, 270
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 1.8083331, -0.41440966875, -0.658749915
+		rotation = 270, 330, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -0.116249985, 1.184027625, -1.3239581625
+		rotation = 270, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 0.116249985, 1.184027625, -1.3239581625
+		rotation = 270, 0, 0
+	}
+	@scale = 1.722222
+	%rescaleFactor = 1.0
+	
+	@node_stack_bottom = 0.0, -0.47924, 0.0, 0.0, -1.0, 0.0, 4
+	@node_stack_top = 0.0, 1.19319, 0.0, 0.0, 1.0, 0.0, 2
+	
+	@buoyancy = 1.05 // has a bit of flotation.
+	!CoMOffset = DEL // VSR sets this
+	
+	@title = Mk2 Pod (4m)
+	@manufacturer = Generic
+	@description = A three-person pod. Comes with built-in RCS thrusters running off NTO/MMH and a small battery. Heat shield required for safe reentry. Center of mass can be offset to allow lifting reentry (toggle Descent Mode).
+	
+	@maxTemp = 900
+	%skinMaxTemp = 3000 // for lifting reentries
+	%emissiveConstant = 0.85 // mostly white, but matte; let's claim it's mostly anodized aluminum.
+	%skinMassPerArea = 2
+	@mass = 3.7
+	@MODULE[ModuleCommand]
+	{
+		@minimumCrew = 1
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 1.895
+		}
+	}
+	
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		basemass = -1
+		type = ServiceModule
+		volume = 1050
+		TANK
+		{
+			name = ElectricCharge
+			amount = 43200
+			maxAmount = 43200
+		}
+		TANK
+		{
+			name = Food
+			amount = 245.7
+			maxAmount = 245.7
+		}
+		TANK
+		{
+			name = Water
+			amount = 162.4
+			maxAmount = 162.4
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1777
+			maxAmount = 24872.34
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 855
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 22.34
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 206.81
+		}
+		TANK
+		{
+			name = MMH
+			amount = 45
+			maxAmount = 45
+		}
+		TANK
+		{
+			name = NTO
+			amount = 45
+			maxAmount = 45
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 31.5
+			maxAmount = 31.5
+		}
+	}
 
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 3.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+
+	!MODULE[ModuleRCS*],*{} // for VenStockRevamp
+
+	MODULE
+	{
+		name = ModuleRCS
+		thrusterTransformName = RCSthruster
+		thrusterPower = 0.4448222
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.50
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.50
+		}
+		atmosphereCurve
+		{
+			key = 0 280.84
+			key = 1 253.498
+		}
+	}
+	MODULE
+	{
+		name = AdjustableCoMShifter
+		DescentModeCoM = 0.0, 0.0, -0.28
+	}
+	MODULE:NEEDS[SDHI]
+	{
+		name = FSanimateGeneric
+		animationName = SDHI_Socket_ShowHide_Toggle
+		startEventGUIName = Install Umbilical Port
+		endEventGUIName = Remove Umbilical Port
+		toggleActionName = Toggle Umbilical Port
+		customAnimationSpeed = 10
+		moduleID = 0
+		availableInEVA = false
+		availableInVessel = false
+		startDeployed = false
+		playAnimationOnEditorSpawn = false
+	}
+}
 @INTERNAL[PodCockpit|PodCockpitRPM]:FOR[RealismOverhaul]
 {
 	%scaleAll = 1.722222, 1.722222, 1.722222
@@ -591,7 +886,7 @@
 	}
 }
 
-@PART[Mark1-2Pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+@PART[Mark1-2Pod|mk1-3pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
     {
@@ -615,7 +910,7 @@
 }
 // In addition, Ven's pod is bigger. So we use a smaller model scaling.
 // Finally, remove (some of) the RCS thruster transforms, unneeded.
-@PART[Mark1-2Pod]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+@PART[Mark1-2Pod|mk1-3pod]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	// scale-related
 	@MODEL
@@ -1226,6 +1521,268 @@
 		DescentModeCoM = 0.0, 0.0, -0.1
 	}
 }
+@PART[mk1pod_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	!mesh = DELETE
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Command/mk1pod_v2/Mk1Pod_v2
+		scale = 1.6, 1.6, 1.6
+		position = 0.0, 0.0, 0.0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 0, 0.99, -0.425
+		rotation = 270, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 0, 0.99, 0.425
+		rotation = 90, 0, 0
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 0.425, 0.99, 0
+		rotation = 0, 0, 270
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -0.425, 0.99, 0
+		rotation = 0, 0, 90
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = 0.1, 0.0, 0.8125
+		rotation = 0, 0, 270
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LinearRCS
+		scale = 0.1, 0.1, 0.1
+		position = -0.1, 0.0, 0.8125
+		rotation = 0, 0, 90
+	}
+	@scale = 1.6
+	%rescaleFactor = 1.0
+	@node_stack_bottom = 0.0, -0.4050379, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.6423756, 0.0, 0.0, 1.0, 0.0, 1
+	
+	@CenterOfDisplacement = 0.0, -0.2, 0.0
+	@buoyancy = 1 // reset to nominal buoyancy
+	!CoMOffset = DEL // VSR sets this
+	
+	@title = Mk1 Pod (2m)
+	@manufacturer = Generic
+	@description = A one-person pod. Comes with built-in RCS thrusters running off High-Test Peroxide (HTP) and a large battery. Heat shield rated for LEO reentries. Center of mass can be offset slightly to allow lifting reentry (toggle Descent Mode).
+	@mass = 0.7
+
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleCommand]
+	{
+		@minimumCrew = 0
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.53
+		}
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 250
+		type = Fuselage
+		basemass = -1
+		TANK
+		{
+			name = ElectricCharge
+			amount = 48600
+			maxAmount = 48600
+		}
+		TANK
+		{
+			name = HTP
+			amount = 30
+			maxAmount = 30
+		}
+		TANK
+		{
+			name = Food
+			amount = 11.7
+			maxAmount = 11.7
+		}
+		TANK
+		{
+			name = Water
+			amount = 7.73
+			maxAmount = 7.73
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1184.4
+			maxAmount = 1184.4
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1023.07
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 1.06
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 9.85
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 1.5
+			maxAmount = 1.5
+		}
+	}
+
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 1.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	// Thermo
+	!MODULE[ModuleAblator] {}
+	!MODULE[ModuleHeatShield] {}
+	!MODULE[ModuleAeroReentry] {}
+	!RESOURCE[AblativeShielding] {}
+	!RESOURCE[Ablator] {}
+	%skinMaxTemp = 2600
+	%maxTemp = 800
+	%emissiveConstant = 0.9 // pretty much black, but not perfect emitter
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 2
+	%skinInternalConductionMult = 6
+	
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		lossExp = -6000
+		lossConst = 0.13
+		pyrolysisLossFactor = 6000
+		ablationTempThresh = 400
+		reentryConductivity = 0.01
+		charMax = 1
+		charMin = 1
+	}
+	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+	{
+		@name = ModuleHeatShield
+		depletedMaxTemp = 1200
+	}
+	RESOURCE
+	{
+		name = Ablator
+		amount = 200
+		maxAmount = 200
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
+		maxAmount = 200
+	}
+
+	MODULE
+	{
+		name = ModuleRCS
+		thrusterTransformName = RCSthruster
+		thrusterPower = 0.107
+		fullThrust = True
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = HTP
+		}
+		atmosphereCurve
+		{
+			key = 0 167
+			key = 1 57
+		}
+	}
+	MODULE
+	{
+		name = AdjustableCoMShifter
+		DescentModeCoM = 0.0, 0.0, -0.1
+	}
+}
 @INTERNAL[mk1PodCockpit|mk1PodCockpitRPM]:BEFORE[RealismOverhaul]
 {
 	%scaleAll = 1.6, 1.6, 1.6
@@ -1237,7 +1794,7 @@
 	}
 }
 
-@PART[mk1pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
+@PART[mk1pod|mk1pod_v2]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
     MODULE
     {
@@ -1260,7 +1817,7 @@
     }
 }
 // 3 Person lander can
-@PART[mk2LanderCabin]:FOR[RealismOverhaul]
+@PART[mk2LanderCabin|mk2LanderCabin_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1490,7 +2047,7 @@
 }
 
 // Ranger Block III
-@PART[probeCoreHex]:FOR[RealismOverhaul]
+@PART[probeCoreHex|probeCoreHex_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1530,7 +2087,7 @@
 	{
 	}
 }
-@PART[probeCoreHex]:AFTER[RemoteTech]
+@PART[probeCoreHex|probeCoreHex_v2]:AFTER[RemoteTech]
 {
 	@MODULE[ModuleRTAntennaPassive]
 	{
@@ -1599,7 +2156,58 @@
 		}
 	}
 }
-@PART[probeCoreOcto]:AFTER[RemoteTech]
+@PART[probeCoreOcto_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	!mesh = DELETE
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Command/probeCoreOcto_v2/probeCoreOcto_v2
+		scale = 3.0, 1.0, 3.0
+	}
+	%rescaleFactor = 1.0
+	@node_stack_bottom = 0.0, -0.1870818, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.1870818, 0.0, 0.0, 1.0, 0.0, 2
+	@mass = 0.12
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@title = (Deprecated) Surveyor Core
+	@manufacturer = Hughes
+	@description = This is only a placeholder to allow your current craft to operate correctly. Please use the new Surveyor Core for all new craft.
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.12
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	@MODULE[ModuleSAS]
+	{
+		%SASServiceLevel = 3
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 150
+		basemass = 0.12
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 15840
+			maxAmount = 15840
+		}
+	}
+}
+@PART[probeCoreOcto|probeCoreOcto_v2]:AFTER[RemoteTech]
 {
 	@MODULE[ModuleRTAntennaPassive]
 	{
@@ -1675,7 +2283,7 @@
 
 
 // Early probe
-@PART[probeCoreOcto2]:FOR[RealismOverhaul]
+@PART[probeCoreOcto2|probeCoreOcto2_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -1713,7 +2321,7 @@
 		}
 	}
 }
-@PART[probeCoreOcto2]:AFTER[RemoteTech]
+@PART[probeCoreOcto2|probeCoreOcto2_v2]:AFTER[RemoteTech]
 {
     @MODULE[ModuleRTAntennaPassive]
     {
@@ -1980,7 +2588,7 @@
 
 +PART[probeCoreOcto]:FOR[RealismOverhaul]
 {
-	@name = RO_earlyControllableCore
+	@name = RO_earlyControllableCore_1
 	%RSSROConfig = True
 	!MODULE[TweakScale]
 	{
@@ -1990,6 +2598,61 @@
 	MODEL
 	{
 		model = Squad/Parts/Command/probeCoreOcto/model
+		scale = 0.678, 0.499, 0.678
+	}
+	%rescaleFactor = 1.0
+	@node_stack_bottom = 0.0, -0.096, 0.0, 0.0, -1.0, 0.0, 0
+	@node_stack_top = 0.0, 0.096, 0.0, 0.0, 1.0, 0.0, 0
+	@mass = 0.05
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@title = Early Controllable Core
+	@manufacturer = Generic
+	@description = This relatively lightweight probe core allows early probes to be controlled during flight. However, it draws a fair amount of electricity for its abilities. Includes data storage for returning data to Earth (use Ship Manifest to transfer the data from the experiment to this core).
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.05
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	@MODULE[ModuleSAS]
+	{
+		%SASServiceLevel = 1
+	}
+	!MODULE[ModuleFuelTanks]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 6.6
+		basemass = 0.05
+		type = Fuselage
+		TANK
+		{
+			name = ElectricCharge
+			amount = 6600
+			maxAmount = 6600
+		}
+	}
+}
++PART[probeCoreOcto_v2]:FOR[RealismOverhaul]
+{
+	@name = RO_earlyControllableCore
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	!mesh = DELETE
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Command/probeCoreOcto_v2/probeCoreOcto_v2
 		scale = 0.678, 0.499, 0.678
 	}
 	%rescaleFactor = 1.0
@@ -2054,7 +2717,7 @@
 // Surveyor Probe
 +PART[probeCoreOcto2]:FOR[RealismOverhaul]
 {
-	@name = RO_surveyorCore
+	@name = RO_surveyorCore_1
 	%RSSROConfig = True
 	!MODULE[TweakScale]
 	{
@@ -2064,6 +2727,57 @@
 	MODEL
 	{
 		model = Squad/Parts/Command/probeCoreOcto2/model
+		scale = 3.541, 3.208, 3.541
+	}
+	%rescaleFactor = 1
+	@node_stack_bottom = 0.0, -0.1870818, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 0.1870818, 0.0, 0.0, 1.0, 0.0, 2
+	@mass = 0.12
+	@title = Surveyor Core
+	@manufacturer = Hughes
+	@description = Avionics and control unit for Surveyor landing probes. Includes data storage for returning data to Earth (use Ship Manifest to transfer the data from the experiment to this core).
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.12
+		}
+	}
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	!MODULE[ModuleFuelTanks]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 565
+		basemass = 0.12
+		type = Fuselage
+		TANK
+		{
+			name = ElectricCharge
+			amount = 15840
+			maxAmount = 15840
+		}
+	}
+}
++PART[probeCoreOcto2_v2]:FOR[RealismOverhaul]
+{
+	@name = RO_surveyorCore
+	%RSSROConfig = True
+	!MODULE[TweakScale]
+	{
+	}
+	!mesh = DELETE
+	!MODEL {}
+	MODEL
+	{
+		model = Squad/Parts/Command/probeCoreOcto_v2/probeCoreOcto_v2
 		scale = 3.541, 3.208, 3.541
 	}
 	%rescaleFactor = 1
@@ -2227,7 +2941,7 @@
 }
 
 // Sputnik
-@PART[probeCoreSphere]:FOR[RealismOverhaul]
+@PART[probeCoreSphere|probeCoreSphere_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	!MODULE[TweakScale]
@@ -2252,7 +2966,7 @@
 	}
 }
 
-@PART[probeCoreSphere]:AFTER[RemoteTech]
+@PART[probeCoreSphere|probeCoreSphere_v2]:AFTER[RemoteTech]
 {
 	@MODULE[ModuleRTAntennaPassive]
 	{
@@ -2286,7 +3000,7 @@
 	@node_stack_bottom = 0.0, -1, 0.0, 0.0, -1.0, 0.0, 1
 	@node_stack_top = 0.0, 1, 0.0, 0.0, 1.0, 0.0, 1
 }
-@PART[mk2LanderCabin]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+@PART[mk2LanderCabin|mk2LanderCabin_v2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	%rescaleFactor = 1.0
 	@MODEL
@@ -2296,7 +3010,7 @@
 	@node_stack_bottom = 0.0, -0.64572, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 1.2031, 0.0, 0.0, 1.0, 0.0, 2
 }
-@PART[probeCoreHex]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+@PART[probeCoreHex|probeCoreHex_v2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	%rescaleFactor = 1.0
 	@MODEL
@@ -2306,7 +3020,7 @@
 	@node_stack_bottom = 0.0, -0.225, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 0.225, 0.0, 0.0, 1.0, 0.0, 0
 }
-@PART[probeCoreOcto2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+@PART[probeCoreOcto2|probeCoreOcto2_v2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	%rescaleFactor = 1.0
 	@MODEL
@@ -2316,7 +3030,7 @@
 	@node_stack_bottom = 0.0, -0.04885, 0.0, 0.0, -1.0, 0.0, 0
 	@node_stack_top = 0.0, 0.04885, 0.0, 0.0, 1.0, 0.0, 0
 }
-@PART[probeCoreSphere]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+@PART[probeCoreSphere|probeCoreSphere_v2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
 {
 	%rescaleFactor = 1.0
 	@MODEL

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -594,6 +594,11 @@
 
 +PART[liquidEngine2-2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
+	@name = RO-RD-0210_1
+}
+
++PART[liquidEngine2-2_v2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
 	@name = RO-RD-0210
 }
 
@@ -715,6 +720,62 @@
 		}
 	}
 }
+@PART[liquidEngine2-2_v2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	%RSSROConfig = True
+
+	!mesh = DELETE
+
+	!MODEL,*{}
+
+	MODEL
+	{
+		model = Squad/Parts/Engine/liquidEnginePoodle_v2/LqdEnginePoodle_v2
+		scale = 1.2, 1.2, 1.2
+	}
+
+	%scale = 1.0
+	%rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.855, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.03, 0.0, 0.0, -1.0, 0.0, 2
+
+	@mass = 0.135
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+
+	%engineType = LMDE
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass False
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 4.67
+		@maxThrust = 43.9
+		@heatProduction = 100
+
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+			@ratio = 0.5017
+		}
+
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.4983
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 311
+			@key,1 = 1 100
+		}
+	}
+}
 
 //  ==================================================
 //  RD-0105/0109 (vacuum engine).
@@ -782,6 +843,68 @@
 	}
 }
 
+@PART[liquidEngine3_v2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	%RSSROConfig = True
+
+	!mesh = DELETE
+
+	!MODEL,*{}
+
+	MODEL
+	{
+		model = Squad/Parts/Engine/liquidEngineLV-909_v2/TerrierV2
+		scale = 1.75, 2.0, 1.75
+	}
+
+	@MODEL:NEEDS[VenStockRevamp]
+	{
+		@model = VenStockRevamp/Squad/Parts/Propulsion/LV909
+	}
+
+	@scale = 1.0
+	%rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.385, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -0.875, 0.0, 0.0, -1.0, 0.0, 2
+
+	@mass = 0.125
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+
+	%engineType = RD0105
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@minThrust = 49.4
+		@maxThrust = 49.4
+		@heatProduction = 100
+
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 0.3594
+		}
+
+		@PROPELLANT[Oxidizer]
+		{
+			@name = LqdOxygen
+			@ratio = 0.6406
+		}
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 316
+			@key,1 = 1 100
+		}
+	}
+}
+
 //  ==================================================
 //  LMAE (vacuum engine).
 //  ==================================================
@@ -797,6 +920,63 @@
 	MODEL
 	{
 		model = Squad/Parts/Engine/liquidEngine48-7S/model
+		scale = 3.5, 3.0, 3.5
+	}
+
+	%scale = 1.0
+	%rescaleFactor = 1.0
+
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.175, 0.0, 0.0, -1.0, 0.0, 2
+
+	@mass = 0.095
+	@crashTolerance = 10
+	@maxTemp = 573.15
+	%skinMaxTemp = 673.15
+
+	%engineType = LMAE
+	%engineTypeMult = 1
+	%massOffset = 0
+	%ignoreMass = False
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+		@maxThrust = 15.57
+		@minThrust = 15.57
+		@heatProduction = 100
+
+		@atmosphereCurve
+		{
+			@key,0 = 0 311
+			@key,1 = 1 100
+		}
+
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+			@ratio = 0.5017
+		}
+
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 0.4983
+		}
+	}
+}
+
+@PART[liquidEngineMini_v2]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	%RSSROConfig = True
+
+	!mesh = DELETE
+
+	!MODEL,*{}
+
+	MODEL
+	{
+		model = Squad/Parts/Engine/liquidEngine48-7S_v2/SparkV2
 		scale = 3.5, 3.0, 3.5
 	}
 
@@ -2366,6 +2546,11 @@
 //  ==================================================
 
 +PART[liquidEngine3]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
+{
+	@name = RO_KVD1_1
+}
+
++PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {
 	@name = RO_KVD1
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -438,7 +438,7 @@
 		@type = Default
 	}
 }
-@PART[Size3to2Adapter]:FOR[RealismOverhaul]
+@PART[Size3to2Adapter|Size3To2Adapter_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.875

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -358,7 +358,7 @@
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
 	@MODULE[ModuleRCS*]
 	{
-		@name = ModuleRCS
+		@name = ModuleRCSFX
 		@thrusterPower = 0.275
 		!resourceName = DELETE
 		PROPELLANT
@@ -370,6 +370,37 @@
 		{
 			@key,0 = 0 254
 			@key,1 = 1 82.08
+		}
+	}
+	!EFFECTS {}
+	EFFECTS
+	{
+		running
+		{
+			AUDIO_MULTI
+			{
+				channel = Ship
+				transformName = RCSjet
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.1 0.0
+				volume = 0.5 0.025
+				volume = 1.0 0.1
+				pitch = 0.0 0.75
+				pitch = 1.0 1.5
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/Monoprop_small
+				transformName = RCSjet
+				emission = 0.0 0.0
+				emission = 0.1 0.0
+				emission = 1.0 1.0
+				speed = 0.0 0.8
+				speed = 1.0 1.0
+				localRotation = -90, 0, 0
+			}
 		}
 	}
 }
@@ -432,7 +463,7 @@
 		%techLevel = 0
 	}
 }
-@PART[roverBody]:FOR[RealismOverhaul]
+@PART[roverBody|roverBody_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.050

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -149,7 +149,7 @@
 	@title = Attitude Jet (550/890 N class)
 	@manufacturer = Generic
 	@description = A generic single RCS thruster. Use this for attitude control or translation/ullage for large stages.
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.55
@@ -356,7 +356,7 @@
 	@title = RCS Quad (275/445 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StarShineIndustries/RO_StarShine_Athena2c.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StarShineIndustries/RO_StarShine_Athena2c.cfg
@@ -571,7 +571,7 @@ MODULE
 			}
 		}
 	}
-	!MODULE[ModuleRCS]
+	!MODULE[ModuleRCS*]
 	{
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_TantaresLV_Proton.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_TantaresLV_Proton.cfg
@@ -353,7 +353,7 @@
 			}
 		}
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 30.98

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Cygnus.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Cygnus.cfg
@@ -203,7 +203,7 @@
 	%title = Cygnus RCS Thrusters
 	%description = Large 5-way thrusters.
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		thrusterPower = 0.6
 		resourceFlowMode = STACK_PRIORITY_SEARCH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fobos_Grunt.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fobos_Grunt.cfg
@@ -188,7 +188,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.275
 		!resourceName = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
@@ -18,7 +18,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		@thrusterPower = 0.1112055
@@ -523,7 +523,7 @@
 	%title = Gemin RCS Block
 	%description = To allow docking and advanced maneuvers.
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		@thrusterPower = 0.4448222

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_LK_BlockD.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_LK_BlockD.cfg
@@ -236,7 +236,7 @@
 		throttle = 1.0
 	}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 10.0275
@@ -371,7 +371,7 @@
 		}
 	}
 
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 5
 		!resourceName = DELETE
@@ -451,7 +451,7 @@
 	%title = LK RCS Thrusters
 	%description = Control the landing and LOK rendez-vous.
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		@thrusterPower = 0.39

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -1015,7 +1015,7 @@
 			massMult = 1.0
 		}
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.27

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -836,7 +836,7 @@
 		%useGimbalResponseSpeed = true
 		%gimbalResponseSpeed = 8
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.27
 		!resourceName = DELETE
@@ -1194,7 +1194,7 @@
 		}
 	}
 	
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 8.1787461
@@ -1628,7 +1628,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.461
 		!resourceName = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Vostok.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Vostok.cfg
@@ -971,7 +971,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@thrusterPower = 0.05
 		!resourceName = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RCS.cfg
@@ -16,7 +16,7 @@
 	%useRcsConfig = RCSBlock // 8 nozzles but of normal size so using normal config
 	%useRcsMass = True
 	%RcsNozzles = 8
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -51,7 +51,7 @@
 	@title = RCS Quad, 45deg (275/445 N class)
 	@manufacturer = Generic
 	@description = A generic RCS quad with 45degree side-thruster orientation. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.275
@@ -88,7 +88,7 @@
 	@title = Inline RCS block (138/223 N class)
 	@manufacturer = Generic
 	@description = A generic inline RCS block. Use this for orientation on small capsules and probes.
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.138

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -542,6 +542,10 @@
 // XLR99
 +PART[liquidEngine3]:FIRST:NEEDS[!RftS,!RealFuels_StockEngines,VenStockRevamp]
 {
+	@name = RO-XLR99_1
+}
++PART[liquidEngine3_v2]:FIRST:NEEDS[!RftS,!RealFuels_StockEngines,VenStockRevamp]
+{
 	@name = RO-XLR99
 }
 @PART[RO-XLR99]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VostokVoskhod/RO_SF_Vostok_Voskhod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VostokVoskhod/RO_SF_Vostok_Voskhod.cfg
@@ -847,7 +847,7 @@
 			maxAmount = 85400
 		}
 	}
-	@MODULE[ModuleRCS]
+	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
 		@thrusterPower = 0.05


### PR DESCRIPTION
-First pass will fix all ModuleRCS to say ModuleRCS* to cover FX modules
also

-Second pass will rename all ModuleRCS to ModuleRCSFX and add EFFECTS
for plume