### PR TITLE
seperAte, not seperEte

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -488,7 +488,7 @@
 
 	@title = Procedural Tank (Separate Structure)
 	@manufacturer = Generic
-	@description = Seperate structure tanks do not have load bearing tanks. This makes them cheaper to produce but they are heavier than other types of tank.
+	@description = Separate structure tanks do not have load bearing tanks. This makes them cheaper to produce but they are heavier than other types of tank.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -486,7 +486,7 @@
 	@name = RO-RFTank-Seperate
 	%RSSROConfig = True
 
-	@title = Procedural Tank (Seperate Structure)
+	@title = Procedural Tank (Separate Structure)
 	@manufacturer = Generic
 	@description = Seperate structure tanks do not have load bearing tanks. This makes them cheaper to produce but they are heavier than other types of tank.
 


### PR DESCRIPTION
Fixes a typo in a part title & description. Does not fix the same typo in the part name, as that would break things.