### PR TITLE
Add 7m lunar heatshield

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
@@ -20,6 +20,7 @@
 	%emissiveConstant = 0.6			// not too absorptive for reentry
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
+	roLunarShield = true
 }
 
 // Adjust some models from Ven's
@@ -64,6 +65,18 @@
 	heatShieldDiameter = 5.0
 	%rescaleFactor = 1.333333	// 3.75 -> 5.0
 }
+
+
+// Even larger diameters all based on the 3.75m model, presumably the most detailed
+// Go up from 5m one sqrt(2) factor at a time, because 2x steps are too big
+// and 1m steps would get silly.
+
++PART[HeatShield3]:FOR[RealismOverhaul]
+{
+	@name = RO_LunarHeatshield7m
+	@heatShieldDiameter = 7.0
+	%rescaleFactor = 1.8666667	// 3.75 -> 7.0
+}
 +PART[HeatShield3]:FOR[RealismOverhaul]
 {
 	@name = Heatshield-10M
@@ -71,9 +84,10 @@
 	%rescaleFactor = 2.666667		// 3.75 -> 10.0
 }
 
-@PART[HeatShield0|HeatShield1|HeatShield2|HeatShield3|Heatshield1m|Heatshield3m|Heatshield-10M]:FOR[RealismOverhaul]
+@PART:HAS[#roLunarShield]:FOR[RealismOverhaul]
 {
 	@title = #Lunar-rated Heat Shield ($heatShieldDiameter$m)
 	@description = Lunar-rated heat shield.
 	!DRAG_CUBE {}
+	!roLunarShield = delete
 }


### PR DESCRIPTION
Adopted naming convention currently used for the restock LEO shield,
because it's saner than the mess of non-restock shields
(Heatshield3m = lunar, Heatshield-3M = LEO, Heatshield-10M = lunar)
