### PR TITLE
Fix for broken ReStock drag cubes

### DIFF
--- a/GameData/RealismOverhaul/DragCubeRescaler.cfg
+++ b/GameData/RealismOverhaul/DragCubeRescaler.cfg
@@ -1,3 +1,13 @@
+// Fix for broken Restock probes
+@PART[probeStackSmall]:HAS[#rescaleCube[*]]:NEEDS[ReStock]:BEFORE[zRORescaleDragCubes]
+{
+	!rescaleCube = DEL
+}
+@PART[probeStackLarge]:HAS[#rescaleCube[*]]:NEEDS[ReStock]:BEFORE[zRORescaleDragCubes]
+{
+	!rescaleCube = DEL
+}
+
 @PART[*]:HAS[#rescaleCube[*]]:FOR[zRORescaleDragCubes]
 {
 	!rescaleCube = DEL


### PR DESCRIPTION
Fixes the drag cube scaling errors during MM patching with latest ReStock.

This is because Restock replaces the drag cubes on parts with rescaleCube set.