### PR TITLE
Add power consupmtion to NSTAR Ion Engine

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NSTAR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NSTAR_Config.cfg
@@ -46,6 +46,12 @@
 				ratio = 1.0
 				DrawGauge = True
 			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4130
+				DrawGauge = True
+			}
 
 			atmosphereCurve
 			{


### PR DESCRIPTION
Consumes 2.3 KW/second, data from NASA documentation listed in the config. This is my first ever pull request, tell me if something's wrong, this stuff is complicated.