### PR TITLE
Revert XLR99 to non-v2 part

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Engines.cfg
@@ -542,11 +542,9 @@
 // XLR99
 +PART[liquidEngine3]:FIRST:NEEDS[!RftS,!RealFuels_StockEngines,VenStockRevamp]
 {
-	@name = RO-XLR99_1
-}
-+PART[liquidEngine3_v2]:FIRST:NEEDS[!RftS,!RealFuels_StockEngines,VenStockRevamp]
-{
 	@name = RO-XLR99
+	!TechHidden = delete
+	%category = Engine
 }
 @PART[RO-XLR99]:FOR[RealismOverhaul]:NEEDS[!RftS,!RealFuels_StockEngines]
 {


### PR DESCRIPTION
_v2-based engine is a bit broken: part variants can't be
selected, and shrouds can't be turned off. Original version
works fine, so unhide and revert to it until someone figures out
what's broken