### PR TITLE
Fix number of ignitions for Raptor_Vacuum

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
@@ -135,7 +135,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = -1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{


### PR DESCRIPTION
Hello everyone,

In this config file, the number of ignitions for Raptor Vacuum is set to -1.

From my understanding, it was done to disable ignition limit for this engine.

However, the game does not interpret this value correctly and thinks that this engine only has 1 ignition.

This make no sense for raptor.

I've tested this change (made this exact change on my installation of KSP RO, did not rebuild anything) and it works.

Related to #2285, but I guess that PR was stuck because of sheer amount of testing && review required?