### PR TITLE
RealPlume Template System

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Cryogenic_UpperBlue_CE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Cryogenic_UpperBlue_CE.cfg
@@ -1,44 +1,44 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Cryogenic_UpperBlue_CE
-		transformName = #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/transformName$
-		emissionMult = 1
+    PLUME
+    {
+        name = Cryogenic_UpperBlue_CE
+        transformName = #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/transformName$
+        emissionMult = 1
         energy = 2.5
         speed = 1
-		alphaMult = 1
+        alphaMult = 1
 
-		plumePosition = 0,0,0.34
-		plumeScale = 0.4
-		plume2Scale = 1
-	
-		corePosition = 0,0,0.34
-		coreScale = 0.845
-		
-		@plumeScale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
-		@plume2Scale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
-		@coreScale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
-		
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
-		@corePosition[2] *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
-		
-		@plumePosition[2] += #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/offset$
-		@corePosition[2] += #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/offset$
-	}
+        plumePosition = 0,0,0.34
+        plumeScale = 0.4
+        plume2Scale = 1
+    
+        corePosition = 0,0,0.34
+        coreScale = 0.845
+        
+        @plumeScale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+        @plume2Scale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+        @coreScale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+        
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+        @corePosition[2] *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+        
+        @plumePosition[2] += #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/offset$
+        @corePosition[2] += #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Cryogenic_UpperBlue_CE
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Cryogenic_UpperBlue_CE
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Cryogenic_UpperBlue_CE
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Cryogenic_UpperBlue_CE
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Cryogenic_UpperBlue_CE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Cryogenic_UpperBlue_CE.cfg
@@ -1,0 +1,44 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Cryogenic_UpperBlue_CE
+		transformName = #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/transformName$
+		emissionMult = 1
+        energy = 2.5
+        speed = 1
+		alphaMult = 1
+
+		plumePosition = 0,0,0.34
+		plumeScale = 0.4
+		plume2Scale = 1
+	
+		corePosition = 0,0,0.34
+		coreScale = 0.845
+		
+		@plumeScale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+		@plume2Scale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+		@coreScale *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+		
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+		@corePosition[2] *= #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/scale$
+		
+		@plumePosition[2] += #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/offset$
+		@corePosition[2] += #$/PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]/offset$
+	}
+}
+@PART[*]:HAS[@PLUME_TEMPLATE[Cryogenic_UpperBlue_CE]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Cryogenic_UpperBlue_CE
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Cryogenic_UpperBlue_CE
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox-Upper.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox-Upper.cfg
@@ -1,0 +1,44 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox-Upper]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hydrolox-Upper
+		transformName = #$/PLUME_TEMPLATE[Hydrolox-Upper]/transformName$
+		
+		saturationMult = 0.7
+		alphaMult = 0.7
+		
+		localRotation = 0,0,0
+        localPosition = 0,0,0
+        speed = 1.2
+
+        flarePosition = 0,0,0.775
+		flareScale = 1.55
+
+        plumePosition = 0,0,1.55
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+		@plumeScale *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+		
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+		
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Hydrolox-Upper]/offset$
+		@plumePosition[2] += #$/PLUME_TEMPLATE[Hydrolox-Upper]/offset$
+	}
+}
+@PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox-Upper]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox-Upper
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hydrolox-Upper
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox-Upper.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox-Upper.cfg
@@ -1,44 +1,44 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox-Upper]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hydrolox-Upper
-		transformName = #$/PLUME_TEMPLATE[Hydrolox-Upper]/transformName$
-		
-		saturationMult = 0.7
-		alphaMult = 0.7
-		
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hydrolox-Upper
+        transformName = #$/PLUME_TEMPLATE[Hydrolox-Upper]/transformName$
+        
+        saturationMult = 0.7
+        alphaMult = 0.7
+        
+        localRotation = 0,0,0
         localPosition = 0,0,0
         speed = 1.2
 
         flarePosition = 0,0,0.775
-		flareScale = 1.55
+        flareScale = 1.55
 
         plumePosition = 0,0,1.55
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
-		@plumeScale *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
-		
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
-		
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Hydrolox-Upper]/offset$
-		@plumePosition[2] += #$/PLUME_TEMPLATE[Hydrolox-Upper]/offset$
-	}
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+        @plumeScale *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+        
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox-Upper]/scale$
+        
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Hydrolox-Upper]/offset$
+        @plumePosition[2] += #$/PLUME_TEMPLATE[Hydrolox-Upper]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox-Upper]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hydrolox-Upper
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hydrolox-Upper
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hydrolox-Upper
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox_UpperBlue.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox_UpperBlue.cfg
@@ -1,0 +1,56 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox_UpperBlue]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hydrolox_UpperBlue
+		transformName = #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/transformName$
+		
+		localRotation = 0,0,0
+        localPosition = 0,0,0
+		energy = 1
+        speed = 1
+		emissionMult = 1
+
+        flarePosition = 0,0,-0.2745
+		flareScale = 0.32746
+
+        fumePosition = 0,0,0.8169
+		fumeScale = 1.6373
+
+		streamPosition = 0,0,0.38
+		streamScale = 1.5282
+		
+		shockconePosition = 0,0,2.7817
+		shockconeScale = 1.0915
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		@fumeScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		@streamScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		@shockconeScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		@streamPosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		@shockconePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+		
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+		@fumePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+		@streamPosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+		@shockconePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+	}
+}
+@PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox_UpperBlue]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hydrolox_UpperBlue
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hydrolox_UpperBlue
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox_UpperBlue.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hydrolox_UpperBlue.cfg
@@ -1,56 +1,56 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox_UpperBlue]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hydrolox_UpperBlue
-		transformName = #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/transformName$
-		
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hydrolox_UpperBlue
+        transformName = #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/transformName$
+        
+        localRotation = 0,0,0
         localPosition = 0,0,0
-		energy = 1
+        energy = 1
         speed = 1
-		emissionMult = 1
+        emissionMult = 1
 
         flarePosition = 0,0,-0.2745
-		flareScale = 0.32746
+        flareScale = 0.32746
 
         fumePosition = 0,0,0.8169
-		fumeScale = 1.6373
+        fumeScale = 1.6373
 
-		streamPosition = 0,0,0.38
-		streamScale = 1.5282
-		
-		shockconePosition = 0,0,2.7817
-		shockconeScale = 1.0915
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		@fumeScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		@streamScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		@shockconeScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		@streamPosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		@shockconePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
-		
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
-		@fumePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
-		@streamPosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
-		@shockconePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
-	}
+        streamPosition = 0,0,0.38
+        streamScale = 1.5282
+        
+        shockconePosition = 0,0,2.7817
+        shockconeScale = 1.0915
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        @fumeScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        @streamScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        @shockconeScale *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        @fumePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        @streamPosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        @shockconePosition[2] *= #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/scale$
+        
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+        @fumePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+        @streamPosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+        @shockconePosition[2] += #$/PLUME_TEMPLATE[Hydrolox_UpperBlue]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hydrolox_UpperBlue]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hydrolox_UpperBlue
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hydrolox_UpperBlue
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hydrolox_UpperBlue
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hydrolox_UpperBlue
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
@@ -44,3 +44,18 @@
         @blazePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hypergolic_LowerOrangeShock
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_LowerOrangeShock
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
@@ -1,0 +1,46 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hypergolic_LowerOrangeShock
+		transformName = #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/transformName$
+		localRotation = 0,0,0
+        localPosition = 0,0,0.39
+        fixedScale = 1.56
+        energy = 1
+        speed = 1
+        emissionMult = 0.75
+        alphaMult = 1
+
+        flarePosition = 0,0,-0.39
+        flareScale = 0.39
+
+        plumePosition = 0,0,0.39
+        plumeScale = 1.95
+
+        fumePosition = 0,0,0.78
+        fumeScale = 2.34
+
+        blazePosition = 0,0,1.5
+        blazeScale = 1.95
+		
+		@fixedScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@localPosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@localPosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@fumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@blazeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		@blazePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+		
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+		@plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+		@fumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+        @blazePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerOrangeShock_Template.cfg
@@ -1,10 +1,10 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hypergolic_LowerOrangeShock
-		transformName = #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/transformName$
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hypergolic_LowerOrangeShock
+        transformName = #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/transformName$
+        localRotation = 0,0,0
         localPosition = 0,0,0.39
         fixedScale = 1.56
         energy = 1
@@ -23,39 +23,39 @@
 
         blazePosition = 0,0,1.5
         blazeScale = 1.95
-		
-		@fixedScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@localPosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@localPosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@fumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@blazeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		@blazePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
-		
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
-		@plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
-		@fumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+        
+        @fixedScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @localPosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @localPosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @fumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @blazeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        @blazePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/scale$
+        
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+        @plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
+        @fumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
         @blazePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]/offset$
-	}
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerOrangeShock]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic_LowerOrangeShock
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hypergolic_LowerOrangeShock
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic_LowerOrangeShock
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic_LowerOrangeShock
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
@@ -1,0 +1,46 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerRed_shock]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hypergolic_LowerRed
+		transformName = #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/transformName$
+		localRotation = 0,0,0
+        localPosition = 0,0,0.39
+        fixedScale = 1.56
+        energy = 1
+        speed = 1
+        emissionMult = 0.75
+        alphaMult = 1
+
+        flarePosition = 0,0,-0.39
+        flareScale = 0.39
+
+        plumePosition = 0,0,0.39
+        plumeScale = 1.95
+
+        fumePosition = 0,0,0.78
+        fumeScale = 2.34
+
+        blazePosition = 0,0,1.5
+        blazeScale = 1.95
+		
+		@fixedScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@localPosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@localPosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@fumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@blazeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		@blazePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+		
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+		@plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+		@fumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+        @blazePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
@@ -1,10 +1,10 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerRed_shock]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hypergolic_LowerRed
-		transformName = #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/transformName$
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hypergolic_LowerRed
+        transformName = #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/transformName$
+        localRotation = 0,0,0
         localPosition = 0,0,0.39
         fixedScale = 1.56
         energy = 1
@@ -23,39 +23,39 @@
 
         blazePosition = 0,0,1.5
         blazeScale = 1.95
-		
-		@fixedScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@localPosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@localPosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@fumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@blazeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		@blazePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
-		
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
-		@plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
-		@fumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+        
+        @fixedScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @localPosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @localPosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @fumeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @blazeScale *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        @blazePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/scale$
+        
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+        @plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
+        @fumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
         @blazePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
-	}
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerRed_shock]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic_LowerRed
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hypergolic_LowerRed
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic_LowerRed
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic_LowerRed
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
@@ -44,3 +44,18 @@
         @blazePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_LowerRed_shock]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerRed_shock]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hypergolic_LowerRed
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_LowerRed
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_LowerRedShock_Template.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerRed_shock]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_LowerRed_shock]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperOrange_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperOrange_Template.cfg
@@ -1,0 +1,48 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperOrange]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hypergolic_UpperOrange
+		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/transformName$
+		localRotation = 0,0,0
+        localPosition = 0,0,0
+		energy = 1
+        speed = 1
+
+        flarePosition = 0,0,-0.5
+		flareScale = 0.37
+
+        fumePosition = 0,0,1.445
+		fumeScale = 3.1
+
+		plumePosition = 0,0,0.321
+		plumeScale = 1.76
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+		@fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+		
+		@flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+		@plumePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+		
+		@flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
+		@fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
+		@plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
+	}
+}
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperOrange]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hypergolic_UpperOrange
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_UpperOrange
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperOrange_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperOrange_Template.cfg
@@ -1,48 +1,48 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperOrange]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hypergolic_UpperOrange
-		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/transformName$
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hypergolic_UpperOrange
+        transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/transformName$
+        localRotation = 0,0,0
         localPosition = 0,0,0
-		energy = 1
+        energy = 1
         speed = 1
 
         flarePosition = 0,0,-0.5
-		flareScale = 0.37
+        flareScale = 0.37
 
         fumePosition = 0,0,1.445
-		fumeScale = 3.1
+        fumeScale = 3.1
 
-		plumePosition = 0,0,0.321
-		plumeScale = 1.76
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
-		@fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
-		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
-		
-		@flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
-		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
-		@plumePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
-		
-		@flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
-		@fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
-		@plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
-	}
+        plumePosition = 0,0,0.321
+        plumeScale = 1.76
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+        @fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+        @plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+        
+        @flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+        @fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+        @plumePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/scale$
+        
+        @flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
+        @fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
+        @plumePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperOrange]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperOrange]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic_UpperOrange
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hypergolic_UpperOrange
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic_UpperOrange
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic_UpperOrange
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
@@ -31,3 +31,18 @@
 		@streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperRed]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hypergolic_UpperRed
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_UpperRed
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
@@ -1,0 +1,33 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperRed]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hypergolic_UpperRed
+		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/transformName$
+		localRotation = 0,0,0
+        localPosition = 0,0,0
+		energy = 1
+        speed = 1
+
+        flarePosition = 0,0,-0.07
+		flareScale = 0.44
+
+        fumePosition = 0,0,0.745
+		fumeScale = 3.1
+
+		streamPosition = 0,0,0.451
+		streamScale = 1.76
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+		@fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+		@streamScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+		
+		@flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+		@streamPosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+		
+		@flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
+		@fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
+		@streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
@@ -9,7 +9,7 @@
 		energy = 1
         speed = 1
 
-        flarePosition = 0,0,-0.07
+        flarePosition = 0,0,-0.08
 		flareScale = 0.44
 
         fumePosition = 0,0,0.745

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperRed_Template.cfg
@@ -1,48 +1,48 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperRed]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hypergolic_UpperRed
-		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/transformName$
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hypergolic_UpperRed
+        transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/transformName$
+        localRotation = 0,0,0
         localPosition = 0,0,0
-		energy = 1
+        energy = 1
         speed = 1
 
         flarePosition = 0,0,-0.08
-		flareScale = 0.44
+        flareScale = 0.44
 
         fumePosition = 0,0,0.745
-		fumeScale = 3.1
+        fumeScale = 3.1
 
-		streamPosition = 0,0,0.451
-		streamScale = 1.76
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
-		@fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
-		@streamScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
-		
-		@flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
-		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
-		@streamPosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
-		
-		@flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
-		@fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
-		@streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
-	}
+        streamPosition = 0,0,0.451
+        streamScale = 1.76
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+        @fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+        @streamScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+        
+        @flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+        @fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+        @streamPosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/scale$
+        
+        @flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
+        @fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
+        @streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperRed]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperRed]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic_UpperRed
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hypergolic_UpperRed
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic_UpperRed
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic_UpperRed
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperWhite_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperWhite_Template.cfg
@@ -1,0 +1,34 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperWhite]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hypergolic_UpperWhite
+		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/transformName$
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+
+		energy = 1
+		speed = 1
+
+		flarePosition = 0,0,-0.14
+		flareScale = 0.507
+
+		plumePosition = 0,0,0.4225
+		plumeScale = 3.408
+
+		corePosition = 0,0,0.3873
+		coreScale = 3.408
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+		@coreScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+		
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+		@corePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+		
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
+		@plumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
+		@corePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperWhite_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperWhite_Template.cfg
@@ -1,49 +1,49 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperWhite]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hypergolic_UpperWhite
-		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/transformName$
-		localRotation = 0,0,0
-		localPosition = 0,0,0
+    PLUME
+    {
+        name = Hypergolic_UpperWhite
+        transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/transformName$
+        localRotation = 0,0,0
+        localPosition = 0,0,0
 
-		energy = 1
-		speed = 1
+        energy = 1
+        speed = 1
 
-		flarePosition = 0,0,-0.14
-		flareScale = 0.507
+        flarePosition = 0,0,-0.14
+        flareScale = 0.507
 
-		plumePosition = 0,0,0.4225
-		plumeScale = 3.408
+        plumePosition = 0,0,0.4225
+        plumeScale = 3.408
 
-		corePosition = 0,0,0.3873
-		coreScale = 3.408
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
-		@plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
-		@coreScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
-		
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
-		@corePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
-		
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
-		@plumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
-		@corePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
-	}
+        corePosition = 0,0,0.3873
+        coreScale = 3.408
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+        @plumeScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+        @coreScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+        
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+        @corePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/scale$
+        
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
+        @plumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
+        @corePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperWhite]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic_UpperWhite
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hypergolic_UpperWhite
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic_UpperWhite
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic_UpperWhite
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperWhite_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperWhite_Template.cfg
@@ -32,3 +32,18 @@
 		@corePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperWhite]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperWhite]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hypergolic_UpperWhite
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_UpperWhite
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperYellow_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperYellow_Template.cfg
@@ -1,48 +1,48 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperYellow]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Hypergolic_UpperYellow
-		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/transformName$
-		localRotation = 0,0,0
+    PLUME
+    {
+        name = Hypergolic_UpperYellow
+        transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/transformName$
+        localRotation = 0,0,0
         localPosition = 0,0,0
-		energy = 1
+        energy = 1
         speed = 1
 
         flarePosition = 0,0,-0.07
-		flareScale = 0.44
+        flareScale = 0.44
 
         fumePosition = 0,0,0.745
-		fumeScale = 3.1
+        fumeScale = 3.1
 
-		streamPosition = 0,0,0.451
-		streamScale = 1.76
-		
-		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
-		@fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
-		@streamScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
-		
-		@flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
-		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
-		@streamPosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
-		
-		@flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
-		@fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
-		@streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
-	}
+        streamPosition = 0,0,0.451
+        streamScale = 1.76
+        
+        @flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+        @fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+        @streamScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+        
+        @flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+        @fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+        @streamPosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+        
+        @flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
+        @fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
+        @streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperYellow]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Hypergolic_UpperYellow
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Hypergolic_UpperYellow
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Hypergolic_UpperYellow
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Hypergolic_UpperYellow
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperYellow_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperYellow_Template.cfg
@@ -1,0 +1,33 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperYellow]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Hypergolic_UpperYellow
+		transformName = #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/transformName$
+		localRotation = 0,0,0
+        localPosition = 0,0,0
+		energy = 1
+        speed = 1
+
+        flarePosition = 0,0,-0.07
+		flareScale = 0.44
+
+        fumePosition = 0,0,0.745
+		fumeScale = 3.1
+
+		streamPosition = 0,0,0.451
+		streamScale = 1.76
+		
+		@flareScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+		@fumeScale  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+		@streamScale *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+		
+		@flarePosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+		@fumePosition[2] *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+		@streamPosition[2]  *= #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/scale$
+		
+		@flarePosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
+		@fumePosition[2] += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
+		@streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperYellow_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Hypergolic_UpperYellow_Template.cfg
@@ -31,3 +31,18 @@
 		@streamPosition[2]  += #$/PLUME_TEMPLATE[Hypergolic_UpperYellow]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Hypergolic_UpperYellow]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Hypergolic_UpperYellow
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_UpperYellow
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
@@ -32,3 +32,18 @@
 		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerAlt]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Kerolox_LowerAlt
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Kerolox_LowerAlt
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
@@ -1,49 +1,49 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerAlt]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Kerolox_LowerAlt
-		transformName = #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/transformName$
-		localRotation = 0,0,0
-		localPosition = 0,0,0
-		emissionMult = 1
-		speed = 1
-		energy = 1
-	
-		flarePosition = 0,0,-0.38
-		flareScale = 0.1
+    PLUME
+    {
+        name = Kerolox_LowerAlt
+        transformName = #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/transformName$
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        emissionMult = 1
+        speed = 1
+        energy = 1
+    
+        flarePosition = 0,0,-0.38
+        flareScale = 0.1
 
-		plumePosition = 0,0,0.4817
-		plumeScale = 1.8
-	
-		flamePosition = 0,0,0.8
-		flameScale = 1.9
-		
-		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
-		@flameScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
-		@flareScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
-		
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
-		@flamePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
-		
-		@plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
-		@flamePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
-	}
+        plumePosition = 0,0,0.4817
+        plumeScale = 1.8
+    
+        flamePosition = 0,0,0.8
+        flameScale = 1.9
+        
+        @plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+        @flameScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+        @flareScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+        
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+        @flamePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+        
+        @plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
+        @flamePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerAlt]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Kerolox_LowerAlt
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Kerolox_LowerAlt
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Kerolox_LowerAlt
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox_LowerAlt
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
@@ -1,0 +1,34 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerAlt]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Kerolox_LowerAlt
+		transformName = #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/transformName$
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		emissionMult = 1
+		speed = 1
+		energy = 1
+	
+		flarePosition = 0,0,-0.38
+		flareScale = 0.1
+
+		plumePosition = 0,0,0.2817
+		plumeScale = 1.8
+
+		flamePosition = 0,0,0.6
+		flameScale = 1.9
+		
+		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+		@flameScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+		@flareScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+		
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+		@flamePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$
+		
+		@plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
+		@flamePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerAlt]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerAlt]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{
@@ -13,10 +13,10 @@
 		flarePosition = 0,0,-0.38
 		flareScale = 0.1
 
-		plumePosition = 0,0,0.2817
+		plumePosition = 0,0,0.6817
 		plumeScale = 1.8
 
-		flamePosition = 0,0,0.6
+		flamePosition = 0,0,1
 		flameScale = 1.9
 		
 		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerAlt_Template.cfg
@@ -13,10 +13,10 @@
 		flarePosition = 0,0,-0.38
 		flareScale = 0.1
 
-		plumePosition = 0,0,0.6817
+		plumePosition = 0,0,0.4817
 		plumeScale = 1.8
-
-		flamePosition = 0,0,1
+	
+		flamePosition = 0,0,0.8
 		flameScale = 1.9
 		
 		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerAlt]/scale$

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
@@ -1,0 +1,34 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerFlame]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Kerolox_LowerFlame
+		transformName = #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/transformName$
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		emissionMult = 1
+		speed = 1
+		energy = 1
+		
+		flarePosition = 0,0,-0.38
+		flareScale = 0.1
+	
+		plumePosition = 0,0,0.2817
+		plumeScale = 1.8
+	
+		flamePosition = 0,0,0.6
+		flameScale = 1.9
+		
+		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+		@flameScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+		@flareScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+		
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+		@flamePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+		
+		@plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
+		@flamePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
@@ -13,10 +13,10 @@
 		flarePosition = 0,0,-0.38
 		flareScale = 0.1
 	
-		plumePosition = 0,0,0.6817
+		plumePosition = 0,0,0.4817
 		plumeScale = 1.8
-
-		flamePosition = 0,0,1
+	
+		flamePosition = 0,0,0.8
 		flameScale = 1.9
 		
 		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
@@ -32,3 +32,18 @@
 		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerFlame]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Kerolox_LowerFlame
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Kerolox_LowerFlame
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerFlame]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerFlame]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{
@@ -13,10 +13,10 @@
 		flarePosition = 0,0,-0.38
 		flareScale = 0.1
 	
-		plumePosition = 0,0,0.2817
+		plumePosition = 0,0,0.6817
 		plumeScale = 1.8
-	
-		flamePosition = 0,0,0.6
+
+		flamePosition = 0,0,1
 		flameScale = 1.9
 		
 		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
@@ -1,49 +1,49 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerFlame]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Kerolox_LowerFlame
-		transformName = #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/transformName$
-		localRotation = 0,0,0
-		localPosition = 0,0,0
-		emissionMult = 1
-		speed = 1
-		energy = 1
-		
-		flarePosition = 0,0,-0.37
-		flareScale = 0.1
-	
-		plumePosition = 0,0,0.4817
-		plumeScale = 1.8
-	
-		flamePosition = 0,0,0.8
-		flameScale = 1.9
-		
-		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
-		@flameScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
-		@flareScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
-		
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
-		@flamePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
-		
-		@plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
-		@flamePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
-	}
+    PLUME
+    {
+        name = Kerolox_LowerFlame
+        transformName = #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/transformName$
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        emissionMult = 1
+        speed = 1
+        energy = 1
+        
+        flarePosition = 0,0,-0.37
+        flareScale = 0.1
+    
+        plumePosition = 0,0,0.4817
+        plumeScale = 1.8
+    
+        flamePosition = 0,0,0.8
+        flameScale = 1.9
+        
+        @plumeScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+        @flameScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+        @flareScale *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+        
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+        @flamePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/scale$
+        
+        @plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
+        @flamePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_LowerFlame]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_LowerFlame]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Kerolox_LowerFlame
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Kerolox_LowerFlame
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Kerolox_LowerFlame
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox_LowerFlame
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_LowerFlame_Template.cfg
@@ -10,7 +10,7 @@
 		speed = 1
 		energy = 1
 		
-		flarePosition = 0,0,-0.38
+		flarePosition = 0,0,-0.37
 		flareScale = 0.1
 	
 		plumePosition = 0,0,0.4817

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
@@ -1,43 +1,43 @@
 @PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_Upper2]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	PLUME
-	{
-		name = Kerolox_Upper2
-		transformName = #$/PLUME_TEMPLATE[Kerolox_Upper2]/transformName$
-		localRotation = 0,0,0
-		localPosition = 0,0,0
-		emissionMult = 1.2
-		speed = 1
-		energy = 1
-		
-		flarePosition = 0,0,-0.3
-		flareScale = 0.1
-	
-		plumePosition = 0,0,0.55
-		plumeScale = 1.7
-		
-		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
-		@flareScale *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
-		
-		@plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
-		@flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
-		
-		@plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
-		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
-	}
+    PLUME
+    {
+        name = Kerolox_Upper2
+        transformName = #$/PLUME_TEMPLATE[Kerolox_Upper2]/transformName$
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        emissionMult = 1.2
+        speed = 1
+        energy = 1
+        
+        flarePosition = 0,0,-0.3
+        flareScale = 0.1
+    
+        plumePosition = 0,0,0.55
+        plumeScale = 1.7
+        
+        @plumeScale *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+        @flareScale *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+        
+        @plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+        @flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+        
+        @plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
+        @flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
+    }
 }
 @PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_Upper2]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		!runningEffectName = DELETE
-		%powerEffectName = Kerolox_Upper2
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%powerEffectName = Kerolox_Upper2
-		}
-	}
+    @MODULE[ModuleEngines*]
+    {
+        !runningEffectName = DELETE
+        %powerEffectName = Kerolox_Upper2
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox_Upper2
+        }
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
@@ -26,3 +26,18 @@
 		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
 	}
 }
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_Upper2]:HAS[~setupEngine[false]]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+	@MODULE[ModuleEngines*]
+	{
+		!runningEffectName = DELETE
+		%powerEffectName = Kerolox_Upper2
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Kerolox_Upper2
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
@@ -1,0 +1,28 @@
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_Upper2]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
+	{
+		name = Kerolox_Upper2
+		transformName = #$/PLUME_TEMPLATE[Kerolox_Upper2]/transformName$
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		emissionMult = 1.2
+		speed = 1
+		energy = 1
+		
+		flarePosition = 0,0,-0.3
+		flareScale = 0.1
+	
+		plumePosition = 0,0,0.55
+		plumeScale = 1.7
+		
+		@plumeScale *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+		@flareScale *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+		
+		@plumePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+		@flarePosition[2] *= #$/PLUME_TEMPLATE[Kerolox_Upper2]/scale$
+		
+		@plumePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
+		@flarePosition[2] += #$/PLUME_TEMPLATE[Kerolox_Upper2]/offset$
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/000_Generic_Plume_Templates/Kerolox_Upper2_Template.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_Upper2]]:BEFORE[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME_TEMPLATE[Kerolox_Upper2]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{


### PR DESCRIPTION
This adds a template system to improve the current workflow of configuring complex RealPlume plumes, by doing part of the work for you. The template sets up the `PLUME`-Node with properly scaled values, and sets up the effects in the engine. 
It requires a `scale` value, an `offset` value, and a `transformName`. Optionally, you can add a `setupEngine = false`, to prevent the template from setting up the effects in the engine module, if you want to use a combined plume, per config plumes, etc.
Examples can be found in the ROEngines repo.

I still have to decide about hydrolox templates, so I left it as a draft PR.