### PR TITLE
Un-hide microEngine-derived engines (1kn, etc)

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -841,6 +841,13 @@
 	}
 }
 
+@PART[microEngine]:BEFORE[RealismOverhaul] // do this before all the +PART[microEngine] to affect all the clones
+{
+	// part was deprecated in ksp 1.7.3; un-hide it.
+	// TODO: consider using the _v2 version
+	!TechHidden = delete
+}
+
 //  ==================================================
 //  TD-339 (vernier engine).
 //  ==================================================


### PR DESCRIPTION
Another case of part deprecated in 1.7.3; just remove the TechHidden=true

Didn't need to deal with category=none; presumably RO itself
is setting category=Engine somewhere

(these are the last techhidden=true parts in my MM cache that are RP-0 configured, so likely the last ones I'll be fixing)