### PR TITLE
Adjust tank masses

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -342,7 +342,7 @@ TANK_DEFINITION
 	title = HP Aluminum Gridded Tank
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
-	basemass = 0.000042 * volume
+	basemass = 0.000052 * volume
 	baseCost = 0.0042 * volume
 	maxMLILayers = 20
 	addResources = true
@@ -365,7 +365,7 @@ TANK_DEFINITION
 	title = Al-Cu Gridded Tank
 	description = Stronger than unalloyed aluminum and workable to boot, advanced new Al-Cu alloys were used in orthogrid and isogrid tanks for all upper stages of the Saturn program. 
 	highlyPressurized = False
-	basemass = 0.0000145 * volume
+	basemass = 0.0000121 * volume
 	baseCost = 0.005 * volume
 	maxMLILayers = 20
 	addResources = true
@@ -376,7 +376,7 @@ TANK_DEFINITION
 {
 	@TANK[*]:HAS[~mass[*]]
 	{
-		mass = 0.0000145
+		mass = 0.0000121
 	}
 }
 
@@ -386,7 +386,7 @@ TANK_DEFINITION
 	title = HP Al-Cu Gridded Tank
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
-	basemass = 0.000028 * volume
+	basemass = 0.000047 * volume
 	baseCost = 0.005 * volume
 	maxMLILayers = 20
 	addResources = true
@@ -408,7 +408,7 @@ TANK_DEFINITION
 	title = Al-Li Gridded Tank
 	description = Since lithium is the least dense elemental metal, Al-Li alloys are significantly less dense than other aluminum alloys while being stronger than even Al-Cu alloys. However, their tendency to work-harden means that machining such alloys is much more difficult than standard alloys. Nevertheless, lightweight Al-Li gridded tanks have been the foundation of the modern era of orbital American rocketry, used in the Atlas V Common Core Booster, the Delta IV Common Booster Core (and DCSS upper stages), the Space Launch System core stage, and the ULA Vulcan rocket.
 	highlyPressurized = False
-	basemass = 0.000013 * volume
+	basemass = 0.0000115 * volume
 	baseCost = 0.0065 * volume
 	maxMLILayers = 100
 	addResources = true
@@ -419,7 +419,7 @@ TANK_DEFINITION
 {
 	@TANK[*]:HAS[~mass[*]]
 	{
-		mass = 0.000013
+		mass = 0.0000115
 	}
 }
 
@@ -429,7 +429,7 @@ TANK_DEFINITION
 	title = HP Al-Li Gridded Tank
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial addditional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
-	basemass = 0.000024 * volume
+	basemass = 0.000039 * volume
 	baseCost = 0.0065 * volume
 	maxMLILayers = 100
 	addResources = true
@@ -451,7 +451,7 @@ TANK_DEFINITION
 	title = Carbon Composite Tank
 	description = The unparalleled low density and high strength of carbon composites have long been the siren call of tank design. Ever since the X-33 and Venture Star program of the 1990s was aborted only a few years years before the leaking problems that had killed Venture Star were solved, space companies have been trying to justify the very high cost of composite materials. Although costs continue to drop, the intensive manufacturing process is still very expensive, requiring the wrapping and weaving of hundreds of layers of carbon fiber with resins that are then baked off in massive autoclaves. Currently, the only rocket to use composite materials is the smallsat Electron orbital launcher developed by Rocket Lab.
 	highlyPressurized = False
-	basemass = 0.000011 * volume
+	basemass = 0.000010 * volume
 	baseCost = 0.008 * volume
 	maxMLILayers = 100
 	balloonTemps = true
@@ -463,7 +463,7 @@ TANK_DEFINITION
 {
 	@TANK[*]:HAS[~mass[*]]
 	{
-		mass = 0.000011
+		mass = 0.000010
 	}
 }
 
@@ -518,7 +518,7 @@ TANK_DEFINITION
 	title = Steel-Al-Cu Balloon Tank
 	description = Balloon tanks do not have an internal framework, but instead rely on internal pressurization to keep its shape. If the pressurization fails, the balloon tank collapses. They are constructed of very think sheets of stainless steel and have very good mass fractions, but the logistics involved in maintaining pressurization make them quite expensive. These advanced balloon tanks were first used by the Centaur G upper stage.
 	highlyPressurized = False
-	basemass = 0.000012 * volume
+	basemass = 0.0000115 * volume
 	baseCost = 0.008 * volume
 	maxMLILayers = 100
 	addResources = true
@@ -541,7 +541,7 @@ TANK_DEFINITION
 	title = Steel-Al-Li Balloon Tank
 	description = Balloon tanks do not have an internal framework, but instead rely on internal pressurization to keep its shape. If the pressurization fails, the balloon tank collapses. They are constructed of very think sheets of stainless steel and have very good mass fractions, but the logistics involved in maintaining pressurization make them quite expensive. These modern balloon tanks were first used by Centaur III.
 	highlyPressurized = False
-	basemass = 0.000011 * volume
+	basemass = 0.000010 * volume
 	baseCost = 0.009 * volume
 	maxMLILayers = 100
 	addResources = true


### PR DESCRIPTION
Decrease most integral and balloon tank masses in order to make S-II and other large hydrolox stages have correct mass ratios. Unfortunately, this means denser kerolox and hypergolic stages get slightly better mass ratios than they should. However, since hydrolox stages are much more sensitive to mass ratio, the difference for denser stages is mostly negligible.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/2301