### PR TITLE
Remove ignitions from early RD-211 configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
@@ -91,6 +91,7 @@
 		configuration = Config_Name_1
 		modded = false
 		origMass = 0.09
+		//%literalZeroIgnitions = true //causes 0 ignitions to be interepted as ground-only, instead of infinite
 
 		CONFIG
 		{
@@ -117,7 +118,6 @@
 			%ullage = True
 			%pressureFed = True
 			%ignitions = 0	// 0 for unlimited, unless literalZeroIgnitions = true
-			//%literalZeroIgnitions = true
 
 			IGNITOR_RESOURCE
 			{
@@ -158,7 +158,6 @@
 			%ullage = True
 			%pressureFed = True
 			%ignitions = 0	// 0 for unlimited, unless literalZeroIgnitions = true
-			//%literalZeroIgnitions = true
 
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -295,7 +295,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 0
+			ignitions = 1
 			
 			IGNITOR_RESOURCE
 			{
@@ -342,7 +342,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 0
+			ignitions = 1
 			
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -153,7 +153,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{
@@ -201,7 +201,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{
@@ -248,7 +248,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{
@@ -295,7 +295,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{
@@ -342,7 +342,7 @@
 			
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0
 			
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -119,6 +119,8 @@
 		configuration = RD-211
 		origMass = 0.635
 		modded = false
+		literalZeroIgnitions = true
+		
 		CONFIG
 		{
 			name = RD-211-8D57
@@ -154,7 +156,6 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 0
-			literalZeroIgnitions = true
 			
 			IGNITOR_RESOURCE
 			{
@@ -203,7 +204,6 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 0
-			literalZeroIgnitions = true
 			
 			IGNITOR_RESOURCE
 			{
@@ -251,7 +251,6 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 0
-			literalZeroIgnitions = true
 			
 			IGNITOR_RESOURCE
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -154,6 +154,7 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 0
+			literalZeroIgnitions = true
 			
 			IGNITOR_RESOURCE
 			{
@@ -202,6 +203,7 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 0
+			literalZeroIgnitions = true
 			
 			IGNITOR_RESOURCE
 			{
@@ -249,6 +251,7 @@
 			ullage = True
 			pressureFed = False
 			ignitions = 0
+			literalZeroIgnitions = true
 			
 			IGNITOR_RESOURCE
 			{


### PR DESCRIPTION
Remove ignitions from early RD-211 configs (later versions allegedly used Tonka250 ignitor fluid, and so are theoretically capable of airlighting)