### PR TITLE
Ion engine and NFP configs rework

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NSTAR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NSTAR_Config.cfg
@@ -47,6 +47,14 @@
 				DrawGauge = True
 			}
 
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4121.09
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
 			atmosphereCurve
 			{
 				key = 0 3100

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Engines.cfg
@@ -1,74 +1,47 @@
-//NEEDS SERIOUS WORK
-//ROGER WILCO
-@PART[ionArgon-125]:FOR[RealismOverhaul]
+@PART[ionArgon-0625]:FOR[RealismOverhaul]
 {
-	//Gyro-Quad Lensed Hall Thruster
-	//http://www.umich.edu/~peplweb/pdf/IEPC-2007-177.pdf
-	%RSSROConfig = Test
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	@mass = 0.6314
-	@title = NASA 457M Hall Thruster[x4] [Test]
-	@description = Testing shows that clustering engines increases performance, further detaching the plume from the spacecraft. Tested in a laboratory, a cluster of 4 NASA 457Ms pushed the top end thrust density to about 57mN/kW, a substantial improvement.  This of course comes with a power cost, requiring 4 times as much power. (288kW) NOTE: This engine is based on a test article and theoretical predictions. 
-	!MODULE[ElectricEngineThrustLimiter]
-	{
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 0.0019864
-		%maxThrust = 0.01701977
-		@heatProduction = 0	
-		!PROPELLANT[ElectricCharge]
-		{
-		}
-		!PROPELLANT[ArgonGas]
-		{
-		}
-		%PROPELLANT[XenonGas]
-		{
-			%ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 2740
-			key = 1 1
-		}
-	}
+	// HERMeS is a 12.5 kW Hall thruster
+	// http://erps.spacegrant.org/uploads/images/2015Presentations/IEPC-2015-186_ISTS-2015-b-186.pdf
+	// https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170001283.pdf
+	// 6.25kW to 12.5kW (13.3 with loss)
+	// 600mN (0.0006kN) max
+	// 2820s
+	// Weight ?
+	// Xenon
+	// 2.1711e-5 kg/s (~22 mg/s, 3.6835e-3 L/s) fuel flow max
+	%RSSROConfig = True
+
+	@title = HERMeS 12.5 kW Hall thruster
+	@manufacturer = Aerojet Rocketdyne
+	@description = The Hall Effect Rocket with Magnetic Shielding (HERMeS) is a 12.5 kW Hall thruster being co-developed by NASA Glenn Research Center and the Jet Propulsion Laboratory. Mass/power ratio: 1.6 kg/kW
+	@mass = 0.02
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		type = ModuleEnginesFX
 		modded = false
-		configuration = NASA-457M-V1-X4
+		configuration = HERMeS
 		CONFIG
 		{
-			name = NASA-457M-V1-X4
-			minThrust = 0.001340
-			maxThrust = 0.0147456
+			name = HERMeS
+			runningEffectName = run_hallm_core
+			powerEffectName = run_hallm_plume
+			thrustVectorTransformName = thrustTransform
+			exhaustDamage = False
+			ignitionThreshold = 0.1
+			minThrust = 0.0003
+			maxThrust = 0.0006
 			heatProduction = 0
 			PROPELLANT
 			{
-				name = KryptonGas
-				ratio = 1.0
+				name = ElectricCharge
+				ratio = 3394.0
+				minResToLeave = 10.0
 				DrawGauge = True
 			}
-			atmosphereCurve
-			{
-				key = 0 3520
-				key = 1 1
-			}
-		}
-		CONFIG
-		{
-			name = NASA-457M-V2-X4
-			minThrust = 0.0019864
-			maxThrust = 0.01701977
-			heatProduction = 0
 			PROPELLANT
 			{
 				name = XenonGas
@@ -77,56 +50,9 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 2740
+				key = 0 2820
 				key = 1 1
 			}
-		}
-	}
-	MODULE
-	{
-		name = ModuleAlternator
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = -288.0
-		}
-	}
-}
-@PART[ionArgon-0625]:FOR[RealismOverhaul]
-{
-	//HERMeS is a 12.5 kW Hall thruster
-	//http://erps.spacegrant.org/uploads/images/2015Presentations/IEPC-2015-186_ISTS-2015-b-186.pdf
-	//https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170001283.pdf
-	//6.25kW to 12.5kW (13.3 with loss)
-	//600mN (0.0006kN) max
-	//2820s
-	//Weight ?
-	//Xenon
-	//2.1711e-5 kg/s (~22 mg/s, 3.6835e-3 L/s) fuel flow max
-	%RSSROConfig = True
-	@mass = 0.02
-	@title = HERMeS 12.5 kW Hall thruster
-	@manufacturer = Aerojet Rocketdyne
-	@description = The Hall Effect Rocket with Magnetic Shielding (HERMeS) is a 12.5 kW Hall thruster being co-developed by NASA Glenn Research Center and the Jet Propulsion Laboratory. 
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 0.0003
-		@maxThrust = 0.0006
-		@heatProduction = 0	
-		@PROPELLANT[ElectricCharge]
-		{
-			@ratio = 3394
-			@minResToLeave = 10.0
-		}
-		@PROPELLANT[ArgonGas]
-		{
-			@name = XenonGas
-			@ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 2820
-			@key,1 = 1 28
 		}
 	}
 	MODULE
@@ -141,44 +67,17 @@
 
 @PART[ionArgon-0625-2]:FOR[RealismOverhaul]
 {
-	//Gyro-Two Lensed Hall Thruster
-	//http://pepl.engin.umich.edu/pdf/IEPC-2011-246.pdf
-	//http://www.umich.edu/~peplweb/pdf/IEPC-01-036_P5-2.pdf
+	// Gyro-Two Lensed Hall Thruster
+	// https://deepblue.lib.umich.edu/bitstream/handle/2027.42/76806/AIAA-2004-3767-604.pdf;sequence=1
 	%RSSROConfig = True
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	@mass = 0.154
-	@title = P5 Hall Thruster
-	@description = Developed jointly by the AFRL and PEPL, the P5 is a dual-stage hall thruster. This means it can more effectively lens the charged ions, giving you more bang for your space-buck!
-	!MODULE[TweakScale]
-	{
-	}
-	!MODULE[ElectricEngineThrustLimiter]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 0.000011
-		%maxThrust = 0.000239
-		@heatProduction = 0	
-		!PROPELLANT[ElectricCharge]
-		{
-		}
-		!PROPELLANT[ArgonGas]
-		{
-		}
-		%PROPELLANT[XenonGas]
-		{
-			%ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 2390
-			key = 1 1
-		}
-	}
+
+	@title = P5 5kW Hall Thruster
+	@description = Developed jointly by the AFRL and PEPL, the P5 is a dual-stage hall thruster. This means it can more effectively lens the charged ions, giving you increased thrust above single-stage operation at the expense of efficiency. Mass/power ratio: 3.08 kg/kW
+	@mass = 0.0154
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -187,9 +86,21 @@
 		CONFIG
 		{
 			name = P5-1
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_hallm1in
+			runningEffectName = run_hallm1
+			exhaustDamage = False
+			ignitionThreshold = 0.1
 			minThrust = 0.000011
 			maxThrust = 0.000239
 			heatProduction = 0
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 3453.58
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
 			PROPELLANT
 			{
 				name = XenonGas
@@ -205,9 +116,21 @@
 		CONFIG
 		{
 			name = P5-2
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_hallm1in
+			runningEffectName = run_hallm1
+			exhaustDamage = False
+			ignitionThreshold = 0.1
 			minThrust = 0.000012
 			maxThrust = 0.000245
 			heatProduction = 0
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 3453.58
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
 			PROPELLANT
 			{
 				name = XenonGas
@@ -221,101 +144,309 @@
 			}
 		}
 	}
-	MODULE
-	{
-		name = ModuleAlternator
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = -5
-		}
-	}
 }
-@PART[ionXenon-125]:FOR[RealismOverhaul]
+
++PART[ionArgon-0625-2]:FOR[RealismOverhaul]
 {
-	//Two-Cluster NEXT Ion Engine
-	//S-IE Twin Ion Engine
+	// NASA-457M Hall Effect Thruster
+	// source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20020090939.pdf
 	%RSSROConfig = True
-	@mass = 0.040
-	@title = NEXT Ion Thruster [x2]
-	@manufacturer = Aerojet Rocketdyne
-	@description = The NASA Evolutionary Xenon Thruster project at NASA GRC produced quite a little marvel.  Certified for flight use, and currently planned for several outer-solar system missions, the efficiency of the Ion thruster greatly increased the payload weight, at the expense of burn time. Hope you've got time on your hands! Oh, and about 6.9kW of electricity (13.8kW for two).
-	@MODULE[ModuleEngines*]
+	@name = RO-457M
+
+	@title = NASA 457M 72kW Hall Thruster
+	@description = This thruster is a 50 kW-class thruster whose development was initiated in 2000 for the NASA Space Solar Power Concept and Technology Maturation Program to enable space solar power systems and other high power spacecraft. A laboratory model version of this high power thruster was fabricated and tested with xenon in 2002 at power levels up to 72 kW with 650V. Mass/power ratio: 2.19 kg/kW
+	@mass = 0.158
+	
+	!MODEL {}
+	!mesh = DELETE
+	MODEL
 	{
-		@minThrust = 0.000040
-		@maxThrust = 0.000472
-		@heatProduction = 0	
-		@PROPELLANT[ElectricCharge]
-		{
-			@ratio = 7076
-			@minResToLeave = 10.0
-		}
-		@PROPELLANT[XenonGas]
-		{
-			@ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 4190
-			@key,1 = 1 41
-		}
+		model = NearFuturePropulsion/Parts/Engines/ionArgon-0625/ionArgon-0625-2
+		scale = 0.7312, 0.7312, 0.7312
 	}
-	MODULE
-	{
-		name = ModuleGimbal
-		gimbalTransformName = thrustTransform
-		gimbalRange = 7
- 		gimbalResponseSpeed = 2
- 		useGimbalResponseSpeed = true
-	}
-}
-@PART[ionXenon-25]:FOR[RealismOverhaul]
-{
-	//Represents cluster of HiPEP engines, see single HiPEP engine below.
-	//Clustered HI-SNAP Ion Thruster
-	%RSSROConfig = True
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	@mass = 2.2516
-	@title = HiPEP Ion Thruster [x12] [Test]
-	@description = The High Power Electric Propulsion unit, designed and tested at NASA Glenn Research Center.  Due to low thrust, they clustered 12 of them to get more thrust! Still doesn't push all that hard. Requires about 471.6kW of electricity. NOTE: This engine is a lab test article, and has not flown.
-	!MODULE[ElectricEngineThrustLimiter]
-	{
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 0.002880
-		%maxThrust = 0.008040
-		@heatProduction = 0	
-		!PROPELLANT[ElectricCharge]
-		{
-		}
-		@PROPELLANT[XenonGas]
-		{
-			@ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 9620
-			key = 1 1
-		}
-	}
+	
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
 	MODULE
 	{
 		name = ModuleEngineConfigs
+		type = ModuleEnginesFX
 		modded = false
-		configuration = HiPEP
+		origMass = 0.158
+		configuration = NASA-457M-V1
 		CONFIG
 		{
-			name = HiPEP
-			minThrust = 0.000240
-			maxThrust = 0.000670
+			name = NASA-457M-V1
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_hallm1in
+			runningEffectName = run_hallm1
+			exhaustDamage = False
+			ignitionThreshold = 0.1
+			minThrust = 0.000398
+			maxThrust = 0.002950
+			heatProduction = 0 // efficiency 0.58
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4063.1333754
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 2929
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			// source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040008600.pdf
+			name = NASA-457M-V1-K
+			description =  Modified 457M thruster with a krypton propellant, keeping the voltage at 650V. Even higher specific impulse due to lower molecular weight of the gas.
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_hallm1in
+			runningEffectName = run_hallm1
+			exhaustDamage = False
+			ignitionThreshold = 0.1
+			minThrust = 0.000622
+			maxThrust = 0.002473
+			heatProduction = 0 // efficiency 0.58
+			PROPELLANT
+			{
+				name = KryptonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4041.574
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 3817
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			// source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120014613.pdf
+			name = NASA-457M-V2
+			description =  The successful test campaign with the laboratory model NASA-457M led to the development of a higher fidelity version of this thruster, labeled the NASA-457M v2.
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_hallm1in
+			runningEffectName = run_hallm1
+			exhaustDamage = False
+			ignitionThreshold = 0.1
+			minThrust = 0.000400
+			maxThrust = 0.0019864
+			heatProduction = 18500 // efficiency 0.63
+			massMult = 0.75
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 3968.25
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 2740
+				key = 1 1
+			}
+		}
+	}
+}
+
+@PART[ionArgon-0625-3]:FOR[RealismOverhaul]
+{
+	// NASA X3 Hall Effect Thruster
+	// source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20190001137.pdf
+	%RSSROConfig = True
+
+	@title = NASA X-3 100kW Hall Thruster
+	@description = This 3-channel thruster was designed for operation up to 250 kW of discharge power at specific impulses ranging from 1800–3500 seconds on xenon propellant and up to 5000 seconds on krypton, all with state of the art total efficiencies in excess of 60%. Mass/power ratio: 2.3 kg/kW
+	@mass = 0.23
+
+	!MODEL {}
+	!mesh = DELETE
+	MODEL
+	{
+		model = NearFuturePropulsion/Parts/Engines/ionArgon-0625/ionArgon-0625-3
+		scale = 1.28, 1.28, 1.28
+	}
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesFX
+		modded = false
+		origMass = 0.23
+		configuration = NASA-X3
+		CONFIG
+		{
+			name = NASA-X3
+			description =  Lab-tested version of the X3 thruster.
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_halla1in
+			runningEffectName = run_halla1
+			exhaustDamage = False
+			minThrust = 0.00039
+			maxThrust = 0.00542
+			heatProduction = 35.6 // efficiency 0.63
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 2486.240575
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 2340
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			name = NASA-X3-HV
+			description =  Uprated X3 thruster operated at 800V and 200kW.
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_halla1in
+			runningEffectName = run_halla1
+			exhaustDamage = False
+			minThrust = 0.002
+			maxThrust = 0.008
+			heatProduction = 74000 // efficiency 0.63
+			massMult = 1.087 // 250 kg
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 5043.08433
+				minResToLeave = 10.0
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 3490
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			name = NASA-X3-K
+			description =  X3 variant using Krypton for increased Isp, at the expense of thrust.
+			thrustVectorTransformName = thrustTransform
+			powerEffectName = run_halla1in
+			runningEffectName = run_halla1
+			exhaustDamage = False
+			minThrust = 0.0016
+			maxThrust = 0.0064
+			heatProduction = 80000 // efficiency 0.6
+			massMult = 1.087 // 250 kg
+			PROPELLANT
+			{
+				name = KryptonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 5043.08433
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 4370
+				key = 1 1
+			}
+		}
+	}
+}
+
+@PART[ionXenon-0625]:FOR[RealismOverhaul]
+{
+	// NEXT Ion Thruster
+	// https://www.grc.nasa.gov/WWW/ion/pdfdocs/AIAA-2007-5856.pdf
+	// 50 cm (0.5m) (36cm beam width)
+	// 0.575kW to 6.9kW (based on input power throttle)
+	// 236mN (0.000236kN)
+	// 4190s max
+	// 12.4kg (+6 kg gimbal assembly)
+	// Xenon
+	// 5.7474e-6 kg/s (9.7513e-4 L/s) fuel flow max
+	%RSSROConfig = True
+
+	@title = NEXT Ion Thruster
+	@manufacturer = Aerojet Rocketdyne
+	@description = The NASA Evolutionary Xenon Thruster project at NASA GRC produced quite a little marvel.  Certified for flight use, and currently planned for several outer-solar system missions, the efficiency of the Ion thruster greatly increased the payload weight, at the expense of burn time. Hope you've got time on your hands! Oh, and about 6.9kW of electricity. Mass/power ratio: 2.67 kg/kW
+	@mass = 0.0184
+
+	!MODEL {}
+	!mesh = DELETE
+	MODEL
+	{
+		model = NearFuturePropulsion/Parts/Engines/ionXenon-0625/ionXenon-0625-1
+	}
+	%rescale = 0.8
+	%rescaleFactor = 0.8
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesFX
+		modded = false
+		configuration = NEXT
+		CONFIG
+		{
+			name = NEXT
+			minThrust = 0.000020
+			maxThrust = 0.000236
 			heatProduction = 0
+			runningEffectName = run_next
+			thrustVectorTransformName = thrustTransform
+			exhaustDamage = False
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 8355.34
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
 			PROPELLANT
 			{
 				name = XenonGas
@@ -324,56 +455,9 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 9620
+				key = 0 4190
 				key = 1 1
 			}
-		}
-	}
-	MODULE
-	{
-		name = ModuleAlternator
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = -471.6
-		}
-	}
-}
-@PART[ionXenon-0625]:FOR[RealismOverhaul]
-{
-	//AFTER Ion Thruster - Represents NEXT Ion Thruster
-	//AFTER = NEXT
-	//https://www.grc.nasa.gov/WWW/ion/pdfdocs/AIAA-2007-5856.pdf
-	//50 cm (0.5m) (36cm beam width)
-	//0.575kW to 6.9kW (based on input power throttle)
-	//236mN (0.000236kN)
-	//4190s max
-	//12.4kg (+6 kg gimbal assembly)
-	//Xenon
-	//5.7474e-6 kg/s (9.7513e-4 L/s) fuel flow max
-	%RSSROConfig = True
-	@mass = 0.02
-	@title = NEXT Ion Thruster
-	@manufacturer = Aerojet Rocketdyne
-	@description = The NASA Evolutionary Xenon Thruster project at NASA GRC produced quite a little marvel.  Certified for flight use, and currently planned for several outer-solar system missions, the efficiency of the Ion thruster greatly increased the payload weight, at the expense of burn time. Hope you've got time on your hands! Oh, and about 6.9kW of electricity
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 0.000020
-		@maxThrust = 0.000236
-		@heatProduction = 0	
-		@PROPELLANT[ElectricCharge]
-		{
-			@ratio = 7076
-			@minResToLeave = 10.0
-		}
-		@PROPELLANT[XenonGas]
-		{
-			@ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 4190
-			@key,1 = 1 41
 		}
 	}
 	MODULE
@@ -387,54 +471,30 @@
 }
 @PART[ionXenon-0625-2]:FOR[RealismOverhaul]
 {
-	//HiPEP Ion Thruster
-	//HI-SNAP = HiPEP
-	//http://www.grc.nasa.gov/WWW/ion/present/hipep.htm
-	//http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040139476.pdf
-	//41x91cm
-	//kW	mN	Isp
-	//9.7	240	5970
-	//15.9	340	7020
-	//20.2	410	7500
-	//24.4	460	8270
-	//29.6	540	8900
-	//34.6	600	9150
-	//39.3	670	9620
-	//Scaling to max values
-	//120kg
+	// HiPEP Ion Thruster
+	// http://www.grc.nasa.gov/WWW/ion/present/hipep.htm
+	// http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040139476.pdf
+	// 41x91cm
+	// kW	mN	Isp
+	// 9.7	240	5970
+	// 15.9	340	7020
+	// 20.2	410	7500
+	// 24.4	460	8270
+	// 29.6	540	8900
+	// 34.6	600	9150
+	// 39.3	670	9620
+	// Scaling to max values
+	// 120 kg
 
 	%RSSROConfig = Test
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	@mass = 0.227
+
 	@title = HiPEP Ion Thruster [Test]
-	@description = The High Power Electric Propulsion unit, designed and tested at NASA Glenn Research Center, can produce significantly more thrust than its smaller cousin.  But not that much more.  Requires about 39.3kW of electricity.
-	!MODULE[ElectricEngineThrustLimiter]
-	{
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 0.000240
-		%maxThrust = 0.000670
-		@heatProduction = 0	
-		!PROPELLANT[ElectricCharge]
-		{
-		}
-		@PROPELLANT[XenonGas]
-		{
-			@ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 9620
-			key = 1 1
-		}
-	}
+	@description = The High Power Electric Propulsion unit, designed and tested at NASA Glenn Research Center, can produce significantly more thrust than its smaller cousin.  But not that much more.  Requires about 39.3kW of electricity. Mass/power ratio: 3.05 kg/kW
+	@mass = 0.120
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -447,6 +507,16 @@
 			minThrust = 0.000240
 			maxThrust = 0.000670
 			heatProduction = 0
+			runningEffectName = run_hipep
+			thrustVectorTransformName = thrustTransform
+			exhaustDamage = False
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 31217.66
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
 			PROPELLANT
 			{
 				name = XenonGas
@@ -460,15 +530,6 @@
 			}
 		}
 	}
-	MODULE
-	{
-		name = ModuleAlternator
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = -39.3
-		}
-	}
 }
 @PART[ionXenon-0625-3]:FOR[RealismOverhaul]
 {
@@ -478,43 +539,23 @@
 	//http://erps.spacegrant.org/uploads/images/images/iepc_articledownload_1988-2007/2009index/IEPC-2009-157.pdf
 	//http://www.alta-space.com/hiper/publications/SP2010_1852027.pdf
 	%RSSROConfig = Test
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	@mass = 0.147
+
 	@title = DS4G Ion Thruster [Test]
-	@description = The Dual Stage 4 Grid Ion Thruster was developed primarily by the European Space Agency for a variety of future deep space missions.  This version is their most robust design, designed for deep space missions. Requires 50kW of electrical power.  NOTE: This engine is based on technical design and test articles.
-	!MODULE[ElectricEngineThrustLimiter]
-	{
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 0.000217
-		%maxThrust = 0.00138
-		@heatProduction = 0	
-		!PROPELLANT[ElectricCharge]
-		{
-		}
-		@PROPELLANT[XenonGas]
-		{
-			@ratio = 1.0
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 6100
-			key = 1 1
-		}
-	}
+	@description = The Dual Stage 4 Grid Ion Thruster was developed primarily by the European Space Agency for a variety of future deep space missions.  This version is their most robust design, designed for deep space missions. Requires 50kW of electrical power.  NOTE: This engine is based on technical design and test articles. Mass/power ratio: 2.94 kg/kW
+	@mass = 0.147
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[ModuleEngineConfigs],* {}
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesFX
 		modded = false
 		configuration = DS4G Xenon
+		runningEffectName = run_ds4g
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = False
 		CONFIG
 		{
 			name = DS4G Xenon
@@ -527,6 +568,13 @@
 				ratio = 1.0
 				DrawGauge = True
 			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 12592.23
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
 			atmosphereCurve
 			{
 				key = 0 6100
@@ -534,194 +582,9 @@
 			}
 		}
 	}
-	MODULE
-	{
-		name = ModuleAlternator
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = -50.0
-		}
-	}
 }
-@PART[mpdt-25]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Theoretical
-	@title ^= :Magnetoplasmadynamic Thruster:MPDT
-	@title ^= :$: [Theoretical]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@PROPELLANT[LiquidHydrogen]
-		{
-			@name = Hydrogen
-		}
-		@maxThrust *=0.001
-	}
-}
-@PART[mpdt-125]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Theoretical
-	@title ^= :Magnetoplasmadynamic Thruster:MPDT
-	@title ^= :$: [Theoretical]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@PROPELLANT[LiquidHydrogen]
-		{
-			@name = Hydrogen
-		}
-		@maxThrust *=0.001
-	}
-}
-@PART[mpdt-0625]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Theoretical
-	@title ^= :Magnetoplasmadynamic Thruster:MPDT
-	@title ^= :$: [Theoretical]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@PROPELLANT[LiquidHydrogen]
-		{
-			@name = Hydrogen
-		}
-		@maxThrust *=0.001
-	}
-}
-@PART[pit-25]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Theoretical
-	@title ^= :$: [Theoretical]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust *=0.001
-	}
-}
-@PART[pit-125]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Theoretical
-	@title ^= :$: [Theoretical]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust *=0.001
-	}
-}
-@PART[pit-0625]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Theoretical
-	@title ^= :$: [Theoretical]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust *=0.001
-	}
-}
-@PART[vasimr-25]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Extrapolated
-	@title ^= :$: [Extrapolated]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEnginesFX],0
-	{
-		@maxThrust = 0.190
-	}
-	@MODULE[ModuleEnginesFX],1
-	{
-		@maxThrust = 0.133
-		@PROPELLANT[LiquidHydrogen]
-		{
-			@name = Hydrogen
-		}
-	}
-	@MODULE[VariableISPEngine]
-	{
-		%Mode1Propellant = ArgonGas
-		%Mode1ThrustMin = 0.070
-		%Mode1ThrustMax = 0.190
-		%Mode2Propellant = Hydrogen
-		%Mode2ThrustMin = 0.0416
-		%Mode2ThrustMax = 0.133
-	}
-}
+
 @PART[vasimr-125]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = Extrapolated
-	@title ^= :$: [Extrapolated]
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	!MODULE[TweakScale]
-	{
-	}
-	@MODULE[ModuleEnginesFX],0
-	{
-		@maxThrust = 0.0342
-	}
-	@MODULE[ModuleEnginesFX],1
-	{
-		@maxThrust = 0.0288
-		@PROPELLANT[LiquidHydrogen]
-		{
-			@name = Hydrogen
-		}
-	}
-	@MODULE[VariableISPEngine]
-	{
-		%Mode1Propellant = ArgonGas
-		%Mode1ThrustMin = 0.0192
-		%Mode1ThrustMax = 0.0342
-		%Mode2Propellant = Hydrogen
-		%Mode2ThrustMin = 0.0115
-		%Mode2ThrustMax = 0.0288
-	}
-}
-@PART[vasimr-0625]:FOR[RealismOverhaul]
 {
 	//VASIMR VX-100 Lab Article
 	//http://www.adastrarocket.com/AdAstra-Release-July-27-2012-English.pdf
@@ -729,33 +592,167 @@
 	//Based on validations of the 100kW article, single thruster config
 	//Interestingly enough, these stats are pretty doggone close to the real deal, only need to adjust the thrust.
 	%RSSROConfig = Test
-	@title ^= :$: [Test]
-	@description = Based on the Ad Astra lab test article built to test the configuration to be flown on the ISS, the VASIMR engine is far more powerful than any other ion engine to this point. It will require about 100kW of power. NOTE: This is a lab test article, flight hardware may differ from this device.
-	!MODULE[TweakScale]
+	%title = VASIMR VF-200
+	%manufacturer = Ad Astra
+	%description = Based on the Ad Astra lab test article built to test the configuration to be flown on the ISS, the VASIMR engine is far more powerful than any other ion engine to this point. It will require about 200kW of power. Mass/power ratio: 2.5 kg/kW
+	@mass = 0.5
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[VariableISPEngine] {}
+	!MODULE[MultiModeEngine] {}
+	!MODULE[ModuleEngineConfigs],* {}
+	!MODULE[ModuleEnginesFX],* {}
+	MODULE
 	{
-	}
-	%MODULE[WarpableEngine]
-	{
-		%name = WarpableEngine
-	}
-	@MODULE[ModuleEnginesFX],0
-	{
-		@maxThrust = 0.0044
-		@atmosphereCurve
+		name = ModuleEnginesFX
+		runningEffectName = run_vasimr_argon_core
+		powerEffectName= run_vasimr_argon_glow
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = True
+		maxThrust = 0.006
+		heatProduction = 0
+		PROPELLANT
 		{
-			@key = 0 6000
+			name = ArgonGas
+			ratio = 1.0
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = ElectricCharge
+			ratio = 2915.844
+			DrawGauge = True
+			minResToLeave = 10.0
+		}
+		atmosphereCurve
+		{
+			key = 0 5000
+			key = 1 1
 		}
 	}
-	!MODULE[ModuleEnginesFX],1
+}
+@PART[vasimr-0625]:FOR[RealismOverhaul]
+{
+	// VASMIR VX-200
+	// http://www.adastrarocket.com/Ben-AIAA-2012-3930-JPC.pdf
+	%RSSROConfig = Test
+	@title = VASIMR VX-200SS
+	%manufacturer = Ad Astra
+	%description = First proper vasimr engine built by Ad Astra, the VX-200SS (Steady State) is built for long-term operation at a wide range of Isp and thrust, with multiple propellant options. Mass/power ratio: 2 kg/kW
+	@mass = 0.4
+
+	!MODEL {}
+	!mesh = DELETE
+	MODEL
 	{
+		model = NearFuturePropulsion/Parts/Engines/vasimr-0625/vasimr-0625
 	}
-	@MODULE[VariableISPEngine]
+	%scale = 1.5
+	%rescaleFactor = 1.5
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+	!MODULE[VariableISPEngine] {}
+	@MODULE[MultiModeEngine]
 	{
-		@ModeCount = 1
-		%Mode1Propellant = ArgonGas
-		%Mode1ThrustMin = 0.0035
-		%Mode1ThrustMax = 0.0044
-		%Mode1IspMin = 6000
-		%Mode1IspMax = 3500
+		@primaryEngineID = ArgonMode
+		@secondaryEngineID = KryptonMode
+		@primaryEngineModeDisplayName = Argon
+		@secondaryEngineModeDisplayName = Krypton
+	}
+	!MODULE[ModuleEngineConfigs],* {}
+	!MODULE[ModuleEnginesFX],* {}
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = ArgonMode
+		runningEffectName = run_vasimr_argon_core
+		powerEffectName= run_vasimr_argon_glow
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = True
+		maxThrust = 0.005
+		heatProduction = 0
+		ignitionThreshold = 0.1
+		EngineType = Electric
+		PROPELLANT
+		{
+			name = ArgonGas
+			ratio = 1.0
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = ElectricCharge
+			ratio = 4198.8143
+			DrawGauge = True
+			minResToLeave = 10.0
+		}
+		atmosphereCurve
+		{
+			key = 0 6000
+			key = 1 1
+		}
+	}
+	MODULE
+	{
+		name = ModuleEnginesFX
+		engineID = KryptonMode
+		runningEffectName = run_vasimr_xe_core
+		powerEffectName= run_vasimr_xe_glow
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = True
+		maxThrust = 0.007
+		heatProduction = 0
+		PROPELLANT
+		{
+			name = KryptonGas
+			ratio = 1.0
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = ElectricCharge
+			ratio = 4040.161
+			DrawGauge = True
+			minResToLeave = 10.0
+		}
+		atmosphereCurve
+		{
+			key = 0 3850
+			key = 1 1
+		}
+	}
+	MODULE
+	{
+		name = VariableISPEngine
+		EnergyUsage = 199.99
+		UseDirectThrottle = false
+		CurThrustSetting = 80
+
+		VARIABLEISPMODE
+		{
+			name = ArgonMode
+			IspThrustCurve
+			{
+				key = 1660 0.012
+				key = 2250 0.0096
+				key = 3000 0.008
+				key = 3600 0.007
+				key = 4500 0.006
+				key = 5000 0.0059
+				key = 6000 0.005
+			}
+		}
+		VARIABLEISPMODE
+		{
+			name = KryptonMode
+			IspThrustCurve // calculated the theoretical krypton efficiency curve in the source
+			{
+				key = 1000 0.017
+				key = 2000 0.00109
+				key = 3850 0.007
+			}
+		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Engines.cfg
@@ -600,18 +600,19 @@
 	!MODULE[TweakScale] {}
 	!EFFECTS[engage] {} // remove ignition sound effects
 	!MODULE[VariableISPEngine] {}
-	!MODULE[MultiModeEngine] {}
-	!MODULE[ModuleEngineConfigs],* {}
-	!MODULE[ModuleEnginesFX],* {}
-	MODULE
+	@MODULE[MultiModeEngine]
 	{
-		name = ModuleEnginesFX
-		runningEffectName = run_vasimr_argon_core
-		powerEffectName= run_vasimr_argon_glow
-		thrustVectorTransformName = thrustTransform
-		exhaustDamage = True
-		maxThrust = 0.006
-		heatProduction = 0
+		%primaryEngineID = ArgonMode
+		%primaryEngineModeDisplayName = Argon
+		%secondaryEngineID = KryptonMode
+		%secondaryEngineModeDisplayName = Krypton
+	}
+	!MODULE[ModuleEngineConfigs],* {}
+	@MODULE[ModuleEnginesFX]:HAS[#engineID[ArgonMode]]
+	{
+		%maxThrust = 0.006
+		%heatProduction = 0
+		!PROPELLANT,* {}
 		PROPELLANT
 		{
 			name = ArgonGas
@@ -625,9 +626,36 @@
 			DrawGauge = True
 			minResToLeave = 10.0
 		}
+		!atmosphereCurve {}
 		atmosphereCurve
 		{
 			key = 0 5000
+			key = 1 1
+		}
+	}
+	@MODULE[ModuleEnginesFX]:HAS[#engineID[XenonMode]]
+	{
+		%engineID = KryptonMode
+		%maxThrust = 0.0084
+		%heatProduction = 0
+		!PROPELLANT,* {}
+		PROPELLANT
+		{
+			name = KryptonGas
+			ratio = 1.0
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = ElectricCharge
+			ratio = 2805.66809
+			DrawGauge = True
+			minResToLeave = 10.0
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 3210
 			key = 1 1
 		}
 	}
@@ -656,25 +684,17 @@
 	!MODULE[VariableISPEngine] {}
 	@MODULE[MultiModeEngine]
 	{
-		@primaryEngineID = ArgonMode
-		@secondaryEngineID = KryptonMode
-		@primaryEngineModeDisplayName = Argon
-		@secondaryEngineModeDisplayName = Krypton
+		%primaryEngineID = ArgonMode
+		%primaryEngineModeDisplayName = Argon
+		%secondaryEngineID = KryptonMode
+		%secondaryEngineModeDisplayName = Krypton
 	}
 	!MODULE[ModuleEngineConfigs],* {}
-	!MODULE[ModuleEnginesFX],* {}
-	MODULE
+	@MODULE[ModuleEnginesFX]:HAS[#engineID[ArgonMode]]
 	{
-		name = ModuleEnginesFX
-		engineID = ArgonMode
-		runningEffectName = run_vasimr_argon_core
-		powerEffectName= run_vasimr_argon_glow
-		thrustVectorTransformName = thrustTransform
-		exhaustDamage = True
-		maxThrust = 0.005
-		heatProduction = 0
-		ignitionThreshold = 0.1
-		EngineType = Electric
+		%maxThrust = 0.005
+		%heatProduction = 0
+		!PROPELLANT,* {}
 		PROPELLANT
 		{
 			name = ArgonGas
@@ -688,22 +708,19 @@
 			DrawGauge = True
 			minResToLeave = 10.0
 		}
+		!atmosphereCurve {}
 		atmosphereCurve
 		{
 			key = 0 6000
 			key = 1 1
 		}
 	}
-	MODULE
+	@MODULE[ModuleEnginesFX]:HAS[#engineID[XenonMode]]
 	{
-		name = ModuleEnginesFX
-		engineID = KryptonMode
-		runningEffectName = run_vasimr_xe_core
-		powerEffectName= run_vasimr_xe_glow
-		thrustVectorTransformName = thrustTransform
-		exhaustDamage = True
-		maxThrust = 0.007
-		heatProduction = 0
+		%engineID = KryptonMode
+		%maxThrust = 0.007
+		%heatProduction = 0
+		!PROPELLANT,* {}
 		PROPELLANT
 		{
 			name = KryptonGas
@@ -717,42 +734,45 @@
 			DrawGauge = True
 			minResToLeave = 10.0
 		}
+		!atmosphereCurve {}
 		atmosphereCurve
 		{
 			key = 0 3850
 			key = 1 1
 		}
 	}
-	MODULE
-	{
-		name = VariableISPEngine
-		EnergyUsage = 199.99
-		UseDirectThrottle = false
-		CurThrustSetting = 80
+	// Disabled as VariableISPEngine doesn't work with ModuleRFengines (yet)
+	
+	// MODULE
+	// {
+	// 	name = VariableISPEngine
+	// 	EnergyUsage = 199.99
+	// 	UseDirectThrottle = false
+	// 	CurThrustSetting = 80
 
-		VARIABLEISPMODE
-		{
-			name = ArgonMode
-			IspThrustCurve
-			{
-				key = 1660 0.012
-				key = 2250 0.0096
-				key = 3000 0.008
-				key = 3600 0.007
-				key = 4500 0.006
-				key = 5000 0.0059
-				key = 6000 0.005
-			}
-		}
-		VARIABLEISPMODE
-		{
-			name = KryptonMode
-			IspThrustCurve // calculated the theoretical krypton efficiency curve in the source
-			{
-				key = 1000 0.017
-				key = 2000 0.00109
-				key = 3850 0.007
-			}
-		}
-	}
+	// 	VARIABLEISPMODE
+	// 	{
+	// 		name = ArgonMode
+	// 		IspThrustCurve
+	// 		{
+	// 			key = 1660 0.012
+	// 			key = 2250 0.0096
+	// 			key = 3000 0.008
+	// 			key = 3600 0.007
+	// 			key = 4500 0.006
+	// 			key = 5000 0.0059
+	// 			key = 6000 0.005
+	// 		}
+	// 	}
+	// 	VARIABLEISPMODE
+	// 	{
+	// 		name = KryptonMode
+	// 		IspThrustCurve // calculated the theoretical krypton efficiency curve in the source
+	// 		{
+	// 			key = 1000 0.017
+	// 			key = 2000 0.00109
+	// 			key = 3850 0.007
+	// 		}
+	// 	}
+	// }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Engines.cfg
@@ -623,7 +623,7 @@
 		{
 			name = ElectricCharge
 			ratio = 2915.844
-			DrawGauge = True
+			DrawGauge = False
 			minResToLeave = 10.0
 		}
 		!atmosphereCurve {}
@@ -649,7 +649,7 @@
 		{
 			name = ElectricCharge
 			ratio = 2805.66809
-			DrawGauge = True
+			DrawGauge = False
 			minResToLeave = 10.0
 		}
 		!atmosphereCurve {}
@@ -705,7 +705,7 @@
 		{
 			name = ElectricCharge
 			ratio = 4198.8143
-			DrawGauge = True
+			DrawGauge = False
 			minResToLeave = 10.0
 		}
 		!atmosphereCurve {}
@@ -731,7 +731,7 @@
 		{
 			name = ElectricCharge
 			ratio = 4040.161
-			DrawGauge = True
+			DrawGauge = False
 			minResToLeave = 10.0
 		}
 		!atmosphereCurve {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Propulsion_Tanks.cfg
@@ -6,9 +6,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -24,9 +23,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -42,9 +40,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -60,9 +57,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -78,9 +74,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -92,9 +87,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -106,9 +100,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[ArgonGas]
-	{
-	}
+	!RESOURCE[ArgonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -124,9 +117,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -142,9 +134,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -160,9 +151,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -174,9 +164,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -188,9 +177,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -202,9 +190,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -216,9 +203,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[LiquidHydrogen]
-	{
-	}
+	!RESOURCE[LiquidHydrogen] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -234,9 +220,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[XenonGas]
-	{
-	}
+	!RESOURCE[XenonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -252,9 +237,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[XenonGas]
-	{
-	}
+	!RESOURCE[XenonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -270,9 +254,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[XenonGas]
-	{
-	}
+	!RESOURCE[XenonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -288,9 +271,8 @@
 	{
 		@type = RealismOverhaulStackHollow
 	}
-	!RESOURCE[XenonGas]
-	{
-	}
+	!RESOURCE[XenonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -302,9 +284,8 @@
 {
 	%RSSROConfig = True
 	@attachRules = 0,1,0,1,0
-	!RESOURCE[XenonGas]
-	{
-	}
+	!RESOURCE[XenonGas] {}
+	!MODULE[ModuleFuelTanks],* {}
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -170,8 +170,6 @@
 		@maxThrust = 0.000092
 		@heatProduction = 0
 
-		!PROPELLANT[ElectricCharge]{}
-
 		@PROPELLANT[XenonGas]
 		{
 			@ratio = 1.0
@@ -185,16 +183,6 @@
 	}
 
 	!MODULE[ElectricEngineThrustLimiter]{}
-
-	MODULE
-	{
-		name = ModuleAlternator
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = -2.3
-		}
-	}
 }
 
 //  ==================================================


### PR DESCRIPTION
This is basically a complete remake of the old (and non-functional) NearFuturePropulsion configs, and how ion engines were treated in general.

I've removed the alternator from the NSTAR config in favor of having ElectricCharge as a propellant, since having a fixed power consumption didn't make much sense, and wasn't even working properly. (Warning: #2258 also does this, but doesn't remove the alternator module)


The same was made for all NFP configs, which I've remade with better numbers, more sources, more accurate model scaling, and updated everything to work with the latest version of NFP. I've also removed speculative configs, but added real (or very painfully extrapolated) configs for various new engines, from Hall thrusters to VASIMR.

Also fixes NFP tanks, but I have left the old mass figures, so no double check on those.