### PR TITLE
Make 1.25m Cockpit 1.25m

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -444,8 +444,6 @@
 	@title = 1.25m Cockpit
 	@description = One-person spaceplane cockpit. Rated for suborbital reentries. X-15 class.
 	@mass = 0.8
-
-	!MODULE[ModuleAnimateGeneric],0:NEEDS[VenStockRevamp] {}
 }
 
 @PART[Mark2Cockpit]:FOR[RealismOverhaul]
@@ -559,15 +557,23 @@
 }
 
 // Use alt VSR graphics for 1.25s if available
-@PART[Mark1Cockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
+// Currently disabled because the model lives in Ven's New Parts
+// and there isn't yet a way to detect it separately from VSR
+@PART[Mark1Cockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevampDISABLED]
 {
 	%rescaleFactor = 1.25
-	
+	@MODEL
+	{
+		@model = VenStockRevamp/Part Bin/NewParts/MK1Cockpit-Alt/MK1Cockpit
+	}
+
 	@INTERNAL
 	{
 		@name = RO-Mk1CockpitInternal-1.25
 		%offset = 0.0, 0.2, 0.0
 	}
+
+//	!MODULE[ModuleAnimateGeneric],0 {} // MIGHT need this line to run if full-VSR is present, rather than just Ven'sNewParts. TODO: test
 
 	@MODULE[ModuleAnimateGeneric]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -557,14 +557,12 @@
 }
 
 // Use alt VSR graphics for 1.25s if available
-// Currently disabled because the model lives in Ven's New Parts
-// and there isn't yet a way to detect it separately from VSR
-@PART[Mark1Cockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevampDISABLED]
+@PART[Mark1Cockpit]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp/PartBin]
 {
 	%rescaleFactor = 1.25
 	@MODEL
 	{
-		@model = VenStockRevamp/Part Bin/NewParts/MK1Cockpit-Alt/MK1Cockpit
+		@model = VenStockRevamp/PartBin/NewParts/MK1Cockpit-Alt/MK1Cockpit
 	}
 
 	@INTERNAL
@@ -572,8 +570,6 @@
 		@name = RO-Mk1CockpitInternal-1.25
 		%offset = 0.0, 0.2, 0.0
 	}
-
-//	!MODULE[ModuleAnimateGeneric],0 {} // MIGHT need this line to run if full-VSR is present, rather than just Ven'sNewParts. TODO: test
 
 	@MODULE[ModuleAnimateGeneric]
 	{
@@ -779,7 +775,7 @@
 
 
 // INTERNAL node manipulation
-+INTERNAL[mk1CockpitInternal]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp]
++INTERNAL[mk1CockpitInternal]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp/PartBin]
 {
 	@name = RO-Mk1CockpitInternal-1.25
 	%scaleAll = 1.25, 1.25, 1.25


### PR DESCRIPTION
Regression from restock/vens cleanup: the use of a vensnewparts model
was removed, but its rescaling was kept, so it ended up enlarging a
1.25m part by another 1.25x

- disable the entire VSR block, it really wants to depend
  on Ven's New Parts. We'll stick to stock model at stock size for now
- bring back the model reference so it's ready to go when the VNP issue
  gets resolved
- don't delete the light animation, because why??

Tested with Ven's New Parts installed by itself.
NOT tested with both VNP and VSR; would probably be a good idea for
someone to try it. It's entirely possible VSR alters the part in ways
that won't work properly without the bits I'm disabling