### PR TITLE
Fix LEO heatshield attach nodes (1m and 1.5m) on ReStock models

### DIFF
--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -15,18 +15,29 @@
 	@name = RP0probeVanguardXray
 }
 
-@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[!ReStock]
 {
-	!MODULE[TweakScale]{}
-
 	@MODEL
 	{
 		%scale = 0.79375, 0.79375, 0.79375
 	}
 
-	%RSSROConfig = true
-
 	@node_stack_bottom = 0.0, -0.516, 0.0, 0.0, -1.0, 0.0, 0
+}
+
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[ReStock]
+{
+	@MODEL
+	{
+		%scale = 0.54654, 0.54654, 0.54654
+	}
+}
+
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]
+{
+	!MODULE[TweakScale]{}
+	
+	%RSSROConfig = true
 
 	@mass = 0.01
 	@maxTemp = 473.15

--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -15,29 +15,18 @@
 	@name = RP0probeVanguardXray
 }
 
-@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]
 {
+	!MODULE[TweakScale]{}
+
 	@MODEL
 	{
 		%scale = 0.79375, 0.79375, 0.79375
 	}
 
-	@node_stack_bottom = 0.0, -0.516, 0.0, 0.0, -1.0, 0.0, 0
-}
-
-@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[ReStock]
-{
-	@MODEL
-	{
-		%scale = 0.54654, 0.54654, 0.54654
-	}
-}
-
-@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]
-{
-	!MODULE[TweakScale]{}
-	
 	%RSSROConfig = true
+
+	@node_stack_bottom = 0.0, -0.516, 0.0, 0.0, -1.0, 0.0, 0
 
 	@mass = 0.01
 	@maxTemp = 473.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_HeatShields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_HeatShields.cfg
@@ -95,7 +95,7 @@
 	}
 	
 	@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_top = 0.0, -0.134, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.134, 0.0, 0.0, -1.0, 0.0, 1
 	
 	@title = LEO Heat Shield [1m]
 	@description = LEO rated heat shield. Not rated for lunar returns.
@@ -233,8 +233,8 @@
 		rescaleZ = 1.2
 	}
 	
-	//@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_top = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	
 	@title = LEO Heat Shield [1.5m]
 	@description = LEO rated heat shield. Not rated for lunar returns.


### PR DESCRIPTION
Looks like a small oversight left these two heatshields (1m and 1.5m) without a functioning bottom attach node.