### PR TITLE
RD-270M Fix

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
@@ -95,11 +95,11 @@
 
 //no data, never flew
 //using RD-253 data
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-270]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-270M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = RD-270
+		name = RD-270M
 		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143


### PR DESCRIPTION
RD-270M testflite config exists but references original RD-270 instead of RD-270M - this fixes that so that RD-270M has a working config