### PR TITLE
Fix MassMult in the first config of the LR-89

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -169,11 +169,11 @@
 			minThrust = 756.8
 			maxThrust = 756.8
 			heatProduction = 100
-			massMult = 0
+			massMult = 1
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 
 			IGNITOR_RESOURCE
 			{


### PR DESCRIPTION
Someone very stupid (me) changed the mass of the first config to 0 instead of the number of ignitions. Thank you @Capkirk123 for spotting it.