### PR TITLE
Add new Methalox plume to RealEngines Raptor

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_Vacuum.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_Vacuum.cfg
@@ -6,23 +6,32 @@
 {
     PLUME
     {
-        name = Hydrolox-Upper
+        name = Methalox_Upper
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 2.4
-        plumeScale = 2.1
-        flarePosition = 0.0, 0.0, 1.35
-        flareScale = 2.1
-        smokePosition = 0.0, 0.0, 0.0
-        smokeScale = 1.0
-        localRotation = 0.0, 0.0, 0.0
+        localRotation = 0,0,0
+        localPosition = 0,0,0.2
+        fixedScale = 0.8
+        energy = 1
+        speed = 1
         emissionMult = 0.5
-        energy = 1.0
-        speed = 1.0
+        alphaMult = 1
+
+        flarePosition = 0,0,0.23
+        flareScale = 0.65
+
+        plumePosition = 0,0,1.2
+        plumeScale = 4
+
+        fumePosition = 0,0,3.5
+        fumeScale = 4.2
+
+        shockPosition = 0,0,3
+        shockScale = 1.06
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Hydrolox-Upper
+        %powerEffectName = Methalox_Upper
         !runningEffectName = DELETE
     }
 
@@ -30,7 +39,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Hydrolox-Upper
+            %powerEffectName = Methalox_Upper
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_engine.cfg
@@ -6,23 +6,32 @@
 {
     PLUME
     {
-        name = Hydrolox-Lower
+        name = Methalox_LowerShock
         transformName = thrustTransform
-        plumePosition = 0.0, 0.0, 0.7
-        plumeScale = 1.2
-        flarePosition = 0.0, 0.0, 0.25
-        flareScale = 1.2
-        smokePosition = 0.0, 0.0, 0.0
-        smokeScale = 1.0
-        localRotation = 0.0, 0.0, 0.0
+        localRotation = 0,0,0
+        localPosition = 0,0,0.2
+        fixedScale = 0.8
+        energy = 1
+        speed = 1
         emissionMult = 0.5
-        energy = 1.0
-        speed = 1.0
+        alphaMult = 1
+
+        flarePosition = 0,0,-0.55
+        flareScale = 0.35
+
+        plumePosition = 0,0,0.3
+        plumeScale = 2.4
+
+        fumePosition = 0,0,0.7
+        fumeScale = 2.6
+
+        blazePosition = 0,0,5
+        blazeScale = 2.4
     }
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Hydrolox-Lower
+        %powerEffectName = Methalox_LowerShock
         !runningEffectName = DELETE
     }
 
@@ -30,7 +39,7 @@
     {
         @CONFIG,*
         {
-            %powerEffectName = Hydrolox-Lower
+            %powerEffectName = Methalox_LowerShock
         }
     }
 }


### PR DESCRIPTION
Plumes were added to RealPlume 13.0.0.

New vacuum variant:
![screenshot81](https://user-images.githubusercontent.com/39596827/67625669-57bbd100-f841-11e9-8deb-bfc1079a905f.png)

New surface level variant:

- at sea level, full throttle 
![screenshot80](https://user-images.githubusercontent.com/39596827/67625690-8df95080-f841-11e9-87b4-dd56c7bfc998.png)

- sea level, minimum throttle
![screenshot79](https://user-images.githubusercontent.com/39596827/67625695-a10c2080-f841-11e9-8c32-f61fa7472226.png)

- Vacuum
![screenshot78](https://user-images.githubusercontent.com/39596827/67625698-b3865a00-f841-11e9-97c4-a887338a93cf.png)


