### PR TITLE
Aerobee Mass Adjustment

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
@@ -83,7 +83,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 0.008
+		origMass = 0.016
 		configuration = WAC-Corporal
 		modded = false
 		// ratio sources: https://books.google.com/books?id=BtJ1COIv6xQC&pg=PT135&lpg=PT135&dq=aniline+%22furfuryl%22&source=bl&ots=ZgEpXYt0co&sig=sQMSt434kQup0YLBLewUAFQWCIc&hl=en&sa=X&ved=0CDEQ6AEwBjgKahUKEwih6ezC44jGAhUBJqwKHahLAGs#v=onepage&q=aniline%20%22furfuryl%22&f=false for Corporal and Aerobee. http://www.tandfonline.com/doi/abs/10.1080/00028895809343554?journalCode=aiha20#.VXoYCUYvxgs for Aerobee 150 (Hydrazine added, skipping water)


### PR DESCRIPTION
Taking action on https://github.com/KSP-RO/RealismOverhaul/issues/1955. I've gone with the conservative value of 16 kg base (double the previous mass), assuming that the lack of a nozzle extension and gimbals will make up for the slightly lower chamber pressure of the aerobee vs. the AJ10-37. If people believe @leudaimon's original guess of 27 kg is better, it can be changed to that instead.