### PR TITLE
X-405H speculative configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -141,8 +141,8 @@
 		{
 			name = X-405H-3
 			description = Speculative upgrade configuration with increased expansion ratio
-			minThrust = 159.36
-			maxThrust = 159.36
+			minThrust = 161.86
+			maxThrust = 161.86
 			heatProduction = 78
 			massMult = 1.15
 			ullage = True
@@ -180,7 +180,8 @@
 
 			atmosphereCurve
 			{
-				key = 0 318
+				key = 0 323
+				//Calculated based on Theoretical ISP, using known performance from X-405H as a correction factor
 				key = 1 200
 			}
 		}
@@ -188,8 +189,8 @@
 		{
 			name = X-405H-4
 			description = Speculative upgrade configuration with increased chamber pressure and upgrades with late 1960s technology.
-			minThrust = 184.3
-			maxThrust = 184.3
+			minThrust = 186.42
+			maxThrust = 186.42
 			heatProduction = 78
 			massMult = 1.15
 			ullage = True
@@ -227,7 +228,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 320
+				key = 0 323.5
 				key = 1 200
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -137,6 +137,100 @@
 				key = 1 208.5
 			}
 		}
+		CONFIG
+		{
+			name = X-405H-3
+			description = Speculative upgrade configuration with increased expansion ratio
+			minThrust = 159.36
+			maxThrust = 159.36
+			heatProduction = 78
+			massMult = 1.15
+			ullage = True
+			pressureFed = False
+			
+			ignitions = 3
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3614
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6233
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				// no ignoreForIsp - data from Convair's report is consistent with HTP being counted in Isp
+				ratio = 0.0153
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 318
+				key = 1 200
+			}
+		}
+		CONFIG
+		{
+			name = X-405H-4
+			description = Speculative upgrade configuration with increased chamber pressure and upgrades with late 1960s technology.
+			minThrust = 184.3
+			maxThrust = 184.3
+			heatProduction = 78
+			massMult = 1.15
+			ullage = True
+			pressureFed = False
+			
+			ignitions = 3
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3614
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6233
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				// no ignoreForIsp - data from Convair's report is consistent with HTP being counted in Isp
+				ratio = 0.0153
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 320
+				key = 1 200
+			}
+		}
 	}
 
 	!MODULE[ModuleAlternator],*{}
@@ -168,6 +262,28 @@
 		ignitionReliabilityEnd = 0.94
 		cycleReliabilityStart = 0.86
 		cycleReliabilityEnd = 0.96
+		techTransfer = X-405:50
+	}
+	TESTFLIGHT
+	{
+		// Copied from H-1.
+		name = X-405H-3
+		ratedBurnTime = 245
+		ignitionReliabilityStart = 0.89
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.93
+		cycleReliabilityEnd = 0.988
+		techTransfer = X-405:50
+	}
+	TESTFLIGHT
+	{
+		// Copied from H-1b.
+		name = X-405H-4
+		ratedBurnTime = 245
+		ignitionReliabilityStart = 0.94
+		ignitionReliabilityEnd = 0.99
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.994
 		techTransfer = X-405:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -274,7 +274,7 @@
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.93
 		cycleReliabilityEnd = 0.988
-		techTransfer = X-405:50
+		techTransfer = X-405,X-405H:50
 	}
 	TESTFLIGHT
 	{
@@ -285,6 +285,6 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.994
-		techTransfer = X-405:50
+		techTransfer = X-405,X-405H,X-405H-3:50
 	}
 }


### PR DESCRIPTION
This adds speculative upgrade configs for the X-405H. Specific impulse and thrust are based on calculations of theoretical performance, using data from the real X-405H as a correction factor. 

The X-405H-3 is a speculative upgrade with a radiative nozzle extension similar to the Agena-D. The X-405H-4 is a speculative late 60s upgrade with increased chamber pressure.