### PR TITLE
Make early first stage engines ground lit only

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
@@ -74,6 +74,7 @@
 		configuration = A-4
 		modded = false
 		origMass = 0.931
+		literalZeroIgnitions = True
 		CONFIG
 		{
 			name = A-4
@@ -110,7 +111,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -135,6 +135,7 @@
 		type = ModuleEngines
 		configuration = S-3
 		origMass = 0.945	// See above for reference information on the S-3D weight
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -149,7 +150,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -194,7 +195,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -244,7 +245,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -292,7 +293,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -338,7 +339,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -142,6 +142,8 @@
 		@configuration:NEEDS[RP-0] = LR87-AJ-3
 		modded = false
 		origMass = 0.839
+		literalZeroIgnitions = True
+		
 		CONFIG
 		{
 			// [5]
@@ -167,7 +169,7 @@
 				key = 1 249.5
 			}
 			ullage = True
-			ignitions = 1
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -161,7 +161,7 @@
 		modded = False
 		configuration = LR43-NA-3
 		origMass = 0.72
-
+		literalZeroIgnitions = True
 		CONFIG
 		{
 			name = LR43-NA-3
@@ -169,7 +169,7 @@
 			minThrust = 756.8
 			maxThrust = 756.8
 			heatProduction = 100
-			massMult = 1
+			massMult = 0
 
 			ullage = True
 			pressureFed = False
@@ -218,7 +218,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -263,7 +263,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -308,7 +308,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -353,7 +353,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -396,7 +396,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -442,7 +442,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -89,6 +89,7 @@
 		type = ModuleEngines
 		configuration = A-6
 		origMass = 0.67
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -99,7 +100,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -145,7 +146,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -132,12 +132,12 @@
 	}
 
 	MODULE
-	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = RD-100
 		origMass = 0.888
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -148,7 +148,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -194,7 +194,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -240,7 +240,7 @@
 			massMult = 0.9966
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -286,7 +286,7 @@
 			massMult = 0.9797
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -331,7 +331,7 @@
 			massMult = 0.9763
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -195,6 +195,7 @@
 		origMass = 1.19
 		configuration = RD-107-8D74
 		modded = false
+		literalZeroIgnitions = True
 		
 		CONFIG
 		{
@@ -206,7 +207,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -258,7 +259,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -310,7 +311,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -362,7 +363,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -414,7 +415,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -466,7 +467,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -518,7 +519,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -570,7 +571,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -621,7 +622,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -673,7 +674,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -203,6 +203,7 @@
 		origMass = 1.278
 		configuration = RD-108-8D75
 		modded = false
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -214,7 +215,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -266,7 +267,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -318,7 +319,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -370,7 +371,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -422,7 +423,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -474,7 +475,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -526,7 +527,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -578,7 +579,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -630,7 +631,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -682,7 +683,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -114,6 +114,7 @@
 		type = ModuleEngines
 		origMass = 6.597
 		configuration = RS-68
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -123,7 +124,7 @@
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -160,7 +161,7 @@
 			heatProduction = 91
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -197,7 +198,7 @@
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -234,7 +235,7 @@
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -106,6 +106,8 @@
 		configuration = RS-25
 		origMass = 3.527
 		modded = false
+		literalZeroIgnitions = True
+		
 		CONFIG
 		{
 			name = RS-25
@@ -131,7 +133,7 @@
 
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 1
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -163,7 +165,7 @@
 
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 1
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -195,7 +197,7 @@
 
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 1
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -227,7 +229,7 @@
 
 			%ullage = True
 			%pressureFed = False
-			%ignitions = 1
+			%ignitions = 0
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -112,6 +112,7 @@
 		type = ModuleEnginesRF
 		configuration = X-405
 		origMass = 0.192
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -122,7 +123,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
@@ -66,7 +66,7 @@
 		type = ModuleEngines
 		configuration = XLR41
 		origMass = 0.791
-
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -78,7 +78,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
@@ -83,7 +83,7 @@
 		type = ModuleEngines
 		configuration = XLR43
 		origMass = 0.670
-
+		literalZeroIgnitions = True
 
 		CONFIG
 		{
@@ -95,7 +95,7 @@
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{
@@ -139,7 +139,7 @@
 			massMult = 0.73
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{


### PR DESCRIPTION
The first commit includes the A-4, RD-100-103M, LR79/89, RD-107/8 and X-405.

Any others I should include?