### PR TITLE
Don't set radial chute model if restock is there

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -318,18 +318,21 @@
 @PART[parachuteRadial]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	!mesh = model.mu
-	MODEL
-	{
-		model = Squad/Parts/Utility/parachuteMk2-R/model
-		scale = 1.0, 1.0, 1.0
-	}
 	%rescaleFactor = 1.0
 	@scale = 1.0
 	@mass = 0.0232
 	@MODULE[RealChuteModule]
 	{
 		@caseMass = 0.01
+	}
+}
+@PART[parachuteRadial]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+{
+	!mesh = model.mu
+	MODEL
+	{
+		model = Squad/Parts/Utility/parachuteMk2-R/model
+		scale = 1.0, 1.0, 1.0
 	}
 }
 @PART[radialDrogue]:FOR[RealismOverhaul]


### PR DESCRIPTION
(because it sets its own and we'd end up with both)