### PR TITLE
Fix .netkan for Smokescreen fixes using new fork

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -17,7 +17,7 @@
         { "name" : "RealFuels" },
         { "name" : "RealHeat" },
         { "name" : "RealPlume" },
-        { "name" : "SmokeScreen" }
+        { "name" : "SmokeScreen-RO" }
     ],
     "recommends" : [
         { "name" : "B9-PWings-Fork" },
@@ -83,6 +83,7 @@
     "conflicts" :   [
         { "name" : "TweakableEverything" },
         { "name" : "RealPlumeConfigs" },
+        { "name" : "Smokescreen" },
 	{ "name" : "KerbalJointReinforcementNext" },
         { "name" : "TestFlightConfig" }
     ],


### PR DESCRIPTION
Change dependency to Sarbian's freshly created RO-branch for Smokescreen.

Needs monitoring if he removes it once we're also on 1.8. 

It fixes the root part bug for plumes. 