### PR TITLE
RN craft fix

### DIFF
--- a/Ships/VAB/RO RN Cygnus 110.craft
+++ b/Ships/VAB/RO RN Cygnus 110.craft
@@ -2050,24 +2050,6 @@ PART
 	}
 	MODULE
 	{
-		name = ModuleDockingNodeNamed
-		isEnabled = True
-		portName = Cygnus Docking Ring
-		initialized = True
-		controlTransformName = 
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = GeometryPartModule
 		isEnabled = True
 		stagingEnabled = True

--- a/Ships/VAB/RO RN Cygnus 120.craft
+++ b/Ships/VAB/RO RN Cygnus 120.craft
@@ -2050,24 +2050,6 @@ PART
 	}
 	MODULE
 	{
-		name = ModuleDockingNodeNamed
-		isEnabled = True
-		portName = Cygnus Docking Ring
-		initialized = True
-		controlTransformName = 
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = GeometryPartModule
 		isEnabled = True
 		stagingEnabled = True

--- a/Ships/VAB/RO RN Cygnus 130.craft
+++ b/Ships/VAB/RO RN Cygnus 130.craft
@@ -2050,24 +2050,6 @@ PART
 	}
 	MODULE
 	{
-		name = ModuleDockingNodeNamed
-		isEnabled = True
-		portName = Cygnus Docking Ring
-		initialized = True
-		controlTransformName = 
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = GeometryPartModule
 		isEnabled = True
 		stagingEnabled = True

--- a/Ships/VAB/RO RN Cygnus Enhanced 230.craft
+++ b/Ships/VAB/RO RN Cygnus Enhanced 230.craft
@@ -1997,24 +1997,6 @@ PART
 	}
 	MODULE
 	{
-		name = ModuleDockingNodeNamed
-		isEnabled = True
-		portName = Cygnus Docking Ring
-		initialized = True
-		controlTransformName = 
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = GeometryPartModule
 		isEnabled = True
 		stagingEnabled = True

--- a/Ships/VAB/RO RN Progress 7K-TG.craft
+++ b/Ships/VAB/RO RN Progress 7K-TG.craft
@@ -4511,27 +4511,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = ModuleAeroReentry
 		isEnabled = True
 		dead = False

--- a/Ships/VAB/RO RN Soyuz 7K-OK-A.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-OK-A.craft
@@ -1345,27 +1345,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True
@@ -5084,27 +5063,6 @@ PART
 		}
 		ACTIONS
 		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
 		}
 		UPGRADESAPPLIED
 		{

--- a/Ships/VAB/RO RN Soyuz 7K-OK-P.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-OK-P.craft
@@ -1345,27 +1345,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True
@@ -3675,27 +3654,6 @@ PART
 		}
 		ACTIONS
 		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
 		}
 		UPGRADESAPPLIED
 		{

--- a/Ships/VAB/RO RN Soyuz 7K-T-AF.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-T-AF.craft
@@ -1345,27 +1345,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True
@@ -3675,27 +3654,6 @@ PART
 		}
 		ACTIONS
 		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
 		}
 		UPGRADESAPPLIED
 		{

--- a/Ships/VAB/RO RN Soyuz 7K-T.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-T.craft
@@ -1345,27 +1345,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True
@@ -5246,27 +5225,6 @@ PART
 		}
 		ACTIONS
 		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
 		}
 		UPGRADESAPPLIED
 		{

--- a/Ships/VAB/RO RN Soyuz ASTP.craft
+++ b/Ships/VAB/RO RN Soyuz ASTP.craft
@@ -1345,27 +1345,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True
@@ -3695,27 +3674,6 @@ PART
 		}
 		ACTIONS
 		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
 		}
 		UPGRADESAPPLIED
 		{

--- a/Ships/VAB/RO RN TKS.craft
+++ b/Ships/VAB/RO RN TKS.craft
@@ -1265,27 +1265,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True

--- a/Ships/VAB/RO RN Zond 7K-L1.craft
+++ b/Ships/VAB/RO RN Zond 7K-L1.craft
@@ -1325,27 +1325,6 @@ PART
 	}
 	MODULE
 	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
 		name = MechJebCore
 		isEnabled = True
 		running = True
@@ -4101,27 +4080,6 @@ PART
 		}
 		ACTIONS
 		{
-		}
-		UPGRADESAPPLIED
-		{
-		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		isEnabled = True
-		offsetPercentSlider = 1
-		IsDescentMode = False
-		stagingEnabled = True
-		EVENTS
-		{
-		}
-		ACTIONS
-		{
-			Toggle
-			{
-				actionGroup = None
-			}
 		}
 		UPGRADESAPPLIED
 		{


### PR DESCRIPTION
-Fix missing module warning in ksp 1.6.1