### PR TITLE
Fix 17D12 data transfer

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -658,6 +658,6 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.875
 		cycleReliabilityEnd = 0.998
-		techTransfer = RD-58S:50
+		techTransfer = RD-58,RD-58M:50
 	}
 }


### PR DESCRIPTION
Engine predates the rd-58S, it shouldn't inherit data from it.
Make it inherit from 58 & 58M instead, like all other late configs