### PR TITLE
Re-enable long-lost derwent alternator

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -38,8 +38,6 @@
 	@manufacturer = Rolls-Royce
 	@description = The Derwent V, rather than being a development of the Derwent line (a straight-through-flow development of the W.2), was instead a scaled-down Nene. It powered the Meteor F.4, and was available in mid-late 1945. SFC 1.03 lb/lbf-hr static. Temperature limit Mach 1.
 
-	!MODULE[ModuleAlternator] {} // until we figure out what the HECK is going wrong.
-
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet


### PR DESCRIPTION
Whatever _the heck_ was going wrong 5 years ago does not appear to be going wrong anymore; alternator is working fine in my tests, and nothing bad seemed to happen.