### PR TITLE
Add missing bracket

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -110,6 +110,7 @@
 			}
 		}
 	}
+}
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[ORM-65]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT


### PR DESCRIPTION
Add missing bracket to the ORM-65 config that was preventing the TF configs from functioning correctly.