### PR TITLE
Add Rolls-Royce RZ.20

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -39,7 +39,7 @@
 
 // spaceuk.org - Liquid Hydrogen Designs:											http://www.spaceuk.org/hydrogen/hydrogen.htm
 // Liquid Hydrogen and the SABRE Engine:											https://stfc.ukri.org/stfc/cache/file/FDAB16B3-AED8-4D39-8B267116989BC4F6.pdf
-// ukrocketman.com:																	http://www.ukrocketman.com/space.shtml
+// ukrocketman.com:														http://www.ukrocketman.com/space.shtml
 // Google Books - A Vertical Empire:												https://books.google.com/books?id=MvG3CgAAQBAJ&pg=PA5&lpg=PA5&dq=RZ.20+rocket&source=bl&ots=9_0AYaolus&sig=ACfU3U1V-0GJjjpkHA_8Xo-YXdMyxiKWdw&hl=en&sa=X&ved=2ahUKEwiMm8fC0sftAhVLCs0KHSUkD4U4ChDoATAHegQIChAC#v=onepage&q=RZ.20%20rocket&f=false
 
 

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -38,8 +38,9 @@
 //	Sources:
 
 // spaceuk.org - Liquid Hydrogen Designs:											http://www.spaceuk.org/hydrogen/hydrogen.htm
-// Liquid Hydrogen and the SABRE Engine												https://stfc.ukri.org/stfc/cache/file/FDAB16B3-AED8-4D39-8B267116989BC4F6.pdf
-// ukrocketman.com																	https://www.google.com/search?q=RZ.20+rocket&oq=RZ.20+rocket&aqs=chrome..69i57.2655j0j7&sourceid=chrome&ie=UTF-8
+// Liquid Hydrogen and the SABRE Engine:											https://stfc.ukri.org/stfc/cache/file/FDAB16B3-AED8-4D39-8B267116989BC4F6.pdf
+// ukrocketman.com:																	http://www.ukrocketman.com/space.shtml
+// Google Books - A Vertical Empire:												https://books.google.com/books?id=MvG3CgAAQBAJ&pg=PA5&lpg=PA5&dq=RZ.20+rocket&source=bl&ots=9_0AYaolus&sig=ACfU3U1V-0GJjjpkHA_8Xo-YXdMyxiKWdw&hl=en&sa=X&ved=2ahUKEwiMm8fC0sftAhVLCs0KHSUkD4U4ChDoATAHegQIChAC#v=onepage&q=RZ.20%20rocket&f=false
 
 
 //	Used by:

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -1,0 +1,178 @@
+//	==================================================
+//	RZ.20
+//
+//	Manufacturer: Rolls-Royce
+//
+//	=================================================================================
+//	RZ.20-Mk1
+//	Rolls-Royce prototype
+//
+//	Dry Mass: ??? Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 70 kN
+//	ISP: ??? SL / 410 Vac
+//	Burn Time: ???
+//	Chamber Pressure: 2.07 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.0
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: ???	//Used electric ignitor system
+//	=================================================================================
+//	RZ.20-Mk2
+//	Increased expansion ratio proposal
+//
+//	Dry Mass: ??? Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): ??? kN
+//	ISP: ??? SL / ??? Vac
+//	Burn Time: ???
+//	Chamber Pressure: 2.07 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.0
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: ???	//Used electric ignitor system
+//	=================================================================================
+
+//	Sources:
+
+// spaceuk.org - Liquid Hydrogen Designs:											http://www.spaceuk.org/hydrogen/hydrogen.htm
+// Liquid Hydrogen and the SABRE Engine												https://stfc.ukri.org/stfc/cache/file/FDAB16B3-AED8-4D39-8B267116989BC4F6.pdf
+// ukrocketman.com																	https://www.google.com/search?q=RZ.20+rocket&oq=RZ.20+rocket&aqs=chrome..69i57.2655j0j7&sourceid=chrome&ie=UTF-8
+
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[RZ20]]:FOR[RealismOverhaulEngines]
+{
+	%title = RZ.20 Series Engine
+	%manufacturer = Rolls-Royce
+	%description = Pump-fed gas generator hydrolox engine, developed as an upper stage for the Black Knight and Blue Streak. The use of furnace brazing, rather than hand brazing as used in many earlier designs, significantly reduced manufacturing costs. The design was tested, but cancelled in the late 60s due to funding concerns.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 10
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.167	//Assumed same as RL10
+		modded = false
+		configuration = RZ20-Mk1
+
+		CONFIG
+		{
+			name = RZ20-Mk1
+			minThrust = 70 //16 klbf
+			maxThrust = 70
+			description = Prototype developed by Rolls-Royce
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7631
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2369 //5.0
+			}
+			atmosphereCurve
+			{
+				key = 0 410
+				key = 1 200
+			}
+			massMult = 0.87
+			%ullage = True
+			%ignitions = 10	//assumed same as RL10, used similar spark ignitor system
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = RZ20-Mk2
+			minThrust = 72.56
+			maxThrust = 72.56
+			description = Increased expansion ratio proposal
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7631
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2369 //5.0
+			}
+			atmosphereCurve
+			{
+				key = 0 425
+				key = 1 200
+			}
+			massMult = 0.95
+			%ullage = True
+			%ignitions = 10	//assumed same as RL10, used similar spark ignitor system
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+		}
+	}
+}
+
+//No Data, never flew
+//Using RL10A-3-1 data, as the gas generator design was simple, and British engineers had access to RL10 data from P&W
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ20-Mk1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RZ20-Mk1
+		ratedBurnTime = 470
+		ignitionReliabilityStart = 0.933333
+		ignitionReliabilityEnd = 0.986667
+		cycleReliabilityStart = 0.933333
+		cycleReliabilityEnd = 0.986667
+		
+		ignitionDynPresFailMultiplier = 0.1
+	}
+}
+//No Data, never flew
+//Using RL10A-3-3 data, as the gas generator design was simple, and British engineers had access to RL10 data from P&W
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RZ20-Mk2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RZ20-Mk2
+		ratedBurnTime = 470
+		ignitionReliabilityStart = 0.994681
+		ignitionReliabilityEnd = 0.998936
+		cycleReliabilityStart = 0.989474
+		cycleReliabilityEnd = 0.997895
+		
+		ignitionDynPresFailMultiplier = 0.1
+	}
+}


### PR DESCRIPTION
Add the Rolls-Royce RZ.20, a hydrolox upper stage developed for Blue Streak. The engine was built and hot-fired, but was cancelled along with the rest of the British space program sometime in the late 60s.