### PR TITLE
Fix rated burn times for STAR 27 and STAR 31

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
@@ -492,7 +492,7 @@
 	TESTFLIGHT
 	{
 		name = Star-27
-		ratedBurnTime = 18
+		ratedBurnTime = 41
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
@@ -259,7 +259,7 @@
 	TESTFLIGHT
 	{
 		name = Star-31
-		ratedBurnTime = 40
+		ratedBurnTime = 51
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.90


### PR DESCRIPTION
Kirk's addition of TestFlight configuration to the ATK Propulsion Pack STAR motors left the STAR 27 and STAR 31 unable to finish burning without going over their rated burn time. This PR sets their burn times to durations just over their actual firing times.