### PR TITLE
Z titan plumes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
@@ -5398,7 +5398,7 @@
 	!MODULE[ModuleGimbal],*{}
 	!MODULE[ModuleEnginesFX],*{}
 	
-	MODULE
+	@MODULE[ModuleEngines*]
 	{
 		name = ModuleEnginesRF
 		exhaustDamage = True
@@ -5582,7 +5582,7 @@
 	@maxTemp = 1073.15
 	
 	!MODULE[ModuleEnginesFX],*{}
-	MODULE
+	@MODULE[ModuleEngines*]
 	{
 		name = ModuleEnginesRF
 		runningEffectName = running_main

--- a/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_us_rockets.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RaiderNick/rn_us_rockets.cfg
@@ -534,6 +534,11 @@
 
 @PART[rn_lr87_11]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+	@MODULE[ModuleEngines*],*
+	{
+		!powerEffectName = DELETE
+		!runningEffectName = DELETE
+	}
 	@MODULE[ModuleEngineConfigs]
     {
 		%type = ModuleEnginesRF
@@ -542,7 +547,17 @@
             %powerEffectName = Hypergolic-Lower
 			%runningEffectName = Hypergolic-Vernier
         }
-		@CONFIG[LR87-AJ-3|LR87-AJ-9-Kero|LR87-AJ-9-Kero-15AR]
+		@CONFIG[LR87-AJ-3]
+		{
+			%powerEffectName = Kerolox-Lower
+			%runningEffectName = Kerolox-Vernier
+		}
+		@CONFIG[LR87-AJ-9-Kero]
+		{
+			%powerEffectName = Kerolox-Lower
+			%runningEffectName = Kerolox-Vernier
+		}
+		@CONFIG[LR87-AJ-9-Kero-15AR]
 		{
 			%powerEffectName = Kerolox-Lower
 			%runningEffectName = Kerolox-Vernier
@@ -604,6 +619,11 @@
 
 @PART[rn_lr91_11]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
+	@MODULE[ModuleEngines*],*
+	{
+		!powerEffectName = DELETE
+		!runningEffectName = DELETE
+	}
 	@MODULE[ModuleEngineConfigs],*
     {
 		%type = ModuleEnginesRF
@@ -612,7 +632,12 @@
             %powerEffectName = Hypergolic-Upper
 			%runningEffectName = Hypergolic-Vernier
         }
-		@CONFIG[LR91-AJ-3|LR91-AJ-9-Kero]
+		@CONFIG[LR91-AJ-3]
+		{
+			%powerEffectName = Kerolox-Upper
+			%runningEffectName = Kerolox-Vernier
+		}
+		@CONFIG[LR91-AJ-9-Kero]
 		{
 			%powerEffectName = Kerolox-Upper
 			%runningEffectName = Kerolox-Vernier


### PR DESCRIPTION
Fix LR87 and LR91 plumes for RN US Rockets versions of the engines--they were not appearing.