### PR TITLE
Bring back dewar flasks in SM tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1443,6 +1443,23 @@ TANK_DEFINITION
 		maxAmount = 0.0
 		//note = (pressurized)
 	}
+
+	// Cryo resources in SM tanks get a dewar flask
+	@TANK[LqdOxygen] {
+		isDewar = True
+	}
+	@TANK[LqdHydrogen] {
+		isDewar = True
+	}
+	@TANK[LqdAmmonia] {
+		isDewar = True
+	}
+	@TANK[LqdMethane] {
+		isDewar = True
+	}
+	@TANK[LqdFluorine] {
+		isDewar = True
+	}
 }
 
 // Add lead


### PR DESCRIPTION
Applied to same resources as in the ServiceModule tankdefinition
(in my MM cache)

Tested by putting a LOX SM tank in orbit; heat penetration goes from watts to milliwatts

The question "why do SMs not reduce boiloff anymore?" comes up every once in a while but never goes anywhere; maybe a PR will get more attention