### PR TITLE
Delete pre-existing ModuleCommand on part rn_lk_lander

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
@@ -40,6 +40,7 @@
 	{
 	}
 	
+    !MODULE[ModuleCommand] {}
 	MODULE
 	{
 		name = ModuleCommand


### PR DESCRIPTION
ModuleCommand was already defined in the original part.  This patch deletes the existing module before re-adding.