### PR TITLE
Proper derwent model for restock+ven's1.13

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -10,19 +10,19 @@
 	}
 
         // ven's 1.x used these paths...
-	MODEL:NEEDS[VenStockRevamp,!ReStock]
+	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Medium
 		position = 0.0, 0.0, 0.0
 		scale = 0.7,0.9,0.7
 	}
-	MODEL:NEEDS[VenStockRevamp,!ReStock]
+	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Small
 		position = 0.0, 0.7, 0.0
 		scale = 1.3,0.3,1.3
 	}
-	MODEL:NEEDS[VenStockRevamp,!ReStock]
+	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Small
 		position = 0.0, 0.7, 0.0
@@ -30,21 +30,22 @@
 		scale = 1.3,0.03,1.3
 	}
 
-        // ven's 2.x uses these paths. 2.x is needed for restock compatibility;
-        // let's assume it's ONLY used alongside restock
-	MODEL:NEEDS[VenStockRevamp,ReStock]
+        // phineas' ven's 2.x uses these paths. 2.x is needed for restock
+	// compatibility in ksp 1.6. We add models for both paths;
+	// the bad path will just get ignored
+	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Assets/Engine/EngineCore-Medium
 		position = 0.0, 0.0, 0.0
 		scale = 0.7,0.9,0.7
 	}
-	MODEL:NEEDS[VenStockRevamp,ReStock]
+	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Assets/Engine/EngineCore-Small
 		position = 0.0, 0.7, 0.0
 		scale = 1.3,0.3,1.3
 	}
-	MODEL:NEEDS[VenStockRevamp,ReStock]
+	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Assets/Engine/EngineCore-Small
 		position = 0.0, 0.7, 0.0


### PR DESCRIPTION
Previous fix was fine for ven's 1.9.6 by itself (using the old
paths), and for restock+ven's2 (using ven's2's changed paths),
ven's2 being the recommended way to get around restock/ven's
incompatibility in ksp1.6.

Turns out there's now a ven's 1.13 for ksp 1.7, and it uses the
same old paths. It's still not restock-compatible, but the "best"
way to fix it is to delete 2 folders rather than grabbing ven's2.

So the "ven's and restock both installed means it must be ven's2"
assumption isn't valid. Plan B: configure models using both old
and new paths, rely on the bad paths getting ignored.