### PR TITLE
Bump up mass of restock lander cans

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_CommandPods.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_CommandPods.cfg
@@ -550,7 +550,7 @@
 	%rescaleFactor = 1.0
 	@node_stack_bottom = 0.0, -0.995, 0.0, 0.0, -1.0, 0.0, 2
 	@node_stack_top = 0.0, 0.985, 0.0, 0.0, 1.0, 0.0, 2
-	@mass = 0.5
+	@mass = 1.2
 	%maxTemp = 800
 	%skinMaxTemp = 800
 	
@@ -687,7 +687,7 @@
 	%manufacturer = Generic
 	%description = This capsule was designed for lightweight non-atmospheric landers, and seats two occupants.
 	
-	%mass = 1.3
+	%mass = 1.6
 	%maxTemp = 800
 	%skinMaxTemp = 800
 	


### PR DESCRIPTION
...to match the bump to non-restock versions from 83766f08832b69d8d347adec97ee4431b6a47781
(restock got forgotten)

not entirely clear that the higher mass is "more correct", but the variants should at least match