### PR TITLE
Make DRE heatshields available even with ReStock

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -33,7 +33,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	@hsp = 400
 }
 
-@PART[0625_Heatshield]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+@PART[0625_Heatshield]:FOR[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -85,7 +85,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		maxAmount = 20
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -152,7 +152,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		@ejectionForce = 20
 	}
 }
-@PART[1.25_Heatshield]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+@PART[1.25_Heatshield]:FOR[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -204,7 +204,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		maxAmount = 80
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -271,7 +271,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		@ejectionForce = 20
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -338,7 +338,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		@ejectionForce = 20
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -405,7 +405,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		@ejectionForce = 40
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -531,7 +531,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		maxAmount = 705
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{
@@ -594,7 +594,7 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 		maxAmount = 800
 	}
 }
-+PART[1.25_Heatshield]:AFTER[RealismOverhaul]:NEEDS[!ReStock]
++PART[1.25_Heatshield]:AFTER[RealismOverhaul]
 {
 	!MODULE[TweakScale]
 	{


### PR DESCRIPTION
Because sometimes you want to build a .craft you can share
with people who don't have ReStock