### PR TITLE
Fix SSME reliability

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -239,22 +239,8 @@
 	}
 }
 
-//**********************************************************************************
-//	SSME Test Flight Data
-//
 //	RS-25 flew on 20 flights with 2 ignition failures and 1 other failure
 //	60 engines, 2 ignition failures, 1 other
-
-//	RS-25A(B) flew on 63 flights with 3 ignition failures
-//	189 engines, 3 ignition failures
-
-//	RS-25C flew on 16 flights with 1 failure
-//	48 engines, 1 failure.
-
-//	RS-25D-E flew on 31 flights with no failures
-//	93 engines, 0 failures
-//**********************************************************************************
-
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-25]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -267,6 +253,9 @@
 		cycleReliabilityEnd = 0.996667
 	}
 }
+
+//	RS-25A(B) flew on 63 flights with 3 ignition failures
+//	189 engines, 3 ignition failures
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-25A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -280,6 +269,9 @@
 		techTransfer = RS-25:50
 	}
 }
+
+//	RS-25C flew on 16 flights with 1 failure
+//	48 engines, 1 failure.
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-25C]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -293,6 +285,9 @@
 		techTransfer = RS-25,RS-25A:50
 	}
 }
+
+//	RS-25D-E flew on 31 flights with no failures
+//	93 engines, 0 failures
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-25D-E]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -243,16 +243,16 @@
 //	SSME Test Flight Data
 //
 //	RS-25 flew on 20 flights with 2 ignition failures and 1 other failure
-//		ignition = 0.8971, cycle = 0.9355
+//	60 engines, 2 ignition failures, 1 other
+
 //	RS-25A(B) flew on 63 flights with 3 ignition failures
-//		ignition = 0.9500, cycle = 0.9948
+//	189 engines, 3 ignition failures
+
 //	RS-25C flew on 16 flights with 1 failure
-//		ignition = 0.9800, cycle = 0.9200
+//	48 engines, 1 failure.
+
 //	RS-25D-E flew on 31 flights with no failures
-//		ignition = 0.9895, cycle = 0.9895
-//
-//	Used a +/- of 0.06 and set the value above at the 80% mark of the curve with a
-//	max of 0.9995
+//	93 engines, 0 failures
 //**********************************************************************************
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-25]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -261,10 +261,10 @@
 	{
 		name = RS-25
 		ratedBurnTime = 480
-		ignitionReliabilityStart = 0.8491
-		ignitionReliabilityEnd = 0.9091
-		cycleReliabilityStart = 0.8875
-		cycleReliabilityEnd = 0.9475
+		ignitionReliabilityStart = 0.966667
+		ignitionReliabilityEnd = 0.993333
+		cycleReliabilityStart = 0.983333
+		cycleReliabilityEnd = 0.996667
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-25A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -273,10 +273,10 @@
 	{
 		name = RS-25A
 		ratedBurnTime = 480
-		ignitionReliabilityStart = 0.902
-		ignitionReliabilityEnd = 0.962
-		cycleReliabilityStart = 0.9468
-		cycleReliabilityEnd = 0.9995
+		ignitionReliabilityStart = 0.984127
+		ignitionReliabilityEnd = 0.996825
+		cycleReliabilityStart = 0.994737
+		cycleReliabilityEnd = 0.998947
 		techTransfer = RS-25:50
 	}
 }
@@ -286,10 +286,10 @@
 	{
 		name = RS-25C
 		ratedBurnTime = 480
-		ignitionReliabilityStart = 0.932
-		ignitionReliabilityEnd = 0.992
-		cycleReliabilityStart = 0.872
-		cycleReliabilityEnd = 0.932
+		ignitionReliabilityStart = 0.979592
+		ignitionReliabilityEnd = 0.995918
+		cycleReliabilityStart = 0.979167
+		cycleReliabilityEnd = 0.995833
 		techTransfer = RS-25,RS-25A:50
 	}
 }
@@ -299,10 +299,10 @@
 	{
 		name = RS-25D-E
 		ratedBurnTime = 480
-		ignitionReliabilityStart = 0.9415
-		ignitionReliabilityEnd = 0.9995
-		cycleReliabilityStart = 0.9415
-		cycleReliabilityEnd = 0.9995
+		ignitionReliabilityStart = 0.989362
+		ignitionReliabilityEnd = 0.997872
+		cycleReliabilityStart = 0.989362
+		cycleReliabilityEnd = 0.997872
 		techTransfer = RS-25,RS-25A,RS-25C:50
 	}
 }


### PR DESCRIPTION
The SSME reliability configs were apparently considering a single RS-25 failure as a failure of all 3 on the Orbiter, resulting in grossly exaggerated failure rates in game. This has been corrected, and changed to match the new format.