### PR TITLE
Add support for integrated RCS in B9 HL and S2 cockpits

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
@@ -38,7 +38,9 @@
 		@basemass = -1
 		@volume *= 2
 	}
+	!MODULE[ModuleFuelTanks],1 {}
 	!MODULE[ModuleReactionWheel] {}
+
 }
 
 @PART[B9_Aero_HL_Adapter_Front]:FOR[zzzRealismOverhaul]
@@ -823,9 +825,24 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	!MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS*]
 	{
+		@name = ModuleRCS
+		@thrusterPower = 0.825
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = Hydrazine
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 254
+			@key,1 = 1 82.08
+		}
 	}
+        useRcsConfig = RCSBlockTriple
+        %useRcsMass = False
 
 	!MODULE[ModuleFuelTanks] {}
 	MODULE
@@ -954,9 +971,24 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	!MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS*]
 	{
+		@name = ModuleRCS
+		@thrusterPower = 0.825
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			ratio = 1.0
+			name = Hydrazine
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 254
+			@key,1 = 1 82.08
+		}
 	}
+        useRcsConfig = RCSBlockTriple
+        %useRcsMass = False
 	!MODULE[ModuleFuelTanks] {}
 	MODULE
 	{
@@ -2075,6 +2107,7 @@
 		typeAvailable = BalloonCryo
 		typeAvailable = Structural
 	}
+	!MODULE[ModuleFuelTanks],1 {}
 }
 @PART[B9_Structure_*]:FOR[zzzRealismOverhaul] // fuel switch
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
@@ -122,9 +122,8 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS translation thruster.
 	@mass = 0.05
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.275
 		!resourceName = DELETE
 		PROPELLANT
@@ -149,9 +148,8 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS translation thruster.
 	@mass = 0.05
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.275
 		!resourceName = DELETE
 		PROPELLANT
@@ -177,9 +175,8 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS thruster block.
 	@mass = 0.0625
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.4125
 		!resourceName = DELETE
 		PROPELLANT
@@ -205,9 +202,8 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Aerodynamic RCS thruster block.
 	@mass = 0.075
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.4125
 		!resourceName = DELETE
 		PROPELLANT
@@ -233,9 +229,8 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Heavy aerodynamic RCS thruster block.
 	@mass = 0.1125
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.825
 		!resourceName = DELETE
 		PROPELLANT
@@ -261,9 +256,8 @@
 	}
     @description = CONTAINS 2 SUBTYPES | Heavy aerodynamic RCS thruster block.
 	@mass = 0.1125
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.825
 		!resourceName = DELETE
 		PROPELLANT
@@ -825,9 +819,8 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.825
 		!resourceName = DELETE
 		PROPELLANT
@@ -971,9 +964,8 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.825
 		!resourceName = DELETE
 		PROPELLANT
@@ -1226,9 +1218,8 @@
 	{
 	}
 	@mass = 0.313 //1 thruster only
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 8.125
 		!resourceName = DELETE
 		PROPELLANT
@@ -1255,9 +1246,8 @@
 	{
 	}
 	@mass = 0.625 // 2 thrusters only
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCSFX]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 8.125
 		!resourceName = DELETE
 		PROPELLANT


### PR DESCRIPTION
Some B9 cockpits have support for integrated RCS, why not add it to RO?
Besides, without this patch, cockpits have RCS FX always on without actual RCS