### PR TITLE
Sounding Rocket SRM Tuning

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/18KS7800_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/18KS7800_Config.cfg
@@ -1,0 +1,104 @@
+//	===============================================================
+//	**Aerojet (1.8KS7800)**
+//	===============================================================
+//	Aerobee 300A 3rd Stage
+//	Length: 57.6 in = 1.46304 m
+//	Diameter: 8 in = 0.2032 m
+//	Thrust: 7,664 lb vac
+//	Burn Time: 1.73s
+//	ISP: 238.8 vac
+//	Propellant Flow: 32.09 lb/s
+//	Nozzle Throat: 4.43 in
+//	Nozzle Exit: 133 in
+//	Nozzle Ratio: 30
+//	Mass: 60 lb
+//	Propellant Mass: 60 lb
+//
+//	www.rasaero.com: The Aerobee 100, 150, and 300 Series Sounding Rockets
+//	===============================================================
+@PART[*]:HAS[#engineType[18KS7800]]:FOR[RealismOverhaulEngines]
+{
+	%title = Aerojet 2.5KS18000
+	%manufacturer = Aerojet
+	%description = Small, solid fueled booster, taken from the AIM-7 Sparrow missile. It was used as the third stage on the Aerobee 300 and Aerobee 300A sounding rockets.
+	
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = SolidBooster
+		%allowShutdown = False
+		%throttleLocked = True
+	}
+	
+	!MODULE[ModuleGimbal] {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 17.01	// 27.21552 kg
+		type = NGNC
+		basemass = -1
+		TANK
+		{
+			name = NGNC
+			amount = 17.01
+			maxAmount = 17.01
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 2_5KS18000
+		origMass = 0.117934
+		
+		CONFIG
+		{
+			name = 2_5KS18000
+			minThrust = 34.09116
+			maxThrust = 34.09116
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = False
+			pressureFed = False
+			ignitions = 1
+			
+			
+			PROPELLANT
+			{
+				name = NGNC
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 238.8  // ISP: 238.8 @ Vac
+				key = 1 200 // Guess
+			}
+			
+			curveResource = NGNC
+			
+			chamberNominalTemp	= 1500
+			maxEngineTemp = 2040
+			
+			//Too early for true dual mode motors, but probably had a longer tailoff to help maintain control
+			thrustCurve
+			{
+				key = 1.00 0.90
+				key = 0.99 0.95
+				key = 0.96 1.0
+				key = 0.92 0.999
+				key = 0.89 0.998
+				key = 0.63 0.960
+				key = 0.37 0.780
+				key = 0.10 0.250
+				key = 0.00 0.040
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/25KS18000_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/25KS18000_Config.cfg
@@ -1,0 +1,100 @@
+//	===============================================================
+//	**Aerojet X103C10 (2.5KS18000)**
+//	===============================================================
+//	Length: 1.728216 m
+//	Diameter: 0.34 m
+//	Thrust: 18,000 lbf
+//	Burn Time: 2.5s
+//	ISP: 178.8s
+//	Mass: 520 lb
+//	Dry Mass: 260 lb
+//	Fins: 28 lb
+//
+//	www.rasaero.com: The Aerobee 100, 150, and 300 Series Sounding Rockets
+//	===============================================================
+@PART[*]:HAS[#engineType[25KS18000]]:FOR[RealismOverhaulEngines]
+{
+	%title = Aerojet 2.5KS18000
+	%manufacturer = Aerojet
+	%description = Small, but powerful solid fueled booster used as the first stage for the Aerobee line of Sounding Rockets.
+	
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = SolidBooster
+		%allowShutdown = False
+		%throttleLocked = True
+	}
+	
+	!MODULE[ModuleGimbal] {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 73.71	// 117.934 kg
+		type = NGNC
+		basemass = -1
+		TANK
+		{
+			name = NGNC
+			amount = 73.71
+			maxAmount = 73.71
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 2_5KS18000
+		origMass = 0.117934
+		
+		CONFIG
+		{
+			name = 2_5KS18000
+			minThrust = 88.06796
+			maxThrust = 88.06796
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = False
+			pressureFed = False
+			ignitions = 1
+			
+			
+			PROPELLANT
+			{
+				name = NGNC
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 198.8 // Guess
+				key = 1 178.8
+			}
+			
+			curveResource = NGNC
+			
+			chamberNominalTemp	= 1500
+			maxEngineTemp = 2040
+			
+			//Same as Tiny Tim, can't find any data
+			thrustCurve
+			{
+				key = 1.00 0.90
+				key = 0.99 0.95
+				key = 0.96 1.0
+				key = 0.92 0.999
+				key = 0.89 0.998
+				key = 0.63 0.960
+				key = 0.37 0.810
+				key = 0.10 0.314
+				key = 0.00 0.03
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/TinyTim_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TinyTim_Config.cfg
@@ -1,0 +1,147 @@
+//	===============================================================
+//	**Tiny Tim**
+//	===============================================================
+//	Length: 5 ft
+//	Diameter: 12 in
+//	Mass: 546 lb
+//	Dry Mass: 400 lb
+//	Thrust: 50,000 lb
+//	Burn Time: 6s
+//	ISP: 202
+//	Exhaust Velocity: 4,425 mph
+//
+//	Development of the Corporal: The Embryo of the Army Missile Program: https://apps.dtic.mil/dtic/tr/fulltext/u2/a434478.pdf
+//	Research and Development at The Jet Propulsion Laboratory, GALCIT (1946).PDF
+//	===============================================================
+@PART[*]:HAS[#engineType[TinyTim]]:FOR[RealismOverhaulEngines]
+{
+	%title = Tiny Tim Booster
+	%manufacturer = CalTech
+	%description = Small solid fueled booster originally used to power anti-shipping missiles during WW2. Used as the kick stage on the WAC Corporal, the USA's first sounding rocket, and reused in modified form for the Aerobee line of sounding rockets.
+	
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = SolidBooster
+		%allowShutdown = False
+		%throttleLocked = True
+	}
+	
+	!MODULE[ModuleGimbal] {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 41.3903  // 66.2245 kg
+		type = NGNC
+		basemass = -1
+		TANK
+		{
+			name = NGNC
+			amount = 41.3903
+			maxAmount = 41.3903
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 30Klbf
+		origMass = 0.181437 // Updated from new primary sources -> Old Value: 277kg dry, minus three fins at 3kg each
+		
+		CONFIG
+		{
+			name = 30Klbf
+			description = 30 Klbf (133.4 kN) peak thrust version used by the military and some WAC launches.
+			minThrust = 146.6
+			maxThrust = 146.6
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = False
+			pressureFed = False
+			ignitions = 1
+			
+			
+			PROPELLANT
+			{
+				name = NGNC
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 222	 // Guess
+				key = 1 202	 // ISP: 202 @ SL
+			}
+			
+			curveResource = NGNC
+			
+			chamberNominalTemp	= 1500
+			maxEngineTemp = 2040
+			
+			thrustCurve
+			{
+				key = 1.00 0.90
+				key = 0.99 0.95
+				key = 0.96 1.0
+				key = 0.92 0.999
+				key = 0.89 0.998
+				key = 0.63 0.960
+				key = 0.37 0.810
+				key = 0.10 0.314
+				key = 0.00 0.03
+			}
+		}
+		
+		CONFIG
+		{
+			name = 50Klbf
+			description = 50 Klbf (222.4 kN) peak thrust version used by later WAC launches.
+			minThrust = 244.4
+			maxThrust = 244.4
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = False
+			pressureFed = False
+			ignitions = 1
+			
+			
+			PROPELLANT
+			{
+				name = NGNC
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 222	 // Guess
+				key = 1 202	 // ISP: 202 @ SL
+			}
+			
+			curveResource = NGNC
+			
+			chamberNominalTemp	= 1500
+			maxEngineTemp = 2040
+			
+			thrustCurve
+			{
+				key = 1.00 0.90
+				key = 0.99 0.95
+				key = 0.96 1.0
+				key = 0.92 0.999
+				key = 0.89 0.998
+				key = 0.63 0.960
+				key = 0.37 0.810
+				key = 0.10 0.314
+				key = 0.00 0.03
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Parts/WACCorporal/TinyTim/TinyTim.cfg
+++ b/GameData/RealismOverhaul/Parts/WACCorporal/TinyTim/TinyTim.cfg
@@ -98,36 +98,19 @@ PART
 	breakingForce = 10000
 	breakingTorque = 10000
 	stagingIcon = SOLID_BOOSTER
-
+	
+	engineType = TinyTim
+	
 	MODULE
 	{
 		name = ModuleEnginesRF
 		thrustVectorTransformName = thrustTransform
-		engineID = TinyTim
-		throttleLocked = True
-		exhaustDamage = True
-		ignitionThreshold = 0.1
-		minThrust = 222.41
-		maxThrust = 222.41  // Thrust: 50,000 lb @ SL
-		heatProduction = 300
-		useEngineResponseTime = True
-		engineAccelerationSpeed = 8.0
+		
+		EngineType = SolidBooster
 		allowShutdown = False
-
-		PROPELLANT
-		{
-			name = SolidFuel
-			ratio = 1.0
-			DrawGauge = True
-		}
-
-		atmosphereCurve
-		{
-			key = 0 222  // Guess
-			key = 1 202  // ISP: 202 @ SL
-		}
+		throttleLocked = True
 	}
-
+	
 	MODULE
 	{
 		name = FXModuleAnimateThrottle
@@ -135,14 +118,6 @@ PART
 		responseSpeed = 0.001
 		dependOnEngineState = True
 		dependOnThrottle = True
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 37.20506  // 66.2245 kg
-		type = Solid
-		basemass = -1
 	}
 
 	MODULE
@@ -177,7 +152,7 @@ PART
 	MODEL:NEEDS[VenStockRevamp]
 	{
 		model = VenStockRevamp/Part Bin/NewParts/NewSolidBoosters/RT1
-    	// Dimensions 0.67164, 1.73286, 0.67164
+		// Dimensions 0.67164, 1.73286, 0.67164
 		scale = 0.5062, 0.9973, 0.5062
 	}
 }
@@ -207,23 +182,8 @@ PART
 
 	@mass = 0.117934
 
-	@MODULE[ModuleEnginesRF]
-	{
-		@engineID = Aerojet25KS18000
-		@minThrust = 88.06796
-		@maxThrust = 88.06796
-
-		@atmosphereCurve
-		{
-			@key,0 = 0 198.8  // Guess
-			@key,1 = 1 178.8  // ISP: 202 @ SL
-		}
-	}
-
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 66.2550562  // 117.934 kg
-	}  
+	@engineType = 25KS18000
+	
 }
 
 //	==================================================================================
@@ -281,23 +241,7 @@ PART
 
 	@mass = 0.027216
 
-	@MODULE[ModuleEnginesRF]
-	{
-		@engineID = Aerojet18KS7800
-		@minThrust = 34.09116
-		@maxThrust = 34.09116
-
-		@atmosphereCurve
-		{
-			@key,0 = 0 238.8  // ISP: 238.8 @ Vac
-			@key,1 = 1 200  // Guess
-		}
-	}
-
-	@MODULE[ModuleFuelTanks]
-	{
-		@volume = 15.2898876  // 27.21552 kg
-	}
+	@engineType = 18KS7800
 }
 
 //  ==================================================


### PR DESCRIPTION
Makes improvements to the Tiny Tim, Aerojet 2.5KS18000 and Aerojet 1.8KS7800 based off analysis of historical footage from Tiny Tim launches from aircraft, and early WAC-Corporal testing. The Tiny Tim now has a thrust curve based off of cross pattern propellant loading. The majority of the impulse still occurs during the rated burn time, however, the engine burns out much more gently and continues generating a low level of thrust for a while longer. Configurations for both the original 30Klbf thrust and the modified 50Klbf thrust Tiny Tim has also been added.

The Aerojet 2.5KS18000 has also been given the same thrust curve as the Tiny Tim, while the Aerojet 1.8KS7800 has been given a thrust curve with a longer tailoff, similar to dual thrust SRMs used on modern missiles, since it was the motor from the AIM-7 Sparrow.

The Configs for the Tiny Tim, Aerojet 2.5KS18000 and Aerojet 1.8KS7800 have also been moved to global configs to allow other mods to use them more easily.