### PR TITLE
Add depth mask to Restock RCS quads

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_RCS.cfg
@@ -1,4 +1,4 @@
-@PART[RCSBlock]:FOR[RealismOverhaul]
+@PART[RCSBlock]:NEEDS[ReStock]:FOR[RealismOverhaul]
 {
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_RCS.cfg
@@ -1,0 +1,8 @@
+@PART[RCSBlock]:FOR[RealismOverhaul]
+{
+    MODULE
+    {
+        name = ModuleRestockDepthMask
+        maskTransform = 4Mask
+    }
+}


### PR DESCRIPTION
Without this patch, the nozzles appear solid/filled in.

Before:

![screenshot1](https://user-images.githubusercontent.com/35266431/111226877-1fdd3700-85b8-11eb-9f2c-d48617522219.png)

After:

![screenshot2](https://user-images.githubusercontent.com/35266431/111226900-25d31800-85b8-11eb-9298-9887735499a5.png)

