### PR TITLE
Fix NK9V gimbals when switching configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -149,6 +149,7 @@
 			}
 
 			ullage = True
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			ignitions = 1
 			IGNITOR_RESOURCE
 			{
@@ -228,6 +229,7 @@
 			}
 
 			ullage = True
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			ignitions = 1
 			IGNITOR_RESOURCE
 			{
@@ -307,6 +309,7 @@
 			}
 
 			ullage = True
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			ignitions = 2 //FIXME: engine supported multiple ignitions, no source on how many, nor how many it had resources for inflight.
 			IGNITOR_RESOURCE
 			{


### PR DESCRIPTION
per
https://github.com/NathanKell/ModularFuelSystem/issues/240#issuecomment-643489770

Explicitly specify a gimbalRange in every CONFIG, instead of only
overriding the ModuleGimbal value in configs that want something else