### PR TITLE
J-2S throttling

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -175,7 +175,7 @@
 		{
 			name = J-2S
 			description = The J-2S (J-2 Simplified) was a improvement on the J-2 Engine. It was completely tested and logged more than 30,000 seconds of static fire before the program was terminated.
-			minThrust = 876.299
+			minThrust = 196.463	// 6:1 throttling thanks to redesigned pumps and injectors
 			maxThrust = 1178.778
 			massMult = 1.036835 // All sources state the J-2S was heavier than J-2
 			heatProduction = 100


### PR DESCRIPTION
Several sources state that the J-2S had much deeper throttling capabilities than the J-2, thanks to the ability to control the hot gas flow and recirculate propellant that was added to convert it to tap-off cycle. A 6:1 throttling ratio seems to be the consensus.