### PR TITLE
KK Launchers Pack config edits

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon9_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon9_Engines.cfg
@@ -120,15 +120,17 @@
 // ======================================
 
 @PART[KK_SPX_Merlin1D]:FOR[RealismOverhaul]{
-  RSSROConfig = True
+	RSSROConfig = True
+	
+	%engineType = Merlin1
 
-  @manufacturer = SpaceX
-  @mass = .47
+	@manufacturer = SpaceX
+	@mass = .47
 
-  @MODULE[ModuleEnginesFX] {
+	@MODULE[ModuleEnginesFX] {
 
 		@minThrust = 483
-    @maxThrust = 690
+		@maxThrust = 690
 		%heatProduction = 225
 		%massMult = 0.6447
 		%ullage = True
@@ -160,10 +162,10 @@
 			amount = 0.5
 		}
 
-    @MODULE[ModuleGimbal]{
-      @gimbalRange = 5
-    }
-  }
+		@MODULE[ModuleGimbal]{
+			@gimbalRange = 5
+		}
+	}
 }
 
 // ======================================
@@ -171,15 +173,16 @@
 // ======================================
 
 @PART[KK_SPX_Merlin1D+]:FOR[RealismOverhaul]{
-  RSSROConfig = True
+	RSSROConfig = True
+	%engineType = Merlin1
+	
+	@manufacturer = SpaceX
+	@mass = .47
 
-  @manufacturer = SpaceX
-  @mass = .47
-
-  @MODULE[ModuleEnginesFX] {
+	@MODULE[ModuleEnginesFX] {
 
 		@minThrust = 504
-    @maxThrust = 720
+		@maxThrust = 720
 		%heatProduction = 225
 		%massMult = 0.6447
 		%ullage = True
@@ -210,10 +213,10 @@
 			amount = 0.5
 		}
 
-    @MODULE[ModuleGimbal]{
-      @gimbalRange = 5
-    }
-  }
+		@MODULE[ModuleGimbal]{
+			@gimbalRange = 5
+		}
+	}
 }
 
 // ======================================
@@ -221,15 +224,16 @@
 // ======================================
 
 @PART[KK_SPX_Merlin1DV]:FOR[RealismOverhaul]{
-  RSSROConfig = True
+	RSSROConfig = True
+	%engineType = Merlin1
 
-  @manufacturer = SpaceX
-  @mass = .47
+	@manufacturer = SpaceX
+	@mass = .47
 
-  @MODULE[ModuleEnginesFX] {
+	@MODULE[ModuleEnginesFX] {
 
 		@minThrust = 504
-    @maxThrust = 845
+		@maxThrust = 845
 		%heatProduction = 225
 		%massMult = 0.6447
 		%ullage = True
@@ -260,10 +264,10 @@
 			amount = 0.5
 		}
 
-    @MODULE[ModuleGimbal]{
-      @gimbalRange = 5
-    }
-  }
+		@MODULE[ModuleGimbal]{
+			@gimbalRange = 5
+		}
+	}
 }
 
 // =========================================
@@ -276,6 +280,7 @@
 
 	%title = Merlin 1D++
 	%category = Engine
+	%engineType = Merlin1
 	%manufacturer = SpaceX
 	%RSSROConfig = True
 	@mass = .47
@@ -283,7 +288,7 @@
 	@MODULE[ModuleEnginesFX] {
 
 		@minThrust = 356.46
-    @maxThrust = 914
+		@maxThrust = 914
 		%heatProduction = 248
 		%massMult = 0.6184
 		%ullage = True
@@ -332,6 +337,7 @@
 
 	%title = Merlin 1D Vacuum+
 	%category = Engine
+	%engineType = Merlin1
 	%manufacturer = SpaceX
 	%RSSROConfig = True
 	@mass = .47
@@ -339,7 +345,7 @@
 	@MODULE[ModuleEnginesFX] {
 
 		@minThrust = 364
-    @maxThrust = 934.12
+		@maxThrust = 934.12
 		%heatProduction = 225
 		%massMult = 0.6447
 		%ullage = True
@@ -376,5 +382,92 @@
 		@gimbalRange = 5.0 //can't find any reliable documentation on this. 5 seems reasonable??
 		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
+	}
+}
+
+
+// =========================================
+//
+// AFTER RealismOverhaulEngines pass
+//
+// =========================================
+
+@PART[KK_SPX_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
+	@title = Merlin 1D Series
+	
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Merlin1D
+		
+		!CONFIG[Merlin1A]{}
+		!CONFIG[Merlin1B]{}
+		!CONFIG[Merlin1BVac]{}
+		!CONFIG[Merlin1C]{}
+		!CONFIG[Merlin1CVac]{}
+		!CONFIG[Merlin1DVac]{}
+		!CONFIG[Merlin1DVac+]{}
+	}
+}
+
+@PART[KK_SPX_Merlin1D+]:AFTER[zzzRealismOverhaul]
+{
+	@title = Merlin 1D Series
+	@category = none	// Hide engines to reduce clutter
+	
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Merlin1D+
+		
+		!CONFIG[Merlin1A]{}
+		!CONFIG[Merlin1B]{}
+		!CONFIG[Merlin1BVac]{}
+		!CONFIG[Merlin1C]{}
+		!CONFIG[Merlin1CVac]{}
+		!CONFIG[Merlin1DVac]{}
+		!CONFIG[Merlin1DVac+]{}
+	}
+}
+
+@PART[KK_SPX_Merlin1D++]:AFTER[zzzRealismOverhaul]
+{
+	@title = Merlin 1D Series
+	@category = none	// Hide engines to reduce clutter
+	
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Merlin1D++
+		
+		!CONFIG[Merlin1A]{}
+		!CONFIG[Merlin1B]{}
+		!CONFIG[Merlin1BVac]{}
+		!CONFIG[Merlin1C]{}
+		!CONFIG[Merlin1CVac]{}
+		!CONFIG[Merlin1DVac]{}
+		!CONFIG[Merlin1DVac+]{}
+	}
+}
+
+@PART[KK_SPX_Merlin1DV]:AFTER[RealismOverhaulEngines]
+{
+	@title = Merlin 1D Vacuum
+	
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Merlin1DVac
+		
+		!CONFIG[*]:HAS[~name[Merlin1DVac]]{}
+	}
+}
+
+@PART[KK_SPX_Merlin1DV+]:AFTER[RealismOverhaulEngines]
+{
+	@title = Merlin 1D Vacuum+
+	
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Merlin1DVac+
+		
+		!CONFIG[*]:HAS[~name[Merlin1DVac+]]{}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon9_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KK Launchers/RO_KK_Falcon9_Tanks.cfg
@@ -58,11 +58,13 @@
 	@title = Falcon 9 Block 4 Upper Fuel Tank
 	@manufacturer = SpaceX
 	@mass = 3.9
+	
+	%CoMOffset = 0.0, 0.8, 0.0
 
 	MODULE{
 
 		name = ModuleFuelTanks
-		volume = 91605.3
+		volume = 91103.3
 		type = Cryogenic
 
 		TANK{
@@ -75,19 +77,16 @@
 			amount = full
 			maxAmount = 57224.6
 		}
-		TANK{
-			name = NTO
-			amount = full
-			maxAmount = 200
-		}
-		TANK{
-			name = MMH
-			amount = full
-			maxAmount = 320
-		}
 	}
 
 	!RESOURCE,*{}
+	
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 80000
+		maxAmount = 80000
+	}
 
 	MODULE
 	{
@@ -147,24 +146,19 @@
 	@MODULE[ModuleRCSFX]{
 
 		!resourceName = NULL
-		@thrusterPower = .4
+		@thrusterPower = 0.14
 
-		PROPELLANT{
+		PROPELLANT
+		{
 
-			name = MMH
+			name = Nitrogen
 			ratio = 1.0
-		}
-
-		PROPELLANT{
-
-			name = NTO
-			ratio = 1.6
 		}
 
 		@atmosphereCurve
         {
-            @key,0 = 0 300
-            @key,1 = 1 85
+            @key,0 = 0 65
+            @key,1 = 1 30
         }
 	}
 }
@@ -390,39 +384,44 @@
 // ==============================
 
 @PART[KK_SPX_F92_S2tank]:FOR[RealismOverhaul]{
-  %RSSROConfig = True
+	%RSSROConfig = True
 
-  @manufacturer = SpaceX
-  @mass = 3.1
+	@manufacturer = SpaceX
+	@mass = 3.1
+	
+	%CoMOffset = 0.0, 0.6, 0.0
 
-  !RESOURCE,*{}
+	!RESOURCE,*{}
+	
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 80000
+		maxAmount = 80000
+	}
 
-  @MODULE[ModuleRCSFX]{
-    @thrusterPower = .4
-    !resourceName = NULL
+	@MODULE[ModuleRCSFX]{
 
-    PROPELLANT{
+		!resourceName = NULL
+		@thrusterPower = 0.14
 
-			name = MMH
+		PROPELLANT
+		{
+
+			name = Nitrogen
 			ratio = 1.0
-		}
-
-		PROPELLANT{
-
-			name = NTO
-			ratio = 1.6
 		}
 
 		@atmosphereCurve
         {
-            @key,0 = 0 300
-            @key,1 = 1 85
+            @key,0 = 0 65
+            @key,1 = 1 30
         }
-  }
+	}
 
   MODULE{
     name = ModuleFuelTanks
-    volume = 72645
+    volume = 72125
     type = Cryogenic
 
     TANK{
@@ -436,18 +435,6 @@
       amount = full
       maxAmount = 45373.8
     }
-
-    TANK{
-			name = NTO
-			amount = full
-			maxAmount = 200
-		}
-
-		TANK{
-			name = MMH
-			amount = full
-			maxAmount = 320
-		}
   }
 
   MODULE

--- a/GameData/RealismOverhaul/RealPlume_Configs/KK Launchers/kk_falcon9_engines.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KK Launchers/kk_falcon9_engines.cfg
@@ -1,0 +1,120 @@
+@PART[KK_SPX_Merlin1D++]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localPosition = 0.0, 0.0, 0.1
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 0.7
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 0.8
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+    }
+}
+
+@PART[KK_SPX_Merlin1D+]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localPosition = 0.0, 0.0, 0.1
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 0.7
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 0.8
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+    }
+}
+
+@PART[KK_SPX_Merlin1D]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Lower
+        transformName = thrustTransform
+        localPosition = 0.0, 0.0, 0.1
+        localRotation = 0.0, 0.0, 0.0
+        fixedScale = 0.7
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        flarePosition = 0.0, 0.0, 0.0
+        flareScale = 0.8
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+    }
+}
+
+
+@PART[KK_SPX_Merlin1DV+]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        localPosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.1
+        fixedScale = 1.1
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        flarePosition = 0.0, 0.0, -0.2
+        flareScale = 1.8
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+    }
+}
+
+@PART[KK_SPX_Merlin1DV]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+    PLUME
+    {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        localPosition = 0.0, 0.0, 0.0
+        localRotation = 0.0, 0.0, 0.1
+        fixedScale = 1.1
+        energy = 1.0
+        speed = 1.0
+        emissionMult = 0.5
+        flarePosition = 0.0, 0.0, -0.2
+        flareScale = 1.8
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Upper
+        !runningEffectName = DELETE
+        !fxOffset = DELETE
+    }
+}


### PR DESCRIPTION
Changes:

- Add RealPlume configs for Merlin 1D and 1DVacuum engines
- Change the Merlin 1D configs to utilize RO's engine configs
- Change Falcon 9 1.1 and  Full Thrust upper stages to use cold gas thrusters instead of MMH/NTO (according to http://spaceflight101.com/spacerockets/falcon-9-ft/)
- Edit the CoM of Falcon 9 1.1 and  Full Thrust upper stages to be roughly in the middle of the model instead of the bottom