### PR TITLE
Fix tweakscale FATAL error

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
@@ -379,7 +379,7 @@
 	@mass = 0.07731
 	@MODULE[TweakScale]
 	{
-		type = RealismOverhaulStackSolid
+		@type = RealismOverhaulStackSolid
 	}
 }
 


### PR DESCRIPTION
Part ended up with the same property twice, tweakscale didn't like that
and threw up the giant scary error screen.

(credit to discord's Airhead for spotting it)