### PR TITLE
Add support for Tokamak industries

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/TokamakIndustries/RO_Tokamak_Industries_Habitat.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/TokamakIndustries/RO_Tokamak_Industries_Habitat.cfg
@@ -1,0 +1,1002 @@
+//mainly reusing old porket configs
+
+@PART[centrifugeSmall]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	%MODEL
+	{
+		%model = TokamakIndustries/parts/centrifugeSmall/centrifugeSmall
+		%scale = 1.4, 1.4, 1.4
+	}
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 1.97, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.62, 0.0, 0.0, -1.0, 0.0, 2
+	@CrewCapacity = 4
+	@mass = 6
+	@cost = 16000
+	@title = ISS Centrifuge Demo
+	@description = A downsized version of the centrifuge from the Nautilus-X design study, proposed to be installed at the ISS to demonstrate the feasibility of the concept. Only large enough to serve as sleeping quarters for 4 people under partial gravity. Not enough space to stand up, too small a radius to provide full gravity. Relatively high spin rate quite possibly makes the whole experience very nauseating. Could nonetheless still be a substantial health benefit for the crew on a long mission.
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+	@MODULE[DeployableHabitat]
+	{
+		@crewCapacityDeployed = 4
+	}
+	MODULE
+	{
+		name = LifeSupportModule
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 300
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 19000
+			maxAmount = 19000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 2520
+			maxAmount = 2520
+		}
+		TANK
+		{
+			name = Food
+			amount = 12
+			maxAmount = 12
+		}
+		TANK
+		{
+			name = Water
+			amount = 6.8
+			maxAmount = 6.8
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1200
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 6
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 10.8
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 3
+			maxAmount = 9
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 4.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	@MODULE[Centrifuge]
+	{
+		@habRadius = 4.6
+		@rotorRPM = 5
+	}
+}
+
++PART[centrifugeSmall]:FIRST
+{
+@name = centrifugeXL
+}
+
+@PART[centrifugeXL]:FOR[RealismOverhaul]
+{
+%RSSROConfig = true
+!mesh = DELETE
+	%MODEL
+	{
+		%model = TokamakIndustries/parts/centrifugeSmall/centrifugeSmall
+		%scale = 2.5, 2.5, 2.5
+	}
+@rescaleFactor = 1
+@node_stack_top = 0.0, 3.51, 0.0, 0.0, 1.0, 0.0, 4
+@node_stack_bottom = 0.0, -2.89, 0.0, 0.0, -1.0, 0.0, 4
+
+@CrewCapacity = 6
+
+@cost = 80000
+@title = Nautilus-X Centrifuge
+@manufacturer = Porky's Snacks & Inflatable Living Spaces
+description = The full-sized version of the centrifuge from the Nautilus-X proposal. With a habitable volume close to that of the entire ISS put together, it's large enough to provide comfortable habitation to six astronauts. Although the diameter remains too small to allow for full Earth-like gravity under tolerable rotation rates, Martian gravity levels are easily achievable.
+
+@mass = 30.0
+@crashTolerance = 12
+@breakingForce = 250
+@breakingTorque = 250
+@maxTemp = 1073.15
+
+@MODULE[DeployableHabitat]
+{
+	@crewCapacityDeployed = 6
+}
+MODULE
+{
+	name = LifeSupportModule
+}
+MODULE
+{
+	name = ModuleFuelTanks
+	volume = 1500
+	basemass = -1
+	type = ServiceModule
+	TANK
+	{
+		name = Oxygen
+		amount = 56700
+		maxAmount = 56700
+	}
+	TANK
+	{
+		name = Food
+		amount = 270
+		maxAmount = 270
+	}
+	TANK
+		{
+			name = Water
+			amount = 153
+			maxAmount = 153
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 4860
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 135
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 243
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 28500
+			maxAmount = 28500
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 13.5
+			maxAmount = 13.5
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 6.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	@MODULE[Centrifuge]
+	{
+		@habRadius = 8.5
+		@rotorRPM = 5
+	}
+}
+
+@PART[TIinflato1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	%MODEL
+	{
+		%model = TokamakIndustries/parts/inflato1/model
+		%scale = 1.52, 1.886, 1.52
+	}
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 6.601, 0.0, 0.0, 1.0, 0.0, 3
+	@node_stack_bottom = 0.0, -4.715, 0.0, 0.0, -1.0, 0.0, 3
+	@CrewCapacity = 6
+	@title = BA330 Inflatable Habitat
+	%manufacturer = Bigelow
+	@description = The upcoming Bigelow BA330 inflatable habitat. As the name suggests, it has 330 cubic meters of pressurized volume. Room for 6, and 30 days of supplies. Add a few tonnes of water for radiation shielding purposes to simulate the Deep Space configuration (otherwise it's only suitable for low Earth orbit).
+	@mass = 20
+	@cost = 17000
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+	@MODULE[DeployableHabitat]
+	{
+		@crewCapacityDeployed = 6
+	}
+	MODULE
+	{
+		name = LifeSupportModule
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 4500
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Oxygen
+			amount = 113400
+			maxAmount = 113400
+		}
+		TANK
+		{
+			name = Food
+			amount = 540
+			maxAmount = 540
+		}
+		TANK
+		{
+			name = Water
+			amount = 306
+			maxAmount = 306
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 9720
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 270
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 486
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 28500
+			maxAmount = 28500
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 27
+			maxAmount = 27
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 6.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+}
+
++PART[TIinflato1]:FIRST
+{
+	@name = inflatoXL
+}
+
+@PART[inflatoXL]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	%MODEL
+	{
+		%model = TokamakIndustries/parts/inflato1/model
+		%scale = 2.74, 3.56, 2.74
+	}
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 12.46, 0.0, 0.0, 1.0, 0.0, 5
+	@node_stack_bottom = 0.0, -8.9, 0.0, 0.0, -1.0, 0.0, 5
+	@CrewCapacity = 18
+	@title = BA2100 "Olympus" Inflatable Habitat
+	%manufacturer = Bigelow
+	@description = The largest of the habitats designed by Bigelow Aerospace. As the name suggests, it has a whooping 2100 cubic meters of pressurized volume, more than twice that of the entire International Space Station combined. Can comfortably house 18 astronauts. Add at least a dozen tonnes of water for radiation shielding purposes to simulate the Deep Space configuration, otherwise it should be kept in low Earth orbit.
+	@mass = 100
+	@cost = 70000
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+	@MODULE[DeployableHabitat]
+	{
+		@crewCapacityDeployed = 18
+	}
+	MODULE
+	{
+		name = LifeSupportModule
+	}
+	// !MODULE[ModuleFuelTanks]
+	// MODULE
+	// {
+	// 	name = ModuleFuelTanks
+	// 	volume = 20000
+	// 	basemass = -1
+	// 	type = ServiceModule
+	// 	TANK
+	// 	{
+	// 		name = Oxygen
+	// 		amount = 340200
+	// 		maxAmount = 340200
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = Food
+	// 		amount = 1620
+	// 		maxAmount = 1620
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = Water
+	// 		amount = 918
+	// 		maxAmount = 918
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = CarbonDioxide
+	// 		amount = 0
+	// 		maxAmount = 27000
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = Waste
+	// 		amount = 0
+	// 		maxAmount = 810
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = WasteWater
+	// 		amount = 0
+	// 		maxAmount = 1458
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = ElectricCharge
+	// 		amount = 85500
+	// 		maxAmount = 85500
+	// 	}
+	// 	TANK
+	// 	{
+	// 		name = LithiumHydroxide
+	// 		amount = 81
+	// 		maxAmount = 81
+	// 	}
+	// }
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 18.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+}
+
+@PART[TIinflato2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = TokamakIndustries/parts/inflato2/model
+		scale = 1.68, 1.891, 1.68
+	}
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 5.1057, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -3.5929, 0.0, 0.0, -1.0, 0.0, 2
+	@CrewCapacity = 3
+	@title = Sundancer Inflatable Habitat
+	%manufacturer = Bigelow
+	@description = A loosely based example of the proposed (now cancelled) Bigelow Sundancer inflatable habitat. Room for 3, and 30 days of supplies.
+	@mass = 8.6184
+	@cost = 10000
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+	@MODULE[DeployableHabitat]
+	{
+		@crewCapacityDeployed = 3
+	}
+	MODULE
+	{
+		name = LifeSupportModule
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1500
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Oxygen
+			amount = 56700
+			maxAmount = 56700
+		}
+		TANK
+		{
+			name = Food
+			amount = 270
+			maxAmount = 270
+		}
+		TANK
+		{
+			name = Water
+			amount = 153
+			maxAmount = 153
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 4860
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 135
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 243
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 16400
+			maxAmount = 16400
+		}
+	TANK
+		{
+			name = LithiumHydroxide
+			amount = 14
+			maxAmount = 14
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 3.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+}
+
+@PART[TIinflatoFlat]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	!mesh = DELETE
+	@MODEL,0 
+	{
+		@scale = 1.37, 1.78, 1.37
+	}
+	@MODEL,1 
+	{
+		@scale = 1.37, 1.78, 1.37
+	}
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 1.67, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -1.67, 0.0, 0.0, -1.0, 0.0, 4
+	@CrewCapacity = 4
+	@MODULE[ModuleDockingNode],0
+	{
+		@nodeType = NASADock
+	}
+	@MODULE[ModuleDockingNode],1
+	{
+		@nodeType = NASADock
+	}
+	@MODULE[ModuleDockingNode],2
+	{
+		@nodeType = NASADock
+	}
+	@title = Inflatable Docking Hub
+	@description = A big balloon with 4 docking ports to help increase the size of an inflatable station. At about 160 cubic meters of pressurized volume it's large enough to replace two conventional station segments.
+	@mass = 16
+	@cost = 12000
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+	MODULE
+	{
+		name = LifeSupportModule
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 2000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Oxygen
+			amount = 75600
+			maxAmount = 75600
+		}
+		TANK
+		{
+			name = Food
+			amount = 360
+			maxAmount = 360
+		}
+		TANK
+		{
+			name = Water
+			amount = 204
+			maxAmount = 204
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 6480
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 180
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 324
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 22000
+			maxAmount = 22000
+		}
+	TANK
+		{
+			name = LithiumHydroxide
+			amount = 14
+			maxAmount = 14
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 4.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+}
+
+@PART[TIorbitalorb]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = TokamakIndustries/parts/orbitalorb/model000
+		scale = 0.944, 1.05, 0.944
+	}
+	@scale = 1.0
+	@rescaleFactor = 1.0
+	@node_stack_top = 0.0, 1.239, 0.0, 0.0, 1.0, 0.0, 2
+	@node_stack_bottom = 0.0, -1.239, 0.0, 0.0, -1.0, 0.0, 2
+	@title = Orbital Module
+	@description = A generic orbital module loosely based on that of the Soviet Soyuz spacecraft. Designed to provide additional habitation space in orbit. As it is not supposed to survive reentry, remember to put a decoupler between this module and your reentry capsule.
+	@mass = 1.37
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+	@MODULE[ModuleCommand]
+	{
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.500
+		}
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Oxygen
+			amount = 8820
+			maxAmount = 8820
+		}
+		TANK
+		{
+			name = Food
+			amount = 42
+			maxAmount = 42
+		}
+		TANK
+		{
+			name = Water
+			amount = 23.8
+			maxAmount = 23.8
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 756
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 21
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 37.8
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10800
+			maxAmount = 10800
+		}
+	TANK
+		{
+			name = LithiumHydroxide
+			amount = 3
+			maxAmount = 7
+		}
+	}
+	MODULE
+	{
+		name = TacGenericConverter
+		converterName = CO2 Scrubber
+		StartActionName = Start CO2 Scrubber
+		StopActionName = Stop CO2 Scrubber
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 2.0	// # of people - Figures based on per/person
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00589121
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+}
+
+@PART[BaseMount]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!mesh = DELETE
+	MODEL
+	{
+		model = TokamakIndustries/parts/basemount/model
+		scale = 1.68, 1.68, 1.68
+	}
+	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 4
+	@node_stack_bottom = 0.0, -0.252, 0.0, 0.0, -1.0, 0.0, 2
+	@mass = 0.42
+	@crashTolerance = 12
+	@breakingForce = 250
+	@breakingTorque = 250
+	@maxTemp = 1073.15
+}
+
+///////Changed the length of BA330, Sundancer and Orbital Module to better match their real-life dimensions. Kept the other two dimensions the same to keep them matched with docking ports.
+//////Estimated prices for everything except the Orbital Module and the Base Mount, and converted them to 1965 dollars.
+/////Wrote new, more detailed descriptions for most parts.
+////Added CO2 scrubbers and Lithium Hydroxide tanks, and reduced CO2 storage capacity to keep the parts in-line with changes made to stock squad parts' configs.
+////Added two new parts, BA-2100 and full-size Nautilus-X centrifuge.
+///Adjusted masses and storage volumes to be more realistic.


### PR DESCRIPTION
basically copied all Porkjet's Habitat Pack configs and changed part names and modules, while trying to get a realistic scale.