### PR TITLE
Reduce the Kerbal EVA pack thruster power by 3x

### DIFF
--- a/GameData/RealismOverhaul/EVA.cfg
+++ b/GameData/RealismOverhaul/EVA.cfg
@@ -1,4 +1,9 @@
 @PART[kerbalEVA|kerbalEVAfemale]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = true
+
+	@MODULE[KerbalEVA]
+	{
+		@linPower /= 3
+	}
 }


### PR DESCRIPTION
I think the `rotPower` deserves some nerfing too but in that case the PID would need some retuning as well