### PR TITLE
Reduce ejection force from Procedural Fairings and interstages

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -109,6 +109,7 @@
 	%MODULE[ModuleDecouple]
 	{
 		%name = ModuleDecouple
+		%ejectionForce = 25
 		%ejectionForcePercent = 0
 		%explosiveNodeID = top
 		%stagingEnabled = True
@@ -172,6 +173,7 @@
 	@MODULE[ModuleDecouple]
 	{
 		%stagingEnabled = True
+		%ejectionForce = 25
 	}
 }
 


### PR DESCRIPTION
Procedural Fairings and Interstages have an ejection force of 250, which amounts to roughly 2.5kN over a second. That is a lot of force, especially if you apply it to a small probe. This PR changes it to 25, equivalent to 250N. Until something similar to the scaled impulse implemented in procedural decouplers is adapted for PF, this should keep these values more sane and less exploitable.