### PR TITLE
Bump up Algol I rated time for thrust curve

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
@@ -119,7 +119,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-I
-		ratedBurnTime = 45
+		ratedBurnTime = 62
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.944444


### PR DESCRIPTION
total burn duration observed in-game is 62s, making a 45s rated time very failure-prone