### PR TITLE
Fix LEO heatshield attach nodes (1m and 1.5m) on ReStock models

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_HeatShields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_HeatShields.cfg
@@ -95,7 +95,7 @@
 	}
 	
 	@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_top = 0.0, -0.134, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.134, 0.0, 0.0, -1.0, 0.0, 1
 	
 	@title = LEO Heat Shield [1m]
 	@description = LEO rated heat shield. Not rated for lunar returns.
@@ -233,8 +233,8 @@
 		rescaleZ = 1.2
 	}
 	
-	//@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_top = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
+	@node_stack_top = 0.0, 0.015, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	
 	@title = LEO Heat Shield [1.5m]
 	@description = LEO rated heat shield. Not rated for lunar returns.


### PR DESCRIPTION
Looks like a small oversight left these two heatshields (1m and 1.5m) without a functioning bottom attach node.
Edit: Re-opened after cleaning up git branching.