### PR TITLE
Adjustments for stock landing gear mass and safe load for KSPWheel

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
@@ -7,6 +7,7 @@
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelBogey]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -16,7 +17,8 @@
 		wheelRadius = 0.3
 		wheelMass = 0.2
 		suspensionTravel = 0.25
-		maxLoadRating = 20
+		// Three of these should carry A340
+		maxLoadRating = 130
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
@@ -43,7 +43,7 @@
 	MODULE
 	{
 		name = KSPWheelBrakes
-		maxBrakeTorque = 12
+		maxBrakeTorque = 18
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
@@ -18,7 +18,7 @@
 		wheelMass = 0.15
 		suspensionTravel = 0.2
 		// Two such struts should be able to carry A321
-		maxLoadRating = 50
+		maxLoadRating = 40
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
@@ -18,7 +18,7 @@
 		wheelMass = 0.15
 		suspensionTravel = 0.2
 		// Two such struts should be able to carry A321
-		maxLoadRating = 40
+		maxLoadRating = 50
 		maxSpeed = 300
 	}
 	MODULE
@@ -44,7 +44,7 @@
 	MODULE
 	{
 		name = KSPWheelBrakes
-		maxBrakeTorque = 12
+		maxBrakeTorque = 16
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
@@ -7,6 +7,7 @@
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -16,7 +17,8 @@
 		wheelRadius = 0.2375
 		wheelMass = 0.15
 		suspensionTravel = 0.2
-		maxLoadRating = 10
+		// Two such struts should be able to carry A321
+		maxLoadRating = 40
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
@@ -18,7 +18,7 @@
 		wheelMass = 0.1
 		suspensionTravel = 0.12
 		// Should correspond to ATR72 / Dash 8 weight
-		maxLoadRating = 20
+		maxLoadRating = 15
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
@@ -7,6 +7,7 @@
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -16,7 +17,8 @@
 		wheelRadius = 0.18
 		wheelMass = 0.1
 		suspensionTravel = 0.12
-		maxLoadRating = 8
+		// Should correspond to ATR72 / Dash 8 weight
+		maxLoadRating = 15
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
@@ -18,7 +18,7 @@
 		wheelMass = 0.1
 		suspensionTravel = 0.12
 		// Should correspond to ATR72 / Dash 8 weight
-		maxLoadRating = 15
+		maxLoadRating = 20
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
@@ -7,6 +7,7 @@
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelBogey]{}
 	-MODULE[ModuleWheelDamage]{}
+	-MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -16,7 +17,9 @@
 		wheelRadius = 0.3
 		wheelMass = 0.3
 		suspensionTravel = 0.527
-		maxLoadRating = 20
+		// Assume, four of this gears should carry fully loaded A380
+		// or just two of them - B777
+		maxLoadRating = 180
 		maxSpeed = 300
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
@@ -50,7 +50,7 @@
 	MODULE
 	{
 		name = KSPWheelBrakes
-		maxBrakeTorque = 12
+		maxBrakeTorque = 24
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedMicro.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedMicro.cfg
@@ -5,6 +5,7 @@
 	-MODULE[ModuleWheelSuspension]{}
 	-MODULE[ModuleWheelSteering]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedSmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedSmall.cfg
@@ -5,6 +5,7 @@
 	-MODULE[ModuleWheelSuspension]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-leg-medium.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-leg-medium.cfg
@@ -9,6 +9,7 @@
 	-MODULE[ModuleWheelLock]{}
 	-MODULE[ModuleWheelBogey]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-leg-small.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-leg-small.cfg
@@ -6,6 +6,7 @@
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelLock]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-large.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-large.cfg
@@ -7,6 +7,7 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 		
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-medium.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-medium.cfg
@@ -9,6 +9,8 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
+
 	MODULE
 	{
 		name = KSPWheelBase

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
@@ -7,6 +7,8 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
+
 	MODULE
 	{
 		name = KSPWheelBase

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-xlarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-xlarge.cfg
@@ -6,6 +6,7 @@
 	-MODULE[ModuleWheelMotorSteering]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
 	
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -130,7 +130,7 @@
 {
     %RSSROConfig = True
     @maxTemp = 1000
-    @mass = 0.04
+    @mass = 0.1
     %skinMaxTemp = 1500
 
     @MODULE[ModuleLight]
@@ -166,7 +166,8 @@
 @PART[GearSmall]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @mass = 0.16
+    // Based on extrapolation of weight of B747 landing gear
+    @mass = 0.46
     @maxTemp = 1500
     %skinMaxTemp = 2500
 
@@ -183,7 +184,8 @@
 @PART[GearMedium]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @mass = 0.48
+    // Based on extrapolation of weight of B747 landing gear
+    @mass = 1.5
     @maxTemp = 1500
     %skinMaxTemp = 2500
 
@@ -200,7 +202,11 @@
 @PART[GearLarge]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @mass = 0.9
+    // B747 body/wing landing gear weighs 2.9 t. Setting it to a bit lower
+    // value despite extra wheels, as for B747 replica the gear like this will probably be upscaled
+    // One fully assembled B747 wheel weighs 180 kg, so 1080 kg for wheels
+    // only
+    @mass = 2.0
     @maxTemp = 1800
     %skinMaxTemp = 2500
 


### PR DESCRIPTION
So I looked up landing gear mass and max load for different real world airliners and guesstimated what should stock landing gear be like. Probably not the ultimate truth, but still something sensible.
This patch also removes Tweakscale from landing gear if KSPWheel is installed.