### PR TITLE
Better Internal Overlay scaling for SXT Ju87 cockpit

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -367,12 +367,13 @@
 
 @INTERNAL[kondorcockpit]:FOR[RealismOverhaul]
 {
-	%scaleAll = 2.3, 1.6, 2.3
+	%scaleAll = 2, 2, 1.57
+	%offset = 0, 0, 0.025
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 2.3, 1.6, 2.3
+		%kerbalScale = 1.25, 1.15, 1.35
 		%kerbalOffset = 0.0, 0.0, 0.0
-		%kerbalEyeOffset = 0.0, 0.165, 0.0
+		%kerbalEyeOffset = 0.0, 0.05, 0.0
 	}
 }
 


### PR DESCRIPTION
Not quite perfectly aligned, but the overlay now has about the same size as the actual cockpit.
And the crew isn't comically deformed anymore.

IVA view feels usable, but I'm not really sure what's "correct".