### PR TITLE
Add :NEEDS to TAC-LS, TF, TU and fix numerous errors on load

### DIFF
--- a/GameData/RealismOverhaul/Parts/WACCorporal/TinyTim/TinyTim.cfg
+++ b/GameData/RealismOverhaul/Parts/WACCorporal/TinyTim/TinyTim.cfg
@@ -401,12 +401,12 @@ KSP_MODEL_SHADER:NEEDS[TexturesUnlimited]
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TexturesUnlimited]
 	{
 		name = TUPartVariant
 	}
 
-	MODULE
+	MODULE:NEEDS[TexturesUnlimited]
 	{
 		name = SSTURecolorGUI
 	}

--- a/GameData/RealismOverhaul/REWORK/RO_AerojetKerbodyne.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_AerojetKerbodyne.cfg
@@ -98,7 +98,7 @@
 			newsize = 4
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = FuelCell
@@ -438,7 +438,7 @@
 			newsize = 5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = FuelCell

--- a/GameData/RealismOverhaul/REWORK/RO_TaurusHCV.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_TaurusHCV.cfg
@@ -228,7 +228,7 @@
 			maxAmount = 886.4
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOXBreathing

--- a/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -557,7 +557,7 @@
 		}
 	}
 }
-+PART[FuelCell]:FOR[zzzRealismOverhaul]
++PART[FuelCell]:NEEDS[TacLifeSupport]:FOR[zzzRealismOverhaul]
 {
   %RSSROConfig = True
 	@name = RO_TACLO2ToO2

--- a/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/TACLS/RO_TACLS_Tanks.cfg
@@ -1,4 +1,4 @@
-@PART[TacLifeSupportMFTContainer]:FOR[RealismOverhaul]
+@PART[TacLifeSupportMFTContainer]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODULE[ModuleFuelTanks]
@@ -14,7 +14,7 @@
 		defaultScale = 1.25
 	}
 }
-@PART[TacLifeSupportMFTContainerLarge]:FOR[RealismOverhaul]
+@PART[TacLifeSupportMFTContainerLarge]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODULE[ModuleFuelTanks]
@@ -30,7 +30,7 @@
 		defaultScale = 2.5
 	}
 }
-@PART[TacLifeSupportMFTContainerSmall]:FOR[RealismOverhaul]
+@PART[TacLifeSupportMFTContainerSmall]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODULE[ModuleFuelTanks]
@@ -46,7 +46,7 @@
 		defaultScale = 0.625
 	}
 }
-@PART[HexCanMFTLifeSupportLarge]:FOR[RealismOverhaul]
+@PART[HexCanMFTLifeSupportLarge]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@description = Large hex tank that can be resized to fit your needs.
@@ -56,7 +56,7 @@
 		@type = LifeSupportAll
 	}
 }
-@PART[HexCanMFTLifeSupport]:FOR[RealismOverhaul]
+@PART[HexCanMFTLifeSupport]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@description = Standard hex tank that can be resized to fit your needs.
@@ -66,7 +66,7 @@
 		@type = LifeSupportAll
 	}
 }
-@PART[HexCanMFTLifeSupportSmall]:FOR[RealismOverhaul]
+@PART[HexCanMFTLifeSupportSmall]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@description = Small hex tank that can be resized to fit your needs.
@@ -76,7 +76,7 @@
 		@type = LifeSupportAll
 	}
 }
-@PART[TacAirFilter]:FOR[RealismOverhaul]
+@PART[TacAirFilter]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -112,7 +112,7 @@
 		}
 	}
 }
-@PART[TacCarbonExtractor]:FOR[RealismOverhaul]
+@PART[TacCarbonExtractor]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -272,7 +272,7 @@
 		@maxAmount = 31.5
 	}
 }
-@PART[TacCarbonExtractorLarge]:FOR[RealismOverhaul]
+@PART[TacCarbonExtractorLarge]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -324,7 +324,7 @@
 	{
 	}
 }
-@PART[TacSabatierRecycler]:FOR[RealismOverhaul]
+@PART[TacSabatierRecycler]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -375,7 +375,7 @@
 	{
 	}
 }
-@PART[TacSabatierRecyclerLarge]:FOR[RealismOverhaul]
+@PART[TacSabatierRecyclerLarge]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -427,7 +427,7 @@
 	{
 	}
 }
-@PART[TacWaterPurifier]:FOR[RealismOverhaul]
+@PART[TacWaterPurifier]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -471,7 +471,7 @@
 	{
 	}
 }
-@PART[TacWaterPurifierLarge]:FOR[RealismOverhaul]
+@PART[TacWaterPurifierLarge]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE
@@ -516,7 +516,7 @@
 	{
 	}
 }
-@PART[TacWaterSplitter]:FOR[RealismOverhaul]
+@PART[TacWaterSplitter]:NEEDS[TacLifeSupport]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Command.cfg
@@ -216,7 +216,7 @@
 	!RESOURCE[MonoPropellant]
 	{
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -515,7 +515,7 @@
 		amount = 280
 		maxAmount = 280
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BahamutoD/Mk2LightningCockpit.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BahamutoD/Mk2LightningCockpit.cfg
@@ -74,7 +74,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_N1.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/BobCat/RO_BobCat_N1.cfg
@@ -630,7 +630,7 @@
 	!MODULE[ModuleGenerator]
 	{}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Fuel Cell
@@ -1443,7 +1443,7 @@
 		maxAmount = 200
 	}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/CSS_Mike_NZ.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/CSS_Mike_NZ.cfg
@@ -376,7 +376,7 @@
 	key = 1 100
 	}
   }
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 	name = TacGenericConverter
 	converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
@@ -250,7 +250,7 @@
 	flowState = False
 	}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 	name = TacGenericConverter
 	converterName = FuelCell
@@ -385,7 +385,7 @@
 	  maxAmount = 689.36
 	  }
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 	name = TacGenericConverter
 	converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CST/RO_CST_Command.cfg
@@ -287,7 +287,7 @@
         }
     }
 
-    MODULE
+    MODULE:NEEDS[TacLifeSupport]
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/SLS/RO_SLS_ORION.cfg
@@ -190,7 +190,7 @@
 		}
 	}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -343,7 +343,7 @@
 		}
 	}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -310,7 +310,7 @@
 			maxAmount = 206.8
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber
@@ -624,7 +624,7 @@
 	!MODULE[ModuleGenerator]
 	{
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 1
@@ -656,7 +656,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 2
@@ -688,7 +688,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 3
@@ -720,7 +720,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_BigG.cfg
@@ -183,7 +183,7 @@
 			maxAmount = 101
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber
@@ -371,7 +371,7 @@
 			maxAmount = 144
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -681,7 +681,7 @@
 			maxAmount = 10
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Fuel Cell
@@ -713,7 +713,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Gemini_Pod.cfg
@@ -378,7 +378,7 @@
 			maxAmount = 29	// 14 days
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber
@@ -760,7 +760,7 @@
 			maxAmount = 762048
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell
@@ -792,7 +792,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_LEM.cfg
@@ -246,7 +246,7 @@
 			maxAmount = 6.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
@@ -100,7 +100,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber
@@ -443,7 +443,7 @@
 			}
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell
@@ -475,7 +475,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_MOLScience.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_MOLScience.cfg
@@ -99,7 +99,7 @@
 			maxAmount = 45
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Mercury_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Mercury_Pod.cfg
@@ -289,7 +289,7 @@
 			key = 1 57
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Other.cfg
@@ -594,7 +594,7 @@
 			maxAmount = 762048
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Fuel Cell
@@ -635,7 +635,7 @@
 			DumpExcess = True
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/JFJohnny/RO_K2_Command_Pod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/JFJohnny/RO_K2_Command_Pod.cfg
@@ -456,7 +456,7 @@
         }
     }
 
-    MODULE
+    MODULE:NEEDS[TacLifeSupport]
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
@@ -96,7 +96,7 @@
 			maxAmount = 131.7
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -143,7 +143,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2
@@ -270,7 +270,7 @@
 			maxAmount = 43.9
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -317,7 +317,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2
@@ -439,7 +439,7 @@
 			maxAmount = 43.9
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -486,7 +486,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_ALCOR.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ASET_ALCOR.cfg
@@ -119,7 +119,7 @@
 			maxAmount = 60
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
@@ -354,7 +354,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -482,7 +482,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -610,7 +610,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -746,7 +746,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -893,7 +893,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1037,7 +1037,7 @@
 			maxAmount = 4.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1160,7 +1160,7 @@
 			maxAmount = 3.0
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1359,7 +1359,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1472,7 +1472,7 @@
 			maxAmount = 3.0
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1585,7 +1585,7 @@
 			maxAmount = 4.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1699,7 +1699,7 @@
 			maxAmount = 9.0
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_ISS.cfg
@@ -178,7 +178,7 @@
 			maxAmount = 1000
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Filter
@@ -225,7 +225,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Oxygen Generator (Electrolysis)
@@ -747,7 +747,7 @@
 			maxAmount = 10000
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Oxygen Generator (Electrolysis)
@@ -1215,7 +1215,7 @@
 			maxAmount = 1200
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Filter
@@ -1262,7 +1262,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Water Recycling System

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_PorkWorks_HabitatPack.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_PorkWorks_HabitatPack.cfg
@@ -82,7 +82,7 @@ MODULE
 			maxAmount = 9
 		}
 	}
-MODULE
+MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -235,7 +235,7 @@ MODULE
 			maxAmount = 13.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -369,7 +369,7 @@ MODULE
 			maxAmount = 27
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -508,7 +508,7 @@ MODULE
 			maxAmount = 81
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -642,7 +642,7 @@ MODULE
 			maxAmount = 14
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -783,7 +783,7 @@ MODULE
 			maxAmount = 14
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -921,7 +921,7 @@ MODULE
 			maxAmount = 7
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Skylab.cfg
@@ -138,7 +138,7 @@
 			}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Extractor

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Vostok_Voskhod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Vostok_Voskhod.cfg
@@ -673,7 +673,7 @@
 		maxAmount = 225
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1043,7 +1043,7 @@
 		maxAmount = 225
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_UtilityPods.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_UtilityPods.cfg
@@ -63,7 +63,7 @@
 		}
 	}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SCA_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SCA_Soyuz.cfg
@@ -402,7 +402,7 @@
 			maxAmount = 3.4		// 30 days
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{	// Russian system combines Potassium Superoxide system with Lithium Hydroxide https://en.wikipedia.org/wiki/Soyuz_(spacecraft)
 		name = TacGenericConverter
 		converterName = Atmosphere Regenerator

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SCB_Apollo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SSTU/SSTU_SCB_Apollo.cfg
@@ -400,7 +400,7 @@
 			maxAmount = 206.8
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -619,7 +619,7 @@
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -793,7 +793,7 @@
 	!MODULE[ModuleSAS]{}
 	!MODULE[ModuleCommand]{}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 1
@@ -826,7 +826,7 @@
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 2
@@ -859,7 +859,7 @@
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 3
@@ -892,7 +892,7 @@
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_LEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_LEM.cfg
@@ -122,7 +122,7 @@
 			maxAmount = 6.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -114,7 +114,7 @@
 		}
     }
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -291,7 +291,7 @@
 		}
     }
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -461,7 +461,7 @@
 		}
     }
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -647,7 +647,7 @@
 		}
     }
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2-O2 Converter
@@ -838,7 +838,7 @@
 		}
     }
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1003,7 +1003,7 @@
 		}
     }
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2-O2 Converter

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -170,7 +170,7 @@
 	}
 	MODEL
 	{
-		model = Squad/Parts/FuelTank/fuelTankJumbo-64/model
+		model = Squad/Parts/FuelTank/RockomaxTanks/Assets/Rockomax64
 		scale = 2.131015, 2.131015, 2.131015
 		position = 0.0, 11.66249483, 0.0
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Science.cfg
@@ -102,7 +102,7 @@
 			maxAmount = 90
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -551,7 +551,7 @@
 			maxAmount = 3.0
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1063,7 +1063,7 @@
 			maxAmount = 12.0
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -185,7 +185,7 @@
 	!MODEL {}
 	MODEL
 	{
-		model = Squad/Parts/Utility/linearRCS/model
+		model = Squad/Parts/Utility/linearVernorRCS/Assets/linearRCS
 		scale:NEEDS[!VenStockRevamp] = 1.28, 1.28, 1.28
 		scale:NEEDS[VenStockRevamp] = 1.41, 1.41, 1.41
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Command.cfg
@@ -87,7 +87,7 @@
 			maxAmount = 29	// 14 days
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber
@@ -329,7 +329,7 @@
 		maxAmount = 225
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -534,7 +534,7 @@
 		maxAmount = 225
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares.cfg
@@ -76,7 +76,7 @@
 			maxAmount = 31.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Gemini.cfg
@@ -232,7 +232,7 @@
 			maxAmount = 29
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -433,7 +433,7 @@
 		}
 	} 
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = Fuel Cell
@@ -474,7 +474,7 @@
 			DumpExcess = True
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2
@@ -654,7 +654,7 @@
 			maxAmount = 63
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -360,7 +360,7 @@
 			maxAmount = 31.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -475,7 +475,7 @@
 			maxAmount = 31.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
@@ -106,7 +106,7 @@
 			maxAmount = 10000
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -264,7 +264,7 @@
 			maxAmount = 1.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -399,7 +399,7 @@
 			maxAmount = 31.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -915,7 +915,7 @@
 			maxAmount = 0.75
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1046,7 +1046,7 @@
 			maxAmount = 31.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Vostok.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Vostok.cfg
@@ -178,7 +178,7 @@
 		maxAmount = 225
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -388,7 +388,7 @@
 		maxAmount = 225
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/TokamakIndustries/RO_Tokamak_Industries_Habitat.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/TokamakIndustries/RO_Tokamak_Industries_Habitat.cfg
@@ -84,7 +84,7 @@
 			maxAmount = 9
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -232,7 +232,7 @@ MODULE
 			maxAmount = 13.5
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -371,7 +371,7 @@ MODULE
 			maxAmount = 27
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -511,7 +511,7 @@ MODULE
 	// 		maxAmount = 81
 	// 	}
 	// }
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -645,7 +645,7 @@ MODULE
 			maxAmount = 14
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -789,7 +789,7 @@ MODULE
 			maxAmount = 14
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -927,7 +927,7 @@ MODULE
 			maxAmount = 7
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/UniversalStorage/RO_UniversalStorage.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/UniversalStorage/RO_UniversalStorage.cfg
@@ -17,7 +17,7 @@
 	{
 	}
 	@mass = 0.04
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LH2-H2
@@ -45,7 +45,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2
@@ -80,7 +80,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LH2-H2
@@ -108,7 +108,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2
@@ -143,7 +143,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LH2-H2
@@ -171,7 +171,7 @@
 			DumpExcess = False
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = LOX-O2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Crew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Crew.cfg
@@ -74,7 +74,7 @@
 			maxAmount = 0.75
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -216,8 +216,8 @@
 			maxAmount = 2.25
 		}
 	}
-	!MODULE[TacGenericConverter] {}
-	MODULE
+	!MODULE[TacGenericConverter]:NEEDS[TacLifeSupport] {}
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -348,7 +348,7 @@
 			maxAmount = 34
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
@@ -221,7 +221,7 @@
 
 @PART[MK2VApod]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
-    MODULE
+    MODULE:NEEDS[TacLifeSupport]
     {
         name = TacGenericConverter
         converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VostokVoskhod/RO_SF_Vostok_Voskhod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VostokVoskhod/RO_SF_Vostok_Voskhod.cfg
@@ -128,7 +128,7 @@
 		amount = 444
 		maxAmount = 444
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -700,7 +700,7 @@
 			maxAmount = 30
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/WildBlueIndustries/RO_WildBlueIndustries_Buffalo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/WildBlueIndustries/RO_WildBlueIndustries_Buffalo.cfg
@@ -159,7 +159,7 @@
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber
@@ -1040,7 +1040,7 @@ description = This sturdy chassis is designed to support a variety of components
 		@chargeRate = 0.64512 // Level 3 @ 0.18kW/m^2
 	}
 
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -1,10 +1,10 @@
 // Handle TF interop
-@PART[*]:HAS[@TESTFLIGHT[*],@MODULE[TestFlightInterop]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*],@MODULE[TestFlightInterop]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	!TESTFLIGHT,* {} // something else is configuring TF, so don't do it.
 }
 
-@PART[*]:HAS[@TESTFLIGHT[*],!MODULE[TestFlightInterop]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*],!MODULE[TestFlightInterop]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -13,7 +13,7 @@
 }
 
 // Preprocess
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	@TESTFLIGHT,*:HAS[~name[]]
 	{
@@ -127,7 +127,7 @@
 }
 
 // Create the nodes.
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -391,7 +391,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -655,7 +655,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -919,7 +919,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -1183,7 +1183,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -1447,7 +1447,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -1711,7 +1711,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -1975,7 +1975,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -2239,7 +2239,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{
@@ -2503,7 +2503,7 @@
 	
 	!TESTFLIGHT,0 {} // remove the node we processed
 }
-@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite]
+@PART[*]:HAS[@TESTFLIGHT[*]]:FOR[zTestFlight]:NEEDS[!TestLite,TestFlight]
 {
 	MODULE
 	{


### PR DESCRIPTION
While those weren't giving explicit errors, the log was full of `Cannot find a PartModule of typename 'TacGenericConverter'` when playing with Kerbalism instead of TACLS. This fixes that and some additional errors.