### PR TITLE
Add TF/TL configs for solids

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -288,3 +288,19 @@
 
     !RESOURCE,*{}
 }
+// No failures so far
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ60A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = AJ60A
+		ratedBurnTime = 94
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground-lit SRMs
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9999
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
@@ -93,3 +93,20 @@
 		}
 	}
 }
+//Assumed same as Altair 2 due to very limited data
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Alcyone]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Alcyone
+		ratedBurnTime = 8
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.995
+
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
@@ -102,3 +102,20 @@
     }
   }
 }
+//18 flown, 1 failure related to Algol
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Algol-I]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Algol-I
+		ratedBurnTime = 45
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.99
+
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
@@ -101,3 +101,20 @@
     }
   }
 }
+//35 flown, 0 failures related to Algol
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Algol-III]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Algol-III
+		ratedBurnTime = 75
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+		techTransfer = Algol-I,Algol-II:50
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
@@ -99,3 +99,20 @@
     }
   }
 }
+//62 flown, 1 failure related to Algol
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Algol-II]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Algol-II
+		ratedBurnTime = 47
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+		techTransfer = Algol-I:50
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
@@ -116,18 +116,18 @@
 		}
 	}
 }
-
+// 74 flown, with 2 failures
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Altair-III]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Altair-III
 		ratedBurnTime = 31
-		ignitionReliabilityStart = 0.94
-		ignitionReliabilityEnd = 0.98
-		cycleReliabilityStart = 0.95
-		cycleReliabilityEnd = 0.985
-		techTransfer = Altair-II:50
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.999
+		techTransfer = Altair,Altair-II:50
 		reliabilityDataRateMultiplier = 2
 		
 		isSolid = True

--- a/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
@@ -115,16 +115,17 @@
 		}
 	}
 }
+//28 flown, 0 failed
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Altair-II]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Altair-II
 		ratedBurnTime = 22
-		ignitionReliabilityStart = 0.94
-		ignitionReliabilityEnd = 0.98
-		cycleReliabilityStart = 0.95
-		cycleReliabilityEnd = 0.985
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.995
 		techTransfer = Altair:50
 		reliabilityDataRateMultiplier = 2
 		

--- a/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
@@ -133,17 +133,17 @@
 		}
 	}
 }
-
+// Over 100 Altair X-248s flown, only 1 failure attributed to Altair and 5 unknown failures
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Altair]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Altair
 		ratedBurnTime = 39
-		ignitionReliabilityStart = 0.9
-		ignitionReliabilityEnd = 0.97
-		cycleReliabilityStart = 0.93
-		cycleReliabilityEnd = 0.98
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.99
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.99
 		reliabilityDataRateMultiplier = 2
 		
 		isSolid = True

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
@@ -96,3 +96,20 @@
     }
   }
 }
+//30 flown, 3 failures related to Antares
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Antares-I]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Antares-I
+		ratedBurnTime = 40
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.90
+		cycleReliabilityEnd = 0.98
+
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_III_Config.cfg
@@ -96,3 +96,20 @@
     }
   }
 }
+//17 flown, 0 failures related to Antares
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Antares-III]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Antares-III
+		ratedBurnTime = 45
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.99
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.99
+		techTransfer = Antares-I,Antares-II:50
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
@@ -98,3 +98,20 @@
     }
   }
 }
+//106 flown, 4 failures related to Antares
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Antares-II]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Antares-II
+		ratedBurnTime = 37
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.99
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.99
+		techTransfer = Antares-I:50
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
@@ -721,3 +721,51 @@
 		%gimbalResponseSpeed = 16
 	}
 }
+//Same as Castor-4A
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-120
+		ratedBurnTime = 80
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.999
+		techTransfer = Castor-120/Regressive,Castor-120/Saddle:100
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120/Regressive]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-120/Regressive
+		ratedBurnTime = 80
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.999
+		techTransfer = Castor-120,Castor-120/Saddle:100
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120/Saddle]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-120/Saddle
+		ratedBurnTime = 80
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.999
+		techTransfer = Castor-120/Regressive,Castor-120:100
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
@@ -258,30 +258,30 @@
 		isSolid = True
 	}
 }
-
+//333 flown, 1 failure
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-1-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Castor-1-SL
 		ratedBurnTime = 41
-		ignitionReliabilityStart = 0.91
-		ignitionReliabilityEnd = 0.994
-		cycleReliabilityStart = 0.94
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground lit SRMs
+		cycleReliabilityStart = 0.99
 		cycleReliabilityEnd = 0.997
 		reliabilityDataRateMultiplier = 2
 		isSolid = True
 		techTransfer = XM-20:50&Castor-1-Vac:100
 	}
 }
-
+//88 flights, 3 failures
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-1-Vac]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Castor-1-Vac
 		ratedBurnTime = 43
-		ignitionReliabilityStart = 0.91
+		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.994
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.997

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -189,8 +189,8 @@
 	{
 		name = Castor-2-SL
 		ratedBurnTime = 39
-		ignitionReliabilityStart = 0.945
-		ignitionReliabilityEnd = 0.997
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.9999	//Not a probable failure for ground lit SRMs
 		cycleReliabilityStart = 0.965
 		cycleReliabilityEnd = 0.9985
 		techTransfer = Castor-1-SL,Castor-1-Vac:50&Castor-2-Vac:100
@@ -198,6 +198,7 @@
 		isSolid = True
 	}
 }
+//74 flown, 1 failure related to Castor
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-2-Vac]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
@@ -257,3 +257,19 @@
 		%gimbalResponseSpeed = 16
 	}
 }
+//Same as Castor-4A
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-30A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-30A
+		ratedBurnTime = 136
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9999
+		techTransfer = Castor-120,Castor-120/Regressive,Castor-120/Saddle:50
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
@@ -177,3 +177,19 @@
 		%gimbalResponseSpeed = 16
 	}
 }
+//Same as Castor-4A
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-30B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-30B
+		ratedBurnTime = 127
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9999
+		techTransfer = Castor-120,Castor-120/Regressive,Castor-120/Saddle,Castor-30A:50
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
@@ -177,3 +177,19 @@
 		%gimbalResponseSpeed = 16
 	}
 }
+//Same as Castor-4A
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-30XL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-30XL
+		ratedBurnTime = 156
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9999
+		techTransfer = Castor-120,Castor-120/Regressive,Castor-120/Saddle,Castor-30A,Castor-30B:50
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
@@ -101,3 +101,19 @@
 		}
 	}
 }
+//Same as Castor-4A
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-4AXL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-4AXL
+		ratedBurnTime = 60
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.999
+		techTransfer = Castor-1-SL,Castor-1-Vac,Castor-2-SL,Castor-2-Vac,Castor-4,Castor-4A:50
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
@@ -95,3 +95,19 @@
 		}
 	}
 }
+//304 flown, 0 failures related to Castor
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-4A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-4A
+		ratedBurnTime = 56
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.999
+		techTransfer = Castor-1-SL,Castor-1-Vac,Castor-2-SL,Castor-2-Vac,Castor-4:50
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
@@ -252,3 +252,19 @@
 		}
 	}
 }
+//342 flown, 1 failures related to Castor
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Castor-4
+		ratedBurnTime = 54
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground lit SRMs
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.999
+		techTransfer = Castor-1-SL,Castor-1-Vac,Castor-2-SL,Castor-2-Vac:50
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
@@ -91,3 +91,20 @@
 		}
 	}
 }
+//8 Flights, one failure
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Dropt]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Dropt
+		ratedBurnTime = 46
+		ignitionReliabilityStart = 0.875
+		ignitionReliabilityEnd = 0.99
+		cycleReliabilityStart = 0.9
+		cycleReliabilityEnd = 0.99
+
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
@@ -125,16 +125,17 @@
 	}
 }
 
+//Due to limited data, set same as Altair-1
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GCRC]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = GCRC
-		ratedBurnTime = 34
-		ignitionReliabilityStart = 0.9
-		ignitionReliabilityEnd = 0.97
-		cycleReliabilityStart = 0.93
-		cycleReliabilityEnd = 0.98
+		ratedBurnTime = 33
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.99
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.99
 		reliabilityDataRateMultiplier = 2
 		
 		isSolid = True

--- a/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
@@ -206,3 +206,32 @@
 		}
 	}  
 }
+//936 flown, 1 failure
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-40/Ground]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-40/Ground
+		ratedBurnTime = 63
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air:100
+		isSolid = True
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-40/Air]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-40/Air
+		ratedBurnTime = 63
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Ground:100
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
@@ -738,3 +738,46 @@
 		}
 	}
 }
+//54 flown, 0 failures
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-46/Fixed-Ground]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-46/Fixed-Ground
+		ratedBurnTime = 77
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/TVC-Ground,GEM-46/Fixed-Air:100
+		isSolid = True
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-46/TVC-Ground]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-46/TVC-Ground
+		ratedBurnTime = 77
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/Fixed-Ground,GEM-46/Fixed-Air:100
+		isSolid = True
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-46/Fixed-Air]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-46/Fixed-Air
+		ratedBurnTime = 77
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/TVC-Ground,GEM-46/Fixed-Ground:100
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
@@ -315,3 +315,32 @@
 		}
 	}
 }
+//Same as GEM-46
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-60/Fixed]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-60/Fixed
+		ratedBurnTime = 91
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground:50 & GEM-60/TVC:100
+		isSolid = True
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-60/TVC]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-60/TVC
+		ratedBurnTime = 91
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground:50 & GEM-60/Fixed:100
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
@@ -137,3 +137,18 @@
 		}
 	}
 }
+//Same as GEM-46
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-63XL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-63XL
+		ratedBurnTime = 84
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-60/TVC,GEM-60/Fixed,GEM-63:50
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
@@ -137,3 +137,18 @@
 		}
 	}
 }
+//Same as GEM-46
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-63]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-63
+		ratedBurnTime = 94
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9989
+		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-60/TVC,GEM-60/Fixed,GEM-63XL:50
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
@@ -259,3 +259,18 @@
 		%gimbalResponseSpeed = 16
 	}
 }
+//Same reliability as redesigned RSRM
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RSRMV]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RSRMV
+		ratedBurnTime = 126
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9999
+		techTransfer = RSRM:50
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -203,3 +203,18 @@
         }
     }
 }
+//Original SRM: 48 flown, 1 near failure, 1 catastrophic failure. Redsigned SRM: 216 flown, 0 failures
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RSRM]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RSRM
+		ratedBurnTime = 123
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.94	//Fundementally flawed design, O-rings at risk of burnthrough on several flights
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -212,7 +212,7 @@
 		ratedBurnTime = 123
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
-		cycleReliabilityStart = 0.94	//Fundementally flawed design, O-rings at risk of burnthrough on several flights
+		cycleReliabilityStart = 0.95	//Fundementally flawed design, O-rings at risk of burnthrough on several flights
 		cycleReliabilityEnd = 0.9999
 
 		isSolid = True

--- a/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
@@ -89,3 +89,18 @@
 		}
 	}
 }
+// 4 flights, 1 failure
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-60/Fixed]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = GEM-60/Fixed
+		ratedBurnTime = 39
+		ignitionReliabilityStart = 0.75
+		ignitionReliabilityEnd = 0.9	//not likely for ground-lit motor
+		cycleReliabilityStart = 0.75
+		cycleReliabilityEnd = 0.9
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
@@ -253,3 +253,18 @@
 		}
 	}
 }
+//No known failures?
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-13B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-13B
+		ratedBurnTime = 15
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
@@ -253,3 +253,18 @@
 		}
 	}
 }
+//No known failures?
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-15G]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-15G
+		ratedBurnTime = 35
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
@@ -253,3 +253,18 @@
 		}
 	}
 }
+//High reliability kick motor for military payloads
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-17A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-17A
+		ratedBurnTime = 25
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star17_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17_Config.cfg
@@ -85,3 +85,18 @@
 
 	!RESOURCE,*{}
 }
+//High reliability kick motor for military payloads
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-17]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-17
+		ratedBurnTime = 18
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
@@ -253,3 +253,21 @@
 		}
 	}
 }
+// 74 flown, with 2 failures
+// Just another name of Altair III? Why does this exist
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-20]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-20
+		ratedBurnTime = 31
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.999
+		techTransfer = Altair,Altair-II:50
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
@@ -339,6 +339,6 @@
         ignitionReliabilityStart = 0.958
         ignitionReliabilityEnd = 0.995
         cycleReliabilityStart = 0.958
-        cycleReliabilityEnd = 0.995
+        cycleReliabilityEnd = 0.9999
     }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
@@ -486,3 +486,18 @@
 		}
 	}
 }
+//59 flown on GPS and weather sats, 0 failed
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-27]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-27
+		ratedBurnTime = 18
+		ignitionReliabilityStart = 0.958
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
@@ -253,3 +253,18 @@
 		}
 	}
 }
+//24 flown, 0 failed
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-30BP]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-30BP
+		ratedBurnTime = 54
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.9999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
@@ -253,3 +253,20 @@
 		}
 	}
 }
+//Star-31 was another name for Anteres-1. Why does this exist?
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-31]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-31
+		ratedBurnTime = 40
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.90
+		cycleReliabilityEnd = 0.98
+
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -339,9 +339,9 @@
         isSolid = True
         ratedBurnTime = 42
         ignitionReliabilityStart = 0.958
-        ignitionReliabilityEnd = 0.995
+        ignitionReliabilityEnd = 0.999
         cycleReliabilityStart = 0.958
-        cycleReliabilityEnd = 0.995
+        cycleReliabilityEnd = 0.9999
         techTransfer = STAR-37:50
     }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -317,3 +317,21 @@
 
     !RESOURCE,*{}
 }
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[STAR-37FM]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = STAR-37FM
+        isSolid = True
+        ratedBurnTime = 64
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.999
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.9999
+        techTransfer = STAR-37,Star-37E:50
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -339,8 +339,8 @@
         isSolid = True
         ratedBurnTime = 42
         ignitionReliabilityStart = 0.958
-        ignitionReliabilityEnd = 0.995
+        ignitionReliabilityEnd = 0.999
         cycleReliabilityStart = 0.958
-        cycleReliabilityEnd = 0.995
+        cycleReliabilityEnd = 0.9999
     }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
@@ -148,3 +148,18 @@
 		}
 	}
 }
+//Terminal Attitude control for MER landers, designed for extremely high reliability
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-3
+		ratedBurnTime = 5
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
@@ -723,3 +723,49 @@
 		gimbalResponseSpeed = 16
 	}
 }
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-48B/Short]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = Star-48B/Short
+        isSolid = True
+        ratedBurnTime = 90
+        ignitionReliabilityStart = 0.9
+        ignitionReliabilityEnd = 0.999
+        cycleReliabilityStart = 0.958
+        cycleReliabilityEnd = 0.995
+        techTransfer = STAR-37,Star-37E:50 & Star-48B/Long,Star-48BV:100
+    }
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-48B/Long]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = Star-48B/Long
+        isSolid = True
+        ratedBurnTime = 90
+        ignitionReliabilityStart = 0.9
+        ignitionReliabilityEnd = 0.999
+        cycleReliabilityStart = 0.958
+        cycleReliabilityEnd = 0.995
+        techTransfer = STAR-37,Star-37E:50 & Star-48B/Short,Star-48BV:100
+    }
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-48BV]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = Star-48BV
+        isSolid = True
+        ratedBurnTime = 90
+        ignitionReliabilityStart = 0.9
+        ignitionReliabilityEnd = 0.999
+        cycleReliabilityStart = 0.958
+        cycleReliabilityEnd = 0.995
+        techTransfer = STAR-37,Star-37E:50 & Star-48B/Short,Star-48/Long:100
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
@@ -253,3 +253,18 @@
 		}
 	}
 }
+//No known failures?
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-5C]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-5C
+		ratedBurnTime = 3
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
@@ -61,3 +61,18 @@
 		}
 	}
 }
+//Terminal Braking motor for Mars Pathfinder, extremely reliable
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-5D]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-5D
+		ratedBurnTime = 4
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.9999
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 0.9999
+		techTransfer = Star-5C:50
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
@@ -253,3 +253,21 @@
 		}
 	}
 }
+//  ==================================================
+//  TestFlight compatibility.
+//  ==================================================
+// 2 flown 0 failures
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-63D]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+        name = Star-63D
+        isSolid = True
+        ratedBurnTime = 120
+        ignitionReliabilityStart = 0.98
+        ignitionReliabilityEnd = 0.999
+        cycleReliabilityStart = 0.98
+        cycleReliabilityEnd = 0.9999
+        techTransfer = Star-48/Short,Star-48B/Long,Star-48BV:50
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
@@ -61,3 +61,18 @@
 		}
 	}
 }
+//Terminal braking for MER landers, designed for extremely high reliability
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-8]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Star-8
+		ratedBurnTime = 5
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.9999
+		techTransfer = Star-5C,Star-5D:50
+		isSolid = True
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
@@ -131,3 +131,20 @@
 		}
 	}
 }
+// very little data
+// Assumed same as Altair-III/Star-20
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Waxwing]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Waxwing
+		ratedBurnTime = 30
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.97
+		cycleReliabilityEnd = 0.999
+		reliabilityDataRateMultiplier = 2
+		
+		isSolid = True
+	}
+}


### PR DESCRIPTION
This adds TF/TL configs for most solid rocket motors. Data from real flights are used to determine reliability. Several SRMs do not have TF/TL configs because I was unable to find any useful data on them.