### PR TITLE
Make rcs quads visible with restock too

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -409,8 +409,6 @@
 	@title = RCS Quad [275/445 N Class]
 	@manufacturer = Generic
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
-        !TechHidden = DELETE
-        @category = Control
 	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
@@ -427,6 +425,12 @@
 			@key,1 = 1 82.08
 		}
 	}
+}
+
+@PART[RCSBlock]:FOR[RealismOverhaul]
+{
+	!TechHidden = DELETE
+        @category = Control
 }
 
 +PART[RCSBlock]:AFTER[RealismOverhaul] // Good for ReStock


### PR DESCRIPTION
Players using restock (Pap) hadn't mentioned an issue, so I'd
assumed only non-restock installs were affected.
Bad assumption.
