### PR TITLE
Improve tank names

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -293,8 +293,8 @@
 	@name = RO-RFTank-Seperate
 	%RSSROConfig = True
 
-	@title = Procedural Tank (Stringer Structure)
-	@description = The most basic form of fuel tank. Stringer structure tanks do not have load bearing tanks. This makes them cheaper to produce but they are heavier than other types of tank.
+	@title = Procedural Tank (Conventional Structure)
+	@description = The most basic form of fuel tank. Conventional structure tanks consist of two parts, a support structure (also known as stringers) and a fuel tank. Earlier iterations also had a separate skin surrounding them, but later tanks moved the structure inside the fuel tanks. This makes them cheap and easy to produce.
 
 	!MODULE[ModuleFuelTanks] {}
 	MODULE
@@ -328,7 +328,7 @@
 	%RSSROConfig = True
 
 	@title = Procedural Tank (Integral Structure)
-	@description = A more complex, but more efficient tank. Integral structure tanks are also load-bearing and form the entire structure of the tank, so no additional mass is needed to maintain rigidity. Manufacturing them can be difficult, however.
+	@description = A more complex, but lightweight tank. Integral structure tanks use machined walls that are also load-bearing and form the entire structure of the tank, so no additional structure is needed to maintain rigidity. Manufacturing them can be difficult, however.
 
 	!MODULE[ModuleFuelTanks] {}
 	MODULE
@@ -379,7 +379,7 @@
 	%RSSROConfig = True
 
 	@title = Procedural Tank (Service Module)
-	@description = Specialized tank for batteries, payloads and life support, not intended to hold fuel. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
+	@description = <b><color=red>Not intended to hold fuel</color></b>, these specialized tanks are for batteries, payloads and life support. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
 
 	!MODULE[ModuleFuelTanks] {}
 	MODULE

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -378,7 +378,7 @@
 	@name = RO-RFTank-SM
 	%RSSROConfig = True
 
-	@title = Procedural Tank (Service Module)
+	@title = Procedural Service Module
 	@description = <b><color=red>Not intended to hold fuel</color></b>, these specialized tanks are for batteries, payloads and life support. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
 
 	!MODULE[ModuleFuelTanks] {}


### PR DESCRIPTION
Improve tank names and descriptions in order to discourage the use of SM tanks by new players.