### PR TITLE
Globally replace ignitions = -1 with ignitions = 0

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
@@ -39,7 +39,7 @@
         %EngineType = LiquidFuel
         %ullage = False
         %pressureFed = True
-        %ignitions = -1
+        %ignitions = 0
     }
 
     !MODULE[ModuleEngineConfigs],*{}
@@ -61,7 +61,7 @@
             massMult = 1.0
             ullage = False
             pressureFed = True
-            ignitions = -1
+            ignitions = 0
 
             IGNITOR_RESOURCE
             {

--- a/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
@@ -88,7 +88,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = -1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -82,7 +82,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -442,7 +442,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AtomicAge/RO_AtomicAge_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AtomicAge/RO_AtomicAge_Engines.cfg
@@ -46,11 +46,11 @@
 		}
 		%ullage = True
 		%pressureFed = False
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		%ullage = True
 		%pressureFed = False
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 	}
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ProbeExpansion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ProbeExpansion.cfg
@@ -1877,7 +1877,7 @@
 		heatProduction = 10
 		ullage = False
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		EngineType = LiquidFuel
 		runningEffectName = running_engine
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Probes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Probes.cfg
@@ -1003,7 +1003,7 @@
 		@heatProduction = 10
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 
 		@PROPELLANT
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
@@ -1582,7 +1582,7 @@
 		@heatProduction = 10
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 
 		@PROPELLANT
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -147,7 +147,7 @@
 		@heatProduction = 10
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 
 		@PROPELLANT
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CSS/RO_CSS.cfg
@@ -475,7 +475,7 @@
 	  }
 	%ullage = True
 	%pressureFed = True
-	%ignitions = -1
+	%ignitions = 0
 	!IGNITOR_RESOURCE,* {}
 	IGNITOR_RESOURCE
 	{
@@ -563,7 +563,7 @@
 	  }
 	%ullage = True
 	%pressureFed = True
-	%ignitions = -1
+	%ignitions = 0
 	!IGNITOR_RESOURCE,* {}
 	IGNITOR_RESOURCE
 	{
@@ -651,7 +651,7 @@
 	  }
 	%ullage = True
 	%pressureFed = True
-	%ignitions = -1
+	%ignitions = 0
 	!IGNITOR_RESOURCE,* {}
 	IGNITOR_RESOURCE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_GroundOps_Propulsion.cfg
@@ -50,7 +50,7 @@
         @heatProduction = 21
         %ullage = False
         %pressureFed = True
-        %ignitions = -1
+        %ignitions = 0
 
         @PROPELLANT[LiquidFuel]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Control.cfg
@@ -635,7 +635,7 @@
         @heatProduction = 11
         %ullage = False
         %pressureFed = True
-        %ignitions = -1
+        %ignitions = 0
 
         @PROPELLANT[MonoPropellant]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Propulsion.cfg
@@ -280,7 +280,7 @@
         @EngineType = LiquidFuel
         %ullage = False
         %pressureFed = True
-        %ignitions = -1
+        %ignitions = 0
 
         IGNITOR_RESOURCE
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_R7.cfg
@@ -911,7 +911,7 @@
         @engineAccelerationSpeed = 0
         %ullage = False
         %pressureFed = False
-        %ignitions = -1
+        %ignitions = 0
 
         @PROPELLANT[Oxidizer]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_Saturn_V.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/RO_DECQ_Saturn_V.cfg
@@ -538,7 +538,7 @@
         @heatProduction = 0
         %ullage = False
         %pressureFed = True
-        %ignitions = -1
+        %ignitions = 0
 
         PROPELLANT
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Agena.cfg
@@ -276,7 +276,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Lunar_Gemini.cfg
@@ -259,7 +259,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_Saturn.cfg
@@ -336,7 +336,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KWRocketry/RO_KWRocketry_Engines.cfg
@@ -102,7 +102,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_LazTek_Historic.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_LazTek_Historic.cfg
@@ -489,7 +489,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_Laztek_Launch.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LazTek/RO_Laztek_Launch.cfg
@@ -1730,7 +1730,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -1965,7 +1965,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_ATV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_ATV.cfg
@@ -166,7 +166,7 @@
 			@key,1 = 1 150
 		}
 		ullage = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = MMH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Atlas.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Atlas.cfg
@@ -51,7 +51,7 @@
 		}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = MMH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Evera.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Evera.cfg
@@ -67,7 +67,7 @@
 		}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = UDMH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_MunarOrbiter.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_MunarOrbiter.cfg
@@ -116,7 +116,7 @@
 		}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = UDMH

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Thor.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Thor.cfg
@@ -50,7 +50,7 @@
             	}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
@@ -108,7 +108,7 @@
             	}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge

--- a/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Valkyrie.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/LionHeadAerospace/RO_LH_Valkyrie.cfg
@@ -75,7 +75,7 @@
 		}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
@@ -188,7 +188,7 @@
 		}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge
@@ -303,7 +303,7 @@
             	}
 		ullage = True
 		pressureFed = True
-		ignitions = -1
+		ignitions = 0
 		IGNITOR_RESOURCE
 		{
 			name = ElectricCharge

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RLA/RO_RLA_Engine.cfg
@@ -359,7 +359,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -467,7 +467,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -822,7 +822,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -880,7 +880,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Cygnus.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Cygnus.cfg
@@ -108,7 +108,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -339,7 +339,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Cassini.cfg
@@ -103,7 +103,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_EOS.cfg
@@ -520,7 +520,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Galileo.cfg
@@ -106,7 +106,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Magellan.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/US_Probes_Magellan.cfg
@@ -94,7 +94,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
@@ -3,7 +3,7 @@
 
 //  Athena Launch Vehicle Family:  https://www.sprsa.org/sites/default/files/conference-presentation/Athena%20Launch%20Vehicle%20Family-Kehrl_PR.pdf
 //  Space Launch Report - Athena:  http://www.spacelaunchreport.com/athena.html
-//  Norbert Brï¿½gge - Athena:       http://www.b14643.de/Spacerockets_2/United_States_2/Athena/Description/Frame.htm
+//  Norbert Brügge - Athena:       http://www.b14643.de/Spacerockets_2/United_States_2/Athena/Description/Frame.htm
 //  Propulsion Systems Data Sheet: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Propulsion%20System%20Data%20Sheets.pdf
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RealScaleBoosters/RO_RSB_Athena.cfg
@@ -3,7 +3,7 @@
 
 //  Athena Launch Vehicle Family:  https://www.sprsa.org/sites/default/files/conference-presentation/Athena%20Launch%20Vehicle%20Family-Kehrl_PR.pdf
 //  Space Launch Report - Athena:  http://www.spacelaunchreport.com/athena.html
-//  Norbert Brügge - Athena:       http://www.b14643.de/Spacerockets_2/United_States_2/Athena/Description/Frame.htm
+//  Norbert Brï¿½gge - Athena:       http://www.b14643.de/Spacerockets_2/United_States_2/Athena/Description/Frame.htm
 //  Propulsion Systems Data Sheet: https://www.rocket.com/files/aerojet/documents/Capabilities/PDFs/Propulsion%20System%20Data%20Sheets.pdf
 
 //  ==================================================
@@ -109,7 +109,7 @@
         @heatProduction = 0
         %ullage = False
         %pressureFed = True
-        %ignitions = -1
+        %ignitions = 0
 
         @PROPELLANT[MonoPropellant]
         {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -946,7 +946,7 @@
 		@heatProduction = 17.5
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 
 		@atmosphereCurve
 		{
@@ -1011,7 +1011,7 @@
 		@heatProduction = 17.5
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 
 		@atmosphereCurve
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_ATV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_ATV.cfg
@@ -165,7 +165,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Cygnus.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Cygnus.cfg
@@ -117,7 +117,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fobos_Grunt.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fobos_Grunt.cfg
@@ -33,7 +33,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fuji.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Fuji.cfg
@@ -92,7 +92,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_LK_BlockD.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_LK_BlockD.cfg
@@ -298,7 +298,7 @@
 		}
 		%ullage = True
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -756,7 +756,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -865,7 +865,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{
@@ -972,7 +972,7 @@
 		}
 		%ullage = False
 		%pressureFed = True
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_TKS.cfg
@@ -617,7 +617,7 @@
 		}
 		%ullage = False
 		%pressureFed = False
-		%ignitions = -1
+		%ignitions = 0
 		!IGNITOR_RESOURCE,* {}
 		IGNITOR_RESOURCE
 		{


### PR DESCRIPTION
From @jwvanderbeck's suggestion:
> tl;dr of the whole investigation was that 0 = infinite unless literalZeroIgnitions (or something similarly named) is true in which cases 0 = 0.  -1 will technically work but only in some situations and it was never intended for -1 to be used for infinite.