### PR TITLE
Reduce Waxwing dry mass to actual value

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
@@ -1,12 +1,26 @@
-//Waxwing
-//SXT
+//	===============================================================
+//	Waxwing
+//
+//	Manufacturer: Bristol Aerojet / RPE
+//	Dimensions: 1.31 x 0.76 m
+//	Nozzle Exit Area: 0.170 m^2
+//
+//	SOURCES:
+//	A Vertical Empire: The History Of The Uk Rocket And Space Programme, 1950-1971 (2nd edition, 2012)
+//		https://books.google.si/books?id=oFC7CgAAQBAJ
+//
+//
+//  Used by:
+//		SXT (SXTWaxWing)
+//  ==================================================
+
 @PART[*]:HAS[#engineType[Waxwing]]:FOR[RealismOverhaulEngines]
 {
 	@title = Waxwing Kick Motor
 	@manufacturer = Bristol Aerojet / RPE
-	@description = Small solid kick motor for circularizing payloads in orbit. Third stage of the Black Arrow launch vehicle. 29.4kN average thrust.
+	@description = The Waxwing was a small solid kick motor for circularizing payloads in orbit, used as a third stage on the Black Arrow launch vehicle in 1970-71. 29.4kN average thrust.
 	
-	@mass = 0.087
+	@mass = 0.035
 	
 	!RESOURCE[SolidFuel] {}
 	


### PR DESCRIPTION
Apparently the empty case was 77 lbs (34.93 kg), with an additional 31 lbs for the payload separation equipment, but the model we have doesn't include it. This passes the sanity check with regards to performance of solids in the late 60s- I have no idea where the 87 kg value first came from. Also some readability changes.