### PR TITLE
Make rcs-fueled generic thrusters pressure-fed and instant-on

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -103,6 +103,18 @@
 	}
 }
 
+// Make all rcs-fueled Engines pressure-fed
+@PART[*]:HAS[#useRcsConfig[*]]:FOR[RO-RCS]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%pressureFed = True
+		}
+	}
+}
+
 //  ==================================================
 //  Apply the min and max thrust levels.
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -104,13 +104,11 @@
 }
 
 //  ==================================================
-//  Parts without a ModuleRCS are generic thrusters
-//  that happen to use RCS fuels.
-//  Turn them into pressure-fed Engines, with instant
-//  ignition and no throttle.
+//  Parts without a ModuleRCS are generic thrusters that happen to use RCS fuels.
+//  Turn them into pressure-fed Engines, with instant ignition and no throttle.
 //  ==================================================
 
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS*]],!MODULE[ModuleRCS*]]:AFTER[RO-RCS]
+@PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS*]],!MODULE[ModuleRCS*]]:AFTER[RO-RCS]
 {
 	@MODULE[ModuleEngineConfigs]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -103,20 +103,11 @@
 	}
 }
 
-// Make all rcs-fueled Engines pressure-fed
-@PART[*]:HAS[#useRcsConfig[*]]:FOR[RO-RCS]
-{
-	@MODULE[ModuleEngineConfigs]
-	{
-		@CONFIG,*
-		{
-			%pressureFed = True
-		}
-	}
-}
-
 //  ==================================================
-//  Apply the min and max thrust levels.
+//  Parts without a ModuleRCS are generic thrusters
+//  that happen to use RCS fuels.
+//  Turn them into pressure-fed Engines, with instant
+//  ignition and no throttle.
 //  ==================================================
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS*]],!MODULE[ModuleRCS*]]:AFTER[RO-RCS]
@@ -131,6 +122,8 @@
 			%maxThrust = #$thrusterPower$
 			%minThrust = #$thrusterPower$
 			!thrusterPower = DEL
+			%pressureFed = True
+			%throttleResponseRate = 1000000
 		}
 	}
 }
@@ -146,3 +139,4 @@
 	!useRcsMass = DEL
 	!RcsNozzles = DEL
 }
+


### PR DESCRIPTION
ROEngines thrusters used to be pressure-fed but no longer are due to side-effect of some cleanup; RO's own generics
never were.

ROEngines thrusters also stopped being instant-on at the same time.