### PR TITLE
Hide deprecated parts from the editor

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -402,6 +402,7 @@
 	@title = Procedural Tank (Deprecated)
 	@manufacturer = Generic
 	@description = Don't use this tank.
+	%category = none
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
@@ -448,6 +449,7 @@
 	@title = Procedural Balloon Tank (Deprecated)
 	@manufacturer = Generic
 	@description = Don't use this tank.
+	%category = none
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15


### PR DESCRIPTION
No need to keep showing them if they're deprecated and shouldn't be used anyway. This will make the part list less cluttered.