### PR TITLE
Add RA modules to RN US probes and RN soviet probes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Molniya_Luna9_Luna10.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Molniya_Luna9_Luna10.cfg
@@ -188,6 +188,22 @@
 		}
 	}
 }
+@PART[molniya1]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.2 //main antenna
+		RFBand = S
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//TV antennas
+		RFBand = UHF		//Default to UHF-band
+	}
+}
 
 @PART[luna_dec]:FOR[RealismOverhaul]
 {
@@ -364,6 +380,16 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[luna_radio|l11_radio]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0		//Guess based on size and construction
+		RFBand = VHF		//Default to VHF-band
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
@@ -183,6 +183,22 @@
 		}
 	}
 }
+@PART[neo_dawn]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.5	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[neo_deepimpact]:FOR[RealismOverhaul]
 {
@@ -303,6 +319,22 @@
 			PacketSize = 0.01
 			PacketResourceCost = 0.02
 		}
+	}
+}
+@PART[neo_deepimpact]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.2	//high gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -580,6 +612,22 @@
 		}
 	}
 }
+@PART[neo_ds1]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.0	//High gain antenna
+		RFBand = Ka	//Default to Ka-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[rn_messenger]:FOR[RealismOverhaul]
 {
@@ -746,6 +794,24 @@
 			PacketSize = 0.01
 			PacketResourceCost = 0.02
 		}
+	}
+}
+@PART[rn_messenger]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 29.0	//High gain phased array
+		referenceFrequency = 8450
+		RFBand = S	//Default to S-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 10.0		//Low gain phased array
+		referenceFrequency = 2295
+		RFBand = X		//Default to X-band
 	}
 }
 
@@ -930,6 +996,22 @@
 		}
 	}
 }
+@PART[neo_near]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.5	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[neo_ulysses]:FOR[RealismOverhaul]
 {
@@ -1050,6 +1132,22 @@
 			PacketSize = 0.01
 			PacketResourceCost = 0.02
 		}
+	}
+}
+@PART[neo_ulysses]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.65	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -1260,6 +1358,22 @@
 			PacketSize = 0.01
 			PacketResourceCost = 0.02
 		}
+	}
+}
+@PART[neo_stardust]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.6	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -1502,5 +1616,21 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[rn_lro]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.8	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0		//Low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
@@ -195,7 +195,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 4.5		//Low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }
@@ -333,7 +333,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//low gain antenna
+		referenceGain = 4.5		//low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }
@@ -624,7 +624,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 4.5		//Low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }
@@ -1008,7 +1008,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 4.5		//Low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }
@@ -1146,7 +1146,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 4.5		//Low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }
@@ -1372,7 +1372,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 4.5		//Low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_NEO.cfg
@@ -804,14 +804,14 @@
 		name = ModuleRealAntenna
 		referenceGain = 29.0	//High gain phased array
 		referenceFrequency = 8450
-		RFBand = S	//Default to S-band
+		RFBand = X	//Default to X-band
 	}
 	MODULE
 	{
 		name = ModuleRealAntenna
 		referenceGain = 10.0		//Low gain phased array
 		referenceFrequency = 2295
-		RFBand = X		//Default to X-band
+		RFBand = S		//Default to S-band
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_SovietProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_SovietProbes.cfg
@@ -65,6 +65,16 @@
 		}
 	}
 }
+@PART[aputnik1]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 2.14		//Theoretical max for antenna system
+		RFBand = VHF		//Default to VHF-band
+	}
+}
 //======================= Sputnik 1 Fairing  ===========================
 @PART[rn_sputnik1_base]:FOR[RealismOverhaul]
 {
@@ -228,6 +238,16 @@
 		}
 	}
 }
+@PART[sputnik2]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on size and construction
+		RFBand = VHF		//Default to VHF-band
+	}
+}
 // ==================== Sputnik 2 Nose Cone =====================
 @PART[rn_sputnik2_nosecone]:FOR[RealismOverhaul]
 {
@@ -316,6 +336,16 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[sputnik3]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on size and construction
+		RFBand = VHF		//Default to VHF-band
 	}
 }
 
@@ -461,6 +491,16 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[luna2|luna3]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0		//Guess based on size and construction
+		RFBand = VHF		//Default to VHF-band
 	}
 }
 
@@ -881,6 +921,16 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[rn_protonn6_4|rn_protonn4_1]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on size and construction
+		RFBand = VHF		//Default to VHF-band
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
@@ -103,6 +103,16 @@ MODULE
 		}
 	}
 }
+@PART[rn_surveyor3]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0	 //Low gain antenna
+		RFBand = S	//Default to S-band
+	}
+}
 
 @PART[rn_surveyor_solar]:FOR[RealismOverhaul]
 {
@@ -155,12 +165,6 @@ MODULE
 		name = ModuleRealAntenna
 		antennaDiameter = 1.0	//High gain antenna
 		RFBand = S	//Default to S-band
-	}
-	MODULE
-	{
-		name = ModuleRealAntenna
-		referenceGain = 3.0		//low gain antenna
-		RFBand = S		//Default to S-band
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Surveyor.cfg
@@ -147,6 +147,22 @@ MODULE
 		}
 	}
 }
+@PART[rn_surveyor_solar]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.0	//High gain antenna
+		RFBand = S	//Default to S-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		//low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[rn_surveyor_engines]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
@@ -124,6 +124,23 @@
 		}
 	}
 }
+@PART[rn_voyager]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 3.66	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 7.0		//Low gain antenna
+		referenceFrequency = 2295
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[rn_vpam]:FOR[RealismOverhaul]
 {
@@ -435,6 +452,22 @@
 		}
 	}
 }
+@PART[rn_new_horizons]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 2.1	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[rn_mariner1_2]:FOR[RealismOverhaul]
 {
@@ -618,6 +651,23 @@
 		}
 	}
 }
+@PART[rn_mariner1_2]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.3
+		RFBand = S	//Default to S-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		
+		RFBand = S		//Default to S-band
+	}
+}
+
 
 @PART[rn_juno_spacecraft]:FOR[RealismOverhaul]
 {
@@ -794,6 +844,23 @@
 			PacketSize = 0.01
 			PacketResourceCost = 0.02
 		}
+	}
+}
+@PART[rn_juno_spacecraft]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 2.5	//High gain antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 8.0		//Low gain antenna
+		referenceFrequency = 2295
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -975,6 +1042,23 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[rn_ladee]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 10.6		//Medium gain antenna
+		referenceFrequency = 2295
+		RFBand = S	//Default to S-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.6		//Low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USProbes.cfg
@@ -464,7 +464,8 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 9.0		//Low gain antenna
+		referenceFrequency = 2295
 		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
@@ -206,6 +206,22 @@
 		}
 	}
 }
+@PART[rn_cassini]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 4.0	//4 meter antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[rn_huygen_hs_chute]:FOR[RealismOverhaul]
 {
@@ -540,5 +556,15 @@
 			PacketSize = 0.03
 			PacketResourceCost = 0.1
 		}
+	}
+}
+@PART[rn_huygens]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0		//Low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
@@ -218,7 +218,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//Low gain antenna
+		referenceGain = 4.5		//Low gain antenna
 		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
@@ -709,7 +709,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 5.0		//S-band antenna array
+		referenceGain = 4.5		//S-band antenna array
 		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
@@ -102,6 +102,22 @@
 		}
 	}
 }
+@PART[eos_aqua]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.5	//0.5 meter antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 2.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[eos_aura]:FOR[RealismOverhaul]
 {
@@ -207,6 +223,22 @@
 		}
 	}
 }
+@PART[eos_aura]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.5	//0.5 meter antenna
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 2.0		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[eos_terra]:FOR[RealismOverhaul]
 {
@@ -310,6 +342,22 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[eos_terra]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.0	//1.0 meter antenna
+		RFBand = Ka	//Default to Ka-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 2.0		//Low gain antenna
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -641,5 +689,27 @@
 			PacketSize = 8.0
 			PacketResourceCost = 2.0
 		}
+	}
+}
+@PART[eos_tdrs|rn_tdrs_ag]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 4.96	//16.3 foot Ka-band antenna
+		RFBand = Ka	//Default to Ka-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 2	// Ka-band downlink
+		RFBand = Ka	//Default to Ka-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 5.0		//S-band antenna array
+		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Explorer6.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Explorer6.cfg
@@ -66,7 +66,7 @@
 		}
 	}
 }
-@PART[pioneer_5]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+@PART[explorer_6]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
 {
 	@MODULE[ModuleDataTransmitter]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Explorer6.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Explorer6.cfg
@@ -66,3 +66,12 @@
 		}
 	}
 }
+@PART[pioneer_5]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
@@ -176,6 +176,22 @@
 		}
 	}
 }
+@PART[galileo_mb]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.5	//Probe relay antenna
+		RFBand = S	//Default to S-band (L-band not in RA)
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0		//Low-gain S-band antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[galileo_aprobe]:FOR[RealismOverhaul]
 {
@@ -259,6 +275,16 @@
 			PacketSize = 0.03
 			PacketResourceCost = 0.1
 		}
+	}
+}
+@PART[galileo_aprobe]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -601,6 +627,16 @@
 		}
 	}
 }
+@PART[gdish_intended]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 4.8	//Dish was 4.8 meters fully unfolded
+		RFBand = X	//Default to X-band
+	}
+}
 
 @PART[gdish_actual]:NEEDS[RemoteTech]
 {
@@ -626,5 +662,15 @@
 			PacketSize = 0.69
 			PacketResourceCost = 0.5
 		}
+	}
+}
+@PART[gdish_actual]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.25	//Simulate partial antenna deployment
+		RFBand = X	//Default to X-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Magellan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Magellan.cfg
@@ -165,6 +165,22 @@
 		}
 	}
 }
+@PART[magellan]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 3.7	//3.7 meter high gain from voyager program
+		RFBand = X	//Default to X-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.8		//Low gain antenna
+		RFBand = S		//Default to S-band
+	}
+}
 
 @PART[rn_magellan_scanner]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
@@ -626,7 +626,7 @@
 	MODULE
 	{
 		name = ModuleRealAntenna
-		referenceGain = 3.0		//Based on size and construction
+		referenceGain = 4.0		//Based on size and construction
 		RFBand = S		//Default to S-band
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Pioneer.cfg
@@ -127,6 +127,15 @@
 		}
 	}
 }
+@PART[pioneer_0_1_2]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 2.0		//Guess based on antenna size and construction
+		RFBand = VHF
+	}
+}
 
 @PART[p1_decoupler]:FOR[RealismOverhaul]
 {
@@ -284,6 +293,15 @@
 		}
 	}
 }
+@PART[pioneer_3_4]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
+	}
+}
 
 @PART[pioneer_5]:FOR[RealismOverhaul]
 {
@@ -347,6 +365,15 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[pioneer_5]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
 	}
 }
 
@@ -448,6 +475,22 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[pioneer_6_7_8_9]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 0.85	//Probe was 0.94 meters in diameter, internal high gain assumed to use most of this space
+		RFBand = S	//Default to S-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 4.0		//Large low gain booms could recieve signals even at maximum range
+		RFBand = S		//Default to S-band
 	}
 }
 
@@ -571,6 +614,23 @@
 		}
 	}
 }
+@PART[pioneer_10_11]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 2.7	//High gain antenna was 2.7 meters
+		RFBand = S	//Default to S-band
+	}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		//Based on size and construction
+		RFBand = S		//Default to S-band
+	}
+}
+
 
 @PART[p10_core]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Vanguard.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Vanguard.cfg
@@ -109,6 +109,15 @@
 		}
 	}
 }
+@PART[vanguard-2]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
+	}
+}
 
 @PART[vanguard-3]:FOR[RealismOverhaul]
 {
@@ -157,6 +166,15 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[vanguard-3]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
 	}
 }
 
@@ -213,6 +231,15 @@
 		}
 	}
 }
+@PART[grab-1]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
+	}
+}
 
 @PART[transit2a]:FOR[RealismOverhaul]
 {
@@ -265,6 +292,15 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[transit2a]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
 	}
 }
 
@@ -323,5 +359,14 @@
 			PacketSize = 0.4
 			PacketResourceCost = 0
 		}
+	}
+}
+@PART[tiros-1]:BEFORE[RealAntennas]:NEEDS[RealAntennas]
+{
+	@MODULE[ModuleDataTransmitter]
+	{
+		@name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on antenna size and construction
+		RFBand = UHF
 	}
 }


### PR DESCRIPTION
High gain antennas are accurate according to available documentation. Some low gain and medium gain antennas are not as accurate due to lack of documentation, or any mention at all in soviet case. In this case, they are set to a guessed value based on size and construction to give player control until at least edge of earth SOI.