### PR TITLE
Add XLR25 engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -1,0 +1,111 @@
+//	==================================================
+//	XLR-25
+//
+//	Manufacturer: Curtiss-Wright
+//
+//	=================================================================================
+//	XLR25-CW-1
+//	X-2
+//
+//	Dry Mass: 157 Kg
+//	Thrust (SL): 66.72 kN
+//	Thrust (Vac): ??? kN
+//	ISP: ??? SL / ??? Vac
+//	Burn Time: 650
+//	Chamber Pressure: ??? MPa
+//	Propellant: LOX / Ethanol75
+//	Prop Ratio: 1.6
+//	Throttle: 66.72 kN to 11.12 kN
+//	Nozzle Ratio: ???
+//	Ignitions: 6	//electrical ignitors and compressed nitrogen was used to start the engine. Going with the same 6 ignitions as XLR99 due to lack of data
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.thisdayinaviation.com/tag/curtiss-wright-xlr25-cw-1/
+//	https://books.google.com/books?id=eq46DwAAQBAJ&pg=PA26&lpg=PA26&dq=curtiss+xlr25&source=bl&ots=0bzRsY-Xjd&sig=ACfU3U0dADSMhaQCd5XnwGIXCcS7hH_Wqg&hl=en&sa=X&ved=2ahUKEwjkoLq3jK_mAhWoZd8KHaxoAOQ4ChDoATACegQIBxAB#v=onepage&q=curtiss%20xlr25&f=false
+//	http://www.astronautix.com/x/xlr25-cw-1.html
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[XLR25]]:FOR[RealismOverhaulEngines]
+{
+	%title = XLR-25
+	%manufacturer = Curtiss-Wright
+	%description = The XLR25 was designed for the X-2, to test higher speeds and altitudes than the X-1. It was the first continously throttlable engine designed in the US. Although the engine was successful, the X-2 proved extremely unstable at high speeds and only a few flights were undertaken.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = XLR25-CW-1
+		origMass = 0.157
+
+		CONFIG
+		{
+			name = XLR25-CW-1
+			minThrust = 12.02
+			maxThrust = 72.17
+			massMult = 1.0
+
+			%ullage = False
+			%pressureFed = False
+			%ignitions = 6
+
+			PROPELLANT	//755.8 gallons LOX, 860.3 alcohol
+			{
+				name = Ethanol75
+				ratio = 0.5324
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4676
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+			atmosphereCurve
+			{
+				key = 0 225
+				key = 1 208
+			}
+		}
+	}
+}
+
+//10 powered flights, 0 failures due to engines
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR25-CW-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = XLR25-CW-1
+		ratedBurnTime = 650 //175 at full thrust
+		ignitionReliabilityStart = 0.909091
+		ignitionReliabilityEnd = 0.981818
+		ignitionDynPresFailMultiplier = 50.0
+		cycleReliabilityStart = 0.909091
+		cycleReliabilityEnd = 0.981818
+		
+		techTransfer = XLR-RM-5,XLR11-RM-13-8K:50	//Used a similar turbopump to the late-model XLR11, and was developed at around the same time
+	}
+}


### PR DESCRIPTION
Add the Curtiss-Wright XLR25, as used in the X-2.