### PR TITLE
Tweak RO-Mk1 cockpit IVAs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -317,12 +317,23 @@
 	}
 }
 
-@INTERNAL[mk2CockpitStandardInternals|mk2CockpitStandardInternalsRPM|MK2_CrewCab_Int]:FOR[RealismOverhaul]
+@INTERNAL[MK2_CrewCab_Int]:FOR[RealismOverhaul]
 {
 	%scaleAll = 1.722222, 1.722222, 1.722222
 	@MODULE[InternalSeat],*
 	{
 		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[mk2CockpitStandardInternals|mk2CockpitStandardInternalsRPM]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.25, 1.25, 1.25
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
@@ -2009,6 +2020,7 @@
 	@INTERNAL
 	{
 		@name = mk2CockpitStandardInternals
+		%offset = 0.0, -0.2, -0.9
 	}
 	!MODULE[TweakScale]
 	{
@@ -2149,7 +2161,7 @@
 	@INTERNAL
 	{
 		@name = mk2CockpitStandardInternals
-		%offset = 0.0, 0.5, 0.0
+		%offset = 0.0, 0.0, -0.2
 	}
 	!MODULE[TweakScale]
 	{


### PR DESCRIPTION
- offset IVA model to better line up with the part in overlay mode
  (best-effort, given the IVA is for a different-shape part)
- make kerbals fit in their seats instead of sticking their head out
