### PR TITLE
Fix issue with KSPWheel when VSR is installed, lower steering response

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
@@ -7,7 +7,7 @@
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -40,6 +40,7 @@
 		steeringName = SteeringPivot
 		maxSteeringAngle = 25
 		steeringAxis = 0, 1, 0
+		steeringResponse = 0.1
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
@@ -7,7 +7,7 @@
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDeployment]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -40,6 +40,7 @@
 		steeringName = SteeringPivot
 		maxSteeringAngle = 25
 		steeringAxis = 0, 1, 0
+		steeringResponse = 0.2
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedMicro.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedMicro.cfg
@@ -5,7 +5,7 @@
 	-MODULE[ModuleWheelSuspension]{}
 	-MODULE[ModuleWheelSteering]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 	
 	MODULE
 	{
@@ -37,6 +37,7 @@
 		steeringName = SteeringPivot
 		maxSteeringAngle = 20
 		steeringAxis = 0, 1, 0
+		steeringResponse = 0.24
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-large.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-large.cfg
@@ -7,7 +7,7 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 		
 	MODULE
 	{
@@ -42,6 +42,7 @@
 		steeringName = SteeringPivot
 		maxSteeringAngle = 30
 		steeringAxis = 0, 1, 0
+		steeringResponse = 0.15
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-medium.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-medium.cfg
@@ -9,7 +9,7 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 
 	MODULE
 	{
@@ -43,6 +43,7 @@
 		steeringName = SteeringPivot
 		maxSteeringAngle = 30
 		steeringAxis = 0, 1, 0
+		steeringResponse = 0.25
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
@@ -7,7 +7,7 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 
 	MODULE
 	{
@@ -78,7 +78,7 @@
 	-MODULE[ModuleWheelMotor]{}
 	-MODULE[ModuleWheelBrakes]{}
 	-MODULE[ModuleWheelDamage]{}
-        -MODULE[TweakScale]{}
+	-MODULE[TweakScale]{}
 
 	MODULE
 	{
@@ -93,7 +93,7 @@
 		maxLoadRating = 1
 		maxSpeed = 11.5
 		groundHeightOffset = 0.175
-        boundsColliderName = collider
+		boundsColliderName = collider
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
@@ -1,5 +1,5 @@
 //roverWheelS2 - the probe wheels
-@PART[roverWheel2]:NEEDS[KSPWheel]:FOR[RealismOverhaul]
+@PART[roverWheel2]:NEEDS[KSPWheel&!VenStockRevamp]:FOR[RealismOverhaul]
 {
 	-MODULE[ModuleWheelBase]{}
 	-MODULE[ModuleWheelSuspension]{}
@@ -42,12 +42,84 @@
 		steeringName = SteeringPivot
 		maxSteeringAngle = 40
 		steeringAxis = 0, 1, 0
-		steeringResponse = 10
+		steeringResponse = 0.15
 	}
 	MODULE
 	{
 		name = KSPWheelMotor
-		maxMotorTorque = 1.23
+		maxMotorTorque = 0.3
+		maxRPM = 650
+	}
+	MODULE
+	{
+		name = KSPWheelBrakes
+		maxBrakeTorque = 2
+	}
+	MODULE
+	{
+		name = KSPWheelDamage
+		wheelName = wheel
+		bustedWheelName = bustedwheel
+	}
+	MODULE
+	{
+		name = KSPWheelDustEffects
+	}
+	MODULE
+	{
+		name = KSPWheelSounds
+	}
+}
+@PART[roverWheel2]:NEEDS[KSPWheel&VenStockRevamp]:FOR[RealismOverhaul]
+{
+	-MODULE[ModuleWheelBase]{}
+	-MODULE[ModuleWheelSuspension]{}
+	-MODULE[ModuleWheelSteering]{}
+	-MODULE[ModuleWheelMotor]{}
+	-MODULE[ModuleWheelBrakes]{}
+	-MODULE[ModuleWheelDamage]{}
+        -MODULE[TweakScale]{}
+
+	MODULE
+	{
+		name = KSPWheelBase
+		wheelColliderName = WheelCollider
+		wheelColliderOffset = 0.1939
+		wheelRadius = 0.1575
+		wheelMass = 0.030
+		suspensionTravel = 0.15
+		loadRating = 0.1
+		minLoadRating = 0.01
+		maxLoadRating = 1
+		maxSpeed = 11.5
+		groundHeightOffset = 0.175
+        boundsColliderName = collider
+	}
+	MODULE
+	{
+		name = KSPWheelRotation
+		wheelMeshName = WheelPivot
+		rotationAxis = 1,0,0
+	}
+	MODULE
+	{
+		name = KSPWheelSuspension
+		suspensionName = SuspensionPivot
+		suspensionOffset = -0.18
+		suspensionAxis = 0, 1, 0
+	}
+	MODULE
+	{
+		name = KSPWheelSteering
+		steeringName = SteeringPivot
+		maxSteeringAngle = 40
+		steeringAxis = 0, 1, 0
+		steeringResponse = 0.15
+	}
+	MODULE
+	{
+		name = KSPWheelMotor
+		maxMotorTorque = 0.3
 		maxRPM = 650
 	}
 	MODULE


### PR DESCRIPTION
This fixes an issue with Vens Stock Revamp, where the smallest rover wheels were breaking instantly. This was caused by a collider on the VSR side, which blocked the KSPWheel collider. Along with that fix, the torque of said rover wheel is lowered to be inline with the other ones, and the steering response for all wheels is lowered to a sensible level.