### PR TITLE
Un-hide deprecated NearFutureSolar parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Solar.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Solar.cfg
@@ -228,3 +228,11 @@
 		@chargeRate = 0.21 // now is comparable to the other panels
     }	
 }
+
+// Temporary: RO-configured parts got deprecated in favor of new, not-yet-RO-configured parts.
+// unhide the deprecated parts until someone configures the new ones.
+@PART[solarpanel-*]:HAS[#author[ChrisAdderley]]:FOR[RealismOverhaul]
+{
+    !TechHidden = delete
+    %category = Electrical
+}


### PR DESCRIPTION
because their replacements aren't RO-configured yet