### PR TITLE
Fix Mk1 Pod Kerbal scaling

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -1182,7 +1182,7 @@
 	%scaleAll = 1.6, 1.6, 1.6
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalScale = 1.2, 1.2, 1.2
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}


### PR DESCRIPTION
The actual IVA is scaled correctly, but the pilot was inflated enough to have half a head out of the capsule.

1.2x looks about right relative to the seat; and first-person point of view also seems roughly right for looking at the instrument panel.

before: https://media.discordapp.net/attachments/331813395424739339/630077187936223262/220200_20191005121927_1.png?width=400&height=225

after:
https://media.discordapp.net/attachments/331813395424739339/630166488602640392/220200_20191005181305_1.png?width=400&height=225