### PR TITLE
BDB Engine Patch Fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Apollo_OLD.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Apollo_OLD.cfg
@@ -183,7 +183,7 @@
 			maxAmount = 206.8
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber
@@ -698,9 +698,7 @@
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
-	
 
-	
 	@title = Apollo Service Module
 	%manufacturer = North American
 	@description = The Apollo Service Module that has a complete package of fuel, monoprop, batteries, fuel cells, and storage bays for your service module.
@@ -709,7 +707,7 @@
 	!RESOURCE,* {}
 	!MODULE[ModuleResourceConverter] {}
 	
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 1
@@ -741,7 +739,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 2
@@ -773,7 +771,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = Fuel Cell 3
@@ -805,7 +803,7 @@
 			%DumpExcess = false // if the batteries are full, we would want the full cell to stop running, right?
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = LOX-O2
@@ -1080,9 +1078,7 @@
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.5646
-	
 
-	
 	@title = Apollo Block III+ Command Module
 	%manufacturer = Bluedog Design Bureau
 	@description = Significant changes were made to better adapt Apollo to its new role as a crew shuttle for LEO, and the internal volume was modified to fit 5 crew for reentry. Be sure to bring extra living space by attaching the Mission Module to dock with after orbiting. By only using the Command Module, you will have resources for 5 crew for 72 hours. FICTIONAL (Eyes Turned Skyward)
@@ -1184,7 +1180,7 @@
 			maxAmount = 51.765
 		}
 	}
-	MODULE
+	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
 		%converterName = CO2 Scrubber

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Solids.cfg
@@ -1,27 +1,31 @@
-// SERGEANT
-
-@PART[bluedog_Sergeant_1x]:NEEDS[RealismOverhaul]
+// Common patches
+@PART[bluedog_Sergeant_*x|bluedog_AIMP_Star13|bluedog_UpperSolids_*|bluedog_*Castor*|bluedog_Delta_GEM*]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
-	@title = MGM-29 "Sergeant" Solid Rocket
-	@description = abc
-	@mass = 0.00567
 	@maxTemp = 900
-	
 	%skinMaxTemp = 2000
 	%emissiveConstant = 0.6
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
+	!MODULE[ModuleEngineIgnitor] {}
+}
+
+@PART[bluedog_SOLTAN_SRB|bluedog_UA120*|bluedog_SRMU_Full|bluedog_IUS_Orbus6|bluedog_IUS_Orbus21|bluedog_Burner2]:FOR[RealismOverhaul]
+{
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!MODULE[ModuleEngineIgnitor] {}
+}
+
+
+// SERGEANT
+@PART[bluedog_Sergeant_*x]:FOR[RealismOverhaul]
+{
+	%rescaleFactor = 1.6
 
 	MODULE
 	{
@@ -33,56 +37,29 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		@allowShutdown = False
-		@allowRestart = True
-		%throttleLocked = true
 		@useEngineResponseTime = False
 		!engineAccelerationSpeed = DELETE
 	}
+}
+
+@PART[bluedog_Sergeant_1x]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = MGM-29 "Sergeant" Solid Rocket
 
 	%engineType = BabySergeant
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
-@PART[bluedog_Sergeant_3x]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sergeant_3x]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
 	@title = MGM-29x3 "Sergeant" Solid Rocket Cluster
-	@description = abc
-	@mass = 0.02
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
-	
-	!RESOURCE[SolidFuel]
+	@MODULE[ModuleFuelTanks]
 	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 38.06
-		basemass = -1
-		type = PSPC
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-		@allowRestart = True
-		%throttleLocked = true
-		@useEngineResponseTime = False
-		!engineAccelerationSpeed = DELETE
+		@volume *= 3
 	}
 
 	%engineType = BabySergeant
@@ -90,44 +67,15 @@
 	%clusterMultiplier = 3
 }
 
-@PART[bluedog_Sergeant_11x]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sergeant_11x]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.6
 
 	@title = MGM-29x11 "Sergeant" Solid Rocket Cluster
-	@description = abc
-	@mass = 0.075
-	@maxTemp = 900
 	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
+	@MODULE[ModuleFuelTanks]
 	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 139.54
-		basemass = -1
-		type = PSPC
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-		@allowRestart = True
-		%throttleLocked = true
-		@useEngineResponseTime = False
-		!engineAccelerationSpeed = DELETE
+		@volume *= 11
 	}
 
 	%engineType = BabySergeant
@@ -135,10 +83,9 @@
 	%clusterMultiplier = 11
 }
 
-
 // KICK STAGES
 
-@PART[bluedog_AIMP_Star13]:NEEDS[RealismOverhaul]
+@PART[bluedog_AIMP_Star13]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -146,25 +93,14 @@
 	@title = Star-13 Solid Rocket Motor
 	@description = Star-series solid rocket motor, model 13-A. Vacuum optimized nozzle, simpler and more reliable than liquid boosters. Includes 0.5m mounting hardware. Used on the Explorer 33 and 35 spacecraft for lunar orbital insertion.
 	@mass = 0.0045
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
+	!RESOURCE[SolidFuel] {}
 
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 20
-		basemass = -1		
+		basemass = -1
 		type = HTPB 
 	}
 	@MODULE[ModuleEngines*]
@@ -186,242 +122,61 @@
 	}
 }
 
-
-@PART[bluedog_UpperSolids_Altair]:NEEDS[RealismOverhaul]
+@PART[bluedog_UpperSolids_Altair]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
 
 	@title = Altair X-248
-	@description = A small solid kick motor. Developed as alternative Vanguard third stage, reused on many later LVs with Able/Delta upper stage (or simply "Thor Burner") to circularize at apogee or perform final payload kick. Burn time 39 seconds.
-	@mass = 0.05
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowRestart = True
-		@allowShutdown = False
-	}
-
 	%engineType = Altair
-	%engineTypeMult = 1
-	%massOffset = 0
-	%ignoreMass = False
-
-
 }
 
-@PART[bluedog_UpperSolids_BE3]:NEEDS[RealismOverhaul]
+@PART[bluedog_UpperSolids_BE3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
 
 	@title = BE-3 Kick Motor
-	@description = BE-3 solid kick motor. Vacuum optimized nozzle, simpler and more reliable than liquid boosters. Includes 0.5m mounting hardware.
-	@mass = 0.02
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 90
-		type = PSPC 		
-		basemass = -1
-		TANK
-		{
-			name = PSPC
-			amount = 90
-			maxAmount = 90
-		}
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-		@allowRestart = True
-		@minThrust = 17.3
-		@maxThrust = 17.3
-		@PROPELLANT
-		{
-			@name = PSPC
-			@ratio = 1
-		}
-		@atmosphereCurve
-		{
-			@key = 0 237.46
-			@key = 1 100
-		}
-	}
-
 	%engineType = GCRC
-
 }
 
-@PART[bluedog_UpperSolids_Star37FMV]:NEEDS[RealismOverhaul]
+@PART[bluedog_UpperSolids_Star37FMV]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB Star-37E
-	@mass = 0.02
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowRestart = True
-		@allowShutdown = False
-	}
-
 	%engineType = Star-37E
-
 }
 
-@PART[bluedog_UpperSolids_Star37BV]:NEEDS[RealismOverhaul]
+@PART[bluedog_UpperSolids_Star37BV]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB Star-37B
-	@mass = 0.02
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowRestart = True
-		@allowShutdown = False
-	}
-
-	%massOffset = 0
-	%ignoreMass = False
 	%engineType = Star-37
-
 }
 
-@PART[bluedog_UpperSolids_Star48BV]:NEEDS[RealismOverhaul]
+@PART[bluedog_UpperSolids_Star48BV]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB Star-48
-	@mass = 0.02
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowRestart = True
-		@allowShutdown = False
-	}
-
-	%massOffset = 0
-	%ignoreMass = False
 	%engineType = Star-48B
-
 }
 
 // CASTOR
-
-@PART[bluedog_Castor2]:NEEDS[RealismOverhaul]
+// Not sure BDB has this specific part anymore
+@PART[bluedog_Castor2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = Castor II
-	@description = The Castor I was originally used as the second stage of the Scout rocket and mounted radially was used to thrust augment Delta rockets (Delta D, E, E1, G & J). The upgraded Castor II was used for Delta L, M, N etc onwards all the way through to Delta 2000.
-	@mass = 0.66
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
 	%engineType = Castor-2
 
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-	}
 	%MODULE[ModuleB9PartSwitch]
 	{
 		name = ModuleB9PartSwitch
@@ -437,29 +192,13 @@
 	}
 }
 
-@PART[bluedog_Scout_Castor_Inline]:NEEDS[RealismOverhaul]
+@PART[bluedog_Scout_Castor_Inline]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = Castor Scout Stage 2
-	@description = Small 1m solid booster motor, useful as an inline stage on small rockets. In addition to a weak Liquid Injection TVC system to emulate gimballing, it has cold-gas attitude jets and a small supply of monoprop. (The Scout second stage was correctly the Castor 1 although this model is overscaled and closer to a Castor 4 in size).
-	@mass = 0.66
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
 	%engineType = Castor-4
-
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
 
 	@MODULE[ModuleRCSFX]
     {
@@ -478,214 +217,67 @@
             !key,4 = DELETE
         }
     }
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-	}
-	%MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 500
-		type = PBAN 		
-		basemass = -1
-		TANK
-		{
-			name = PBAN
-			amount = 90
-			maxAmount = 90
-		}
-		TANK
-		{
-			name = HTP
-			amount = 100
-			maxAmount = 100
-		}
-	}
 }
 
-@PART[bluedog_Scout_Castor_Radial]:NEEDS[RealismOverhaul]
+@PART[bluedog_Scout_Castor_Radial]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = Castor IV
-	@description = Small 0.625m solid booster motor, useful as a radial booster. The nozzle is angled to deflect the thrust away from the core stage. Used as Strap on boosters on some Delta, Delta II (6000 series) and Atlas IIAS.
-	@mass = 0.66
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
 	%engineType = Castor-4
-
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
-	@MODULE[ModuleEngines*]
-	{
-		@allowShutdown = False
-	}
-	%MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 500
-		type = PBAN 		
-		basemass = -1
-		TANK
-		{
-			name = PBAN
-			amount = 90
-			maxAmount = 90
-		}
-	}
 }
 
 // GEM
 
-@PART[bluedog_Delta_GEM40]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_GEM40]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB GEM40
-	@mass = 1.2
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
-
 	%engineType = GEM-40
 }
 
-@PART[bluedog_Delta_GEM40_Inline]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_GEM40_Inline]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB GEM40 inline
-	@mass = 1.2
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
 	%engineType = GEM-40
 }
 
-@PART[bluedog_Delta_GEM46]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_GEM46]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB GEM46
-	@mass = 2
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineType = GEM-46
 }
 
-@PART[bluedog_Delta_GEM60]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_GEM60]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB GEM60
-	@mass = 3.4
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
 	%engineType = GEM-60
 }
 
-@PART[bluedog_Delta_GEM60XL]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_GEM60XL]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB GEM60XL
-	@mass = 3.4
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
 	%engineType = GEM-60
 }
 
-
-
 // TITAN
 
-@PART[bluedog_SOLTAN_SRB]:NEEDS[RealismOverhaul]
+@PART[bluedog_SOLTAN_SRB]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -693,12 +285,6 @@
 	@title = Soltan 2.4m Solid Rocket Booster
 	@description = Short 4-segment strap-on solid rocket booster for the Titan-I. Not much ever came of the design although Titan finally got solids with the bigger 3m boosters for Titan-III. Traditionally, these are fired on the launchpad, and the main stack's liquid first stage is fired 10 seconds before SRB burnout.
 	@mass = 0.66
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	!RESOURCE, * {}
 
@@ -766,7 +352,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 500
-		type = PBAN 		
+		type = PBAN
 		basemass = -1
 		TANK
 		{
@@ -777,488 +363,48 @@
 	}
 }
 
-@PART[bluedog_UA1205]:NEEDS[RealismOverhaul]
+@PART[bluedog_UA1205]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = UA1205 Solid Rocket Booster
-	@description = 3m 5-segment strap-on solid rocket booster for Titan rockets. Traditionally, these are fired on the launchpad, and the main stack's liquid first stage is fired 10 seconds before SRB burnout. Used on the Titan III-C, III-D, 23C and III-E.
-	@mass = 36.75
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 108606.12
-		type = PBAN
-		basemass = -1
-	}
-
-	
-
-	@MODULE[ModuleEnginesFX],1
-	{
-		@allowShutdown = False
-		@minThrust = 5962
-		@maxThrust = 5962
-		@PROPELLANT
-		{
-			@name = PBAN
-			@ratio = 1
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 263
-			@key,1 = 1 238
-		}
-	}
-
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = UA1205
-		modded = false
-		CONFIG
-		{
-			name = UA1205
-			minThrust = 5962
-			maxThrust = 5962
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = PBAN
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 266
-				key = 1 238
-			}
-			curveResource = PBAN
-			// guesses (note: max is above nominal * thrust_curve_max)
-			%chamberNominalTemp  = 2420
-			%maxEngineTemp = 2430
-			thrustCurve
-			//NTRS 19760021170 / NASA TM X-71692
-			// Thrust curve represents vacuum thrust
-			// p. V-25 (note: "slow burners" , cf p. V10)
-			{
-				key = 1.00000 1.00000   3.74587   0.00000
-				key = 0.97950 0.92000  -0.45237   4.07101
-				key = 0.94981 0.93333  -0.25725  -0.44590
-				key = 0.88444 0.95000  -0.25274  -0.25274
-				key = 0.81792 0.96667   0.18451  -0.24838
-				key = 0.74616 0.95333   0.00000   0.18709
-				key = 0.72579 0.95333   0.65483   0.00000
-				key = 0.69557 0.93333   0.66886   0.66886
-				key = 0.63705 0.89333   0.46587   0.69880
-				key = 0.58066 0.86667   0.45019   0.48020
-				key = 0.53193 0.84444   0.46204   0.46204
-				key = 0.48447 0.82222   0.47453   0.47453
-				key = 0.43827 0.80000   0.41070   0.48771
-				key = 0.38492 0.77778   0.42244   0.42243
-				key = 0.33306 0.75556   0.43486   0.43486
-				key = 0.28271 0.73333   0.51076   0.44804
-				key = 0.24409 0.71333   0.35006   0.52508
-				key = 0.18160 0.69111   0.36131   0.36131
-				key = 0.12108 0.66889   0.37332   0.37331
-				key = 0.06254 0.64667   5.88233   0.38614
-				key = 0.04840 0.55733   6.82691   6.81961
-				key = 0.03636 0.46800   8.13423   8.11931
-				key = 0.02641 0.37867  10.06544  10.02963
-				key = 0.01856 0.28933  13.22173  13.11034
-				key = 0.01282 0.20000   7.80920  18.89608
-				key = 0.00890 0.16667   9.37684   9.35696
-				key = 0.00570 0.13333  16.18469  11.68894
-				key = 0.00249 0.06667  13.87259  30.05728
-				key = 0.00062 0.03333  28.14741  25.76339
-				key = 0.00000 0.01000   0.00000  68.48464
-			}
-		}
-	}
-	// %engineType = UA1205
+	%engineType = UA1205
 }
 
-@PART[bluedog_UA1206]:NEEDS[RealismOverhaul]
+@PART[bluedog_UA1206]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = UA1206 Solid Rocket Booster
-	@description = 3m 6-segment strap-on solid rocket booster for Titan rockets. Traditionally, these are fired on the launchpad, and the main stack's liquid first stage is fired 10 seconds before SRB burnout. Used on the Titan 34D and Commercial Titan III.
-	@mass = 40.8
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 121313
-		type = PBAN
-		basemass = -1
-	}
-
-	
-
-	@MODULE[ModuleEnginesFX],1
-	{
-		@allowShutdown = False
-		@minThrust = 6959
-		@maxThrust = 6959
-		@PROPELLANT
-		{
-			@name = PBAN
-			@ratio = 1
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 265
-			@key,1 = 1 240
-		}
-	}
-
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = UA1206
-		modded = false
-		CONFIG
-		{
-			name = UA1206
-			minThrust = 6959
-			maxThrust = 6959
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = PBAN
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 265
-				key = 1 240
-			}
-			curveResource = PBAN
-			// guesses (note: max is above nominal * thrust_curve_max)
-			%chamberNominalTemp  = 2420
-			%maxEngineTemp = 2430
-			thrustCurve
-			//NTRS 19760021170 / NASA TM X-71692
-			// Thrust curve represents vacuum thrust
-			// p. V-25 (note: "slow burners" , cf p. V10)
-			{
-				key = 1.00000 1.00000   3.74587   0.00000
-				key = 0.97950 0.92000  -0.45237   4.07101
-				key = 0.94981 0.93333  -0.25725  -0.44590
-				key = 0.88444 0.95000  -0.25274  -0.25274
-				key = 0.81792 0.96667   0.18451  -0.24838
-				key = 0.74616 0.95333   0.00000   0.18709
-				key = 0.72579 0.95333   0.65483   0.00000
-				key = 0.69557 0.93333   0.66886   0.66886
-				key = 0.63705 0.89333   0.46587   0.69880
-				key = 0.58066 0.86667   0.45019   0.48020
-				key = 0.53193 0.84444   0.46204   0.46204
-				key = 0.48447 0.82222   0.47453   0.47453
-				key = 0.43827 0.80000   0.41070   0.48771
-				key = 0.38492 0.77778   0.42244   0.42243
-				key = 0.33306 0.75556   0.43486   0.43486
-				key = 0.28271 0.73333   0.51076   0.44804
-				key = 0.24409 0.71333   0.35006   0.52508
-				key = 0.18160 0.69111   0.36131   0.36131
-				key = 0.12108 0.66889   0.37332   0.37331
-				key = 0.06254 0.64667   5.88233   0.38614
-				key = 0.04840 0.55733   6.82691   6.81961
-				key = 0.03636 0.46800   8.13423   8.11931
-				key = 0.02641 0.37867  10.06544  10.02963
-				key = 0.01856 0.28933  13.22173  13.11034
-				key = 0.01282 0.20000   7.80920  18.89608
-				key = 0.00890 0.16667   9.37684   9.35696
-				key = 0.00570 0.13333  16.18469  11.68894
-				key = 0.00249 0.06667  13.87259  30.05728
-				key = 0.00062 0.03333  28.14741  25.76339
-				key = 0.00000 0.01000   0.00000  68.48464
-			}
-		}
-	}
-	// %engineType = UA1206
+	%engineType = UA1206
 }
 
-@PART[bluedog_UA1207]:NEEDS[RealismOverhaul]
+@PART[bluedog_UA1207]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = UA1207 Solid Rocket Booster
-	@description = 3m 7-segment strap-on solid rocket booster for Titan rockets. Traditionally, these are fired on the launchpad, and the main stack's liquid first stage is fired 10 seconds before SRB burnout. Used on the Titan IVA.
-	@mass = 43.5
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 152048.4
-		type = PBAN
-		basemass = -1
-	}
-
-	
-
-	@MODULE[ModuleEnginesFX],1
-	{
-		@allowShutdown = False
-		@minThrust = 7954
-		@maxThrust = 7954
-		@PROPELLANT
-		{
-			@name = PBAN
-			@ratio = 1
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 272
-			@key,1 = 1 245
-		}
-	}
-
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = UA1207
-		modded = false
-		CONFIG
-		{
-			name = UA1207
-			minThrust = 7954
-			maxThrust = 7954
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = PBAN
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 272
-				key = 1 245
-			}
-			curveResource = PBAN
-			// guesses (note: max is above nominal * thrust_curve_max)
-			%chamberNominalTemp  = 2420
-			%maxEngineTemp = 2430
-			thrustCurve
-			//NTRS 19760021170 / NASA TM X-71692
-			// Thrust curve represents vacuum thrust
-			// p. V-25 (note: "slow burners" , cf p. V10)
-			{
-				key = 1.00000 1.00000   3.74587   0.00000
-				key = 0.97950 0.92000  -0.45237   4.07101
-				key = 0.94981 0.93333  -0.25725  -0.44590
-				key = 0.88444 0.95000  -0.25274  -0.25274
-				key = 0.81792 0.96667   0.18451  -0.24838
-				key = 0.74616 0.95333   0.00000   0.18709
-				key = 0.72579 0.95333   0.65483   0.00000
-				key = 0.69557 0.93333   0.66886   0.66886
-				key = 0.63705 0.89333   0.46587   0.69880
-				key = 0.58066 0.86667   0.45019   0.48020
-				key = 0.53193 0.84444   0.46204   0.46204
-				key = 0.48447 0.82222   0.47453   0.47453
-				key = 0.43827 0.80000   0.41070   0.48771
-				key = 0.38492 0.77778   0.42244   0.42243
-				key = 0.33306 0.75556   0.43486   0.43486
-				key = 0.28271 0.73333   0.51076   0.44804
-				key = 0.24409 0.71333   0.35006   0.52508
-				key = 0.18160 0.69111   0.36131   0.36131
-				key = 0.12108 0.66889   0.37332   0.37331
-				key = 0.06254 0.64667   5.88233   0.38614
-				key = 0.04840 0.55733   6.82691   6.81961
-				key = 0.03636 0.46800   8.13423   8.11931
-				key = 0.02641 0.37867  10.06544  10.02963
-				key = 0.01856 0.28933  13.22173  13.11034
-				key = 0.01282 0.20000   7.80920  18.89608
-				key = 0.00890 0.16667   9.37684   9.35696
-				key = 0.00570 0.13333  16.18469  11.68894
-				key = 0.00249 0.06667  13.87259  30.05728
-				key = 0.00062 0.03333  28.14741  25.76339
-				key = 0.00000 0.01000   0.00000  68.48464
-			}
-		}
-	}
 	// %engineType = UA1207
 }
 
-@PART[bluedog_SRMU_Full]:NEEDS[RealismOverhaul]
+@PART[bluedog_SRMU_Full]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = SRMU Solid Rocket Booster
-	@description = 3m 2.5-segment strap-on solid rocket booster for Titan rockets. Traditionally, these are fired on the launchpad, and the main stack's liquid first stage is fired 10 seconds before SRB burnout. Used on the Titan IVB.
-	@mass = 37.5
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 182000
-		type = HTPB
-		basemass = -1
-	}
-
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = SRMU
-		modded = false
-		CONFIG
-		{
-			name = SRMU
-			minThrust = 8450
-			maxThrust = 8450
-			heatProduction = 100
-			PROPELLANT
-			{
-				name = HTPB
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 286
-				key = 1 259
-			}
-			curveResource = HTPB
-			%chamberNominalTemp  = 2420
-			%maxEngineTemp = 2430
-			thrustCurve
-			{
-				key	= 1.00000 0.88833
-				key = 0.97923 0.92565
-				key = 0.94596 0.94389
-				key = 0.91202 0.96394
-				key = 0.87734 0.98475
-				key = 0.84203 1.00000
-				key = 0.80580 0.99720
-				key = 0.77114 0.99243
-				key = 0.73594 0.98676
-				key = 0.70096 0.98063
-				key = 0.66621 0.97401
-				key = 0.63174 0.96500
-				key = 0.60505 0.94644
-				key = 0.58783 0.90621
-				key = 0.56526 0.87347
-				key = 0.53548 0.84310
-				key = 0.50541 0.81384
-				key = 0.47749 0.79194
-				key = 0.44974 0.76924
-				key = 0.42258 0.75861
-				key = 0.39556 0.76069
-				key = 0.36851 0.76031
-				key = 0.34152 0.75763
-				key = 0.31462 0.75520
-				key = 0.28784 0.75104
-				key = 0.26126 0.74374
-				key = 0.23494 0.73663
-				key = 0.20889 0.72883
-				key = 0.18311 0.72093
-				key = 0.15747 0.71134
-				key = 0.13264 0.69520
-				key = 0.10811 0.68457
-				key = 0.08822 0.65933
-				key = 0.07355 0.62530
-				key = 0.06069 0.59157
-				key = 0.04950 0.55954
-				key = 0.04170 0.52646
-				key = 0.03741 0.49165
-				key = 0.03421 0.45776
-				key = 0.03050 0.42220
-				key = 0.02606 0.38816
-				key = 0.02106 0.35155
-				key = 0.01710 0.31875
-				key = 0.01482 0.28222
-				key = 0.01303 0.24773
-				key = 0.01129 0.21130
-				key = 0.00916 0.17771
-				key = 0.00699 0.14314
-				key = 0.00509 0.10658
-				key = 0.00345 0.06968
-				key = 0.00196 0.03716
-				key = 0.00096 0.01930
-				key = 0.00042 0.01106
-				key = 0.00013 0.01000
-				key = 0.00000 0.01000
-			}
-		}
-	}
-	// %engineType = SRMU
+	%engineType = SRMU
 }
-
 
 // INERTIAL UPPER STAGE
 
-@PART[bluedog_IUS_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_IUS_Avionics]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
-	
 
 	@title = IUS Avionics and Control Package
 	@description = Avionics for the Inertial Upper Stage. Place an Orbus 6 solid motor in the inner node and then attach the interstage to the bottom.
@@ -1319,18 +465,17 @@
 	}
 }
 
-@PART[bluedog_IUS_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_IUS_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
-	
 
 	@title = IUS Interstage Adapter
 	@description = 2.4m interstage decoupler for the Inertial Upper Stage. Attach to the bottom of the Avionics and Control Package.
 	@mass = 0.1
 }
 
-@PART[bluedog_IUS_Orbus6]:NEEDS[RealismOverhaul]
+@PART[bluedog_IUS_Orbus6]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1338,25 +483,14 @@
 	@title = Orbus 6E
 	@description = Second motor for the Inertial Upper Stage. Place inside the Avionics and Control Package before attaching the interstage.
 	@mass = 0.3
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
+	!RESOURCE[SolidFuel] {}
 
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 1300
-		type = HTPB 		
+		type = HTPB
 		basemass = -1
 		TANK
 		{
@@ -1385,7 +519,7 @@
 	}
 }
 
-@PART[bluedog_IUS_Orbus21]:NEEDS[RealismOverhaul]
+@PART[bluedog_IUS_Orbus21]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1393,25 +527,14 @@
 	@title = Orbus 21
 	@description = First motor for the Inertial Upper Stage as well as the core of the Transfer Orbit Stage. Features switchable attach points to attach to either the IUS interstage ot the TOS Avionics.
 	@mass = 0.64
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
-	!RESOURCE[SolidFuel]
-	{
-	}
-	!MODULE[ModuleEngineIgnitor]
-	{
-	}
+	!RESOURCE[SolidFuel] {}
 
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 4900
-		type = HTPB 		
+		type = HTPB
 		basemass = -1
 		TANK
 		{
@@ -1440,11 +563,10 @@
 	}
 }
 
-@PART[bluedog_TOS_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_TOS_Avionics]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
-	
 
 	@title = TOS Avionics and Control Package
 	@description = Avionics and attitude control for the Transfer Orbit Stage. Switch the Orbus 21 to TOS mode and attach.
@@ -1508,7 +630,7 @@
 
 // BURNER 2
 
-@PART[bluedog_Burner2]:NEEDS[RealismOverhaul]
+@PART[bluedog_Burner2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1517,12 +639,6 @@
 	@title = Burner II
 	@description = This small RCS kit can be used to add 3-axis control and a set of small monopropellant engines to the Star 37 kick motor.
 	@mass = 0.05
-	@maxTemp = 900
-	
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	!RESOURCE, * {}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_engines.cfg
@@ -11,7 +11,7 @@
 !PARTUPGRADE[bluedog_Atlas1] {}
 !PARTUPGRADE[bluedog_Atlas2] {}
 
-// Commons patching
+// Common patching
 @PART[bluedog_LR87_LH2_V|bluedog_Saturn_Engine*|bluedog_Redstone_A7_Bare|bluedog_Redstone_A7_TailUnit|bluedog_Juno4_Engine_*|bluedog_Jupiter_Vernier|bluedog_Vanguard_GE405]:FOR[RealismOverhaul]
 {
 	@maxTemp = 900
@@ -70,7 +70,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB LR87-LH-V
-	@mass = 1.25
 
 	%engineType = LR87LH2
 	%engineTypeMult = 1
@@ -85,7 +84,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB H1C
-	@mass = 1.25
 
 	%engineType = H1
 	%engineTypeMult = 1
@@ -98,7 +96,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB H1D
-	@mass = 1.25
 
 	%engineType = H1
 	%engineTypeMult = 1
@@ -111,7 +108,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB F1
-	@mass = 1.25
 
 	%engineType = F1
 	%engineTypeMult = 1
@@ -124,7 +120,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB J2
-	@mass = 1.25
 
 	%engineType = J2
 	%engineTypeMult = 1
@@ -137,7 +132,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB J2S
-	@mass = 1.25
 
 	%engineType = J2
 	%engineTypeMult = 1
@@ -152,7 +146,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB A-7
-	@mass = 0.7
 
 	%engineType = NAA75_110
 
@@ -169,7 +162,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB JPL 6K
-	@mass = 1.25
 
 	%engineType = Juno6k
 	%engineTypeMult = 1
@@ -182,7 +174,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB JPL 45K
-	@mass = 1.25
 
 	%engineType = Juno45k
 	%engineTypeMult = 1
@@ -360,14 +351,12 @@
 @PART[bluedog_Atlas_LR89]:FOR[RealismOverhaul]
 {
 	@title = BDB LR89
-	@mass = 0.7
 	%engineType = LR89
 }
 
 @PART[bluedog_Atlas_LR105]:FOR[RealismOverhaul]
 {
 	@title = BDB LR105
-	@mass = 0.48
 	%engineType = LR105
 }
 
@@ -378,7 +367,6 @@
 
 	%rescaleFactor = 1.6
 	%scale = 1.0
-	@mass = 0.0241
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinTemp = 773.15
@@ -429,7 +417,6 @@
 
 	%rescaleFactor = 1.6
 	%scale = 1.0
-	@mass = 0.0241
 	@crashTolerance = 10
 	@maxTemp = 673.15
 	%skinTemp = 773.15
@@ -481,7 +468,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB H-1D engine
-	@mass = 1.25
 
 	%engineType = H1
 }
@@ -494,7 +480,6 @@
 	%rescaleFactor = 1.3
 
 	@title = BDB AJ10-37
-	@mass = 0.08
 
 	%engineType = AJ10_Early
 }
@@ -505,7 +490,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-104
-	@mass = 0.09
 
 	%engineType = AJ10_Mid
 }
@@ -518,7 +502,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB LR79
-	@mass = 1
 
 	%engineType = LR79
 	!MODULE[ModuleAlternator] {}
@@ -531,7 +514,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB Thor LR-101 Vernier
-	@mass = 0.1
 
 	%engineType = LR101
 }
@@ -545,7 +527,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-118K
-	@mass = 0.09
 
 	%engineType = AJ10_Adv
 }
@@ -556,7 +537,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-104
-	@mass = 0.09
 
 	%engineType = AJ10_Adv
 }
@@ -567,7 +547,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-104
-	@mass = 0.09
 
 	%engineType = LMDE
 }
@@ -665,7 +644,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB XLR81 Agena Engine
-	@mass = 0.091
 
 	%engineType = Agena
 
@@ -735,7 +713,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB XLR81 Agena Engine
-	@mass = 0.091
 
 	%engineType = Agena
 }
@@ -747,7 +724,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@mass = 1
 	%engineType = RL10
 	!MODULE[ModuleAlternator] {}
 	!RESOURCE[ElectricCharge] {}
@@ -1782,7 +1758,6 @@
 	%rescaleFactor = 1.6
 
 	@title = BDB Titan Transtage
-	@mass = 1.9
 
 	!RESOURCE, * {}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_engines.cfg
@@ -1,284 +1,201 @@
 // ENGINES
+@PART[bluedog*]:HAS[@MODULE[ModuleB9PartSwitch]]:FOR[RealismOverhaul]
+{
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]],* {}
+}
+@PART[bluedog*]:HAS[#techtag]:FOR[RealismOverhaul]		// Remove when BDB cleans its own tags up
+{
+    !techtag = DEL
+}
 
 !PARTUPGRADE[bluedog_Atlas1] {}
 !PARTUPGRADE[bluedog_Atlas2] {}
 
-@PART[bluedog_LR87_LH2_V]:NEEDS[RealismOverhaul]
+// Commons patching
+@PART[bluedog_LR87_LH2_V|bluedog_Saturn_Engine*|bluedog_Redstone_A7_Bare|bluedog_Redstone_A7_TailUnit|bluedog_Juno4_Engine_*|bluedog_Jupiter_Vernier|bluedog_Vanguard_GE405]:FOR[RealismOverhaul]
+{
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+}
+
+@PART[bluedog_H1D|bluedog_Able*Engine|bluedog_Thor_LR*|bluedog_DeltaK_AJ10|bluedog_AJ10_*|bluedog_TR_201|bluedog_Delta2_RS27]:FOR[RealismOverhaul]
+{
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+}
+
+@PART[bluedog_Agena_Engine_XLR81|bluedog_Agena_Engine_8096C|bluedog_Centaur_RL10*|bluedog_LR87_3]:FOR[RealismOverhaul]
+{
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+}
+
+@PART[bluedog_LR91_3|bluedog_LR91_3_SingleVernier|bluedog_LR87_5|bluedog_LR91_5|bluedog_LR91_5_FourVernier]:FOR[RealismOverhaul]
+{
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+}
+
+@PART[bluedog_LR87_11|bluedog_LR91_11|bluedog_LR91_11_FourVernier|bluedog_Titan_Transtage|bluedog_Ranger_Engine]:FOR[RealismOverhaul]
+{
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+}
+
+
+@PART[bluedog_Saturn_Engine*]:FOR[RealismOverhaul]
+{
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE,* {}
+}
+
+@PART[bluedog_LR87_LH2_V]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB LR87-LH-V
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = LR87LH2
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
 // SATURN
 
-@PART[bluedog_Saturn_Engine_H1C]:NEEDS[RealismOverhaul]
+@PART[bluedog_Saturn_Engine_H1C]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB H1C
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = H1
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
-
-	!MODULE[ModuleAlternator] {}
-	!RESOURCE,*{}
-
 }
 
-@PART[bluedog_Saturn_Engine_H1D]:NEEDS[RealismOverhaul]
+@PART[bluedog_Saturn_Engine_H1D]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB H1D
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = H1
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
-
-	!MODULE[ModuleAlternator] {}
-	!RESOURCE,*{}
-
 }
 
-@PART[bluedog_Saturn_Engine_F1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Saturn_Engine_F1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB F1
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = F1
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
-
-	!MODULE[ModuleAlternator] {}
-	!RESOURCE,*{}
-
 }
 
-@PART[bluedog_Saturn_Engine_J2]:NEEDS[RealismOverhaul]
+@PART[bluedog_Saturn_Engine_J2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB J2
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = J2
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
-
-	!MODULE[ModuleAlternator] {}
-	!RESOURCE,*{}
-
 }
 
-@PART[bluedog_Saturn_Engine_J2S]:NEEDS[RealismOverhaul]
+@PART[bluedog_Saturn_Engine_J2S]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB J2S
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = J2
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
-
-	!MODULE[ModuleAlternator] {}
-	!RESOURCE,*{}
-
 }
 
 // JUNO
 
-@PART[bluedog_Redstone_A7_Bare]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_A7_Bare|bluedog_Redstone_A7_TailUnit]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB A-7
 	@mass = 0.7
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = NAA75_110
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	!MODULE[PartStatsUpgradeModule] {}
-  	!MODULE[ModuleAlternator] {}
-
-  	!RESOURCE,*{}
-}
-
-@PART[bluedog_Redstone_A7_TailUnit]:NEEDS[RealismOverhaul]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
-	@title = BDB A-7
-	@mass = 0.7
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	%engineType = NAA75_110
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
-	!MODULE[PartStatsUpgradeModule] {}
-  	!MODULE[ModuleAlternator] {}
-
-  	!RESOURCE,*{}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE,*{}
 }
 
 // JUPITER
 
-@PART[bluedog_Juno4_Engine_6K]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_Engine_6K]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB JPL 6K
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = Juno6k
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
-@PART[bluedog_Juno4_Engine_45K]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_Engine_45K]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB JPL 45K
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = Juno45k
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
-@PART[bluedog_Jupiter_Vernier]:NEEDS[RealismOverhaul]
+@PART[bluedog_Jupiter_Vernier]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = Jupiter Vernier Engine
-
 	@mass = 0.03
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	@MODULE[ModuleEnginesFX]
 	{
@@ -291,14 +208,14 @@
 
 		@PROPELLANT[LiquidFuel]
 		{
-				@name = Kerosene
-				@ratio = 0.3929
+			@name = Kerosene
+			@ratio = 0.3929
 		}
 
 		@PROPELLANT[Oxidizer]
 		{
-				@name = LqdOxygen
-				@ratio = 0.6071
+			@name = LqdOxygen
+			@ratio = 0.6071
 		}
 
 		IGNITOR_RESOURCE
@@ -309,23 +226,19 @@
 
 		@atmosphereCurve
 		{
-				@key,0 = 0 288
-				@key,1 = 1 248
+			@key,0 = 0 288
+			@key,1 = 1 248
 		}
 	}
 
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 }
 
 
 // VANGUARD
 
-@PART[bluedog_Vanguard_GE405]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_GE405]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -333,12 +246,6 @@
 	@title = X-405
 	@description = Early rocket engine used to power the Vanguard rocket. Later evolved into Vega's X-405H upper stage engine.
 	@mass = 0.192
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	@MODULE[ModuleEnginesFX],0
     	{
@@ -426,75 +333,45 @@
         	}
     	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
+@PART[bluedog_Atlas_LR89|bluedog_Atlas_LR105]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@maxTemp = 900
+	%skinMaxTemp = 2000
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+
+	!MODULE[PartStatsUpgradeModule] {}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE,*{}
+}
 
 // ATLAS
 
-@PART[bluedog_Atlas_LR89]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_LR89]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
 	@title = BDB LR89
 	@mass = 0.7
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
 	%engineType = LR89
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
-	!MODULE[PartStatsUpgradeModule] {}
-  	!MODULE[ModuleAlternator] {}
-
-  	!RESOURCE,*{}
 }
 
-@PART[bluedog_Atlas_LR105]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_LR105]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
 	@title = BDB LR105
 	@mass = 0.48
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
 	%engineType = LR105
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
-	!MODULE[PartStatsUpgradeModule] {}
-  	!MODULE[ModuleAlternator] {}
-
-  	!RESOURCE,*{}
 }
 
-@PART[bluedog_Atlas_LR101_Inline]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_LR101_Inline]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%engineType = LR101
@@ -545,11 +422,10 @@
 	}
 }
 
-@PART[bluedog_Atlas_LR101_Radial]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_LR101_Radial]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%engineType = LR101
-
 
 	%rescaleFactor = 1.6
 	%scale = 1.0
@@ -597,206 +473,106 @@
 	}
 }
 
-
 // SATURN
 
-@PART[bluedog_H1D]:NEEDS[RealismOverhaul]
+@PART[bluedog_H1D]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB H-1D engine
 	@mass = 1.25
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = H1
 }
 
 // ABLE
 
-@PART[bluedog_Able_Engine]:NEEDS[RealismOverhaul]
+@PART[bluedog_Able_Engine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
 
 	@title = BDB AJ10-37
 	@mass = 0.08
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = AJ10_Early
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
 }
 
-@PART[bluedog_Ablestar_Engine]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ablestar_Engine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-104
 	@mass = 0.09
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = AJ10_Mid
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
 }
 
 // THOR
 
-@PART[bluedog_Thor_LR79]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_LR79]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB LR79
 	@mass = 1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = LR79
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 }
 
-@PART[bluedog_Thor_LR101]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_LR101]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB Thor LR-101 Vernier
 	@mass = 0.1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = LR101
-
 }
 
 
 // DELTA
 
-@PART[bluedog_DeltaK_AJ10]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_AJ10]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-118K
 	@mass = 0.09
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = AJ10_Adv
 }
 
-@PART[bluedog_AJ10_118F]:NEEDS[RealismOverhaul]
+@PART[bluedog_AJ10_118F|bluedog_AJ10_118K|bluedog_AJ10_118X]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-104
 	@mass = 0.09
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = AJ10_Adv
 }
 
-@PART[bluedog_AJ10_118K]:NEEDS[RealismOverhaul]
+@PART[bluedog_TR_201]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB AJ10-104
 	@mass = 0.09
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	%engineType = AJ10_Adv
-}
-
-@PART[bluedog_AJ10_118X]:NEEDS[RealismOverhaul]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
-	@title = BDB AJ10-104
-	@mass = 0.09
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	%engineType = AJ10_Adv
-}
-
-@PART[bluedog_TR_201]:NEEDS[RealismOverhaul]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
-	@title = BDB AJ10-104
-	@mass = 0.09
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = LMDE
 }
 
-@PART[bluedog_Delta2_RS27]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta2_RS27]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -804,12 +580,6 @@
 	@title = RS-27 Liquid Engine
 	@description = A development of the venerable LR-79 engine, the RS-27 is both more powerful and more efficient. The perfect engine for a new family of rockets based on old designs.
 	@mass = 0.589
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	@MODULE[ModuleEnginesFX],0
     	{
@@ -880,39 +650,22 @@
         	}
     	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
+
 // AGENA
 
-@PART[bluedog_Agena_Engine_XLR81]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Engine_XLR81]:FOR[RealismOverhaul]
 {
-
-	!MODULE[ModuleB9PartSwitch]
-	{
-	}
-
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB XLR81 Agena Engine
 	@mass = 0.091
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = Agena
 
@@ -976,106 +729,48 @@
 	}
 }
 
-@PART[bluedog_Agena_Engine_8096C]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Engine_8096C]:FOR[RealismOverhaul]
 {
-
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB XLR81 Agena Engine
 	@mass = 0.091
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	%engineType = Agena
-
 }
 
 
 // CENTAUR
-
-@PART[bluedog_Centaur_RL10]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_RL10|bluedog_Centaur_RL10A41|bluedog_Centaur_RL10B2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
+	@mass = 1
+	%engineType = RL10
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
+}
+
+@PART[bluedog_Centaur_RL10]:FOR[RealismOverhaul]
+{
 	@title = BDB RL10
-	@mass = 1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	%engineType = RL10
-
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
 }
 
-@PART[bluedog_Centaur_RL10A41]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_RL10A41]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
 	@title = BDB RL10 extendable
-	@mass = 1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	%engineType = RL10
-
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
 }
 
-@PART[bluedog_Centaur_RL10B2]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_RL10B2]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	%rescaleFactor = 1.6
-
 	@title = BDB RL10 extendable 2
-	@mass = 1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
-
-	%engineType = RL10
-
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
 }
 
 // TITAN I
 
-@PART[bluedog_LR87_3]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR87_3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1083,12 +778,6 @@
 	@title = BDB LR87-AJ3
 	@description = Used in the first stage of the Titan rocket family, the LR87 is composed of two engines with separate turbomachinery integrated into one unit. The version used on Titan I burned kerosene and liquid oxygen, while Titan II through Titan IV burned storable propellants. A modified version burning liquid hydrogen was developed for the upper stages of Saturn V and Saturn IB, but the J-2 was selected instead. Diameter: [3.0 m].
 	@mass = 0.839
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	@MODULE[ModuleEnginesFX]
 	{
@@ -1124,15 +813,11 @@
 		}
 	}
 
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 }
 
-@PART[bluedog_LR91_3]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR91_3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1140,12 +825,6 @@
 	@title = LR91-AJ3
 	@description = Powerful 2.4m second stage engine for the Titan-I rocket.
 	@mass = 0.59
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	//%engineType = LR91
 
@@ -1218,17 +897,13 @@
         	}
     	}
 
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
-@PART[bluedog_LR91_3_SingleVernier]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR91_3_SingleVernier]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1236,12 +911,6 @@
 	@title = LR91-AJ3-A1
 	@description = Alternative configuration for the Titan I second stage engine with a single vernier for roll control.
 	@mass = 0.59
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	//%engineType = LR91
 
@@ -1314,31 +983,21 @@
         	}
     	}
 
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
 // TITAN II
 
-@PART[bluedog_LR87_5]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR87_5]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB LR87-AJ5
 	@mass = 1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	MODULE
 	{
@@ -1451,20 +1110,13 @@
 		}
 	}
 
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 2
 	%clusterMultiplier = 1.5
 }
 
-@PART[bluedog_LR91_5]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR91_5]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1472,12 +1124,6 @@
 	@title = LR91-AJ5
 	@description = Powerful 3m second stage engine for the Titan-II rocket. As with the LR87, the LR91 was successfully converted from a kerolox burning engine to one that ran on storable hypergolic propellants. This engine can gimbal although a single vernier is still used for roll control.
 	@mass = 0.5
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	//%engineType = LR91
 
@@ -1623,20 +1269,13 @@
   	}
 	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
-@PART[bluedog_LR91_5_FourVernier]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR91_5_FourVernier]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1644,12 +1283,6 @@
 	@title = LR91-AJ5-A4
 	@description = Titan II second stage engine. modified to retain the four vernier arrangment of the LR91-AJ3 from the Titan I.
 	@mass = 0.5
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	//%engineType = LR91
 
@@ -1795,34 +1428,22 @@
   	}
 	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
+
 // TITAN III
 
-@PART[bluedog_LR87_11]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR87_11]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB LR87-AJ11
 	@mass = 1
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	MODULE
 	{
@@ -1895,20 +1516,14 @@
 		}
 	}
 
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
+
 	%engineTypeMult = 2
 	%clusterMultiplier = 1.5
 }
 
-@PART[bluedog_LR91_11]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR91_11]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1916,12 +1531,6 @@
 	@title = LR91-AJ11
 	@description = Powerful 3m second stage engine for the Titan-II rocket. As with the LR87, the LR91 was successfully converted from a kerolox burning engine to one that ran on storable hypergolic propellants. This engine can gimbal although a single vernier is still used for roll control.
 	@mass = 0.5
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	//%engineType = LR91
 
@@ -2033,20 +1642,13 @@
   	}
 	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
-@PART[bluedog_LR91_11_FourVernier]:NEEDS[RealismOverhaul]
+@PART[bluedog_LR91_11_FourVernier]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2054,12 +1656,6 @@
 	@title = LR91-AJ11-FourVernier
 	@description = Titan III and IV second stage engine, modified to retain the four vernier arrangement of the LR91-AJ3 from the Titan I.
 	@mass = 0.5
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	//%engineType = LR91
 
@@ -2171,36 +1767,22 @@
   	}
 	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-	!MODULE[ModuleAlternator]
-	{
-	}
-	!RESOURCE[ElectricCharge]
-	{
-	}
+	!MODULE[ModuleAlternator] {}
+	!RESOURCE[ElectricCharge] {}
 	%engineTypeMult = 1
 	%clusterMultiplier = 1
 }
 
 // TRANSTAGE
 
-@PART[bluedog_Titan_Transtage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage]:FOR[RealismOverhaul]
 {
-
 	@name = BDB-Transtage-RO
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = BDB Titan Transtage
 	@mass = 1.9
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	!RESOURCE, * {}
 
@@ -2228,10 +1810,6 @@
 		%SASServiceLevel = 1
 	}
 
-	!MODULE[ModuleB9PartSwitch],0
-	{
-	}
-
 	%engineTypeMult = 2
 	%clusterMultiplier = 1.5
 }
@@ -2249,19 +1827,13 @@
 
 // RANGER
 
-@PART[bluedog_Ranger_Engine]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Engine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
 	@title = Ranger/Mariner Midcourse Correction Engine
 	@mass = 0.015
-	@maxTemp = 900
-
-	%skinMaxTemp = 2000
-	%emissiveConstant = 0.6
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 
 	@MODULE[ModuleEnginesFX]
     	{


### PR DESCRIPTION
Move BDB engine patching to FOR[RealismOverhaul] instead of legacy pass.
Add missing NEEDS[TacLifeSupport] to some Apollo parts.
Remove deprecated engineSwitch modules for ModuleB9PartSwitch
Remove left-over part tag meant to signal a different tech tree mod.  Should go away once BDB cleans up after itself, but in the meantime it spams the PartLoader section of the log with warnings.

Fixes https://github.com/KSP-RO/RealismOverhaul/issues/2168
