### PR TITLE
Better guesstimates for the Rutherford engines.

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -14,7 +14,8 @@
 		type = ModuleEngines
 		configuration = Rutherford-SL
 		modded = false
-		origMass = 0.016
+		origMass = 0.035
+		// from Wikipedia
 		CONFIG
 		{
 			name = Rutherford-SL
@@ -24,18 +25,31 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.4
+				ratio = 0.36
+				// no source, just a wild guess
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.6
+				ratio = 0.64
+				// no source, just a wild guess
 			}
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1
+				ratio = 5.73
+				// ConsumedElectricPower = 40 kW (wild guess)
+				// 
+				// ElectricCharge_ratio[J/L] =
+				//   ConsumedElectricPower[kW] *
+				//   (LqdOxygen_ratio * LqdOxygen_density[t/L] +
+				//     Kerosene_ratio * Kerosene_density[t/L]) *
+				//   g0[m/s^2] * Isp_vac[s] / maxThrust[kN]
+				// 
+				// LqdOxygen_density = 0.001141 t/L
+				// Kerosene_density = 0.00082 t/L
+				// g0 = 9.80665 m/s^2
 			}
 			atmosphereCurve
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -14,28 +14,42 @@
 		type = ModuleEngines
 		configuration = RutherfordVac
 		modded = false
-		origMass = 0.020
+		origMass = 0.040
+		// no source, but should be heavier than SL version
 		CONFIG
 		{
 			name = RutherfordVac
-			minThrust = 22.0
-			maxThrust = 22.24
+			minThrust = 23.74
+			maxThrust = 24.00
 			heatProduction = 90
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.4
+				ratio = 0.36
+				// no source, just a wild guess
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.6
+				ratio = 0.64
+				// no source, just a wild guess
 			}
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1
+				ratio = 5.73
+				// ConsumedElectricPower = 40 kW (wild guess)
+				// 
+				// ElectricCharge_ratio[J/L] =
+				//   ConsumedElectricPower[kW] *
+				//   (LqdOxygen_ratio * LqdOxygen_density[t/L] +
+				//     Kerosene_ratio * Kerosene_density[t/L]) *
+				//   g0[m/s^2] * Isp_vac[s] / maxThrust[kN]
+				// 
+				// LqdOxygen_density = 0.001141 t/L
+				// Kerosene_density = 0.00082 t/L
+				// g0 = 9.80665 m/s^2
 			}
 			atmosphereCurve
 			{


### PR DESCRIPTION
I suspect the current Rutherford engine’s stats to be way off. On the other hand, I haven’t found any exact numbers, all I have is guesstimates.

- Mass.
  All sources give the mass of 35 kg. It’s almost double the current value in the cfg. Someone made _lb_ to _kg_ conversion twice by mistake?
  I found nothing about the difference in mass between the SL and Vac versions.

- Thrust and Isp.
  Different sources give slightly different figures, possibly, because of different versions of the engine. I haven’t found, however, anything about particular versions, so I sticked to the stats in the current cfg.
  I only made the propellant consumption of the SL an Vac versions equal (by making thrust and Isp proportional) since it’s the same engine with different nozzles.

- Fuel/oxidizer ratio.
  The figures in the current configuration (Kerosene ratio = 0.4, LqdOxygen ratio = 0.6) do not look like precise ones and make Rutherford the most fuel-rich among kerolox engines which it probably isn’t.
  I changed the ratio a bit towards the optimum.

- Electric consumption.
  The current value (ratio = 1) gives 7.0 kW for Rutherford-LS and 6.5 kW for the vacuum version. This seems way too low.
  I didn’t manage to find the true values however.
  Wikipedia mentions  37 kW, the source of which is the following quote:
  > Each Rutherford engine has two electric motors the size of a soda can, Beck says, one for each propellant. The small motors generate 50 hp while spinning at 40,000 rpm, “not a trivial problem,” he says.
  
  Obviously, 50 hp is a ballpark estimate here, not an exact figure. So it can be 50 ± 10 hp or so. If I get it right, it’s the generated mechanical power. The consumed electric power will be a bit greater but, since the motor efficiency is about 90–95%, this won’t change much. Say, 40 ± 10 kW instead of 37 ± 10.
  The other question is whether it’s 40 kW per motor or per engine. It’s not quite clear from the quotation, at least for me.
  Some other figures that can be found in different sources are ≈1 MW power and about ≈200 kg mass of the Electron’s first stage battery block.
  40 kW per engine gives us only 360 kW for 9 engines of the first stage.
  40 kW per motor (720 kW for 9 engines) is closer to “1 MW”.
  9.25 t of propellant in the 1st stage result in 144 seconds of flight and 103.7 MJ of electric energy in the batteries. So, 200 kg batteries should have a specific energy of 518 kJ/kg which, I believe, is more or less OK for Li-Po cells.
  40 kW per engine, however gives a specific energy value much more close to one of the Procedural Batteries in KSP-RO which is 264 kJ/kg. This would allow a more close Electron replica. So I chose this variant.

What do you think?
Does anyone have any exact (or at least, more exact) figures?