### PR TITLE
Improve descriptions and tank types

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -13,7 +13,7 @@
 
 TANK_DEFINITION
 {
-	name = Fuselage-Steel
+	name = Tank-Sep-Steel
 	title = Steel Fuselage 
 	description = Simple steel tank and fuselage designs were used only on very early rockets such as the German V-2 and its American and Soviet clones. Tank and fuselage tankage is no more advanced than that used in the construction of early airplanes.
 	highlyPressurized = False
@@ -34,7 +34,7 @@ TANK_DEFINITION
 
 TANK_DEFINITION
 {
-	name = Fuselage-Steel-HP
+	name = Tank-Sep-Steel-HP
 	title = HP Steel Fuselage
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
@@ -57,8 +57,8 @@ TANK_DEFINITION
 
 TANK_DEFINITION
 {
-	name = Fuselage-Al
-	title = Steel Fuselage 
+	name = Tank-Sep-Al
+	title = Aluminum Fuselage 
 	description = Aluminum tank and fuselage construction was first used on the American Viking sounding rocket and then, perplexingly, on the massive Soviet N-1 lunar rocket.
 	highlyPressurized = False
 	basemass = 0.00004 * volume
@@ -78,7 +78,7 @@ TANK_DEFINITION
 
 TANK_DEFINITION
 {
-	name = Fuselage-Al-HP
+	name = Tank-Sep-Al-HP
 	title = HP Aluminum Fuselage
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -13,7 +13,7 @@
 
 TANK_DEFINITION
 {
-	name = Tank-Sep-Steel
+	name = Fuselage-Steel
 	title = Steel Fuselage 
 	description = Simple steel tank and fuselage designs were used only on very early rockets such as the German V-2 and its American and Soviet clones. Tank and fuselage tankage is no more advanced than that used in the construction of early airplanes.
 	highlyPressurized = False
@@ -34,7 +34,7 @@ TANK_DEFINITION
 
 TANK_DEFINITION
 {
-	name = Tank-Sep-Steel-HP
+	name = Fuselage-Steel-HP
 	title = HP Steel Fuselage
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
@@ -57,7 +57,7 @@ TANK_DEFINITION
 
 TANK_DEFINITION
 {
-	name = Tank-Sep-Al
+	name = Fuselage-Al
 	title = Steel Fuselage 
 	description = Aluminum tank and fuselage construction was first used on the American Viking sounding rocket and then, perplexingly, on the massive Soviet N-1 lunar rocket.
 	highlyPressurized = False
@@ -78,7 +78,7 @@ TANK_DEFINITION
 
 TANK_DEFINITION
 {
-	name = Tank-Sep-Al-HP
+	name = Fuselage-Al-HP
 	title = HP Aluminum Fuselage
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
@@ -151,7 +151,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00002 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 0
+	maxMLILayers = 20
 	addResources = true
 	addLead = true
 	maxUtilization = 92

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1301,6 +1301,16 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 	}
+	TANK
+	{
+		name = Water
+		//mass = 0.00001
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		//note = (pressurized)
+	}
 }
 
 // HP resources
@@ -1366,16 +1376,6 @@ TANK_DEFINITION
 	TANK
 	{
 		name = Food
-		//mass = 0.00001
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		//note = (pressurized)
-	}
-	TANK
-	{
-		name = Water
 		//mass = 0.00001
 		utilization = 1
 		fillable = True

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -628,7 +628,7 @@
 
 	@title = Procedural Tank (Service Module)
 	@manufacturer = Generic
-	@description = Specialized procedural tank for batteries and life support, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
+	@description = Specialized tank for batteries and life support, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -628,7 +628,7 @@
 
 	@title = Procedural Tank (Service Module)
 	@manufacturer = Generic
-	@description = Specialized tank for batteries and life support, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
+	@description = Specialized tank for batteries, payloads and life support, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -628,7 +628,7 @@
 
 	@title = Procedural Tank (Service Module)
 	@manufacturer = Generic
-	@description = Specialized procedural tank for service modules, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
+	@description = Specialized procedural tank for batteries and life support, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -540,7 +540,7 @@
 
 	@title = Procedural Tank (Integral Structure)
 	@manufacturer = Generic
-	@description = A more complex, but more effecient tank. Integral structure tanks are also load-bearing and form the entire structure of the tank, so no additional mass is needed to maintain rigidity. Manufacturing them can be difficult, however.
+	@description = A more complex, but more efficient tank. Integral structure tanks are also load-bearing and form the entire structure of the tank, so no additional mass is needed to maintain rigidity. Manufacturing them can be difficult, however.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -501,11 +501,11 @@
 		utilizationTweakable = true
 		maxUtilization = 88
 		utilization = 88
-		type = Fuselage-Steel
-		typeAvailable = Fuselage-Steel
-		typeAvailable = Fuselage-Steel-HP
-		typeAvailable = Fuselage-Al
-		typeAvailable = Fuselage-Al-HP
+		type = Tank-Sep-Steel
+		typeAvailable = Tank-Sep-Steel
+		typeAvailable = Tank-Sep-Steel-HP
+		typeAvailable = Tank-Sep-Al
+		typeAvailable = Tank-Sep-Al-HP
 		typeAvailable = Tank-Sep-Al2
 		typeAvailable = Tank-Sep-Al2-HP
 		typeAvailable = Tank-Sep-AlCu

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -486,9 +486,9 @@
 	@name = RO-RFTank-Seperate
 	%RSSROConfig = True
 
-	@title = Procedural Tank (Separate Structure)
+	@title = Procedural Tank (Stringer Structure)
 	@manufacturer = Generic
-	@description = Separate structure tanks do not have load bearing tanks. This makes them cheaper to produce but they are heavier than other types of tank.
+	@description = The most basic form of fuel tank. Stringer structure tanks do not have load bearing tanks. This makes them cheaper to produce but they are heavier than other types of tank.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
@@ -501,11 +501,11 @@
 		utilizationTweakable = true
 		maxUtilization = 88
 		utilization = 88
-		type = Tank-Sep-Steel
-		typeAvailable = Tank-Sep-Steel
-		typeAvailable = Tank-Sep-Steel-HP
-		typeAvailable = Tank-Sep-Al
-		typeAvailable = Tank-Sep-Al-HP
+		type = Fuselage-Steel
+		typeAvailable = Fuselage-Steel
+		typeAvailable = Fuselage-Steel-HP
+		typeAvailable = Fuselage-Al
+		typeAvailable = Fuselage-Al-HP
 		typeAvailable = Tank-Sep-Al2
 		typeAvailable = Tank-Sep-Al2-HP
 		typeAvailable = Tank-Sep-AlCu
@@ -540,7 +540,7 @@
 
 	@title = Procedural Tank (Integral Structure)
 	@manufacturer = Generic
-	@description = Integral structure tanks are also load-bearing and form the entire structure of the tank, so no additional mass is needed to maintain rigidity. Manufacturing them can be difficult, however.
+	@description = A more complex, but more effecient tank. Integral structure tanks are also load-bearing and form the entire structure of the tank, so no additional mass is needed to maintain rigidity. Manufacturing them can be difficult, however.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
@@ -586,7 +586,7 @@
 
 	@title = Procedural Tank (Balloon)
 	@manufacturer = Generic
-	@description = Balloon tanks are expensive and complex as they need to be pressurized at all times, but they are much lighter than regular tanks. These are similar to tanks used on the Atlas and Centaur stages. <b><color=green>Min Utilization: 99% - Max Utilization: 100%</color></b>
+	@description = A very expensive and fragile, but also very light tank. Balloon tanks are expensive and complex as they need to be pressurized at all times, but they are much lighter than regular tanks. These are similar to tanks used on the Atlas and Centaur stages. <b><color=green>Min Utilization: 99% - Max Utilization: 100%</color></b>
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
@@ -628,7 +628,7 @@
 
 	@title = Procedural Tank (Service Module)
 	@manufacturer = Generic
-	@description = Specialized procedural tank for service modules. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
+	@description = Specialized procedural tank for service modules, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15


### PR DESCRIPTION
- Improve Proc part descriptions, under the assumption that most new players can't read anything more than a sentence long. A concise but mostly accurate description of all tank types has been added to the first sentence of all tank descriptions

- Water can now be added to all tanks, rather than only SMs. There are several situations in which you would want water for reasons other than life support, such as the Viking and Vikas engines, which require water to cool their turbopumps, or to use it as a radiation shield.