### PR TITLE
Increase number of ignitions for RD-58 and RD-58 to 7

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -12,6 +12,7 @@
 //      http://www.astronautix.com/engines/rd58.htm
 //      https://en.wikipedia.org/wiki/List_of_R-7_launches
 //      http://s001.radikal.ru/i196/1109/b8/202f80f773b3.jpg
+//		http://www.buran.ru/htm/gud%2025.htm
 
 //  Used by:
 //      Squad
@@ -173,12 +174,12 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 4
+			ignitions = 7
 
 			IGNITOR_RESOURCE
 			{
 				name = TEATEB
-				amount = 0.5
+				amount = 0.3571428
 			}
 
 			PROPELLANT
@@ -212,12 +213,12 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 4
+			ignitions = 7
 
 			IGNITOR_RESOURCE
 			{
 				name = TEATEB
-				amount = 0.625
+				amount = 0.3571428
 			}
 
 			PROPELLANT


### PR DESCRIPTION
Several Russian sources claim that the 11D58 and 11D58M varients intended for the Blok-D and Blok-DM of the Soviet Moon rocket could be restarted at least 7 times.

This increases the number of ignitions for the RD-58 and RD-58M variants.