### PR TITLE
New Agena Configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AgenaSPS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AgenaSPS_Config.cfg
@@ -42,7 +42,7 @@
 {
 	@title = Agena-D Secondary Propulsion System
 	@manufacturer = Bell Aerosystems Company
-	@description = A Secondary Propulsion System developed for use in the Gemini program and used on the Agena stage. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
+	@description = A Secondary Propulsion System developed for use in the Gemini program on the Agena Target Vehicle, allowing for fine control and orbital manuevers without igniting the main engine. It was also later made available to commercial customers as an optional upgrade for Agena. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
 
 	!MODULE[ModuleAlternator] {}
 	!RESOURCE,* {}
@@ -57,7 +57,6 @@
 		CONFIG
 		{
 			name = AgenaSPS
-			description = Secondary propulsion system allowing for fine control and orbital manuevers without igniting the main engine, developed for the Agena Target Vehicle, and later used as an optional upgrade for commercial launches
 			maxThrust = 0.9608 //200 + 16 lbf (1)
 			minThrust = 0.0712 //16 lbf (1)
 			heatProduction = 20
@@ -106,12 +105,12 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 0.5	//Assuming 100 psi chamber pressure and 75% pumping effeciency
+				ratio = 1.13	//Assuming 200 psi chamber pressure and 75% pumping effeciency
 			}
 
 			atmosphereCurve
 			{
-				key = 0 225 //(1)
+				key = 0 305 //(2)
 				key = 1 90
 			}
 
@@ -123,7 +122,7 @@
 		{
 			name = TRW-SPS-HDA
 			description = Upgrade for the Agena SPS developed by TRW, using an electric pump system to allow it to draw directly from the Agena fuel tanks. HDA version
-			maxThrust = 0.471 //90 + 16 lbf (2)
+			maxThrust = 0.516 //100 + 16 lbf (2)
 			minThrust = 0.0712 //16 lbf (1)
 			heatProduction = 20
 			massMult = 0.8	//Remove mass of internal fuel tanks since they are no longer needed
@@ -145,12 +144,12 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 0.5	//Assuming 100 psi chamber pressure and 75% pumping effeciency
+				ratio = 1.13	//Assuming 200 psi chamber pressure and 75% pumping effeciency
 			}
 
 			atmosphereCurve
 			{
-				key = 0 225 //(1)
+				key = 0 305 //(2)
 				key = 1 90
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/AgenaSPS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AgenaSPS_Config.cfg
@@ -1,20 +1,52 @@
-//  Agena SPS
+//	==================================================
+//	Agena SPS Engine
 //
-//	FASA
-//	BDB
+//	Manufacturer: TRW & Lockheed
 //
+//	=================================================================================
+//	Agena SPS
+//	Original SPS
+//
+//	Dry Mass: 57.5 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 0.9608 kN
+//	ISP: ??? SL / 225 Vac
+//	Burn Time: ???
+//	Chamber Pressure: ??? MPa
+//	Propellant: MON3 / UDMH
+//	Prop Ratio: ???
+//	Throttle: 200 lbf chamber + 16 lbf chamber
+//	Nozzle Ratio: ???
+//	Ignitions: 20
+//	=================================================================================
+//	Agena Electric SPS
+//	TRW developed SPS with electric pumps
+//
+//	Dry Mass: 47 Kg	//guess
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 0.471 kN
+//	ISP: ??? SL / 225 Vac
+//	Burn Time: ???
+//	Chamber Pressure: ??? MPa
+//	Propellant: IRFNA-III / UDMH
+//	Prop Ratio: ???
+//	Throttle: 90 lbf chamber + 16 lbf chamber
+//	Nozzle Ratio: ???
+//	Ignitions: infinite
+//	=================================================================================
 // ------Sources--------
 //	(1) 1966 NASA Agena D Mission Capabilities and Restraints Catalog Vol 2 - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660009137.pdf
+//	(2) History of Liquid Propellant Rocket Engines - https://books.google.com/books?id=s1C9Oo2I4VYC
 //
 @PART[*]:HAS[#engineType[AgenaSPS]]:FOR[RealismOverhaulEngines]
 {
-  @title = Agena-D Secondary Propulsion System
+	@title = Agena-D Secondary Propulsion System
 	@manufacturer = Bell Aerosystems Company
-  @description = A Secondary Propulsion System developed for use in the Gemini program and used on the Agena stage. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
-  
-  !MODULE[ModuleAlternator] {}
+	@description = A Secondary Propulsion System developed for use in the Gemini program and used on the Agena stage. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
+
+	!MODULE[ModuleAlternator] {}
 	!RESOURCE,* {}
-  
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -25,6 +57,7 @@
 		CONFIG
 		{
 			name = AgenaSPS
+			description = Secondary propulsion system allowing for fine control and orbital manuevers without igniting the main engine, developed for the Agena Target Vehicle, and later used as an optional upgrade for commercial launches
 			maxThrust = 0.9608 //200 + 16 lbf (1)
 			minThrust = 0.0712 //16 lbf (1)
 			heatProduction = 20
@@ -47,6 +80,83 @@
 			ullage = False
 			pressureFed = True 
 			ignitions = 20 //(1)
+		}
+		CONFIG
+		{
+			name = TRW-SPS
+			description = Upgrade for the Agena SPS developed by TRW, using an electric pump system to allow it to draw directly from the Agena fuel tanks.
+			maxThrust = 0.471 //90 + 16 lbf (2)
+			minThrust = 0.0712 //16 lbf (1)
+			heatProduction = 20
+			massMult = 0.8	//Remove mass of internal fuel tanks since they are no longer needed
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4492
+			}
+
+			PROPELLANT
+			{
+				name = IRFNA-III
+				ratio = 0.5508
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 0.5	//Assuming 100 psi chamber pressure and 75% pumping effeciency
+			}
+
+			atmosphereCurve
+			{
+				key = 0 225 //(1)
+				key = 1 90
+			}
+
+			ullage = False
+			pressureFed = False
+			ignitions = 0
+		}
+		CONFIG
+		{
+			name = TRW-SPS-HDA
+			description = Upgrade for the Agena SPS developed by TRW, using an electric pump system to allow it to draw directly from the Agena fuel tanks. HDA version
+			maxThrust = 0.471 //90 + 16 lbf (2)
+			minThrust = 0.0712 //16 lbf (1)
+			heatProduction = 20
+			massMult = 0.8	//Remove mass of internal fuel tanks since they are no longer needed
+
+			PROPELLANT
+			{
+				name	  = UDMH
+				ratio	  = 0.4838
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name	  = IRFNA-IV
+				ratio	  = 0.5161
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 0.5	//Assuming 100 psi chamber pressure and 75% pumping effeciency
+			}
+
+			atmosphereCurve
+			{
+				key = 0 225 //(1)
+				key = 1 90
+			}
+
+			ullage = False
+			pressureFed = False
+			ignitions = 0
 		}
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -1,35 +1,183 @@
-//  XLR81 family of engines.
+//	==================================================
+//	XLR81/Bell Model 8000 Series Engine
 //
-//	Propellant: IRFNA / UDMH
+//	Manufacturer: Bell Aerosystems
 //
-//  =================================================================================
-//	Bell 8048
-//	Diameter: 0.637599 m
+//	=================================================================================
+//	Model 117
+//	B-58 Hustler rocket pod
+//
+//	Dry Mass: 127 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 67 kN
+//	ISP: ??? SL / 265.5 Vac
+//	Burn Time: 60
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-III / RP1
+//	Prop Ratio: 2.55
+//	Throttle: N/A
+//	Nozzle Ratio: 15
+//	Ignitions: 1
+//	=================================================================================
+//	XLR81-BA-3
+//	Bell Model 8001, Agena Prototype
+//
+//	Dry Mass: 127 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 67 kN
+//	ISP: ??? SL / 265.5 Vac
+//	Burn Time: 100
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-III / RP1
+//	Prop Ratio: 2.55
+//	Throttle: N/A
+//	Nozzle Ratio: 15
+//	Ignitions: 1
+//	=================================================================================
+//	XLR81-BA-5
+//	Bell Model 8048, Agena A
+//
+//	Dry Mass: 127 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 68.9 kN
+//	ISP: ??? SL / 276 Vac
+//	Burn Time: 120
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-III / UDMH
+//	Prop Ratio: 2.57
+//	Throttle: N/A
 //	Nozzle Ratio: 20
-//
-//
-//	Bell 8096
-//	Atlas SM65D-Agena D
-//
-//	Dry Mass: ???
-//	Thrust (SL): 0
-//	Thrust (Vac): 16,027 lbf = 
-//	ISP: 289.5 vac
-//	Burn Time: ???
-//	Chamber Pressure: 508
-//	Propellant: LOX / RP1
-//	Ratio: ???
-//	Nozzle Diameter: 35.5 in = 0.9017 m
-//	Nozzle Exit Area: 770 in^2 = 0.49677 m^2
-//	Nozzle Ratio: 45:1
 //	Ignitions: 2
-//  =================================================================================
-
-
-//	SOURCES
-//	#1: NASA Launch Vehicle Handbook (1961): https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=11323.0;attach=276498;sess=0
-
-
+//	=================================================================================
+//	XLR81-BA-7
+//	Bell Model 8081, Agena B
+//
+//	Dry Mass: 130 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 70.7 kN	//15890 lbf
+//	ISP: ??? SL / 285 Vac
+//	Burn Time: 240
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-III / UDMH
+//	Prop Ratio: 2.57
+//	Throttle: N/A
+//	Nozzle Ratio: 45
+//	Ignitions: 2
+//	=================================================================================
+//	XLR81-BA-11
+//	Bell Model 8096, Agena D
+//
+//	Dry Mass: 132 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 71.2 kN
+//	ISP: ??? SL / 291 Vac
+//	Burn Time: 240
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-III / UDMH
+//	Prop Ratio: 2.57
+//	Throttle: N/A
+//	Nozzle Ratio: 45
+//	Ignitions: 2
+//	=================================================================================
+//	XLR81-BA-13
+//	Bell Model 8247, Gemini ATV
+//
+//	Dry Mass: 132 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 71.2 kN	//Thrust increase proportional with ISP increase
+//	ISP: ??? SL / 291 Vac
+//	Burn Time: 240
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-III / UDMH
+//	Prop Ratio: 2.57
+//	Throttle: N/A
+//	Nozzle Ratio: 45
+//	Ignitions: 15
+//	=================================================================================
+//	Bell Model 8096-39, Agena D HDA
+//
+//	Dry Mass: 132 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 75.3 kN
+//	ISP: ??? SL / 300 Vac
+//	Burn Time: 240
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-IV / UDMH
+//	Prop Ratio: 2.69
+//	Throttle: N/A
+//	Nozzle Ratio: 45
+//	Ignitions: 3
+//	=================================================================================
+//	Bell Model 8096A, Agena Growth Option
+//
+//	Dry Mass: 132 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 78.3 kN	//Thrust increase proportional with ISP increase
+//	ISP: ??? SL / 312 Vac
+//	Burn Time: 240
+//	Chamber Pressure: 3.4 MPa
+//	Propellant: IRFNA-IV / UDMH
+//	Prop Ratio: 2.69
+//	Throttle: N/A
+//	Nozzle Ratio: 75
+//	Ignitions: 3
+//	=================================================================================
+//	Bell Model 8096L, Reusable Agena for STS
+//
+//	Dry Mass: 132 Kg	//guess
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 71.1 kN
+//	ISP: ??? SL / 324 Vac
+//	Burn Time: 1200
+//	Chamber Pressure: 3.34 MPa
+//	Propellant: IRFNA-IV / MMH
+//	Prop Ratio: 2.03
+//	Throttle: N/A
+//	Nozzle Ratio: 150
+//	Ignitions: 15
+//	=================================================================================
+//	Bell Model 8096C, Agena Growth Option
+//
+//	Dry Mass: 84.3 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 53.4 kN
+//	ISP: ??? SL / 336 Vac
+//	Burn Time: 240
+//	Chamber Pressure: 5.17 MPa
+//	Propellant: NTO / MMH
+//	Prop Ratio: 1.88
+//	Throttle: N/A
+//	Nozzle Ratio: 250
+//	Ignitions: 15
+//	=================================================================================
+//	Agena 2000
+//
+//	Dry Mass: 130 Kg	//guess
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 67.5 kN
+//	ISP: ??? SL / 336 Vac
+//	Burn Time: 700
+//	Chamber Pressure: 4.95 MPa
+//	Propellant: MON3 / MMH
+//	Prop Ratio: 1.83
+//	Throttle: N/A
+//	Nozzle Ratio: 275
+//	Ignitions: 15
+//	=================================================================================
+//	Apollo Agena SPS
+//	Proposal for GE Apollo SPS
+//
+//	Dry Mass: 150 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 53.7 kN
+//	ISP: ??? SL / 446.2 Vac
+//	Burn Time: 360
+//	Chamber Pressure: 2.06 MPa
+//	Propellant: LF2 / LH2
+//	Prop Ratio: 11.92
+//	Throttle: 17.7 kN in PF mode
+//	Nozzle Ratio: 45
+//	Ignitions: 15
 
 
 //	FASA, BDB, VSR
@@ -49,33 +197,98 @@
 	@title = XLR81 (Agena) Vacuum Engine
 	@manufacturer = Bell Aerosystems Company
 	@description = Gas-generator nitric acid/UDMH vacuum engine used on Agena. The XLR81 family was derived from the Bell Hustler Rocket Engine, which was developed for use on an air-to-surface missile. Early engines were nearly identical to the Hustler engine, while later variants offered new capabilities and improved performance. Engine restart was introduced on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D used propellant sumps to eliminate the need for ullage thrust. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
-  
+
 	!MODULE[ModuleAlternator] {}
 	!RESOURCE,* {}
-  
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = XLR81-BA-5
+		configuration = Model-117
 		modded = false
-		origMass = 0.132
+		origMass = 0.127
 		CONFIG
 		{
-			name = XLR81-BA-5
-			description = Model 8048, Agena A
-			maxThrust = 67 //15 klbf
+			name = Model-117
+			description = B-58 Hustler rocket pod
+			maxThrust = 67
 			minThrust = 67
 			heatProduction = 100
+			gimbalRange = 0
 			PROPELLANT
 			{
-				name = UDMH
-				ratio = 0.451
+				name = Kerosene
+				ratio = 0.4422
 			}
 			PROPELLANT
 			{
 				name = IRFNA-III
-				ratio = 0.549
+				ratio = 0.5578
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 265.5
+				key = 1 100
+			}
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = XLR81-BA-3
+			description = Model 8001, Agena Prototype
+			maxThrust = 67
+			minThrust = 67
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.4422
+			}
+			PROPELLANT
+			{
+				name = IRFNA-III
+				ratio = 0.5578
+				DrawGauge = True
+			}
+			atmosphereCurve
+			{
+				key = 0 265.5
+				key = 1 100
+			}
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = XLR81-BA-5
+			description = Model 8048, Agena A
+			maxThrust = 68.9
+			minThrust = 68.9
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4492
+			}
+			PROPELLANT
+			{
+				name = IRFNA-III
+				ratio = 0.5508
 				DrawGauge = True
 			}
 			atmosphereCurve
@@ -96,18 +309,19 @@
 		{
 			name = XLR81-BA-7
 			description = Model 8081, Agena B
-			maxThrust = 71 //16 klbf
-			minThrust = 71
+			maxThrust = 70.7
+			minThrust = 70.7
 			heatProduction = 100
+			massMult = 1.0236
 			PROPELLANT
 			{
 				name = UDMH
-				ratio = 0.449
+				ratio = 0.4492
 			}
 			PROPELLANT
 			{
 				name = IRFNA-III
-				ratio = 0.551
+				ratio = 0.5508
 				DrawGauge = True
 			}
 			atmosphereCurve
@@ -129,24 +343,25 @@
 		{
 			name	       = XLR81-BA-11
 			description    = Model 8096, Agena D
-			maxThrust      = 71 //16 klbf
-			minThrust      = 71
+			maxThrust      = 71.2
+			minThrust      = 71.2
 			heatProduction = 100
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 2
+			massMult = 1.0394
 
 			PROPELLANT
 			{
 				name	  = UDMH
-				ratio	  = 0.449
+				ratio	  = 0.4492
 				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
 				name	  = IRFNA-III
-				ratio	  = 0.551
+				ratio	  = 0.5508
 				DrawGauge = True
 			}
 
@@ -166,18 +381,19 @@
 		{
 			name = XLR81-BA-13
 			description = Model 8247, Gemini ATV
-			maxThrust = 71 //16 klbf
-			minThrust = 71
+			maxThrust = 71.2
+			minThrust = 71.2
 			heatProduction = 100
+			massMult = 1.0394
 			PROPELLANT
 			{
 				name = UDMH
-				ratio = 0.449
+				ratio = 0.4492
 			}
 			PROPELLANT
 			{
 				name = IRFNA-III
-				ratio = 0.551
+				ratio = 0.5508
 				DrawGauge = True
 			}
 			atmosphereCurve
@@ -197,13 +413,14 @@
 		CONFIG
 		{
 			name	       = Model8096-39
-			description    = Improved propellant (HDA)
-			maxThrust      = 76 //17 klbf
-			minThrust      = 76
+			description    = Improved propellant, using high density acid (HDA)
+			maxThrust      = 75.3 //17 klbf
+			minThrust      = 75.3
 			heatProduction = 100
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
-			ignitions      = 2
+			ignitions      = 3
+			massMult = 1.0394
 
 			PROPELLANT
 			{
@@ -234,13 +451,14 @@
 		CONFIG
 		{
 			name	       = Model8096A // (5)
-			description    = Higher expansion ratio nozzle
-			maxThrust      = 76 //17 klbf
-			minThrust      = 76
+			description    = Higher expansion ratio nozzle prototype
+			maxThrust      = 78.3
+			minThrust      = 78.3
 			heatProduction = 100
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 3 // (6)
+			massMult = 1.0394
 
 			PROPELLANT
 			{
@@ -278,6 +496,7 @@
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 15 // '10 to 100' depending on cert; go with 8247 for now.
+			massMult = 1.0394
 
 			PROPELLANT // (6) - 2.03 ratio for HDA/MMH
 			{
@@ -308,16 +527,16 @@
 		CONFIG
 		{
 			name	       = Model8096C // (6)
-			description    = Growth Agena option
+			description    = Growth Agena option, sacrificing thrust for improved effeciency
 			maxThrust      = 53.4 //12 klbf
 			minThrust      = 53.4
 			heatProduction = 100
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 15 // '10 to 100' depending on cert; go with 8247 for now.
-			massMult = 0.65
+			massMult = 0.6638
 
-			PROPELLANT // (6) - 1.88 ratio for HDA/MMH
+			PROPELLANT // (6) - 1.88 ratio for NTO/MMH
 			{
 				name	  = MMH
 				ratio	  = 0.4671
@@ -346,14 +565,14 @@
 		CONFIG
 		{
 			name	       = Agena-2000	//(7)
-			description    = Agena upgrade for proposed Atlas V upper stage
+			description    = Agena upgrade for proposed Atlas V upper stage. Tested, but cancelled when studies showed it would be more economical to use single engine centaur instead.
 			maxThrust      = 67.5 //15170 lbf
 			minThrust      = 67.5
 			heatProduction = 100
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False
 			ignitions      = 15
-			massMult	 = 0.65
+			massMult	 = 1.0394
 
 			PROPELLANT // (6) - 1.83 ratio for MON3/MMH
 			{
@@ -391,7 +610,7 @@
 			ullage 	       = False //(1) p 1-4
 			pressureFed    = False	//Because engine was intended to be used mostly in pump-fed mode, pressureization system is included in engine mass
 			ignitions      = 15
-			massMult	   = 1.136	//Including mass of pressurization system that allowed it to function in HP mode
+			massMult	   = 1.1811	//Including mass of pressurization system that allowed it to function in HP mode
 
 			PROPELLANT // (5) - 11.92 ratio for LF2/LH2
 			{
@@ -429,6 +648,38 @@
 	}
 }
 
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model-117]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Model-117
+		ratedBurnTime = 60
+		// pump-fed, so failure is as likely to be ignition as during runtime
+		ignitionReliabilityStart = 0.8
+		ignitionReliabilityEnd = 0.85
+		ignitionDynPresFailMultiplier = 10.0 //was intended to be launched from a B-58
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.9
+		reliabilityDataRateMultiplier = 1
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR81-BA-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = XLR81-BA-3
+		ratedBurnTime = 100
+		// pump-fed, so failure is as likely to be ignition as during runtime
+		//Identical to XLR81-BA-5 other than nozzle, give same reliability since only two were launched
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.92
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.85
+		cycleReliabilityEnd = 0.92
+		techTransfer = Model-117:50
+		reliabilityDataRateMultiplier = 1
+	}
+}
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR81-BA-5]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -441,7 +692,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.85
 		cycleReliabilityEnd = 0.92
-		techTransfer = 
+		techTransfer = Model-117,XLR81-BA-3:50
 		reliabilityDataRateMultiplier = 1
 	}
 }
@@ -457,7 +708,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.89
 		cycleReliabilityEnd = 0.94
-		techTransfer = XLR81-BA-5:50
+		techTransfer = Model-117,XLR81-BA-3,XLR81-BA-5:50
 		reliabilityDataRateMultiplier = 1
 	}
 }
@@ -473,7 +724,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.98
-		techTransfer = XLR81-BA-5,XLR81-BA-7:50
+		techTransfer = Model-117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7:50
 		reliabilityDataRateMultiplier = 1
 	}
 }
@@ -489,7 +740,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.993
-		techTransfer = XLR81-BA-5,XLR81-BA-7,XLR81-BA-11:50
+		techTransfer = Model-117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11:50
 		reliabilityDataRateMultiplier = 1
 	}
 }
@@ -505,7 +756,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.965
 		cycleReliabilityEnd = 0.994
-		techTransfer = XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
+		techTransfer = Model-117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
 }
@@ -521,7 +772,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.968
 		cycleReliabilityEnd = 0.996
-		techTransfer = XLR81-BA-11,XLR81-BA-13,Model8096-39:50
+		techTransfer = Model-117,XLR81-BA-3,XLR81-BA-11,XLR81-BA-13,Model8096-39:50
 		reliabilityDataRateMultiplier = 1
 	}
 }
@@ -562,7 +813,7 @@
 	TESTFLIGHT
 	{
 		name = Agena-2000
-		ratedBurnTime = 1200
+		ratedBurnTime = 700
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -585,7 +836,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
-		techTransfer = XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
+		techTransfer = Model-117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -205,12 +205,12 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Model-117
+		configuration = Model117
 		modded = false
 		origMass = 0.127
 		CONFIG
 		{
-			name = Model-117
+			name = Model117
 			description = B-58 Hustler rocket pod
 			maxThrust = 67
 			minThrust = 67

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -230,7 +230,7 @@
 			atmosphereCurve
 			{
 				key = 0 265.5
-				key = 1 100
+				key = 1 220	//sea level nozzle
 			}
 			ullage = True
 			pressureFed = False
@@ -248,6 +248,7 @@
 			maxThrust = 67
 			minThrust = 67
 			heatProduction = 100
+			gimbalRange = 5
 			PROPELLANT
 			{
 				name = Kerosene
@@ -262,7 +263,7 @@
 			atmosphereCurve
 			{
 				key = 0 265.5
-				key = 1 100
+				key = 1 220	//sea level nozzle
 			}
 			ullage = True
 			pressureFed = False
@@ -280,6 +281,7 @@
 			maxThrust = 68.9
 			minThrust = 68.9
 			heatProduction = 100
+			gimbalRange = 5
 			PROPELLANT
 			{
 				name = UDMH
@@ -313,6 +315,7 @@
 			minThrust = 70.7
 			heatProduction = 100
 			massMult = 1.0236
+			gimbalRange = 5
 			PROPELLANT
 			{
 				name = UDMH
@@ -350,6 +353,7 @@
 			pressureFed    = False
 			ignitions      = 2
 			massMult = 1.0394
+			gimbalRange = 5
 
 			PROPELLANT
 			{
@@ -385,6 +389,8 @@
 			minThrust = 71.2
 			heatProduction = 100
 			massMult = 1.0394
+			gimbalRange = 5
+
 			PROPELLANT
 			{
 				name = UDMH
@@ -421,6 +427,7 @@
 			pressureFed    = False
 			ignitions      = 3
 			massMult = 1.0394
+			gimbalRange = 5
 
 			PROPELLANT
 			{
@@ -459,6 +466,7 @@
 			pressureFed    = False
 			ignitions      = 3 // (6)
 			massMult = 1.0394
+			gimbalRange = 5
 
 			PROPELLANT
 			{
@@ -497,6 +505,7 @@
 			pressureFed    = False
 			ignitions      = 15 // '10 to 100' depending on cert; go with 8247 for now.
 			massMult = 1.0394
+			gimbalRange = 5
 
 			PROPELLANT // (6) - 2.03 ratio for HDA/MMH
 			{
@@ -535,6 +544,7 @@
 			pressureFed    = False
 			ignitions      = 15 // '10 to 100' depending on cert; go with 8247 for now.
 			massMult = 0.6638
+			gimbalRange = 5
 
 			PROPELLANT // (6) - 1.88 ratio for NTO/MMH
 			{
@@ -573,6 +583,7 @@
 			pressureFed    = False
 			ignitions      = 15
 			massMult	 = 1.0394
+			gimbalRange = 5
 
 			PROPELLANT // (6) - 1.83 ratio for MON3/MMH
 			{
@@ -611,6 +622,7 @@
 			pressureFed    = False	//Because engine was intended to be used mostly in pump-fed mode, pressureization system is included in engine mass
 			ignitions      = 15
 			massMult	   = 1.1811	//Including mass of pressurization system that allowed it to function in HP mode
+			gimbalRange = 5
 
 			PROPELLANT // (5) - 11.92 ratio for LF2/LH2
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -648,11 +648,11 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model-117]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Model117]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = Model-117
+		name = Model117
 		ratedBurnTime = 60
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.8


### PR DESCRIPTION
Add the Bell Model 117 (used by the B-58 Hustler) and the Bell Model 8001 (Used by the first 2 Agena Launches) to the XLR81, as well as update and fine tune the mass, O/F ratios, and thrust of existing configs.

Also add the TRW Agena SPS, an upgrade of the Agena SPS that used electric pumps to draw directly from the Agena fuel tank, rather than using a dedicated pressurized tank.