### PR TITLE
Update M55 model path for new Vens releases

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NK_M55.cfg
@@ -22,7 +22,7 @@
 	
 	MODEL:NEEDS[VenStockRevamp]
 	{
-		model = VenStockRevamp/Squad/Parts/Propulsion/RT20
+		model = VenStockRevamp/Part Bin/NewParts/Propulsion/RT20
 		scale = 1.67, 1.8683984, 1.67
 		position = 0.0, -1.483571, 0.0
 	}


### PR DESCRIPTION
[ERR 19:42:00.012] PartCompiler: Cannot clone model 'VenStockRevamp/Squad/Parts/Propulsion/RT20' as model does not exist

Model got moved to a different folder in recent releases. I'm presuming there's no need to support older ones.