### PR TITLE
More consistent diameter/mass ratios for fairing bases

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_Remass.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_Remass.cfg
@@ -1,39 +1,32 @@
 // Note: Pass zaPFRemass runs after everything else but before zPFFE
-@PART[KzResizableFairingBaseRing]:FOR[zaPFRemass]
+
+// Give every base the same mass-to-diameter behaviour, regardless of
+// how "hollow" or how "thick" it looks. There's no particular
+// real-world basis for these, so let the choice of part be
+// purely aesthetic.
+// FIXME: the actual values may or may not make any sense
+@PART:HAS[@MODULE[KzFairingBaseResizer]]:FOR[zaPFRemass]
 {
 	@MODULE[KzFairingBaseResizer]
 	{
 		%specificMass = 0.0008, 0.03, 0.02, 0
 	}
-	@MODULE[KzFairingBaseResizer]
-	{
-		@costPerTonne *= 1.3
-	}
 }
-@PART[KzResizableFairingBase]:FOR[zaPFRemass]
-{
-	@MODULE[KzFairingBaseResizer]
-	{
-		%specificMass = 0.001, 0.06, 0.02, 0
-	}
-}
-@PART[KzInterstageAdapter2]:FOR[zaPFRemass]
+@PART:HAS[@MODULE[ProceduralFairingAdapter]]:FOR[zaPFRemass]
 {
 	@MODULE[ProceduralFairingAdapter]
 	{
 		%specificMass = 0.0008, 0.03, 0.02, 0
-		@costPerTonne *= 1.3
 	}
 }
-@PART[KzFlatAdapter]:FOR[zaPFRemass]
+
+// however, boattail adapters ARE mechanically different. Without a decoupler,
+// they get to be much lighter
+@PART:HAS[@MODULE[ProceduralFairingAdapter],!MODULE[ModuleDecouple]]:FOR[zaPFRemass]
 {
 	@MODULE[ProceduralFairingAdapter]
 	{
-		%specificMass = 0.0002, 0.02, 0.005, 0
-	}
-	@MODULE[KzFairingBaseResizer]
-	{
-		@costPerTonne *= 2.6
+		%specificMass = 0.0002, 0.01, 0.005, 0
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -203,11 +203,6 @@
 		@scale = 1.0, 0.25, 1.0
 		!texture = DELETE
 	}
-
-	@MODULE[ProceduralFairingAdapter]
-	{
-		%specificMass = 0.0002, 0.01, 0.005, 0
-	}
 	
 	!MODULE[ModuleDecouple] {}
 	
@@ -226,11 +221,6 @@
 	@title = Boattail Adapter (Ribbed)
 	@description = Mounting point for boattails for a stage bottom. Note: floating node **does not decouple** and **should not be used**.
 
-	@MODULE[ProceduralFairingAdapter]
-	{
-		%specificMass = 0.0002, 0.01, 0.005, 0
-	}
-	
 	!MODULE[ModuleDecouple] {}
 	
 	%MODULE[ModuleToggleCrossfeed]
@@ -248,11 +238,6 @@
 	@title = Boattail Adapter (Hollow Ring)
 	@description = Mounting point for boattails for a stage bottom. Note: floating node **does not decouple** and **should not be used**.
 
-	@MODULE[ProceduralFairingAdapter]
-	{
-		%specificMass = 0.0002, 0.01, 0.005, 0
-	}
-	
 	!MODULE[ModuleDecouple] {}
 	
 	%MODULE[ModuleToggleCrossfeed]
@@ -270,11 +255,6 @@
 	@title = Boattail Adapter (Hollow Truss)
 	@description = Mounting point for boattails for a stage bottom. Note: floating node **does not decouple** and **should not be used**.
 
-	@MODULE[ProceduralFairingAdapter]
-	{
-		%specificMass = 0.0002, 0.01, 0.005, 0
-	}
-	
 	!MODULE[ModuleDecouple] {}
 	
 	%MODULE[ModuleToggleCrossfeed]
@@ -292,11 +272,6 @@
 	@title = Boattail Adapter (Truss)
 	@description = Mounting point for boattails for a stage bottom. Note: floating node **does not decouple** and **should not be used**.
 
-	@MODULE[ProceduralFairingAdapter]
-	{
-		%specificMass = 0.0002, 0.01, 0.005, 0
-	}
-	
 	!MODULE[ModuleDecouple] {}
 	
 	%MODULE[ModuleToggleCrossfeed]
@@ -379,11 +354,6 @@
 	@title = Interstage Adapter (Passable)
 	@description = This interstage adapter allows crew transfer. Slightly heavier than equivalent interstage ring.
 	
-	@MODULE[ProceduralFairingAdapter]
-	{
-		%specificMass = 0.001, 0.033, 0.022, 0
-	}
-
 	MODULE
 	{
 		name = ModuleConnectedLivingSpace


### PR DESCRIPTION
Give all payload and interstage bases the same coefficients,
instead of making it sort of mass how the model looks

Main impact is actually to apply consistent formulas to new-ish
(SSTU-derived) bases that weren't handled by RO, and ended up
lighter when smaller, but heavier when larger, than the "old" bases.

(also removed some 'costPerTonne' values; RO doesn't care about cost)