### PR TITLE
Move ratedBurnTime from TF config to engine config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
@@ -99,6 +99,7 @@
 			description = ???
 			minThrust = 1
 			maxThrust = 1
+			ratedBurnTime = 120
 			heatProduction = 100
 			massMult = 1.0
 
@@ -139,6 +140,7 @@
 			description = ???
 			minThrust = 35.2
 			maxThrust = 35.2
+			ratedBurnTime = 120
 			heatProduction = 100
 			massMult = 1.0
 
@@ -181,7 +183,7 @@
 	TESTFLIGHT
 	{
 		name = Config_Name_1
-		ratedBurnTime = 1
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Config_Name_1]/ratedBurnTime$
 
 		ignitionReliabilityStart = 0.90
 		ignitionReliabilityEnd = 0.99
@@ -201,7 +203,7 @@
 	TESTFLIGHT
 	{
 		name = Config_Name_2
-		ratedBurnTime = 1
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Config_Name_2]/ratedBurnTime$
 
 		ignitionReliabilityStart = 0.90
 		ignitionReliabilityEnd = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
@@ -80,6 +80,7 @@
 			name = A-4
 			maxThrust = 311.8
 			minThrust = 311.8
+			ratedBurnTime = 70
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
 	
@@ -125,6 +126,7 @@
 			name = A-9
 			maxThrust = 288.68
 			minThrust = 288.68
+			ratedBurnTime = 115
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
 			//speculative = fictional
@@ -172,7 +174,7 @@
 	TESTFLIGHT
 	{
 		name = A-4
-		ratedBurnTime = 70
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.89 // a bit worse than Hermes
 		ignitionReliabilityEnd = 0.97 // a bit better than Hermes, combined with cycle leads to V-2 total reliability
 		ignitionDynPresFailMultiplier = 2.0 // fairly robust
@@ -186,7 +188,7 @@
 	TESTFLIGHT
 	{
 		name = A-9
-		ratedBurnTime = 115
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-9]/ratedBurnTime$
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.9
 		ignitionDynPresFailMultiplier = 4.0

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -75,6 +75,7 @@
 			name = AJ10-137
 			minThrust = 90.0
 			maxThrust = 90.0
+			ratedBurnTime = 750
 			heatProduction = 38
 			gimbalRange = 4.5
 
@@ -133,7 +134,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-137
-		ratedBurnTime = 750
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-137]/ratedBurnTime$
 		ignitionReliabilityStart = 0.987342
 		ignitionReliabilityEnd = 0.997468
 		cycleReliabilityStart = 0.944444

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -91,6 +91,7 @@
 			name = AJ10-190-OMS
 			minThrust = 26.7
 			maxThrust = 26.7
+			ratedBurnTime = 3600
 			heatProduction = 28
 			massMult = 1.0
 			ullage = False
@@ -128,6 +129,7 @@
 			name = AJ10-190-Orion
 			minThrust = 33.4
 			maxThrust = 33.4
+			ratedBurnTime = 3600
 			massMult = 1.0
 			ullage = False
 			pressureFed = True
@@ -174,7 +176,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-190-OMS
-		ratedBurnTime = 3600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-190-OMS]/ratedBurnTime$
 		ignitionReliabilityStart = 0.998758
 		ignitionReliabilityEnd = 0.999752
 		cycleReliabilityStart = 0.996283
@@ -189,7 +191,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-190-Orion
-		ratedBurnTime = 3600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-190-Orion]/ratedBurnTime$
 		ignitionReliabilityStart = 0.998758
 		ignitionReliabilityEnd = 0.999752
 		cycleReliabilityStart = 0.996283

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -104,6 +104,7 @@
 			description = Upper Stage engine used on the Titan Transtage
 			maxThrust = 35.585
 			minThrust = 35.585
+			ratedBurnTime = 450
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -142,6 +143,7 @@
 			description = Delta-F Upper Stage Engine
 			minThrust = 42.3
 			maxThrust = 42.3
+			ratedBurnTime = 450
 			heatProduction = 100
 
 			PROPELLANT
@@ -184,6 +186,7 @@
 			description = Upper stage engine for the Delta-K
 			minThrust = 43.7
 			maxThrust = 43.7
+			ratedBurnTime = 450
 			heatProduction = 100
 
 			PROPELLANT
@@ -224,6 +227,7 @@
 			description = AJ10 variant burning liquid hydrogen and oxygen, proposed for use on the GE D-2 Apollo vehicle.
 			minThrust = 26.67
 			maxThrust = 26.67
+			ratedBurnTime = 546
 			heatProduction = 100
 			
 			PROPELLANT
@@ -267,7 +271,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-138
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-138]/ratedBurnTime$
 		ignitionReliabilityStart = 0.992424
 		ignitionReliabilityEnd = 0.998485
 		cycleReliabilityStart = 0.893617
@@ -287,7 +291,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118F
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118F]/ratedBurnTime$
 		ignitionReliabilityStart = 0.923077
 		ignitionReliabilityEnd = 0.984615
 		cycleReliabilityStart = 0.875000	// 1 failure out of 8 flights
@@ -303,7 +307,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118K
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.996094
 		ignitionReliabilityEnd = 0.999219
 		cycleReliabilityStart = 0.994152
@@ -316,7 +320,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-133-LH
-		ratedBurnTime = 546
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-133-LH]/ratedBurnTime$
 		ignitionReliabilityStart = 0.96
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -145,6 +145,7 @@
 			description = Developed for the upper stage of the Vanguard launch vehicle.
 			minThrust = 33.8
 			maxThrust = 33.8
+			ratedBurnTime = 115
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -178,6 +179,7 @@
 			description = More reliable version of the AJ10-37 used on the Able Upper Stage.
 			minThrust = 33.0
 			maxThrust = 33.0
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -211,6 +213,7 @@
 			description = Used on the improved version of the Able upper stage for Thor-Able and Atlas-Able.
 			minThrust = 33.4
 			maxThrust = 33.4
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -244,6 +247,7 @@
 			description = Used as the upper stage engine on the very late Thor-Able and very early Thor-Delta launch vehicles.
 			minThrust = 34.25
 			maxThrust = 34.25
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -277,6 +281,7 @@
 			description = Second stage engine for the Thor-Delta A.
 			minThrust = 33.1
 			maxThrust = 33.1
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -309,6 +314,7 @@
 			name = AJ10-118D
 			minThrust = 33.7
 			maxThrust = 33.7
+			ratedBurnTime = 180
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -345,7 +351,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-37
-			ratedBurnTime = 115
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-37]/ratedBurnTime$
 			ignitionReliabilityStart = 0.888889
 			ignitionReliabilityEnd = 0.977778
 			cycleReliabilityStart = 0.555556
@@ -360,7 +366,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-42
-			ratedBurnTime = 150
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-42]/ratedBurnTime$
 			ignitionReliabilityStart = 0.928571
 			ignitionReliabilityEnd = 0.985714
 			cycleReliabilityStart = 0.928571
@@ -376,7 +382,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-142
-			ratedBurnTime = 150
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-142]/ratedBurnTime$
 			ignitionReliabilityStart = 0.916667
 			ignitionReliabilityEnd = 0.983333
 			cycleReliabilityStart = 0.916667
@@ -393,7 +399,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-101A
-			ratedBurnTime = 150
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-101A]/ratedBurnTime$
 			ignitionReliabilityStart = 0.916667
 			ignitionReliabilityEnd = 0.983333
 			cycleReliabilityStart = 0.916667
@@ -409,7 +415,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-118
-			ratedBurnTime = 150
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118]/ratedBurnTime$
 			ignitionReliabilityStart = 0.9398
 			ignitionReliabilityEnd = 0.9879
 			cycleReliabilityStart = 0.9398
@@ -430,7 +436,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-118D
-			ratedBurnTime = 180
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118D]/ratedBurnTime$
 			ignitionReliabilityStart = 0.962963
 			ignitionReliabilityEnd = 0.992593
 			cycleReliabilityStart = 0.962963

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
@@ -83,6 +83,7 @@
 			description = The AJ10-104 was used on the Thor-Able-Star and it was the first upper stage engine with the ability to restart.
 			minThrust = 35.1
 			maxThrust = 35.1
+			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -117,6 +118,7 @@
 			description = Upgrade to the AJ10-118 used on the Delta E-N upper stages.
 			minThrust = 35.2
 			maxThrust = 35.2
+			ratedBurnTime = 400
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -162,7 +164,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-104
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-104]/ratedBurnTime$
 		ignitionReliabilityStart = 0.967742
 		ignitionReliabilityEnd = 0.993548
 		ignitionDynPresFailMultiplier = 0.1
@@ -193,7 +195,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118E
-		ratedBurnTime = 400
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118E]/ratedBurnTime$
 		ignitionReliabilityStart = 0.986301
 		ignitionReliabilityEnd = 0.997260
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Transtar_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Transtar_Config.cfg
@@ -115,6 +115,7 @@
 			description = Planned upgrade for space shuttle OMS, cancelled after Challenger disaster
 			minThrust = 26.7
 			maxThrust = 26.7
+			ratedBurnTime = 54000
 			heatProduction = 28
 			massMult = 2.58
 			ullage = False
@@ -153,6 +154,7 @@
 			description = Engine for Transtar I, a high performance upper stage
 			minThrust = 16.7
 			maxThrust = 16.7
+			ratedBurnTime = 3600
 			heatProduction = 28
 			massMult = 1.02
 			ullage = False
@@ -191,6 +193,7 @@
 			description = Hydrolox engine, for high performance reusable space shuttle upper stages
 			minThrust = 13.3
 			maxThrust = 13.3
+			ratedBurnTime = 72000
 			heatProduction = 28
 			massMult = 0.72
 			ullage = False
@@ -227,6 +230,7 @@
 			description = Engine for Transtar III, reusable upgrade of Transtar I
 			minThrust = 16.7
 			maxThrust = 16.7
+			ratedBurnTime = 54000
 			heatProduction = 28
 			massMult = 0.83
 			ullage = False
@@ -271,7 +275,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-151-OMS		//Same reliability as Shuttle OMS
-		ratedBurnTime = 54000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-151-OMS]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -284,7 +288,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-153		//Same reliability as AJ10-118K
-		ratedBurnTime = 3600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-153]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.9625
@@ -297,7 +301,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-154
-		ratedBurnTime = 72000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-154]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.9625
@@ -310,7 +314,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-156
-		ratedBurnTime = 54000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-156]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.9625

--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -93,6 +93,7 @@
 			name = AJ-60A
 			minThrust = 1688.4
 			maxThrust = 1688.4
+			ratedBurnTime = 94
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -332,6 +333,7 @@
 			name = AJ-60A_TVC
 			minThrust = 1688.4
 			maxThrust = 1688.4
+			ratedBurnTime = 94
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -573,7 +575,7 @@
 	TESTFLIGHT
 	{
 		name = AJ-60A
-		ratedBurnTime = 94
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ-60A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.991935
@@ -589,7 +591,7 @@
 	TESTFLIGHT
 	{
 		name = AJ-60A_TVC
-		ratedBurnTime = 94
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ-60A_TVC]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.991935

--- a/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
@@ -63,6 +63,7 @@
 			name = AMBR-623N
 			minThrust = 0.445
 			maxThrust = 0.623
+			ratedBurnTime = 3600
 			heatProduction = 10
 			ullage = False
 			pressureFed = True
@@ -354,7 +355,7 @@
 	TESTFLIGHT
 	{
 		name = AMBR-623N
-		ratedBurnTime = 3600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AMBR-623N]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
@@ -64,6 +64,7 @@
 			name = AR-1
 			minThrust = 1244
 			maxThrust = 2487
+			ratedBurnTime = 450
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -111,7 +112,7 @@
 	TESTFLIGHT
 	{
 		name = AR-1
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AR-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.983
 		ignitionReliabilityEnd = 0.9975
 		cycleReliabilityStart = 0.983

--- a/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
@@ -95,6 +95,7 @@
 			description = A RATO booster modified to be used on the WAC-Corporal for the US Army
 			maxThrust = 7.733 // 1500lbf (6.672kN) at _sea level_, vac calculated
 			minThrust = 7.733
+			ratedBurnTime = 47
 			heatProduction = 40
 
 			PROPELLANT
@@ -136,6 +137,7 @@
 			description = Developed for the Aerobee X-8, an improved WAC-Corporal for upper atmosphere research to replace the limited stocks of captured V-2s
 			maxThrust = 13.7628
 			minThrust = 13.7628
+			ratedBurnTime = 40
 			heatProduction = 40
 			PROPELLANT
 			{
@@ -171,6 +173,7 @@
 			description = Developed as an upgrade to the XASR-1. Continued to be used until the 1980s for meteorlogical studies.
 			maxThrust = 21.28
 			minThrust = 21.28
+			ratedBurnTime = 52
 			heatProduction = 40
 			PROPELLANT
 			{
@@ -208,7 +211,7 @@
 	TESTFLIGHT
 	{
 			name = WAC-Corporal
-			ratedBurnTime = 47
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[WAC-Corporal]/ratedBurnTime$
 			ignitionReliabilityStart = 0.90
 			ignitionReliabilityEnd = 0.96
 			cycleReliabilityStart = 0.86
@@ -220,7 +223,7 @@
 	TESTFLIGHT
 	{
 			name = XASR-1
-			ratedBurnTime = 40
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XASR-1]/ratedBurnTime$
 			ignitionReliabilityStart = 0.93
 			ignitionReliabilityEnd = 0.97
 			cycleReliabilityStart = 0.91
@@ -234,7 +237,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-27
-			ratedBurnTime = 52
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-27]/ratedBurnTime$
 			ignitionReliabilityStart = 0.95
 			ignitionReliabilityEnd = 0.98
 			cycleReliabilityStart = 0.95

--- a/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
@@ -91,6 +91,7 @@
 			name = Aestus
 			minThrust = 30.0
 			maxThrust = 30.0
+			ratedBurnTime = 1100
 			heatProduction = 36
 			massMult = 1.0
 			ullage = True
@@ -130,6 +131,7 @@
 			description = Developed privately in collaboration with Rocketdyne. Turbopump system from XLR-32 added, allowing much higher performance. A.K.A RS-72
 			minThrust = 55.4
 			maxThrust = 55.4
+			ratedBurnTime = 2500
 			heatProduction = 56
 			massMult = 1.2432
 			ullage = True
@@ -175,7 +177,7 @@
 	TESTFLIGHT
 	{
 		name = Aestus
-		ratedBurnTime = 1100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Aestus]/ratedBurnTime$
 		ignitionReliabilityStart = 0.968
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.967742
@@ -188,7 +190,7 @@
 	TESTFLIGHT
 	{
 		name = Aestus-II
-		ratedBurnTime = 2500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Aestus-II]/ratedBurnTime$
 		ignitionReliabilityStart = 0.968
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.97

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -230,6 +230,7 @@
 			description = B-58 Hustler rocket pod
 			maxThrust = 67
 			minThrust = 67
+			ratedBurnTime = 60
 			heatProduction = 100
 			gimbalRange = 0
 			PROPELLANT
@@ -263,6 +264,7 @@
 			description = Model 8001, Agena Prototype
 			maxThrust = 67
 			minThrust = 67
+			ratedBurnTime = 100
 			heatProduction = 100
 			gimbalRange = 5
 			PROPELLANT
@@ -296,6 +298,7 @@
 			description = Model 8048, Agena A
 			maxThrust = 68.9
 			minThrust = 68.9
+			ratedBurnTime = 120
 			heatProduction = 100
 			gimbalRange = 5
 			PROPELLANT
@@ -329,6 +332,7 @@
 			description = Model 8081, Agena B
 			maxThrust = 70.7
 			minThrust = 70.7
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.0236
 			gimbalRange = 5
@@ -364,6 +368,7 @@
 			description		= Model 8096, Agena D
 			maxThrust		= 71.2
 			minThrust		= 71.2
+			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -403,6 +408,7 @@
 			description = Model 8247, Gemini ATV
 			maxThrust = 71.2
 			minThrust = 71.2
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.0394
 			gimbalRange = 5
@@ -438,6 +444,7 @@
 			description		= Improved propellant, using high density acid (HDA)
 			maxThrust		= 75.3 //17 klbf
 			minThrust		= 75.3
+			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -477,6 +484,7 @@
 			description		= Higher expansion ratio nozzle prototype
 			maxThrust		= 78.3
 			minThrust		= 78.3
+			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -516,6 +524,7 @@
 			description		= Reusable Agena for STS
 			maxThrust		= 71.1 //16 klbf
 			minThrust		= 71.1
+			ratedBurnTime = 1200
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -555,6 +564,7 @@
 			description		= Growth Agena option, sacrificing thrust for improved effeciency
 			maxThrust		= 53.4 //12 klbf
 			minThrust		= 53.4
+			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -594,6 +604,7 @@
 			description		= Agena upgrade for proposed Atlas V upper stage. Tested, but cancelled when studies showed it would be more economical to use single engine centaur instead.
 			maxThrust		= 67.5 //15170 lbf
 			minThrust		= 67.5
+			ratedBurnTime = 700
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -633,6 +644,7 @@
 			description		= Liquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
 			maxThrust		= 53.7 //12 klbf
 			minThrust		= 17.7 //3.98 klbf
+			ratedBurnTime = 360
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False	//Because engine was intended to be used mostly in pump-fed mode, pressureization system is included in engine mass
@@ -675,7 +687,7 @@
 	TESTFLIGHT
 	{
 		name = Model117
-		ratedBurnTime = 60
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model117]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.85
@@ -693,7 +705,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-3
-		ratedBurnTime = 100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-3]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		//Identical to XLR81-BA-5 other than nozzle, give same reliability since only two were launched
 		ignitionReliabilityStart = 0.800000
@@ -714,7 +726,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-5
-		ratedBurnTime = 120
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-5]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.800000
 		ignitionReliabilityEnd = 0.960000
@@ -736,7 +748,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-7
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-7]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.916667
 		ignitionReliabilityEnd = 0.983333
@@ -762,7 +774,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-11
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-11]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.958763
 		ignitionReliabilityEnd = 0.991753
@@ -780,7 +792,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-13
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-13]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.958763
 		ignitionReliabilityEnd = 0.991753
@@ -805,7 +817,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096-39
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096-39]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.957746
 		ignitionReliabilityEnd = 0.991549
@@ -823,7 +835,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096A
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096A]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.996
@@ -841,7 +853,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096L
-		ratedBurnTime = 1200
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096L]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -859,7 +871,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096C
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096C]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -877,7 +889,7 @@
 	TESTFLIGHT
 	{
 		name = Agena-2000
-		ratedBurnTime = 700
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Agena-2000]/ratedBurnTime$
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -895,7 +907,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-LF2-SPS
-		ratedBurnTime = 360	//No burn time listed. Time assumed to allow for mission completion even with single engine failiure, with margin.
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-LF2-SPS]/ratedBurnTime$	//No burn time listed. Time assumed to allow for mission completion even with single engine failiure, with margin.
 		// pump-fed pressure fed hybrid. Allegedly only 1% worse reliability than pure pressurefed engine
 		ignitionReliabilityStart = 0.995305
 		ignitionReliabilityEnd = 0.999061

--- a/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
@@ -66,6 +66,7 @@
 			name = Alcyone
 			minThrust = 27.491
 			maxThrust = 27.491
+			ratedBurnTime = 8
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -100,7 +101,7 @@
 	TESTFLIGHT
 	{
 		name = Alcyone
-		ratedBurnTime = 8
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Alcyone]/ratedBurnTime$
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.97

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
@@ -82,6 +82,7 @@
 			name = Algol-I
 			minThrust = 493.6442
 			maxThrust = 493.6442
+			ratedBurnTime = 62
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -119,7 +120,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-I
-		ratedBurnTime = 62
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Algol-I]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.944444

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
@@ -81,6 +81,7 @@
 			name = Algol-III
 			minThrust = 530.25896
 			maxThrust = 530.25896
+			ratedBurnTime = 75
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -119,7 +120,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-III
-		ratedBurnTime = 75
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Algol-III]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.972222

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
@@ -81,6 +81,7 @@
 			name = Algol-II
 			minThrust = 449.02112
 			maxThrust = 449.02112
+			ratedBurnTime = 80
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -118,7 +119,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-II
-		ratedBurnTime = 80
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Algol-II]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.983871

--- a/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
@@ -66,6 +66,7 @@
 			name = Altair-III
 			minThrust = 31
 			maxThrust = 31
+			ratedBurnTime = 31
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -124,7 +125,7 @@
 	TESTFLIGHT
 	{
 		name = Altair-III
-		ratedBurnTime = 31
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Altair-III]/ratedBurnTime$
 		ignitionReliabilityStart = 0.972973
 		ignitionReliabilityEnd = 0.994595
 		cycleReliabilityStart = 0.972973

--- a/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
@@ -64,6 +64,7 @@
 			name = Altair-II
 			minThrust = 35
 			maxThrust = 35
+			ratedBurnTime = 22
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -122,7 +123,7 @@
 	TESTFLIGHT
 	{
 		name = Altair-II
-		ratedBurnTime = 22
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Altair-II]/ratedBurnTime$
 		ignitionReliabilityStart = 0.965517
 		ignitionReliabilityEnd = 0.993103
 		cycleReliabilityStart = 0.965517

--- a/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
@@ -82,6 +82,7 @@
 			name = Altair
 			minThrust = 16.35
 			maxThrust = 16.35
+			ratedBurnTime = 39
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -140,7 +141,7 @@
 	TESTFLIGHT
 	{
 		name = Altair
-		ratedBurnTime = 39
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Altair]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.990000

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
@@ -77,6 +77,7 @@
 			name = Antares-I
 			minThrust = 62.27508
 			maxThrust = 62.27508
+			ratedBurnTime = 40
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -135,7 +136,7 @@
 	TESTFLIGHT
 	{
 		name = Antares-I
-		ratedBurnTime = 40
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Antares-I]/ratedBurnTime$
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_III_Config.cfg
@@ -76,6 +76,7 @@
 			name = Antares-III
 			minThrust = 100.37408
 			maxThrust = 100.37408
+			ratedBurnTime = 45
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -134,7 +135,7 @@
 	TESTFLIGHT
 	{
 		name = Antares-III
-		ratedBurnTime = 45
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Antares-III]/ratedBurnTime$
 		ignitionReliabilityStart = 0.962264
 		ignitionReliabilityEnd = 0.992453
 		cycleReliabilityStart = 0.962264

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
@@ -76,6 +76,7 @@
 			name = Antares-II
 			minThrust = 93.074555
 			maxThrust = 93.074555
+			ratedBurnTime = 37
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -134,7 +135,7 @@
 	TESTFLIGHT
 	{
 		name = Antares-II
-		ratedBurnTime = 37
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Antares-II]/ratedBurnTime$
 		ignitionReliabilityStart = 0.962264
 		ignitionReliabilityEnd = 0.992453
 		cycleReliabilityStart = 0.962264

--- a/GameData/RealismOverhaul/Engine_Configs/Astris_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Astris_Config.cfg
@@ -85,6 +85,7 @@
 			description = Used on Europa I. Extremely unreliable
 			maxThrust = 22.56
 			minThrust = 22.56
+			ratedBurnTime = 330
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -114,6 +115,7 @@
 			description = Upgrade developed for Europa II. Cancelled after first launch following continued failures and lack of funding
 			maxThrust = 23.3
 			minThrust = 23.3
+			ratedBurnTime = 330
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -144,7 +146,7 @@
 	TESTFLIGHT
 	{
 		name = AstrisI
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AstrisI]/ratedBurnTime$
 		ignitionReliabilityStart = 0.50
 		ignitionReliabilityEnd = 0.85
 		ignitionDynPresFailMultiplier = 0.1
@@ -159,7 +161,7 @@
 	TESTFLIGHT
 	{
 		name = AstrisII
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AstrisII]/ratedBurnTime$
 		ignitionReliabilityStart = 0.75
 		ignitionReliabilityEnd = 0.92
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/BE-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-4_Config.cfg
@@ -72,6 +72,7 @@
 			name = BE-4
 			minThrust = 794.25
 			maxThrust = 2647.5
+			ratedBurnTime = 400
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True
@@ -116,7 +117,7 @@
 	TESTFLIGHT
 	{
 		name = BE-4
-		ratedBurnTime = 400
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[BE-4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Baby_Sergeant.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Baby_Sergeant.cfg
@@ -78,6 +78,7 @@
 			description = Derived from the Sergeant ballistic missile, for use as an upper stage to the Juno-C to test high velocity re-entry.
 			minThrust = 8
 			maxThrust = 8
+			ratedBurnTime = 6
 			heatProduction = 27
 			massMult = 1.0
 			ullage = False
@@ -104,6 +105,7 @@
 			description = Improved fuel mix created by JPL
 			minThrust = 8
 			maxThrust = 8
+			ratedBurnTime = 6
 			heatProduction = 29
 			massMult = 1.0
 			ullage = False
@@ -136,7 +138,7 @@
 	{
 		name = T17-E2
 		isSolid = True
-		ratedBurnTime = 6
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[T17-E2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -151,7 +153,7 @@
 	{
 		name = JPL-532A
 		isSolid = True
-		ratedBurnTime = 6
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[JPL-532A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/COBRAHigh_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/COBRAHigh_Config.cfg
@@ -66,6 +66,7 @@
 			name = COBRAH
 			minThrust = 2669				 //60%
 			maxThrust = 4448
+			ratedBurnTime = 540
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -101,7 +102,7 @@
 	TESTFLIGHT
 	{
 		name = COBRAH
-		ratedBurnTime = 540	 
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[COBRAH]/ratedBurnTime$	 
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.995

--- a/GameData/RealismOverhaul/Engine_Configs/COBRA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/COBRA_Config.cfg
@@ -67,6 +67,7 @@
 			name = COBRA
 			maxThrust = 2669
 			minThrust = 1335
+			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -110,7 +111,7 @@
 	TESTFLIGHT
 	{
 		name = COBRA
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[COBRA]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Cajun_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Cajun_Config.cfg
@@ -84,6 +84,7 @@
 			name = Cajun
 			minThrust = 36
 			maxThrust = 36
+			ratedBurnTime = 3
 			heatProduction = 100
 			
 			PROPELLANT
@@ -108,7 +109,7 @@
 	{
 		name = Cajun
 		isSolid = True
-		ratedBurnTime = 3
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Cajun]/ratedBurnTime$
 		ignitionReliabilityStart = 0.958853
 		ignitionReliabilityEnd = 0.991771
 		cycleReliabilityStart = 0.995885					// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
@@ -52,6 +52,7 @@
 			name = Castor-120
 			minThrust = 1875
 			maxThrust = 1875
+			ratedBurnTime = 80
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -282,6 +283,7 @@
 		{
 			name = Castor-120/Saddle
 			maxThrust = 1950
+			ratedBurnTime = 80
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -512,7 +514,8 @@
 		{
 			name = Castor-120/Regressive
 			minThrust = 2125
-	  maxThrust = 2125
+			maxThrust = 2125
+			ratedBurnTime = 80
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -747,7 +750,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-120
-		ratedBurnTime = 80
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-120]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -758,12 +761,12 @@
 		isSolid = True
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120/Regressive]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120Regressive]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Castor-120/Regressive
-		ratedBurnTime = 80
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-120?Regressive]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -779,7 +782,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-120/Saddle
-		ratedBurnTime = 80
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-120?Saddle]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
@@ -90,6 +90,7 @@
 			name = XM-20
 			minThrust = 304.3
 			maxThrust = 304.3
+			ratedBurnTime = 38
 			heatProduction = 100
 
 			PROPELLANT
@@ -139,6 +140,7 @@
 			name = Castor-1-SL
 			minThrust = 324.6
 			maxThrust = 324.6
+			ratedBurnTime = 41
 			heatProduction = 100
 
 			PROPELLANT
@@ -190,6 +192,7 @@
 			name = Castor-1-Vac
 			minThrust = 349.3
 			maxThrust = 349.3
+			ratedBurnTime = 43
 			heatProduction = 100
 
 			PROPELLANT
@@ -244,7 +247,7 @@
 	TESTFLIGHT
 	{
 		name = XM-20
-		ratedBurnTime = 38
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XM-20]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.93
@@ -259,7 +262,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-1-SL
-		ratedBurnTime = 41
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-1-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.996997
@@ -275,7 +278,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-1-Vac
-		ratedBurnTime = 43
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-1-Vac]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.994
 		cycleReliabilityStart = 0.965909

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -71,6 +71,7 @@
 			name = Castor-2-SL
 			minThrust = 293.865
 			maxThrust = 293.865
+			ratedBurnTime = 39
 			heatProduction = 100
 
 			PROPELLANT
@@ -127,6 +128,7 @@
 			name = Castor-2-Vac
 			minThrust = 318.1
 			maxThrust = 318.1
+			ratedBurnTime = 39
 			heatProduction = 100
 
 			PROPELLANT
@@ -188,7 +190,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-2-SL
-		ratedBurnTime = 39
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-2-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure for ground lit SRMs
 		cycleReliabilityStart = 0.965
@@ -204,7 +206,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-2-Vac
-		ratedBurnTime = 39
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-2-Vac]/ratedBurnTime$
 		ignitionReliabilityStart = 0.945
 		ignitionReliabilityEnd = 0.997
 		cycleReliabilityStart = 0.965

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
@@ -50,6 +50,7 @@
 			name = Castor-30A
 			minThrust = 330.7653 //taken from atk catalog
 			maxThrust = 330.7653
+			ratedBurnTime = 136
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -284,7 +285,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-30A
-		ratedBurnTime = 136
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-30A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
@@ -50,6 +50,7 @@
 			name = Castor-30B
 			minThrust = 396.2921 //taken from atk catalog
 			maxThrust = 396.2921
+			ratedBurnTime = 127
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -204,7 +205,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-30B
-		ratedBurnTime = 127
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-30B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
@@ -50,6 +50,7 @@
 			name = Castor-30XL
 			minThrust = 533.3418 //taken from atk catalog
 			maxThrust = 533.3418
+			ratedBurnTime = 156
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -204,7 +205,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-30XL
-		ratedBurnTime = 156
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-30XL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
@@ -48,6 +48,7 @@
 			name = Castor-4AXL
 			minThrust = 765
 			maxThrust = 765
+			ratedBurnTime = 60
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -130,7 +131,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-4AXL
-		ratedBurnTime = 60
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-4AXL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.996721

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
@@ -46,6 +46,7 @@
 			name = Castor-4A
 			minThrust = 538
 			maxThrust = 538
+			ratedBurnTime = 56
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -124,7 +125,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-4A
-		ratedBurnTime = 56
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-4A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.996721

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
@@ -47,6 +47,7 @@
 			name = Castor-4
 			minThrust = 460
 			maxThrust = 460
+			ratedBurnTime = 54
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -281,7 +282,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-4
-		ratedBurnTime = 54
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.997076

--- a/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
@@ -59,6 +59,7 @@
 			name = Dropt
 			minThrust = 50
 			maxThrust = 50
+			ratedBurnTime = 46
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -98,7 +99,7 @@
 	TESTFLIGHT
 	{
 		name = Dropt
-		ratedBurnTime = 46
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Dropt]/ratedBurnTime$
 		ignitionReliabilityStart = 0.875
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.875000

--- a/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
@@ -81,6 +81,7 @@
 			name = E-1
 			minThrust = 1884.59 // 380klbf sea level
 			maxThrust = 1884.59
+			ratedBurnTime = 165
 			heatProduction = 100
 			massMult = 1.0
 
@@ -126,6 +127,7 @@
 			description = Speculative upgrade configuration for the E-1 intended for use with the Dyna Soar project.
 			minThrust = 2335.3155
 			maxThrust = 2335.3155
+			ratedBurnTime = 210
 			heatProduction = 100
 			massMult = 1.435  // 4000 pounds
 
@@ -171,6 +173,7 @@
 			description = Speculative upgrade configuration using late 1960s technology.
 			minThrust = 2355
 			maxThrust = 2355
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.5
 			//speculative = fictional
@@ -228,7 +231,7 @@
 	TESTFLIGHT
 	{
 		name = E-1
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[E-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.89
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.93
@@ -243,7 +246,7 @@
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade
-		ratedBurnTime = 210
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[E-1-Upgrade]/ratedBurnTime$
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
@@ -258,7 +261,7 @@
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade2
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[E-1-Upgrade2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.997
 		cycleReliabilityStart = 0.96

--- a/GameData/RealismOverhaul/Engine_Configs/EAP241_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EAP241_Config.cfg
@@ -101,6 +101,7 @@
 			name = MPS-241
 			minThrust = 7040
 			maxThrust = 7040
+			ratedBurnTime = 130
 			heatProduction = 20
 			massMult = 1.0
 			curveResource = HTPB
@@ -340,6 +341,7 @@
 			name = MPS-241A
 			minThrust = 7040
 			maxThrust = 7040
+			ratedBurnTime = 130
 			heatProduction = 20
 			massMult = 0.9524
 			curveResource = HTPB
@@ -589,7 +591,7 @@
 	TESTFLIGHT
 	{
 		name = MPS-241
-		ratedBurnTime = 130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MPS-241]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.995392
@@ -604,7 +606,7 @@
 	TESTFLIGHT
 	{
 		name = MPS-241A
-		ratedBurnTime = 130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MPS-241A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.995392

--- a/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
@@ -51,6 +51,7 @@
 			name = F-1A_ETS
 			minThrust = 5513.8
 			maxThrust = 9189.6
+			ratedBurnTime = 315
 			massMult = 0.97673
 			heatProduction = 100
 			//speculative = fictional
@@ -103,7 +104,7 @@
 	TESTFLIGHT
 	{
 		name = F-1A_ETS
-		ratedBurnTime = 315					// Was proposed as a Sustainer engine like the LR105
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1A_ETS]/ratedBurnTime$					// Was proposed as a Sustainer engine like the LR105
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.985

--- a/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
@@ -65,6 +65,7 @@
 			name = F-1B
 			minThrust = 6390 // http://www.thespacereview.com/article/2410/1 2015-11-17, throttleable 8 MN - 5.8 MN sea level
 			maxThrust = 8815
+			ratedBurnTime = 315
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -113,7 +114,7 @@
 	TESTFLIGHT
 	{
 		name = F-1B
-		ratedBurnTime = 315
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1B]/ratedBurnTime$
 		//Copied from F-1A, used mostly unmodified F-1A turbomachinery
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998

--- a/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
@@ -92,6 +92,7 @@
 			description = Early production version
 			minThrust = 7652.2
 			maxThrust = 7652.2
+			ratedBurnTime = 165
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -130,6 +131,7 @@
 			description = Later model, with redesigned injectors
 			minThrust = 7740.5
 			maxThrust = 7740.5
+			ratedBurnTime = 165
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -168,6 +170,7 @@
 			description = Uprated and simplified F-1 developed for post-Apollo launch vehicles. Tested extensively, but cancelled following the cancellation of Apollo
 			minThrust = 7855.6
 			maxThrust = 9189.6
+			ratedBurnTime = 315
 			massMult = 0.97673
 			heatProduction = 100
 			PROPELLANT
@@ -219,7 +222,7 @@
 	TESTFLIGHT
 	{
 		name = F-1-1.5M
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1-1.5M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984615
 		ignitionReliabilityEnd = 0.996923
 		cycleReliabilityStart = 0.984615
@@ -232,7 +235,7 @@
 	TESTFLIGHT
 	{
 		name = F-1-1.52M
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1-1.52M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984615
 		ignitionReliabilityEnd = 0.996923
 		cycleReliabilityStart = 0.984615
@@ -248,7 +251,7 @@
 	TESTFLIGHT
 	{
 		name = F-1A
-		ratedBurnTime = 315					// Was proposed as a Sustainer engine like the LR105
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1A]/ratedBurnTime$					// Was proposed as a Sustainer engine like the LR105
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.985

--- a/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
@@ -108,6 +108,7 @@
 			name = GCRC
 			minThrust = 17.3 // With thrust curve gives avg of 12.45
 			maxThrust = 17.3
+			ratedBurnTime = 33
 			techRequired = solids1957
 			heatProduction = 100
 			PROPELLANT
@@ -158,7 +159,7 @@
 	TESTFLIGHT
 	{
 		name = GCRC
-		ratedBurnTime = 33
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GCRC]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95

--- a/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
@@ -44,6 +44,7 @@
 			name = GEM-40/Ground
 			minThrust = 644
 			maxThrust = 644
+			ratedBurnTime = 63
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -128,6 +129,7 @@
 			name = GEM-40/Air
 			minThrust = 666
 			maxThrust = 666
+			ratedBurnTime = 63
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -215,7 +217,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-40/Ground
-		ratedBurnTime = 63
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40/Ground]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998932
@@ -229,7 +231,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-40/Air
-		ratedBurnTime = 63
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40/Air]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.998932

--- a/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
@@ -217,7 +217,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-40/Ground
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40/Ground]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40?Ground]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998932
@@ -231,7 +231,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-40/Air
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40/Air]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40?Air]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.998932

--- a/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
@@ -45,6 +45,7 @@
 			name = GEM-46/TVC-Ground
 			minThrust = 875
 			maxThrust = 875 //Checked
+			ratedBurnTime = 77
 			heatProduction = 100
 			gimbalRange = 5 //Checked
 			massMult = 1.1375 //2.275
@@ -279,6 +280,7 @@
 			gimbalRange = 0
 			minThrust = 885
 			maxThrust = 885 //Checked
+			ratedBurnTime = 77
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -510,6 +512,7 @@
 			name = GEM-46/Fixed-Air
 			minThrust = 915
 			maxThrust = 915 //Checked
+			ratedBurnTime = 77
 			massMult = 1.1020 //2.204
 			heatProduction = 100
 			gimbalRange = 0
@@ -746,7 +749,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/Fixed-Ground
-		ratedBurnTime = 77
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46/Fixed-Ground]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.981818
@@ -760,7 +763,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/TVC-Ground
-		ratedBurnTime = 77
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46/TVC-Ground]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.981818
@@ -774,7 +777,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/Fixed-Air
-		ratedBurnTime = 77
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46/Fixed-Air]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.981818

--- a/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
@@ -749,7 +749,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/Fixed-Ground
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46/Fixed-Ground]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46?Fixed-Ground]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.981818
@@ -763,7 +763,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/TVC-Ground
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46/TVC-Ground]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46?TVC-Ground]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.981818
@@ -777,7 +777,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/Fixed-Air
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46/Fixed-Air]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46?Fixed-Air]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.981818

--- a/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
@@ -73,6 +73,7 @@
 			name = GEM-60/TVC
 			minThrust = 1235.947
 			maxThrust = 1235.947
+			ratedBurnTime = 91
 			heatProduction = 100
 			gimbalRange = 5.0
 
@@ -195,6 +196,7 @@
 			name = GEM-60/Fixed
 			minThrust = 1248.91
 			maxThrust = 1248.91
+			ratedBurnTime = 91
 			gimbalRange = 0
 			heatProduction = 100
 			massMult = 0.9822
@@ -320,7 +322,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-60/Fixed
-		ratedBurnTime = 91
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60/Fixed]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99
@@ -334,7 +336,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-60/TVC
-		ratedBurnTime = 91
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60/TVC]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
@@ -322,7 +322,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-60/Fixed
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60/Fixed]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60?Fixed]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99
@@ -336,7 +336,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-60/TVC
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60/TVC]/ratedBurnTime$
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60?TVC]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
@@ -46,6 +46,7 @@
 			name = GEM-63XL
 			minThrust = 2026
 			maxThrust = 2026
+			ratedBurnTime = 84
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -165,7 +166,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-63XL
-		ratedBurnTime = 84
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-63XL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
@@ -47,6 +47,7 @@
 			name = GEM-63
 			minThrust = 1658
 			maxThrust = 1658
+			ratedBurnTime = 94
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -166,7 +167,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-63
-		ratedBurnTime = 94
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-63]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
@@ -65,6 +65,7 @@
 			name = Gamma-2
 			minThrust = 68.236
 			maxThrust = 68.236
+			ratedBurnTime = 140
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -105,7 +106,7 @@
 	TESTFLIGHT
 	{
 		name = Gamma-2
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
@@ -79,6 +79,7 @@
 			name = Gamma-201
 			minThrust = 73
 			maxThrust = 73
+			ratedBurnTime = 145
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -112,6 +113,7 @@
 			name = Gamma-301
 			minThrust = 96
 			maxThrust = 96
+			ratedBurnTime = 145
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -152,7 +154,7 @@
 	TESTFLIGHT
 	{
 		name = Gamma-201
-		ratedBurnTime = 145
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-201]/ratedBurnTime$
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034
@@ -165,7 +167,7 @@
 	TESTFLIGHT
 	{
 		name = Gamma-301
-		ratedBurnTime = 145
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-301]/ratedBurnTime$
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
@@ -64,6 +64,7 @@
 			name = Gamma-8
 			minThrust = 256.395
 			maxThrust = 256.395
+			ratedBurnTime = 140
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -104,7 +105,7 @@
 	TESTFLIGHT
 	{
 		name = Gamma-8
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-8]/ratedBurnTime$
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034

--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -148,6 +148,7 @@
 			description = Earliest prototype version of the H-1 Engine that flew on the Saturn I, Block I. It is rated at 165k lbf sea level thrust.
 			minThrust = 807
 			maxThrust = 807
+			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -194,6 +195,7 @@
 			description = Improved version of the H-1 Engine for the Saturn I, Block II. It is rated at 188k lbf sea level thrust.
 			minThrust = 920
 			maxThrust = 920
+			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -240,6 +242,7 @@
 			description = H-1 Engine that flew on the first 5 Saturn IB launches. It is rated at 200k lbf sea level thrust.
 			minThrust = 979
 			maxThrust = 979
+			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -286,6 +289,7 @@
 			description = Final version of the H-1 Engine for the Saturn IB that flew on the 4 flights of Skylab and ASTP. It is rated at 205k lbf sea level thrust.
 			minThrust = 1018
 			maxThrust = 1018
+			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -332,6 +336,7 @@
 			description = Remanufactured H-1 for use with Delta
 			maxThrust = 1023
 			minThrust = 1023
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.0395
 
@@ -378,6 +383,7 @@
 			description = RS-27 with a higher expansion nozzle for Delta II
 			maxThrust = 1054
 			minThrust = 1054
+			ratedBurnTime = 285
 			heatProduction = 100
 			massMult = 1.10425
 
@@ -434,7 +440,7 @@
 	TESTFLIGHT
 	{
 		name = H-1-165K
-		ratedBurnTime = 155
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-165K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.969697
 		ignitionReliabilityEnd = 0.993939
 		cycleReliabilityStart = 0.969697
@@ -449,7 +455,7 @@
 	TESTFLIGHT
 	{
 		name = H-1-188K
-		ratedBurnTime = 155
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-188K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979592
@@ -464,7 +470,7 @@
 	TESTFLIGHT
 	{
 		name = H-1-200K
-		ratedBurnTime = 155
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-200K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
 		cycleReliabilityStart = 0.975610
@@ -479,7 +485,7 @@
 	TESTFLIGHT
 	{
 		name = H-1-205K
-		ratedBurnTime = 155
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-205K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.969697
 		ignitionReliabilityEnd = 0.993939
 		cycleReliabilityStart = 0.969697
@@ -508,7 +514,7 @@
 	TESTFLIGHT
 	{
 		name = RS-27
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-27]/ratedBurnTime$
 		ignitionReliabilityStart = 0.990000
 		ignitionReliabilityEnd = 0.998000
 		cycleReliabilityStart = 0.990000
@@ -532,7 +538,7 @@
 	TESTFLIGHT
 	{
 		name = RS-27A
-		ratedBurnTime = 285
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-27A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.992958
 		ignitionReliabilityEnd = 0.998592
 		cycleReliabilityStart = 0.992958

--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -44,6 +44,7 @@
 			name = HG-3
 			minThrust = 938.469
 			maxThrust = 1400.70
+			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -76,6 +77,7 @@
 			name = HG-3-SL
 			minThrust = 925.987
 			maxThrust = 1382.07
+			ratedBurnTime = 600
 			massMult = 0.973574409
 			heatProduction = 100
 			PROPELLANT
@@ -110,6 +112,7 @@
 			description = Speculative upgrade, using lessons learned from experience with HG-3 in service and development of RS-25 to improve reliability.
 			minThrust = 938.469
 			maxThrust = 1400.70
+			ratedBurnTime = 600
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -144,6 +147,7 @@
 			description = Sea-level variant of HG-3A upgrade
 			minThrust = 925.987
 			maxThrust = 1382.07
+			ratedBurnTime = 600
 			massMult = 0.973574409
 			heatProduction = 100
 			//speculative = fictional
@@ -179,6 +183,7 @@
 			description = Further refinement of the HG-3 engine, taking into account developements with the RL-10 and RS-25. Run time and reliability are extended compared to original models, although turbopump throughput is decreased to reduce strain on engine components.
 			minThrust = 938.469
 			maxThrust = 1400.70
+			ratedBurnTime = 750
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -213,6 +218,7 @@
 			description = Sea-level variant of HG-3B upgrade. Increased specific impulse compared to other sea-level variants prior to B version development results in slightly higher thrust for the same level of turbopump throughput as the HG-3B vacuum engine.
 			minThrust = 926.174
 			maxThrust = 1382.35
+			ratedBurnTime = 750
 			massMult = 0.973574409
 			heatProduction = 100
 			//speculative = fictional
@@ -248,6 +254,7 @@
 			description = Modified version of HG-3B, running the turbopumps harder to generate the same level of mass flow as in previous models. This results in improved thrust compared to the normal B model, at the cost of slightly less reliability in comparison.
 			minThrust = 950.035
 			maxThrust = 1422.44
+			ratedBurnTime = 750
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -282,6 +289,7 @@
 			description = Sea-level version of HG-3B-2 upgrade and modification. The improved specific impulse now means that this version produces more vacuum thrust than previous vacuum versions of the engine.
 			minThrust = 940.553
 			maxThrust = 1403.81
+			ratedBurnTime = 750
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -318,7 +326,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
@@ -330,7 +338,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3-SL
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
@@ -342,7 +350,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3A
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.91
@@ -355,7 +363,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3A-SL
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3A-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.91
@@ -368,7 +376,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3B
-		ratedBurnTime = 750
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.91488
@@ -381,7 +389,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3B-SL
-		ratedBurnTime = 750
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.91488
@@ -394,7 +402,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3B-2
-		ratedBurnTime = 750
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.90
@@ -407,7 +415,7 @@
 	TESTFLIGHT
 	{
 		name = HG-3B-SL-2
-		ratedBurnTime = 750
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-SL-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.90

--- a/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
@@ -119,6 +119,7 @@
 			description = Developed for Ariane 1
 			maxThrust = 62.4
 			minThrust = 62.4
+			ratedBurnTime = 570
 			massMult = 0.909
 
 			ullage = True
@@ -158,6 +159,7 @@
 			description = Improved version of the HM-7 used for Ariane 3 and 4.
 			maxThrust = 64.2
 			minThrust = 64.2
+			ratedBurnTime = 730
 			massMult = 1.0
 
 			ullage = True
@@ -197,6 +199,7 @@
 			description = Upgraded for higher performance on Ariane 4.
 			maxThrust = 64.6
 			minThrust = 64.6
+			ratedBurnTime = 980
 			massMult = 1.0
 
 			ullage = True
@@ -236,6 +239,7 @@
 			description = Upgraded for higher performance for later Ariane 4s and Ariane 5
 			maxThrust = 64.8
 			minThrust = 64.8
+			ratedBurnTime = 980
 			massMult = 1.0
 
 			ullage = True
@@ -277,7 +281,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7
-		ratedBurnTime = 570
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7]/ratedBurnTime$
 		ignitionReliabilityStart = 0.82
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.82
@@ -304,7 +308,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7B
-		ratedBurnTime = 730
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.966102
 		ignitionReliabilityEnd = 0.993220
 		cycleReliabilityStart = 0.982456
@@ -325,7 +329,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7B+
-		ratedBurnTime = 980
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B+]/ratedBurnTime$
 		ignitionReliabilityStart = 0.986301
 		ignitionReliabilityEnd = 0.997260
 		cycleReliabilityStart = 0.986301
@@ -342,7 +346,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7B++
-		ratedBurnTime = 980
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B++]/ratedBurnTime$
 		ignitionReliabilityStart = 0.986667
 		ignitionReliabilityEnd = 0.997333
 		cycleReliabilityStart = 0.986667

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -80,6 +80,7 @@
 			name = J-2T-200K
 			maxThrust = 889.3
 			minThrust = 177.8
+			ratedBurnTime = 500
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -109,6 +110,7 @@
 			name = J-2T-250K
 			maxThrust = 1111.6
 			minThrust = 222.32
+			ratedBurnTime = 500
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -141,7 +143,7 @@
 	{
 		name = J-2T-200K
 		// Copied from J-2S, used J-2S turbomachinery
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2T-200K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665
@@ -155,7 +157,7 @@
 	{
 		name = J-2T-250K
 		// Copied from J-2S, used J-2S turbomachinery
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2T-250K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665

--- a/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
@@ -63,6 +63,7 @@
 			name = J-2X
 			maxThrust = 1308
 			minThrust = 1072
+			ratedBurnTime = 500
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -97,7 +98,7 @@
 	{
 		name = J-2X
 		// Using J-2S data
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2X]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -116,6 +116,7 @@
 			description = This was the earliest variant of the J-2 that flew on the first 3 Saturn IB flights AS-201 to AS-203.
 			minThrust = 685.026
 			maxThrust = 889.644
+			ratedBurnTime = 500
 			heatProduction = 100
 			massMult = 1.00
 			PROPELLANT	// 5.0 Mixture Ratio
@@ -150,6 +151,7 @@
 			description = The uprated 225k variant was flown starting with SA-501 Saturn V.
 			minThrust = 770.654
 			maxThrust = 1000.850
+			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -183,6 +185,7 @@
 			description = The final version of the J-2 that flew on the Saturn, the 230k variant flew starting with Apollo 8, SA-208 and all subsequent flights.
 			minThrust = 787.780
 			maxThrust = 1023.091
+			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -216,6 +219,7 @@
 			description = The J-2S (J-2 Simplified) was a improvement on the J-2 Engine. It was completely tested and logged more than 30,000 seconds of static fire before the program was terminated.
 			minThrust = 196.463	// 6:1 throttling thanks to redesigned pumps and injectors
 			maxThrust = 1178.778
+			ratedBurnTime = 500
 			massMult = 1.036835 // All sources state the J-2S was heavier than J-2
 			heatProduction = 100
 			PROPELLANT
@@ -256,7 +260,7 @@
 	{
 		name = J-2-200K
 		// 3/3 successful flights, but still new technology
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2-200K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.909091
@@ -275,7 +279,7 @@
 	{
 		name = J-2-225K
 		// Only failures (Apollo 6) but was caused more by F-1 POGO issues than J-2
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2-225K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.909091
@@ -296,7 +300,7 @@
 	{
 		name = J-2-230K
 		// No failures, refined design (starts low as should have good data transfer)
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2-230K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.987179
 		ignitionReliabilityEnd = 0.997436
 		cycleReliabilityStart = 0.985294
@@ -310,7 +314,7 @@
 	{
 		name = J-2S
 		// Simplified version of a well-refined engine
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2S]/ratedBurnTime$
 		ignitionReliabilityStart = 0.987
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.985

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -64,6 +64,7 @@
 			name = Juno45k
 			minThrust = 200.17
 			maxThrust = 200.17
+			ratedBurnTime = 135
 			heatProduction = 100
 			
 			PROPELLANT
@@ -103,7 +104,7 @@
 	TESTFLIGHT
 	{
 			name = Juno45k
-			ratedBurnTime = 135
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Juno45k]/ratedBurnTime$
 			ignitionReliabilityStart = 0.80	 // Guesses, but should be about the same as X-405H
 			ignitionReliabilityEnd = 0.94
 			cycleReliabilityStart = 0.86

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -64,6 +64,7 @@
 			name = Juno6k
 			minThrust = 26.68932
 			maxThrust = 26.68932
+			ratedBurnTime = 450
 			heatProduction = 100
 			
 			PROPELLANT
@@ -103,7 +104,7 @@
 	TESTFLIGHT
 	{
 			name = Juno6k
-			ratedBurnTime = 450
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Juno6k]/ratedBurnTime$
 			ignitionReliabilityStart = 0.85
 			ignitionReliabilityEnd = 0.95
 			cycleReliabilityStart = 0.79

--- a/GameData/RealismOverhaul/Engine_Configs/KIWIA24_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KIWIA24_Config.cfg
@@ -51,6 +51,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 4.2				
 			maxThrust = 29.3				
+			ratedBurnTime = 360
 			massMult = 1			
 			ignitions = 2
 			%ullage = True
@@ -109,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = KIWIA24-Hydrogen
-		ratedBurnTime = 360 // 6 minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[KIWIA24-Hydrogen]/ratedBurnTime$ // 6 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/KIWIB48_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KIWIB48_Config.cfg
@@ -40,6 +40,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 22
 			maxThrust = 220
+			ratedBurnTime = 750
 			massMult = 1			
 			ignitions = 4
 			%ullage = True
@@ -99,7 +100,7 @@
 	TESTFLIGHT
 	{
 		name = KIWIB48-Hydrogen
-		ratedBurnTime = 750 // 12 minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[KIWIB48-Hydrogen]/ratedBurnTime$ // 12 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
@@ -97,6 +97,7 @@
 			description = Developed for use as an N-1 upper stage. Cancelled with the N-1, but considered for use on Proton and Angara
 			minThrust = 69.6
 			maxThrust = 69.6
+			ratedBurnTime = 800
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -130,6 +131,7 @@
 			description = AKA RD-56M. Upgraded model of the RD-56. Never saw use in the USSR, but was sold to India, and later license built in India. Poor overall reliability
 			minThrust = 73.58
 			maxThrust = 73.58
+			ratedBurnTime = 800
 			heatProduction = 100
 			massMult = 0.585
 			PROPELLANT
@@ -164,6 +166,7 @@
 			description = Natively developed Indian upgrade of the KVD-1 following embargos and poor performance. Used for GSLV Mk.II.
 			minThrust = 69.55
 			maxThrust = 69.55
+			ratedBurnTime = 850
 			heatProduction = 100
 			massMult = 0.585
 			ignitions = 5
@@ -193,7 +196,7 @@
 	{
 		name = RD-56
 		//Never flew, guess based on performance of KVD-1
-		ratedBurnTime = 800
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-56]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.5
@@ -212,7 +215,7 @@
 	TESTFLIGHT
 	{
 		name = KVD-1
-		ratedBurnTime = 800
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[KVD-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
 		cycleReliabilityStart = 0.500000
@@ -233,7 +236,7 @@
 	TESTFLIGHT
 	{
 		name = CE-7.5
-		ratedBurnTime = 850
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CE-7.5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.928571
 		ignitionReliabilityEnd = 0.985714
 		cycleReliabilityStart = 0.857143

--- a/GameData/RealismOverhaul/Engine_Configs/Kestrel_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Kestrel_Config.cfg
@@ -78,6 +78,7 @@
 			name = Kestrel
 			minThrust = 30.5
 			maxThrust = 30.5
+			ratedBurnTime = 415
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -162,7 +163,7 @@
 	TESTFLIGHT
 	{
 			name = Kestrel
-			ratedBurnTime = 415
+			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Kestrel]/ratedBurnTime$
 			ignitionReliabilityStart = 0.750000
 			ignitionReliabilityEnd = 0.950000
 			cycleReliabilityStart = 0.666667

--- a/GameData/RealismOverhaul/Engine_Configs/LE7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LE7_Config.cfg
@@ -97,6 +97,7 @@
 			description = Developed as a first stage engine for the Japanese H-II.
 			maxThrust = 1078
 			minThrust = 1078
+			ratedBurnTime = 350
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -128,6 +129,7 @@
 			description = Simplified design for the H-IIA. Lower cost and better reliability, at the cost of lower performance. Intended to have a nozzle extension, but it had to be removed due to unexpected combustion instability issues.
 			maxThrust = 1074
 			minThrust = 773
+			ratedBurnTime = 400
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -160,6 +162,7 @@
 			description = A Redesigned nozzle extension allowed for the LE-7A to achieve its intended performance, at the cost of slightly more weight.
 			maxThrust = 1098
 			minThrust = 790
+			ratedBurnTime = 400
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -196,7 +199,7 @@
 	TESTFLIGHT
 	{
 		name = LE-7
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LE-7]/ratedBurnTime$
 		ignitionReliabilityStart = 0.857143
 		ignitionReliabilityEnd = 0.971429
 		cycleReliabilityStart = 0.857143
@@ -209,7 +212,7 @@
 	TESTFLIGHT
 	{
 		name = LE-7A
-		ratedBurnTime = 400
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LE-7A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.976190
 		ignitionReliabilityEnd = 0.995238
 		cycleReliabilityStart = 0.976190
@@ -224,7 +227,7 @@
 	TESTFLIGHT
 	{
 		name = LE-7A-2
-		ratedBurnTime = 400
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LE-7A-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.947368
 		ignitionReliabilityEnd = 0.989474
 		cycleReliabilityStart = 0.947368

--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -78,6 +78,7 @@
 			name = LMAE
 			minThrust = 15.57
 			maxThrust = 15.57
+			ratedBurnTime = 560
 			heatProduction = 20
 			massMult = 1.0
 			ullage = True
@@ -117,6 +118,7 @@
 			description = LMAE converted to run on Methalox for use on future manned Lunar and Martian landers. Developed and test fired, but cancelled in 2020 in favor of commercially developed landers.
 			minThrust = 24.5
 			maxThrust = 24.5
+			ratedBurnTime = 560
 			heatProduction = 20
 			massMult = 1.0
 			ullage = True
@@ -157,7 +159,7 @@
 	TESTFLIGHT
 	{
 		name = LMAE
-		ratedBurnTime = 560
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LMAE]/ratedBurnTime$
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.833333
@@ -171,7 +173,7 @@
 	{
 		//guess, based on LMAE
 		name = RS-18
-		ratedBurnTime = 560
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-18]/ratedBurnTime$
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.985

--- a/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
@@ -109,6 +109,7 @@
 			description = Lunar Module Descent Engine used up to Apollo 15
 			minThrust = 4.67
 			maxThrust = 43.9
+			ratedBurnTime = 960
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -148,6 +149,7 @@
 			description = LMDE upgraded for J-class missions. Improved performance and more fuel allowed the LEM to carry rovers and extra scientific equipment to the surface.
 			minThrust = 4.67
 			maxThrust = 45.04
+			ratedBurnTime = 960
 			heatProduction = 36
 			massMult = 1.0
 			ullage = True
@@ -187,6 +189,7 @@
 			description = Simplifed LMDE used on Delta-P as an upper stage engine.
 			minThrust = 43.8
 			maxThrust = 43.8
+			ratedBurnTime = 360
 			heatProduction = 48
 			massMult = 0.7151 //mass is 0.113
 			ullage = True
@@ -233,7 +236,7 @@
 	TESTFLIGHT
 	{
 		name = LMDE-H
-		ratedBurnTime = 960
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LMDE-H]/ratedBurnTime$
 		ignitionReliabilityStart = 0.933333 // ignition chance will be this at 0 data
 		ignitionReliabilityEnd = 0.986667 // and this at 10000 data
 		
@@ -272,7 +275,7 @@
 	TESTFLIGHT
 	{
 		name = LMDE-J
-		ratedBurnTime = 960
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LMDE-J]/ratedBurnTime$
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		ignitionDynPresFailMultiplier = 0.1
@@ -303,7 +306,7 @@
 	TESTFLIGHT
 	{
 		name = TR-201
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[TR-201]/ratedBurnTime$
 		ignitionReliabilityStart = 0.989130
 		ignitionReliabilityEnd = 0.997826
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -86,6 +86,7 @@
 			description = First production version. Used on Thor and Atlas as vernier engines
 			minThrust = 5.1144
 			maxThrust = 5.1144
+			ratedBurnTime = 360
 			heatProduction = 10
 
 			ullage = True
@@ -125,6 +126,7 @@
 			description = Developed for later, larger Thor variants, with improved performance
 			minThrust = 5.369
 			maxThrust = 5.369
+			ratedBurnTime = 360
 			heatProduction = 10
 
 			ullage = True
@@ -163,6 +165,7 @@
 			description = Downrated for later Atlas variants when studies showed much lower thrust could be used to maintain control
 			minThrust = 2.976
 			maxThrust = 2.976
+			ratedBurnTime = 360
 			heatProduction = 10
 			massMult = 0.8
 
@@ -204,7 +207,7 @@
 	TESTFLIGHT
 	{
 		name = LR101-NA-3
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
@@ -217,7 +220,7 @@
 	TESTFLIGHT
 	{
 		name = LR101-NA-11
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-11]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
@@ -231,7 +234,7 @@
 	TESTFLIGHT
 	{
 		name = LR101-NA-15
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-15]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -170,6 +170,7 @@
 			description = Prototype MA-1 Atlas sustainer sustainer. An XLR43 modified with vaccum optimzed nozzle and burning kerosene. Used on Atlas B (Atlas A had no sustainer)
 			minThrust = 240.2
 			maxThrust = 240.2
+			ratedBurnTime = 330
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True
@@ -212,6 +213,7 @@
 			description = MA-1 Atlas sustainer engine. Significantly upgraded and simplified, used on Atlas B/C
 			minThrust = 352.2
 			maxThrust = 352.2
+			ratedBurnTime = 330
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True
@@ -253,6 +255,7 @@
 			description = MA-3 Atlas Sustainer engine. Developed for the USAF for Atlas D
 			minThrust = 366.1
 			maxThrust = 366.1
+			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
 			ullage = True
@@ -293,6 +296,7 @@
 			description = MA-3 Atlas sustainer engine. Slightly upgraded for Atlas E/F
 			minThrust = 373.2
 			maxThrust = 373.2
+			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
 			ullage = True
@@ -333,6 +337,7 @@
 			description = MA-5.1 sustainer engine for Atlas-Agena launches
 			minThrust = 385.2
 			maxThrust = 385.2
+			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 1.02174 // 470kg engine, same source
 			ullage = True
@@ -373,6 +378,7 @@
 			description = MA-5.2 sustainer engine for Atlas-Centaur launches
 			minThrust = 386.4
 			maxThrust = 386.4
+			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 1.02174 // 470kg engine, same source
 			ullage = True
@@ -413,6 +419,7 @@
 			description = Atlas MA-5A sustainer engine. Upgraded with RS-27 components to reduce cost and improve performance. Used on Atlas II
 			minThrust = 386.4
 			maxThrust = 386.4
+			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 1.0 // total guess, lower than above because H-1 was lighter...?
 			ullage = True
@@ -468,7 +475,7 @@
 	TESTFLIGHT
 	{
 		name = LR43-NA-5
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR43-NA-5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.826087
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
@@ -484,7 +491,7 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-3
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -520,7 +527,7 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-5
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.956710
 		ignitionReliabilityEnd = 0.991342
 		cycleReliabilityStart = 0.956710
@@ -549,7 +556,7 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-6
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-6]/ratedBurnTime$
 		ignitionReliabilityStart = 0.939394
 		ignitionReliabilityEnd = 0.987879
 		cycleReliabilityStart = 0.939394
@@ -566,7 +573,7 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-7.1
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-7.1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
@@ -583,7 +590,7 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-7.2
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-7.2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
@@ -601,7 +608,7 @@
 	TESTFLIGHT
 	{
 		name = RS-56-OSA
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-56-OSA]/ratedBurnTime$
 		ignitionReliabilityStart = 0.994737
 		ignitionReliabilityEnd = 0.998947
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
@@ -99,6 +99,7 @@
 			description = Prototype for USAF ISINGLASS rocketplane
 			minThrust = 217.1
 			maxThrust = 1085.4
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -131,6 +132,7 @@
 			description = Production model for USAF ISINGLASS rocketplane
 			minThrust = 222.4
 			maxThrust = 1112.1
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -163,6 +165,7 @@
 			description = P&W proposal for Space Shuttle Main Engine
 			minThrust = 778.5
 			maxThrust = 1556.9
+			ratedBurnTime = 480
 			massMult = 1.25	//Guess
 			PROPELLANT
 			{
@@ -196,6 +199,7 @@
 			description = Speculative upgrade
 			minThrust = 809.6
 			maxThrust = 1619.2
+			ratedBurnTime = 480
 			massMult = 1.25	//Guess
 			//speculative = fictional
 			PROPELLANT
@@ -248,7 +252,7 @@
 	TESTFLIGHT
 	{
 		name = XLR129-P-1
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR129-P-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.8491
 		ignitionReliabilityEnd = 0.9091
 		cycleReliabilityStart = 0.8875
@@ -260,7 +264,7 @@
 	TESTFLIGHT
 	{
 		name = LR129-P-1
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.962
 		cycleReliabilityStart = 0.9468
@@ -273,7 +277,7 @@
 	TESTFLIGHT
 	{
 		name = LR129-P-2
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.932
 		ignitionReliabilityEnd = 0.992
 		cycleReliabilityStart = 0.872
@@ -286,7 +290,7 @@
 	TESTFLIGHT
 	{
 		name = LR129-P-3
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9415
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9415

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -145,6 +145,7 @@
 			minThrust = 696.6
 			// OLD REFERENCE-NO LONGER USED: https://forum.nasaspaceflight.com/index.php?PHPSESSID=br6ak5uvm7sfiqsbqv53ej40g4&topic=40733.0
 			maxThrust = 696.6
+			ratedBurnTime = 182
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -190,6 +191,7 @@
 			description = Main engine for the Jupiter / Juno II launch vehicle
 			minThrust = 766.34
 			maxThrust = 766.34
+			ratedBurnTime = 182
 			heatProduction = 100
 			massMult = 1.0
 
@@ -238,6 +240,7 @@
 			// 176,000 lbf * 0.00444822 = 782.88672 kN
 			// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 783
+			ratedBurnTime = 165
 			heatProduction = 100
 			// Linear steps from S-3 to LR79-NA-9 to LR79-NA-11 to LR79-NA-13
 			// Only known two masses are S-3 and LR79-NA-13
@@ -286,6 +289,7 @@
 			description = Main engine for MB-3-II propulsion system
 			minThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
+			ratedBurnTime = 165
 			heatProduction = 100
 			// Linear steps from S-3 to LR79-NA-9 to LR79-NA-11 to LR79-NA-13
 			// Only known two masses are S-3 and LR79-NA-13
@@ -334,6 +338,7 @@
 			description = Main engine for MB-3-III propulsion system
 			minThrust = 873	// Source #6
 			maxThrust = 873	// Source #6
+			ratedBurnTime = 260
 			heatProduction = 100
 			massMult = 0.965 // Source #7
 
@@ -389,7 +394,7 @@
 	TESTFLIGHT
 	{
 		name = S-3
-		ratedBurnTime = 182
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -406,7 +411,7 @@
 	TESTFLIGHT
 	{
 		name = S-3D
-		ratedBurnTime = 182
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S-3D]/ratedBurnTime$
 		ignitionReliabilityStart = 0.882353
 		ignitionReliabilityEnd = 0.976471
 		cycleReliabilityStart = 0.882353
@@ -442,7 +447,7 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-9
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-9]/ratedBurnTime$
 		ignitionReliabilityStart = 0.789773
 		ignitionReliabilityEnd = 0.957955
 		cycleReliabilityStart = 0.789773
@@ -466,7 +471,7 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-11
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-11]/ratedBurnTime$
 		ignitionReliabilityStart = 0.936364
 		ignitionReliabilityEnd = 0.987273
 		cycleReliabilityStart = 0.936364
@@ -510,7 +515,7 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-13
-		ratedBurnTime = 260
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-13]/ratedBurnTime$
 		ignitionReliabilityStart = 0.964646
 		ignitionReliabilityEnd = 0.992929
 		cycleReliabilityStart = 0.964646

--- a/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
@@ -65,6 +65,7 @@
 			name = XLR83-NA-1
 			minThrust = 2072
 			maxThrust = 2072
+			ratedBurnTime = 100
 			heatProduction = 100
 
 			PROPELLANT
@@ -102,7 +103,7 @@
 	{
 		//Cancelled before it could fly. Reliability assumed to be the same as LR43
 		name = XLR83-NA-1
-		ratedBurnTime = 100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR83-NA-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.70
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.80

--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
@@ -41,6 +41,7 @@
 			description = Developed for Titan C
 			minThrust = 667.0
 			maxThrust = 667.0
+			ratedBurnTime = 300
 			heatProduction = 175
 			ignitions = 1
 			PROPELLANT
@@ -66,6 +67,7 @@
 			description = Developed as Aerojets proposal for the Saturn V upper stage engines. It could be ready much earlier than its competition, but the J-2 was chosen due to its higher performance.
 			minThrust = 778.0
 			maxThrust = 778.0
+			ratedBurnTime = 360
 			heatProduction = 175
 			ignitions = 2
 			massMult = 1.14865
@@ -92,6 +94,7 @@
 			description = Speculative upgrade for Titan C
 			minThrust = 801 // 180 klbf
 			maxThrust = 801
+			ratedBurnTime = 480
 			heatProduction = 175
 			massMult = 1.08109
 			ignitions = 2
@@ -119,6 +122,7 @@
 			description = Speculative upgrade for use on later Saturn V missions
 			minThrust = 889.0
 			maxThrust = 889.0
+			ratedBurnTime = 480
 			heatProduction = 175
 			massMult = 1.18
 			ignitions = 3
@@ -147,7 +151,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-TitanC
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-TitanC]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.892
@@ -163,7 +167,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-Vacuum
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-Vacuum]/ratedBurnTime$
 		ignitionReliabilityStart = 0.92
 		ignitionReliabilityEnd = 0.975
 		cycleReliabilityStart = 0.93
@@ -179,7 +183,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-SustainerUpgrade
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-SustainerUpgrade]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
@@ -194,7 +198,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-VacuumUpgrade
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-VacuumUpgrade]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.96

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -151,6 +151,7 @@
 			description = First stage engine for the Titan I ICBM
 			minThrust = 765.95
 			maxThrust = 765.95
+			ratedBurnTime = 137
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -187,6 +188,7 @@
 			description = First stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
 			minThrust = 1075.5
 			maxThrust = 1075.5
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -220,6 +222,7 @@
 			description = First stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
 			minThrust = 1097.2
 			maxThrust = 1097.2
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -254,6 +257,7 @@
 			description = First stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
 			minThrust = 1130
 			maxThrust = 1130
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -286,6 +290,7 @@
 			description = First stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Modified to light in midair, since the UA120x boosters used by Titan III could lift Titan without assistance. Ignited just before booster burnout.
 			minThrust = 1170
 			maxThrust = 1170
+			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -318,6 +323,7 @@
 			description = First stage engine for Titan IVA and IVB. Equipped with a nozzle extension to improve vacuum performance, since it was not needed at sea level.
 			minThrust = 1210.9
 			maxThrust = 1210.9
+			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -350,6 +356,7 @@
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design
 			minThrust = 1012
 			maxThrust = 1012
+			ratedBurnTime = 150
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -383,6 +390,7 @@
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design. Equipped with nozzle extensions to increase vacuum performance
 			minThrust = 1026
 			maxThrust = 1026
+			ratedBurnTime = 150
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -420,7 +428,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-3
-		ratedBurnTime = 137
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.898305
 		ignitionReliabilityEnd = 0.979661
 		cycleReliabilityStart = 0.898305
@@ -440,7 +448,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-5
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.962766
 		ignitionReliabilityEnd = 0.992553
 		cycleReliabilityStart = 0.962766
@@ -459,7 +467,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-7
-		ratedBurnTime = 150 // [1] Page 11.C-9, 147s rounded up to 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-7]/ratedBurnTime$ // [1] Page 11.C-9, 147s rounded up to 150
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.960000
@@ -480,7 +488,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9]/ratedBurnTime$
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.975000
@@ -498,7 +506,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9-Kero-15AR
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9-Kero-15AR]/ratedBurnTime$
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.975000
@@ -516,7 +524,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9-Kero
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9-Kero]/ratedBurnTime$
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.975000
@@ -545,7 +553,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11
-		ratedBurnTime = 300 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-11]/ratedBurnTime$ // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
 		ignitionReliabilityStart = 0.982143
 		ignitionReliabilityEnd = 0.996429
 		cycleReliabilityStart = 0.982143
@@ -570,7 +578,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11A
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-11A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988372
 		ignitionReliabilityEnd = 0.997674
 		cycleReliabilityStart = 0.988372

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -168,6 +168,7 @@
 			description = MA-0 and prototype MA-1 Atlas Booster engine. An XLR43 modified to burn kerosene. Used on Convair X12 and Atlas A
 			minThrust = 756.8
 			maxThrust = 756.8
+			ratedBurnTime = 135
 			heatProduction = 100
 			massMult = 1
 
@@ -213,6 +214,7 @@
 			description = MA-1 Atlas booster engine. Significantly upgraded and simplified, with both engines sharing turbopumps. Used on Atlas B/C
 			minThrust = 758.7
 			maxThrust = 758.7
+			ratedBurnTime = 135
 			heatProduction = 100
 			massMult = 0.89
 
@@ -258,6 +260,7 @@
 			description = MA-3 Atlas booster engine. Each engine had its own turbopump allow for engines to be quickly swapped. Developed for the USAF for Atlas D
 			minThrust = 831.4
 			maxThrust = 831.4
+			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 1.15		 // https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf. With a 1.61t skirt, this should result in each booster weighing 0.828t resulting in a 3.266t total weight which includes residuals.
 
@@ -303,6 +306,7 @@
 			description = MA-3 Atlas booster engine. Slightly upgraded for Atlas E/F
 			minThrust = 846.6
 			maxThrust = 846.6
+			ratedBurnTime = 160
 			heatProduction = 100
 			massMult = 1.2264		// https://ia601201.us.archive.org/30/items/NASA_NTRS_Archive_19700011207/NASA_NTRS_Archive_19700011207.pdf. With a 1.61t skirt, this should result in each booster weighing 0.883t resulting in the 3.376t total weight (including residuals) of AC-13.
 
@@ -348,6 +352,7 @@
 			description = MA-5.1 booster engine. Both engines shared turbopumps due to NASA preferring that configuration. Used for Atlas-Agena launches
 			minThrust = 931.7
 			maxThrust = 931.7
+			ratedBurnTime = 165
 			heatProduction = 100
 			massMult = 1.414		// astronautix.com MA-5. With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
@@ -391,6 +396,7 @@
 			description = MA-5.2 booster engine. Both engines shared turbopumps due to NASA preferring that configuration. Used for Atlas-Centaur launches
 			minThrust = 950.8
 			maxThrust = 950.8
+			ratedBurnTime = 165
 			heatProduction = 100
 			massMult = 1.414		// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
@@ -436,6 +442,7 @@
 			description = Atlas MA-5A booster engine. Upgraded with RS-27 components to reduce cost and improve performance. Used on Atlas II
 			minThrust = 1077.6
 			maxThrust = 1077.6
+			ratedBurnTime = 170
 			heatProduction = 100
 			massMult = 1.7896		// astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
 			//massMult = 1.11805	FIXME maybe revert to this value?
@@ -493,7 +500,7 @@
 	TESTFLIGHT
 	{
 		name = LR43-NA-3
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR43-NA-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.826087
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
@@ -509,7 +516,7 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-3
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -545,7 +552,7 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-5
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.956710
 		ignitionReliabilityEnd = 0.991342
 		cycleReliabilityStart = 0.956710
@@ -574,7 +581,7 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-6
-		ratedBurnTime = 160
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-6]/ratedBurnTime$
 		ignitionReliabilityStart = 0.939394
 		ignitionReliabilityEnd = 0.987879
 		cycleReliabilityStart = 0.939394
@@ -591,7 +598,7 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-7.1
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-7.1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
@@ -608,7 +615,7 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-7.2
-		ratedBurnTime = 165
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-7.2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
@@ -626,7 +633,7 @@
 	TESTFLIGHT
 	{
 		name = RS-56-OBA
-		ratedBurnTime = 170
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-56-OBA]/ratedBurnTime$
 		ignitionReliabilityStart = 0.994737
 		ignitionReliabilityEnd = 0.998947
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -145,6 +145,7 @@
 			description = Second stage engine for the Titan I ICBM.
 			minThrust = 362.87
 			maxThrust = 362.87 // added the Verniers back to the thrust
+			ratedBurnTime = 160
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -179,6 +180,7 @@
 			description = Second stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
 			minThrust = 448.2
 			maxThrust = 448.2 // added the Verniers back to the thrust
+			ratedBurnTime = 180
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -213,6 +215,7 @@
 			description = Second stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
+			ratedBurnTime = 190
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -246,6 +249,7 @@
 			description = Second stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
+			ratedBurnTime = 210
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -279,6 +283,7 @@
 			description = Second stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Slightly improved performance.
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
+			ratedBurnTime = 250
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -312,6 +317,7 @@
 			description = Second stage engine for Titan IVA and IVB. Slightly improved performance
 			minThrust = 474.6
 			maxThrust = 474.6 // added the Verniers back to the thrust
+			ratedBurnTime = 250
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -354,6 +360,7 @@
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design
 			minThrust = 394.9
 			maxThrust = 394.9 // added the Verniers back to the thrust
+			ratedBurnTime = 210
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -392,7 +399,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-3
-		ratedBurnTime = 160 // http://www.astronautix.com/engines/lr913.htm claims 225s but that makes no sense. Titan I-2 burn time was 155s, so let's round up to 180.
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-3]/ratedBurnTime$ // http://www.astronautix.com/engines/lr913.htm claims 225s but that makes no sense. Titan I-2 burn time was 155s, so let's round up to 180.
 		ignitionReliabilityStart = 0.950000
 		ignitionReliabilityEnd = 0.990000
 		cycleReliabilityStart = 0.950000
@@ -410,7 +417,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-5
-		ratedBurnTime = 180 // Titan II SLV and Titan 23G.
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-5]/ratedBurnTime$ // Titan II SLV and Titan 23G.
 		ignitionReliabilityStart = 0.956044
 		ignitionReliabilityEnd = 0.991209
 		cycleReliabilityStart = 0.956044
@@ -429,7 +436,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-7
-		ratedBurnTime = 190 // Titan II GLV, had a 9s stage stretch, round to 190s.
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-7]/ratedBurnTime$ // Titan II GLV, had a 9s stage stretch, round to 190s.
 		ignitionReliabilityStart = 0.961165
 		ignitionReliabilityEnd = 0.992233
 		cycleReliabilityStart = 0.961165
@@ -450,7 +457,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-9
-		ratedBurnTime = 210 // Titan III stretch
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-9]/ratedBurnTime$ // Titan III stretch
 		ignitionReliabilityStart = 0.974359
 		ignitionReliabilityEnd = 0.994872
 		cycleReliabilityStart = 0.974359
@@ -468,7 +475,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-9-Kero
-		ratedBurnTime = 210 // Titan III stretch
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-9-Kero]/ratedBurnTime$ // Titan III stretch
 		ignitionReliabilityStart = 0.974359
 		ignitionReliabilityEnd = 0.994872
 		cycleReliabilityStart = 0.974359
@@ -497,7 +504,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-11
-		ratedBurnTime = 250 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-11]/ratedBurnTime$ // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
 		ignitionReliabilityStart = 0.972727
 		ignitionReliabilityEnd = 0.994545
 		cycleReliabilityStart = 0.972727
@@ -522,7 +529,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-11A
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-11A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
 		cycleReliabilityStart = 0.975610

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -132,6 +132,7 @@
 			description = Initial version of the M-1, generating 1.2 mlbf of thrust
 			minThrust = 5337.866
 			maxThrust = 5337.866
+			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -164,6 +165,7 @@
 			description = Production version of the M-1, generating 1.5 mlbf of thrust
 			minThrust = 6672.332
 			maxThrust = 6672.332
+			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -196,6 +198,7 @@
 			description = 1990s proposal to convert the M-1 into a sea level sustainer engine for super-heavy launch vehicles
 			minThrust = 6928
 			maxThrust = 6928
+			ratedBurnTime = 500
 			heatProduction = 100
 			massMult = 1.01
 			PROPELLANT
@@ -229,6 +232,7 @@
 			description = M-1, uprated to 1.8 mlbf. All M-1 components were designed to handle 1200 psi chamber to allow this upgrade.
 			minThrust = 8006.799
 			maxThrust = 8006.799
+			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -261,6 +265,7 @@
 			description = Sea level M-1, but running at 1200 psi chamber pressure.
 			minThrust = 7708.87
 			maxThrust = 7708.87
+			ratedBurnTime = 500
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -296,7 +301,7 @@
 	TESTFLIGHT
 	{
 		name = M-1-Spec
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1-Spec]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9182
 		ignitionReliabilityEnd = 0.9932
 		cycleReliabilityStart = 0.9182
@@ -308,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = M-1
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9257
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9257
@@ -321,7 +326,7 @@
 	TESTFLIGHT
 	{
 		name = M-1SL
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
@@ -334,7 +339,7 @@
 	TESTFLIGHT
 	{
 		name = M-1U
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1U]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
@@ -347,7 +352,7 @@
 	TESTFLIGHT
 	{
 		name = M-1U-SL
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1U-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -347,7 +347,7 @@
 		techTransfer = M-1-Spec,M-1,M-1SL:50
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[M-1U]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[M-1U-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/M55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M55_Config.cfg
@@ -74,6 +74,7 @@
 			name = M55
 			minThrust = 876
 			maxThrust = 876
+			ratedBurnTime = 75
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -113,7 +114,7 @@
 	TESTFLIGHT
 	{
 		name = M55
-		ratedBurnTime = 75
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M55]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999		//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.972315

--- a/GameData/RealismOverhaul/Engine_Configs/MB35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB35_Config.cfg
@@ -65,6 +65,7 @@
 			name = MB-35
 			maxThrust = 155.7
 			minThrust = 155.7
+			ratedBurnTime = 1130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -98,7 +99,7 @@
 	TESTFLIGHT
 	{
 		name = MB-35					//assume same as RL10-B2
-		ratedBurnTime = 1130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-35]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643

--- a/GameData/RealismOverhaul/Engine_Configs/MB45_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB45_Config.cfg
@@ -65,6 +65,7 @@
 			name = MB-XX-Demo
 			maxThrust = 177.9
 			minThrust = 177.9
+			ratedBurnTime = 720
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -95,6 +96,7 @@
 			name = MB-45
 			maxThrust = 200.2
 			minThrust = 200.2
+			ratedBurnTime = 1130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -128,7 +130,7 @@
 	TESTFLIGHT
 	{
 		name = MB-XX-Demo					//assume same as RL10-B2
-		ratedBurnTime = 720
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-XX-Demo]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -144,7 +146,7 @@
 	TESTFLIGHT
 	{
 		name = MB-45					//assume same as RL10-B2
-		ratedBurnTime = 1130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-45]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.985

--- a/GameData/RealismOverhaul/Engine_Configs/MB60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB60_Config.cfg
@@ -65,6 +65,7 @@
 			name = MB-60
 			maxThrust = 266.9
 			minThrust = 266.9
+			ratedBurnTime = 1130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -98,7 +99,7 @@
 	TESTFLIGHT
 	{
 		name = MB-60					//assume same as RL10-B2
-		ratedBurnTime = 1130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-60]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643

--- a/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
@@ -59,6 +59,7 @@
 			name = MR-80B
 			minThrust = 0.031
 			maxThrust = 3.603
+			ratedBurnTime = 350
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -89,7 +90,7 @@
 	{
 		name = MR-80B
 		//Extremely simple and reliable monopropellant engines
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MR-80B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -217,6 +217,7 @@
 			description = Used on Falcon 1 first stage
 			minThrust = 369.2
 			maxThrust = 369.2
+			ratedBurnTime = 300
 			heatProduction = 58
 			massMult = 1.0
 
@@ -262,6 +263,7 @@
 			name = Merlin1B
 			minThrust = 394.6
 			maxThrust = 394.6
+			ratedBurnTime = 300
 			heatProduction = 64
 			massMult = 1.0			// From Wikipedia: turbopump weight was unchanged at 150 lbs.
 
@@ -307,6 +309,7 @@
 			name = Merlin1BVac
 			minThrust = 421.6
 			maxThrust = 421.6
+			ratedBurnTime = 345
 			heatProduction = 63
 			massMult = 1.2			// No good source but it should be heavier than the SL version.
 
@@ -353,6 +356,7 @@
 			description = Used on Falcon 9 Block 1 (v1.0)
 			minThrust = 482.63
 			maxThrust = 482.63
+			ratedBurnTime = 300
 			heatProduction = 96
 			massMult = 0.829
 
@@ -399,6 +403,7 @@
 			description = Used on Falcon 9 Block 1 (v1.0)
 			minThrust = 314.94
 			maxThrust = 524.9		// [9]
+			ratedBurnTime = 345
 			heatProduction = 76
 			massMult = 1.0
 
@@ -445,6 +450,7 @@
 			description = Used on Falcon 9 v1.1
 			minThrust = 290
 			maxThrust = 742.4
+			ratedBurnTime = 350
 			heatProduction = 196
 			massMult = 0.6184
 
@@ -491,6 +497,7 @@
 			description = Used on Falcon 9 v1.2 (Full Thrust)
 			minThrust = 330
 			maxThrust = 825			//[2]
+			ratedBurnTime = 350
 			heatProduction = 225
 			massMult = 0.6184
 
@@ -537,6 +544,7 @@
 			description = Used on Falcon 9 Block 5
 			minThrust = 330			// [5]
 			maxThrust = 914.12		// [3]
+			ratedBurnTime = 350
 			heatProduction = 248
 			massMult = 0.6184
 
@@ -583,6 +591,7 @@
 			description = Used on Falcon 9 v1.1
 			minThrust = 360
 			maxThrust = 805
+			ratedBurnTime = 375
 			heatProduction = 233
 			massMult = 0.6447
 
@@ -628,6 +637,7 @@
 			description = Used on Falcon 9 v1.2 (Full Thrust and Block 5)
 			minThrust = 360
 			maxThrust = 934.12		 // [2]
+			ratedBurnTime = 400
 			heatProduction = 225
 			massMult = 0.6447
 
@@ -687,7 +697,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1A
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.800000
 		ignitionReliabilityEnd = 0.960000
 		cycleReliabilityStart = 0.800000
@@ -701,7 +711,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1B
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -716,7 +726,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1BVac
-		ratedBurnTime = 345
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1BVac]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -732,7 +742,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1C
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1C]/ratedBurnTime$
 		ignitionReliabilityStart = 0.977778
 		ignitionReliabilityEnd = 0.995556
 		cycleReliabilityStart = 0.977778
@@ -748,7 +758,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1CVac
-		ratedBurnTime = 345
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1CVac]/ratedBurnTime$
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -765,7 +775,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D]/ratedBurnTime$
 		ignitionReliabilityStart = 0.993711
 		ignitionReliabilityEnd = 0.998742
 		cycleReliabilityStart = 0.992593
@@ -783,7 +793,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D+
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D+]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997481
 		ignitionReliabilityEnd = 0.999496
 		cycleReliabilityStart = 0.996923
@@ -803,7 +813,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D++
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D++]/ratedBurnTime$
 		ignitionReliabilityStart = 0.998689
 		ignitionReliabilityEnd = 0.999738
 		cycleReliabilityStart = 0.998316
@@ -822,7 +832,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1DVac
-		ratedBurnTime = 375
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac]/ratedBurnTime$
 		ignitionReliabilityStart = 0.965517
 		ignitionReliabilityEnd = 0.993103
 		cycleReliabilityStart = 0.933333
@@ -843,7 +853,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1DVac+
-		ratedBurnTime = 400
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac+]/ratedBurnTime$
 		ignitionReliabilityStart = 0.992481
 		ignitionReliabilityEnd = 0.998496
 		cycleReliabilityStart = 0.985075

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockA_Config.cfg
@@ -18,6 +18,7 @@
 			name = 30x_NK-15
 			maxThrust = 50308
 			minThrust = 10061// 6 engines
+			ratedBurnTime = 180
 			PROPELLANT
 			{
 				name = Kerosene
@@ -41,6 +42,7 @@
 			name = 30x_NK-33
 			minThrust = 10092// 6 engines
 			maxThrust = 50460
+			ratedBurnTime = 240
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -68,7 +70,7 @@
 	TESTFLIGHT
 	{
 		name = 30x_NK-15
-		ratedBurnTime = 180
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[30x_NK-15]/ratedBurnTime$
 		ignitionReliabilityStart = 0.6682  // Rate of NK-15 = 0.87, (Average of Rel and Rel^SQRT(30))
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.6303  // Rate of NK-15 = 0.85, (Average of Rel and Rel^SQRT(30))
@@ -82,7 +84,7 @@
 	TESTFLIGHT
 	{
 		name = 30x_NK-33
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[30x_NK-33]/ratedBurnTime$
 		ignitionReliabilityStart = 0.801  // Rate of NK-33 = 0.93, (Average of Rel and Rel^SQRT(30))
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.7767  // Rate of NK-33 = 0.93, (Average of Rel and Rel^SQRT(30))

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockB_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockB_Config.cfg
@@ -18,6 +18,7 @@
 			name = 8x_NK-15V
 			maxThrust = 13184
 			minThrust = 13184
+			ratedBurnTime = 240
 			PROPELLANT
 			{
 				name = Kerosene
@@ -41,6 +42,7 @@
 			name = 8x_NK-43
 			minThrust = 7020
 			maxThrust = 14040
+			ratedBurnTime = 360
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -68,7 +70,7 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 8x_NK-15V
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[8x_NK-15V]/ratedBurnTime$
 		ignitionReliabilityStart = 0.7722  // Rate of NK-15V = 0.87, (Average of Rel and Rel^SQRT(8))
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.7407  // Rate of NK-15V = 0.85, (Average of Rel and Rel^SQRT(8))
@@ -81,7 +83,7 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 8x_NK-43
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[8x_NK-43]/ratedBurnTime$
 		ignitionReliabilityStart = 0.8722  // Rate of NK-43 = 0.93, (Average of Rel and Rel^SQRT(8))
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.855  // Rate of NK-43 = 0.92, (Average of Rel and Rel^SQRT(8))

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockV_Config.cfg
@@ -18,6 +18,7 @@
 			name = 4x_NK-21
 			maxThrust = 1608
 			minThrust = 1608
+			ratedBurnTime = 450
 			PROPELLANT
 			{
 				name = Kerosene
@@ -41,6 +42,7 @@
 			name = 4x_NK-39
 			minThrust = 1628
 			maxThrust = 1628
+			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -68,7 +70,7 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 4x_NK-21
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[4x_NK-21]/ratedBurnTime$
 		ignitionReliabilityStart = 0.7863  // Rate of NK-21 = 0.9, (Average of Rel and Rel^SQRT(4))
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.7728  // Rate of NK-21 = 0.89, (Average of Rel and Rel^SQRT(4))
@@ -82,7 +84,7 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 4x_NK-39
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[4x_NK-39]/ratedBurnTime$
 		ignitionReliabilityStart = 0.8272  // Rate of NK-39 = 0.93, (Average of Rel and Rel^SQRT(4))
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.8411  // Rate of NK-39 = 0.94, (Average of Rel and Rel^SQRT(4))

--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -96,6 +96,7 @@
 			name = A-6
 			minThrust = 395.9
 			maxThrust = 395.9
+			ratedBurnTime = 145
 			heatProduction = 41
 			massMult = 1.0
 			ullage = True
@@ -142,6 +143,7 @@
 			name = A-7
 			minThrust = 416.2
 			maxThrust = 416.2
+			ratedBurnTime = 155
 			heatProduction = 45
 			massMult = 1.0
 			ullage = True
@@ -201,7 +203,7 @@
 	TESTFLIGHT
 	{
 		name = A-6
-		ratedBurnTime = 145
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-6]/ratedBurnTime$
 		ignitionReliabilityStart = 0.879121
 		ignitionReliabilityEnd = 0.975824
 		cycleReliabilityStart = 0.879121
@@ -219,7 +221,7 @@
 	TESTFLIGHT
 	{
 		name = A-7
-		ratedBurnTime = 155
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-7]/ratedBurnTime$
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889

--- a/GameData/RealismOverhaul/Engine_Configs/NERVAII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVAII_Config.cfg
@@ -56,6 +56,8 @@
 			minThrust = 750 //a bit of throttle, no sources
 			maxThrust = 867 //195000 lbf of thrust
 			
+			ratedBurnTime = 36000
+			
 			ignitions = 60
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
@@ -147,7 +149,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA-II
-		ratedBurnTime = 36000 // 10 hours
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA-II]/ratedBurnTime$ // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/NERVANRX_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVANRX_Config.cfg
@@ -51,6 +51,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 122
 			maxThrust = 243
+			ratedBurnTime = 3720
 			massMult = 1			
 			ignitions = 30
 			%ullage = True
@@ -110,7 +111,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA_NRX-Hydrogen
-		ratedBurnTime = 3720 // ~1 hours
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA_NRX-Hydrogen]/ratedBurnTime$ // ~1 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/NERVAXE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVAXE_Config.cfg
@@ -51,6 +51,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 119
 			maxThrust = 239
+			ratedBurnTime = 36000
 			massMult = 1
 			ignitions = 60
 			%ullage = True
@@ -107,7 +108,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA_XE-Hydrogen
-		ratedBurnTime = 36000 // 10 hours
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA_XE-Hydrogen]/ratedBurnTime$ // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/NERVA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVA_Config.cfg
@@ -54,6 +54,8 @@
 			minThrust = 222 //can't find a good source, just gonna go with this.
 			maxThrust = 334
 			
+			ratedBurnTime = 36000
+			
 			ignitions = 60
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
@@ -145,7 +147,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA-I
-		ratedBurnTime = 36000 // 10 hours
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA-I]/ratedBurnTime$ // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -102,6 +102,7 @@
 			description = Developed as the first stage engine of the N-1 moon rocket. Gimbal, differential throttle.
 			maxThrust = 1681 // 378,000 Ibf 
 			minThrust = 841
+			ratedBurnTime = 180
 			heatProduction = 100
 			massMult = 1.21812 // 1.020458 (NK-15, no gimbal) * 1.1937 (increase % for gimbal)
 			gimbalRange = 6
@@ -142,6 +143,7 @@
 			description = Developed as the first stage engine of the N-1 moon rocket. No gimbal, differential throttle.
 			maxThrust = 1681
 			minThrust = 841
+			ratedBurnTime = 180
 			heatProduction = 100
 			massMult = 1.020458
 			gimbalRange = 0
@@ -182,6 +184,7 @@
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. Gimbal, differential throttle.
 			maxThrust = 1766 //105% rated thrust
 			minThrust = 841
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.1937 // 1.459t, mass value from AJ26-59
 			gimbalRange = 6
@@ -222,6 +225,7 @@
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. No gimbal, differential throttle.
 			maxThrust = 1766
 			minThrust = 841
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1
 			gimbalRange = 0
@@ -262,6 +266,7 @@
 			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. Formerly used for the Antares-100 series
 			maxThrust = 1815
 			minThrust = 941.92
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.1937
 			ignitions = 2
@@ -319,7 +324,7 @@
 	TESTFLIGHT
 	{
 		name = NK-15
-		ratedBurnTime = 180
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15]/ratedBurnTime$
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -334,7 +339,7 @@
 	TESTFLIGHT
 	{
 		name = NK-15-Original-NoGimbal
-		ratedBurnTime = 180
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15-Original-NoGimbal]/ratedBurnTime$
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -356,7 +361,7 @@
 	TESTFLIGHT
 	{
 		name = NK-33
-		ratedBurnTime = 240 //based on Antares and Soyuz 2-1v burn times.
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-33]/ratedBurnTime$ //based on Antares and Soyuz 2-1v burn times.
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		cycleReliabilityStart = 0.937500
@@ -369,7 +374,7 @@
 	TESTFLIGHT
 	{
 		name = NK-33-Original-NoGimbal
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-33-Original-NoGimbal]/ratedBurnTime$
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		cycleReliabilityStart = 0.937500
@@ -382,7 +387,7 @@
 	TESTFLIGHT
 	{
 		name = AJ26-62
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ26-62]/ratedBurnTime$
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		cycleReliabilityStart = 0.937500

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -82,6 +82,7 @@
 			description = Developed as the second stage engine of the N-1 moon rocket. Gimbal, differential throttle.
 			maxThrust = 1755
 			minThrust = 877.5
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.15009 // 0.963467 (NK-15V, no gimbal) * 1.1937 (increase % for gimbal)
 			gimbalRange = 6
@@ -122,6 +123,7 @@
 			description = Developed as the second stage engine of the N-1 moon rocket. No gimbal, differential throttle.
 			maxThrust = 1755
 			minThrust = 877.5
+			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 0.963467
 			gimbalRange = 0
@@ -162,6 +164,7 @@
 			description =  Developed as an upgrade to the NK-15V, and then abandoned with the cancellation of the N-1. Gimbal, differential throttle.
 			minThrust = 877.5
 			maxThrust = 1755
+			ratedBurnTime = 360
 			heatProduction = 100
 			massMult = 1.1937 // 1 (NK-43, no gimbal) * 1.1937 (increase % for gimbal)
 			gimbalRange = 6
@@ -202,6 +205,7 @@
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. No gimbal, differential throttle.
 			maxThrust = 1755
 			minThrust = 877.5
+			ratedBurnTime = 360
 			heatProduction = 100
 			massMult = 1
 			gimbalRange = 0
@@ -251,7 +255,7 @@
 	TESTFLIGHT
 	{
 		name = NK-15V
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15V]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.85
@@ -266,7 +270,7 @@
 	TESTFLIGHT
 	{
 		name = NK-15V-Original-NoGimbal
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15V-Original-NoGimbal]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.85
@@ -281,7 +285,7 @@
 	TESTFLIGHT
 	{
 		name = NK-43
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-43]/ratedBurnTime$
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
@@ -294,7 +298,7 @@
 	TESTFLIGHT
 	{
 		name = NK-43-Original-NoGimbal
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-43-Original-NoGimbal]/ratedBurnTime$
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92

--- a/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
@@ -68,6 +68,7 @@
 			description = Developed for R-9 ICBM, and later used as the first stage engine for GR-1, the N-1 predecessor.
 			maxThrust = 421 // sources differ. Nautix says 441kN for the engine, but 421kN for the GR-1's stage. lpre.de also says 421 kn, so go with this
 			minThrust = 421
+			ratedBurnTime = 150
 			heatProduction = 205
 			PROPELLANT
 			{
@@ -106,6 +107,7 @@
 			description = Speculative upgrade, assuming technologies from the NK-15 were integrated back into the NK-9
 			maxThrust = 421
 			minThrust = 421
+			ratedBurnTime = 190
 			heatProduction = 205
 			// speculative = fictional
 			PROPELLANT
@@ -145,6 +147,7 @@
 			description = Speculative upgrade, assuming technologies from the NK-33 were integrated back into the NK-9
 			maxThrust = 436 // (for same TWR as NK-33 - (1766 / 1459) * 360)
 			minThrust = 436
+			ratedBurnTime = 240
 			heatProduction = 205
 			// speculative = fictional
 			PROPELLANT
@@ -184,6 +187,7 @@
 			description = Speculative upgrade, assuming Aerojet purchased and upgraded NK-9s for their own use.
 			maxThrust = 448 // (for same TWR as AJ26-62 - (1815 / (1222 * 1.1937)) * 360)
 			minThrust = 448
+			ratedBurnTime = 240
 			heatProduction = 205
 			// speculative = fictional
 			// 2.7 O/F mass ratio (Antares UG)
@@ -234,7 +238,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
@@ -251,7 +255,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9-1969
-		ratedBurnTime = 190
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9-1969]/ratedBurnTime$
 		ignitionReliabilityStart = 0.90
 		ignitionReliabilityEnd = 0.983
 		cycleReliabilityStart = 0.885
@@ -266,7 +270,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9-1972
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9-1972]/ratedBurnTime$
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
@@ -281,7 +285,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9-2009
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9-2009]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.96

--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -128,6 +128,7 @@
 			description = Original vacuum version of NK-9 for the GR-1 rocket.
 			maxThrust = 451.1 // b14643
 			minThrust = 451.1
+			ratedBurnTime = 240
 			heatProduction = 205
 			massMult = 1
 			// 2.5 O/F mass ratio (b14643.de)
@@ -167,6 +168,7 @@
 			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
 			maxThrust = 400 // b14643
 			minThrust = 240 // assume 60% throttle.
+			ratedBurnTime = 450
 			heatProduction = 205
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -206,6 +208,7 @@
 			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
 			maxThrust = 400
 			minThrust = 240
+			ratedBurnTime = 450
 			heatProduction = 205
 			massMult = 1 // I...guess?
 			// 2.5 O/F mass ratio (b14643.de)
@@ -245,6 +248,7 @@
 			description = Improved for N1F Block V. No gimbal, differential throttle.
 			maxThrust = 400
 			minThrust = 240 //FIXME guessing 60% min throttle
+			ratedBurnTime = 600
 			heatProduction = 205
 			massMult = 1.09375 // 700kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
 			// 2.6 O/F mass ratio (b14643.de)
@@ -284,6 +288,7 @@
 			description = Improved for N1F Block G. Relightable. Gimbal, throttle.
 			maxThrust = 402 // b14643
 			minThrust = 240 // assume some level of throttle, engine design was capable, and LH2 replacement engine for this stage had throttle.
+			ratedBurnTime = 600
 			heatProduction = 205
 			massMult = 1.128125 // 722kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
 			// 2.6 O/F mass ratio (b14643.de)
@@ -345,7 +350,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9V
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9V]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
@@ -362,7 +367,7 @@
 	TESTFLIGHT
 	{
 		name = NK-21
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-21]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.89
@@ -379,7 +384,7 @@
 	TESTFLIGHT
 	{
 		name = NK-19
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-19]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.89
@@ -396,7 +401,7 @@
 	TESTFLIGHT
 	{
 		name = NK-39
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-39]/ratedBurnTime$
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
@@ -411,7 +416,7 @@
 	TESTFLIGHT
 	{
 		name = NK-31
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-31]/ratedBurnTime$
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94

--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -68,6 +68,7 @@
 			name = ORM-65
 			minThrust = 0.510
 			maxThrust = 1.785
+			ratedBurnTime = 80
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -97,6 +98,7 @@
 			description = Simplified ORM-65 for the RP-318 rocket planes
 			minThrust = 0.499
 			maxThrust = 1.460
+			ratedBurnTime = 200
 			massMult = 0.86
 			heatProduction = 100
 			PROPELLANT
@@ -131,6 +133,7 @@
 			description = Uprated RDA-1-300, to allow the RP-318 to take off under its own power. Test site was overrun by the German army before it could be tested.
 			minThrust = 0.499
 			maxThrust = 2.942
+			ratedBurnTime = 200
 			massMult = 0.86
 			heatProduction = 100
 			PROPELLANT
@@ -167,7 +170,7 @@
 	{
 		//reliability largley copied from aerobee, too few tests of ORM-65 to get accurate reliability info
 		name = ORM-65
-		ratedBurnTime = 80
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[ORM-65]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.96
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -181,7 +184,7 @@
 	{
 		//was man rated and flew several times in rocket glider without major incident
 		name = RDA-1-150
-		ratedBurnTime = 200
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RDA-1-150]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -196,7 +199,7 @@
 	{
 		//same as RDA-1-150 due to lack of information
 		name = RDA-1-300
-		ratedBurnTime = 200
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RDA-1-300]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa

--- a/GameData/RealismOverhaul/Engine_Configs/PEWEE100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/PEWEE100_Config.cfg
@@ -50,6 +50,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 22				
 			maxThrust = 111	
+			ratedBurnTime = 2400
 			massMult = 1
 			heatProduction = 12
 			
@@ -111,7 +112,7 @@
 	TESTFLIGHT
 	{
 		name = PEWEE100-Hydrogen
-		ratedBurnTime = 2400 // 40 minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[PEWEE100-Hydrogen]/ratedBurnTime$ // 40 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/Phoebus1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Phoebus1_Config.cfg
@@ -51,6 +51,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 99				
 			maxThrust = 299				
+			ratedBurnTime = 2700
 			massMult = 1			
 			ignitions = 4
 			%ullage = True
@@ -109,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = Phoebus1N50-Hydrogen
-		ratedBurnTime = 2700 //45 minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Phoebus1N50-Hydrogen]/ratedBurnTime$ //45 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/Phoebus2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Phoebus2_Config.cfg
@@ -51,6 +51,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 228				
 			maxThrust = 913	
+			ratedBurnTime = 2700
 			massMult = 1			
 			ignitions = 8
 			%ullage = True
@@ -109,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = Phoebus2N100-Hydrogen
-		ratedBurnTime = 2700 //45 minutes (limited by hydrogen supply, assumed same as 1B)
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Phoebus2N100-Hydrogen]/ratedBurnTime$ //45 minutes (limited by hydrogen supply, assumed same as 1B)
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
@@ -100,6 +100,7 @@
 			description = 164:1 nozzle ratio version used on the Cassini probe
 			minThrust = 0.490
 			maxThrust = 0.490
+			ratedBurnTime = 12000
 			heatProduction = 10
 			massMult = 1.0
 			ullage = False
@@ -217,7 +218,7 @@
 	TESTFLIGHT
 	{
 		name = R-4D-11
-		ratedBurnTime = 12000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[R-4D-11]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD-0410NTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD-0410NTR_Config.cfg
@@ -80,6 +80,7 @@
 			ignitionThreshold = 0.1
 			minThrust = 0
 			maxThrust = 35.3
+			ratedBurnTime = 36000
 			massMult = 1
 			ignitions = 10
 			%ullage = True
@@ -157,7 +158,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0410MID-Hydrogen
-		ratedBurnTime = 36000 // 10 hours
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0410MID-Hydrogen]/ratedBurnTime$ // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
@@ -87,6 +87,7 @@
 			description = Modified RD-107 vernier for use as an independent upper stage for the R-7. Used on Luna and early Vostok rockets
 			minThrust = 49.4
 			maxThrust = 49.4
+			ratedBurnTime = 440
 			heatProduction = 100
 			massMult = 1.0
 
@@ -131,6 +132,7 @@
 			description = RD-0105 upgraded with increase reliability and performance for manned flight. Used on Vostok
 			minThrust = 54.5
 			maxThrust = 54.5
+			ratedBurnTime = 440
 			heatProduction = 100
 			massMult = 0.9307
 
@@ -186,7 +188,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0105
-		ratedBurnTime = 440
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0105]/ratedBurnTime$
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		ignitionDynPresFailMultiplier = 0.1
@@ -205,7 +207,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0109
-		ratedBurnTime = 440
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0109]/ratedBurnTime$
 		ignitionReliabilityStart = 0.966216
 		ignitionReliabilityEnd = 0.993243
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
@@ -76,6 +76,7 @@
 			name = RD-0110R
 			minThrust = 68.3
 			maxThrust = 68.3
+			ratedBurnTime = 250
 			gimbalRange = 42.0
 			massMult = 1.0
 			ullage = True
@@ -133,7 +134,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0110R
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110R]/ratedBurnTime$
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
@@ -77,6 +77,7 @@
 			name = RD-0110-Vernier
 			minThrust = 6.0
 			maxThrust = 6.0
+			ratedBurnTime = 250
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
@@ -120,7 +121,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0110-Vernier
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110-Vernier]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984362
 		ignitionReliabilityEnd = 0.996872
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
@@ -64,6 +64,7 @@
 			description = Upper stage for the R-7 developed from the RD-0106 booster engine. Used on Vostok and early Molniya rockets.
 			maxThrust = 297.9
 			minThrust = 269.69 //90.5%
+			ratedBurnTime = 250
 			massMult = 1.0
 			PROPELLANT
 			{
@@ -101,6 +102,7 @@
 			description = Developed for the upgraded Molniya-M, and later used on Soyuz.
 			maxThrust = 298.2
 			minThrust = 269.69 //90.5%
+			ratedBurnTime = 250
 			massMult = 1.0
 			PROPELLANT
 			{
@@ -162,7 +164,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0107
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0107]/ratedBurnTime$
 		ignitionReliabilityStart = 0.937870
 		ignitionReliabilityEnd = 0.987574
 		ignitionDynPresFailMultiplier = 0.1
@@ -187,7 +189,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0110
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984362
 		ignitionReliabilityEnd = 0.996872
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
@@ -78,6 +78,7 @@
 			name = RD-0120
 			minThrust = 882.45
 			maxThrust = 1961
+			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -110,6 +111,7 @@
 			name = RD-0120M
 			minThrust = 745.44
 			maxThrust = 1961.7
+			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -146,7 +148,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0120
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0120]/ratedBurnTime$
 		//Rated to 1670 seconds, but based on SSME would probably only be able to complete 1 burn (600s) before overhaul
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
@@ -161,7 +163,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0120M
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0120M]/ratedBurnTime$
 		//Rated to 1670 seconds, but based on SSME would probably only be able to complete 1 burn (600s) before overhaul
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
@@ -63,6 +63,7 @@
 			name = RD-0124
 			minThrust = 294.3
 			maxThrust = 294.3
+			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 1.0
 			PROPELLANT
@@ -119,7 +120,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0124
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0124]/ratedBurnTime$
 		ignitionReliabilityStart = 0.983607
 		ignitionReliabilityEnd = 0.996721
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
@@ -81,6 +81,7 @@
 			description = High performance upper stage engine for Proton. Tested extensively by KB Khimavtomatika and P&W, but never flew.
 			minThrust = 98.1
 			maxThrust = 98.1
+			ratedBurnTime = 1100
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -113,6 +114,7 @@
 			description = Upgrade, intended for Angara.
 			minThrust = 73.5
 			maxThrust = 73.5
+			ratedBurnTime = 1100
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -148,7 +150,7 @@
 	{
 		name = RD-0146
 		//Copied from RL10A-4-1-2
-		ratedBurnTime = 1100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0146]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.94968
@@ -166,7 +168,7 @@
 	{
 		name = RD-0146D
 		//Copied from RL10A-4-1-2
-		ratedBurnTime = 1100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0146D]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.94968

--- a/GameData/RealismOverhaul/Engine_Configs/RD0162_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0162_Config.cfg
@@ -78,6 +78,7 @@
 			name = RD-0162
 			minThrust = 995							 //45%
 			maxThrust = 2210
+			ratedBurnTime = 360
 			heatProduction = 100
 			PROPELLANT								 //OF 3.5
 			{
@@ -115,6 +116,7 @@
 			description = Variant uprated for 136% thrust.
 			minThrust = 1355						 //45%
 			maxThrust = 3011
+			ratedBurnTime = 240
 			heatProduction = 100
 			PROPELLANT								 //OF 3.5
 			{
@@ -163,7 +165,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0162
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0162]/ratedBurnTime$
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991
@@ -177,7 +179,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0162A
-		ratedBurnTime = 240
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0162A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991

--- a/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
@@ -64,6 +64,7 @@
 			name = RD-0164
 			minThrust = 1725		//45%
 			maxThrust = 3831
+			ratedBurnTime = 360
 			heatProduction = 100
 			PROPELLANT				//OF 3.5
 			{
@@ -112,7 +113,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0164
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0164]/ratedBurnTime$
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991

--- a/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
@@ -63,6 +63,7 @@
 			name = RD-0169
 			minThrust = 716
 			maxThrust = 716
+			ratedBurnTime = 720
 			heatProduction = 100
 			PROPELLANT								//OF 3.5
 			{
@@ -110,7 +111,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0169
-		ratedBurnTime = 720
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0169]/ratedBurnTime$
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991

--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -88,6 +88,7 @@
 			description = Used on the UR-500 second stage. AKA 8D411
 			minThrust = 574.05
 			maxThrust = 574.05
+			ratedBurnTime = 150
 			gimbalRange = 3.25
 			ullage = True
 			pressureFed = False
@@ -127,6 +128,7 @@
 			description = Slight upgrade for use on the Proton second stage. AKA 8D411K
 			minThrust = 584.77
 			maxThrust = 584.77
+			ratedBurnTime = 238
 			gimbalRange = 3.25
 			ullage = True
 			pressureFed = False
@@ -172,7 +174,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0208
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0208]/ratedBurnTime$
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		ignitionDynPresFailMultiplier = 0.1
@@ -206,7 +208,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0210
-		ratedBurnTime = 238
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0210]/ratedBurnTime$
 		ignitionReliabilityStart = 0.992063
 		ignitionReliabilityEnd = 0.998413
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -73,6 +73,7 @@
 			name = RD-0212
 			minThrust = 584.77
 			maxThrust = 584.77
+			ratedBurnTime = 250
 			gimbalRange = 45.0
 			ullage = True
 			pressureFed = False
@@ -133,7 +134,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0212
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0212]/ratedBurnTime$
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
@@ -66,6 +66,7 @@
 			name = RD-0213
 			minThrust = 582.1
 			maxThrust = 582.1
+			ratedBurnTime = 250
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -110,7 +111,7 @@
 	{
 		name = RD-0213
 		//Copied from RD-0212
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0213]/ratedBurnTime$
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -48,6 +48,7 @@
 			name = RD-0214
 			minThrust = 30.98
 			maxThrust = 30.98
+			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -91,7 +92,7 @@
 	{
 		name = RD-0214
 		//Copied from RD-0212
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0214]/ratedBurnTime$
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
@@ -68,6 +68,7 @@
 			name = RD-0242M2
 			minThrust = 30.0
 			maxThrust = 50.0
+			ratedBurnTime = 600
 			ullage = False
 			pressureFed = True
 			ignitions = 6
@@ -108,7 +109,7 @@
 	{
 		name = RD-0242M2
 		//Copied from RD-0212
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0242M2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.857
 		ignitionReliabilityEnd = 0.995
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -144,6 +144,7 @@
 			name = RD-100
 			minThrust = 307.0
 			maxThrust = 307.0
+			ratedBurnTime = 70
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -190,6 +191,7 @@
 			name = RD-101
 			minThrust = 404.0
 			maxThrust = 404.0
+			ratedBurnTime = 85
 			heatProduction = 45
 			massMult = 1.0
 			ullage = True
@@ -236,6 +238,7 @@
 			name = RD-102
 			minThrust = 428.0
 			maxThrust = 428.0
+			ratedBurnTime = 83
 			heatProduction = 45
 			massMult = 0.9966
 			ullage = True
@@ -282,6 +285,7 @@
 			name = RD-103
 			minThrust = 490.33
 			maxThrust = 490.33
+			ratedBurnTime = 130
 			heatProduction = 55
 			massMult = 0.9797
 			ullage = True
@@ -327,6 +331,7 @@
 			name = RD-103M
 			minThrust = 500.14
 			maxThrust = 500.14
+			ratedBurnTime = 140
 			heatProduction = 57
 			massMult = 0.9763
 			ullage = True
@@ -379,7 +384,7 @@
 	TESTFLIGHT
 	{
 		name = RD-100
-		ratedBurnTime = 70
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-100]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		ignitionDynPresFailMultiplier = 2.0
@@ -394,7 +399,7 @@
 	TESTFLIGHT
 	{
 		name = RD-101
-		ratedBurnTime = 85
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-101]/ratedBurnTime$
 		ignitionReliabilityStart = 0.86
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0
@@ -410,7 +415,7 @@
 	TESTFLIGHT
 	{
 		name = RD-102
-		ratedBurnTime = 83
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-102]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
 		ignitionDynPresFailMultiplier = 2.0
@@ -426,7 +431,7 @@
 	TESTFLIGHT
 	{
 		name = RD-103
-		ratedBurnTime = 130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-103]/ratedBurnTime$
 		ignitionReliabilityStart = 0.82
 		ignitionReliabilityEnd = 0.93
 		ignitionDynPresFailMultiplier = 2.0
@@ -442,7 +447,7 @@
 	TESTFLIGHT
 	{
 		name = RD-103M
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-103M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.84
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -203,6 +203,7 @@
 			description = Used on R-7 8K71
 			maxThrust = 1000.28
 			minThrust = 1000.28
+			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -255,6 +256,7 @@
 			description = Used on Sputnik 8K71PS
 			maxThrust = 972.3
 			minThrust = 972.3
+			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -307,6 +309,7 @@
 			description = Used on Sputnik 8A91
 			maxThrust = 972.8
 			minThrust = 972.8
+			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -359,6 +362,7 @@
 			description = Used on Luna 8K72
 			maxThrust = 996.4
 			minThrust = 996.4
+			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -411,6 +415,7 @@
 			description = Used on Vostok 8K72K
 			maxThrust = 996.4
 			minThrust = 996.4
+			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -463,6 +468,7 @@
 			description = Used on Molniya 8K78 and Voskhod 11A57-1
 			maxThrust = 995.37
 			minThrust = 995.37
+			ratedBurnTime = 140
 			massMult = 0.9912
 
 			ullage = True
@@ -515,6 +521,7 @@
 			description = Used on Molniya-M 8K78M and Soyuz 11A511
 			maxThrust = 995.37
 			minThrust = 995.37
+			ratedBurnTime = 140
 			massMult = 0.9912
 
 			ullage = True
@@ -567,6 +574,7 @@
 			description = Used on Soyuz-U 11A511U (also known as RD-117)
 			maxThrust = 977.72
 			minThrust = 977.72
+			ratedBurnTime = 140
 			massMult = 1.0396
 
 			ullage = True
@@ -620,6 +628,8 @@
 			maxThrust = 996.4
 			minThrust = 996.4
 
+			ratedBurnTime = 140
+
 			ullage = True
 			pressureFed = False
 			ignitions = 0
@@ -670,6 +680,7 @@
 			description = Used on Soyuz-FG
 			maxThrust = 1019.89
 			minThrust = 1019.89
+			ratedBurnTime = 140
 			massMult = 0.9427
 
 			ullage = True
@@ -736,7 +747,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74]/ratedBurnTime$
 		ignitionReliabilityStart = 0.915385
 		ignitionReliabilityEnd = 0.983077
 		cycleReliabilityStart = 0.915385
@@ -755,7 +766,7 @@
 	TESTFLIGHT
 	{	
 		name = RD-107-8D74PS
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74PS]/ratedBurnTime$
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
 		cycleReliabilityStart = 0.909091
@@ -774,7 +785,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D76
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D76]/ratedBurnTime$
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
@@ -793,7 +804,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74-1958
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74-1958]/ratedBurnTime$
 		ignitionReliabilityStart = 0.938462
 		ignitionReliabilityEnd = 0.987692
 		cycleReliabilityStart = 0.938462
@@ -811,7 +822,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74-1959
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74-1959]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
 		cycleReliabilityStart = 0.984848
@@ -830,7 +841,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74K
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999410
 		ignitionReliabilityEnd = 0.999882
 		cycleReliabilityStart = 0.999410
@@ -853,7 +864,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D728
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D728]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999286
 		ignitionReliabilityEnd = 0.999857
 		cycleReliabilityStart = 0.999286
@@ -871,7 +882,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-11D511
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-11D511]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999227
 		ignitionReliabilityEnd = 0.999845
 		cycleReliabilityStart = 0.999227
@@ -889,7 +900,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-11D511P
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-11D511P]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997230
 		ignitionReliabilityEnd = 0.999446
 		cycleReliabilityStart = 0.997230
@@ -909,7 +920,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107A-14D22
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107A-14D22]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997732
 		ignitionReliabilityEnd = 0.999546
 		cycleReliabilityStart = 0.997732

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -211,6 +211,7 @@
 			description = Used on R-7 8K71
 			maxThrust = 941.44
 			minThrust = 941.44
+			ratedBurnTime = 340
 			massMult = 1.0
 
 			ullage = True
@@ -263,6 +264,7 @@
 			description = Used on Sputnik 8K71PS
 			maxThrust = 918.3
 			minThrust = 918.3
+			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -315,6 +317,7 @@
 			description = Used on Sputnik 8A91
 			maxThrust = 803.2
 			minThrust = 803.2
+			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -367,6 +370,7 @@
 			description = Used on Luna 8K72
 			maxThrust = 945.4
 			minThrust = 945.4
+			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -419,6 +423,7 @@
 			description = Used on Vostok 8K72K
 			maxThrust = 941
 			minThrust = 941
+			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -471,6 +476,7 @@
 			description = Used on Molniya 8K78 and Voskhod 11A57-1
 			maxThrust = 941.47
 			minThrust = 941.47
+			ratedBurnTime = 340
 			massMult = 0.979
 
 			ullage = True
@@ -523,6 +529,7 @@
 			description = Used on Molniya-M 8K78M and Soyuz 11A511
 			maxThrust = 973.8
 			minThrust = 973.8
+			ratedBurnTime = 340
 			massMult = 0.9612
 
 			ullage = True
@@ -575,6 +582,7 @@
 			description = Used on Soyuz-U 11A511U (also known as RD-118)
 			maxThrust = 999.3
 			minThrust = 999.3
+			ratedBurnTime = 340
 			massMult = 1.0985
 
 			ullage = True
@@ -627,6 +635,7 @@
 			description = Used on Soyuz-U2 11A511U2 (also known as RD-118P)
 			maxThrust = 1011
 			minThrust = 1011
+			ratedBurnTime = 340
 			massMult = 1.0985
 
 			ullage = True
@@ -679,6 +688,7 @@
 			description = Used on Soyuz-FG
 			maxThrust = 990.47
 			minThrust = 990.47
+			ratedBurnTime = 340
 			massMult = 0.836
 
 			ullage = True
@@ -747,7 +757,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75]/ratedBurnTime$
 		ignitionReliabilityStart = 0.915385
 		ignitionReliabilityEnd = 0.983077
 		cycleReliabilityStart = 0.915385
@@ -765,7 +775,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75PS
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75PS]/ratedBurnTime$
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
 		cycleReliabilityStart = 0.909091
@@ -783,7 +793,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D77
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D77]/ratedBurnTime$
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
@@ -800,7 +810,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75-1958
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75-1958]/ratedBurnTime$
 		ignitionReliabilityStart = 0.938462
 		ignitionReliabilityEnd = 0.987692
 		cycleReliabilityStart = 0.938462
@@ -816,7 +826,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75-1959
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75-1959]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
 		cycleReliabilityStart = 0.984848
@@ -833,7 +843,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75K
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999410
 		ignitionReliabilityEnd = 0.999882
 		cycleReliabilityStart = 0.999410
@@ -854,7 +864,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D727
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D727]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999286
 		ignitionReliabilityEnd = 0.999857
 		cycleReliabilityStart = 0.999286
@@ -870,7 +880,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-11D512
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-11D512]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999227
 		ignitionReliabilityEnd = 0.999845
 		cycleReliabilityStart = 0.999227
@@ -886,7 +896,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-11D512P
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-11D512P]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997230
 		ignitionReliabilityEnd = 0.999446
 		cycleReliabilityStart = 0.997230
@@ -904,7 +914,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108A-14D21
-		ratedBurnTime = 340
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108A-14D21]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997732
 		ignitionReliabilityEnd = 0.999546
 		cycleReliabilityStart = 0.997732

--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -78,6 +78,7 @@
 			description = Prototype for the R-7 (8K73) project
 			minThrust = 101.6
 			maxThrust = 101.6
+			ratedBurnTime = 330
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -114,6 +115,7 @@
 			description = Upper stage for Kosmos-2 (11K63)
 			minThrust = 105.5
 			maxThrust = 105.5
+			ratedBurnTime = 260
 			massMult = 0.8	//168 kg
 			heatProduction = 100
 			PROPELLANT
@@ -153,7 +155,7 @@
 	TESTFLIGHT
 	{
 		name = RD-109-8D711
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-109-8D711]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.9
@@ -168,7 +170,7 @@
 	TESTFLIGHT
 	{
 		name = RD-119-8D710
-		ratedBurnTime = 260
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-119-8D710]/ratedBurnTime$
 		ignitionReliabilityStart = 0.952000
 		ignitionReliabilityEnd = 0.990400
 		cycleReliabilityStart = 0.952000

--- a/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
@@ -98,6 +98,7 @@
 			name = RD-120
 			minThrust = 583.49
 			maxThrust = 833.56
+			ratedBurnTime = 290
 			gimbalRange = 0
 			massMult = 1.0
 			ullage = True
@@ -142,6 +143,7 @@
 			name = RD-120F
 			minThrust = 583.49
 			maxThrust = 912.02
+			ratedBurnTime = 290
 			gimbalRange = 0
 			massMult = 1.0
 			ullage = True
@@ -186,6 +188,7 @@
 			name = RD-120K
 			minThrust = 416.78
 			maxThrust = 853.18
+			ratedBurnTime = 305
 			gimbalRange = 6.0
 			massMult = 0.96
 			ullage = True
@@ -245,7 +248,7 @@
 	TESTFLIGHT
 	{
 		name = RD-120
-		ratedBurnTime = 290		//Only burned for ~300s, but rated for 2200s
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-120]/ratedBurnTime$		//Only burned for ~300s, but rated for 2200s
 		ignitionReliabilityStart = 0.986111
 		ignitionReliabilityEnd = 0.997222
 		cycleReliabilityStart = 0.888889
@@ -259,7 +262,7 @@
 	TESTFLIGHT
 	{
 		name = RD-120K
-		ratedBurnTime = 305
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-120K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.92		//not much is known about this
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.92
@@ -280,7 +283,7 @@
 	TESTFLIGHT
 	{
 		name = RD-120F
-		ratedBurnTime = 290
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-120F]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988764
 		ignitionReliabilityEnd = 0.997753
 		cycleReliabilityStart = 0.977273

--- a/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
@@ -110,6 +110,7 @@
 			description = Used on Energia liquid rocket boosters
 			minThrust = 3953
 			maxThrust = 7904
+			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 1.02632
 			PROPELLANT
@@ -148,6 +149,7 @@
 			description = Used on Zenit, a rocket derived from Energia boosters
 			minThrust = 3953
 			maxThrust = 7904
+			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -185,6 +187,7 @@
 			description = Uprated RD-171 for the Vulkan ("Volcano"), baseline for the RD-180, RD-191 and it's derivatives.
 			minThrust = 3953
 			maxThrust = 8316 //[2]
+			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 1.07947
 			PROPELLANT
@@ -223,6 +226,7 @@
 			description = Modernized model for use on Zenit
 			minThrust = 3953
 			maxThrust = 7904
+			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 0.97894
 			PROPELLANT
@@ -273,7 +277,7 @@
 	TESTFLIGHT
 	{
 		name = RD-170
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-170]/ratedBurnTime$
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889
@@ -289,7 +293,7 @@
 	TESTFLIGHT
 	{
 		name = RD-171
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-171]/ratedBurnTime$
 		ignitionReliabilityStart = 0.944444
 		ignitionReliabilityEnd = 0.988889
 		cycleReliabilityStart = 0.944444
@@ -304,7 +308,7 @@
 	TESTFLIGHT
 	{
 		name = RD-172-173
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-172-173]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9384
@@ -320,7 +324,7 @@
 	TESTFLIGHT
 	{
 		name = RD-171M
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-171M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979592

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -67,6 +67,7 @@
 			name = RD-180
 			minThrust = 1951.44
 			maxThrust = 4152
+			ratedBurnTime = 255
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -119,7 +120,7 @@
 	TESTFLIGHT
 	{
 		name = RD-180
-		ratedBurnTime = 255
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-180]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889

--- a/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
@@ -94,6 +94,7 @@
 			name = RD-191
 			minThrust = 565
 			maxThrust = 2085
+			ratedBurnTime = 255
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -131,6 +132,7 @@
 			name = RD-151
 			minThrust = 565
 			maxThrust = 1918
+			ratedBurnTime = 255
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -168,6 +170,7 @@
 			description = Modified for the Antares to replace the NK-33.
 			minThrust = 980
 			maxThrust = 2085
+			ratedBurnTime = 255
 			heatProduction = 100
 			gimbalRange = 5
 			massMult = 0.9607
@@ -207,6 +210,7 @@
 			description = No gimbal, planned to replace the NK-33 on Soyuz 2-1v.
 			minThrust = 834
 			maxThrust = 2085
+			ratedBurnTime = 255
 			heatProduction = 100
 			gimbalRange = 0
 			massMult = 0.8297
@@ -260,7 +264,7 @@
 	{
 		name = RD-191
 		//Copied from RD-180
-		ratedBurnTime = 255
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-191]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
@@ -276,7 +280,7 @@
 	{
 		name = RD-151
 		//Copied from RD-180
-		ratedBurnTime = 255
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-151]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
@@ -294,7 +298,7 @@
 	{
 		name = RD-181
 		//Copied from RD-180
-		ratedBurnTime = 255
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-181]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
@@ -310,7 +314,7 @@
 	{
 		name = RD-193
 		//Copied from RD-180
-		ratedBurnTime = 255
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-193]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889

--- a/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
@@ -54,6 +54,7 @@
 			description = 
 			minThrust = 12.6
 			maxThrust = 12.6
+			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -120,7 +121,7 @@
 	{
 		//Over 100 flights in the Pe-2RD. Early flights had difficulty with ignitions
 		name = RD-1
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.7
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.8

--- a/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
@@ -69,6 +69,7 @@
 			description = First multi-chamber engine designed by Glushko, basis of RD-107/108 and RD-214
 			minThrust = 98.51
 			maxThrust = 98.51
+			ratedBurnTime = 605
 			heatProduction = 100
 			massMult = 1.0
 
@@ -118,7 +119,7 @@
 	TESTFLIGHT
 	{
 		name = RD-200
-		ratedBurnTime = 605		//Needs confirmation
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-200]/ratedBurnTime$		//Needs confirmation
 		ignitionReliabilityStart = 0.86
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -127,6 +127,7 @@
 			description = Prototype for the R-12 (8K63)
 			minThrust = 642.3
 			maxThrust = 642.3
+			ratedBurnTime = 122
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -175,6 +176,7 @@
 			description = Prototype for Buran cruise missile
 			minThrust = 437.0
 			maxThrust = 622.7
+			ratedBurnTime = 100
 			massMult = 1.01	//642 kg
 			heatProduction = 100
 			PROPELLANT
@@ -222,6 +224,7 @@
 			description = Prototype for Buran cruise missile
 			minThrust = 549.0
 			maxThrust = 749.2
+			ratedBurnTime = 110
 			massMult = 0.984	//625 kg
 			heatProduction = 100
 			PROPELLANT
@@ -269,6 +272,7 @@
 			description = Engine for the R-12 (8K63)
 			minThrust = 730.2
 			maxThrust = 730.2
+			ratedBurnTime = 140
 			massMult = 1.03	//625 kg
 			heatProduction = 100
 			PROPELLANT
@@ -316,6 +320,7 @@
 			description = Engine for the R-12U (8K63S) and Kosmos-2 (11K63)
 			minThrust = 730.6
 			maxThrust = 730.6
+			ratedBurnTime = 140
 			massMult = 1.03	//625 kg
 			heatProduction = 100
 			PROPELLANT
@@ -373,7 +378,7 @@
 	TESTFLIGHT
 	{
 		name = RD-211-8D57
-		ratedBurnTime = 122
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-211-8D57]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.94
 		cycleReliabilityStart = 0.75
@@ -388,7 +393,7 @@
 	TESTFLIGHT
 	{
 		name = RD-212-8D41
-		ratedBurnTime = 100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-212-8D41]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
 		cycleReliabilityStart = 0.8
@@ -403,7 +408,7 @@
 	TESTFLIGHT
 	{
 		name = RD-213-8D13
-		ratedBurnTime = 110
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-213-8D13]/ratedBurnTime$
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
 		cycleReliabilityStart = 0.8
@@ -418,7 +423,7 @@
 	TESTFLIGHT
 	{
 		name = RD-214-8D59
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-214-8D59]/ratedBurnTime$
 		ignitionReliabilityStart = 0.942308
 		ignitionReliabilityEnd = 0.988462
 		cycleReliabilityStart = 0.942308
@@ -436,7 +441,7 @@
 	TESTFLIGHT
 	{
 		name = RD-214U-8D59U
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-214U-8D59U]/ratedBurnTime$
 		ignitionReliabilityStart = 0.945455
 		ignitionReliabilityEnd = 0.989091
 		cycleReliabilityStart = 0.945455

--- a/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
@@ -151,6 +151,7 @@
 			description = Used on R-14 8K65 as RD-216
 			minThrust = 869.9
 			maxThrust = 869.9
+			ratedBurnTime = 146
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -187,6 +188,7 @@
 			description = Used on R-16 8K64 as RD-218
 			minThrust = 869.9
 			maxThrust = 869.9
+			ratedBurnTime = 90
 			massMult = 0.967	//653 kg
 			heatProduction = 100
 			PROPELLANT
@@ -222,6 +224,7 @@
 			description = Used on R-26 8K66 as RD-224
 			minThrust = 887.5
 			maxThrust = 887.5
+			ratedBurnTime = 120
 			massMult = 0.967	//653 kg
 			heatProduction = 100
 			PROPELLANT
@@ -257,6 +260,7 @@
 			description = Used on Kosmos-3M 8K65M as RD-216M
 			minThrust = 872.3
 			maxThrust = 872.3
+			ratedBurnTime = 146
 			massMult = 0.97		//655 kg
 			heatProduction = 100
 			PROPELLANT
@@ -292,6 +296,7 @@
 			description = Used on R-36 and Tsiklon-2 8K65M as RD-251
 			minThrust = 881.3
 			maxThrust = 881.3
+			ratedBurnTime = 120
 			heatProduction = 100
 			massMult = 0.853	//576 kg
 			PROPELLANT
@@ -327,6 +332,7 @@
 			description = Used on Tsiklon-2M and Tsiklon-3 11K68 as RD-261
 			minThrust = 882.6
 			maxThrust = 882.6
+			ratedBurnTime = 120
 			heatProduction = 100
 			massMult = 0.853	//576 kg
 			PROPELLANT
@@ -367,7 +373,7 @@
 	TESTFLIGHT
 	{
 		name = RD-215-8D513
-		ratedBurnTime = 146
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-215-8D513]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.96
 		cycleReliabilityStart = 0.88
@@ -384,7 +390,7 @@
 	TESTFLIGHT
 	{
 		name = RD-217-8D515
-		ratedBurnTime = 90
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-217-8D515]/ratedBurnTime$
 		ignitionReliabilityStart = 0.891667
 		ignitionReliabilityEnd = 0.978333
 		cycleReliabilityStart = 0.891667
@@ -401,7 +407,7 @@
 	TESTFLIGHT
 	{
 		name = RD-225-8D721
-		ratedBurnTime = 120
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-225-8D721]/ratedBurnTime$
 		ignitionReliabilityStart = 0.928
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.928
@@ -419,7 +425,7 @@
 	TESTFLIGHT
 	{
 		name = RD-215M-8D613
-		ratedBurnTime = 146
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-215M-8D613]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995506
 		ignitionReliabilityEnd = 0.999101
 		cycleReliabilityStart = 0.995506
@@ -440,7 +446,7 @@
 	TESTFLIGHT
 	{
 		name = RD-250-8D518
-		ratedBurnTime = 120
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-250-8D518]/ratedBurnTime$
 		ignitionReliabilityStart = 0.992701
 		ignitionReliabilityEnd = 0.998540
 		cycleReliabilityStart = 0.992701
@@ -458,7 +464,7 @@
 	TESTFLIGHT
 	{
 		name = RD-250PM
-		ratedBurnTime = 120
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-250PM]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997268
 		ignitionReliabilityEnd = 0.999454
 		cycleReliabilityStart = 0.997268

--- a/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
@@ -100,6 +100,7 @@
 			description = Used on R-16 8K64
 			minThrust = 882.6
 			maxThrust = 882.6
+			ratedBurnTime = 125
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -135,6 +136,7 @@
 			description = Used on R-36 and Tsiklon-2 8K67
 			minThrust = 940.8
 			maxThrust = 940.8
+			ratedBurnTime = 160
 			heatProduction = 100
 			massMult = 0.941	//715 kg
 			PROPELLANT
@@ -170,6 +172,7 @@
 			description = Used on Tsiklon-2M and Tsiklon-3 11K68
 			minThrust = 941.4
 			maxThrust = 941.4
+			ratedBurnTime = 160
 			heatProduction = 100
 			massMult = 0.957	//728 kg
 			PROPELLANT
@@ -208,7 +211,7 @@
 	TESTFLIGHT
 	{
 		name = RD-219-8D713
-		ratedBurnTime = 125
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-219-8D713]/ratedBurnTime$
 		ignitionReliabilityStart = 0.980769
 		ignitionReliabilityEnd = 0.996154
 		cycleReliabilityStart = 0.980769
@@ -225,7 +228,7 @@
 	TESTFLIGHT
 	{
 		name = RD-252-8D724
-		ratedBurnTime = 160
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-252-8D724]/ratedBurnTime$
 		ignitionReliabilityStart = 0.985401
 		ignitionReliabilityEnd = 0.997080
 		cycleReliabilityStart = 0.985401
@@ -241,7 +244,7 @@
 	TESTFLIGHT
 	{
 		name = RD-262-11D26
-		ratedBurnTime = 160
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-262-11D26]/ratedBurnTime$
 		ignitionReliabilityStart = 0.991803
 		ignitionReliabilityEnd = 0.998361
 		cycleReliabilityStart = 0.991803

--- a/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
@@ -143,6 +143,7 @@
 			name = RD-253
 			minThrust = 1545
 			maxThrust = 1545
+			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -176,6 +177,7 @@
 			name = RD-253-Mk2
 			minThrust = 1635
 			maxThrust = 1635
+			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -210,6 +212,7 @@
 			name = RD-253-Mk3
 			minThrust = 1698
 			maxThrust = 1698
+			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -243,6 +246,7 @@
 			name = RD-253-Mk4
 			minThrust = 1748
 			maxThrust = 1748
+			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -277,6 +281,7 @@
 			description = Mid-90s upgrade to improve performance of Proton
 			minThrust = 1746
 			maxThrust = 1746
+			ratedBurnTime = 129
 			heatProduction = 100
 			massMult = 0.99074 // 1.07
 			PROPELLANT
@@ -312,6 +317,7 @@
 			description = Modern upgrade to improve performance of Proton. AKA RD-276
 			minThrust = 1830
 			maxThrust = 1830
+			ratedBurnTime = 129
 			heatProduction = 100
 			massMult = 0.99074 // 1.07
 			PROPELLANT
@@ -365,7 +371,7 @@
 	TESTFLIGHT
 	{
 		name = RD-253
-		ratedBurnTime = 148
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -381,7 +387,7 @@
 	TESTFLIGHT
 	{
 		name = RD-253-Mk2
-		ratedBurnTime = 148
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -398,7 +404,7 @@
 	TESTFLIGHT
 	{
 		name = RD-253-Mk3
-		ratedBurnTime = 148
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -415,7 +421,7 @@
 	TESTFLIGHT
 	{
 		name = RD-253-Mk4
-		ratedBurnTime = 148
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -435,7 +441,7 @@
 	TESTFLIGHT
 	{
 		name = RD-275
-		ratedBurnTime = 129
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-275]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995261
 		ignitionReliabilityEnd = 0.999052
 		cycleReliabilityStart = 0.995261
@@ -456,7 +462,7 @@
 	TESTFLIGHT
 	{
 		name = RD-275M
-		ratedBurnTime = 129
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-275M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.997753
 		ignitionReliabilityEnd = 0.999551
 		cycleReliabilityStart = 0.997753

--- a/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
@@ -64,6 +64,7 @@
 			name = RD-270M
 			minThrust = 6443.1
 			maxThrust = 7159
+			ratedBurnTime = 148
 			heatProduction = 225
 			PROPELLANT
 			{
@@ -100,7 +101,7 @@
 	TESTFLIGHT
 	{
 		name = RD-270M
-		ratedBurnTime = 148
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-270M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713

--- a/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
@@ -64,6 +64,7 @@
 			name = RD-270
 			minThrust = 5644.8
 			maxThrust = 6272
+			ratedBurnTime = 148
 			heatProduction = 205
 			PROPELLANT
 			{
@@ -100,7 +101,7 @@
 	TESTFLIGHT
 	{
 		name = RD-270
-		ratedBurnTime = 148
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-270]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713

--- a/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
@@ -81,6 +81,7 @@
 			name = RD-57
 			minThrust = 78.46
 			maxThrust = 392.3
+			ratedBurnTime = 800
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -113,6 +114,7 @@
 			name = RD-57M
 			minThrust = 79.4 // some sources suggest min throttle is 303.0, this sounds unlikely. 
 			maxThrust = 397
+			ratedBurnTime = 800
 			heatProduction = 100
 			
 			PROPELLANT
@@ -151,7 +153,7 @@
 	{
 		name = RD-57
 		//Never flew, guess based on performance of similar KVD-1/RD-56
-		ratedBurnTime = 800
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-57]/ratedBurnTime$
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
 		cycleReliabilityStart = 0.500000
@@ -166,7 +168,7 @@
 	{
 		name = RD-57M
 		//Never flew, guess based on performance of similar KVD-1/RD-56
-		ratedBurnTime = 800
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-57M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.928571
 		ignitionReliabilityEnd = 0.985714
 		cycleReliabilityStart = 0.857143

--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -176,6 +176,7 @@
 			description = Used on Molnyia (Blok L)
 			minThrust = 63.7
 			maxThrust = 63.7
+			ratedBurnTime = 250
 			heatProduction = 100
 			massMult = 1.02
 
@@ -217,6 +218,7 @@
 			description = Developed version of S1.5400 engine for the Blok ML and Blok MVL stage of the Molniya-M launch vehicle. Slightly better performance.
 			minThrust = 66.7
 			maxThrust = 66.7
+			ratedBurnTime = 270
 			heatProduction = 100
 			massMult = 1.02
 
@@ -257,6 +259,7 @@
 			description = The S1.5400A engine, as used on Block 2BLM of the Molniya launch vehicle. Further performance improvements.
 			minThrust = 67.3
 			maxThrust = 67.3
+			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 0.9867
 
@@ -297,6 +300,7 @@
 			description = Upgrade developed for use on the Blok D stage of the N-1, and later used on Proton. Significant upgrade over the S1.5400
 			maxThrust = 83.36
 			minThrust = 83.36
+			ratedBurnTime = 600
 			heatProduction = 100
 			massMult = 1.534
 
@@ -337,6 +341,7 @@
 			description = Modification of the RD-58 for use on Proton Blok DM, after the N-1 was cancelled. 
 			maxThrust = 83.36
 			minThrust = 83.36
+			ratedBurnTime = 720
 			heatProduction = 100
 			massMult = 1.534
 
@@ -377,6 +382,7 @@
 			description = Modification of the RD-58 burning Syntin instead of Kerosene. Used on Proton (Blok DM-2M)
 			maxThrust = 86.3
 			minThrust = 86.3
+			ratedBurnTime = 680
 			heatProduction = 100
 			massMult = 1.534
 
@@ -417,6 +423,7 @@
 			description = Modification of the RD-58M with a Carbon Composite Nozzle extension for better vacuum performance. Used on Zenit Blok DM-SL.
 			maxThrust = 85
 			minThrust = 85
+			ratedBurnTime = 1200
 			heatProduction = 100
 			massMult = 1.6824
 
@@ -456,6 +463,7 @@
 			description = OMS engine for the Buran orbiter
 			maxThrust = 86.24
 			minThrust = 86.24
+			ratedBurnTime = 680
 			heatProduction = 100
 			massMult = 1.5333		// 230 kg
 
@@ -509,7 +517,7 @@
 	TESTFLIGHT
 	{
 		name = S1_5400
-		ratedBurnTime = 250
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S1_5400]/ratedBurnTime$
 		ignitionReliabilityStart = 0.952381
 		ignitionReliabilityEnd = 0.990476
 		ignitionDynPresFailMultiplier = 0.1
@@ -529,7 +537,7 @@
 	TESTFLIGHT
 	{
 		name = 11D33
-		ratedBurnTime = 270
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[11D33]/ratedBurnTime$
 		ignitionReliabilityStart = 0.982405
 		ignitionReliabilityEnd = 0.996481
 		ignitionDynPresFailMultiplier = 0.1
@@ -549,7 +557,7 @@
 	TESTFLIGHT
 	{
 		name = 11D33M
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[11D33M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
 		ignitionDynPresFailMultiplier = 0.1
@@ -568,7 +576,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58
-		ratedBurnTime = 600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58]/ratedBurnTime$
 		ignitionReliabilityStart = 0.954545
 		ignitionReliabilityEnd = 0.990909
 		ignitionDynPresFailMultiplier = 0.1
@@ -594,7 +602,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58M
-		ratedBurnTime = 720
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58M]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984733
 		ignitionReliabilityEnd = 0.996947
 		ignitionDynPresFailMultiplier = 0.1
@@ -615,7 +623,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58S
-		ratedBurnTime = 680
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58S]/ratedBurnTime$
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
 		ignitionDynPresFailMultiplier = 0.1
@@ -636,7 +644,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58M-CCN
-		ratedBurnTime = 1200
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58M-CCN]/ratedBurnTime$
 		ignitionReliabilityStart = 0.987654
 		ignitionReliabilityEnd = 0.997531
 		ignitionDynPresFailMultiplier = 0.1
@@ -652,7 +660,7 @@
 	TESTFLIGHT
 	{
 		name = 17D12
-		ratedBurnTime = 680
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[17D12]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.998
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
@@ -70,6 +70,7 @@
 			name = RD-805
 			minThrust = 19.6
 			maxThrust = 19.6
+			ratedBurnTime = 1100
 			heatProduction = 69
 			gimbalRange = 8.0
 			massMult = 1.0
@@ -130,7 +131,7 @@
 	TESTFLIGHT
 	{
 		name = RD-805
-		ratedBurnTime = 1100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-805]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.997
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
@@ -66,6 +66,7 @@
 			name = RD-855
 			maxThrust = 83
 			minThrust = 83
+			ratedBurnTime = 127
 			PROPELLANT
 			{
 				name = UDMH
@@ -100,7 +101,7 @@
 	{
 		name = RD-855
 		//Copied from RD-250
-		ratedBurnTime = 127
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-855]/ratedBurnTime$
 		ignitionReliabilityStart = 0.992701
 		ignitionReliabilityEnd = 0.998540
 		cycleReliabilityStart = 0.992701

--- a/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
@@ -75,6 +75,7 @@
 			name = RD-856
 			minThrust = 13.55
 			maxThrust = 13.55
+			ratedBurnTime = 163
 			heatProduction = 55
 			ullage = True
 			pressureFed = False
@@ -121,7 +122,7 @@
 	TESTFLIGHT
 	{
 		name = RD-856
-		ratedBurnTime = 163
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-856]/ratedBurnTime$
 		ignitionReliabilityStart = 0.985401
 		ignitionReliabilityEnd = 0.997080
 		cycleReliabilityStart = 0.985401

--- a/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
@@ -23,7 +23,7 @@
 //	Sources:
 
 //	Yuzhnoye Design Office - RD-8 engine:		http://www.yuzhnoye.com/en/technique/rocket-engines/steering/rd-8
-//	Norbert Brügge - Ukrainian rocket engines:	http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
+//	Norbert Brï¿½gge - Ukrainian rocket engines:	http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
 //	Encyclopedia Astronautica - RD-8 engine:	http://www.astronautix.com/r/rd-8.html
 
 //	Used by:
@@ -73,6 +73,7 @@
 			description = Vernier engine for the Zenit second stage.
 			minThrust = 78.44
 			maxThrust = 78.44
+			ratedBurnTime = 1100
 			gimbalRange = 33.0
 			massMult = 1.0
 			ullage = True
@@ -131,7 +132,7 @@
 	TESTFLIGHT
 	{
 		name = RD-8
-		ratedBurnTime = 1100
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-8]/ratedBurnTime$
 		ignitionReliabilityStart = 0.970588
 		ignitionReliabilityEnd = 0.994118
 		cycleReliabilityStart = 0.941176

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -315,6 +315,7 @@
 			name = RL10A-1
 			minThrust = 65.6
 			maxThrust = 65.6
+			ratedBurnTime = 430
 			heatProduction = 100
 			description = Prototype. Used for Early Atlas-Centaur launches. Very unreliable
 			PROPELLANT
@@ -348,6 +349,7 @@
 			name = RL10A-3-1
 			minThrust = 68.05
 			maxThrust = 68.05
+			ratedBurnTime = 470
 			heatProduction = 100
 			description = First production model of the RL10. Used for Atlas-Centaur and Saturn 1 launches.
 			PROPELLANT
@@ -381,6 +383,7 @@
 			name = RL10A-3-3
 			minThrust = 70.05
 			maxThrust = 70.05
+			ratedBurnTime = 470
 			heatProduction = 100
 			description = Upgraded model with slightly higher performance. Used for the majority of Atlas-Centaur D Launches.
 			PROPELLANT
@@ -414,6 +417,7 @@
 			name = RL10A-3-3-Lunex
 			minThrust = 11.5	//6:1 throttling goal
 			maxThrust = 69.4	//Some performance loss from extra baffling and hydrogen bleed assumed
+			ratedBurnTime = 600
 			heatProduction = 100
 			description = Speculative throttling configuration for the USAF Lunex lander
 			PROPELLANT
@@ -447,6 +451,7 @@
 			name = RL10A-3-3A
 			minThrust = 73.4
 			maxThrust = 73.4
+			ratedBurnTime = 550
 			heatProduction = 100
 			description = Heavily reworked turbopumps for higher performance on Atlas-Centaur G and Titan-Centaur.
 			PROPELLANT
@@ -480,6 +485,7 @@
 			name = RL10A-4
 			minThrust = 91.2
 			maxThrust = 91.2
+			ratedBurnTime = 392
 			heatProduction = 100
 			description = Reworked turbopumps, nozzle extenstion and electric TVC to improve performance for Atlas II
 			PROPELLANT
@@ -513,6 +519,7 @@
 			name = RL10A-4-1-2
 			minThrust = 97.9
 			maxThrust = 97.9
+			ratedBurnTime = 850
 			heatProduction = 100
 			description = Reworked turbopumps and improved performance for usage in a single & dual engine configuration on Atlas II & Atlas III & single engine configuration on Atlas V
 			PROPELLANT
@@ -546,6 +553,7 @@
 			name = RL10A-4-2N
 			minThrust = 99.2
 			maxThrust = 99.2
+			ratedBurnTime = 850
 			heatProduction = 100
 			description = Reworked turbopumps, nozzle extenstion and improved performance for usage in a single engine configuration on Atlas V
 			PROPELLANT
@@ -579,6 +587,7 @@
 			name = RL10A-5
 			minThrust = 19.4
 			maxThrust = 64.75
+			ratedBurnTime = 430
 			gimbalRange = 8.5 //average of 8 and 9 from 2 sources.
 			heatProduction = 100
 			description = Sea level RL10 for use on the Delta Clipper (DC-X) project.
@@ -613,6 +622,7 @@
 			name = RL10B-2
 			minThrust = 109.4
 			maxThrust = 109.4
+			ratedBurnTime = 1130
 			heatProduction = 100
 			description = Extremely large nozzle extenstion developed for Delta III, and used on Delta IV
 			PROPELLANT
@@ -646,6 +656,7 @@
 			name = RL10C-1
 			minThrust = 101.85
 			maxThrust = 101.85
+			ratedBurnTime = 1130
 			heatProduction = 100
 			description = Cost reduced model with modern production techniques, used in single or double engine configurations on Atlas V.
 			PROPELLANT
@@ -679,6 +690,7 @@
 			name = RL10C-1-1
 			minThrust = 105.9
 			maxThrust = 105.9
+			ratedBurnTime = 1200
 			heatProduction = 100
 			description = Planned upgrade of RL10C-1 for use on Vulcan-Centaur, OmegA, and later Atlas V launches
 			PROPELLANT
@@ -712,6 +724,7 @@
 			name = RL10C-2-1	//Mentioned as identical to the B-2, probably a cost-reduced drop-in replacement for DCSS
 			minThrust = 111.2 
 			maxThrust = 111.2
+			ratedBurnTime = 1130
 			heatProduction = 100
 			description = RL10B-2 using RL10C-1 components to reduce cost.
 			PROPELLANT
@@ -745,6 +758,7 @@
 			name = RL10C-3
 			minThrust = 108.5
 			maxThrust = 108.5
+			ratedBurnTime = 1350
 			heatProduction = 100
 			description = Man-rated for use on the EUS for Lunar missions.
 			PROPELLANT
@@ -778,6 +792,7 @@
 			name = CECE-Base
 			minThrust = 4.5 //15:1, target was 10-20:1 throttling
 			maxThrust = 67
+			ratedBurnTime = 10000
 			heatProduction = 100
 			description = Technology demonstrator, with deep throttling capability
 			PROPELLANT
@@ -811,6 +826,7 @@
 			name = CECE-High
 			minThrust = 110
 			maxThrust = 110
+			ratedBurnTime = 10000
 			heatProduction = 100
 			description = Technology Demonstrator, with extremely high performance turbopumps
 			PROPELLANT
@@ -844,6 +860,7 @@
 			name = CECE-Methane
 			minThrust = 17 //4:1, target was 3-5:1
 			maxThrust = 67
+			ratedBurnTime = 10000
 			heatProduction = 100
 			description = Technology demonstrator, modified to burn methane
 			PROPELLANT
@@ -883,7 +900,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-1
-		ratedBurnTime = 430
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -900,7 +917,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-1
-		ratedBurnTime = 470
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -925,7 +942,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3
-		ratedBurnTime = 470
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
 		cycleReliabilityStart = 0.989474
@@ -944,7 +961,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3-Lunex
-		ratedBurnTime = 600 //Longer burn time to account for throttling
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3-Lunex]/ratedBurnTime$ //Longer burn time to account for throttling
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
 		cycleReliabilityStart = 0.989474
@@ -967,7 +984,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3A
-		ratedBurnTime = 550
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
 		cycleReliabilityStart = 0.962963
@@ -989,7 +1006,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4
-		ratedBurnTime = 392
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995305
 		ignitionReliabilityEnd = 0.999061
 		cycleReliabilityStart = 0.990654
@@ -1021,7 +1038,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4-1-2
-		ratedBurnTime = 850
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-1-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
 		cycleReliabilityStart = 0.980000
@@ -1038,7 +1055,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4-2N
-		ratedBurnTime = 850
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-2N]/ratedBurnTime$
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
 		cycleReliabilityStart = 0.980000
@@ -1059,7 +1076,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-5
-		ratedBurnTime = 430
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.977273
 		ignitionReliabilityEnd = 0.995455
 		cycleReliabilityStart = 0.977273
@@ -1087,7 +1104,7 @@
 	TESTFLIGHT
 	{
 		name = RL10B-2
-		ratedBurnTime = 1130
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10B-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.988235
 		ignitionReliabilityEnd = 0.997647
 		cycleReliabilityStart = 0.952381
@@ -1115,7 +1132,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-1
-		ratedBurnTime = 1130 //is modified RL10B-2
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-1]/ratedBurnTime$ //is modified RL10B-2
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1134,7 +1151,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-1-1
-		ratedBurnTime = 1200 //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-1-1]/ratedBurnTime$ //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1153,7 +1170,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-2-1
-		ratedBurnTime = 1130 //is modified RL10B-2
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-2-1]/ratedBurnTime$ //is modified RL10B-2
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1172,7 +1189,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-3
-		ratedBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-3]/ratedBurnTime$ //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1189,7 +1206,7 @@
 	TESTFLIGHT
 	{
 		name = CECE-Base
-		ratedBurnTime = 10000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CECE-Base]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99975
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.99975 //total design reliability = 0.9995
@@ -1206,7 +1223,7 @@
 	TESTFLIGHT
 	{
 		name = CECE-High
-		ratedBurnTime = 10000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CECE-High]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99975
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.99975
@@ -1223,7 +1240,7 @@
 	TESTFLIGHT
 	{
 		name = CECE-Methane
-		ratedBurnTime = 10000
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CECE-Methane]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99975
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.99975

--- a/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
@@ -78,6 +78,7 @@
 			name = RL60
 			maxThrust = 267
 			minThrust = 267
+			ratedBurnTime = 4050
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -110,6 +111,7 @@
 			massMult = 1.100
 			maxThrust = 180
 			minThrust = 180
+			ratedBurnTime = 4050
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -145,7 +147,7 @@
 	TESTFLIGHT
 	{
 		name = RL60
-		ratedBurnTime = 4050
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL60]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98		//Copied from RL10B-2
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -163,7 +165,7 @@
 	TESTFLIGHT
 	{
 		name = Vinci-180
-		ratedBurnTime = 4050
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vinci-180]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98		//Copied from RL10B-2
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643

--- a/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
@@ -65,6 +65,7 @@
 			name = RS-2100
 			maxThrust = 2399.5
 			minThrust = 1320
+			ratedBurnTime = 450
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -105,7 +106,7 @@
 	TESTFLIGHT
 	{
 		name = RS-2100
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-2100]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -121,6 +121,7 @@
 			name = RS-68
 			maxThrust = 3370
 			minThrust = 1890
+			ratedBurnTime = 330
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -158,6 +159,7 @@
 			name = RS-68A
 			maxThrust = 3570
 			minThrust = 1820
+			ratedBurnTime = 330
 			heatProduction = 91
 			ullage = True
 			pressureFed = False
@@ -195,6 +197,7 @@
 			description = RS-68 upgrade with regeneratively cooled nozzle, allowing the engine to burn hotter.
 			maxThrust = 3647
 			minThrust = 2006
+			ratedBurnTime = 450
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -232,6 +235,7 @@
 			descriptions = Proposed upgrade for Delta IV
 			maxThrust = 4110
 			minThrust = 2261
+			ratedBurnTime = 450
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -316,7 +320,7 @@
 	TESTFLIGHT
 	{
 		name = RS-68
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-68]/ratedBurnTime$
 		ignitionReliabilityStart = 0.976744
 		ignitionReliabilityEnd = 0.995349
 		cycleReliabilityStart = 0.976744
@@ -335,7 +339,7 @@
 	TESTFLIGHT
 	{
 		name = RS-68A
-		ratedBurnTime = 330
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-68A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.976744
 		ignitionReliabilityEnd = 0.995349
 		cycleReliabilityStart = 0.976744
@@ -349,7 +353,7 @@
 	TESTFLIGHT
 	{
 		name = RS-68K
-		ratedBurnTime = 450						 //burntime increase due to regen cooled nozzle
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-68K]/ratedBurnTime$						 //burntime increase due to regen cooled nozzle
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -363,7 +367,7 @@
 	TESTFLIGHT
 	{
 		name = RS-800
-		ratedBurnTime = 450
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-800]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
@@ -67,6 +67,7 @@
 			name = RS-76
 			maxThrust = 4378.81
 			minThrust = 2846.23
+			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -166,7 +167,7 @@
 	TESTFLIGHT
 	{
 		name = RS-76
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-76]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RS83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS83_Config.cfg
@@ -69,6 +69,7 @@
 			name = RS-83
 			maxThrust = 3300
 			minThrust = 1650
+			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -113,7 +114,7 @@
 	TESTFLIGHT
 	{
 		name = RS-83
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-83]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RS84_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS84_Config.cfg
@@ -68,6 +68,7 @@
 			name = RS-84
 			maxThrust = 5026.49
 			minThrust = 3267.22
+			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -124,7 +125,7 @@
 	TESTFLIGHT
 	{
 		name = RS-84
-		ratedBurnTime = 500
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-84]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
@@ -85,6 +85,7 @@
 			name = RSRMV
 			minThrust = 15800 //Checked, 3550 klbf
 			maxThrust = 15800
+			ratedBurnTime = 126
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -320,7 +321,7 @@
 	TESTFLIGHT
 	{
 		name = RSRMV
-		ratedBurnTime = 126
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RSRMV]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995392

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -96,6 +96,7 @@
 			description = Original version of the RSRM, used on early shuttle launches
 			minThrust = 14819
 			maxThrust = 14819
+			ratedBurnTime = 138
 			heatProduction = 100
 			curveResource = PBAN
 			gimbalRange = 5.0
@@ -247,6 +248,7 @@
 			description = Redesigned RSRM, after Challenger disaster
 			minThrust = 14819
 			maxThrust = 14819
+			ratedBurnTime = 138
 			heatProduction = 100
 			curveResource = PBAN
 			gimbalRange = 5.0
@@ -400,7 +402,7 @@
 	TESTFLIGHT
 	{
 		name = RSRM-1981
-		ratedBurnTime = 138
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RSRM-1981]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.958333
@@ -416,7 +418,7 @@
 	TESTFLIGHT
 	{
 		name = RSRM-1986
-		ratedBurnTime = 138
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RSRM-1986]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995392

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -83,6 +83,7 @@
 			name = RZ20-Mk1
 			minThrust = 70 //16 klbf
 			maxThrust = 70
+			ratedBurnTime = 470
 			description = Prototype developed by Rolls-Royce
 			heatProduction = 100
 			PROPELLANT
@@ -115,6 +116,7 @@
 			name = RZ20-Mk2
 			minThrust = 72.56
 			maxThrust = 72.56
+			ratedBurnTime = 470
 			description = Increased expansion ratio proposal
 			heatProduction = 100
 			PROPELLANT
@@ -152,7 +154,7 @@
 	TESTFLIGHT
 	{
 		name = RZ20-Mk1
-		ratedBurnTime = 470
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ20-Mk1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -168,7 +170,7 @@
 	TESTFLIGHT
 	{
 		name = RZ20-Mk2
-		ratedBurnTime = 470
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ20-Mk2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
 		cycleReliabilityStart = 0.989474

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -93,6 +93,7 @@
 			description = License-Built version of the Rocketdyne S-3
 			minThrust = 696.6
 			maxThrust = 696.6
+			ratedBurnTime = 156
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -138,6 +139,7 @@
 			description = Production engine for the Blue Streak missile, based on the rocketdyne S-3D
 			minThrust = 763
 			maxThrust = 763
+			ratedBurnTime = 156
 			heatProduction = 100
 			massMult = 1.0
 
@@ -183,6 +185,7 @@
 			description = Uprated for Europa I and II
 			minThrust = 791.2
 			maxThrust = 791.2
+			ratedBurnTime = 156
 			heatProduction = 100
 			massMult = 1.0
 
@@ -241,7 +244,7 @@
 	TESTFLIGHT
 	{
 		name = RZ.1
-		ratedBurnTime = 156
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ.1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -257,7 +260,7 @@
 	{
 
 		name = RZ.2-Mk3
-		ratedBurnTime = 156
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ.2-Mk3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889
@@ -272,7 +275,7 @@
 	TESTFLIGHT
 	{
 		name = RZ.2-Mk4
-		ratedBurnTime = 156
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ.2-Mk4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.923077
 		ignitionReliabilityEnd = 0.984615
 		cycleReliabilityStart = 0.923077

--- a/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
@@ -105,6 +105,7 @@
 			name = Raptor //[6]
 			maxThrust = 1650
 			minThrust = 660 // 40% throttle [3]
+			ratedBurnTime = 1800
 			heatProduction = 100
 			PROPELLANT // Ratio = 3.55 [1]
 			{
@@ -151,6 +152,7 @@
 			name = Raptor Non-Throttleable // [7]
 			maxThrust = 3000
 			minThrust = 3000
+			ratedBurnTime = 1800
 			heatProduction = 100
 			PROPELLANT // Ratio = 3.55 [1]
 			{
@@ -197,6 +199,7 @@
 			name = Raptor Vacuum
 			maxThrust = 2240.0 // ~ Guess
 			minThrust = 896.0 // 40% throttle [3]
+			ratedBurnTime = 3600
 			heatProduction = 100
 			PROPELLANT // Ratio = 3.55 [1]
 			{
@@ -250,7 +253,7 @@
 	TESTFLIGHT
 	{
 		name = Raptor
-		ratedBurnTime = 1800 // ~ Guess to Allow it to Burn For 30 Minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Raptor]/ratedBurnTime$ // ~ Guess to Allow it to Burn For 30 Minutes
 		ignitionReliabilityStart = 0.98 // ~ Slight Chance of the Torch-lit system failing
 		ignitionReliabilityEnd = 0.995 // ~ Slight Chance of the Torch-lit system failing
 		cycleReliabilityStart = 0.99975
@@ -263,7 +266,7 @@
 	TESTFLIGHT
 	{
 		name = Raptor Non-Throttleable
-		ratedBurnTime = 1800 // ~ Guess to Allow it to Burn For 30 Minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Raptor Non-Throttleable]/ratedBurnTime$ // ~ Guess to Allow it to Burn For 30 Minutes
 		ignitionReliabilityStart = 0.98 // ~ Slight Chance of the Torch-lit system failing
 		ignitionReliabilityEnd = 0.995 // ~ Slight Chance of the Torch-lit system failing
 		cycleReliabilityStart = 0.99975
@@ -276,7 +279,7 @@
 	TESTFLIGHT
 	{
 		name = Raptor Vacuum
-		ratedBurnTime = 3600 // ~ Guess to Allow it to Burn For 1 Hour
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Raptor Vacuum]/ratedBurnTime$ // ~ Guess to Allow it to Burn For 1 Hour
 		ignitionReliabilityStart = 0.98 // ~ Slight Chance of the Torch-lit system failing
 		ignitionReliabilityEnd = 0.995 // ~ Slight Chance of the Torch-lit system failing
 		cycleReliabilityStart = 0.99975

--- a/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
@@ -78,6 +78,7 @@
 			name = Rubis
 			minThrust = 53
 			maxThrust = 53
+			ratedBurnTime = 45
 			heatProduction = 100
 
 			PROPELLANT
@@ -117,7 +118,7 @@
 	TESTFLIGHT
 	{
 		name = Rubis
-		ratedBurnTime = 45
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Rubis]/ratedBurnTime$
 		ignitionReliabilityStart = 0.75
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.75

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -63,6 +63,7 @@
 			name = Rutherford-SL
 			minThrust = 17.05	//Guess
 			maxThrust = 24.91
+			ratedBurnTime = 150
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -118,7 +119,7 @@
 	{
 		name = Rutherford-SL
 		//Simple and reliable engine, all failures due to other parts
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Rutherford-SL]/ratedBurnTime$
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
 		cycleReliabilityStart = 0.990826

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -63,6 +63,7 @@
 			name = RutherfordVac
 			minThrust = 17.5	//guess
 			maxThrust = 25.79
+			ratedBurnTime = 288
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -116,7 +117,7 @@
 	{
 		name = RutherfordVac
 		//Simple and reliable engine, all failures due to other parts
-		ratedBurnTime = 288
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RutherfordVac]/ratedBurnTime$
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
 		cycleReliabilityStart = 0.990826

--- a/GameData/RealismOverhaul/Engine_Configs/S155.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S155.cfg
@@ -52,6 +52,7 @@
 			name = S-155
 			minThrust = 19.5
 			maxThrust = 39
+			ratedBurnTime = 1200
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -92,7 +93,7 @@
 	TESTFLIGHT
 	{
 		name = S-155
-		ratedBurnTime = 1200	//Ye-50/3 contained 20 minutes of fuel
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S-155]/ratedBurnTime$	//Ye-50/3 contained 20 minutes of fuel
 		ignitionReliabilityStart = 0.857143
 		ignitionReliabilityEnd = 0.971429
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -117,6 +117,7 @@
 			description = Derived from the German Wasserfall engine, used on the R-11 (Scud-A)
 			minThrust = 93.3
 			maxThrust = 93.3
+			ratedBurnTime = 95
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -161,6 +162,7 @@
 			description = Pump-fed upgrade, used on the R-11MU and some R-17 prototypes. Never entered service
 			minThrust = 127.5
 			maxThrust = 127.5
+			ratedBurnTime = 65
 			heatProduction = 35
 			massMult = 0.53
 			ullage = True
@@ -205,6 +207,7 @@
 			description = Upgrade, used on the Production R-17 and R-17M missile, A.K.A Scud-B and Scud-C. This was the most heavily exported variant, and copies were built by many countries.
 			minThrust = 146.3
 			maxThrust = 146.3
+			ratedBurnTime = 75
 			heatProduction = 35
 			massMult = 0.53
 			ullage = True
@@ -249,6 +252,7 @@
 			description = Upgrade used for the R-17MU, A.K.A Scud-D. It saw very little use in the Soviet Union due to mediocore performance, so the remaining missiles were sold to North Korea, providing the basis for North Korean missile development.
 			minThrust = 165.5
 			maxThrust = 165.5
+			ratedBurnTime = 90
 			heatProduction = 35
 			massMult = 0.53
 			ullage = True
@@ -301,7 +305,7 @@
 	{
 		//R-11A Sounding Rocket. 26 successes, 0 failures 
 		name = S2.253
-		ratedBurnTime = 95
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S2.253]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -317,7 +321,7 @@
 	{
 		//no data, assumed same as S5.2
 		name = S3.42T
-		ratedBurnTime = 65
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S3.42T]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -333,7 +337,7 @@
 	{
 		//R-17 acceptance trials. 20 launches, 5 failures
 		name = S5.2
-		ratedBurnTime = 75
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S5.2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -349,7 +353,7 @@
 	{
 		//no data, assumed same as S5.2
 		name = Isayev-R17
-		ratedBurnTime = 90
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Isayev-R17]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5

--- a/GameData/RealismOverhaul/Engine_Configs/SNTPPFE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SNTPPFE_Config.cfg
@@ -68,6 +68,7 @@
 			description = LV-03/DE-01 technology demonstrator
 			minThrust = 41.2
 			maxThrust = 206
+			ratedBurnTime = 600
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			massMult = 1			
@@ -102,6 +103,7 @@
 			description = Production engine predicted performance. Increased core temperature to 3000K and Carbon-Carbon turbopumps to handle higher flow rates and inlet temperatures
 			minThrust = 49
 			maxThrust = 245.2
+			ratedBurnTime = 1050
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			massMult = 1
@@ -162,7 +164,7 @@
 	TESTFLIGHT
 	{
 		name = SNTPPFE100-Prototype
-		ratedBurnTime = 600 // 10 minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SNTPPFE100-Prototype]/ratedBurnTime$ // 10 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -180,7 +182,7 @@
 	TESTFLIGHT
 	{
 		name = SNTPPFE100
-		ratedBurnTime = 1050 // 17.5 minutes
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SNTPPFE100]/ratedBurnTime$ // 17.5 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997

--- a/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
@@ -78,6 +78,7 @@
 			name = SRMU
 			minThrust = 8233.777
 			maxThrust = 8233.777
+			ratedBurnTime = 145
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -164,7 +165,7 @@
 	TESTFLIGHT
 	{
 		name = SRMU
-		ratedBurnTime = 145
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SRMU]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.971429

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -114,6 +114,7 @@
 			description = Phase I SSME
 			minThrust = 1358.5
 			maxThrust = 2090
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -146,6 +147,7 @@
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
 			minThrust = 1358.5
 			maxThrust = 2173.6
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -178,6 +180,7 @@
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
 			minThrust = 1358.5
 			maxThrust = 2278.1
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -210,6 +213,7 @@
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
 			minThrust = 1358.5
 			maxThrust = 2319.9
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -246,7 +250,7 @@
 	TESTFLIGHT
 	{
 		name = RS-25
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25]/ratedBurnTime$
 		ignitionReliabilityStart = 0.966667
 		ignitionReliabilityEnd = 0.993333
 		cycleReliabilityStart = 0.983333
@@ -261,7 +265,7 @@
 	TESTFLIGHT
 	{
 		name = RS-25A
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.984127
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.994737
@@ -277,7 +281,7 @@
 	TESTFLIGHT
 	{
 		name = RS-25C
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25C]/ratedBurnTime$
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979167
@@ -293,7 +297,7 @@
 	TESTFLIGHT
 	{
 		name = RS-25D-E
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25D-E]/ratedBurnTime$
 		ignitionReliabilityStart = 0.989362
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362

--- a/GameData/RealismOverhaul/Engine_Configs/STBE1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STBE1_Config.cfg
@@ -92,6 +92,7 @@
 			name = STBE-1A
 			minThrust = 1475				//45%
 			maxThrust = 3275
+			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -128,6 +129,7 @@
 			name = STBE-1B
 			minThrust = 1475					//45%
 			maxThrust = 3273
+			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 1.001
 			PROPELLANT
@@ -165,6 +167,7 @@
 			name = STBE-3
 			minThrust = 1428						//45%
 			maxThrust = 3172
+			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 0.985
 			PROPELLANT								//OF 3.5
@@ -214,7 +217,7 @@
 	TESTFLIGHT
 	{
 		name = STBE-1A
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE-1A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995
@@ -227,7 +230,7 @@
 	TESTFLIGHT
 	{
 		name = STBE-1B
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE-1B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995
@@ -240,7 +243,7 @@
 	TESTFLIGHT
 	{
 		name = STBE-3
-		ratedBurnTime = 300
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995

--- a/GameData/RealismOverhaul/Engine_Configs/STBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STBE_Config.cfg
@@ -64,6 +64,7 @@
 			name = STBE
 			minThrust = 8896.4
 			maxThrust = 8896.4
+			ratedBurnTime = 315
 			PROPELLANT
 			{
 				name = Kerosene
@@ -109,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = STBE
-		ratedBurnTime = 315
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9371
 		ignitionReliabilityEnd = 0.9971
 		cycleReliabilityStart = 0.9371

--- a/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
@@ -64,6 +64,7 @@
 			name = STME
 			minThrust = 2023.9
 			maxThrust = 2891.3
+			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -99,7 +100,7 @@
 	TESTFLIGHT
 	{
 		name = STME
-		ratedBurnTime = 480
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STME]/ratedBurnTime$
 		ignitionReliabilityStart = 0.932
 		ignitionReliabilityEnd = 0.992
 		cycleReliabilityStart = 0.9415

--- a/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-13B
 			minThrust = 9.61
 			maxThrust = 9.61
+			ratedBurnTime = 16
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -312,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-13B
-		ratedBurnTime = 16
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-13B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-15G
 			minThrust = 12.5
 			maxThrust = 12.5
+			ratedBurnTime = 36
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -312,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-15G
-		ratedBurnTime = 36
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-15G]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-17A
 			minThrust = 17.4
 			maxThrust = 17.4
+			ratedBurnTime = 25
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -311,7 +312,7 @@
 	TESTFLIGHT
 	{
 		name = Star-17A
-		ratedBurnTime = 25
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-17A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-20
 			minThrust = 28.9
 			maxThrust = 28.9
+			ratedBurnTime = 31
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +314,7 @@
 	TESTFLIGHT
 	{
 		name = Star-20
-		ratedBurnTime = 31
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-20]/ratedBurnTime$
 		ignitionReliabilityStart = 0.972973
 		ignitionReliabilityEnd = 0.994595
 		cycleReliabilityStart = 0.972973

--- a/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
@@ -86,6 +86,7 @@
 			name = STAR-24C
 			minThrust = 21.35
 			maxThrust = 21.35
+			ratedBurnTime = 30
 			heatProduction = 123
 			gimbalRange = 0
 			masMult = 1.0
@@ -334,7 +335,7 @@
 	{
 		name = STAR-24C
 		isSolid = True
-		ratedBurnTime = 30
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-24C]/ratedBurnTime$
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.958

--- a/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
@@ -92,6 +92,7 @@
 			name = Star-27
 			minThrust = 28.2
 			maxThrust = 28.2
+			ratedBurnTime = 47
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -559,7 +560,7 @@
 	TESTFLIGHT
 	{
 		name = Star-27
-		ratedBurnTime = 47
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-27]/ratedBurnTime$
 		ignitionReliabilityStart = 0.983333
 		ignitionReliabilityEnd = 0.996667
 		cycleReliabilityStart = 0.983333

--- a/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-30BP
 			minThrust = 30.9
 			maxThrust = 30.9
+			ratedBurnTime = 55
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -312,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-30BP
-		ratedBurnTime = 55
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-30BP]/ratedBurnTime$
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.960000

--- a/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
@@ -78,6 +78,7 @@
 			name = Star-31
 			minThrust = 95.6
 			maxThrust = 95.6
+			ratedBurnTime = 51
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +314,7 @@
 	TESTFLIGHT
 	{
 		name = Star-31
-		ratedBurnTime = 51
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-31]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.90

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -90,6 +90,7 @@
 			name = STAR-37E
 			minThrust = 68.8
 			maxThrust = 68.8
+			ratedBurnTime = 42
 			heatProduction = 95
 			gimbalRange = 0
 			masMult = 1.0
@@ -337,7 +338,7 @@
 	{
 		name = STAR-37E
 		isSolid = True
-		ratedBurnTime = 42
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-37E]/ratedBurnTime$
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -86,6 +86,7 @@
 			name = STAR-37FM
 			minThrust = 54.8
 			maxThrust = 54.8
+			ratedBurnTime = 64
 			gimbalRange = 0
 			masMult = 1.0
 			ullage = False
@@ -331,7 +332,7 @@
 	{
 		name = STAR-37FM
 		isSolid = True
-		ratedBurnTime = 64
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-37FM]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -92,6 +92,7 @@
 			name = STAR-37
 			minThrust = 43.5
 			maxThrust = 43.5
+			ratedBurnTime = 42
 			heatProduction = 73
 			gimbalRange = 0
 			massMult = 1.0
@@ -339,7 +340,7 @@
 	{
 		name = STAR-37
 		isSolid = True
-		ratedBurnTime = 42
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-37]/ratedBurnTime$
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958

--- a/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
@@ -76,6 +76,7 @@
 			name = Star-3
 			minThrust = 2
 			maxThrust = 2
+			ratedBurnTime = 5
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -208,7 +209,7 @@
 	TESTFLIGHT
 	{
 		name = Star-3
-		ratedBurnTime = 5
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
@@ -112,6 +112,7 @@
 			name = Star-48B/Short
 			minThrust = 76.1
 			maxThrust = 76.1
+			ratedBurnTime = 90
 			heatProduction = 100
 			massMult = 0.9521
 			PROPELLANT
@@ -344,6 +345,7 @@
 			name = Star-48B/Long
 			minThrust = 78
 			maxThrust = 78
+			ratedBurnTime = 90
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -574,6 +576,7 @@
 		{
 			name = Star-48BV
 			maxThrust = 78
+			ratedBurnTime = 90
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -813,7 +816,7 @@
 	{
 		name = Star-48B/Short
 		isSolid = True
-		ratedBurnTime = 90
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-48B?Short]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
@@ -827,7 +830,7 @@
 	{
 		name = Star-48B/Long
 		isSolid = True
-		ratedBurnTime = 90
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-48B?Long]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
@@ -841,7 +844,7 @@
 	{
 		name = Star-48BV
 		isSolid = True
-		ratedBurnTime = 90
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-48BV]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958

--- a/GameData/RealismOverhaul/Engine_Configs/Star4G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star4G_Config.cfg
@@ -76,6 +76,7 @@
 			name = Star-4G
 			minThrust = 0.3
 			maxThrust = 0.3
+			ratedBurnTime = 10
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -311,7 +312,7 @@
 	TESTFLIGHT
 	{
 		name = Star-4G
-		ratedBurnTime = 10
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-4G]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
@@ -76,6 +76,7 @@
 			name = Star-5C
 			minThrust = 2.468
 			maxThrust = 2.468
+			ratedBurnTime = 3
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -310,7 +311,7 @@
 	TESTFLIGHT
 	{
 		name = Star-5C
-		ratedBurnTime = 3
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-5C]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-5D
 			minThrust = 6.272
 			maxThrust = 6.272
+			ratedBurnTime = 4
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -104,7 +105,7 @@
 	TESTFLIGHT
 	{
 		name = Star-5D
-		ratedBurnTime = 4
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-5D]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
@@ -76,6 +76,7 @@
 			name = Star-63D
 			minThrust = 119
 			maxThrust = 119
+			ratedBurnTime = 120
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -314,7 +315,7 @@
 	{
 		name = Star-63D
 		isSolid = True
-		ratedBurnTime = 120
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-63D]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star6B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star6B_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-6B
 			minThrust = 2.82
 			maxThrust = 2.82
+			ratedBurnTime = 8
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -312,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-6B
-		ratedBurnTime = 8
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-6B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
@@ -77,6 +77,7 @@
 			name = Star-8
 			minThrust = 7.749
 			maxThrust = 7.749
+			ratedBurnTime = 5
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -104,7 +105,7 @@
 	TESTFLIGHT
 	{
 		name = Star-8
-		ratedBurnTime = 5
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-8]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Star9_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star9_Config.cfg
@@ -78,6 +78,7 @@
 			name = Star-9
 			minThrust = 5.83
 			maxThrust = 5.83
+			ratedBurnTime = 10
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +314,7 @@
 	TESTFLIGHT
 	{
 		name = Star-9
-		ratedBurnTime = 10
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-9]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
@@ -66,6 +66,7 @@
 			description = Booster for the Blue Steel missile
 			minThrust = 110
 			maxThrust = 110
+			ratedBurnTime = 60
 			heatProduction = 100
 			massMult = 1.0
 
@@ -107,7 +108,7 @@
 	TESTFLIGHT
 	{
 		name = Stentor
-		ratedBurnTime = 60
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Stentor]/ratedBurnTime$
 
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207

--- a/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
@@ -65,6 +65,7 @@
 			name = SuperDraco
 			minThrust = 17.0
 			maxThrust = 85.0
+			ratedBurnTime = 350
 			heatProduction = 54
 
 			PROPELLANT
@@ -110,7 +111,7 @@
 	TESTFLIGHT
 	{
 		name = SuperDraco
-		ratedBurnTime = 350
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SuperDraco]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
@@ -70,6 +70,7 @@
 			name = TD-339
 			minThrust = 0.133
 			maxThrust = 0.462
+			ratedBurnTime = 495
 			heatProduction = 100
 			ullage = False
 			pressureFed = True
@@ -109,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = TD-339
-		ratedBurnTime = 495		//Enough to deplete fuel tanks at low throttle
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[TD-339]/ratedBurnTime$		//Enough to deplete fuel tanks at low throttle
 		ignitionReliabilityStart = 0.984127
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.954545

--- a/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
@@ -62,6 +62,7 @@
 			name = MR-80-TDE
 			minThrust = 0.276
 			maxThrust = 2.811
+			ratedBurnTime = 215
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -93,7 +94,7 @@
 	{
 		name = MR-80-TDE
 		//Extremely simple and reliable monopropellant engines
-		ratedBurnTime = 215
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MR-80-TDE]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/TR107_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TR107_Config.cfg
@@ -66,6 +66,7 @@
 			name = TR-107
 			maxThrust = 5323
 			minThrust = 3460
+			ratedBurnTime = 3600
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -121,7 +122,7 @@
 	TESTFLIGHT
 	{
 		name = TR-107
-		ratedBurnTime = 3600
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[TR-107]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
@@ -85,6 +85,7 @@
 			name = UA1204
 			minThrust = 4151.3
 			maxThrust = 4151.3
+			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -153,7 +154,7 @@
 	TESTFLIGHT
 	{
 		name = UA1204
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1204]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
@@ -84,6 +84,7 @@
 			name = UA1205
 			minThrust = 5338
 			maxThrust = 5338
+			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -151,7 +152,7 @@
 	TESTFLIGHT
 	{
 		name = UA1205
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1205]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
@@ -86,6 +86,7 @@
 			name = UA1206
 			minThrust = 6227
 			maxThrust = 6227
+			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -153,7 +154,7 @@
 	TESTFLIGHT
 	{
 		name = UA1206
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1206]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
@@ -86,6 +86,7 @@
 			name = UA1207
 			minThrust = 7450
 			maxThrust = 7450
+			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -147,7 +148,7 @@
 	TESTFLIGHT
 	{
 		name = UA1207
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1207]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
@@ -86,6 +86,7 @@
 			name = UA1208
 			minThrust = 7450
 			maxThrust = 7450
+			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -147,7 +148,7 @@
 	TESTFLIGHT
 	{
 		name = UA1208
-		ratedBurnTime = 135
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1208]/ratedBurnTime$
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737

--- a/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
@@ -101,6 +101,7 @@
 			description = Prototype, used for early tests
 			minThrust = 44.4
 			maxThrust = 44.4
+			ratedBurnTime = 6.5
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -146,6 +147,7 @@
 			description = Production Engine
 			minThrust = 44.4
 			maxThrust = 44.4
+			ratedBurnTime = 45
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -191,6 +193,7 @@
 			description = Turpentine fuel for increased performance
 			minThrust = 43.6
 			maxThrust = 43.6
+			ratedBurnTime = 49
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -236,6 +239,7 @@
 			description = Uprated version
 			minThrust = 65.3
 			maxThrust = 65.3
+			ratedBurnTime = 56
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -294,7 +298,7 @@
 	{
 		//7 successes, 1 failure
 		name = VeroniqueR
-		ratedBurnTime = 6.5
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[VeroniqueR]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.875000
@@ -308,7 +312,7 @@
 	{
 		//35 successes, 19 failures
 		name = Veronique
-		ratedBurnTime = 45
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Veronique]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.648148
@@ -322,7 +326,7 @@
 	{
 		//8 successes, 1 failure
 		name = VeroniqueAGI
-		ratedBurnTime = 49
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[VeroniqueAGI]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.888889
@@ -336,7 +340,7 @@
 	{
 		//21 successes, 0 failure
 		name = Veronique61
-		ratedBurnTime = 56
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Veronique61]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.954545

--- a/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
@@ -125,6 +125,7 @@
 			description = Used for the "Super-Veronique" Vesta sounding rocket. Has no gimbal
 			minThrust = 153.7
 			maxThrust = 153.7
+			ratedBurnTime = 56
 			heatProduction = 100
 			massMult = 1.0
 
@@ -168,6 +169,7 @@
 			description = First stage engine for the "precious stones" series of sounding rockets, culminating in the Diamant Launch Vehicle.
 			minThrust = 310.1
 			maxThrust = 310.1
+			ratedBurnTime = 96
 			heatProduction = 100
 			massMult = 1.0
 
@@ -211,6 +213,7 @@
 			description = Modified for vaccuum use and converted to UDMH/NTO as the second stage of the Europa Launch Vehicle.
 			minThrust = 262
 			maxThrust = 262
+			ratedBurnTime = 96
 			heatProduction = 100
 			massMult = 1.0
 
@@ -248,6 +251,7 @@
 			description = Upgraded version of Vexin, used in the first stage of the Amethyste sounding rocket and Diamant-B launch vehicle.
 			minThrust = 407.7
 			maxThrust = 407.7
+			ratedBurnTime = 110
 			heatProduction = 100
 			massMult = 1.0
 
@@ -287,6 +291,7 @@
 			description = Engine for the Diamant-BP first stage
 			minThrust = 373.5
 			maxThrust = 373.5
+			ratedBurnTime = 110
 			heatProduction = 100
 			massMult = 1.0
 
@@ -328,7 +333,7 @@
 	{
 		//5 successes, 0 failures
 		name = Vesta
-		ratedBurnTime = 56
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vesta]/ratedBurnTime$
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.9
 		cycleReliabilityStart = 0.833333
@@ -344,7 +349,7 @@
 		//Emeraude: 2 successes, 3 failures
 		//Diamant: 4 successes, 0 failures
 		name = Vexin
-		ratedBurnTime = 96
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vexin]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.666667
@@ -360,7 +365,7 @@
 		//Europa I: 3 successes, 2 failures
 		//Europa II: 1 success, 0 failures
 		name = Vexin-A
-		ratedBurnTime = 96
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vexin-A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.666667
@@ -375,7 +380,7 @@
 	{
 		//Diamant-B: 5 successes, 0 failures
 		name = Valois-A
-		ratedBurnTime = 110
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Valois-A]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.833333
@@ -390,7 +395,7 @@
 	{
 		//Diamant-BP.4: 3 successes, 0 failures
 		name = Valois-B
-		ratedBurnTime = 110
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Valois-B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.750000

--- a/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
@@ -44,6 +44,7 @@
 			description = License built copy of the European Viking-5 engine.
             minThrust = 680.5
             maxThrust = 680.5
+            ratedBurnTime = 154
             heatProduction = 100
             massMult = 0.9178
 
@@ -92,6 +93,7 @@
 			description = Uprated version of the Vikas-1.
             minThrust = 765.5
             maxThrust = 765.5
+            ratedBurnTime = 154
             heatProduction = 100
             massMult = 0.9178
 
@@ -140,6 +142,7 @@
 			description = License built copy of the Viking-4 vacuum engine.
             minThrust = 725
             maxThrust = 725
+            ratedBurnTime = 133
             heatProduction = 100
             massMult = 1.0
 
@@ -188,6 +191,7 @@
 			description = Uprated version of the Vikas-2.
             minThrust = 804.5
             maxThrust = 804.5
+            ratedBurnTime = 140
             heatProduction = 100
             massMult = 1.0
 
@@ -247,7 +251,7 @@
 	TESTFLIGHT
 	{
 		name = Vikas-1
-		ratedBurnTime = 154
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.94
@@ -259,7 +263,7 @@
 	TESTFLIGHT
 	{
 		name = Vikas-1+
-		ratedBurnTime = 154
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-1+]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9965
 		cycleReliabilityStart = 0.98
@@ -272,7 +276,7 @@
 	TESTFLIGHT
 	{
 		name = Vikas-2
-		ratedBurnTime = 133
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.94
@@ -284,7 +288,7 @@
 	TESTFLIGHT
 	{
 		name = Vikas-2B
-		ratedBurnTime = 140
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-2B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9965
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -135,6 +135,7 @@
 			description = First stage engine for Ariane 1
 			minThrust = 690
 			maxThrust = 690
+			ratedBurnTime = 145
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -183,6 +184,7 @@
 			description = Second stage engine for Ariane 1
 			minThrust = 713
 			maxThrust = 713
+			ratedBurnTime = 132
 			heatProduction = 100
 			massMult = 1.064
 			gimbalRange = 5.0
@@ -231,6 +233,7 @@
 			description = First stage engine for Ariane 2/3. Uses UH25 for extra performance.
 			minThrust = 720
 			maxThrust = 720
+			ratedBurnTime = 205
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -279,6 +282,7 @@
 			description = Second stage engine for Ariane 2/3/4. Uses UH25 for extra performance.
 			minThrust = 805
 			maxThrust = 805
+			ratedBurnTime = 125
 			heatProduction = 100
 			massMult = 1.064
 			gimbalRange = 5.0
@@ -327,6 +331,7 @@
 			description = First stage engine for Ariane 4
 			minThrust = 758
 			maxThrust = 758
+			ratedBurnTime = 205
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -375,6 +380,7 @@
 			description = Booster engine for Ariane 4
 			minThrust = 758
 			maxThrust = 758
+			ratedBurnTime = 142
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 0.0
@@ -429,7 +435,7 @@
 	{
 		//10 1st stage successes, 1 failure. 43 engines succeeded, 1 failed
 		name = Viking-2
-		ratedBurnTime = 145
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.976744
@@ -443,7 +449,7 @@
 	{
 		//9 2nd stage successes, 0 failure. 9 engines succeeded, 0 failed
 		name = Viking-4
-		ratedBurnTime = 132
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.9
@@ -458,7 +464,7 @@
 		//Ariane 2: 6 1st stage successes, 0 failure. 24 engines succeeded, 0 failed
 		//Ariane 3: 11 1st stage successes, 0 failure. 44 engines succeeded, 0 failed
 		name = Viking-2B
-		ratedBurnTime = 205
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-2B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.997
 		cycleReliabilityStart = 0.985294
@@ -474,7 +480,7 @@
 		//Ariane 3: 11 2nd stage successes, 0 failure. 11 engines succeeded, 0 failed
 		//Ariane 4: 115 2nd stage successes, 0 failures. 115 engines succeeded, 0 failed
 		name = Viking-4B
-		ratedBurnTime = 125
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4B]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.992424
@@ -488,7 +494,7 @@
 	{
 		//Ariane 4: 115 1st stage successes, 1 failures. 463 engines succeeded, 1 failed
 		name = Viking-5C
-		ratedBurnTime = 205
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-5C]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.997840
@@ -502,7 +508,7 @@
 	{
 		//Ariane 4: 238 booster stage successes, 0 failures. 238 engines succeeded, 0 failed
 		name = Viking-6
-		ratedBurnTime = 142
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-6]/ratedBurnTime$
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.995798

--- a/GameData/RealismOverhaul/Engine_Configs/Vulcain_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vulcain_Config.cfg
@@ -80,6 +80,7 @@
 			name = Vulcain
 			maxThrust = 1113
 			minThrust = 1113
+			ratedBurnTime = 580
 			massMult = 0.72
 			PROPELLANT
 			{
@@ -112,6 +113,7 @@
 			description = Upgrade, utilizing flim cooling and new turbopumps for higher thrust.
 			maxThrust = 1359
 			minThrust = 1359
+			ratedBurnTime = 580
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -145,7 +147,7 @@
 	TESTFLIGHT
 	{
 		name = Vulcain
-		ratedBurnTime = 580
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vulcain]/ratedBurnTime$
 		ignitionReliabilityStart = 0.961538
 		ignitionReliabilityEnd = 0.992308
 		cycleReliabilityStart = 0.961538
@@ -160,7 +162,7 @@
 	TESTFLIGHT
 	{
 		name = Vulcain-2
-		ratedBurnTime = 580
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vulcain-2]/ratedBurnTime$
 		ignitionReliabilityStart = 0.987952
 		ignitionReliabilityEnd = 0.997590
 		cycleReliabilityStart = 0.987952

--- a/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
@@ -71,6 +71,7 @@
 			name = Waxwing
 			minThrust = 34.35
 			maxThrust = 34.35
+			ratedBurnTime = 30
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -175,7 +176,7 @@
 	TESTFLIGHT
 	{
 		name = Waxwing
-		ratedBurnTime = 30
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Waxwing]/ratedBurnTime$
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.97

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -344,7 +344,7 @@
 //	TestFlight compatibility.
 //	==================================================
 
-@PART[*]:HAS[#engineType[X405],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
@@ -356,6 +356,9 @@
 		cycleReliabilityEnd = 0.94
 		techTransfer = A-4:10
 	}
+}
+@PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405H]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
 	TESTFLIGHT
 	{
 		name = X-405H
@@ -366,6 +369,9 @@
 		cycleReliabilityEnd = 0.96
 		techTransfer = X-405:50
 	}
+}
+@PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405H-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
 	TESTFLIGHT
 	{
 		// Copied from H-1.
@@ -377,6 +383,9 @@
 		cycleReliabilityEnd = 0.988
 		techTransfer = X-405,X-405H:50
 	}
+}
+@PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405H-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
 	TESTFLIGHT
 	{
 		// Copied from H-1b.

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -119,6 +119,7 @@
 			name = X-405
 			minThrust = 135.5
 			maxThrust = 135.5 // 27835lbf at sea level
+			ratedBurnTime = 145
 			heatProduction = 78
 			massMult = 1.0
 			ullage = True
@@ -171,6 +172,7 @@
 			name = X-405H
 			minThrust = 156.3
 			maxThrust = 156.3
+			ratedBurnTime = 245
 			heatProduction = 78
 			massMult = 1.141
 			ullage = True
@@ -225,6 +227,7 @@
 			description = Speculative upgrade configuration with increased expansion ratio
 			minThrust = 161.86
 			maxThrust = 161.86
+			ratedBurnTime = 245
 			heatProduction = 78
 			massMult = 1.15
 			ullage = True
@@ -279,6 +282,7 @@
 			description = Speculative upgrade configuration with increased chamber pressure and upgrades with late 1960s technology.
 			minThrust = 186.42
 			maxThrust = 186.42
+			ratedBurnTime = 245
 			heatProduction = 78
 			massMult = 1.15
 			ullage = True
@@ -345,7 +349,7 @@
 	TESTFLIGHT
 	{
 		name = X-405
-		ratedBurnTime = 145
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405]/ratedBurnTime$
 		ignitionReliabilityStart = 0.70
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.86
@@ -355,7 +359,7 @@
 	TESTFLIGHT
 	{
 		name = X-405H
-		ratedBurnTime = 245
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405H]/ratedBurnTime$
 		ignitionReliabilityStart = 0.80
 		ignitionReliabilityEnd = 0.94
 		cycleReliabilityStart = 0.86
@@ -366,7 +370,7 @@
 	{
 		// Copied from H-1.
 		name = X-405H-3
-		ratedBurnTime = 245
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405H-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.89
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.93
@@ -377,7 +381,7 @@
 	{
 		// Copied from H-1b.
 		name = X-405H-4
-		ratedBurnTime = 245
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405H-4]/ratedBurnTime$
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95

--- a/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
@@ -114,6 +114,7 @@
 			name = XLR11-RM-3
 			minThrust = 7.2
 			maxThrust = 28.80
+			ratedBurnTime = 150
 			massMult = 0.61
 			heatProduction = 100
 			pressureFed = True
@@ -140,6 +141,7 @@
 			name = XLR11-RM-5
 			minThrust = 7.2
 			maxThrust = 28.80
+			ratedBurnTime = 360
 			massMult = 1.0
 			heatProduction = 100
 			%pressureFed = False
@@ -173,6 +175,7 @@
 			name = XLR11-RM-13-8K
 			minThrust = 9.6125
 			maxThrust = 38.45
+			ratedBurnTime = 360
 			massMult = 1.0
 			heatProduction = 100
 			%pressureFed = False
@@ -206,6 +209,7 @@
 			name = XLR11-RM-13-10K	//Uprated version used in X-24B
 			minThrust = 11.77
 			maxThrust = 47.08
+			ratedBurnTime = 360
 			massMult = 1.0
 			heatProduction = 100
 			%pressureFed = False
@@ -241,7 +245,7 @@
 	TESTFLIGHT
 	{
 		name = XLR11-RM-3
-		ratedBurnTime = 150
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.987
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -254,7 +258,7 @@
 	TESTFLIGHT
 	{
 		name = XLR11-RM-5
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-5]/ratedBurnTime$
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.987
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -268,7 +272,7 @@
 	TESTFLIGHT
 	{
 		name = XLR11-RM-13-8K
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-13-8K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99	//Never failed to ignite on X-15
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -282,7 +286,7 @@
 	TESTFLIGHT
 	{
 		name = XLR11-RM-13-10K
-		ratedBurnTime = 360
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-13-10K]/ratedBurnTime$
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa

--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -60,6 +60,7 @@
 			name = XLR25-CW-1
 			minThrust = 12.02
 			maxThrust = 72.17
+			ratedBurnTime = 650
 			massMult = 1.0
 
 			%ullage = False
@@ -99,7 +100,7 @@
 	TESTFLIGHT
 	{
 		name = XLR25-CW-1
-		ratedBurnTime = 650 //175 at full thrust
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR25-CW-1]/ratedBurnTime$ //175 at full thrust
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
 		ignitionDynPresFailMultiplier = 50.0

--- a/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
@@ -75,6 +75,7 @@
 			chamberNominalTemp = 2923
 			minThrust = 333
 			maxThrust = 333
+			ratedBurnTime = 70
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
@@ -126,7 +127,7 @@
 	TESTFLIGHT
 	{
 		name = XLR41-NA-1
-		ratedBurnTime = 70
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR41-NA-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.89	//Almost identical to A-4. Never flew, so no data is availible
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.75

--- a/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
@@ -92,6 +92,7 @@
 			chamberNominalTemp = 2923
 			minThrust = 392.6
 			maxThrust = 392.6
+			ratedBurnTime = 60
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
@@ -136,6 +137,7 @@
 			name = XLR43-NA-3
 			minThrust = 617.4
 			maxThrust = 617.4
+			ratedBurnTime = 65
 			massMult = 0.73
 			ullage = True
 			pressureFed = False
@@ -181,7 +183,7 @@
 	TESTFLIGHT
 	{
 		name = XLR43-NA-1
-		ratedBurnTime = 60
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR43-NA-1]/ratedBurnTime$
 		ignitionReliabilityStart = 0.70	//Broadly the same performance of Redstone, slightly worse because it was first large single chamber engine
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.75
@@ -195,7 +197,7 @@
 	TESTFLIGHT
 	{
 		name = XLR43-NA-3
-		ratedBurnTime = 65
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR43-NA-3]/ratedBurnTime$
 		ignitionReliabilityStart = 0.80
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.80

--- a/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
@@ -58,6 +58,7 @@
 			name = XLR99
 			minThrust = 131.2
 			maxThrust = 262.4
+			ratedBurnTime = 2700
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -99,7 +100,7 @@
 	TESTFLIGHT
 	{
 		name = XLR99
-		ratedBurnTime = 2700 // "after one hour of operation, it required an overhaul" - but let's underspec a bit
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR99]/ratedBurnTime$ // "after one hour of operation, it required an overhaul" - but let's underspec a bit
 		// static-fired for long periods between refurb.
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.996 // pretty much all flights were successful, but ground tests failed

--- a/GameData/RealismOverhaul/Engine_Configs/YF-77.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/YF-77.cfg
@@ -47,6 +47,7 @@
 			name = YF-77
 			minThrust = 700
 			maxThrust = 700
+			ratedBurnTime = 485
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -75,7 +76,7 @@
 	TESTFLIGHT
 	{
 		name = YF-77
-		ratedBurnTime = 485 //20 extra for padding
+		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[YF-77]/ratedBurnTime$ //20 extra for padding
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa


### PR DESCRIPTION
This would allow showing engine rated burntimes in RF without even having a reliability mod installed. In the past this was done using a plugin which extracted the values directly from TF. AFAIK the code in that plugin has been broken for a while so it's better to get rid of it and move the burntime info directly to engine configs.