### PR TITLE
Sync up radiator configs with comments

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -696,8 +696,6 @@
 @PART[radPanelEdge]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    %rescaleFactor = 1.333
-    %scale = 1.0
 
     @title = EATCS Radiator Panel (Fin)
     @manufacturer = Roscosmos
@@ -836,7 +834,7 @@
 
     @MODEL
     {
-        %scale = 2.6, 2.6, 1.7
+        %scale = 4.27, 4.27, 3.75
     }
 
     @title = EATCS Retractable Radiator (Small)
@@ -852,7 +850,7 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 50000
+        @maxEnergyTransfer = 312
         @overcoolFactor = 0.01
 
         @RESOURCE[ElectricCharge]
@@ -869,6 +867,7 @@
 
 //  Dimensions: 3.4 m x 23.3 m
 //  Mass: 1122.64 Kg
+//   plus rotary joint. 1/3 of the 420kg for the Large is probably generous, but whatever
 //  Thermal Dissipation: 11600 W
 
 //  Source: https://www.nasa.gov/pdf/473486main_iss_atcs_overview.pdf
@@ -880,7 +879,7 @@
 
     @MODEL
     {
-        %scale = 1.0, 1.0, 1.72
+        %scale = 2.0, 2.0, 3.13
     }
 
     @scale = 1.0
@@ -889,7 +888,7 @@
     @manufacturer = Boeing Co.
     @description = A medium retractable External Active Thermal Control System radiator.
 
-    @mass = 1.1226
+    @mass = 1.263
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 1073.15
@@ -898,7 +897,7 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 50000
+        @maxEnergyTransfer = 580
         @overcoolFactor = 0.0186367
 
         @RESOURCE[ElectricCharge]
@@ -915,8 +914,8 @@
 
 //  Dimensions: 10.2 m x 23.3 m
 //  Mass: 3367.920 Kg (14 Kg/m2)
+//   plus 420kg for the rotary joint
 //  Thermal Dissipation: 35000 W (147 W/m2)
-
 //  Source: https://www.nasa.gov/pdf/473486main_iss_atcs_overview.pdf
 //  ==================================================
 
@@ -935,7 +934,7 @@
     @manufacturer = Boeing Co.
     @description = A large retractable External Active Thermal Control System radiator.
 
-    @mass = 3.3679
+    @mass = 3.788
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 1073.15
@@ -944,7 +943,7 @@
 
     @MODULE[ModuleActiveRadiator]
     {
-        @maxEnergyTransfer = 50000
+        @maxEnergyTransfer = 1750
         @overcoolFactor = 0.0186367
 
         @RESOURCE[ElectricCharge]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -686,8 +686,8 @@
 //  Accepted a mass factor of 6 Kg/m2.
 //  Accepted a dissipation factor of 175 W/m2.
 
-//  Dimensions: 0.85 m x 1.9 m
-//  Mass: 12.11 Kg
+//  Dimensions: 1.2 m x 2.69 m
+//  Mass: 19.4 Kg
 //  Dissipation: 565.25 W
 
 //  Source: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120015407.pdf
@@ -701,7 +701,8 @@
     @manufacturer = Roscosmos
     @description = A radial surface - mounted External Active Thermal Control System radiator panel.
 
-    @mass = 0.0121
+    %rescaleFactor = 1.404 // sqrt(2), to double surface area and get something more useful
+    @mass = 0.0194
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 1073.15


### PR DESCRIPTION
- Edge radiators had mass, area and dissipation numbers that didn't
  line up with each other
- Folding radiators were ~half as big as the comments claimed
- Foldings had a weirdly high maxEnergyTransfer
  Non-foldings have a Core Heat Xfer matching the comments'
  Thermal Dissipation, coming from maxEnergyTransfer*20
- Increase mass of medium and large foldings to account for rotary joint
  as documented in source pdf. Couldn't find a value for small, but
  its mass is already oddly high

Tested dimensions both with plain stock and with restock, they matched (or near enough).
And yes, _not_ rescaling the Edge radiator gives the right size. 🤷 