### PR TITLE
Configure SRM fuel load

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ260FL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ260FL_Config.cfg
@@ -56,7 +56,7 @@
 		basemass = -1
 		TANK
 		{
-			name = HTPB
+			name = PBAN
 			amount = 842116
 			maxAmount = 842116
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/AJ260SL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ260SL_Config.cfg
@@ -65,7 +65,7 @@
 		basemass = -1
 		TANK
 		{
-			name = HTPB
+			name = PBAN
 			amount = 429112
 			maxAmount = 429112
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -38,6 +38,27 @@
 	!MODULE[ModuleGimbal],*{}
 
 	!MODULE[ModuleEngineConfigs],*{}
+	
+	!MODULE[ModuleAlternator],*{}
+
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = HTPB
+		volume = 24040
+		basemass = -1
+
+		//	HTPB/AP propellant mixture mass 42550 Kg.
+
+		TANK
+		{
+			name = HTPB
+			amount = 24040
+			maxAmount = 24040
+		}
+	}
 
 	MODULE
 	{
@@ -45,6 +66,7 @@
 		type = ModuleEngines
 		configuration = AJ-60A
 		modded = False
+		origMass = 3.95
 
 		CONFIG
 		{
@@ -284,10 +306,6 @@
 			}
 		}
 	}
-
-	!MODULE[ModuleAlternator],*{}
-
-	!RESOURCE,*{}
 }
 // No failures so far
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ60A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]

--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -40,6 +40,8 @@
 	!MODULE[ModuleEngineConfigs],*{}
 	
 	!MODULE[ModuleAlternator],*{}
+	
+	!MODULE[ModuleFuelTanks],* {}
 
 	!RESOURCE,*{}
 	

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
@@ -14,6 +14,31 @@
 		%throttleLocked = True
 	}
 	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+		@gimbalRange = 5.5
+	}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 27655
+		type = HTPB
+		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 27655
+			maxAmount = 27655
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -25,7 +50,7 @@
 		CONFIG
 		{
 			name = Castor-120
-	  minThrust = 1875
+			minThrust = 1875
 			maxThrust = 1875
 			heatProduction = 100
 			PROPELLANT
@@ -714,12 +739,6 @@
 				key =	0	0.0023
 			}
 		}
-	}
-	@MODULE[ModuleGimbal]
-	{
-		gimbalRange = 5.5
-		%useGimbalResponseSpeed = true
-		%gimbalResponseSpeed = 16
 	}
 }
 //Same as Castor-4A

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
@@ -13,12 +13,38 @@
 		%throttleLocked = True
 	}
 	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+		@gimbalRange = 3.5
+	}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7250
+		type = HTPB
+		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 7250
+			maxAmount = 7250
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-30A
 		modded = false
+		origMass = 1.224
 		CONFIG
 		{
 			name = Castor-30A

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
@@ -13,12 +13,38 @@
 		%throttleLocked = True
 	}
 	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+		@gimbalRange = 3.5
+	}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7250
+		type = HTPB
+		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 7250
+			maxAmount = 7250
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-30B
 		modded = false
+		origMass = 1.224
 		CONFIG
 		{
 			name = Castor-30B

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
@@ -13,12 +13,38 @@
 		%throttleLocked = True
 	}
 	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalResponseSpeed = 16
+		%useGimbalResponseSpeed = true
+		@gimbalRange = 3.5
+	}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12824.8
+		type = HTPB
+		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 12824.8
+			maxAmount = 12824.8
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-30XL
 		modded = false
+		origMass = 2.3
 		CONFIG
 		{
 			name = Castor-30XL

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
@@ -15,12 +15,34 @@
 		%throttleLocked = True
 	}
 	
+	!MODULE[ModuleGimbal],*{}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 13126.2
+		type = HTPB
+		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 13126.2
+			maxAmount = 13126.2
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-4AXL
 		modded = false
+		origMass = 1.723
+		
 		CONFIG
 		{
 			name = Castor-4AXL

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
@@ -13,12 +13,34 @@
 		%throttleLocked = True
 	}
 	
+	!MODULE[ModuleGimbal],*{}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5718
+		type = HTPB
+		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 5718
+			maxAmount = 5718
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-4A
 		modded = false
+		origMass = 1.457
+		
 		CONFIG
 		{
 			name = Castor-4A

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
@@ -14,12 +14,34 @@
 		%throttleLocked = True
 	}
 	
+	!MODULE[ModuleGimbal],*{}
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleFuelTanks],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5228.5
+		type = PBAN
+		basemass = -1
+		TANK
+		{
+			name = PBAN
+			amount = 5228.5
+			maxAmount = 5228.5
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Castor-4
 		modded = false
+		origMass = 1.269
+		
 		CONFIG
 		{
 			name = Castor-4

--- a/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
@@ -8,6 +8,7 @@
 	@description = The Graphite-Epoxy Motor (GEM) replaced the steel case used on earlier Castor-series boosters with a lighter composite case. The 40-inch (1-meter) diameter GEM 40 was used on the Delta II 7000-series in sets of three, four, or nine. When nine boosters were used, six were ignited at liftoff and the remaining three were ignited after burnout and jettison of the first six. Burn time: 58 seconds.
 	
 	!RESOURCE,*{}
+	!MODULE[ModuleFuelTanks],*{}
 	
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
@@ -10,6 +10,7 @@
 	
 	!MODULE[ModuleAlternator],*{}
 	!RESOURCE,*{}
+	!MODULE[ModuleFuelTanks],*{}
 	
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
@@ -14,12 +14,35 @@
 		%throttleLocked = True
 	}
 	
+	!MODULE[ModuleEngineConfigs],*{}
+	
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+	
+	!MODULE[ModuleFuelTanks],*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = HTPB
+		volume = 27118
+		basemass = -1
+		
+		TANK
+		{
+			name = HTPB
+			amount = 27118
+			maxAmount = 27118
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = GEM-63XL
 		modded = false
+		origMass = 5.4
 		CONFIG
 		{
 			name = GEM-63XL

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
@@ -14,12 +14,36 @@
 		%throttleLocked = True
 	}
 	
+	!MODULE[ModuleEngineConfigs],*{}
+	
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+	
+	!MODULE[ModuleFuelTanks],*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = HTPB
+		volume = 24971
+		basemass = -1
+		
+		TANK
+		{
+			name = HTPB
+			amount = 24971
+			maxAmount = 24971
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = GEM-63
 		modded = false
+		origMass = 5.1
+		
 		CONFIG
 		{
 			name = GEM-63

--- a/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
@@ -16,11 +16,39 @@
 		%throttleLocked = True
 	}
 	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 8.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+	
+	!RESOURCE,*{}
+	!MODULE[ModuleFuelTanks],*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = PBAN
+		volume = 365485
+		basemass = -1
+
+		//	PBAN/AP propellant mixture mass 647640 Kg.
+
+		TANK
+		{
+			name = PBAN
+			amount = 365485
+			maxAmount = 365485
+		}
+	}
+	
 	MODULE
 	{
 		name = ModuleEngineConfigs	
 		configuration = RSRMV
 		modded = false
+		origMass = 85.5
 		CONFIG
 		{
 			name = RSRMV

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -37,6 +37,26 @@
 		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
 	}
+	
+	!RESOURCE,*{}
+	!MODULE[ModuleFuelTanks],*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = PBAN
+		volume = 283446
+		basemass = -1
+
+		//	PBAN/AP propellant mixture mass 501700 Kg.
+
+		TANK
+		{
+			name = PBAN
+			amount = 283126
+			maxAmount = 283126
+		}
+	}
 
 	MODULE
 	{
@@ -44,6 +64,7 @@
 		type = ModuleEngines
 		configuration = RSRM
 		modded = False
+		origMass = 65.77
 
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
@@ -13,13 +13,28 @@
 		%throttleLocked = True
 	}
 	
-	!MODULE[ModuleFuelTanks] {}
+	!RESOURCE,*{}
+	!MODULE[ModuleFuelTanks],*{}
+	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 5.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 178214.9045
 		type = HTPB
 		basemass = -1
+		TANK
+		{
+			name = HTPB
+			amount = 178214.9045
+			maxAmount = 178214.9045
+		}
 	}
 	
 	MODULE
@@ -28,6 +43,7 @@
 		type = ModuleEngines
 		configuration = SRMU
 		modded = false
+		origMass = 36.2145
 		CONFIG
 		{
 			name = SRMU

--- a/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
@@ -48,13 +48,21 @@
 		%throttleLocked = True
 	}
 	
-	!MODULE[ModuleFuelTanks] {}
+	!RESOURCE,*{}
+	!MODULE[ModuleFuelTanks],*{}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 84462.45
 		type = PBAN
 		basemass = -1
+		TANK
+		{
+			name = PBAN
+			amount = 84462.45
+			maxAmount = 84462.45
+		}
 	}
 	MODULE
 	{
@@ -62,6 +70,7 @@
 		type = ModuleEngines
 		configuration = UA1204
 		modded = false
+		origMass = 27.839
 		CONFIG
 		{
 			name = UA1204

--- a/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
@@ -62,6 +62,7 @@
 		type = ModuleEngines
 		configuration = UA1205
 		modded = false
+		origMass = 33.79
 		CONFIG
 		{
 			name = UA1205

--- a/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
@@ -62,6 +62,7 @@
 		type = ModuleEngines
 		configuration = UA1206
 		modded = false
+		origMass = 39.757
 		CONFIG
 		{
 			name = UA1206

--- a/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
@@ -63,6 +63,7 @@
 		type = ModuleEngines
 		configuration = UA1207
 		modded = false
+		origMass = 40.782
 		CONFIG
 		{
 			name = UA1207

--- a/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
@@ -63,6 +63,7 @@
 		type = ModuleEngines
 		configuration = UA1208
 		modded = false
+		origMass = 44.734
 		CONFIG
 		{
 			name = UA1208


### PR DESCRIPTION
Add mass, fuel load and gimbals to the global configs of SRMs which are missing them.