### PR TITLE
Don't delete RD-107 vernier gimbals

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -186,7 +186,7 @@
 	!RESOURCE,*{}
 
 	//Verniers need to be set up on a part-by-part basis
-	!MODULE[ModuleGimbal],*{}
+	//!MODULE[ModuleGimbal],*{}
 
 	MODULE
 	{


### PR DESCRIPTION
!MODULE[ModuleGimbal],*{} stops gimbaling verniers from working on ROEngines rd107 (probably others based on how this is implemented). Removing this line restores functionality.