### PR TITLE
Stretch SXT skylab

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -515,8 +515,8 @@
 
 //  Realism Overhaul configuration.
 
-//  Dimensions: 6.6 m x 7.0 m
-//  Gross Mass: 28000.0 Kg
+//  Dimensions: 6.6 m x 14.7 m (source: wikipedia)
+//  Gross Mass: 28000.0 Kg FIXME: source? wikipedia says 35000; if we include supplies we get close, but unclear if we should
 //  ==================================================
 
 @PART[SXTISSHabISK30]:FOR[RealismOverhaul]
@@ -527,14 +527,14 @@
 
     @MODEL
     {
-        %scale = 1.762, 1.762, 1.762
+        %scale = 1.762, 3.92, 1.762
     }
 
     %scale = 1.0
     @rescaleFactor = 1.0
 
-    @node_stack_top = 0.0, 3.35, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom = 0.0, -3.35, 0.0, 0.0, -1.0, 0.0, 2
+    @node_stack_top = 0.0, 7.4, 0.0, 0.0, 1.0, 0.0, 3
+    @node_stack_bottom = 0.0, -7.4, 0.0, 0.0, -1.0, 0.0, 2
     @node_attach = 0.0, 0.0, 3.1, 0.0, -1.0, 0.0, 2
 	
     @title = Skylab Orbital Workshop


### PR DESCRIPTION
Because 7m is much shorter than the real thing.
Stretched model looks ok, except for a very tall hatch

A bit dubious, but if we're going to pretend it's skylab, making it the right shape is more important than how pretty it is?