### PR TITLE
Heating & heatshield changes

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_FAR.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_FAR.cfg
@@ -1,0 +1,7 @@
+@FARConfig:FOR[RealismOverhaul]
+{
+	@Settings
+	{
+		%exposedAreaLimited = false
+	}
+}

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -28,22 +28,20 @@
 		ablativeResource = Ablator
 		outputResource = CharredAblator
 		outputMult = 0.75
-		lossExp = -40000
-		lossConst = 15000
-		pyrolysisLossFactor = 40000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
+		lossExp = -25000
+		lossConst = 350
+		pyrolysisLossFactor = 30000
+		ablationTempThresh = 1250
+		reentryConductivity = 0.0025
 		infoTemp = 3000
-		//reentryConductivity = 0.12
-		//@reentryConductivity = #$../heatConductivity$ // if it exists, use it
 	}
 }
 
 // Apply physics properties for LEO-rated shield
 @PART:HAS[#heatShieldTag[LEO]]:FOR[RealismOverhaul_HeatShield]
 {
-	%maxTemp = 1500
-	%skinMaxTemp = 2600
+	%maxTemp = 1300
+	%skinMaxTemp = 2350
 	%heatShieldDensity = 0.01
 	%heatShieldAblator = 50
 
@@ -54,12 +52,10 @@
 		outputResource = CharredAblator
 		outputMult = 1
 		lossExp = -6000
-		lossConst = 0.13
-		pyrolysisLossFactor = 6000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
-		//reentryConductivity = 0.12
-		//@reentryConductivity = #$../heatConductivity$ // if it exists, use it
+		lossConst = 0.095
+		pyrolysisLossFactor = 8210
+		ablationTempThresh = 750
+		reentryConductivity = 0.0065
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -136,6 +136,8 @@
 	%skinMassPerArea = 50.0 // 50kg/m^2, so basically half the mass is skin thermal mass, for a heatsink-only part.
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.95
+	
+	%heatShieldNoAblator = true
 
 
 	!MODULE[ModuleAblator] {}
@@ -190,11 +192,15 @@
 	}
 }
 
-// Finish configuration: Ablator resources, Charred Ablator
+// Finish configuration: RSSConfig
 @PART:HAS[#heatShieldTag]:FOR[RealismOverhaul_HeatShield]
 {
 	%RSSROConfig = True
+}
 
+// Finish configuration: Ablator resources, Charred Ablator
+@PART:HAS[#heatShieldTag,~heatShieldNoAblator[?rue]]:FOR[RealismOverhaul_HeatShield]
+{
 	@MODULE[ModuleAblator]:HAS[~outputMult[]]
 	{
 		%outputMult = 1
@@ -228,6 +234,7 @@
 	!resetHeatShieldMass = DEL
 	!heatShieldDensity = DEL
 	!heatShieldAblator = DEL
+	!heatShieldNoAblator = DEL
 }
 @PART:HAS[#heatShieldDiameter]:FOR[RealismOverhaul_HeatShield_Late]
 {
@@ -237,4 +244,5 @@
 	!resetHeatShieldMass = DEL
 	!heatShieldDensity = DEL
 	!heatShieldAblator = DEL
+	!heatShieldNoAblator = DEL
 }

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -28,7 +28,6 @@
 
 	%MODULE[ModuleAblator]
 	{
-		%name = ModuleAblator
 		%ablativeResource = Ablator
 		%outputResource = CharredAblator
 		%outputMult = 0.8
@@ -53,10 +52,8 @@
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.4
 
-
 	%MODULE[ModuleAblator]
 	{
-		%name = ModuleAblator
 		%ablativeResource = Ablator
 		%outputResource = CharredAblator
 		%outputMult = 0.9
@@ -83,7 +80,6 @@
 
 	%MODULE[ModuleAblator]
 	{
-		%name = ModuleAblator
 		%ablativeResource = Ablator
 		%outputResource = CharredAblator
 		%outputMult = 1
@@ -109,7 +105,6 @@
 
 	%MODULE[ModuleAblator]
 	{
-		%name = ModuleAblator
 		%ablativeResource = Ablator
 		%outputResource = CharredAblator
 		%outputMult = 1
@@ -171,7 +166,6 @@
 
 	%MODULE[ModuleAblator]
 	{
-		%name = ModuleAblator
 		%ablativeResource = Ablator
 		%outputResource = CharredAblator
 		%outputMult = 1
@@ -194,9 +188,8 @@
 @PART:HAS[#resetHeatShieldAblator[?rue],#heatShieldDiameter,#heatShieldAblator]:FOR[RealismOverhaul_HeatShield]
 {
 	!RESOURCE[Ablator] {}
-	RESOURCE
+	%RESOURCE[Ablator]
 	{
-		name = Ablator
 		maxAmount = #$../heatShieldDiameter$
 		@maxAmount != 2
 		@maxAmount *= #$../heatShieldAblator$
@@ -212,20 +205,19 @@
 // Finish configuration: Ablator resources, Charred Ablator
 @PART:HAS[#heatShieldTag,~heatShieldNoAblator[?rue]]:FOR[RealismOverhaul_HeatShield]
 {
-	@MODULE[ModuleAblator]:HAS[~outputMult[]]
+	@MODULE[ModuleAblator],*
 	{
-		%outputMult = 1
+		&outputMult = 1
 	}
 	@RESOURCE[Ablator]
 	{
 		amount = #$maxAmount$
 	}
-	RESOURCE
+	%RESOURCE[CharredAblator]
 	{
-		name = CharredAblator
-		maxAmount = #$../RESOURCE[Ablator]/maxAmount$
+		%maxAmount = #$../RESOURCE[Ablator]/maxAmount$
 		@maxAmount *= #$../MODULE[ModuleAblator]/outputMult$
-		amount = 0
+		%amount = 0
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -128,8 +128,8 @@
 	// Beryllium melting point: 1560K
 	%maxTemp = 1500
 	%skinMaxTemp = 1500
-	@maxTemp:NEEDS[DeadlyReentry] = 1700
-	@skinMaxTemp:NEEDS[DeadlyReentry] = 1700
+	@maxTemp:NEEDS[DeadlyReentry] = 1750
+	@skinMaxTemp:NEEDS[DeadlyReentry] = 1750
 	%heatShieldDensity = 0.0125
 	%thermalMassModifier = 2.28125 // 1825 J/kg-K
 	%skinThermalMassModifier = 1.0 // all one material
@@ -137,12 +137,23 @@
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.95
 	
+	%heatConductivity = 0.03 // default is 0.12
+	
 	%heatShieldNoAblator = true
 
 
 	!MODULE[ModuleAblator] {}
 	!RESOURCE[Ablator] {}
 	!RESOURCE[CharredAblator] {}
+	
+	//%MODULE[ModuleConductionMultiplier]
+	//{
+	//	%modifiedConductionFactor = 0.25
+	//	%convectionFluxThreshold = 50.0 // per unit of area
+	//	
+	//	// Will lerp between 1x conduction and 0.25x conduction
+	//	// between 50kW/m^2 and 100kW/m^2
+	//}
 }
 
 // Apply physics properties for LEO-rated shield

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -20,30 +20,30 @@
 	%maxTemp = 2400
 	%skinMaxTemp = 3600
 	%heatShieldDensity = 0.0125
-	%heatShieldAblator = 62.5
+	%heatShieldAblator = 30
 
 	MODULE
 	{
 		name = ModuleAblator
 		ablativeResource = Ablator
 		outputResource = CharredAblator
-		outputMult = 0.75
+		outputMult = 0.8
 		lossExp = -25000
-		lossConst = 350
-		pyrolysisLossFactor = 30000
+		lossConst = 150
+		pyrolysisLossFactor = 145833
 		ablationTempThresh = 1250
 		reentryConductivity = 0.0025
 		infoTemp = 3000
 	}
 }
 
-// Apply physics properties for Gemini-rated shield
-@PART:HAS[#heatShieldTag[Gemini]]:FOR[RealismOverhaul_HeatShield]
+// Apply physics properties for EarlyLunar shield
+@PART:HAS[#heatShieldTag[EarlyLunar]]:FOR[RealismOverhaul_HeatShield]
 {
 	%maxTemp = 1300
 	%skinMaxTemp = 3350
-	%heatShieldDensity = 0.01
-	%heatShieldAblator = 37 // Gemini used 1.145x the weight for 1.48x the area
+	%heatShieldDensity = 0.0125
+	%heatShieldAblator = 37
 	%thermalMassModifier = 2.5
 	%skinMassPerArea = 5.0
 	%skinInternalConductionMult = 0.25
@@ -54,7 +54,7 @@
 		name = ModuleAblator
 		ablativeResource = Ablator
 		outputResource = CharredAblator
-		outputMult = 1
+		outputMult = 0.9
 		lossExp = -8600
 		lossConst = 0.214
 		pyrolysisLossFactor = 102625
@@ -63,13 +63,13 @@
 	}
 }
 
-// Apply physics properties for LEO-rated shield
-@PART:HAS[#heatShieldTag[LEO]]:FOR[RealismOverhaul_HeatShield]
+// Apply physics properties for Gemini-rated shield
+@PART:HAS[#heatShieldTag[Gemini]]:FOR[RealismOverhaul_HeatShield]
 {
 	%maxTemp = 1300
-	%skinMaxTemp = 2500
+	%skinMaxTemp = 2350
 	%heatShieldDensity = 0.01
-	%heatShieldAblator = 50
+	%heatShieldAblator = 25
 	%thermalMassModifier = 2.0
 	%skinMassPerArea = 4.0
 	%skinInternalConductionMult = 0.25
@@ -82,8 +82,61 @@
 		outputResource = CharredAblator
 		outputMult = 1
 		lossExp = -6000
-		lossConst = 0.13
-		pyrolysisLossFactor = 8210
+		lossConst = 0.075
+		pyrolysisLossFactor = 22300
+		ablationTempThresh = 750
+		reentryConductivity = 0.0065
+	}
+}
+
+// Apply physics properties for Mercury-rated shield
+@PART:HAS[#heatShieldTag[Mercury]]:FOR[RealismOverhaul_HeatShield]
+{
+	%maxTemp = 1300
+	%skinMaxTemp = 2350
+	%heatShieldDensity = 0.02
+	%heatShieldAblator = 25
+	%thermalMassModifier = 2.0
+	%skinMassPerArea = 4.0
+	%skinInternalConductionMult = 0.25
+	%emissiveConstant = 0.8
+
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 1
+		lossExp = -6000
+		lossConst = 0.14
+		pyrolysisLossFactor = 7800
+		ablationTempThresh = 750
+		reentryConductivity = 0.0065
+	}
+}
+
+// Apply physics properties for LEO-rated shield
+// Same as Gemini for now. Best to use Mercury or Apollo directly instead of this.
+@PART:HAS[#heatShieldTag[LEO]]:FOR[RealismOverhaul_HeatShield]
+{
+	%maxTemp = 1300
+	%skinMaxTemp = 2350
+	%heatShieldDensity = 0.01
+	%heatShieldAblator = 25
+	%thermalMassModifier = 2.0
+	%skinMassPerArea = 4.0
+	%skinInternalConductionMult = 0.25
+	%emissiveConstant = 0.8
+
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 1
+		lossExp = -6000
+		lossConst = 0.075
+		pyrolysisLossFactor = 22300
 		ablationTempThresh = 750
 		reentryConductivity = 0.0065
 	}

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -24,7 +24,7 @@
 	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 5.0
 	%skinInternalConductionMult = 0.25
-	%emissiveConstant = 0.8
+	%emissiveConstant = 0.4
 
 	%MODULE[ModuleAblator]
 	{
@@ -51,7 +51,7 @@
 	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 5.0
 	%skinInternalConductionMult = 0.25
-	%emissiveConstant = 0.8
+	%emissiveConstant = 0.4
 
 
 	%MODULE[ModuleAblator]

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -21,45 +21,51 @@
 	%skinMaxTemp = 3600
 	%heatShieldDensity = 0.0125
 	%heatShieldAblator = 30
+	%skinThermalMassModifier = 1.5
+	%skinMassPerArea = 5.0
+	%skinInternalConductionMult = 0.25
+	%emissiveConstant = 0.8
 
-	MODULE
+	%MODULE[ModuleAblator]
 	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.8
-		lossExp = -25000
-		lossConst = 150
-		pyrolysisLossFactor = 145833
-		ablationTempThresh = 1250
-		reentryConductivity = 0.0025
-		infoTemp = 3000
+		%name = ModuleAblator
+		%ablativeResource = Ablator
+		%outputResource = CharredAblator
+		%outputMult = 0.8
+		%lossExp = -25000
+		%lossConst = 150
+		%pyrolysisLossFactor = 145833
+		%ablationTempThresh = 1250
+		%reentryConductivity = 0.0025
+		%infoTemp = 3000
 	}
 }
 
 // Apply physics properties for EarlyLunar shield
 @PART:HAS[#heatShieldTag[EarlyLunar]]:FOR[RealismOverhaul_HeatShield]
 {
-	%maxTemp = 1300
-	%skinMaxTemp = 3350
+	%maxTemp = 2000
+	%skinMaxTemp = 3400
 	%heatShieldDensity = 0.0125
-	%heatShieldAblator = 37
-	%thermalMassModifier = 2.5
+	%heatShieldAblator = 35
+	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 5.0
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.8
 
-	MODULE
+
+	%MODULE[ModuleAblator]
 	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.9
-		lossExp = -8600
-		lossConst = 0.214
-		pyrolysisLossFactor = 102625
-		ablationTempThresh = 750
-		reentryConductivity = 0.0065
+		%name = ModuleAblator
+		%ablativeResource = Ablator
+		%outputResource = CharredAblator
+		%outputMult = 0.9
+		%lossExp = -25000
+		%lossConst = 350
+		%pyrolysisLossFactor = 60000
+		%ablationTempThresh = 1250
+		%reentryConductivity = 0.0025
+		%infoTemp = 3000
 	}
 }
 
@@ -70,22 +76,22 @@
 	%skinMaxTemp = 2350
 	%heatShieldDensity = 0.01
 	%heatShieldAblator = 25
-	%thermalMassModifier = 2.0
+	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 4.0
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.8
 
-	MODULE
+	%MODULE[ModuleAblator]
 	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 1
-		lossExp = -6000
-		lossConst = 0.075
-		pyrolysisLossFactor = 22300
-		ablationTempThresh = 750
-		reentryConductivity = 0.0065
+		%name = ModuleAblator
+		%ablativeResource = Ablator
+		%outputResource = CharredAblator
+		%outputMult = 1
+		%lossExp = -6000
+		%lossConst = 0.075
+		%pyrolysisLossFactor = 22300
+		%ablationTempThresh = 750
+		%reentryConductivity = 0.0065
 	}
 }
 
@@ -96,23 +102,45 @@
 	%skinMaxTemp = 2350
 	%heatShieldDensity = 0.02
 	%heatShieldAblator = 25
-	%thermalMassModifier = 2.0
-	%skinMassPerArea = 4.0
+	%skinThermalMassModifier = 1.5
+	%skinMassPerArea = 5.0
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.8
 
-	MODULE
+	%MODULE[ModuleAblator]
 	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 1
-		lossExp = -6000
-		lossConst = 0.14
-		pyrolysisLossFactor = 7800
-		ablationTempThresh = 750
-		reentryConductivity = 0.0065
+		%name = ModuleAblator
+		%ablativeResource = Ablator
+		%outputResource = CharredAblator
+		%outputMult = 1
+		%lossExp = -6000
+		%lossConst = 0.14
+		%pyrolysisLossFactor = 7800
+		%ablationTempThresh = 750
+		%reentryConductivity = 0.0065
+		%infoTemp = 1600
 	}
+}
+
+// Apply physics properties for Heatsink shield
+@PART:HAS[#heatShieldTag[Heatsink]]:FOR[RealismOverhaul_HeatShield]
+{
+	// Beryllium melting point: 1560K
+	%maxTemp = 1500
+	%skinMaxTemp = 1500
+	@maxTemp:NEEDS[DeadlyReentry] = 1700
+	@skinMaxTemp:NEEDS[DeadlyReentry] = 1700
+	%heatShieldDensity = 0.0125
+	%thermalMassModifier = 2.28125 // 1825 J/kg-K
+	%skinThermalMassModifier = 1.0 // all one material
+	%skinMassPerArea = 50.0 // 50kg/m^2, so basically half the mass is skin thermal mass, for a heatsink-only part.
+	%skinInternalConductionMult = 0.25
+	%emissiveConstant = 0.95
+
+
+	!MODULE[ModuleAblator] {}
+	!RESOURCE[Ablator] {}
+	!RESOURCE[CharredAblator] {}
 }
 
 // Apply physics properties for LEO-rated shield
@@ -128,17 +156,18 @@
 	%skinInternalConductionMult = 0.25
 	%emissiveConstant = 0.8
 
-	MODULE
+	%MODULE[ModuleAblator]
 	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 1
-		lossExp = -6000
-		lossConst = 0.075
-		pyrolysisLossFactor = 22300
-		ablationTempThresh = 750
-		reentryConductivity = 0.0065
+		%name = ModuleAblator
+		%ablativeResource = Ablator
+		%outputResource = CharredAblator
+		%outputMult = 1
+		%lossExp = -6000
+		%lossConst = 0.075
+		%pyrolysisLossFactor = 22300
+		%ablationTempThresh = 750
+		%reentryConductivity = 0.0065
+		%infoTemp = 1800
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -37,13 +37,43 @@
 	}
 }
 
+// Apply physics properties for Gemini-rated shield
+@PART:HAS[#heatShieldTag[Gemini]]:FOR[RealismOverhaul_HeatShield]
+{
+	%maxTemp = 1300
+	%skinMaxTemp = 3350
+	%heatShieldDensity = 0.01
+	%heatShieldAblator = 37 // Gemini used 1.145x the weight for 1.48x the area
+	%thermalMassModifier = 2.5
+	%skinMassPerArea = 5.0
+	%skinInternalConductionMult = 0.25
+	%emissiveConstant = 0.8
+
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 1
+		lossExp = -8600
+		lossConst = 0.214
+		pyrolysisLossFactor = 102625
+		ablationTempThresh = 750
+		reentryConductivity = 0.0065
+	}
+}
+
 // Apply physics properties for LEO-rated shield
 @PART:HAS[#heatShieldTag[LEO]]:FOR[RealismOverhaul_HeatShield]
 {
 	%maxTemp = 1300
-	%skinMaxTemp = 2350
+	%skinMaxTemp = 2500
 	%heatShieldDensity = 0.01
 	%heatShieldAblator = 50
+	%thermalMassModifier = 2.0
+	%skinMassPerArea = 4.0
+	%skinInternalConductionMult = 0.25
+	%emissiveConstant = 0.8
 
 	MODULE
 	{
@@ -52,7 +82,7 @@
 		outputResource = CharredAblator
 		outputMult = 1
 		lossExp = -6000
-		lossConst = 0.095
+		lossConst = 0.13
 		pyrolysisLossFactor = 8210
 		ablationTempThresh = 750
 		reentryConductivity = 0.0065

--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -67,6 +67,8 @@
 	// ANALYTIC
 	@analyticLerpRateSkin = 0.002
 	@analyticLerpRateInternal = 0.0005
+	@analyticConvectionSensitivityBase = 20
+	@analyticConvectionSensitivityFinal = 40
 	
 	// BUOYANCY
 	@buoyancyScalar = 1.0

--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -77,3 +77,8 @@
 	@stack_PriUsesSurf = True
 	
 }
+
+@FARConfig:HAS[@Occlusion:HAS[#useRaycaster[?rue]]]:FINAL
+{
+	*@PHYSICSGLOBALS/machConvectionFactor *= 0.7
+}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -108,6 +108,7 @@
 	@crashTolerance = 12
 	@maxTemp = 1000         // MainSailor: 873.15
 	%skinMaxTemp = 2000     // MainSailor: 3273.15
+	%skinThermalMassModifier = 5.0
 }
 
 @PART:HAS[@MODULE[ProceduralFairing*]]:AFTER[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -53,8 +53,6 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 @PART[0625_Heatshield|1.25_Heatshield|2.5_Heatshield|3.75_Heatshield]:FOR[RealismOverhaul]
 {
 	!MODULE[TweakScale] {}
-	!MODULE[ModuleAblator] {}
-	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_DeadlyReEntry.cfg
@@ -59,13 +59,10 @@ RESOURCE_DEFINITION:NEEDS[!DeadlyReentry]
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}
 	!RESOURCE[CharredAblator] {}
-	%heatShieldTag = LEO
+	%heatShieldTag = Gemini
 	%resetHeatShieldMass = true			// Ask RO_Heatshields to configure part mass
 	%resetHeatShieldAblator = true		// Ask RO_Heatshields to configure ablator quantity
 	@category = Thermal
-	%emissiveConstant = 0.6 // not too absorptive for reentry
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 4
 }
 
 // Declare shield diameter

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -5,7 +5,7 @@
 RESOURCE_DEFINITION
 {
   name = CharredAblator
-  density = 0.000975
+  density = 0.000925
   hsp = 200
   flowMode = NO_FLOW
   transfer = NONE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
@@ -65,13 +65,13 @@
 	
 	@mass = 0.00001
 	@maxTemp = 415
-	%skinMaxTemp = 415
+	%skinMaxTemp = 475
 	%thermalMassModifier = 0.75
 	%emissiveConstant = 0.4
 
 	@MODULE[FARWingAerodynamicModel]
 	{
-		%massMultiplier = 0.25
+		%massMultiplier = 0.35
 	}
 }
 @PART[RO-B9Proc*-Supersonic]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
@@ -66,7 +66,8 @@
 	@mass = 0.00001
 	@maxTemp = 415
 	%skinMaxTemp = 475
-	%thermalMassModifier = 1.0
+	%thermalMassModifier = 0.75
+	%skinThermalMassModifier = 3.0
 	%emissiveConstant = 0.4
 
 	@MODULE[FARWingAerodynamicModel]
@@ -82,6 +83,7 @@
 	@maxTemp = 800
 	%skinMaxTemp = 900
 	%thermalMassModifier = 1.0
+	%skinThermalMassModifier = 3.0
 	%emissiveConstant = 0.75
 	
 	@MODULE[FARWingAerodynamicModel]
@@ -98,6 +100,7 @@
 	@maxTemp = 1500
 	%skinMaxTemp = 2500
 	%thermalMassModifier = 1.25
+	%skinThermalMassModifier = 3.0
 	%emissiveConstant = 0.95
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
@@ -66,7 +66,7 @@
 	@mass = 0.00001
 	@maxTemp = 415
 	%skinMaxTemp = 475
-	%thermalMassModifier = 0.75
+	%thermalMassModifier = 1.0
 	%emissiveConstant = 0.4
 
 	@MODULE[FARWingAerodynamicModel]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Thermal.cfg
@@ -36,7 +36,7 @@
     @manufacturer = European Space Agency (ESA)
     @description = AQ60 tiles cover this heatshield assembly designed to protect the Huygens atmospheric lander during entry. A combination of aerodynamic shaping and ablative material transfers the heat caused by atmospheric compression away from the lander.
 
-    heatShieldTag = LEO
+    heatShieldTag = Gemini
     heatShieldDiameter = 2.7
     @category = Thermal
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_HeatShields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_HeatShields.cfg
@@ -4,8 +4,6 @@
 
 @PART[FASAGeminiPod2|FASAGeminiPod2White|FASAApollo_CM|FASAApollo_CM_HeatShield|FASAGeminiBigG|FASAGeminiBigGWhite|FASAMercuryPod]:FOR[RealismOverhaul]
 {
-	!MODULE[ModuleAblator] {}
-	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_HeatShields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_HeatShields.cfg
@@ -14,7 +14,7 @@
 
 @PART[FASAMercuryPod]:FOR[RealismOverhaul]
 {
-	heatShieldTag = LEO
+	heatShieldTag = Mercury
 	heatShieldDiameter = 1.8
 	// Ablator resource is a little low for the "default" (1.8 * 1.8 * 50 = 162)
 	RESOURCE
@@ -26,7 +26,7 @@
 
 @PART[FASAGeminiBigG|FASAGeminiBigGWhite]:FOR[RealismOverhaul]
 {
-	heatShieldTag = LEO
+	heatShieldTag = Gemini
 	heatShieldDiameter = 3.91
 
 	RESOURCE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -505,8 +505,6 @@
 @PART[mk1pod_v2]:FOR[RealismOverhaul]
 {
 	// Thermo
-	!MODULE[ModuleAblator] {}
-	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -512,7 +512,7 @@
 	!RESOURCE[Ablator] {}
 	!RESOURCE[CharredAblator] {}
 	// Set up for RO_Heatshields handling.  Patch custom values in later pass.
-	%heatShieldTag = LEO
+	%heatShieldTag = Mercury
 	%heatShieldDiameter = 2
 	%resetHeatShieldAblator = true
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
@@ -171,7 +171,7 @@
 {
 	@title = #LEO Heat Shield ($heatShieldDiameter$m)
 	@description = LEO rated heat shield. Not rated for lunar returns.
-	%heatShieldTag = LEO
+	%heatShieldTag = Gemini
 
 	// If variant is present (ie ReStock), differentiate the look from Lunar Rated Shields
 	@MODULE[ModulePartVariants]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
@@ -21,8 +21,6 @@
 // From Squad folder, Heatshield0: 0.625m, 1: 1.25m, 2: 2.5m, 3: 3.75m, all rescaleFactor=1
 @PART[HeatShield0|HeatShield1|HeatShield2|HeatShield3]:FOR[RealismOverhaul]
 {
-	!MODULE[ModuleAblator] {}
-	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Command.cfg
@@ -140,34 +140,13 @@
 		}
 	}
 	// Thermo
-	!MODULE[ModuleAblator] {}
-	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}
 	!RESOURCE[CharredAblator] {}
-	%emissiveConstant = 0.8
-	%thermalMassModifier = 1.0
-	%skinMassPerArea = 3
-	%heatShieldTag = Lunar
-	RESOURCE
-	{
-		name = Ablator
-		maxAmount = 144	// Match Gemini model
-	}
-}
-@PART[Mk2Pod]:AFTER[RealismOverhaul_HeatShield]
-{
-	%skinMaxTemp = 3350
-	%maxTemp = 900
-	@MODULE[ModuleAblator]
-	{
-		%lossExp = -8600
-		%lossConst = 0.214
-		%pyrolysisLossFactor = 75000
-		%charMax = 1
-		%charMin = 1
-	}
+	%heatShieldTag = Gemini
+	%resetHeatShieldAblator = true
+	%heatShieldDiameter = 2.2
 }
 
 @PART[Mk2Pod]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
@@ -203,8 +182,6 @@
 	!RESOURCE[CarbonDioxide] {}
 	!RESOURCE[Waste] {}
 	!RESOURCE[WasteWater] {}
-	!MODULE[ModuleAblator] {}
-	!MODULE[ModuleHeatShield] {}
 	!MODULE[ModuleAeroReentry] {}
 	!RESOURCE[AblativeShielding] {}
 	!RESOURCE[Ablator] {}
@@ -224,12 +201,9 @@
 	}
 
 	// Thermo
-	%heatShieldTag = Lunar
-	RESOURCE
-	{
-		name = Ablator
-		maxAmount = 225
-	}
+	%heatShieldTag = Gemini
+	%resetHeatShieldAblator = true
+	%heatShieldDiameter = 3.0
 }
 
 @PART[kv1Pod]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -221,21 +221,13 @@
 	@name = SoyuzHeatshield
 	%heatShieldTag = Lunar
 	%heatShieldDiameter = 2.2
-	!resetHeatShieldMass = DEL
-	!resetHeatShieldAblator = DEL
+	%resetHeatShieldAblator = true
+	%resetHeatShieldMass = true
 	%rescaleFactor = 1.76
 
 	@title = Soyuz Heat Shield (2.2m)
 	@description = Lunar-rated heat shield.
 	@mass = 0.06655
-	%emissiveConstant = 0.6 // not too absorptive for reentry
-	%thermalMassModifier = 1.0
-	!RESOURCE[Ablator] {}
-	RESOURCE
-	{
-		name = Ablator
-		maxAmount = 266
-	}
 	MODULE
 	{
 		name = ModuleDecouple
@@ -268,10 +260,10 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	%heatShieldTag = LEO
+	%heatShieldTag = Gemini
 	%heatShieldDiameter = 2.2
-	%resetHeatShieldMass = true
 	%resetHeatShieldAblator = true
+	%resetHeatShieldMass = true
 	%rescaleFactor = 0.88
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
@@ -151,8 +151,6 @@
 
     %MODULE[AdjustableCoMShifter] { %DescentModeCoM = 0.0, 0.0, -0.17 }
 
-    !MODULE[ModuleAblator] {}
-    !MODULE[ModuleHeatShield] {}
     !MODULE[ModuleAeroReentry] {}
     !RESOURCE[AblativeShielding] {}
     !RESOURCE[Ablator] {}


### PR DESCRIPTION
* Unlock the full convective heating in FAR. Previously exposed area was clamped to some arbitrary percentage because that is what stock code also did for whatever reason.
* Make 1 unit of LEO heatshield ablator a bit more effective to account for the increased thermal loads.
* Reduce the max skin temperature on LEO heatshields to make them explode when subjected to very high peak heat loads.
* Rework Lunar heatshields such that they actually ablate and keep temperatures at levels more similar to LEO shields.
* Reduce conduction for both LEO and Lunar heatshields to give parts with low thermal masses that are directly attached to the HS a better chance of survival.
* Slightly increase the skin temperature limits for Early B9 wings to account for the increased thermal loads.
* Increase the mass multiplier on Early B9 wings to make them more beginner-friendly. Higher thermal mass is helpful for sounding rockets where the fins are subject to short but high thermal loads. Another benefit is that it's harder to snap the wings off from planes with high-G maneuvers.