### PR TITLE
CryoEngines update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
@@ -1,340 +1,220 @@
-//Vulcain 1 and 2
-@PART[cryoengine-125-1]:FOR[RealismOverhaul]
+//=============
+//	Vulcain 2
+//=============
+
+
+@PART[cryoengine-vesuvius-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL,0
-	{
-		@scale = 1.68,1.68,1.68
-	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.1686, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.3581, 0.0, 0.0, -1.0, 0.0, 1
+	%rescaleFactor = 2
 	
-	%mass = 1.8
 	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[ModuleEngines*]
-	{
-		%maxThrust = 1390
-		%minThrust = 1390
-		%heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 433
-			@key,1 = 1 318
-		}
-		@PROPELLANT[LiquidFuel]
-		{
-			%name = LqdHydrogen
-			%ratio = 0.763
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.237
-		}
-	}
-	engineType = Vulcain
+	
+	%engineType = Vulcain
 }
 
-//RL10B-2
-@PART[cryoengine-125-2]:FOR[RealismOverhaul]
+// Remove Vulcain 1 config
+
+@PART[cryoengine-vesuvius-1]:AFTER[RealismOverhaulEngines]
+{
+	@title = Vulcain 2
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Vulcain-2
+		!CONFIG[Vulcain] {}
+	}
+}
+
+//===============
+//	RL10B-2/C-2
+//===============
+
+@PART[cryoengine-hecate-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL,0
-	{
-		@scale = 1.6,1.6,1.6
-	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.404, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -1.01, 0.0, 0.0, -1.0, 0.0, 1
+
+	%rescaleFactor = 2
 	
-	%mass = 0.277
-	%maxTemp = 1970
+	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[ModuleEngines*]
-	{
-		%maxThrust = 111.2
-		%minThrust = 111.2
-		%heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 462
-			@key,1 = 1 235
-		}
-		@PROPELLANT[LqdHydrogen]
-		{
-			%ratio = 0.733
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.267
-		}
-	}
-	engineType = RL10
+
+	%engineType = RL10
 }
-//remove all configs apart from the B-2
-@PART[cryoengine-125-2]:AFTER[RealismOverhaulEnginesPost] 
+
+//	Remove all RL10 configs except B-2 and C-2
+
+@PART[cryoengine-hecate-1]:AFTER[RealismOverhaulEngines] 
 {
-	%title = RL10B-2
-	%description = 1990s low-medium TWR, vacuum use. Developed for the Delta Cryogenic Second Stage (DCSS), which was first used on the Delta III then modified for the Delta IV. Its extending nozzle increases specific impulse compared to the RL10A, at the cost of greater dry mass. Boeing purchased a large number of these engines for the Delta IV, but the launcher's low flight rate led to ULA converting many of them to RL10C-1 engines for use on the Atlas V's Centaur upper stage.  min stage diameter 2.0m
+	%title = RL10B-2/C-2
+	%description = 1990s low-medium TWR, vacuum use. Developed for the Delta Cryogenic Second Stage (DCSS), which was first used on the Delta III then modified for the Delta IV. Its extending nozzle increases specific impulse compared to the RL10A, at the cost of greater dry mass. Boeing purchased a large number of these engines for the Delta IV, but the launcher's low flight rate led to ULA converting many of them to RL10C-1 engines for use on the Atlas V's Centaur upper stage.  Min. stage diameter 2.0m
+
 	@MODULE[ModuleEngineConfigs] 
 	{ 
-		!CONFIG,*:HAS[~name[RL10B-2]|~name[RL10C-2-1]|~name[RL10C-3]] {} 
+		@configuration = RL10B-2
+		!CONFIG[*]:HAS[#name[RL10A*]] {}
+		!CONFIG[*]:HAS[#name[RL10C-1*]] {}
+		!CONFIG[*]:HAS[#name[RL10C-3]] {}
+		!CONFIG[*]:HAS[#name[CECE*]] {}
 	}
 }
 
-//LE-7
-@PART[cryoengine-25-1]:FOR[RealismOverhaul]
+//========
+//	LE-9
+//========
+
+// Using LE-7 config until there's an LE-9 config available
+
+@PART[cryoengine-fuji-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL,0
-	{
-		@scale = 1.2,1.2,1.2
-	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.06455, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -2.52855, 0.0, 0.0, -1.0, 0.0, 2
-	
+	// No rescale needed, model nozzle exit diameter matches LE-9 spec
+
 	%mass = 1.72
-	%maxTemp = 1970
+	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[ModuleEngines*]
-	{
-		%maxThrust = 1078
-		%minThrust = 1078
-		%heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 446
-			@key,1 = 1 349
-		}
-		@PROPELLANT[LqdHydrogen]
-		{
-			%ratio = 0.729
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.271
-		}
-	}
-	engineType = LE7
+
+	%engineType = LE7
 }
 
-//J-2X
-@PART[cryoengine-25-2]:FOR[RealismOverhaul]
+//========
+//	J-2X
+//========
+
+@PART[cryoengine-ulysses-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL,0
-	{
-		@scale = 1.6,1.6,1.6
-	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 1.777, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -2.0626, 0.0, 0.0, -1.0, 0.0, 2
+	@rescaleFactor = 1.667
+
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = J2X
+}
+
+//=========
+//	RS-68
+//=========
+
+@PART[cryoengine-etna-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.3333 // Actually 1.461, but this way we keep the shroud at 5 meters for use on Delta IV's CBC
 	
-	%mass = 2.47
-	%maxTemp = 1970
+	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[ModuleEngines*]
-	{
-		%maxThrust = 1308
-		%minThrust = 1072
-		%heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 448
-			@key,1 = 1 200
-		}
-		@PROPELLANT[LqdHydrogen]
-		{
-			%ratio = 0.745
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.255
-		}
-	}
-	engineType = J2X
-}
-
-//RS-68
-@PART[cryoengine-375-1]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@MODEL,0
-	{
-		@scale = 1.36,1.36,1.36
-	}
-	MODEL
-	{
-		model = RealismOverhaul/Models/KVDvernStock
-		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
-		scale = 1, 1, 1
-		position = -1.55, 0.45, 0
-		rotation = 0, 90, 0
-	}
-	@MODEL,1:NEEDS[VenStockRevamp]		//Hex-editted mu files originally by Ven, re-distributed under CC-BY-4.0
-	{
-		@model = RealismOverhaul/Models/KVDvernVSR
-		!texture = DELETE
-		texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Engine/SmallEngines_CLR
-		texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Engine/SmallEngines_NRM
-	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 2.46287, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, -3.05898, 0.0, 0.0, -1.0, 0.0, 3
 	
-	%mass = 6.597
-	%maxTemp = 1970
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
+	%engineType = RS68
+	
 	@MODULE[ModuleEngines*]
 	{
-		%maxThrust = 3370
-		%minThrust = 1890
-		%engineID = mainEngine
-		%heatProduction = 100
-		@atmosphereCurve
+		// Values from Rocket Propulsion Elements by Sutton
+		@transformMultipliers
 		{
-			@key,0 = 0 409
-			@key,1 = 1 357
-		}
-		@PROPELLANT[LqdHydrogen]
-		{
-			%ratio = 0.7258
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.2715
+			@trf0 = 0.975
+			@trf1 = 0.0125
+			@trf2 = 0.0125
 		}
 	}
-	MODULE
-	{
-		name = ModuleEnginesFX
-		thrustVectorTransformName = vern01Transform
-		engineID = vernier
-		minThrust = 4
-		maxThrust = 4
-		heatProduction = 0
-		exhaustDamage = False
-		ignitionThreshold = 0.1
-		PROPELLANT
-		{
-			name = LqdHydrogen
-			ratio = 0.7285
-		}
-		PROPELLANT[Oxidizer]
-		{
-			name = LqdOxygen
-			ratio = 0.2715
-		}
-		atmosphereCurve
-		{
-			key,0 = 0 409
-			key,1 = 1 357
-		}
-	}
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEnginesFX
-		configuration = Gas-Generator-Exhaust
-		engineID = vernier
-		isMaster = false
-		modded = false
-		CONFIG
-		{
-			name = Gas-Generator-Exhaust
-			minThrust = 4
-			maxThrust = 4
-			heatProduction = 10
-			PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 0.7285
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.2715
-			}
-			atmosphereCurve
-			{
-				key = 0 409
-				key = 1 357
-			}
-		}
-	}
-	MODULE
-	{
-		name = ModuleGimbal
-		gimbalTransformName = vern01Transform
-		gimbalRange = 26
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
-	}
-	engineType = RS68
-}
 
-//FIXME: does this actually do anything?
-@PART[cryoengine-375-1]:AFTER[RealismOverhaulEnginesPost] 
-{
-	@MODULE[ModuleEngineConfigs],1
-	{ 
-		engineID = mainEngine
-		isMaster = true
+	@MODULE[ModuleGimbal]:HAS[#gimbalTransformName[B_EtnaGimbalTurbo]]
+	{
+		@gimbalRange = 15
+		@gimbalRangeXN = 15
+		@gimbalRangeXP = 15
 	}
 }
 
-//RD-0120
-@PART[cryoengine-375-2]:FOR[RealismOverhaul]
+//===========
+//	RD-0120
+//===========
+
+@PART[cryoengine-erebus-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL,0
-	{
-		@scale = 1.091,1.091,1.091
-	}
-	%rescaleFactor = 1.0
-	@node_stack_top = 0.0, 2.0287, 0.0, 0.0, 1.0, 0.0, 3
-	@node_stack_bottom = 0.0, -2.5752, 0.0, 0.0, -1.0, 0.0, 3
-	%mass = 3.45
-	%maxTemp = 1970
+	@rescaleFactor = 1.458
+	
+	%maxTemp = 1700
 	%crashTolerance = 12
 	%breakingForce = 250
 	%breakingTorque = 250
-	@MODULE[ModuleEngines*]
+
+	%engineType = RD0120
+}
+
+//=========
+//	RL-60
+//=========
+
+@PART[cryoengine-pavonis-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.317
+
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = RL60
+}
+
+//===========
+//	RL-60x2
+//===========
+
+@PART[cryoengine-tharsis-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.317
+
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = RL60
+	%engineTypeMult = 2
+}
+
+//===========
+//	RL10A-5
+//===========
+
+@PART[cryoengine-stromboli-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	// No rescale needed, model inner nozzle exit diameter matches RL10A-5 spec
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = RL10
+}
+
+//	Remove all RL10 configs except the A-5
+
+@PART[cryoengine-stromboli-1]:AFTER[RealismOverhaulEngines]
+{
+	@title = RL10A-5
+
+	@MODULE[ModuleEngineConfigs]
 	{
-		%minThrust = 882.45
-		%maxThrust = 1961
-		%heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 455
-			@key,1 = 1 359
-		}
-		@PROPELLANT[LqdHydrogen]
-		{
-			%ratio = 0.729
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.271
-		}
+		@configuration = RL10A-5
+
+		!CONFIG[*]:HAS[~name[RL10A-5]] {}
 	}
-	engineType = RD0120
 }


### PR DESCRIPTION
Just an update to make this config work with the latest version of CryoEngines.

Apart from the changes in part names, I also added new parts (RL10A-5, RL-60 and RL-60 cluster) and made some tweaks.

A couple of notes:

1. Edited the Vulcain engine to only use the Vulcain 2 config since that's what the part is modeled after. I can change this if it's not desired.

2. Even though the RS-68 roll control exhaust animation is broken, it works just fine. Couldn't find what the deflection angle is, so I used 15 degrees (copied from ROEngines).

3. Rescaled the RS-68 based on the boattail diameter (so it fits the Delta IV's CBC) instead of the nozzle exit diameter. As a result, the engine is slightly smaller than the real RS-68.

4. Since there's no LE-9 default config available, I used the LE-7 one for the Fuji, but kept the scale of the engine according to the LE-9 nozzle exit diameter (1.59m according to the NF_Realism team).