### PR TITLE
Fix InflatableHAB tank volume

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
@@ -89,13 +89,13 @@
     @breakingTorque = 250
     @maxTemp = 1073.15
 
-    %ROLSCrew = 8
+    %ROLSCrew = 10
     %ROLSTankStorage = 920
 
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 5625
+        volume = 17725
         basemass = -1
         type = ServiceModule
         TANK


### PR DESCRIPTION
Because ROLSTankStorage expects the tank to be big enough,
and it wasn't close. This way the tank won't start out with
negative available space.

Likewise make ROLSCrew match the actual number of seats when inflated