### PR TITLE
Add ORM-65

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -1,0 +1,141 @@
+/  ==================================================
+//  NPO Energomash ORM-65 engine series global engine configuration.
+
+//	GLOBAL SETTINGS
+//	Gimbal: N/A
+//	Propellant: AK20 and Kerosene
+//  O/F Ratio: Unknown
+//	Chamber Pressure: 367 psi
+
+//	ORM-65 (1936)
+//	Thrust (sl): 1.750 kN
+//	ISP: 215 s
+//	Throttle: 100% to 28%
+//	Burn Time: 80 s
+
+//	RDA-1-150 (1939)
+//	Thrust (sl): 1.431 kN
+//	ISP: 215 s
+//	Throttle: 100% to 34%
+//	Burn Time: 200 s
+
+
+//  Sources:
+
+//	russianspaceweb.com - Cruise missile is born in the midst of "Great terror":			http://www.russianspaceweb.com/212.html
+//	mentallandscape.com - The R-7 Missile:													http://mentallandscape.com/S_R7.htm
+//	Google Books - History of Liquid Propellant Rocket Engines:								https://books.google.com/books?id=s1C9Oo2I4VYC&pg=PA553&lpg=PA553&dq=ORM65&source=bl&ots=eP7bS4fpKW&sig=ACfU3U0TyKrTXW5kLFPosGw--5ipVSnsVg&hl=en&sa=X&ved=2ahUKEwjr26zI7r3mAhXQdN8KHQcoC5AQ6AEwEXoECAkQAQ#v=onepage&q=ORM65&f=false
+//	ram-home.com - RP-318-1 (РП-318-1) by S.P.Korolev and A.V.Pallo:						http://ram-home.com/ram-old/rp-318-1.html
+
+//  Used by:
+
+// *ROEngines
+
+//  Notes:
+
+//  * 
+//  ==================================================
+@PART[*]:HAS[#engineType[ORM65]]:FOR[RealismOverhaulEngines]
+{
+	@title = ORM-65
+	%manufacturer = NPO Energomash
+	@description = Very early Soviet rocket engine, designed in the late 1930s for use on cruise missiles and other rocket powered aircraft. It was the first reliable, regenerativley cooled rocket
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = ORM65
+		origMass = 0.0143
+		CONFIG
+		{
+			name = ORM-65
+			minThrust = 0.510
+			maxThrust = 1.785
+			massMult = 1.0
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.373
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = AK20
+				ratio = 0.373
+			}
+			atmosphereCurve
+			{
+				key = 0 215
+				key = 1 210
+			}
+			
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 1
+		}
+		CONFIG
+		{
+			name = RDA-1-150
+			minThrust = 0.499
+			maxThrust = 1.460
+			massMult = 0.86
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.373
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = AK20
+				ratio = 0.373
+			}
+			atmosphereCurve
+			{
+				key = 0 215
+				key = 1 210
+			}
+			
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 2
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+	}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[ORM-65]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//reliability largley copied from aerobee, too few tests of ORM-65 to get accurate reliability info
+		name = ORM-65
+		ratedBurnTime = 80
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.96
+		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
+		cycleReliabilityStart = 0.7
+		cycleReliabilityEnd = 0.9
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RDA-1-150]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//was man rated and flew several times in rocket glider without major incident
+		name = RDA-1-150
+		ratedBurnTime = 200
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.98
+		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.99
+		techTransfer = ORM-65:50
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -4,7 +4,7 @@
 //	GLOBAL SETTINGS
 //	Gimbal: N/A
 //	Propellant: AK20 and Kerosene
-//  O/F Ratio: Unknown
+//  O/F Ratio: 4.0 (60 kg Nitric acid and 15 kg Kerosene fuel load in RP-318. 2.12 by volume)
 //	Chamber Pressure: 367 psi
 
 //	ORM-65 (1936)
@@ -39,14 +39,14 @@
 {
 	@title = ORM-65
 	%manufacturer = NPO Energomash
-	@description = Very early Soviet rocket engine, designed in the late 1930s for use on cruise missiles and other rocket powered aircraft. It was the first reliable, regenerativley cooled rocket
+	@description = Very early Soviet rocket engine, designed by Glushko in 1936 for use on the KR-212 cruise missile, and modified for the rocket aircraft RP-318. It was the first reliable, regenerativley cooled rocket.
 
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		configuration = ORM65
+		configuration = ORM-65
 		origMass = 0.0143
 		CONFIG
 		{
@@ -58,13 +58,13 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.373
+				ratio = 0.3205
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = AK20
-				ratio = 0.373
+				ratio = 0.6795
 			}
 			atmosphereCurve
 			{
@@ -86,13 +86,13 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.373
+				ratio = 0.3205
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = AK20
-				ratio = 0.373
+				ratio = 0.6795
 			}
 			atmosphereCurve
 			{


### PR DESCRIPTION
Add the ORM-65. The ORM-65 was a very early Soviet rocket engine, designed by Glushko in 1936 for use on the KR-212 cruise missile, and modified for the rocket aircraft RP-318. It provides a Soviet alternative to the Aerobee, and also provides a throttling and restarting engine in the starting parts.

RP-1 PR: https://github.com/KSP-RO/RP-0/pull/1172
ROEngines PR (with model from Basila): https://github.com/KSP-RO/ROEngines/pull/36