### PR TITLE
RN titan iv booster fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
@@ -5649,191 +5649,16 @@
 	@description = Strap-on booster for Titan IIIM and Titan IV. Burn time 125s.
 	@mass = 40.4325 //40.7825-0.1-0.25 for decoupler and nosecone
 	@maxTemp = 1073.15
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust = 7395
-		@heatProduction = 100
-		%allowShutdown = False
-		@atmosphereCurve
-		{
-			@key,0 = 0 269.5
-			@key,1 = 1 240.3
-		}
-	}
 	!RESOURCE[SolidFuel]
 	{
 	}
+	%engineType = UA1207
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 151758.1332
 		type = PBAN
 		basemass = -1
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = UA-1207
-		modded = false
-		CONFIG
-		{
-			name = UA-1207
-			maxThrust = 7395
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = PBAN
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 269.5
-				key = 1 240.3
-			}
-			curveResource = PBAN
-			// guesses (note: max is above nominal * thrust_curve_max)
-			%chamberNominalTemp  = 2420
-			%maxEngineTemp = 2430
-			thrustCurve
-			{
-				key = 0.99597 1
-				key = 0.98568 0.989
-				key = 0.97585 0.944
-				key = 0.96596 0.95
-				key = 0.95606 0.951
-				key = 0.94613 0.954
-				key = 0.93617 0.957
-				key = 0.92616 0.961
-				key = 0.91612 0.965
-				key = 0.90603 0.969
-				key = 0.89589 0.975
-				key = 0.88572 0.977
-				key = 0.8755 0.982
-				key = 0.86525 0.984
-				key = 0.855 0.985
-				key = 0.84473 0.986
-				key = 0.83444 0.988
-				key = 0.82417 0.987
-				key = 0.8139 0.986
-				key = 0.80365 0.985
-				key = 0.7934 0.984
-				key = 0.78319 0.982
-				key = 0.77298 0.98
-				key = 0.76281 0.977
-				key = 0.75267 0.974
-				key = 0.74259 0.969
-				key = 0.73252 0.967
-				key = 0.72246 0.967
-				key = 0.71241 0.966
-				key = 0.70239 0.962
-				key = 0.6924 0.96
-				key = 0.68244 0.956
-				key = 0.67252 0.953
-				key = 0.66265 0.948
-				key = 0.65283 0.944
-				key = 0.64306 0.938
-				key = 0.63335 0.932
-				key = 0.6237 0.927
-				key = 0.61415 0.918
-				key = 0.60468 0.91
-				key = 0.59528 0.903
-				key = 0.58599 0.893
-				key = 0.57676 0.887
-				key = 0.56759 0.881
-				key = 0.55849 0.874
-				key = 0.54943 0.87
-				key = 0.54043 0.865
-				key = 0.53147 0.861
-				key = 0.52254 0.857
-				key = 0.51364 0.855
-				key = 0.5048 0.849
-				key = 0.49601 0.845
-				key = 0.48728 0.839
-				key = 0.47858 0.836
-				key = 0.46994 0.83
-				key = 0.46134 0.826
-				key = 0.45276 0.824
-				key = 0.44422 0.821
-				key = 0.43572 0.816
-				key = 0.42727 0.812
-				key = 0.41885 0.809
-				key = 0.41046 0.806
-				key = 0.40211 0.802
-				key = 0.39381 0.797
-				key = 0.38554 0.794
-				key = 0.37731 0.791
-				key = 0.3691 0.789
-				key = 0.36091 0.786
-				key = 0.35277 0.782
-				key = 0.34466 0.78
-				key = 0.33659 0.775
-				key = 0.32856 0.772
-				key = 0.32056 0.768
-				key = 0.31259 0.766
-				key = 0.30467 0.761
-				key = 0.29679 0.757
-				key = 0.28897 0.751
-				key = 0.28122 0.744
-				key = 0.27352 0.74
-				key = 0.26588 0.734
-				key = 0.25827 0.732
-				key = 0.25069 0.728
-				key = 0.24314 0.725
-				key = 0.23562 0.723
-				key = 0.22812 0.72
-				key = 0.22065 0.718
-				key = 0.21319 0.717
-				key = 0.20576 0.713
-				key = 0.19836 0.711
-				key = 0.19097 0.71
-				key = 0.18359 0.709
-				key = 0.17624 0.706
-				key = 0.16892 0.703
-				key = 0.16162 0.701
-				key = 0.15437 0.697
-				key = 0.14712 0.696
-				key = 0.13989 0.694
-				key = 0.13268 0.693
-				key = 0.1255 0.69
-				key = 0.11833 0.688
-				key = 0.1112 0.685
-				key = 0.10409 0.684
-				key = 0.09699 0.681
-				key = 0.08994 0.678
-				key = 0.08292 0.674
-				key = 0.07592 0.672
-				key = 0.06897 0.668
-				key = 0.06213 0.657
-				key = 0.05542 0.644
-				key = 0.04894 0.623
-				key = 0.04282 0.588
-				key = 0.03708 0.551
-				key = 0.03172 0.515
-				key = 0.02687 0.466
-				key = 0.02261 0.409
-				key = 0.01903 0.344
-				key = 0.01597 0.294
-				key = 0.01342 0.245
-				key = 0.0112 0.213
-				key = 0.00929 0.183
-				key = 0.00766 0.156
-				key = 0.00631 0.13
-				key = 0.00518 0.108
-				key = 0.00428 0.087
-				key = 0.00355 0.071
-				key = 0.00296 0.056
-				key = 0.00248 0.047
-				key = 0.00208 0.039
-				key = 0.00173 0.033
-				key = 0.00145 0.027
-				key = 0.00117 0.026
-				key = 0.00095 0.022
-				key = 0.00082 0.013
-				key = 0.00077 0.005
-			}
-		}
 	}
 }
 
@@ -6629,114 +6454,16 @@
 	@description = Strap-on booster for Titan IV-B. Burn time 135.7s.
 	@mass = 36.2145 //36.5645-0.1-0.25 for decoupler and nosecone
 	@maxTemp = 1073.15
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust = 8233.777
-		@heatProduction = 100
-		%allowShutdown = False
-		@atmosphereCurve
-		{
-			@key,0 = 0 286
-			@key,1 = 1 259
-		}
-	}
 	!RESOURCE[SolidFuel]
 	{
 	}
+	%engineType = SRMU
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 178214.9045
 		type = HTPB
 		basemass = -1
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = SRMU
-		modded = false
-		CONFIG
-		{
-			name = SRMU
-			maxThrust = 8233.777
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = HTPB
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 286
-				key = 1 259
-			}
-			curveResource = HTPB
-			// guesses (note: max is above nominal * thrust_curve_max)
-			%chamberNominalTemp  = 2420
-			%maxEngineTemp = 2430
-			thrustCurve
-			{
-				key	= 1.00000 0.88833
-				key = 0.97923 0.92565
-				key = 0.94596 0.94389
-				key = 0.91202 0.96394
-				key = 0.87734 0.98475
-				key = 0.84203 1.00000
-				key = 0.80580 0.99720
-				key = 0.77114 0.99243
-				key = 0.73594 0.98676
-				key = 0.70096 0.98063
-				key = 0.66621 0.97401
-				key = 0.63174 0.96500
-				key = 0.60505 0.94644
-				key = 0.58783 0.90621
-				key = 0.56526 0.87347
-				key = 0.53548 0.84310
-				key = 0.50541 0.81384
-				key = 0.47749 0.79194
-				key = 0.44974 0.76924
-				key = 0.42258 0.75861
-				key = 0.39556 0.76069
-				key = 0.36851 0.76031
-				key = 0.34152 0.75763
-				key = 0.31462 0.75520
-				key = 0.28784 0.75104
-				key = 0.26126 0.74374
-				key = 0.23494 0.73663
-				key = 0.20889 0.72883
-				key = 0.18311 0.72093
-				key = 0.15747 0.71134
-				key = 0.13264 0.69520
-				key = 0.10811 0.68457
-				key = 0.08822 0.65933
-				key = 0.07355 0.62530
-				key = 0.06069 0.59157
-				key = 0.04950 0.55954
-				key = 0.04170 0.52646
-				key = 0.03741 0.49165
-				key = 0.03421 0.45776
-				key = 0.03050 0.42220
-				key = 0.02606 0.38816
-				key = 0.02106 0.35155
-				key = 0.01710 0.31875
-				key = 0.01482 0.28222
-				key = 0.01303 0.24773
-				key = 0.01129 0.21130
-				key = 0.00916 0.17771
-				key = 0.00699 0.14314
-				key = 0.00509 0.10658
-				key = 0.00345 0.06968
-				key = 0.00196 0.03716
-				key = 0.00096 0.01930
-				key = 0.00042 0.01106
-				key = 0.00013 0.01000
-				key = 0.00000 0.01000
-
-		
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
-Switch titan iv boosters to use generic configs for fixes to thrust
curves