### PR TITLE
Remove duplicate converters from SNAP-9, SNAP-19 and MMRTG

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Electrical.cfg
@@ -171,6 +171,7 @@
     %skinMaxTemp = 1773.15
     %fuelCrossFeed = False
 
+    !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
 
     MODULE
@@ -268,6 +269,7 @@
     %skinMaxTemp = 1773.15
     %fuelCrossFeed = False
 
+    !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
 
     MODULE
@@ -365,6 +367,7 @@
     %skinMaxTemp = 1773.15
     %fuelCrossFeed = False
 
+    !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
 
     MODULE


### PR DESCRIPTION
These parts had an additional ModuleResourceConverter that wasn't deleted from the config of the SNAP-3 part.