### PR TITLE
Scale Bonanza IVA to match the RO model size

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Bonanza.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Bonanza.cfg
@@ -66,6 +66,7 @@
 		}
 	}
 }
+
 // Bonny cockpit (the Beech Bonanza cabin)
 @PART[625mBonny]:FOR[RealismOverhaul]
 {
@@ -132,6 +133,20 @@
 		maxAmount = 23.2
 	}
 }
+
+// Bonanza IVA
+@INTERNAL[BonnyInternals]:FOR[RealismOverhaul]
+{
+        %scaleAll = 1.9, 1.9, 1.8
+	%offset = 0, 0, 0.55
+        @MODULE[InternalSeat],*
+        {
+                %kerbalScale = 1.4, 1.4, 1.45
+                %kerbalOffset = 0.0, -0.1, 0.0
+                %kerbalEyeOffset = 0.0, 0.0, 0.0
+        }
+}
+
 // Tail for the Bonny
 @PART[LMiniAircaftTail]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Like the Ju-87, not perfectly aligned, but much better than stock-size