### PR TITLE
Restore original ejection force on payload bases

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -109,7 +109,7 @@
 	%MODULE[ModuleDecouple]
 	{
 		%name = ModuleDecouple
-		%ejectionForce = 0
+		%ejectionForcePercent = 0
 		%explosiveNodeID = top
 		%stagingEnabled = True
 	}


### PR DESCRIPTION
Instead set ejectionForcePercent to default to 0%.  This way if the player wants to have some ejection force, they can by increasing the percentage in the PAW, but by default, the behaviour will be as before.

**NOTE**: While this does not break existing craft, those crafts would most likely have been saved with 100% ejection force, so in most cases, the player will want to set that to 0% manually before using the craft,

Fixes #2254 
