### PR TITLE
Let SM tanks capture boiloff products

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1423,6 +1423,14 @@ TANK_DEFINITION
 		maxAmount = 0.0
 		//note = (pressurized)
 	}
+	TANK
+	{
+		name = Ammonia
+		utilization = 100
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
 }
 
 // SM resources
@@ -1511,20 +1519,26 @@ TANK_DEFINITION
 	}
 
 	// Cryo resources in SM tanks get a dewar flask
+	// and the gas can be captured
 	@TANK[LqdOxygen] {
 		isDewar = True
+		boiloffProduct = Oxygen
 	}
 	@TANK[LqdHydrogen] {
 		isDewar = True
+		boiloffProduct = Hydrogen
 	}
 	@TANK[LqdAmmonia] {
 		isDewar = True
+		boiloffProduct = Ammonia
 	}
 	@TANK[LqdMethane] {
 		isDewar = True
+		boiloffProduct = Methane
 	}
 	@TANK[LqdFluorine] {
 		isDewar = True
+		boiloffProduct = Fluorine
 	}
 	@TANK[FLOX30] {
 		isDewar = True


### PR DESCRIPTION
The old ServiceModule tank definition was set this way,
but it got forgotten from SM-I and friends

Only tested with LOX.

Also added Ammonia to HP tanks while I was at it; it would have
been silly to define a boiloff product that can't be stored anywhere.
(Kerbalism processes will also benefit)