### PR TITLE
Correct RealEngines Raptor node position

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_American.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealEngines/RO_RealEngines_American.cfg
@@ -511,9 +511,9 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.638, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -1.35, 0.0, 0.0, -1.0, 0.0, 2
-    @node_attach = 0.0, 0.638, 0.0, 0.0, 1.0, 0.0
+    @node_stack_top = 0.0, 1.6, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -0.59, 0.0, 0.0, -1.0, 0.0, 2
+    @node_attach = 0.0, 1.6, 0.0, 0.0, 1.0, 0.0
 
     @mass = 1.6
     @crashTolerance = 10
@@ -569,9 +569,9 @@
     @scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 0.615, 0.0, 0.0, 1.0, 0.0, 2
-    @node_stack_bottom = 0.0, -3.275, 0.0, 0.0, -1.0, 0.0, 3
-    @node_attach = 0.0, 0.615, 0.0, 0.0, 1.0, 0.0
+    @node_stack_top = 0.0, 1.54, 0.0, 0.0, 1.0, 0.0, 2
+    @node_stack_bottom = 0.0, -2.425, 0.0, 0.0, -1.0, 0.0, 3
+    @node_attach = 0.0, 1.54, 0.0, 0.0, 1.0, 0.0
 
     @mass = 1.76
     @crashTolerance = 10


### PR DESCRIPTION
The Raptor attachement nodes are a bit offset downward, so this should correct it.