### PR TITLE
STME Engine Config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
@@ -4,7 +4,7 @@
 // https://www.alternatewars.com/BBOW/Space_Engines/STME_Data_Excerpt.pdf
 // http://www.astronautix.com/s/stme.html
 //
-@PART[*]:HAS[#engineType[SSME]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[STME]]:FOR[RealismOverhaulEngines]
 {
 	@title = Space Transportation Main Engine (STME)
 	@manufacturer = Rocketdyne

--- a/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
@@ -1,0 +1,88 @@
+// STME
+//
+// ------Sources--------
+// https://www.alternatewars.com/BBOW/Space_Engines/STME_Data_Excerpt.pdf
+// http://www.astronautix.com/s/stme.html
+//
+@PART[*]:HAS[#engineType[SSME]]:FOR[RealismOverhaulEngines]
+{
+	@title = Space Transportation Main Engine (STME)
+	@manufacturer = Rocketdyne
+	@description = Rocketdyne LOx/LH2 rocket engine. Cancelled 1984. Space Transportation Main Engine. Rocketdyne was teamed with Aerojet and Pratt & Whitney on the STME, which was to have powered the next generation of large launch vehicles. Diameter: [2.57 m].
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = STME
+		origMass = 4.127
+		modded = false
+		CONFIG
+		{
+			name = STME
+			minThrust = 2023.9
+			maxThrust = 2891.3
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7276
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2724
+			}
+			atmosphereCurve
+			{
+				key = 0 428.5
+				key = 1 364.5
+			}
+
+			%ullage = True
+			%pressureFed = False
+			%ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+
+	!MODULE[ModuleAlternator]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	{
+	}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 9.7
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+}
+
+//**********************************************************************************
+//  STME Test Flight Data
+//
+//	STME Design Reliability of 5500 secs 
+//		ignition = 0.99, cycle = 0.99995
+//
+//	Used a +/- of 0.06 and set the value above at the 80% mark of the curve with a
+//	max of 0.9995
+//**********************************************************************************
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[STME]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = STME
+		ratedBurnTime = 550
+		ignitionReliabilityStart = 0.932
+		ignitionReliabilityEnd = 0.992
+		cycleReliabilityStart = 0.9415
+		cycleReliabilityEnd = 0.9995
+		techTransfer = RS-25A:50
+	}
+}


### PR DESCRIPTION
Created the STME Engine to fill the gap between the Rs-25 and RS-68 since the STME served as a starting point for the RS-68.

https://www.alternatewars.com/BBOW/Space_Engines/STME_Data_Excerpt.pdf
http://www.astronautix.com/s/stme.html

Using those sources i managed to recreate the engine with as much data that is available.
Since no rated burntime is available i set it a little higher then the rs 25 to simulate a improved RS-25.
The Testflight values are set as a RS-25C/Rs-25D-E