### PR TITLE
Make rcs quads visible in ksp 1.7.3

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -409,6 +409,8 @@
 	@title = RCS Quad [275/445 N Class]
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
+        !TechHidden = DELETE
+        @category = Control
 	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS


### PR DESCRIPTION
1.7.3 deprecated the part and introduced a _v2 version.
Might be better to switch RO to the _v2 version, but that's
above my pay grade.

(note that issue doesn't seem to show up with restock installed,
presumably because it replaces the part altogether)