### PR TITLE
Add a RSRM part based on stock's kickback

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -74,6 +74,38 @@
 	}
 }
 
+// Shuttle SRM
++PART[MassiveBooster]:BEFORE[RealismOverhaul] // after restock applies its model to MassiveBooster, and before we turn MassiveBooster into RSRMV
+{
+	// Not a perfect fit, kickback has 5 segments; but better than nothing
+	@name = RO-RSRM
+}
+
+@PART[RO-RSRM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	engineType = RSRM
+
+	!EFFECTS {}
+	!MODULE[TweakScale] {}
+
+	// Dimensions with restock-engine-srb-kickback-1 model: diameter: 1.25m x 14.9m
+	// RO dimensions of already-configured-but-deprecated restock-srb-anvil-1 part:  3.71m x 40.3m.
+	// A good example to follow, since both this and that lack the nose cone.
+	// That means diameter needs 2.968x, length needs 2.705x
+	@MODEL
+	{
+		// Keep MODEL.scale.y at 1x so top/bottom nodes move properly with rescaleFactor
+		scale = 1.098, 1, 1.098 // 2.968/2.705
+	}
+	%rescaleFactor = 2.705
+
+	// TODO: test without restock: with Ven's Stock Revamp, and plain stock.
+	// See RSRMV's config below for possible clues to needed tweaks
+	// (model and gimbal, in particular)
+}
+
+
 // RSRMV
 @PART[MassiveBooster]:HAS[#mesh]:BEFORE[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -99,10 +99,6 @@
 		scale = 1.098, 1, 1.098 // 2.968/2.705
 	}
 	%rescaleFactor = 2.705
-
-	// TODO: test without restock: with Ven's Stock Revamp, and plain stock.
-	// See RSRMV's config below for possible clues to needed tweaks
-	// (model and gimbal, in particular)
 }
 
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-RSRM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-RSRM.cfg
@@ -9,7 +9,7 @@
         localRotation = 0,0,0
         flarePosition = 0,0,0.5
         plumePosition = 0,0,1
-	smokePosition = 0,0,5
+        smokePosition = 0,0,5
         fixedScale = 3.4
         energy = 1
         speed = 1

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-RSRM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-RSRM.cfg
@@ -1,0 +1,24 @@
+// 4-segment RSRM, config copied from MassiveBooster (5-segment RSRMV)
+// with minimal tweaks
+@PART[RO-RSRM]:BEFORE[RealPlume]
+{
+    PLUME
+    {
+        name = Solid-Lower
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        flarePosition = 0,0,0.5
+        plumePosition = 0,0,1
+	smokePosition = 0,0,5
+        fixedScale = 3.4
+        energy = 1
+        speed = 1
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            %powerEffectName = Solid-Lower
+        }
+    }
+}


### PR DESCRIPTION
Because it's weird for RO to provide a "default" RSRMV but no RSRM.
Only tested with restock.