### PR TITLE
Fix Lacuga bottom node

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -13,17 +13,7 @@
 
     !mesh = NULL
 
-    @MODEL
-    {
-        %scale = 1.655, 1.655, 1.655
-    }
-
-    %scale = 1.0
-    @rescaleFactor = 1.0
-
-    @node_stack_top = 0.0, 1.912, 0.0, 0.0, 1.0, 0.0, 3
-    @node_stack_bottom,1 = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 3
-    @node_stack_bottom,2 = 0.0, -1.843, 0.0, 0.0, -1.0, 0.0, 2
+    @rescaleFactor = 1.655
 
     @title = SPKTR-10 Lacuga Storage Container
     @description = Hold 2 people with 30 days of supplies. An extension adapter for the PPD-10 Hitchhiker storage container.


### PR DESCRIPTION
Use rescaleFactor instead of overriding model scale then trying to
relocate nodes (and failing because the names are wrong)

Note that in addition to the top and bottom nodes, this part has a pair of nodes buried in the middle of the part. No idea what they're for, so no idea if they're where they "should" be, but they'll be where SXT wants them