### PR TITLE
IVA tweaks: Mk1 Crew Carrier, MediumCan seating

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Crew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/Crew.cfg
@@ -264,6 +264,11 @@
 			DumpExcess = False
 		}
 	}
+        !INTERNAL[*] {}
+        INTERNAL
+        {
+            name = landerCabinMediumInternal 
+        }
 }
 
 //  ==================================================


### PR DESCRIPTION
- generate the Medium IVA even if restock is there, the
  landerCabinMedium needs it (no idea why it was this way)
- remove ALL IVAs from landerCabinMedium before adding the medium
  one, to catch the RPM variant
- use the Medium IVA for the 3-seat Mk1 Crew Carrier, instead of
  leaving the 1-seat Small IVA
- add an extra seat to the medium IVA
- do NOT use made-up names for seatTransforms; that makes the
  seat positioning be relative to the root part
  (original commit makes it clear this was known not to work right)
- enlarge the Medium IVA to more or less fill both parts;
  arrange extra seats in a plausible way

Main motivation was adding the missing seats to the Crew Carrier;
it seems Ship Manifest's crew transfer (and EVA?) breaks when there's
no free seat in the target pod.