### PR TITLE
Make Derwent V compatible with Ven's 2.x

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -6,23 +6,47 @@
 	@name = RO-DerwentV
 	@MODEL
 	{
-		@scale = 0.844, 0.844, 0.844
+		%scale = 0.844, 0.844, 0.844
 	}
-	MODEL:NEEDS[VenStockRevamp]
+
+        // ven's 1.x used these paths...
+	MODEL:NEEDS[VenStockRevamp,!ReStock]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Medium
 		position = 0.0, 0.0, 0.0
 		scale = 0.7,0.9,0.7
 	}
-	MODEL:NEEDS[VenStockRevamp]
+	MODEL:NEEDS[VenStockRevamp,!ReStock]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Small
 		position = 0.0, 0.7, 0.0
 		scale = 1.3,0.3,1.3
 	}
-	MODEL:NEEDS[VenStockRevamp]
+	MODEL:NEEDS[VenStockRevamp,!ReStock]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Small
+		position = 0.0, 0.7, 0.0
+		rotation = 180, 0, 0
+		scale = 1.3,0.03,1.3
+	}
+
+        // ven's 2.x uses these paths. 2.x is needed for restock compatibility;
+        // let's assume it's ONLY used alongside restock
+	MODEL:NEEDS[VenStockRevamp,ReStock]
+	{
+		model = VenStockRevamp/Assets/Engine/EngineCore-Medium
+		position = 0.0, 0.0, 0.0
+		scale = 0.7,0.9,0.7
+	}
+	MODEL:NEEDS[VenStockRevamp,ReStock]
+	{
+		model = VenStockRevamp/Assets/Engine/EngineCore-Small
+		position = 0.0, 0.7, 0.0
+		scale = 1.3,0.3,1.3
+	}
+	MODEL:NEEDS[VenStockRevamp,ReStock]
+	{
+		model = VenStockRevamp/Assets/Engine/EngineCore-Small
 		position = 0.0, 0.7, 0.0
 		rotation = 180, 0, 0
 		scale = 1.3,0.03,1.3
@@ -164,3 +188,4 @@
 		}
 	}
 }
+


### PR DESCRIPTION
The models still exist, but changed location vs ven's 1.x
(not the best solution, but can't think of an objectively better one)

Also: fix the scaling of the tail model to actually apply.
