### PR TITLE
Fixed typos in the engine config naming of the Agena Engine

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -432,11 +432,11 @@
 		reliabilityDataRateMultiplier = 1
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model8096-39A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model8096A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = Model8096-39A
+		name = Model8096A
 		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
@@ -448,11 +448,11 @@
 		reliabilityDataRateMultiplier = 1
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model8096-39L]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model8096L]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = Model8096-39L
+		name = Model8096L
 		ratedBurnTime = 1200
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97


### PR DESCRIPTION
Changed the referenced engine configs:
From Model8096-39A and Model8096-39L
To Model8096A and Model8096L.

This fixes [issue 2147](https://github.com/KSP-RO/RealismOverhaul/issues/2147).