### PR TITLE
More consistent maxTemps for early probe cores

### DIFF
--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -22,8 +22,8 @@
 	%RSSROConfig = true
 
 	@mass = 0.01
-	@maxTemp = 473.15
-	%skinMaxTemp = 473.15
+	@maxTemp = 773.15
+	%skinMaxTemp = 773.15
 	@crashTolerance = 8
 	%fuelCrossFeed = False
 	%CoMOffset = 0.0, -0.1125, 0.0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -15,8 +15,8 @@
 	@description = The first satellite to orbit the Earth.
 	@node_stack_bottom = 0.0, -0.515425, 0.0, 0.0, -1.0, 0.0, 0
 	@mass = 0.081
-	@maxTemp = 773.15
-	@skinMaxTemp = 873.15
+	%maxTemp = 773.15
+	%skinMaxTemp = 773.15
 
 	@RESOURCE[ElectricCharge]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -2092,6 +2092,8 @@
 	!MODULE[TweakScale] {}
 	%rescaleFactor = 0.624
 	@mass = 0.081
+	%skinMaxTemp = 773.15
+	%maxTemp = 773.15
 
 	@title = Sputnik PS-1
 	@manufacturer = NPO Energomash


### PR DESCRIPTION
(per #rp1-feedback discussion)

Make the SXT and stock sputniks match, at 773-773.
(stock set nothing and inherited 1073; sxt tried to set skinMax=873
but failed due to using @ on a nonexistent property)

And make the 20in match them too (up from 473)

The choice of 773-773 isn't based on any historical source.