### PR TITLE
Remove kerbalCrewMass

### DIFF
--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -1,8 +1,6 @@
 @PHYSICSGLOBALS:FOR[RealismOverhaul]
 {
 
-	%kerbalCrewMass = 0.1
-	
 	// AeroFX
 	@aeroFXDensityScalar1 = 0.00004
 	@aeroFXDensityExponent1 = 0.7


### PR DESCRIPTION
The way this is implemented in KSP generates bugs in mods.  Technically
this is solvable in mods but they all need to be updated to delay the
code they are calling to FashionablyLate or BetterLateThanNever by
calling FixedUpdateAdd to schedule the analysis after the part is
updated in Part.FixedUpdate().

This is a gigantic pain in the ass.

The Kerbalism author has also found other areas where its deeply
annoying:

https://github.com/Kerbalism/Kerbalism/blob/475866007fb94684336e959a67ae933dc64c8771/GameData/KerbalismConfig/Profiles/Default.cfg#L2396-L2405

It affects both KER and MJ at the very least, and as I'd consider the
way it is implmented in KSP itself to be active hostile to mod
development and all it does is troll users, with the standard
recommendation to users being to turn it off, lets just turn it off.