### PR TITLE
Fix KerbCan IVA scaling

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -875,10 +875,10 @@
 
 @INTERNAL[landerCabinSmallInternal|landerCabinSmallInternalRPM]:BEFORE[RealismOverhaul]
 {
-	%scaleAll = 1.6, 1.6, 1.6
+	%scaleAll = 1, 1, 1
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalScale = 1, 1, 1
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}


### PR DESCRIPTION
Yet another case of comically oversized IVA. At this point I'm guessing
KSP just changed the way IVAs were scaled and values that used to
be fine suddenly weren't.

Only tested with the RPM variant on the 1-crew KerbCan; hopefully
the change is valid for all permutations. If not, something more
sophisticated will be needed