### PR TITLE
Add obscure engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -79,8 +79,43 @@
 		CONFIG
 		{
 			name = RDA-1-150
+			description = Simplified ORM-65 for the RP-318 rocket planes
 			minThrust = 0.499
 			maxThrust = 1.460
+			massMult = 0.86
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3205
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = AK20
+				ratio = 0.6795
+			}
+			atmosphereCurve
+			{
+				key = 0 215
+				key = 1 210
+			}
+			
+			%ullage = True
+			%pressureFed = True
+			%ignitions = 2
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.500
+			}
+		}
+		CONFIG
+		{
+			name = RDA-1-300
+			description = Uprated RDA-1-300, to allow the RP-318 to take off under its own power. Test site was overrun by the German army before it could be tested.
+			minThrust = 0.499
+			maxThrust = 2.942
 			massMult = 0.86
 			heatProduction = 100
 			PROPELLANT
@@ -138,5 +173,20 @@
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.99
 		techTransfer = ORM-65:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RDA-1-300]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//same as RDA-1-150 due to lack of information
+		name = RDA-1-300
+		ratedBurnTime = 200
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.98
+		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.99
+		techTransfer = ORM-65, RDA-1-150:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
@@ -51,7 +51,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = RD-111
+		configuration = RD-111-8D716
 		origMass = 1.492
 
 		CONFIG

--- a/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
@@ -127,10 +127,10 @@
 		//85 successes, 22 failures
 		name = RD-111
 		ratedBurnTime = 110
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
-		techTransfer = 
+		ignitionReliabilityStart = 0.8
+		ignitionReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.741176
+		cycleReliabilityEnd = 0.948235
+		techTransfer = RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:20
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
@@ -1,0 +1,136 @@
+//	==================================================
+//	RD-111 Series Engine
+//
+//	Manufacturer: NPO Energomash
+//
+//	=================================================================================
+//	RD-111
+//	8D716
+//
+//	Dry Mass: 1492 Kg
+//	Thrust (SL): 1413.4 kN
+//	Thrust (Vac): 1628 kN
+//	ISP: 275 SL / 317 Vac
+//	Burn Time: 110
+//	Chamber Pressure: 7.85 MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.39
+//	Throttle: N/A
+//	Nozzle Ratio: 18
+//	Ignitions: 1
+//	===================================================================================
+//
+//	SOURCES
+//	Russian space-rocket and missile liquid-propellant engines:												http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//	Astronautix - RD-111:																					http://www.astronautix.com/r/rd-111.html
+//	fas.org - R-9 - SS-8 Sasin:																				https://fas.org/nuke/guide/russia/icbm/r-9.htm
+
+//	Used by:
+//
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[RD111]]:FOR[RealismOverhaulEngines]
+{
+	%title = RD-111
+	%manufacturer = NPO Energomash
+	%description = 1st stage engine for the R-9 ICBM. Derived from the RD-107/108 engines of the R-7, the RD-111 was intended to provide a much quicker reaction time than the R-7. Although still using cryogenic liquid oxygen, it could be fuelled and launched in under 20 minutes. This, combined with its high performance, meant it was the last cryogenic ICBM to leave service.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 5	//complete guess
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RD-111
+		origMass = 1.492
+
+		CONFIG
+		{
+			name = RD-111-8D716
+			description = 
+			minThrust = 1628
+			maxThrust = 1628
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3680
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6320
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 317
+				key = 1 275
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+
+	!RESOURCE,*{}
+
+	RESOURCE
+	{
+		name = TEATEB
+		amount = 1
+		maxAmount = 1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-111]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//85 successes, 22 failures
+		name = RD-111
+		ratedBurnTime = 110
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = 
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
@@ -1,0 +1,130 @@
+//	==================================================
+//	RD-1 Series Engine
+//
+//	Manufacturer: Glushko
+//
+//	=================================================================================
+//	RD-1
+//	4-chamber version developed by glushko (there were 3 engines called the RD-1, one from Isayev, one from Glushko, and one from Korolev)
+//
+//	Dry Mass: 56 Kg
+//	Thrust (SL): 11.7 kN
+//	Thrust (Vac): ??? kN
+//	ISP: 200 SL / ??? Vac
+//	Burn Time: 300	//guess, based on planned 10 minute flight times, assumed half under power, and half gliding
+//	Chamber Pressure: ??? MPa
+//	Propellant: AK20 / RP1
+//	Prop Ratio: 2.12
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	===================================================================================
+//
+//	SOURCES
+//	Energiya-Buran: The Soviet Space Shuttle:																https://books.google.com/books?id=VRb1yAGVWNsC&dq=RD-1+engine&source=gbs_navlinks_s
+
+//	Used by:
+//
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[RD1]]:FOR[RealismOverhaulEngines]
+{
+	%title = RD-1
+	%manufacturer = Glushko
+	%description = Four-chamber nitric acid and kerosene developed by Glushko duting WW2. Used in various rocket powered aircraft proposals, and tested extensivley in the Pe-2RD, a Pe-2 bomber with an RD-1 installed in the fuselage. Abandoned after WW2, as jet engines proved to be more reliable for high performance aircraft.
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleGimbal],*
+	{
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RD-1
+		origMass = 0.056
+
+		CONFIG
+		{
+			name = RD-1
+			description = 
+			minThrust = 12.6
+			maxThrust = 12.6
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Ethane
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3205
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = AK20
+				ratio = 0.6795
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 215
+				key = 1 200
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+
+	!RESOURCE,*{}
+
+	RESOURCE
+	{
+		name = Ethane
+		amount = 1
+		maxAmount = 1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Over 100 flights in the Pe-2RD. Early flights had difficulty with ignitions
+		name = RD-1
+		ratedBurnTime = 300
+		ignitionReliabilityStart = 0.7
+		ignitionReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -1,0 +1,203 @@
+//	==================================================
+//	RZ Series Engine
+//
+//	Manufacturer: Rolls-Royce
+//
+//	=================================================================================
+//	RZ.1
+//	License-Built copy of the S-3
+//
+//	Assuming identical to S-3
+//	Dry Mass: 945.3 Kg
+//	Thrust (SL): 600.51 kN
+//	Thrust (Vac): 696.6 kN
+//	ISP: 247.62 SL / 288 Vac
+//	Burn Time: 182
+//	Chamber Pressure: ??? MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.4
+//	Throttle: N/A
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//	===================================================================================
+//	RZ.2
+//	Anglicized S-3, built for Blue Streak. Production version
+//
+//	Dry Mass: 945.3 kg	assuming same as S-3D
+//	Thrust (SL): 665 kN
+//	Thrust (vac): 756 kN	assumed same as S-3D
+//	ISP: 248 SL / 282 vac
+//	Burn Time: 156
+//	Chamber Pressure: 3.6 MPa
+//	Propellant: LOX / RP1
+///	Prop Ratio: 2.4
+//	Throttle: N/A
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//	=================================================================================
+//
+//	SOURCES
+//	#1: Blue Streak: Britain's Medium Range Ballistic Missile:								https://books.google.com/books?id=wRmgDwAAQBAJ&dq=Rolls+Royce+RZ.1&source=gbs_navlinks_s
+//	#2: Astronautix - RZ.2:																	http://www.astronautix.com/r/rz2.html
+//	#3: Wikipedia - Rolls Royce RZ.2:														https://en.wikipedia.org/wiki/Rolls-Royce_RZ.2
+//
+//	Used by:
+//
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[RZ]]:FOR[RealismOverhaulEngines]
+{
+	%title = RZ Series
+	%manufacturer = Rolls-Royce
+	%description = British kerolox booster engine for the Blue Streak missile and first stage of the Europa launch vehicle. Derived from the Rocketdyne S-3, with minor modifications.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 7
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RZ.1
+		origMass = 0.945  // See above for reference information on the S-3D weight
+
+		CONFIG
+		{
+			name = RZ.1
+			description = License-Built version of the Rocketdyne S-3
+			minThrust = 696.6
+			maxThrust = 696.6
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3929
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6071
+			}
+
+			atmosphereCurve
+			{
+				key = 0 288
+				key = 1 248
+			}
+		}
+		
+		CONFIG
+		{
+			name = RZ.2
+			description = Production engine for the Blue Streak missile, based on the rocketdyne S-3D
+			minThrust = 756
+			maxThrust = 756
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3929
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6071
+			}
+
+			atmosphereCurve
+			{
+				key = 0 282
+				key = 1 248
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+
+	!RESOURCE,*{}
+
+	RESOURCE
+	{
+		name = TEATEB
+		amount = 1
+		maxAmount = 1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ.1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//assumed same as S-3
+		name = RZ.1
+		ratedBurnTime = 156
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = XLR43-NA-3,S-3:50	//Direct derivative of S-3
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ.2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//12 launches, no first stage failures
+		name = RZ.2
+		ratedBurnTime = 156
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.92
+		cycleReliabilityEnd = 0.97
+		techTransfer = XLR43-NA-3,S-3,S-3D,RZ.1:50
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -20,17 +20,32 @@
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	===================================================================================
-//	RZ.2
+//	RZ.2 Mk3
 //	Anglicized S-3, built for Blue Streak. Production version
 //
 //	Dry Mass: 945.3 kg	assuming same as S-3D
-//	Thrust (SL): 665 kN
-//	Thrust (vac): 756 kN	assumed same as S-3D
+//	Thrust (SL): 671 kN
+//	Thrust (vac): 763 kN
 //	ISP: 248 SL / 282 vac
 //	Burn Time: 156
 //	Chamber Pressure: 3.6 MPa
 //	Propellant: LOX / RP1
 ///	Prop Ratio: 2.4
+//	Throttle: N/A
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//	===================================================================================
+//	RZ.2 Mk4
+//	Anglicized S-3, built for Blue Streak. Europa version
+//
+//	Dry Mass: 945.3 kg	assuming same as S-3D
+//	Thrust (SL): 735.5 kN
+//	Thrust (vac): 791.2 kN
+//	ISP: 249 SL / 284 vac
+//	Burn Time: 156
+//	Chamber Pressure: 3.96 MPa
+//	Propellant: LOX / RP1
+///	Prop Ratio: 2.16
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -40,6 +55,7 @@
 //	#1: Blue Streak: Britain's Medium Range Ballistic Missile:								https://books.google.com/books?id=wRmgDwAAQBAJ&dq=Rolls+Royce+RZ.1&source=gbs_navlinks_s
 //	#2: Astronautix - RZ.2:																	http://www.astronautix.com/r/rz2.html
 //	#3: Wikipedia - Rolls Royce RZ.2:														https://en.wikipedia.org/wiki/Rolls-Royce_RZ.2
+//	#4: b14643 - European space-rocket liquid-propellant engines:							http://www.b14643.de/Spacerockets/Specials/European_Rocket_engines/engines.htm
 //
 //	Used by:
 //
@@ -117,10 +133,10 @@
 		
 		CONFIG
 		{
-			name = RZ.2
+			name = RZ.2-Mk3
 			description = Production engine for the Blue Streak missile, based on the rocketdyne S-3D
-			minThrust = 756
-			maxThrust = 756
+			minThrust = 763
+			maxThrust = 763
 			heatProduction = 100
 			massMult = 1.0
 
@@ -159,6 +175,51 @@
 				key = 1 248
 			}
 		}
+
+		CONFIG
+		{
+			name = RZ.2-Mk4
+			description = Uprated for Europa I and II
+			minThrust = 791.2
+			maxThrust = 791.2
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3918
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6082
+			}
+
+			atmosphereCurve
+			{
+				key = 0 284
+				key = 1 249
+			}
+		}
 	}
 
 	!MODULE[ModuleAlternator]{}
@@ -187,17 +248,31 @@
 		techTransfer = XLR43-NA-3,S-3:50	//Direct derivative of S-3
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ.2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ.2-Mk3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		//12 launches, no first stage failures
-		name = RZ.2
+		//Blue Streak: 4 successes, 1 failures. 9 engines succeeded, 1 failed
+		name = RZ.2-Mk3
 		ratedBurnTime = 156
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.97
-		cycleReliabilityStart = 0.92
-		cycleReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.888889
+		cycleReliabilityEnd = 0.977778
 		techTransfer = XLR43-NA-3,S-3,S-3D,RZ.1:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ.2-Mk4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Europa I & II: 6 launches, no first stage failures. 12 engines succeeded, 0 failed
+		name = RZ.2-Mk4
+		ratedBurnTime = 156
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.923077
+		cycleReliabilityEnd = 0.984615
+		techTransfer = XLR43-NA-3,S-3,S-3D,RZ.1,RZ.2-Mk3:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -50,7 +50,23 @@
 //	Prop Ratio: 3.55
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 8.2
+//	Ignitions: 1
+//	=================================================================================
+//	Isayev-R17
+//	R-17MU (Scud-D)
+//
+//	Dry Mass: 160 kg
+//	Thrust (SL): 149.9 kN
+//	Thrust (Vac): 165.5 kN
+//	ISP: 240 SL / 265 Vac
+//	Burn Time: 90
+//	Chamber Pressure: ??? MPa
+//	Propellant: AK27 / UDMH
+//	Prop Ratio: 2.32	//8.5 m2 UDMH, 10.46 m2 AK27, 1.23 volume
+//	Engine Nozzle: ???
+//	Nozzle Exit Area: ???
+//	Nozzle Ratio: 9.6
 //	Ignitions: 1
 
 //	Sources:
@@ -103,6 +119,7 @@
 		CONFIG
 		{
 			name = S2.253
+			description = Derived from the German Wasserfall engine, used on the R-11 (Scud-A)
 			minThrust = 93.3
 			maxThrust = 93.3
 			heatProduction = 35
@@ -146,6 +163,7 @@
 		CONFIG
 		{
 			name = S3.42T
+			description = Pump-fed upgrade, used on the R-11MU and some R-17 prototypes. Never entered service
 			minThrust = 127.5
 			maxThrust = 127.5
 			heatProduction = 35
@@ -189,6 +207,7 @@
 		CONFIG
 		{
 			name = S5.2
+			description = Upgrade, used on the Production R-17 and R-17M missile, A.K.A Scud-B and Scud-C. This was the most heavily exported variant, and copies were built by many countries.
 			minThrust = 146.3
 			maxThrust = 146.3
 			heatProduction = 35
@@ -228,6 +247,45 @@
 				key = 1 226
 			}
 		}
+
+		CONFIG
+		{
+			name = Isayev-R17
+			description = Upgrade used for the R-17MU, A.K.A Scud-D. It saw very little use in the Soviet Union due to mediocore performance, so the remaining missiles were sold to North Korea, providing the basis for North Korean missile development.
+			minThrust = 165.5
+			maxThrust = 165.5
+			heatProduction = 35
+			massMult = 0.53
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT // 2.32 mixture ratio
+			{
+				name = UDMH
+				ratio = 0.4484
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = AK27
+				ratio = 0.5516
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 265
+				key = 1 240
+			}
+		}
 	}
 
 
@@ -251,13 +309,14 @@
 {
 	TESTFLIGHT
 	{
+		//R-11A Sounding Rocket. 26 successes, 0 failures 
 		name = S2.253
 		ratedBurnTime = 95
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
-		cycleReliabilityStart = 0.82
-		cycleReliabilityEnd = 0.92
+		cycleReliabilityStart = 0.961538
+		cycleReliabilityEnd = 0.992308
 		reliabilityDataRateMultiplier = 1
 		techTransfer = RD-100:20
 	}
@@ -266,30 +325,48 @@
 {
 	TESTFLIGHT
 	{
+		//no data, assumed same as S5.2
 		name = S3.42T
 		ratedBurnTime = 65
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
-		cycleReliabilityStart = 0.85
-		cycleReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.80
+		cycleReliabilityEnd = 0.96
 		reliabilityDataRateMultiplier = 1
 		techTransfer = S2.253:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S3.42T]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5.2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
+		//R-17 acceptance trials. 20 launches, 5 failures
 		name = S5.2
 		ratedBurnTime = 75
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
-		cycleReliabilityStart = 0.85
-		cycleReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.80
+		cycleReliabilityEnd = 0.96
 		reliabilityDataRateMultiplier = 1
 		techTransfer = S2.253,S3.42T:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Isayev-R17]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//no data, assumed same as S5.2
+		name = Isayev-R17
+		ratedBurnTime = 90
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.98
+		ignitionDynPresFailMultiplier = 1.5
+		cycleReliabilityStart = 0.80
+		cycleReliabilityEnd = 0.96
+		reliabilityDataRateMultiplier = 1
+		techTransfer = S2.253,S3.42T,S5.2:50
 	}
 }
 

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -72,9 +72,6 @@
 
 	@MODULE[ModuleEngines,*]
 	{
-		%minThrust = 93.3
-		%maxThrust = 93.3
-		%heatProduction = 35
 		%EngineType = LiquidFuel
 		@useEngineResponseSpeed = False
 		%useThrustCurve = False
@@ -231,8 +228,6 @@
 				key = 1 226
 			}
 		}
-
-	   
 	}
 
 

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -84,7 +84,7 @@
 	%category = Engine
 	%title = S2.253 Engine
 	%manufacturer = OKB Isayev
-	%description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile, based on the Wasserfall engine using Kerosene and Nitric Acid as propellants. Better known by its western designation, Scud, it was used as a sounding rocket, and later versions where exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
+	%description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile and sounding rocket, based on the German Wasserfall engine. Better known by its western designation, Scud, later versions where exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
 
 	@MODULE[ModuleEngines,*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -84,21 +84,16 @@
 	%category = Engine
 	%title = S2.253 Engine
 	%manufacturer = OKB Isayev
-	%description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile and sounding rocket, based on the German Wasserfall engine. Better known by its western designation, Scud, later versions where exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
+	%description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile and sounding rocket, based on the German Wasserfall engine. Better known by its western designation, Scud, later versions were exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
 
-	@MODULE[ModuleEngines,*]
+	@MODULE[ModuleEngines],*
 	{
 		%EngineType = LiquidFuel
-		@useEngineResponseSpeed = False
-		%useThrustCurve = False
-		%ullage = True
-		%pressureFed = True
-		%ignitions = 1
-
-		!IGNITOR_RESOURCE,*{}
-
-		!thrustCurve,*{}
 	}
+
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
 
 	@MODULE[ModuleGimbal],*
 	{
@@ -287,11 +282,6 @@
 			}
 		}
 	}
-
-
-	!MODULE[ModuleAlternator],*{}
-
-	!RESOURCE,*{}
 
 	RESOURCE
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
@@ -1,0 +1,177 @@
+//	==================================================
+//	Veronique Engine
+//
+//	Manufacturer: LRBA
+//
+//	=================================================================================
+//	Veronique R
+//	Prototype
+//
+//	Dry Mass: 150 Kg
+//	Thrust (SL): 40 kN
+//	Thrust (Vac): ??? kN
+//	ISP: 180 SL / 200 Vac	//Calculated from fuel load, thrust and burn time
+//	Burn Time: 6.5
+//	Chamber Pressure: ??? MPa
+//	Propellant: IRFNA / RP1
+//	Prop Ratio: 3.07	//guess, from scud O/F ratio (also used a kerosene/nitric acid wassefall engine)
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Veronique
+//	Production version
+//
+//	Dry Mass: 150 Kg
+//	Thrust (SL): 40 kN
+//	Thrust (Vac): ??? kN
+//	ISP: 180 SL / 200 Vac	//Calculated from fuel load, thrust and burn time
+//	Burn Time: 45
+//	Chamber Pressure: ??? MPa
+//	Propellant: IRFNA / RP1
+//	Prop Ratio: 3.07
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Veronique AGI
+//	Turpentine fuel
+//
+//	Dry Mass: 150 Kg
+//	Thrust (SL): 40 kN
+//	Thrust (Vac): ??? kN
+//	ISP: 202 SL / 220 Vac	//Calculated from fuel load, thrust and burn time
+//	Burn Time: 49
+//	Chamber Pressure: ??? MPa
+//	Propellant: IWFNA / Turpentine
+//	Prop Ratio: 3.57	//Vesta O/F ratio
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Veronique 61
+//	Increased performance
+//
+//	Dry Mass: 150 Kg
+//	Thrust (SL): 60 kN
+//	Thrust (Vac): ??? kN
+//	ISP: 202 SL / 220 Vac	//Calculated from fuel load, thrust and burn time
+//	Burn Time: 56
+//	Chamber Pressure: ??? MPa
+//	Propellant: IWFNA / Turpentine
+//	Prop Ratio: 3.57	//Vesta O/F ratio
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	===================================================================================
+//
+//	SOURCES
+//	sat-net.com - Veronique and Vesta:																		http://www.sat-net.com/serra/lrba_e.htm#evol_V
+//	Astronautix - Veronique:																				http://www.astronautix.com/v/veronique.html
+//
+//
+//	Used by:
+//
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[Veronique]]:FOR[RealismOverhaulEngines]
+{
+	%title = Veronique
+	%manufacturer = LRBA
+	%description = Wasserfall derivative engine, developed by German and French engineers after WW2 for the sounding rocket of the same name. It was the first French high altitude sounding rocket
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleGimbal],*
+	{
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Veronique
+		origMass = 0.056
+
+		CONFIG
+		{
+			name = RD-1
+			description = 
+			minThrust = 12.6
+			maxThrust = 12.6
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Ethane
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3205
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = AK20
+				ratio = 0.6795
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 215
+				key = 1 200
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+
+	!RESOURCE,*{}
+
+	RESOURCE
+	{
+		name = Ethane
+		amount = 1
+		maxAmount = 1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Over 100 flights in the Pe-2RD. Early flights had difficulty with ignitions
+		name = RD-1
+		ratedBurnTime = 300
+		ignitionReliabilityStart = 0.7
+		ignitionReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
@@ -8,9 +8,9 @@
 //	Prototype
 //
 //	Dry Mass: 150 Kg
-//	Thrust (SL): 40 kN
-//	Thrust (Vac): ??? kN
-//	ISP: 180 SL / 200 Vac	//Calculated from fuel load, thrust and burn time
+//	Thrust (SL): 38.2 kN
+//	Thrust (Vac): 48.1 kN
+//	ISP: 198 SL / 249 Vac
 //	Burn Time: 6.5
 //	Chamber Pressure: ??? MPa
 //	Propellant: IRFNA / RP1
@@ -23,9 +23,9 @@
 //	Production version
 //
 //	Dry Mass: 150 Kg
-//	Thrust (SL): 40 kN
-//	Thrust (Vac): ??? kN
-//	ISP: 180 SL / 200 Vac	//Calculated from fuel load, thrust and burn time
+//	Thrust (SL): 38.2 kN
+//	Thrust (Vac): 48.1 kN
+//	ISP: 198 SL / 249 Vac
 //	Burn Time: 45
 //	Chamber Pressure: ??? MPa
 //	Propellant: IRFNA / RP1
@@ -38,9 +38,9 @@
 //	Turpentine fuel
 //
 //	Dry Mass: 150 Kg
-//	Thrust (SL): 40 kN
-//	Thrust (Vac): ??? kN
-//	ISP: 202 SL / 220 Vac	//Calculated from fuel load, thrust and burn time
+//	Thrust (SL): 40.2 kN
+//	Thrust (Vac): 44.3 kN
+//	ISP: 189 SL / 208 Vac	//Calculated from fuel load, thrust and burn time
 //	Burn Time: 49
 //	Chamber Pressure: ??? MPa
 //	Propellant: IWFNA / Turpentine
@@ -53,9 +53,9 @@
 //	Increased performance
 //
 //	Dry Mass: 150 Kg
-//	Thrust (SL): 60 kN
-//	Thrust (Vac): ??? kN
-//	ISP: 202 SL / 220 Vac	//Calculated from fuel load, thrust and burn time
+//	Thrust (SL): 57.4 kN
+//	Thrust (Vac): 63.2 kN
+//	ISP: 189 SL / 208 Vac
 //	Burn Time: 56
 //	Chamber Pressure: ??? MPa
 //	Propellant: IWFNA / Turpentine
@@ -68,7 +68,7 @@
 //	SOURCES
 //	sat-net.com - Veronique and Vesta:																		http://www.sat-net.com/serra/lrba_e.htm#evol_V
 //	Astronautix - Veronique:																				http://www.astronautix.com/v/veronique.html
-//
+//	b14643 - European space-rocket liquid-propellant engines:												http://www.b14643.de/Spacerockets/Specials/European_Rocket_engines/engines.htm
 //
 //	Used by:
 //
@@ -92,15 +92,15 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Veronique
-		origMass = 0.056
+		configuration = VeroniqueR
+		origMass = 0.150
 
 		CONFIG
 		{
-			name = RD-1
-			description = 
-			minThrust = 12.6
-			maxThrust = 12.6
+			name = VeroniqueR
+			description = Prototype, used for early tests
+			minThrust = 44.4
+			maxThrust = 44.4
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -116,35 +116,162 @@
 
 			IGNITOR_RESOURCE
 			{
-				name = Ethane
+				name = Tonka250
 				amount = 1
 			}
 
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.3205
+				ratio = 0.3971
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name = AK20
-				ratio = 0.6795
-			}
-
-			PROPELLANT
-			{
-				name = HTP
-				ratio = 0.01
-				ignoreForIsp = True
-				DrawGauge = False
+				name = IRFNA-III
+				ratio = 0.6029
 			}
 
 			atmosphereCurve
 			{
-				key = 0 215
-				key = 1 200
+				key = 0 200
+				key = 1 180
+			}
+		}
+
+		CONFIG
+		{
+			name = Veronique
+			description = Production Engine
+			minThrust = 44.4
+			maxThrust = 44.4
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Tonka250
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3971
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = IRFNA-III
+				ratio = 0.6029
+			}
+
+			atmosphereCurve
+			{
+				key = 0 200
+				key = 1 180
+			}
+		}
+
+		CONFIG
+		{
+			name = VeroniqueAGI
+			description = Turpentine fuel for increased performance
+			minThrust = 43.6
+			maxThrust = 43.6
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Tonka250
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Turpentine
+				ratio = 0.3464
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.6536
+			}
+
+			atmosphereCurve
+			{
+				key = 0 220
+				key = 1 202
+			}
+		}
+
+		CONFIG
+		{
+			name = Veronique61
+			description = Uprated version
+			minThrust = 65.3
+			maxThrust = 65.3
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Tonka250
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Turpentine
+				ratio = 0.3464
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.6536
+			}
+
+			atmosphereCurve
+			{
+				key = 0 220
+				key = 1 202
 			}
 		}
 	}
@@ -155,23 +282,65 @@
 
 	RESOURCE
 	{
-		name = Ethane
+		name = Tonka250
 		amount = 1
 		maxAmount = 1
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[VeroniqueR]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		//Over 100 flights in the Pe-2RD. Early flights had difficulty with ignitions
-		name = RD-1
-		ratedBurnTime = 300
-		ignitionReliabilityStart = 0.7
-		ignitionReliabilityEnd = 0.95
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		//7 successes, 1 failure
+		name = VeroniqueR
+		ratedBurnTime = 6.5
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.875000
+		cycleReliabilityEnd = 0.975000
 
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Veronique]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//35 successes, 19 failures
+		name = Veronique
+		ratedBurnTime = 45
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.648148
+		cycleReliabilityEnd = 0.929630
+		techTransfer = VeroniqueR:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[VeroniqueAGI]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//8 successes, 1 failure
+		name = VeroniqueAGI
+		ratedBurnTime = 49
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.888889
+		cycleReliabilityEnd = 0.977778
+		techTransfer = VeroniqueR,Veronique:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Veronique61]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//21 successes, 0 failure
+		name = Veronique61
+		ratedBurnTime = 56
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.97
+		cycleReliabilityStart = 0.954545
+		cycleReliabilityEnd = 0.990909
+		techTransfer = VeroniqueR,Veronique,VeroniqueAGI:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
@@ -1,203 +1,190 @@
-//  ==================================================
-//  Global engine configuration for Vexin/Valois engines.
+//	==================================================
+//	Global engine configuration for Vexin/Valois engines.
 
-//  Inert Mass: ?, set to 450 kg
-//  Throttle Range: not throttleable
-//  Burn Time: 56s Vesta, 93s Vexin, 118s Valois
-//  O/F Ratio: 3.57 (Vesta, Vexin), 4.4 (Valois).
-//  Chamber pressure: 19.6 bar
-//  Ignition method: Fantol starter slug (Vexin), represented with Furfuryl
+//	Inert Mass: ?, set to 450 kg
+//	Throttle Range: not throttleable
+//	Burn Time: 56s Vesta, 93s Vexin, 118s Valois
+//	O/F Ratio: 3.57 (Vesta, Vexin), 4.4 (Valois).
+//	Chamber pressure: 19.6 bar
+//	Ignition method: Fantol starter slug (Vexin), represented with Furfuryl
 
-//  Sources:
+//	Sources:
 
-//  http://www.b14643.de/Spacerockets/Diverse/European_Rocket_engines/engines.htm
-//  http://www.capcomespace.net/dossiers/espace_europeen/ariane/espace_francais/diamant_A.htm
-//  https://books.google.si/books?id=wRujBQAAQBAJ&pg=PR3&lpg=PR3&dq=propulsion+re-entry+physics+proceedings (search for "Valois")
-//  http://nospremieresannees.fr/lanceurs/06_diamant/lafa_developpement/lafa2-caractechniques_perinnelle/texte01.html
+//	http://www.b14643.de/Spacerockets/Diverse/European_Rocket_engines/engines.htm
+//	http://www.capcomespace.net/dossiers/espace_europeen/ariane/espace_francais/diamant_A.htm
+//	https://books.google.si/books?id=wRujBQAAQBAJ&pg=PR3&lpg=PR3&dq=propulsion+re-entry+physics+proceedings (search for "Valois")
+//	http://nospremieresannees.fr/lanceurs/06_diamant/lafa_developpement/lafa2-caractechniques_perinnelle/texte01.html
 
-//  BDB
-//  ==================================================
+//	BDB
+//	==================================================
 
 @PART[*]:HAS[#engineType[Vexin]]:FOR[RealismOverhaulEngines]
 {
-    %mass = 0.45
-    %title = LRBA Vexin/Valois engine
-    %manufacturer = LRBA
-    %description = Early French hypergolic engines that propelled the Diamant series of rockets, first flown in 1965. Early models had low efficiency due to the propellants being nitric acid and turpentine- later versions (called Valois, first flown in 1970) used UDMH and N2O4 and enjoyed the benefits of higher thrust and specific impulse. "Vesta" config doesn't gimbal!
-    
-    MODULE
-	  {
-		  name = ModuleFuelTanks
-		  type = ServiceModule
-		  volume = 100
-		  basemass = -1
-		  TANK
-	  	{
-		  	name = Furfuryl
-			  amount = 100
-			  maxAmount = 100
-		  }
-	  }
+	%mass = 0.45
+	%title = LRBA Vexin/Valois engine
+	%manufacturer = LRBA
+	%description = Early French hypergolic engines that propelled the Diamant series of rockets, first flown in 1965. Early models had low efficiency due to the propellants being nitric acid and turpentine- later versions (called Valois, first flown in 1970) used UDMH and N2O4 and enjoyed the benefits of higher thrust and specific impulse. "Vesta" config doesn't gimbal!
 	
-    @MODULE[ModuleEngines*]
-    {
-        %EngineType = LiquidFuel
-    }
-    
-    !MODULE[ModuleAlternator]{}
-    
-    !RESOURCE,*{}
-    
-    @MODULE[ModuleGimbal]
-  	{
-		  %gimbalRange = 5.0
-		  %useGimbalResponseSpeed = true
-		  %gimbalResponseSpeed = 4
-	  }
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 10
+		basemass = -1
+		TANK
+		{
+			name = Furfuryl
+			amount = 10
+			maxAmount = 10
+		}
+	}
+	
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+	
+	!MODULE[ModuleAlternator]{}
+	
+	!RESOURCE,*{}
+	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 5.0
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 4
+	}
 
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        type = ModuleEngines
-        configuration = Valois
-        origMass = 0.450
-        modded = False
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Valois
+		origMass = 0.450
+		modded = False
 
-        CONFIG
-        {
-            name = Vesta_sounding_rocket
-            minThrust = 153.7
-            maxThrust = 153.7
-            heatProduction = 100
-            massMult = 1.0
+		CONFIG
+		{
+			name = Vesta_sounding_rocket
+			minThrust = 153.7
+			maxThrust = 153.7
+			heatProduction = 100
+			massMult = 1.0
 
-            ullage = True
-            pressureFed = True
-            ignitions = 1
-            gimbalRange = 0
-            useEngineResponseTime = True
-			      engineAccelerationSpeed = 0.9
+			ullage = True
+			pressureFed = True
+			ignitions = 1
+			gimbalRange = 0
+			useEngineResponseTime = True
+			engineAccelerationSpeed = 0.9
 
-            IGNITOR_RESOURCE
-		        {
-		        	name = Furfuryl
-        			amount = 100
-        		}
+			IGNITOR_RESOURCE
+			{
+				name = Furfuryl
+				amount = 10
+			}
 
-            PROPELLANT
-            {
-                name = Turpentine
-                ratio = 0.3464
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = Turpentine
+				ratio = 0.3464
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = IWFNA
-                ratio = 0.6536
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.6536
+				DrawGauge = False
+			}
 
-            atmosphereCurve
-            {
-                key = 0 208
-                key = 1 189
-            }
-        }
-        
-        CONFIG
-        {
-            name = Vexin
-            minThrust = 301.6
-            maxThrust = 301.6
-            heatProduction = 100
-            massMult = 1.0
+			atmosphereCurve
+			{
+				key = 0 208
+				key = 1 189
+			}
+		}
 
-            ullage = True
-            pressureFed = True
-            ignitions = 1
-            gimbalRange = 5.0
-            useEngineResponseTime = True
-			      engineAccelerationSpeed = 0.9
+		CONFIG
+		{
+			name = Vexin
+			minThrust = 301.6
+			maxThrust = 301.6
+			heatProduction = 100
+			massMult = 1.0
 
-            IGNITOR_RESOURCE
-		        {
-		        	name = Furfuryl
-        			amount = 100
-        		}
+			ullage = True
+			pressureFed = True
+			ignitions = 1
+			gimbalRange = 5.0
+			useEngineResponseTime = True
+			engineAccelerationSpeed = 0.9
 
-            PROPELLANT
-            {
-                name = Turpentine
-                ratio = 0.3464
-                DrawGauge = True
-            }
+			IGNITOR_RESOURCE
+			{
+				name = Furfuryl
+				amount = 10
+			}
 
-            PROPELLANT
-            {
-                name = IWFNA
-                ratio = 0.6536
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = Turpentine
+				ratio = 0.3464
+				DrawGauge = True
+			}
 
-            atmosphereCurve
-            {
-                key = 0 233
-                key = 1 205
-            }
-        }
-        
-        CONFIG
-        {
-            name = Valois
-            minThrust = 407.7
-            maxThrust = 407.7
-            heatProduction = 100
-            massMult = 0.8
-            
-            //  To offset the unused starting slug, since I don't know of a way to make ModuleFuelTanks disappear
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.6536
+				DrawGauge = False
+			}
 
-            ullage = True
-            pressureFed = True
-            ignitions = 1
-            gimbalRange = 5.0
-            useEngineResponseTime = True
-			      engineAccelerationSpeed = 0.9
-            
-            !IGNITOR_RESOURCE,* {}
-            
-            IGNITOR_RESOURCE
-		        {
-		        	name = UDMH
-        			amount = 0.294
-        		}
-        		IGNITOR_RESOURCE
-		        {
-		        	name = NTO
-        			amount = 0.706
-        		}
+			atmosphereCurve
+			{
+				key = 0 233
+				key = 1 205
+			}
+		}
 
-            PROPELLANT
-            {
-                name = UDMH
-                ratio = 0.294
-                DrawGauge = True
-            }
+		CONFIG
+		{
+			name = Valois
+			minThrust = 407.7
+			maxThrust = 407.7
+			heatProduction = 100
+			massMult = 1.0
 
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.706
-                DrawGauge = False
-            }
+			ullage = True
+			pressureFed = True
+			ignitions = 1
+			gimbalRange = 5.0
+			useEngineResponseTime = True
+			engineAccelerationSpeed = 0.9
 
-            atmosphereCurve
-            {
-                key = 0 254.3
-                key = 1 217
-            }
-        }
-    }
+			!IGNITOR_RESOURCE,* {}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.294
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.706
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 254.3
+				key = 1 217
+			}
+		}
+	}
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vesta_sounding_rocket]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]

--- a/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
@@ -1,16 +1,87 @@
 //	==================================================
-//	Global engine configuration for Vexin/Valois engines.
-
-//	Inert Mass: ?, set to 450 kg
-//	Throttle Range: not throttleable
-//	Burn Time: 56s Vesta, 93s Vexin, 118s Valois
-//	O/F Ratio: 3.57 (Vesta, Vexin), 4.4 (Valois).
-//	Chamber pressure: 19.6 bar
-//	Ignition method: Fantol starter slug (Vexin), represented with Furfuryl
-
+//	Vexin/Valois Engine
+//
+//	Manufacturer: LRBA
+//
+//	=================================================================================
+//	Vesta
+//	Super-Veronique sounding rocket
+//
+//	Dry Mass: 200 Kg	//guess
+//	Thrust (SL): 139.8 kN
+//	Thrust (Vac): 153.7 kN
+//	ISP: 189 SL / 208 Vac
+//	Burn Time: 56
+//	Chamber Pressure: ??? MPa
+//	Propellant: IWFNA / Turpentine
+//	Prop Ratio: 3.57
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Vexin
+//	First stage for Emeraude, Saphir, and Diamant
+//
+//	Dry Mass: 190 Kg
+//	Thrust (SL): 273.7 kN
+//	Thrust (Vac): 310.1 kN
+//	ISP: 203 SL / 230 Vac
+//	Burn Time: 96
+//	Chamber Pressure: 1.76 MPa
+//	Propellant: IWFNA / Turpentine
+//	Prop Ratio: 3.57
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	===================================================================================
+//	Vexin A
+//	Second stage for Europa
+//
+//	Dry Mass: 192 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 262 kN
+//	ISP: ??? SL / 281 Vac
+//	Burn Time: 96
+//	Chamber Pressure: 1.38 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.0
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	===================================================================================
+//	Valois A
+//	First stage for Amethyste, Diamant-B
+//
+//	Dry Mass: 252 Kg
+//	Thrust (SL): 347.9 kN
+//	Thrust (Vac): 407.7 kN
+//	ISP: 221 SL / 259 Vac
+//	Burn Time: 110
+//	Chamber Pressure: 1.96 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 4.4
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	===================================================================================
+//	Valois B
+//	First stage for Diamant-BP
+//
+//	Dry Mass: 252 Kg
+//	Thrust (SL): 316.7 kN
+//	Thrust (Vac): 373.5 kN
+//	ISP: 212 SL / 250 Vac
+//	Burn Time: 110
+//	Chamber Pressure: 1.96 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 4.4
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	===================================================================================
 //	Sources:
 
-//	http://www.b14643.de/Spacerockets/Diverse/European_Rocket_engines/engines.htm
+//	http://www.b14643.de/Spacerockets/Specials/European_Rocket_engines/engines.htm
 //	http://www.capcomespace.net/dossiers/espace_europeen/ariane/espace_francais/diamant_A.htm
 //	https://books.google.si/books?id=wRujBQAAQBAJ&pg=PR3&lpg=PR3&dq=propulsion+re-entry+physics+proceedings (search for "Valois")
 //	http://nospremieresannees.fr/lanceurs/06_diamant/lafa_developpement/lafa2-caractechniques_perinnelle/texte01.html
@@ -20,24 +91,9 @@
 
 @PART[*]:HAS[#engineType[Vexin]]:FOR[RealismOverhaulEngines]
 {
-	%mass = 0.45
 	%title = LRBA Vexin/Valois engine
 	%manufacturer = LRBA
 	%description = Early French hypergolic engines that propelled the Diamant series of rockets, first flown in 1965. Early models had low efficiency due to the propellants being nitric acid and turpentine- later versions (called Valois, first flown in 1970) used UDMH and N2O4 and enjoyed the benefits of higher thrust and specific impulse. "Vesta" config doesn't gimbal!
-	
-	MODULE
-	{
-		name = ModuleFuelTanks
-		type = ServiceModule
-		volume = 10
-		basemass = -1
-		TANK
-		{
-			name = Furfuryl
-			amount = 10
-			maxAmount = 10
-		}
-	}
 	
 	@MODULE[ModuleEngines*]
 	{
@@ -59,13 +115,14 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Valois
+		configuration = Vesta
 		origMass = 0.450
 		modded = False
 
 		CONFIG
 		{
-			name = Vesta_sounding_rocket
+			name = Vesta
+			description = Used for the "Super-Veronique" Vesta sounding rocket. Has no gimbal
 			minThrust = 153.7
 			maxThrust = 153.7
 			heatProduction = 100
@@ -81,7 +138,7 @@
 			IGNITOR_RESOURCE
 			{
 				name = Furfuryl
-				amount = 10
+				amount = 1
 			}
 
 			PROPELLANT
@@ -100,7 +157,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 208
+				key = 0 202
 				key = 1 189
 			}
 		}
@@ -108,8 +165,9 @@
 		CONFIG
 		{
 			name = Vexin
-			minThrust = 301.6
-			maxThrust = 301.6
+			description = First stage engine for the "precious stones" series of sounding rockets, culminating in the Diamant Launch Vehicle.
+			minThrust = 310.1
+			maxThrust = 310.1
 			heatProduction = 100
 			massMult = 1.0
 
@@ -123,7 +181,7 @@
 			IGNITOR_RESOURCE
 			{
 				name = Furfuryl
-				amount = 10
+				amount = 1
 			}
 
 			PROPELLANT
@@ -142,14 +200,52 @@
 
 			atmosphereCurve
 			{
-				key = 0 233
-				key = 1 205
+				key = 0 230
+				key = 1 203
 			}
 		}
 
 		CONFIG
 		{
-			name = Valois
+			name = Vexin-A
+			description = Modified for vaccuum use and converted to UDMH/NTO as the second stage of the Europa Launch Vehicle.
+			minThrust = 262
+			maxThrust = 262
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = True
+			ignitions = 1
+			gimbalRange = 5.0
+			useEngineResponseTime = True
+			engineAccelerationSpeed = 0.9
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.5218
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4782
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 281
+				key = 1 150
+			}
+		}
+
+		CONFIG
+		{
+			name = Valois-A
+			description = Upgraded version of Vexin, used in the first stage of the Amethyste sounding rocket and Diamant-B launch vehicle.
 			minThrust = 407.7
 			maxThrust = 407.7
 			heatProduction = 100
@@ -167,36 +263,77 @@
 			PROPELLANT
 			{
 				name = UDMH
-				ratio = 0.294
+				ratio = 0.2941
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.706
+				ratio = 0.7059
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
-				key = 0 254.3
-				key = 1 217
+				key = 0 259
+				key = 1 221
+			}
+		}
+
+		CONFIG
+		{
+			name = Valois-B
+			description = Engine for the Diamant-BP first stage
+			minThrust = 373.5
+			maxThrust = 373.5
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = True
+			ignitions = 1
+			gimbalRange = 5.0
+			useEngineResponseTime = True
+			engineAccelerationSpeed = 0.9
+
+			!IGNITOR_RESOURCE,* {}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.2941
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.7059
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 250
+				key = 1 212
 			}
 		}
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vesta_sounding_rocket]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vesta]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = Vesta_sounding_rocket
-		ratedBurnTime = 60
+		//5 successes, 0 failures
+		name = Vesta
+		ratedBurnTime = 56
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.9
-		cycleReliabilityStart = 0.80
-		cycleReliabilityEnd = 0.90
+		cycleReliabilityStart = 0.833333
+		cycleReliabilityEnd = 0.966667
+		techTransfer = VeroniqueR,Veronique,VeroniqueAGI:40
 	}
 }
 
@@ -204,24 +341,60 @@
 {
 	TESTFLIGHT
 	{
+		//Emeraude: 2 successes, 3 failures
+		//Diamant: 4 successes, 0 failures
 		name = Vexin
-		ratedBurnTime = 95
+		ratedBurnTime = 96
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
-		cycleReliabilityStart = 0.70
-		cycleReliabilityEnd = 0.93
+		cycleReliabilityStart = 0.666667
+		cycleReliabilityEnd = 0.933333
+		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta:40
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Valois]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vexin-A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = Valois
-		ratedBurnTime = 120
+		//Europa I: 3 successes, 2 failures
+		//Europa II: 1 success, 0 failures
+		name = Vexin-A
+		ratedBurnTime = 96
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
-		cycleReliabilityStart = 0.85
-		cycleReliabilityEnd = 0.93
+		cycleReliabilityStart = 0.666667
+		cycleReliabilityEnd = 0.933333
+		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin:40
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Valois-A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Diamant-B: 5 successes, 0 failures
+		name = Valois-A
+		ratedBurnTime = 110
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.833333
+		cycleReliabilityEnd = 0.966667
+		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin,Vexin-A:40
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Valois-B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Diamant-BP.4: 3 successes, 0 failures
+		name = Valois-B
+		ratedBurnTime = 110
+		ignitionReliabilityStart = 0.85
+		ignitionReliabilityEnd = 0.95
+		cycleReliabilityStart = 0.750000
+		cycleReliabilityEnd = 0.950000
+		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin,Vexin-A,Valois-A:40
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -430,10 +430,10 @@
 		//10 1st stage successes, 1 failure. 43 engines succeeded, 1 failed
 		name = Viking-2
 		ratedBurnTime = 145
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		ignitionReliabilityStart = 0.97
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.976744
+		cycleReliabilityEnd = 0.995349
 		techTransfer = Viking-4:50
 	}
 }
@@ -444,10 +444,10 @@
 		//9 2nd stage successes, 0 failure. 9 engines succeeded, 0 failed
 		name = Viking-4
 		ratedBurnTime = 132
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		ignitionReliabilityStart = 0.9
+		ignitionReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.9
+		cycleReliabilityEnd = 0.98
 		techTransfer = Viking-2:50
 	}
 }
@@ -459,10 +459,10 @@
 		//Ariane 3: 11 1st stage successes, 0 failure. 44 engines succeeded, 0 failed
 		name = Viking-2B
 		ratedBurnTime = 205
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.997
+		cycleReliabilityStart = 0.985294
+		cycleReliabilityEnd = 0.997059
 		techTransfer = Viking-2,Viking-4,Viking-4B:50
 	}
 }
@@ -475,10 +475,10 @@
 		//Ariane 4: 115 2nd stage successes, 0 failures. 115 engines succeeded, 0 failed
 		name = Viking-4B
 		ratedBurnTime = 125
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.998
+		cycleReliabilityStart = 0.992424
+		cycleReliabilityEnd = 0.998485
 		techTransfer = Viking-2,Viking-4,Viking-2B:50
 	}
 }
@@ -489,10 +489,10 @@
 		//Ariane 4: 115 1st stage successes, 1 failures. 463 engines succeeded, 1 failed
 		name = Viking-5C
 		ratedBurnTime = 205
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.997840
+		cycleReliabilityEnd = 0.999568
 		techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B:50
 	}
 }
@@ -503,10 +503,10 @@
 		//Ariane 4: 238 booster stage successes, 0 failures. 238 engines succeeded, 0 failed
 		name = Viking-6
 		ratedBurnTime = 142
-		ignitionReliabilityStart = 0.79
-		ignitionReliabilityEnd = 0.87
-		cycleReliabilityStart = 0.8
-		cycleReliabilityEnd = 0.867
+		ignitionReliabilityStart = 0.99
+		ignitionReliabilityEnd = 0.999
+		cycleReliabilityStart = 0.995798
+		cycleReliabilityEnd = 0.999160
 		techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B,Viking-5C:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -1,0 +1,512 @@
+//	==================================================
+//	Viking Series Engine
+//
+//	Manufacturer: Société Européenne de Propulsion
+//
+//	=================================================================================
+//	Viking 2
+//	
+//
+//	Dry Mass: 776 Kg
+//	Thrust (SL): 611 kN
+//	Thrust (Vac): 690 kN
+//	ISP: 248 SL / 281 Vac
+//	Burn Time: 145
+//	Chamber Pressure: 5.5 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 1.86
+//	Throttle: N/A
+//	Nozzle Ratio: 11
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 2B
+//	UH25 fuel for increased performance
+//
+//	Dry Mass: 776 kg
+//	Thrust (SL): 642 kN
+//	Thrust (vac): 720 kN
+//	ISP: 248 SL / 278 vac
+//	Burn Time: 205
+//	Chamber Pressure: 5.9 MPa
+//	Propellant: NTO / UH25
+///	Prop Ratio: 1.70
+//	Throttle: N/A
+//	Nozzle Ratio: 11
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 4
+//	Vac version
+//
+//	Dry Mass: 826 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 713 kN
+//	ISP: 200 SL / 296 Vac
+//	Burn Time: 132
+//	Chamber Pressure: 5.4 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 1.86
+//	Throttle: N/A
+//	Nozzle Ratio: 31
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 4B
+//	UH25 fuel for increased performance
+//
+//	Dry Mass: 826 kg
+//	Thrust (SL): ??? kN
+//	Thrust (vac): 805 kN
+//	ISP: 210 SL / 296 vac
+//	Burn Time: 125
+//	Chamber Pressure: 5.85 MPa
+//	Propellant: NTO / UH25
+///	Prop Ratio: 1.70
+//	Throttle: N/A
+//	Nozzle Ratio: 31
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 5C
+//	UH25 fuel for increased performance
+//
+//	Dry Mass: 776 kg
+//	Thrust (SL): 678 kN
+//	Thrust (vac): 758 kN
+//	ISP: 248 SL / 278 vac
+//	Burn Time: 205
+//	Chamber Pressure: 5.5 MPa
+//	Propellant: NTO / UH25
+///	Prop Ratio: 1.70
+//	Throttle: N/A
+//	Nozzle Ratio: 11
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 6
+//	Booster version
+//
+//	Dry Mass: 776 kg
+//	Thrust (SL): 678 kN
+//	Thrust (vac): 758 kN
+//	ISP: 248 SL / 278 vac
+//	Burn Time: 142
+//	Chamber Pressure: 5.5 MPa
+//	Propellant: NTO / UH25
+///	Prop Ratio: 1.71
+//	Throttle: N/A
+//	Nozzle Ratio: 11
+//	Ignitions: 1
+//	=================================================================================
+//
+//	SOURCES
+//	Wikipedia - Viking (rocket engine):																		https://en.wikipedia.org/wiki/Viking_(rocket_engine)
+//	History of Liquid Propellant Rocket Engines:															https://books.google.com/books/about/History_of_Liquid_Propellant_Rocket_Engi.html?id=s1C9Oo2I4VYC
+//	Astronautix - Viking 2:																					http://www.astronautix.com/v/viking2.html
+//
+//	Used by:
+//
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[Viking]]:FOR[RealismOverhaulEngines]
+{
+	%title = Viking Series
+	%manufacturer = Snecma S.A.
+	%description = Hypergolic booster engine developed for the European Ariane launch vehicle. Used as both a first stage engine, and second stage when equipped with an extended nozzle, and a booster version was also created for the Ariane 4 strap-on liquid boosters. Average performance compared to its contemporaries, but reliable.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 5	//complete guess
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Viking-2
+		origMass = 0.776  // See above for reference information on the S-3D weight
+
+		CONFIG
+		{
+			name = Viking-2
+			description = First stage engine for Ariane 1
+			minThrust = 690
+			maxThrust = 690
+			heatProduction = 100
+			massMult = 1.0
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4964
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5036
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 281
+				key = 1 248
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-4
+			description = Second stage engine for Ariane 1
+			minThrust = 713
+			maxThrust = 713
+			heatProduction = 100
+			massMult = 1.064
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4964
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5036
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 296
+				key = 1 200
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-2B
+			description = First stage engine for Ariane 2/3. Uses UH25 for extra performance.
+			minThrust = 720
+			maxThrust = 720
+			heatProduction = 100
+			massMult = 1.0
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.5071
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4929
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 248
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-4B
+			description = Second stage engine for Ariane 2/3/4. Uses UH25 for extra performance.
+			minThrust = 805
+			maxThrust = 805
+			heatProduction = 100
+			massMult = 1.064
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.5071
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4929
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 296
+				key = 1 210
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-5C
+			description = First stage engine for Ariane 4
+			minThrust = 758
+			maxThrust = 758
+			heatProduction = 100
+			massMult = 1.0
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.5071
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4929
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 248
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-6
+			description = Booster engine for Ariane 4
+			minThrust = 758
+			maxThrust = 758
+			heatProduction = 100
+			massMult = 1.0
+			gimbalRange = 0.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.5057
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4943
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 248
+			}
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+
+	!RESOURCE,*{}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//10 1st stage successes, 1 failure. 43 engines succeeded, 1 failed
+		name = Viking-2
+		ratedBurnTime = 145
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = Viking-4:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//9 2nd stage successes, 0 failure. 9 engines succeeded, 0 failed
+		name = Viking-4
+		ratedBurnTime = 132
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = Viking-2:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-2B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Ariane 2: 6 1st stage successes, 0 failure. 24 engines succeeded, 0 failed
+		//Ariane 3: 11 1st stage successes, 0 failure. 44 engines succeeded, 0 failed
+		name = Viking-2B
+		ratedBurnTime = 205
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = Viking-2,Viking-4,Viking-4B:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-4B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Ariane 2: 6 2ndt stage successes, 0 failure. 6 engines succeeded, 0 failed
+		//Ariane 3: 11 2nd stage successes, 0 failure. 11 engines succeeded, 0 failed
+		//Ariane 4: 115 2nd stage successes, 0 failures. 115 engines succeeded, 0 failed
+		name = Viking-4B
+		ratedBurnTime = 125
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = Viking-2,Viking-4,Viking-2B:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-5C]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Ariane 4: 115 1st stage successes, 1 failures. 463 engines succeeded, 1 failed
+		name = Viking-5C
+		ratedBurnTime = 205
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B:50
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-6]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		//Ariane 4: 238 booster stage successes, 0 failures. 238 engines succeeded, 0 failed
+		name = Viking-6
+		ratedBurnTime = 142
+		ignitionReliabilityStart = 0.79
+		ignitionReliabilityEnd = 0.87
+		cycleReliabilityStart = 0.8
+		cycleReliabilityEnd = 0.867
+		techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B,Viking-5C:50
+	}
+}


### PR DESCRIPTION
Add various obscure engines, mostly of European origin, including:

- The RDA-1-300 config for the ORM-65

- RD-111, the first stage engine of the R-9 ICBM

- RD-1, a successor to the ORM-65 designed by Glushko, intended for rocket planes

- RZ.1/2, a license built british version of the S-3D

- Add configs for the R-11MU, R-17 and R-17MU to the S2.253 (scud engine)

- Veronique engine, a French sounding rocket engine derived from the Wasserfall engine

- Update and Improve the Vexin engine configs (Diamant/Europa engines)

- Viking engine series, the first and second stage engines for Ariane 1-4