### PR TITLE
Tweak RD-58 TF configs to prevent the regression from 11D33M

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -424,11 +424,11 @@
 	{
 		name = RD-58
 		ratedBurnTime = 600
-		ignitionReliabilityStart = 0.714
-		ignitionReliabilityEnd = 0.933
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.6
-		cycleReliabilityEnd = 0.867
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.982
 	techTransfer = 11D33M:25
 	}
 }
@@ -438,11 +438,11 @@
 	{
 		name = RD-58M
 		ratedBurnTime = 720
-		ignitionReliabilityStart = 0.75
-		ignitionReliabilityEnd = 0.979
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.99
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.75
-		cycleReliabilityEnd = 0.958
+		cycleReliabilityStart = 0.85
+		cycleReliabilityEnd = 0.99
         techTransfer = RD-58:50
 	}
 }
@@ -452,7 +452,7 @@
 	{
 		name = RD-58S
 		ratedBurnTime = 680
-		ignitionReliabilityStart = 0.875
+		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.998
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.875
@@ -460,13 +460,13 @@
         techTransfer = RD-58,RD-58M:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-58S]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[17D12]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = 17D12
 		ratedBurnTime = 680
-		ignitionReliabilityStart = 0.875
+		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.998
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.875


### PR DESCRIPTION
Previously there was a serious decline in engine config reliability when going from the 11D33M config to the first RD-58 configs. Based on flight history, I didn't find any evidence to claim that these were unreliable engines.