### PR TITLE
RO_Squad_Command: Fix model file path for some probes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -1377,7 +1377,7 @@
 	!MODEL {}
 	MODEL
 	{
-		model = Squad/Parts/Command/probeCoreCube/model
+		model = Squad/Parts/Command/probeCoreCube/probeCoreCube
 		scale = 3.0, 3.0, 3.0
 	}
 	@mass = 0.512
@@ -1513,7 +1513,7 @@
 	!MODEL {}
 	MODEL
 	{
-		model = Squad/Parts/Command/probeCoreOcto_v2/model
+		model = Squad/Parts/Command/probeCoreOcto_v2/probeCoreOcto_v2
 		scale = 0.9842, 0.7275, 0.9842
 	}
 	%rescaleFactor = 1.0
@@ -1723,7 +1723,7 @@
 	!MODEL {}
 	MODEL
 	{
-		model = Squad/Parts/Command/probeCoreCube/model
+		model = Squad/Parts/Command/probeCoreCube/probeCoreCube
 		scale = 3.0, 3.0, 3.0
 	}
 	@mass = 0.66
@@ -1799,7 +1799,7 @@
 	!MODEL {}
 	MODEL
 	{
-		model = Squad/Parts/Command/probeCoreCube/model
+		model = Squad/Parts/Command/probeCoreCube/probeCoreCube
 		scale = 4.0, 4.0, 4.0
 	}
 	@mass = 0.776
@@ -1887,7 +1887,7 @@
 	!MODEL {}
 	MODEL
 	{
-		model = Squad/Parts/Command/probeCoreCube/model
+		model = Squad/Parts/Command/probeCoreCube/probeCoreCube
 		scale = 4.09, 6.154, 6.544
 	}
 	@mass = 1.26


### PR DESCRIPTION
Some probes from the stock game were broken due to incorrect model file paths. This should fix those