### PR TITLE
Fix Soundingcore

### DIFF
--- a/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
@@ -14,7 +14,7 @@
 	!DRAG_CUBE,*{}
 }
 
-@PART[RP0probeSounding0-3m]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+@PART[RP0probeSounding0-3m]:FOR[RealismOverhaul]:HAS[#mesh]
 {
 	!mesh = NULL
 	MODEL

--- a/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
@@ -14,6 +14,15 @@
 	!DRAG_CUBE,*{}
 }
 
+@PART[RP0probeSounding0-3m]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+{
+	!mesh = NULL
+	MODEL
+	{
+		model = Squad/Parts/Command/advancedSasModuleLarge/model
+	}
+}
+
 @PART[RP0probeSounding0-3m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = true

--- a/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Sounding0-3m.cfg
@@ -14,7 +14,7 @@
 	!DRAG_CUBE,*{}
 }
 
-@PART[RP0probeSounding0-3m]:FOR[RealismOverhaul]:HAS[#mesh]
+@PART[RP0probeSounding0-3m]:HAS[#mesh]:FOR[RealismOverhaul]
 {
 	!mesh = NULL
 	MODEL


### PR DESCRIPTION
The default KSP SAS module uses mesh = x instead of MODEL, which prevents rescaling from properly affecting it. Manually set its model if ReStock is not installed to ensure it is rescaled correctly.

resolves https://github.com/KSP-RO/RealismOverhaul/issues/2353