### PR TITLE
Fix Kerbal Scaling for the Mk2 Lander Can IVA

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -1240,7 +1240,7 @@
 	%scaleAll = 1.6, 1.6, 1.6
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1.6, 1.6, 1.6
+		%kerbalScale = 1.3, 1.3, 1.3
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}


### PR DESCRIPTION
As above.

Before: 
![20201030044231_1](https://user-images.githubusercontent.com/3977048/97749092-d8508580-1ac4-11eb-8902-3ce46390a48d.jpg)

After:
![20201030151206_1](https://user-images.githubusercontent.com/3977048/97749099-dab2df80-1ac4-11eb-8daa-1bbb1ffce34d.jpg)

There is also no IVA for the third kerbal in the can, but that would likely require a new IVA, which is beyond my abilities.