### PR TITLE
VSR Path Updates (Again)

### DIFF
--- a/GameData/RealismOverhaul/Parts/Avionics/Able.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Able.cfg
@@ -26,7 +26,7 @@
 	@category = Pods
 	
 	%rescaleFactor = 1.0
-	%rescaleFactor:NEEDS[VenStockRevamp] = 1.05
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 1.05
 
 	@mass = 0.140 // 140kg guess => correct Able mass with Fuselage tank and default utilization
 

--- a/GameData/RealismOverhaul/Parts/Avionics/Centaur.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Centaur.cfg
@@ -33,7 +33,7 @@
 
     %scale = 1.0
     %rescaleFactor = 1.0
-    %rescaleFactor:NEEDS[VenStockRevamp] = 1.05
+    %rescaleFactor:NEEDS[VenStockRevamp/Squad] = 1.05
 
     @category = Pods
     @title = Centaur Avionics Package [3.05m]

--- a/GameData/RealismOverhaul/Parts/Avionics/Delta.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/Delta.cfg
@@ -26,7 +26,7 @@
 
 	%scale = 1.0
 	%rescaleFactor = 1.0
-	%rescaleFactor:NEEDS[VenStockRevamp] = 1.05
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 1.05
 
 	@mass = 0.16 // slightly more than Able, more than half Agena but way cheaper.
 	@maxTemp = 573.15

--- a/GameData/RealismOverhaul/Parts/Avionics/SaturnIU.cfg
+++ b/GameData/RealismOverhaul/Parts/Avionics/SaturnIU.cfg
@@ -10,7 +10,7 @@
 	
 	%scale = 1.0
 	%rescaleFactor = 2.64
-	%rescaleFactor:NEEDS[VenStockRevamp] *= 1.05
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] *= 1.05
 
 	rescaleCube = 1
 	@DRAG_CUBE

--- a/GameData/RealismOverhaul/Parts/WACCorporal/TinyTim/TinyTim.cfg
+++ b/GameData/RealismOverhaul/Parts/WACCorporal/TinyTim/TinyTim.cfg
@@ -136,43 +136,42 @@ PART
 	@name = ROAerojet25KS18000
 }
 
-@PART[ROAerojet25KS18000]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+@PART[ROAerojet25KS18000]:FOR[RealismOverhaul]
 {
 	!mesh = NULL
-	!MODEL,*{}
-
-	MODEL:NEEDS[!VenStockRevamp]
+	!MODEL,* {}
+	MODEL
 	{
 		model = Squad/Parts/Engine/Size1_SRBs/SRB5
 		// Stock Dimension: 1.77143 x 1.26702
 		// Real Dimensions: 1.728216 x 0.34
 		scale = 0.2683, 0.9756, 0.2683
 	}
-	
-	MODEL:NEEDS[VenStockRevamp]
+}
+
+@PART[ROAerojet25KS18000]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp/PartBin]
+{
+	@MODEL
 	{
-		model = VenStockRevamp/Part Bin/NewParts/NewSolidBoosters/RT1
+		@model = VenStockRevamp/PartBin/NewParts/NewSolidBoosters/RT1
 		// Dimensions 0.67164, 1.73286, 0.67164
-		scale = 0.5062, 0.9973, 0.5062
+		@scale = 0.5062, 0.9973, 0.5062
 	}
 }
 
 @PART[ROAerojet25KS18000]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
-	!mesh = NULL
-	!MODEL,*{}
-
-	MODEL
+	@MODEL
 	{
-		model = ReStock/Assets/Engine/restock-engine-srb-flea-1
+		@model = ReStock/Assets/Engine/restock-engine-srb-flea-1
 		// Stock Dimension: 1.77459 x 1.34851
 		// Real Dimensions: 1.728216 x 0.34
-		scale = 0.2521, 0.9739, 0.2521
-	} 
+		@scale = 0.2521, 0.9739, 0.2521
+	}
 }
-  
+
 @PART[ROAerojet25KS18000]:FOR[RealismOverhaul]
-{ 
+{
 	%node_stack_top = 0.0, 0.9175344, 0.0, 0.0, 1.0, 0.0, 0  // 0.92
 	%node_stack_bottom = 0.0, -0.81068, 0.0, 0.0, -1.0, 0.0, 0  // -0.81286
 
@@ -183,7 +182,6 @@ PART
 	@mass = 0.117934
 
 	@engineType = 25KS18000
-	
 }
 
 //	==================================================================================
@@ -195,39 +193,38 @@ PART
 	@name = ROAerojet18KS7800
 }
 
-@PART[ROAerojet18KS7800]:FOR[RealismOverhaul]:NEEDS[!ReStock]
+@PART[ROAerojet18KS7800]:FOR[RealismOverhaul]
 {
 	!mesh = NULL
-	!MODEL,*{}
-
-	MODEL:NEEDS[!VenStockRevamp]
+	!MODEL,* {}
+	MODEL
 	{
 		model = Squad/Parts/Engine/Size1_SRBs/SRB5
 		// Stock Dimension: 1.77143 x 1.26702
 		// Real Dimensions: 1.728216 x 0.34
 		scale = 0.1604, 0.8259, 0.1604
 	}
-	
-	MODEL:NEEDS[VenStockRevamp]
+}
+
+@PART[ROAerojet18KS7800]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp/PartBin]
+{
+	@MODEL
 	{
-		model = VenStockRevamp/Part Bin/NewParts/NewSolidBoosters/RT1
-    	// Dimensions 0.67164, 1.73286, 0.67164
-		scale = 0.302543, 0.844292, 0.302543
+		@model = VenStockRevamp/PartBin/NewParts/NewSolidBoosters/RT1
+		// Dimensions 0.67164, 1.73286, 0.67164
+		@scale = 0.302543, 0.844292, 0.302543
 	}
 }
 
 @PART[ROAerojet18KS7800]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
-	!mesh = NULL
-	!MODEL,*{}
-
-	MODEL
+	@MODEL
 	{
-		model = ReStock/Assets/Engine/restock-engine-srb-flea-1
+		@model = ReStock/Assets/Engine/restock-engine-srb-flea-1
 		// Stock Dimension: 1.77459 x 1.34851
 		// Real Dimensions: 1.728216 x 0.34
-		scale = 0.1507, 0.8244, 0.1507
-	} 
+		@scale = 0.1507, 0.8244, 0.1507
+	}
 }
 
 @PART[ROAerojet18KS7800]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_RealFuels_Engines.cfg
@@ -118,14 +118,12 @@
 @PART[solidBoosterSmall]:FOR[RealismOverhaul]:NEEDS[!ReStock]
 {
 	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
+	!MODULE[TweakScale] {}
 	@MODEL
 	{
 		@scale = 2.3368, 1.829634, 2.3368
 	}
-	@MODEL:NEEDS[VenStockRevamp]
+	@MODEL:NEEDS[VenStockRevamp/Squad]
 	{
 		@model = VenStockRevamp/Squad/Parts/Propulsion/RT5
 		@scale = 2.3368, 3.085630306, 2.3368
@@ -153,13 +151,11 @@
 			@key,1 = 0 100
 		}
 	}
-	@MODULE[ModuleEngines*]:NEEDS[VenStockRevamp]
+	@MODULE[ModuleEngines*]:NEEDS[VenStockRevamp/Squad]
 	{
 		@thrustVectorTransformName = thrustTransform
 	}
-	!RESOURCE[SolidFuel]
-	{
-	}
+	!RESOURCE[SolidFuel] {}
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -167,7 +163,7 @@
 		type = HTPB
 		basemass = -1
 	}
-	MODULE:NEEDS[!VenStockRevamp]
+	MODULE:NEEDS[!VenStockRevamp/Squad]
 	{
 		name = ModuleGimbal
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AIES/RO_AIES_Engine.cfg
@@ -313,7 +313,7 @@
 		position = -1.0, 0.45, 0
 		rotation = 0, 90, 0
 	}
-	@MODEL,1:NEEDS[VenStockRevamp]		//Hex-editted mu files originally by Ven, re-distributed under CC-BY-4.0
+	@MODEL,1:NEEDS[VenStockRevamp/Squad]		//Hex-editted mu files originally by Ven, re-distributed under CC-BY-4.0
 	{
 		@model = RealismOverhaul/Models/KVDvernVSR
 		!texture = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-wheel-small.cfg
@@ -1,13 +1,13 @@
 //roverWheelS2 - the probe wheels
-@PART[roverWheel2]:NEEDS[KSPWheel&!VenStockRevamp]:FOR[RealismOverhaul]
+@PART[roverWheel2]:NEEDS[KSPWheel]:FOR[RealismOverhaul]
 {
-	-MODULE[ModuleWheelBase]{}
-	-MODULE[ModuleWheelSuspension]{}
-	-MODULE[ModuleWheelSteering]{}
-	-MODULE[ModuleWheelMotor]{}
-	-MODULE[ModuleWheelBrakes]{}
-	-MODULE[ModuleWheelDamage]{}
-	-MODULE[TweakScale]{}
+	-MODULE[ModuleWheelBase] {}
+	-MODULE[ModuleWheelSuspension] {}
+	-MODULE[ModuleWheelSteering] {}
+	-MODULE[ModuleWheelMotor] {}
+	-MODULE[ModuleWheelBrakes] {}
+	-MODULE[ModuleWheelDamage] {}
+	-MODULE[TweakScale] {}
 
 	MODULE
 	{
@@ -55,90 +55,22 @@
 		name = KSPWheelBrakes
 		maxBrakeTorque = 2
 	}
+
+	%MODULE[KSPWheelDustEffects] {}
+	%MODULE[KSPWheelSounds] {}
 	MODULE
 	{
 		name = KSPWheelDamage
 		wheelName = wheel
 		bustedWheelName = bustedwheel
-	}
-	MODULE
-	{
-		name = KSPWheelDustEffects
-	}
-	MODULE
-	{
-		name = KSPWheelSounds
 	}
 }
-@PART[roverWheel2]:NEEDS[KSPWheel&VenStockRevamp]:FOR[RealismOverhaul]
-{
-	-MODULE[ModuleWheelBase]{}
-	-MODULE[ModuleWheelSuspension]{}
-	-MODULE[ModuleWheelSteering]{}
-	-MODULE[ModuleWheelMotor]{}
-	-MODULE[ModuleWheelBrakes]{}
-	-MODULE[ModuleWheelDamage]{}
-	-MODULE[TweakScale]{}
 
-	MODULE
+@PART[roverWheel2]:NEEDS[KSPWheel&VenStockRevamp/Squad]:FOR[RealismOverhaul]
+{
+	@MODULE[KSPWheelBase]
 	{
-		name = KSPWheelBase
-		wheelColliderName = WheelCollider
-		wheelColliderOffset = 0.1939
-		wheelRadius = 0.1575
-		wheelMass = 0.030
-		suspensionTravel = 0.15
-		loadRating = 0.1
-		minLoadRating = 0.01
-		maxLoadRating = 1
-		maxSpeed = 11.5
-		groundHeightOffset = 0.175
-		boundsColliderName = collider
-	}
-	MODULE
-	{
-		name = KSPWheelRotation
-		wheelMeshName = WheelPivot
-		rotationAxis = 1,0,0
-	}
-	MODULE
-	{
-		name = KSPWheelSuspension
-		suspensionName = SuspensionPivot
-		suspensionOffset = -0.18
-		suspensionAxis = 0, 1, 0
-	}
-	MODULE
-	{
-		name = KSPWheelSteering
-		steeringName = SteeringPivot
-		maxSteeringAngle = 40
-		steeringAxis = 0, 1, 0
-		steeringResponse = 0.15
-	}
-	MODULE
-	{
-		name = KSPWheelMotor
-		maxMotorTorque = 0.3
-		maxRPM = 650
-	}
-	MODULE
-	{
-		name = KSPWheelBrakes
-		maxBrakeTorque = 2
-	}
-	MODULE
-	{
-		name = KSPWheelDamage
-		wheelName = wheel
-		bustedWheelName = bustedwheel
-	}
-	MODULE
-	{
-		name = KSPWheelDustEffects
-	}
-	MODULE
-	{
-		name = KSPWheelSounds
+		@suspensionTravel = 0.15
+		%boundsColliderName = collider
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Liquidhype/RO_LqdH_Delta3.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Liquidhype/RO_LqdH_Delta3.cfg
@@ -259,14 +259,14 @@
 		position = 0, -0.5, 0.585
 		rotation = 0, 180, 0
 	}
-	@MODEL,1:NEEDS[VenStockRevamp]		//Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0
+	@MODEL,1:NEEDS[VenStockRevamp/Squad]		//Hex-edited mu files originally by Ven, re-distributed under CC-BY-4.0
 	{
 		@model = RealismOverhaul/Models/KVDvernVSR
 		!texture = DELETE
 		texture = SmallEngines_CLR, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_CLR
 		texture = SmallEngines_NRM, VenStockRevamp/Squad/Parts/Propulsion/SmallEngines_NRM
 	}
-	@MODEL,2:NEEDS[VenStockRevamp]
+	@MODEL,2:NEEDS[VenStockRevamp/Squad]
 	{
 		@model = RealismOverhaul/Models/KVDvernVSR
 		!texture = DELETE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_Engines_SRB.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_Engines_SRB.cfg
@@ -105,11 +105,6 @@
 	@attachRules = 1,1,1,1,0
 	@maxTemp = 1973.15
 
-	@MODULE[ModuleEngines*]:NEEDS[VenStockRevamp]
-	{
-		@thrustVectorTransformName = thrustTransform
-	}
-	
 	%MODULE[ModuleGimbal] { %gimbalTransformName = thrustTransform }
 	
 	%engineType = Castor-30B

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -295,7 +295,7 @@
 
     @title = RA-2 Parabolic Antenna (1m)
     @rescaleFactor = 1.0
-    @rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.8333
+    @rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.8333
 
     @description = A fixed Cassegrain parabolic antenna for general applications. Features a composite protective cover for the reflector.
     @mass = 0.035
@@ -412,7 +412,7 @@
     %RSSROConfig = True
 
     @rescaleFactor = 1.0
-    %rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.8333
+    %rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.8333
 
     @title = RA-15 Parabolic Antenna (2m)
     @manufacturer = Generic
@@ -472,7 +472,7 @@
     %RSSROConfig = True
 
     %rescaleFactor = 1.3333
-    %rescaleFactor:NEEDS[VenStockRevamp] = 1.13
+    %rescaleFactor:NEEDS[VenStockRevamp/Squad] = 1.13
     %rescaleFactor:NEEDS[ReStock] = 1.3115
 
     @title = RA-100 Parabolic Antenna (4m)

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
@@ -25,7 +25,7 @@
 	@title = XT2 Solar Panel Array Mk1
 	@description = Shielded extendable Level 2 solar panel. 1.5m^2.
 	%rescaleFactor = 1.2
-	%rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.7971
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.7971
 
 	SolarConfig
 	{
@@ -40,7 +40,7 @@
 {
 	@title = XT1 Solar Panel Array Mk1
 	@description = Extendable Level 1 solar panel. 0.96m^2.
-	%rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.631
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.631
 
 	SolarConfig
 	{
@@ -55,7 +55,7 @@
 	@title = XT2 Solar Panel Array Mk2
 	@description = Shielded extendable sun-tracking Level 3 solar panel. 1.5m^2.
 	%rescaleFactor = 1.2
-	%rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.818
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.818
 
 	SolarConfig
 	{
@@ -70,7 +70,7 @@
 {
 	@title = XT1 Solar Panel Array Mk2
 	@description = Extendable sun-tracking Level 3 solar panel. 0.96m^2.
-	%rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.6634
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.6634
 
 	SolarConfig
 	{
@@ -84,7 +84,7 @@
 {
 	@title = XT4 Solar Panel Array Mk1
 	@description = Extendable sun-tracking Level 4 solar panel. 13.0m^2.
-	%rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 1.03
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 1.03
 
 	SolarConfig
 	{
@@ -100,7 +100,7 @@
 	@title = XT3 Solar Panel Array Mk1
 	@description = Extendable sun-tracking Level 3 solar panel. 6.0m^2.
 	@rescaleFactor *= 0.67937
-	%rescaleFactor:NEEDS[VenStockRevamp,!ReStock] = 0.69986
+	%rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.69986
 
 	@SolarConfig
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -181,7 +181,7 @@
 }
 
 //  TD-339 (vernier engine).
-@PART[RO-SurveyorVernier]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp,!ReStock]
+@PART[RO-SurveyorVernier]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@MODEL
 	{
@@ -236,7 +236,7 @@
 	@rescaleFactor = 2.225
 }
 
-@PART[SSME]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp,!ReStock]
+@PART[SSME]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@rescaleFactor = 2.78
 }
@@ -292,7 +292,7 @@
 }
 
 //  Castor 30XL.
-@PART[solidBooster_v2]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp,!ReStock]
+@PART[solidBooster_v2]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@MODEL
 	{
@@ -347,7 +347,7 @@
 	@rescaleFactor = 1.1
 }
 
-@PART[RO-GCRC|RO-X-258|RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp,!ReStock]
+@PART[RO-GCRC|RO-X-258|RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@MODEL
 	{
@@ -357,14 +357,14 @@
 	@rescaleFactor = 0.85309
 }
 
-@PART[RO-X-258|RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp,!ReStock]
+@PART[RO-X-258|RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@fx_exhaustFlame_yellow = 0.0, -6.756, 0.0, 0.0, 1.0, 0.0, running
 	@fx_exhaustSparks_yellow = 0.0, -6.756, 0.0, 0.0, 1.0, 0.0, running
 	@fx_smokeTrail_medium = 0.0, -6.756, 0.0, 0.0, 1.0, 0.0, running
 }
 
-@PART[RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp,!ReStock]
+@PART[RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@MODEL
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -347,11 +347,11 @@
 	@rescaleFactor = 1.1
 }
 
-@PART[RO-GCRC|RO-X-258|RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
+@PART[RO-GCRC|RO-X-258|RO-AltairIII]:BEFORE[RealismOverhaul]:NEEDS[VenStockRevamp/PartBin,!ReStock]
 {
 	@MODEL
 	{
-		@model = VenStockRevamp/Squad/Parts/Propulsion/RT1
+		@model = VenStockRevamp/PartBin/NewParts/NewSolidBoosters/RT1
 		@scale = 0.785, 1, 0.785
 	}
 	@rescaleFactor = 0.85309

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Heatshields.cfg
@@ -23,9 +23,9 @@
 }
 
 // Adjust some models from Ven's
-@PART[HeatShield1|HeatShield2]:FOR[RealismOverhaul]
+@PART[HeatShield1|HeatShield2]:FOR[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
-	@MODEL:NEEDS[VenStockRevamp,!ReStock]
+	@MODEL
 	{
 		%scale = 1.0, 1.2, 1.0
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -99,7 +99,7 @@
 	@mass = 85.4187
 	@maxTemp = 1973.15
 	!RESOURCE[SolidFuel] {}
-	MODULE:NEEDS[!VenStockRevamp]
+	MODULE:NEEDS[!VenStockRevamp/Squad]
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -138,7 +138,7 @@
 	@PhysicsSignificance = 0
 	!MODULE[TweakScale] {}
 	%rescaleFactor = 2.56
-	@rescaleFactor:NEEDS[VenStockRevamp] *= 1.1
+	@rescaleFactor:NEEDS[VenStockRevamp/Squad] *= 1.1
 
 	@mass = 0.012
 	%useRcsConfig = RCSBlockDouble

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_TantaresLV_Antares.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_TantaresLV_Antares.cfg
@@ -174,7 +174,7 @@
 		type = HTPB
 		basemass = -1
 	}
-	MODULE:NEEDS[!VenStockRevamp]
+	MODULE:NEEDS[!VenStockRevamp/Squad]
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/RO_VSR_Command.cfg
@@ -1,7 +1,7 @@
 // VSR has two different pod sizes, and sets the nodes differently
 // NODE settings in PartVariants are unaffected by rescaleFactor
 // This patch is still safe if we ran with ReStock+VNP and think we have VSR
-@PART[mk1pod_v2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp]
+@PART[mk1pod_v2]:AFTER[RealismOverhaul]:NEEDS[VenStockRevamp/Squad]
 {
 	@MODULE[ModulePartVariants]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
@@ -4,7 +4,7 @@
 
 @PART[RO-2kN-Thruster]:FOR[RealPlume]:NEEDS[SmokeScreen]
 {
-    PLUME:NEEDS[!VenStockRevamp]
+    PLUME:NEEDS[!VenStockRevamp/Squad]
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
@@ -19,7 +19,7 @@
         speed = 1.5
     }
 
-    PLUME:NEEDS[!VenStockRevamp]
+    PLUME:NEEDS[!VenStockRevamp/Squad]
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform
@@ -34,7 +34,7 @@
         speed = 1.0
     }
 	
-	PLUME:NEEDS[VenStockRevamp]
+	PLUME:NEEDS[VenStockRevamp/Squad]
     {
         name = Hypergolic-OMS-Red
         transformName = thrustTransform
@@ -49,7 +49,7 @@
         speed = 1.5
     }
 
-    PLUME:NEEDS[VenStockRevamp]
+    PLUME:NEEDS[VenStockRevamp/Squad]
     {
         name = Hypergolic-OMS-White
         transformName = thrustTransform


### PR DESCRIPTION
More thorough look at patches referencing VenStockRevamp.
Ubiquitously use VenStockRevamp/Squad to check for VSR, or VenStockRevamp/PartBin to check for VNP.
As of time of this PR, VSR has committed to the path renaming in its master branch but has not released.  Patches in RO referencing VenStockRevamp/PartBin will be broken until VSR releases again.