### PR TITLE
Resolve scaling conflict for Xray core when using Restock model

### DIFF
--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -19,14 +19,7 @@
 {
 	!MODULE[TweakScale]{}
 
-	@MODEL
-	{
-		%scale = 0.79375, 0.79375, 0.79375
-	}
-
 	%RSSROConfig = true
-
-	@node_stack_bottom = 0.0, -0.516, 0.0, 0.0, -1.0, 0.0, 0
 
 	@mass = 0.01
 	@maxTemp = 473.15
@@ -57,6 +50,21 @@
 	{
 		@ejectionForce = 2.5
 	}
+}
+
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+{
+	@MODEL
+	{
+		%scale = 0.79375, 0.79375, 0.79375
+	}
+
+	@node_stack_bottom = 0.0, -0.516, 0.0, 0.0, -1.0, 0.0, 0
+}
+
+@PART[RP0probeVanguardXray]:FOR[RealismOverhaul]:NEEDS[ReStock]
+{
+	%rescaleFactor = 0.54654
 }
 
 //  ==================================================


### PR DESCRIPTION
This .cfg uses the Restock model for the x-ray core if available and uses the SXT model otherwise.
The rescaling and node positions were, however, specific for the SXT model. When applied to the Restock model, the result was a floating bottom attach node and an oversized model.

I've made the config check for the Restock model and then rescale accordingly. For the rescaleFactor, I assumed the rescaleFactor for this model's use as the Sputnik core (0.624, in /RO_SuggestedMods/Squad/RO_Squad_Command.cfg) corresponds to a final diameter of 58 cm. That is, 0.624 / 58 cm = 0.54654 / 50.8 cm, where 50.8 cm is the diameter of the x-ray core.