### PR TITLE
Resolve Issues

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
@@ -118,7 +118,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-II
-		ratedBurnTime = 47
+		ratedBurnTime = 80
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.983871

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -11,7 +11,7 @@
 //	Thrust (SL): 150,000 lbf = 667.233 kN
 //	Thrust (Vac): 172,193 lbf = 765.9523465 kN
 //	ISP: 249.5 SL / 286 Vac
-//	Burn Time: ???
+//	Burn Time: 137
 //	Chamber Pressure: 4.05 MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: ???
@@ -27,7 +27,7 @@
 //	Thrust (SL): 215,000 lbf = 956.3673 kN
 //	Thrust (Vac): 237,500 lbf = 1056.4523 kN
 //	ISP: 260 SL / 284 Vac
-//	Burn Time: ???
+//	Burn Time: 149.26
 //	Chamber Pressure: 5.56 MPa
 //	Propellant: NTO / A50
 //	Prop Ratio: 1.93
@@ -43,7 +43,7 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1097.2 kN
 //	ISP: 262 SL / 298 Vac
-//	Burn Time: ???
+//	Burn Time: 156
 //	Chamber Pressure: 5.56 MPa
 //	Propellant: NTO / A50
 //	Prop Ratio: 1.93
@@ -73,7 +73,7 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1170 kN
 //	ISP: 254 SL / 302 Vac
-//	Burn Time: ???
+//	Burn Time: 190
 //	Chamber Pressure: 5.70 MPa
 //	Propellant: NTO / A50
 //	Prop Ratio: 1.91
@@ -88,7 +88,7 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1210.9 kN
 //	ISP: 252.2 SL / 303.9 Vac
-//	Burn Time: ???
+//	Burn Time: 190
 //	Chamber Pressure: 5.70 MPa
 //	Propellant: NTO / A50
 //	Prop Ratio: 1.91
@@ -418,7 +418,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-3
-		ratedBurnTime = 140
+		ratedBurnTime = 137
 		ignitionReliabilityStart = 0.898305
 		ignitionReliabilityEnd = 0.979661
 		cycleReliabilityStart = 0.898305
@@ -438,7 +438,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-5
-		ratedBurnTime = 140
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.962766
 		ignitionReliabilityEnd = 0.992553
 		cycleReliabilityStart = 0.962766
@@ -543,7 +543,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11
-		ratedBurnTime = 300 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s.  164s used in Titan 34D and 190 in titan IV
+		ratedBurnTime = 300 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
 		ignitionReliabilityStart = 0.982143
 		ignitionReliabilityEnd = 0.996429
 		cycleReliabilityStart = 0.982143

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -60,7 +60,7 @@
 		CONFIG
 		{
 			name = Rutherford-SL
-			minThrust = 22.0
+			minThrust = 16.68	//Guess
 			maxThrust = 22.24
 			heatProduction = 90
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -60,7 +60,7 @@
 		CONFIG
 		{
 			name = RutherfordVac
-			minThrust = 23.74
+			minThrust = 18.00	//guess
 			maxThrust = 24.00
 			heatProduction = 90
 			PROPELLANT


### PR DESCRIPTION
Resolve issues

- "Fixes https://github.com/KSP-RO/RealismOverhaul/issues/2307" : Rutherford engine throttling. No data on the throttle range of the Rutherford engines is available, a conservative 25% throttle range is assumed

- "Fixes https://github.com/KSP-RO/RealismOverhaul/issues/2313" : Increase Algol II rated burn time to 80 seconds

- "Fixes https://github.com/KSP-RO/RealismOverhaul/issues/2297" : Adjust LR-87 burn times according to era documentation.
