### PR TITLE
Adjust Derwent Performance

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -14,20 +14,20 @@
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Medium
 		position = 0.0, 0.0, 0.0
-		scale = 0.7,0.9,0.7
+		scale = 0.7,1.1,0.7
 	}
 	MODEL:NEEDS[VenStockRevamp/Squad]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Small
-		position = 0.0, 0.7, 0.0
-		scale = 1.3,0.3,1.3
+		position = 0.0, 0.8, 0.0
+		scale = 1.4,0.4,1.4
 	}
 	MODEL:NEEDS[VenStockRevamp/Squad]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Small
-		position = 0.0, 0.7, 0.0
+		position = 0.0, 0.8, 0.0
 		rotation = 180, 0, 0
-		scale = 1.3,0.03,1.3
+		scale = 1.4,0.03,1.4
 	}
 
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -1,5 +1,6 @@
 // Clone minijet to be Derwent V
 // source: http://krause-motores.tripod.com/derwent/datos/datos_derwent_i.htm
+//	https://www.avialogs.com/engines-r/rolls-royce/item/7573-rolls-royce-derwent-turbo-jet-aero-engines
 +PART[SXTMiniJet]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -34,6 +34,9 @@
 	@mass = 0.57
 	%CoMOffset = 0, 0.25, 0
 	
+	@maxTemp = 573
+	%skinMaxTemp = 773
+	
 	@title = Derwent V
 	@manufacturer = Rolls-Royce
 	@description = The Derwent V, rather than being a development of the Derwent line (a straight-through-flow development of the W.2), was instead a scaled-down Nene. It powered the Meteor F.4, and was available in mid-late 1945. SFC 1.03 lb/lbf-hr static. Temperature limit Mach 1.
@@ -42,25 +45,26 @@
 	{
 		@name = ModuleEnginesAJEJet
 		%maxThrust = 15.6
-		%Area = 0.124
-		%BPR = 0
-		%CPR = 4.45 // 4.0 effective
-		%FPR = 0
-		%TPR = 1
-		%Mdes = 0.5
-		%Tdes = 250
-		%eta_c = 0.95
-		%eta_t = 0.95
-		%eta_n = 0.8
-		%FHV = 22500000
-		%TIT = 1168
-		%TAB = 0
+		%machHeatMult = 3.7
+		%Area = 0.124	//Compressor Area
+		%BPR = 0		//Bypass Ratio
+		%CPR = 4.45		//Compressor Pressure Ratio, 4.0 effective
+		%FPR = 0		//Fan Ratio
+		%TPR = 0.8		//Turbine Pressure Ratio
+		%Mdes = 0.3		//Mach Design Point
+		%Tdes = 280		//Temp Design Point
+		%eta_c = 0.8	//Efficiency at burner inlet
+		%eta_t = 0.8	//Efficiency at burner exit
+		%eta_n = 0.8	//Efficiency at afterburner rear / nozzle entrance
+		%FHV = 22500000	//Fuel heat of burning (joules?)
+		%TIT = 1168		//Combustion peak temp
+		%TAB = 0		//Afterburner temp?
 		%exhaustMixer = False
-		%thrustUpperLimit = 30
-		%maxT3 = 500
+		%thrustUpperLimit = 20
+		%maxT3 = 500	//Turbine max temperature
 		
 		// Engine fitting params
-		%dryThrust = 16.1
+		%dryThrust = 15.6
 		%wetThrust = 0
 		%drySFC = 1.03
 		


### PR DESCRIPTION
Adjust Derwent V performance based on historical documents

The Derwent will not overheat at full throttle when stationary, although it will overheat by the time you reach 100 m/s, so players will have about 30 seconds to decrease throttle, if they are paying attention (this margin may be much smaller in warmer areas, but will be much larger at higher altitudes).

Although this sadly does not prevent supersonic Derwent-powered aircraft, it makes supersonic flight at sea level nearly impossible for them, and reduces their max speed at altitude by 20-50 m/s.