### PR TITLE
Fix Conic Cockpit IVA Overlay offset

### DIFF
--- a/GameData/RealismOverhaul/Parts/NoseconeCockpit/Nosecone_cockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/NoseconeCockpit/Nosecone_cockpit.cfg
@@ -60,6 +60,7 @@ PART
 	INTERNAL
 	{
 	  name = mk1CockpitInternal
+	  offset = 0.0, 0.0, 1.0
 	}
 
 	MODULE


### PR DESCRIPTION
Current offset is putting the overlay about 1 cockpit length in front of the actual cockpit. This brings it roughly at the right place (can't be perfect, the shape is wrong)

not 100% confident on this one, I'm a little confused about the relationship between RP0-Nose-Cockpit (which uses mk1CockpitInternal) and Mark1Cockpit (which uses RO-Mk1CockpitInternal-1.25). But this works for me.