### PR TITLE
Increase internal SM tank volume

### DIFF
--- a/GameData/RealismOverhaul/Parts/AdvCapsule/ROAdvCapsule.cfg
+++ b/GameData/RealismOverhaul/Parts/AdvCapsule/ROAdvCapsule.cfg
@@ -392,7 +392,7 @@ PART
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 60
+        volume = 525 // match volume of ROC Gemini
         basemass = -1
 
         //  Batteries 4 kWh.


### PR DESCRIPTION
Increase internal SM volume to 530l even without TACLS, for Kerbalism players

Fixes #2275