### PR TITLE
Don't delete gimbals from S5.98M engine

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -40,7 +40,6 @@
         !thrustCurve,*{}
     }
 
-    !MODULE[ModuleGimbal],*{}
 
     !MODULE[ModuleEngineConfigs],*{}
 


### PR DESCRIPTION
This engine is historically installed in a gimbal suspension on the Briz-M upper stage. The NicheParts/ROEngines part model even details the whole gimbal suspension, so there is no reason to delete the gimbal module.