### PR TITLE
Rework all the ratedBurnTime patches

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
@@ -195,6 +195,7 @@
 
 		techTransfer = 
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Config_Name_1] { %ratedBurnTime = #$/TESTFLIGHT[Config_Name_1]/ratedBurnTime$ } }
 }
 
 // x launches, x failures. x Engines succeeded, x failed
@@ -217,4 +218,5 @@
 
 		reliabilityDataRateMultiplier = 2	//increases rate at which data is gathered
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Config_Name_2] { %ratedBurnTime = #$/TESTFLIGHT[Config_Name_2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
@@ -80,7 +80,6 @@
 			name = A-4
 			maxThrust = 311.8
 			minThrust = 311.8
-			ratedBurnTime = 70
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
 	
@@ -126,7 +125,6 @@
 			name = A-9
 			maxThrust = 288.68
 			minThrust = 288.68
-			ratedBurnTime = 115
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
 			//speculative = fictional
@@ -174,13 +172,14 @@
 	TESTFLIGHT
 	{
 		name = A-4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-4]/ratedBurnTime$
+		ratedBurnTime = 70
 		ignitionReliabilityStart = 0.89 // a bit worse than Hermes
 		ignitionReliabilityEnd = 0.97 // a bit better than Hermes, combined with cycle leads to V-2 total reliability
 		ignitionDynPresFailMultiplier = 2.0 // fairly robust
 		cycleReliabilityStart = 0.75 // broadly in line with Hermes
 		cycleReliabilityEnd = 0.95 // higher than achieved for Hermes/Bumper, but on track with total V-2 launches
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[A-4] { %ratedBurnTime = #$/TESTFLIGHT[A-4]/ratedBurnTime$ } }
 }
 //no data, never flew
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[A-9]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -188,11 +187,12 @@
 	TESTFLIGHT
 	{
 		name = A-9
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-9]/ratedBurnTime$
+		ratedBurnTime = 115
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.9
 		ignitionDynPresFailMultiplier = 4.0
 		cycleReliabilityStart = 0.73
 		cycleReliabilityEnd = 0.9
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[A-9] { %ratedBurnTime = #$/TESTFLIGHT[A-9]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -75,7 +75,6 @@
 			name = AJ10-137
 			minThrust = 90.0
 			maxThrust = 90.0
-			ratedBurnTime = 750
 			heatProduction = 38
 			gimbalRange = 4.5
 
@@ -134,11 +133,12 @@
 	TESTFLIGHT
 	{
 		name = AJ10-137
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-137]/ratedBurnTime$
+		ratedBurnTime = 750
 		ignitionReliabilityStart = 0.987342
 		ignitionReliabilityEnd = 0.997468
 		cycleReliabilityStart = 0.944444
 		cycleReliabilityEnd = 0.998889
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-138:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-137] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-137]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -91,7 +91,6 @@
 			name = AJ10-190-OMS
 			minThrust = 26.7
 			maxThrust = 26.7
-			ratedBurnTime = 3600
 			heatProduction = 28
 			massMult = 1.0
 			ullage = False
@@ -129,7 +128,6 @@
 			name = AJ10-190-Orion
 			minThrust = 33.4
 			maxThrust = 33.4
-			ratedBurnTime = 3600
 			massMult = 1.0
 			ullage = False
 			pressureFed = True
@@ -176,13 +174,14 @@
 	TESTFLIGHT
 	{
 		name = AJ10-190-OMS
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-190-OMS]/ratedBurnTime$
+		ratedBurnTime = 3600
 		ignitionReliabilityStart = 0.998758
 		ignitionReliabilityEnd = 0.999752
 		cycleReliabilityStart = 0.996283
 		cycleReliabilityEnd = 0.999257
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-190-OMS] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-190-OMS]/ratedBurnTime$ } }
 }
 //no data, never flown
 //assumed to be the same as shuttle OMS
@@ -191,11 +190,12 @@
 	TESTFLIGHT
 	{
 		name = AJ10-190-Orion
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-190-Orion]/ratedBurnTime$
+		ratedBurnTime = 3600
 		ignitionReliabilityStart = 0.998758
 		ignitionReliabilityEnd = 0.999752
 		cycleReliabilityStart = 0.996283
 		cycleReliabilityEnd = 0.999257
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-190-Orion] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-190-Orion]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -104,7 +104,6 @@
 			description = Upper Stage engine used on the Titan Transtage
 			maxThrust = 35.585
 			minThrust = 35.585
-			ratedBurnTime = 450
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -143,7 +142,6 @@
 			description = Delta-F Upper Stage Engine
 			minThrust = 42.3
 			maxThrust = 42.3
-			ratedBurnTime = 450
 			heatProduction = 100
 
 			PROPELLANT
@@ -186,7 +184,6 @@
 			description = Upper stage engine for the Delta-K
 			minThrust = 43.7
 			maxThrust = 43.7
-			ratedBurnTime = 450
 			heatProduction = 100
 
 			PROPELLANT
@@ -227,7 +224,6 @@
 			description = AJ10 variant burning liquid hydrogen and oxygen, proposed for use on the GE D-2 Apollo vehicle.
 			minThrust = 26.67
 			maxThrust = 26.67
-			ratedBurnTime = 546
 			heatProduction = 100
 			
 			PROPELLANT
@@ -271,13 +267,14 @@
 	TESTFLIGHT
 	{
 		name = AJ10-138
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-138]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.992424
 		ignitionReliabilityEnd = 0.998485
 		cycleReliabilityStart = 0.893617
 		cycleReliabilityEnd = 0.978723
 		techTransfer = AJ10-104,AJ10-118E:15	// New dual design lead to many early growing pains issues
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-138] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-138]/ratedBurnTime$ } }
 }
 //Delta 300: 3 flights, 1 failure
 //Delta 900: 2 flights, 0 failures
@@ -291,13 +288,14 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118F
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118F]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.923077
 		ignitionReliabilityEnd = 0.984615
 		cycleReliabilityStart = 0.875000	// 1 failure out of 8 flights
 		cycleReliabilityEnd = 0.975000
 		techTransfer = AJ10-138,AJ10-118E:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118F] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118F]/ratedBurnTime$ } }
 }
 //170 flights, 0 failures
 //Used for many different missions, with and without a third stage. Assuming 1.5 ignitions average
@@ -307,23 +305,25 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118K]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.996094
 		ignitionReliabilityEnd = 0.999219
 		cycleReliabilityStart = 0.994152
 		cycleReliabilityEnd = 0.998830
 		techTransfer = AJ10-138,AJ10-118E,AJ10-118F:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118K] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118K]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-133-LH]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ10-133-LH
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-133-LH]/ratedBurnTime$
+		ratedBurnTime = 546
 		ignitionReliabilityStart = 0.96
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985		//Reliable but not incredibly so 4 were used for a reason
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-133-LH] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-133-LH]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -145,7 +145,6 @@
 			description = Developed for the upper stage of the Vanguard launch vehicle.
 			minThrust = 33.8
 			maxThrust = 33.8
-			ratedBurnTime = 115
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -179,7 +178,6 @@
 			description = More reliable version of the AJ10-37 used on the Able Upper Stage.
 			minThrust = 33.0
 			maxThrust = 33.0
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -213,7 +211,6 @@
 			description = Used on the improved version of the Able upper stage for Thor-Able and Atlas-Able.
 			minThrust = 33.4
 			maxThrust = 33.4
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -247,7 +244,6 @@
 			description = Used as the upper stage engine on the very late Thor-Able and very early Thor-Delta launch vehicles.
 			minThrust = 34.25
 			maxThrust = 34.25
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -281,7 +277,6 @@
 			description = Second stage engine for the Thor-Delta A.
 			minThrust = 33.1
 			maxThrust = 33.1
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -314,7 +309,6 @@
 			name = AJ10-118D
 			minThrust = 33.7
 			maxThrust = 33.7
-			ratedBurnTime = 180
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -351,7 +345,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-37
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-37]/ratedBurnTime$
+			ratedBurnTime = 115
 			ignitionReliabilityStart = 0.888889
 			ignitionReliabilityEnd = 0.977778
 			cycleReliabilityStart = 0.555556
@@ -359,6 +353,7 @@
 
 			techTransfer = WAC-Corporal,XASR-1,AJ10-27:10
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-37] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-37]/ratedBurnTime$ } }
 }
 //Thor-Able (various versions): 13 flights, 0 failures.
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-42]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -366,7 +361,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-42
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-42]/ratedBurnTime$
+			ratedBurnTime = 150
 			ignitionReliabilityStart = 0.928571
 			ignitionReliabilityEnd = 0.985714
 			cycleReliabilityStart = 0.928571
@@ -374,6 +369,7 @@
 
 			techTransfer = AJ10-37:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-42] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-42]/ratedBurnTime$ } }
 }
 
 //Delta: 12 Flights, 1 failure. 1 ignition failure
@@ -382,7 +378,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-142
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-142]/ratedBurnTime$
+			ratedBurnTime = 150
 			ignitionReliabilityStart = 0.916667
 			ignitionReliabilityEnd = 0.983333
 			cycleReliabilityStart = 0.916667
@@ -390,6 +386,7 @@
 
 			techTransfer = AJ10-37,AJ10-42:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-142] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-142]/ratedBurnTime$ } }
 }
 //Atlas-D Able: 1 Flight, 1 failure. 1 Ignition failure
 //Thor Able-3: 1 Flight, 0 failures.
@@ -399,7 +396,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-101A
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-101A]/ratedBurnTime$
+			ratedBurnTime = 150
 			ignitionReliabilityStart = 0.916667
 			ignitionReliabilityEnd = 0.983333
 			cycleReliabilityStart = 0.916667
@@ -407,6 +404,7 @@
 
 			techTransfer = AJ10-37,AJ10-42:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-101A] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-101A]/ratedBurnTime$ } }
 }
 //Delta-A: 2 flights, 0 failures.
 //due to very little data, using average of AJ10-142 and AJ10-118D
@@ -415,7 +413,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-118
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118]/ratedBurnTime$
+			ratedBurnTime = 150
 			ignitionReliabilityStart = 0.9398
 			ignitionReliabilityEnd = 0.9879
 			cycleReliabilityStart = 0.9398
@@ -423,6 +421,7 @@
 
 			techTransfer = AJ10-37,AJ10-42,AJ10-142:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118]/ratedBurnTime$ } }
 }
 //Delta-B: 9 flights, 0 failures
 //Delta-C: 11 flights, 0 failures
@@ -436,7 +435,7 @@
 	TESTFLIGHT
 	{
 			name = AJ10-118D
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118D]/ratedBurnTime$
+			ratedBurnTime = 180
 			ignitionReliabilityStart = 0.962963
 			ignitionReliabilityEnd = 0.992593
 			cycleReliabilityStart = 0.962963
@@ -444,4 +443,5 @@
 
 			techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118D] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118D]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
@@ -83,7 +83,6 @@
 			description = The AJ10-104 was used on the Thor-Able-Star and it was the first upper stage engine with the ability to restart.
 			minThrust = 35.1
 			maxThrust = 35.1
-			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -118,7 +117,6 @@
 			description = Upgrade to the AJ10-118 used on the Delta E-N upper stages.
 			minThrust = 35.2
 			maxThrust = 35.2
-			ratedBurnTime = 400
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -164,7 +162,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-104
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-104]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.967742
 		ignitionReliabilityEnd = 0.993548
 		ignitionDynPresFailMultiplier = 0.1
@@ -172,6 +170,7 @@
 		cycleReliabilityEnd = 0.966667
 		techTransfer = AJ10-37,AJ10-42,AJ10-142:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-104] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-104]/ratedBurnTime$ } }
 }
 
 # Test Flight data (400 second burn time) taken from here: http://www.astronautix.com/a/aj10-118e.html
@@ -195,7 +194,7 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118E
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118E]/ratedBurnTime$
+		ratedBurnTime = 400
 		ignitionReliabilityStart = 0.986301
 		ignitionReliabilityEnd = 0.997260
 		ignitionDynPresFailMultiplier = 0.1
@@ -204,4 +203,5 @@
 		techTransfer =	AJ10-37,AJ10-104,AJ10-42,AJ10-142:50
 		reliabilityDataRateMultiplier = 2
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118E] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118E]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Transtar_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Transtar_Config.cfg
@@ -115,7 +115,6 @@
 			description = Planned upgrade for space shuttle OMS, cancelled after Challenger disaster
 			minThrust = 26.7
 			maxThrust = 26.7
-			ratedBurnTime = 54000
 			heatProduction = 28
 			massMult = 2.58
 			ullage = False
@@ -154,7 +153,6 @@
 			description = Engine for Transtar I, a high performance upper stage
 			minThrust = 16.7
 			maxThrust = 16.7
-			ratedBurnTime = 3600
 			heatProduction = 28
 			massMult = 1.02
 			ullage = False
@@ -193,7 +191,6 @@
 			description = Hydrolox engine, for high performance reusable space shuttle upper stages
 			minThrust = 13.3
 			maxThrust = 13.3
-			ratedBurnTime = 72000
 			heatProduction = 28
 			massMult = 0.72
 			ullage = False
@@ -230,7 +227,6 @@
 			description = Engine for Transtar III, reusable upgrade of Transtar I
 			minThrust = 16.7
 			maxThrust = 16.7
-			ratedBurnTime = 54000
 			heatProduction = 28
 			massMult = 0.83
 			ullage = False
@@ -275,50 +271,54 @@
 	TESTFLIGHT
 	{
 		name = AJ10-151-OMS		//Same reliability as Shuttle OMS
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-151-OMS]/ratedBurnTime$
+		ratedBurnTime = 54000
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-151-OMS] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-151-OMS]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-153]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ10-153		//Same reliability as AJ10-118K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-153]/ratedBurnTime$
+		ratedBurnTime = 3600
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.9625
 		cycleReliabilityEnd = 0.995
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-153] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-153]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-154]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ10-154
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-154]/ratedBurnTime$
+		ratedBurnTime = 72000
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.9625
 		cycleReliabilityEnd = 0.995
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-133-LH,AJ10-137,AJ10-138,AJ10-190-OMS:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-154] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-154]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-156]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ10-156
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-156]/ratedBurnTime$
+		ratedBurnTime = 54000
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.9625
 		cycleReliabilityEnd = 0.9999
 		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-156] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-156]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -93,7 +93,6 @@
 			name = AJ-60A
 			minThrust = 1688.4
 			maxThrust = 1688.4
-			ratedBurnTime = 94
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -333,7 +332,6 @@
 			name = AJ-60A_TVC
 			minThrust = 1688.4
 			maxThrust = 1688.4
-			ratedBurnTime = 94
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -575,7 +573,7 @@
 	TESTFLIGHT
 	{
 		name = AJ-60A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ-60A]/ratedBurnTime$
+		ratedBurnTime = 94
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.991935
@@ -584,6 +582,7 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ-60A] { %ratedBurnTime = #$/TESTFLIGHT[AJ-60A]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ-60A_TVC]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -591,7 +590,7 @@
 	TESTFLIGHT
 	{
 		name = AJ-60A_TVC
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ-60A_TVC]/ratedBurnTime$
+		ratedBurnTime = 94
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.991935
@@ -600,4 +599,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ-60A_TVC] { %ratedBurnTime = #$/TESTFLIGHT[AJ-60A_TVC]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
@@ -63,7 +63,6 @@
 			name = AMBR-623N
 			minThrust = 0.445
 			maxThrust = 0.623
-			ratedBurnTime = 3600
 			heatProduction = 10
 			ullage = False
 			pressureFed = True
@@ -355,11 +354,12 @@
 	TESTFLIGHT
 	{
 		name = AMBR-623N
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AMBR-623N]/ratedBurnTime$
+		ratedBurnTime = 3600
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 		techTransfer = R-4D-11:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AMBR-623N] { %ratedBurnTime = #$/TESTFLIGHT[AMBR-623N]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
@@ -64,7 +64,6 @@
 			name = AR-1
 			minThrust = 1244
 			maxThrust = 2487
-			ratedBurnTime = 450
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -112,10 +111,11 @@
 	TESTFLIGHT
 	{
 		name = AR-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AR-1]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.983
 		ignitionReliabilityEnd = 0.9975
 		cycleReliabilityStart = 0.983
 		cycleReliabilityEnd = 0.9975
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AR-1] { %ratedBurnTime = #$/TESTFLIGHT[AR-1]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
@@ -95,7 +95,6 @@
 			description = A RATO booster modified to be used on the WAC-Corporal for the US Army
 			maxThrust = 7.733 // 1500lbf (6.672kN) at _sea level_, vac calculated
 			minThrust = 7.733
-			ratedBurnTime = 47
 			heatProduction = 40
 
 			PROPELLANT
@@ -137,7 +136,6 @@
 			description = Developed for the Aerobee X-8, an improved WAC-Corporal for upper atmosphere research to replace the limited stocks of captured V-2s
 			maxThrust = 13.7628
 			minThrust = 13.7628
-			ratedBurnTime = 40
 			heatProduction = 40
 			PROPELLANT
 			{
@@ -173,7 +171,6 @@
 			description = Developed as an upgrade to the XASR-1. Continued to be used until the 1980s for meteorlogical studies.
 			maxThrust = 21.28
 			minThrust = 21.28
-			ratedBurnTime = 52
 			heatProduction = 40
 			PROPELLANT
 			{
@@ -211,19 +208,20 @@
 	TESTFLIGHT
 	{
 			name = WAC-Corporal
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[WAC-Corporal]/ratedBurnTime$
+			ratedBurnTime = 47
 			ignitionReliabilityStart = 0.90
 			ignitionReliabilityEnd = 0.96
 			cycleReliabilityStart = 0.86
 			cycleReliabilityEnd = 0.93
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[WAC-Corporal] { %ratedBurnTime = #$/TESTFLIGHT[WAC-Corporal]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XASR-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 			name = XASR-1
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XASR-1]/ratedBurnTime$
+			ratedBurnTime = 40
 			ignitionReliabilityStart = 0.93
 			ignitionReliabilityEnd = 0.97
 			cycleReliabilityStart = 0.91
@@ -231,13 +229,14 @@
 
 			techTransfer = WAC-Corporal:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XASR-1] { %ratedBurnTime = #$/TESTFLIGHT[XASR-1]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ10-27]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 			name = AJ10-27
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-27]/ratedBurnTime$
+			ratedBurnTime = 52
 			ignitionReliabilityStart = 0.95
 			ignitionReliabilityEnd = 0.98
 			cycleReliabilityStart = 0.95
@@ -245,4 +244,5 @@
 
 			techTransfer = WAC-Corporal,XASR-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-27] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-27]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
@@ -91,7 +91,6 @@
 			name = Aestus
 			minThrust = 30.0
 			maxThrust = 30.0
-			ratedBurnTime = 1100
 			heatProduction = 36
 			massMult = 1.0
 			ullage = True
@@ -131,7 +130,6 @@
 			description = Developed privately in collaboration with Rocketdyne. Turbopump system from XLR-32 added, allowing much higher performance. A.K.A RS-72
 			minThrust = 55.4
 			maxThrust = 55.4
-			ratedBurnTime = 2500
 			heatProduction = 56
 			massMult = 1.2432
 			ullage = True
@@ -177,12 +175,13 @@
 	TESTFLIGHT
 	{
 		name = Aestus
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Aestus]/ratedBurnTime$
+		ratedBurnTime = 1100
 		ignitionReliabilityStart = 0.968
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.967742
 		cycleReliabilityEnd = 0.993548
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Aestus] { %ratedBurnTime = #$/TESTFLIGHT[Aestus]/ratedBurnTime$ } }
 }
 // no data, never flew
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Aestus-II]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -190,11 +189,12 @@
 	TESTFLIGHT
 	{
 		name = Aestus-II
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Aestus-II]/ratedBurnTime$
+		ratedBurnTime = 2500
 		ignitionReliabilityStart = 0.968
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.97
 		cycleReliabilityEnd = 0.985
 		techTransfer = Aestus:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Aestus-II] { %ratedBurnTime = #$/TESTFLIGHT[Aestus-II]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -230,7 +230,6 @@
 			description = B-58 Hustler rocket pod
 			maxThrust = 67
 			minThrust = 67
-			ratedBurnTime = 60
 			heatProduction = 100
 			gimbalRange = 0
 			PROPELLANT
@@ -264,7 +263,6 @@
 			description = Model 8001, Agena Prototype
 			maxThrust = 67
 			minThrust = 67
-			ratedBurnTime = 100
 			heatProduction = 100
 			gimbalRange = 5
 			PROPELLANT
@@ -298,7 +296,6 @@
 			description = Model 8048, Agena A
 			maxThrust = 68.9
 			minThrust = 68.9
-			ratedBurnTime = 120
 			heatProduction = 100
 			gimbalRange = 5
 			PROPELLANT
@@ -332,7 +329,6 @@
 			description = Model 8081, Agena B
 			maxThrust = 70.7
 			minThrust = 70.7
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.0236
 			gimbalRange = 5
@@ -368,7 +364,6 @@
 			description		= Model 8096, Agena D
 			maxThrust		= 71.2
 			minThrust		= 71.2
-			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -408,7 +403,6 @@
 			description = Model 8247, Gemini ATV
 			maxThrust = 71.2
 			minThrust = 71.2
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.0394
 			gimbalRange = 5
@@ -444,7 +438,6 @@
 			description		= Improved propellant, using high density acid (HDA)
 			maxThrust		= 75.3 //17 klbf
 			minThrust		= 75.3
-			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -484,7 +477,6 @@
 			description		= Higher expansion ratio nozzle prototype
 			maxThrust		= 78.3
 			minThrust		= 78.3
-			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -524,7 +516,6 @@
 			description		= Reusable Agena for STS
 			maxThrust		= 71.1 //16 klbf
 			minThrust		= 71.1
-			ratedBurnTime = 1200
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -564,7 +555,6 @@
 			description		= Growth Agena option, sacrificing thrust for improved effeciency
 			maxThrust		= 53.4 //12 klbf
 			minThrust		= 53.4
-			ratedBurnTime = 240
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -604,7 +594,6 @@
 			description		= Agena upgrade for proposed Atlas V upper stage. Tested, but cancelled when studies showed it would be more economical to use single engine centaur instead.
 			maxThrust		= 67.5 //15170 lbf
 			minThrust		= 67.5
-			ratedBurnTime = 700
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
@@ -644,7 +633,6 @@
 			description		= Liquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
 			maxThrust		= 53.7 //12 klbf
 			minThrust		= 17.7 //3.98 klbf
-			ratedBurnTime = 360
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False	//Because engine was intended to be used mostly in pump-fed mode, pressureization system is included in engine mass
@@ -687,7 +675,7 @@
 	TESTFLIGHT
 	{
 		name = Model117
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model117]/ratedBurnTime$
+		ratedBurnTime = 60
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.85
@@ -696,6 +684,7 @@
 		cycleReliabilityEnd = 0.9
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Model117] { %ratedBurnTime = #$/TESTFLIGHT[Model117]/ratedBurnTime$ } }
 }
 
 //Thor-DM18 Agena-A: 2 flights, 0 failures?
@@ -705,7 +694,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-3]/ratedBurnTime$
+		ratedBurnTime = 100
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		//Identical to XLR81-BA-5 other than nozzle, give same reliability since only two were launched
 		ignitionReliabilityStart = 0.800000
@@ -716,6 +705,7 @@
 		techTransfer = Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-3] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-3]/ratedBurnTime$ } }
 }
 
 //Thor-DM18 Agena-A: 17 flights, 3 failures
@@ -726,7 +716,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-5]/ratedBurnTime$
+		ratedBurnTime = 120
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.800000
 		ignitionReliabilityEnd = 0.960000
@@ -736,6 +726,7 @@
 		techTransfer = Model117,XLR81-BA-3:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-5] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-5]/ratedBurnTime$ } }
 }
 
 //Atlas-LV3 Agena-B: 26 flights, 2 failures
@@ -748,7 +739,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-7
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-7]/ratedBurnTime$
+		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.916667
 		ignitionReliabilityEnd = 0.983333
@@ -758,6 +749,7 @@
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-7] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-7]/ratedBurnTime$ } }
 }
 
 //Atlas-LV3 Agena-D: 15 flights, 0 failures
@@ -774,7 +766,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-11
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-11]/ratedBurnTime$
+		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.958763
 		ignitionReliabilityEnd = 0.991753
@@ -784,6 +776,7 @@
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-11] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-11]/ratedBurnTime$ } }
 }
 
 //due to limited data, using BA-11 stats
@@ -792,7 +785,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-13
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-13]/ratedBurnTime$
+		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.958763
 		ignitionReliabilityEnd = 0.991753
@@ -802,6 +795,7 @@
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-13] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-13]/ratedBurnTime$ } }
 }
 
 //Atlas-SLV3A Agena-D: 12 flights, 1 failure
@@ -817,7 +811,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096-39
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096-39]/ratedBurnTime$
+		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.957746
 		ignitionReliabilityEnd = 0.991549
@@ -827,6 +821,7 @@
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096-39] { %ratedBurnTime = #$/TESTFLIGHT[Model8096-39]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -835,7 +830,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096A]/ratedBurnTime$
+		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.996
@@ -845,6 +840,7 @@
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-11,XLR81-BA-13,Model8096-39:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096A] { %ratedBurnTime = #$/TESTFLIGHT[Model8096A]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -853,7 +849,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096L
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096L]/ratedBurnTime$
+		ratedBurnTime = 1200
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -863,6 +859,7 @@
 		techTransfer = Model8096-39,Model8096-39A:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096L] { %ratedBurnTime = #$/TESTFLIGHT[Model8096L]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -871,7 +868,7 @@
 	TESTFLIGHT
 	{
 		name = Model8096C
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Model8096C]/ratedBurnTime$
+		ratedBurnTime = 240
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -881,6 +878,7 @@
 		techTransfer = Model8096-39,Model8096-39A:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096C] { %ratedBurnTime = #$/TESTFLIGHT[Model8096C]/ratedBurnTime$ } }
 }
 
 //no data, never flew. Using RL10A-4 data, since it shared many components with the RL10A-4
@@ -889,7 +887,7 @@
 	TESTFLIGHT
 	{
 		name = Agena-2000
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Agena-2000]/ratedBurnTime$
+		ratedBurnTime = 700
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.997
@@ -899,6 +897,7 @@
 		techTransfer = Model8096-39,Model8096A,Model8096L:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Agena-2000] { %ratedBurnTime = #$/TESTFLIGHT[Agena-2000]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -907,7 +906,7 @@
 	TESTFLIGHT
 	{
 		name = XLR81-LF2-SPS
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-LF2-SPS]/ratedBurnTime$	//No burn time listed. Time assumed to allow for mission completion even with single engine failiure, with margin.
+		ratedBurnTime = 360	//No burn time listed. Time assumed to allow for mission completion even with single engine failiure, with margin.
 		// pump-fed pressure fed hybrid. Allegedly only 1% worse reliability than pure pressurefed engine
 		ignitionReliabilityStart = 0.995305
 		ignitionReliabilityEnd = 0.999061
@@ -917,4 +916,5 @@
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-LF2-SPS] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-LF2-SPS]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
@@ -66,7 +66,6 @@
 			name = Alcyone
 			minThrust = 27.491
 			maxThrust = 27.491
-			ratedBurnTime = 8
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -101,7 +100,7 @@
 	TESTFLIGHT
 	{
 		name = Alcyone
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Alcyone]/ratedBurnTime$
+		ratedBurnTime = 8
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.97
@@ -111,4 +110,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Alcyone] { %ratedBurnTime = #$/TESTFLIGHT[Alcyone]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
@@ -82,7 +82,6 @@
 			name = Algol-I
 			minThrust = 493.6442
 			maxThrust = 493.6442
-			ratedBurnTime = 62
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -120,7 +119,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-I
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Algol-I]/ratedBurnTime$
+		ratedBurnTime = 62
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.944444
@@ -130,4 +129,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Algol-I] { %ratedBurnTime = #$/TESTFLIGHT[Algol-I]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
@@ -81,7 +81,6 @@
 			name = Algol-III
 			minThrust = 530.25896
 			maxThrust = 530.25896
-			ratedBurnTime = 75
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -120,7 +119,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-III
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Algol-III]/ratedBurnTime$
+		ratedBurnTime = 75
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.972222
@@ -130,4 +129,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Algol-III] { %ratedBurnTime = #$/TESTFLIGHT[Algol-III]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
@@ -81,7 +81,6 @@
 			name = Algol-II
 			minThrust = 449.02112
 			maxThrust = 449.02112
-			ratedBurnTime = 80
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -119,7 +118,7 @@
 	TESTFLIGHT
 	{
 		name = Algol-II
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Algol-II]/ratedBurnTime$
+		ratedBurnTime = 80
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.983871
@@ -129,4 +128,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Algol-II] { %ratedBurnTime = #$/TESTFLIGHT[Algol-II]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
@@ -66,7 +66,6 @@
 			name = Altair-III
 			minThrust = 31
 			maxThrust = 31
-			ratedBurnTime = 31
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -125,7 +124,7 @@
 	TESTFLIGHT
 	{
 		name = Altair-III
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Altair-III]/ratedBurnTime$
+		ratedBurnTime = 31
 		ignitionReliabilityStart = 0.972973
 		ignitionReliabilityEnd = 0.994595
 		cycleReliabilityStart = 0.972973
@@ -135,4 +134,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Altair-III] { %ratedBurnTime = #$/TESTFLIGHT[Altair-III]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
@@ -64,7 +64,6 @@
 			name = Altair-II
 			minThrust = 35
 			maxThrust = 35
-			ratedBurnTime = 22
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -123,7 +122,7 @@
 	TESTFLIGHT
 	{
 		name = Altair-II
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Altair-II]/ratedBurnTime$
+		ratedBurnTime = 22
 		ignitionReliabilityStart = 0.965517
 		ignitionReliabilityEnd = 0.993103
 		cycleReliabilityStart = 0.965517
@@ -133,4 +132,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Altair-II] { %ratedBurnTime = #$/TESTFLIGHT[Altair-II]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
@@ -82,7 +82,6 @@
 			name = Altair
 			minThrust = 16.35
 			maxThrust = 16.35
-			ratedBurnTime = 39
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -141,7 +140,7 @@
 	TESTFLIGHT
 	{
 		name = Altair
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Altair]/ratedBurnTime$
+		ratedBurnTime = 39
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.990000
@@ -150,4 +149,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Altair] { %ratedBurnTime = #$/TESTFLIGHT[Altair]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
@@ -77,7 +77,6 @@
 			name = Antares-I
 			minThrust = 62.27508
 			maxThrust = 62.27508
-			ratedBurnTime = 40
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -136,7 +135,7 @@
 	TESTFLIGHT
 	{
 		name = Antares-I
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Antares-I]/ratedBurnTime$
+		ratedBurnTime = 40
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
@@ -146,4 +145,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Antares-I] { %ratedBurnTime = #$/TESTFLIGHT[Antares-I]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_III_Config.cfg
@@ -76,7 +76,6 @@
 			name = Antares-III
 			minThrust = 100.37408
 			maxThrust = 100.37408
-			ratedBurnTime = 45
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -135,7 +134,7 @@
 	TESTFLIGHT
 	{
 		name = Antares-III
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Antares-III]/ratedBurnTime$
+		ratedBurnTime = 45
 		ignitionReliabilityStart = 0.962264
 		ignitionReliabilityEnd = 0.992453
 		cycleReliabilityStart = 0.962264
@@ -145,4 +144,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Antares-III] { %ratedBurnTime = #$/TESTFLIGHT[Antares-III]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
@@ -76,7 +76,6 @@
 			name = Antares-II
 			minThrust = 93.074555
 			maxThrust = 93.074555
-			ratedBurnTime = 37
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -135,7 +134,7 @@
 	TESTFLIGHT
 	{
 		name = Antares-II
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Antares-II]/ratedBurnTime$
+		ratedBurnTime = 37
 		ignitionReliabilityStart = 0.962264
 		ignitionReliabilityEnd = 0.992453
 		cycleReliabilityStart = 0.962264
@@ -145,4 +144,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Antares-II] { %ratedBurnTime = #$/TESTFLIGHT[Antares-II]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Astris_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Astris_Config.cfg
@@ -85,7 +85,6 @@
 			description = Used on Europa I. Extremely unreliable
 			maxThrust = 22.56
 			minThrust = 22.56
-			ratedBurnTime = 330
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -115,7 +114,6 @@
 			description = Upgrade developed for Europa II. Cancelled after first launch following continued failures and lack of funding
 			maxThrust = 23.3
 			minThrust = 23.3
-			ratedBurnTime = 330
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -146,13 +144,14 @@
 	TESTFLIGHT
 	{
 		name = AstrisI
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AstrisI]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.50
 		ignitionReliabilityEnd = 0.85
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.50
 		cycleReliabilityEnd = 0.90
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AstrisI] { %ratedBurnTime = #$/TESTFLIGHT[AstrisI]/ratedBurnTime$ } }
 }
 
 // Created slightly better reliably ratings here
@@ -161,7 +160,7 @@
 	TESTFLIGHT
 	{
 		name = AstrisII
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AstrisII]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.75
 		ignitionReliabilityEnd = 0.92
 		ignitionDynPresFailMultiplier = 0.1
@@ -169,5 +168,6 @@
 		cycleReliabilityEnd = 0.92
 		techTransfer = AstrisI:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AstrisII] { %ratedBurnTime = #$/TESTFLIGHT[AstrisII]/ratedBurnTime$ } }
 }
 

--- a/GameData/RealismOverhaul/Engine_Configs/BE-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-4_Config.cfg
@@ -72,7 +72,6 @@
 			name = BE-4
 			minThrust = 794.25
 			maxThrust = 2647.5
-			ratedBurnTime = 400
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True
@@ -117,10 +116,11 @@
 	TESTFLIGHT
 	{
 		name = BE-4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[BE-4]/ratedBurnTime$
+		ratedBurnTime = 400
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[BE-4] { %ratedBurnTime = #$/TESTFLIGHT[BE-4]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Baby_Sergeant.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Baby_Sergeant.cfg
@@ -78,7 +78,6 @@
 			description = Derived from the Sergeant ballistic missile, for use as an upper stage to the Juno-C to test high velocity re-entry.
 			minThrust = 8
 			maxThrust = 8
-			ratedBurnTime = 6
 			heatProduction = 27
 			massMult = 1.0
 			ullage = False
@@ -105,7 +104,6 @@
 			description = Improved fuel mix created by JPL
 			minThrust = 8
 			maxThrust = 8
-			ratedBurnTime = 6
 			heatProduction = 29
 			massMult = 1.0
 			ullage = False
@@ -138,13 +136,14 @@
 	{
 		name = T17-E2
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[T17-E2]/ratedBurnTime$
+		ratedBurnTime = 6
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.9985					// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.
 		reliabilityDataRateMultiplier = 1.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[T17-E2] { %ratedBurnTime = #$/TESTFLIGHT[T17-E2]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[JPL-532A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -153,7 +152,7 @@
 	{
 		name = JPL-532A
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[JPL-532A]/ratedBurnTime$
+		ratedBurnTime = 6
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -161,4 +160,5 @@
 		reliabilityDataRateMultiplier = 1.5
 		techTransfer = T17-E2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[JPL-532A] { %ratedBurnTime = #$/TESTFLIGHT[JPL-532A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/COBRAHigh_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/COBRAHigh_Config.cfg
@@ -66,7 +66,6 @@
 			name = COBRAH
 			minThrust = 2669				 //60%
 			maxThrust = 4448
-			ratedBurnTime = 540
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -102,11 +101,12 @@
 	TESTFLIGHT
 	{
 		name = COBRAH
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[COBRAH]/ratedBurnTime$	 
+		ratedBurnTime = 540	 
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.995
 		cycleReliabilityEnd = 0.999995
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[COBRAH] { %ratedBurnTime = #$/TESTFLIGHT[COBRAH]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/COBRA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/COBRA_Config.cfg
@@ -67,7 +67,6 @@
 			name = COBRA
 			maxThrust = 2669
 			minThrust = 1335
-			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -111,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = COBRA
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[COBRA]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -119,4 +118,5 @@
 
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[COBRA] { %ratedBurnTime = #$/TESTFLIGHT[COBRA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Cajun_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Cajun_Config.cfg
@@ -84,7 +84,6 @@
 			name = Cajun
 			minThrust = 36
 			maxThrust = 36
-			ratedBurnTime = 3
 			heatProduction = 100
 			
 			PROPELLANT
@@ -109,11 +108,13 @@
 	{
 		name = Cajun
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Cajun]/ratedBurnTime$
+		ratedBurnTime = 3
 		ignitionReliabilityStart = 0.958853
 		ignitionReliabilityEnd = 0.991771
 		cycleReliabilityStart = 0.995885					// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.
 		cycleReliabilityEnd = 0.999177
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Cajun] { %ratedBurnTime = #$/TESTFLIGHT[Cajun]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
@@ -52,7 +52,6 @@
 			name = Castor-120
 			minThrust = 1875
 			maxThrust = 1875
-			ratedBurnTime = 80
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -283,7 +282,6 @@
 		{
 			name = Castor-120/Saddle
 			maxThrust = 1950
-			ratedBurnTime = 80
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -514,8 +512,7 @@
 		{
 			name = Castor-120/Regressive
 			minThrust = 2125
-			maxThrust = 2125
-			ratedBurnTime = 80
+	  maxThrust = 2125
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -750,7 +747,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-120
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-120]/ratedBurnTime$
+		ratedBurnTime = 80
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -760,13 +757,14 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-120] { %ratedBurnTime = #$/TESTFLIGHT[Castor-120]/ratedBurnTime$ } }
 }
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120Regressive]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120/Regressive]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Castor-120/Regressive
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-120?Regressive]/ratedBurnTime$
+		ratedBurnTime = 80
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -776,13 +774,14 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-120?Regressive] { %ratedBurnTime = #$/TESTFLIGHT[Castor-120?Regressive]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-120/Saddle]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Castor-120/Saddle
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-120?Saddle]/ratedBurnTime$
+		ratedBurnTime = 80
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -791,4 +790,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-120?Saddle] { %ratedBurnTime = #$/TESTFLIGHT[Castor-120?Saddle]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
@@ -90,7 +90,6 @@
 			name = XM-20
 			minThrust = 304.3
 			maxThrust = 304.3
-			ratedBurnTime = 38
 			heatProduction = 100
 
 			PROPELLANT
@@ -140,7 +139,6 @@
 			name = Castor-1-SL
 			minThrust = 324.6
 			maxThrust = 324.6
-			ratedBurnTime = 41
 			heatProduction = 100
 
 			PROPELLANT
@@ -192,7 +190,6 @@
 			name = Castor-1-Vac
 			minThrust = 349.3
 			maxThrust = 349.3
-			ratedBurnTime = 43
 			heatProduction = 100
 
 			PROPELLANT
@@ -247,7 +244,7 @@
 	TESTFLIGHT
 	{
 		name = XM-20
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XM-20]/ratedBurnTime$
+		ratedBurnTime = 38
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.93
@@ -255,6 +252,7 @@
 		reliabilityDataRateMultiplier = 2
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XM-20] { %ratedBurnTime = #$/TESTFLIGHT[XM-20]/ratedBurnTime$ } }
 }
 //333 flown, 1 failure
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-1-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -262,7 +260,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-1-SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-1-SL]/ratedBurnTime$
+		ratedBurnTime = 41
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.996997
@@ -271,6 +269,7 @@
 		isSolid = True
 		techTransfer = XM-20:50&Castor-1-Vac:100
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-1-SL] { %ratedBurnTime = #$/TESTFLIGHT[Castor-1-SL]/ratedBurnTime$ } }
 }
 //88 flights, 3 failures
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-1-Vac]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -278,7 +277,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-1-Vac
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-1-Vac]/ratedBurnTime$
+		ratedBurnTime = 43
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.994
 		cycleReliabilityStart = 0.965909
@@ -287,4 +286,5 @@
 		isSolid = True
 		techTransfer = XM-20:50&Castor-1-SL:100
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-1-Vac] { %ratedBurnTime = #$/TESTFLIGHT[Castor-1-Vac]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -71,7 +71,6 @@
 			name = Castor-2-SL
 			minThrust = 293.865
 			maxThrust = 293.865
-			ratedBurnTime = 39
 			heatProduction = 100
 
 			PROPELLANT
@@ -128,7 +127,6 @@
 			name = Castor-2-Vac
 			minThrust = 318.1
 			maxThrust = 318.1
-			ratedBurnTime = 39
 			heatProduction = 100
 
 			PROPELLANT
@@ -190,7 +188,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-2-SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-2-SL]/ratedBurnTime$
+		ratedBurnTime = 39
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999	//Not a probable failure for ground lit SRMs
 		cycleReliabilityStart = 0.965
@@ -199,6 +197,7 @@
 		reliabilityDataRateMultiplier = 2
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-2-SL] { %ratedBurnTime = #$/TESTFLIGHT[Castor-2-SL]/ratedBurnTime$ } }
 }
 //74 flown, 1 failure related to Castor
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Castor-2-Vac]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -206,7 +205,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-2-Vac
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-2-Vac]/ratedBurnTime$
+		ratedBurnTime = 39
 		ignitionReliabilityStart = 0.945
 		ignitionReliabilityEnd = 0.997
 		cycleReliabilityStart = 0.965
@@ -215,4 +214,5 @@
 		reliabilityDataRateMultiplier = 2
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-2-Vac] { %ratedBurnTime = #$/TESTFLIGHT[Castor-2-Vac]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
@@ -50,7 +50,6 @@
 			name = Castor-30A
 			minThrust = 330.7653 //taken from atk catalog
 			maxThrust = 330.7653
-			ratedBurnTime = 136
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -285,7 +284,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-30A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-30A]/ratedBurnTime$
+		ratedBurnTime = 136
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -294,4 +293,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-30A] { %ratedBurnTime = #$/TESTFLIGHT[Castor-30A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
@@ -50,7 +50,6 @@
 			name = Castor-30B
 			minThrust = 396.2921 //taken from atk catalog
 			maxThrust = 396.2921
-			ratedBurnTime = 127
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -205,7 +204,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-30B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-30B]/ratedBurnTime$
+		ratedBurnTime = 127
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -214,4 +213,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-30B] { %ratedBurnTime = #$/TESTFLIGHT[Castor-30B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
@@ -50,7 +50,6 @@
 			name = Castor-30XL
 			minThrust = 533.3418 //taken from atk catalog
 			maxThrust = 533.3418
-			ratedBurnTime = 156
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -205,7 +204,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-30XL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-30XL]/ratedBurnTime$
+		ratedBurnTime = 156
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
@@ -214,4 +213,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-30XL] { %ratedBurnTime = #$/TESTFLIGHT[Castor-30XL]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
@@ -48,7 +48,6 @@
 			name = Castor-4AXL
 			minThrust = 765
 			maxThrust = 765
-			ratedBurnTime = 60
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -131,7 +130,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-4AXL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-4AXL]/ratedBurnTime$
+		ratedBurnTime = 60
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.996721
@@ -140,4 +139,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-4AXL] { %ratedBurnTime = #$/TESTFLIGHT[Castor-4AXL]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
@@ -46,7 +46,6 @@
 			name = Castor-4A
 			minThrust = 538
 			maxThrust = 538
-			ratedBurnTime = 56
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -125,7 +124,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-4A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-4A]/ratedBurnTime$
+		ratedBurnTime = 56
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.996721
@@ -134,4 +133,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-4A] { %ratedBurnTime = #$/TESTFLIGHT[Castor-4A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
@@ -47,7 +47,6 @@
 			name = Castor-4
 			minThrust = 460
 			maxThrust = 460
-			ratedBurnTime = 54
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -282,7 +281,7 @@
 	TESTFLIGHT
 	{
 		name = Castor-4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Castor-4]/ratedBurnTime$
+		ratedBurnTime = 54
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.997076
@@ -291,4 +290,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Castor-4] { %ratedBurnTime = #$/TESTFLIGHT[Castor-4]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
@@ -59,7 +59,6 @@
 			name = Dropt
 			minThrust = 50
 			maxThrust = 50
-			ratedBurnTime = 46
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -99,7 +98,7 @@
 	TESTFLIGHT
 	{
 		name = Dropt
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Dropt]/ratedBurnTime$
+		ratedBurnTime = 46
 		ignitionReliabilityStart = 0.875
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.875000
@@ -109,4 +108,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Dropt] { %ratedBurnTime = #$/TESTFLIGHT[Dropt]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
@@ -81,7 +81,6 @@
 			name = E-1
 			minThrust = 1884.59 // 380klbf sea level
 			maxThrust = 1884.59
-			ratedBurnTime = 165
 			heatProduction = 100
 			massMult = 1.0
 
@@ -127,7 +126,6 @@
 			description = Speculative upgrade configuration for the E-1 intended for use with the Dyna Soar project.
 			minThrust = 2335.3155
 			maxThrust = 2335.3155
-			ratedBurnTime = 210
 			heatProduction = 100
 			massMult = 1.435  // 4000 pounds
 
@@ -173,7 +171,6 @@
 			description = Speculative upgrade configuration using late 1960s technology.
 			minThrust = 2355
 			maxThrust = 2355
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.5
 			//speculative = fictional
@@ -231,12 +228,13 @@
 	TESTFLIGHT
 	{
 		name = E-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[E-1]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.89
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.93
 		cycleReliabilityEnd = 0.988
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[E-1] { %ratedBurnTime = #$/TESTFLIGHT[E-1]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[E-1-Upgrade]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -246,13 +244,14 @@
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[E-1-Upgrade]/ratedBurnTime$
+		ratedBurnTime = 210
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.994
 		techTransfer = E-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[E-1-Upgrade] { %ratedBurnTime = #$/TESTFLIGHT[E-1-Upgrade]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[E-1-Upgrade2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -261,11 +260,12 @@
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[E-1-Upgrade2]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.997
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.998
 		techTransfer = E-1,E-1-Upgrade:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[E-1-Upgrade2] { %ratedBurnTime = #$/TESTFLIGHT[E-1-Upgrade2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/EAP241_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EAP241_Config.cfg
@@ -101,7 +101,6 @@
 			name = MPS-241
 			minThrust = 7040
 			maxThrust = 7040
-			ratedBurnTime = 130
 			heatProduction = 20
 			massMult = 1.0
 			curveResource = HTPB
@@ -341,7 +340,6 @@
 			name = MPS-241A
 			minThrust = 7040
 			maxThrust = 7040
-			ratedBurnTime = 130
 			heatProduction = 20
 			massMult = 0.9524
 			curveResource = HTPB
@@ -591,7 +589,7 @@
 	TESTFLIGHT
 	{
 		name = MPS-241
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MPS-241]/ratedBurnTime$
+		ratedBurnTime = 130
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.995392
@@ -599,6 +597,7 @@
 		
 		isSolid = true
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MPS-241] { %ratedBurnTime = #$/TESTFLIGHT[MPS-241]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[MPS-241A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -606,7 +605,7 @@
 	TESTFLIGHT
 	{
 		name = MPS-241A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MPS-241A]/ratedBurnTime$
+		ratedBurnTime = 130
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.995392
@@ -615,4 +614,5 @@
 		
 		isSolid = true
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MPS-241A] { %ratedBurnTime = #$/TESTFLIGHT[MPS-241A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
@@ -51,7 +51,6 @@
 			name = F-1A_ETS
 			minThrust = 5513.8
 			maxThrust = 9189.6
-			ratedBurnTime = 315
 			massMult = 0.97673
 			heatProduction = 100
 			//speculative = fictional
@@ -104,11 +103,12 @@
 	TESTFLIGHT
 	{
 		name = F-1A_ETS
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1A_ETS]/ratedBurnTime$					// Was proposed as a Sustainer engine like the LR105
+		ratedBurnTime = 315					// Was proposed as a Sustainer engine like the LR105
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.998
 		techTransfer = F-1-1.5M, F-1-1.52M:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[F-1A_ETS] { %ratedBurnTime = #$/TESTFLIGHT[F-1A_ETS]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
@@ -65,7 +65,6 @@
 			name = F-1B
 			minThrust = 6390 // http://www.thespacereview.com/article/2410/1 2015-11-17, throttleable 8 MN - 5.8 MN sea level
 			maxThrust = 8815
-			ratedBurnTime = 315
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -114,7 +113,7 @@
 	TESTFLIGHT
 	{
 		name = F-1B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1B]/ratedBurnTime$
+		ratedBurnTime = 315
 		//Copied from F-1A, used mostly unmodified F-1A turbomachinery
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998
@@ -122,4 +121,5 @@
 		cycleReliabilityEnd = 0.998
 		techTransfer = F-1-1.5M, F-1-1.52M, F-1A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[F-1B] { %ratedBurnTime = #$/TESTFLIGHT[F-1B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
@@ -92,7 +92,6 @@
 			description = Early production version
 			minThrust = 7652.2
 			maxThrust = 7652.2
-			ratedBurnTime = 165
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -131,7 +130,6 @@
 			description = Later model, with redesigned injectors
 			minThrust = 7740.5
 			maxThrust = 7740.5
-			ratedBurnTime = 165
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -170,7 +168,6 @@
 			description = Uprated and simplified F-1 developed for post-Apollo launch vehicles. Tested extensively, but cancelled following the cancellation of Apollo
 			minThrust = 7855.6
 			maxThrust = 9189.6
-			ratedBurnTime = 315
 			massMult = 0.97673
 			heatProduction = 100
 			PROPELLANT
@@ -222,12 +219,13 @@
 	TESTFLIGHT
 	{
 		name = F-1-1.5M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1-1.5M]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.984615
 		ignitionReliabilityEnd = 0.996923
 		cycleReliabilityStart = 0.984615
 		cycleReliabilityEnd = 0.996923
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[F-1-1.5M] { %ratedBurnTime = #$/TESTFLIGHT[F-1-1.5M]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[F-1-1.52M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -235,13 +233,14 @@
 	TESTFLIGHT
 	{
 		name = F-1-1.52M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1-1.52M]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.984615
 		ignitionReliabilityEnd = 0.996923
 		cycleReliabilityStart = 0.984615
 		cycleReliabilityEnd = 0.996923
 		techTransfer = F-1-1.5M:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[F-1-1.52M] { %ratedBurnTime = #$/TESTFLIGHT[F-1-1.52M]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -251,11 +250,12 @@
 	TESTFLIGHT
 	{
 		name = F-1A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[F-1A]/ratedBurnTime$					// Was proposed as a Sustainer engine like the LR105
+		ratedBurnTime = 315					// Was proposed as a Sustainer engine like the LR105
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.998
 		techTransfer = F-1-1.5M, F-1-1.52M:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[F-1A] { %ratedBurnTime = #$/TESTFLIGHT[F-1A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
@@ -108,7 +108,6 @@
 			name = GCRC
 			minThrust = 17.3 // With thrust curve gives avg of 12.45
 			maxThrust = 17.3
-			ratedBurnTime = 33
 			techRequired = solids1957
 			heatProduction = 100
 			PROPELLANT
@@ -159,7 +158,7 @@
 	TESTFLIGHT
 	{
 		name = GCRC
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GCRC]/ratedBurnTime$
+		ratedBurnTime = 33
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
@@ -168,4 +167,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GCRC] { %ratedBurnTime = #$/TESTFLIGHT[GCRC]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
@@ -44,7 +44,6 @@
 			name = GEM-40/Ground
 			minThrust = 644
 			maxThrust = 644
-			ratedBurnTime = 63
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -129,7 +128,6 @@
 			name = GEM-40/Air
 			minThrust = 666
 			maxThrust = 666
-			ratedBurnTime = 63
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -217,7 +215,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-40/Ground
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40?Ground]/ratedBurnTime$
+		ratedBurnTime = 63
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998932
@@ -225,13 +223,14 @@
 		techTransfer = GEM-40/Air:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-40?Ground] { %ratedBurnTime = #$/TESTFLIGHT[GEM-40?Ground]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-40/Air]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = GEM-40/Air
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-40?Air]/ratedBurnTime$
+		ratedBurnTime = 63
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.998932
@@ -239,4 +238,5 @@
 		techTransfer = GEM-40/Ground:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-40?Air] { %ratedBurnTime = #$/TESTFLIGHT[GEM-40?Air]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
@@ -45,7 +45,6 @@
 			name = GEM-46/TVC-Ground
 			minThrust = 875
 			maxThrust = 875 //Checked
-			ratedBurnTime = 77
 			heatProduction = 100
 			gimbalRange = 5 //Checked
 			massMult = 1.1375 //2.275
@@ -280,7 +279,6 @@
 			gimbalRange = 0
 			minThrust = 885
 			maxThrust = 885 //Checked
-			ratedBurnTime = 77
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -512,7 +510,6 @@
 			name = GEM-46/Fixed-Air
 			minThrust = 915
 			maxThrust = 915 //Checked
-			ratedBurnTime = 77
 			massMult = 1.1020 //2.204
 			heatProduction = 100
 			gimbalRange = 0
@@ -749,7 +746,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-46/Fixed-Ground
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46?Fixed-Ground]/ratedBurnTime$
+		ratedBurnTime = 77
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.981818
@@ -757,13 +754,14 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/TVC-Ground,GEM-46/Fixed-Air:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-46?Fixed-Ground] { %ratedBurnTime = #$/TESTFLIGHT[GEM-46?Fixed-Ground]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-46/TVC-Ground]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = GEM-46/TVC-Ground
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46?TVC-Ground]/ratedBurnTime$
+		ratedBurnTime = 77
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.981818
@@ -771,13 +769,14 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/Fixed-Ground,GEM-46/Fixed-Air:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-46?TVC-Ground] { %ratedBurnTime = #$/TESTFLIGHT[GEM-46?TVC-Ground]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-46/Fixed-Air]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = GEM-46/Fixed-Air
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-46?Fixed-Air]/ratedBurnTime$
+		ratedBurnTime = 77
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.981818
@@ -785,4 +784,5 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/TVC-Ground,GEM-46/Fixed-Ground:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-46?Fixed-Air] { %ratedBurnTime = #$/TESTFLIGHT[GEM-46?Fixed-Air]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
@@ -73,7 +73,6 @@
 			name = GEM-60/TVC
 			minThrust = 1235.947
 			maxThrust = 1235.947
-			ratedBurnTime = 91
 			heatProduction = 100
 			gimbalRange = 5.0
 
@@ -196,7 +195,6 @@
 			name = GEM-60/Fixed
 			minThrust = 1248.91
 			maxThrust = 1248.91
-			ratedBurnTime = 91
 			gimbalRange = 0
 			heatProduction = 100
 			massMult = 0.9822
@@ -322,7 +320,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-60/Fixed
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60?Fixed]/ratedBurnTime$
+		ratedBurnTime = 91
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99
@@ -330,13 +328,14 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground:50 & GEM-60/TVC:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-60?Fixed] { %ratedBurnTime = #$/TESTFLIGHT[GEM-60?Fixed]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[GEM-60/TVC]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = GEM-60/TVC
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-60?TVC]/ratedBurnTime$
+		ratedBurnTime = 91
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.99
@@ -344,4 +343,5 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground:50 & GEM-60/Fixed:100
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-60?TVC] { %ratedBurnTime = #$/TESTFLIGHT[GEM-60?TVC]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
@@ -46,7 +46,6 @@
 			name = GEM-63XL
 			minThrust = 2026
 			maxThrust = 2026
-			ratedBurnTime = 84
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -166,7 +165,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-63XL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-63XL]/ratedBurnTime$
+		ratedBurnTime = 84
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99
@@ -174,4 +173,5 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-60/TVC,GEM-60/Fixed,GEM-63:50
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-63XL] { %ratedBurnTime = #$/TESTFLIGHT[GEM-63XL]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
@@ -47,7 +47,6 @@
 			name = GEM-63
 			minThrust = 1658
 			maxThrust = 1658
-			ratedBurnTime = 94
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -167,7 +166,7 @@
 	TESTFLIGHT
 	{
 		name = GEM-63
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[GEM-63]/ratedBurnTime$
+		ratedBurnTime = 94
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.99
@@ -175,4 +174,5 @@
 		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-60/TVC,GEM-60/Fixed,GEM-63XL:50
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-63] { %ratedBurnTime = #$/TESTFLIGHT[GEM-63]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
@@ -65,7 +65,6 @@
 			name = Gamma-2
 			minThrust = 68.236
 			maxThrust = 68.236
-			ratedBurnTime = 140
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -106,11 +105,12 @@
 	TESTFLIGHT
 	{
 		name = Gamma-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-2]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034
 		cycleReliabilityEnd = 0.986207
 		techTransfer = Gamma-201, Gamma-301, Gamma-8:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-2] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
@@ -79,7 +79,6 @@
 			name = Gamma-201
 			minThrust = 73
 			maxThrust = 73
-			ratedBurnTime = 145
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -113,7 +112,6 @@
 			name = Gamma-301
 			minThrust = 96
 			maxThrust = 96
-			ratedBurnTime = 145
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -154,12 +152,13 @@
 	TESTFLIGHT
 	{
 		name = Gamma-201
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-201]/ratedBurnTime$
+		ratedBurnTime = 145
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034
 		cycleReliabilityEnd = 0.986207
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-201] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-201]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Gamma-301]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -167,11 +166,12 @@
 	TESTFLIGHT
 	{
 		name = Gamma-301
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-301]/ratedBurnTime$
+		ratedBurnTime = 145
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034
 		cycleReliabilityEnd = 0.986207
 		techTransfer = Gamma-201:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-301] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-301]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
@@ -64,7 +64,6 @@
 			name = Gamma-8
 			minThrust = 256.395
 			maxThrust = 256.395
-			ratedBurnTime = 140
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -105,11 +104,12 @@
 	TESTFLIGHT
 	{
 		name = Gamma-8
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-8]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034
 		cycleReliabilityEnd = 0.986207
 		techTransfer = Gamma-201, Gamma-301, Gamma-2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-8] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-8]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -148,7 +148,6 @@
 			description = Earliest prototype version of the H-1 Engine that flew on the Saturn I, Block I. It is rated at 165k lbf sea level thrust.
 			minThrust = 807
 			maxThrust = 807
-			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -195,7 +194,6 @@
 			description = Improved version of the H-1 Engine for the Saturn I, Block II. It is rated at 188k lbf sea level thrust.
 			minThrust = 920
 			maxThrust = 920
-			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -242,7 +240,6 @@
 			description = H-1 Engine that flew on the first 5 Saturn IB launches. It is rated at 200k lbf sea level thrust.
 			minThrust = 979
 			maxThrust = 979
-			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -289,7 +286,6 @@
 			description = Final version of the H-1 Engine for the Saturn IB that flew on the 4 flights of Skylab and ASTP. It is rated at 205k lbf sea level thrust.
 			minThrust = 1018
 			maxThrust = 1018
-			ratedBurnTime = 155
 			heatProduction = 100
 			massMult = 1.0
 
@@ -336,7 +332,6 @@
 			description = Remanufactured H-1 for use with Delta
 			maxThrust = 1023
 			minThrust = 1023
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.0395
 
@@ -383,7 +378,6 @@
 			description = RS-27 with a higher expansion nozzle for Delta II
 			maxThrust = 1054
 			minThrust = 1054
-			ratedBurnTime = 285
 			heatProduction = 100
 			massMult = 1.10425
 
@@ -440,13 +434,14 @@
 	TESTFLIGHT
 	{
 		name = H-1-165K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-165K]/ratedBurnTime$
+		ratedBurnTime = 155
 		ignitionReliabilityStart = 0.969697
 		ignitionReliabilityEnd = 0.993939
 		cycleReliabilityStart = 0.969697
 		cycleReliabilityEnd = 0.993939
 		techTransfer = S-3, S-3D:25	//Based on S-3
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-165K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-165K]/ratedBurnTime$ } }
 }
 //Saturn 1 Block II: 6 flights, 0 failures
 //48 engines, 0 failures
@@ -455,13 +450,14 @@
 	TESTFLIGHT
 	{
 		name = H-1-188K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-188K]/ratedBurnTime$
+		ratedBurnTime = 155
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979592
 		cycleReliabilityEnd = 0.995918
 		techTransfer = H-1-165K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-188K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-188K]/ratedBurnTime$ } }
 }
 //Saturn 1B: 5 flights, 0 failures
 //40 engines, 0 failures
@@ -470,13 +466,14 @@
 	TESTFLIGHT
 	{
 		name = H-1-200K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-200K]/ratedBurnTime$
+		ratedBurnTime = 155
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
 		cycleReliabilityStart = 0.975610
 		cycleReliabilityEnd = 0.995122
 		techTransfer = H-1-165K,H-1-188K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-200K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-200K]/ratedBurnTime$ } }
 }
 //Saturn 1B (Skylab): 4 flights, 0 failures
 //32 engines, 0 failures
@@ -485,13 +482,14 @@
 	TESTFLIGHT
 	{
 		name = H-1-205K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[H-1-205K]/ratedBurnTime$
+		ratedBurnTime = 155
 		ignitionReliabilityStart = 0.969697
 		ignitionReliabilityEnd = 0.993939
 		cycleReliabilityStart = 0.969697
 		cycleReliabilityEnd = 0.993939
 		techTransfer = H-1-165K,H-1-188K,H-1-205K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-205K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-205K]/ratedBurnTime$ } }
 }
 //Delta 2310: 3 flights, 0 failures
 //Delta 2313: 3 flights, 0 failures
@@ -514,13 +512,14 @@
 	TESTFLIGHT
 	{
 		name = RS-27
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-27]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.990000
 		ignitionReliabilityEnd = 0.998000
 		cycleReliabilityStart = 0.990000
 		cycleReliabilityEnd = 0.998000
 		techTransfer = H-1-188K,H-1-200K,H-1-205K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-27] { %ratedBurnTime = #$/TESTFLIGHT[RS-27]/ratedBurnTime$ } }
 }
 //Delta 7320: 12 flights, 0 failures
 //Delta 7326: 3 flights, 0 failures
@@ -538,11 +537,12 @@
 	TESTFLIGHT
 	{
 		name = RS-27A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-27A]/ratedBurnTime$
+		ratedBurnTime = 285
 		ignitionReliabilityStart = 0.992958
 		ignitionReliabilityEnd = 0.998592
 		cycleReliabilityStart = 0.992958
 		cycleReliabilityEnd = 0.998592
 		techTransfer = H-1-188K,H-1-200K,H-1-205K,RS-27:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-27A] { %ratedBurnTime = #$/TESTFLIGHT[RS-27A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -44,7 +44,6 @@
 			name = HG-3
 			minThrust = 938.469
 			maxThrust = 1400.70
-			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -77,7 +76,6 @@
 			name = HG-3-SL
 			minThrust = 925.987
 			maxThrust = 1382.07
-			ratedBurnTime = 600
 			massMult = 0.973574409
 			heatProduction = 100
 			PROPELLANT
@@ -112,7 +110,6 @@
 			description = Speculative upgrade, using lessons learned from experience with HG-3 in service and development of RS-25 to improve reliability.
 			minThrust = 938.469
 			maxThrust = 1400.70
-			ratedBurnTime = 600
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -147,7 +144,6 @@
 			description = Sea-level variant of HG-3A upgrade
 			minThrust = 925.987
 			maxThrust = 1382.07
-			ratedBurnTime = 600
 			massMult = 0.973574409
 			heatProduction = 100
 			//speculative = fictional
@@ -183,7 +179,6 @@
 			description = Further refinement of the HG-3 engine, taking into account developements with the RL-10 and RS-25. Run time and reliability are extended compared to original models, although turbopump throughput is decreased to reduce strain on engine components.
 			minThrust = 938.469
 			maxThrust = 1400.70
-			ratedBurnTime = 750
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -218,7 +213,6 @@
 			description = Sea-level variant of HG-3B upgrade. Increased specific impulse compared to other sea-level variants prior to B version development results in slightly higher thrust for the same level of turbopump throughput as the HG-3B vacuum engine.
 			minThrust = 926.174
 			maxThrust = 1382.35
-			ratedBurnTime = 750
 			massMult = 0.973574409
 			heatProduction = 100
 			//speculative = fictional
@@ -254,7 +248,6 @@
 			description = Modified version of HG-3B, running the turbopumps harder to generate the same level of mass flow as in previous models. This results in improved thrust compared to the normal B model, at the cost of slightly less reliability in comparison.
 			minThrust = 950.035
 			maxThrust = 1422.44
-			ratedBurnTime = 750
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -289,7 +282,6 @@
 			description = Sea-level version of HG-3B-2 upgrade and modification. The improved specific impulse now means that this version produces more vacuum thrust than previous vacuum versions of the engine.
 			minThrust = 940.553
 			maxThrust = 1403.81
-			ratedBurnTime = 750
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -326,100 +318,108 @@
 	TESTFLIGHT
 	{
 		name = HG-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
 		cycleReliabilityEnd = 0.96
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3] { %ratedBurnTime = #$/TESTFLIGHT[HG-3]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3-SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3-SL]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
 		cycleReliabilityEnd = 0.96
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3-SL] { %ratedBurnTime = #$/TESTFLIGHT[HG-3-SL]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3A]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.91
 		cycleReliabilityEnd = 0.98
 		techTransfer = HG-3,HG-3-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3A] { %ratedBurnTime = #$/TESTFLIGHT[HG-3A]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3A-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3A-SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3A-SL]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.91
 		cycleReliabilityEnd = 0.98
 		techTransfer = HG-3,HG-3-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3A-SL] { %ratedBurnTime = #$/TESTFLIGHT[HG-3A-SL]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B]/ratedBurnTime$
+		ratedBurnTime = 750
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.91488
 		cycleReliabilityEnd = 0.99
 		techTransfer = HG-3A,HG-3A-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3B] { %ratedBurnTime = #$/TESTFLIGHT[HG-3B]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3B-SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-SL]/ratedBurnTime$
+		ratedBurnTime = 750
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.91488
 		cycleReliabilityEnd = 0.99
 		techTransfer = HG-3A,HG-3A-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3B-SL] { %ratedBurnTime = #$/TESTFLIGHT[HG-3B-SL]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3B-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-2]/ratedBurnTime$
+		ratedBurnTime = 750
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.90
 		cycleReliabilityEnd = 0.988
 		techTransfer = HG-3A,HG-3A-SL,HG-3B,HG-3B-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3B-2] { %ratedBurnTime = #$/TESTFLIGHT[HG-3B-2]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[HG-3B-SL-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = HG-3B-SL-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-SL-2]/ratedBurnTime$
+		ratedBurnTime = 750
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.90
 		cycleReliabilityEnd = 0.988
 		techTransfer = HG-3A,HG-3A-SL,HG-3B,HG-3B-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3B-SL-2] { %ratedBurnTime = #$/TESTFLIGHT[HG-3B-SL-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
@@ -119,7 +119,6 @@
 			description = Developed for Ariane 1
 			maxThrust = 62.4
 			minThrust = 62.4
-			ratedBurnTime = 570
 			massMult = 0.909
 
 			ullage = True
@@ -159,7 +158,6 @@
 			description = Improved version of the HM-7 used for Ariane 3 and 4.
 			maxThrust = 64.2
 			minThrust = 64.2
-			ratedBurnTime = 730
 			massMult = 1.0
 
 			ullage = True
@@ -199,7 +197,6 @@
 			description = Upgraded for higher performance on Ariane 4.
 			maxThrust = 64.6
 			minThrust = 64.6
-			ratedBurnTime = 980
 			massMult = 1.0
 
 			ullage = True
@@ -239,7 +236,6 @@
 			description = Upgraded for higher performance for later Ariane 4s and Ariane 5
 			maxThrust = 64.8
 			minThrust = 64.8
-			ratedBurnTime = 980
 			massMult = 1.0
 
 			ullage = True
@@ -281,13 +277,14 @@
 	TESTFLIGHT
 	{
 		name = HM-7
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7]/ratedBurnTime$
+		ratedBurnTime = 570
 		ignitionReliabilityStart = 0.82
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.82
 		cycleReliabilityEnd = 0.95
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HM-7] { %ratedBurnTime = #$/TESTFLIGHT[HM-7]/ratedBurnTime$ } }
 }
 //Ariane 2: 6 flights, 1 failure. 1 ignition failure
 //Ariane 3: 11 flights, 1 failure. 1 ignition failure
@@ -308,7 +305,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B]/ratedBurnTime$
+		ratedBurnTime = 730
 		ignitionReliabilityStart = 0.966102
 		ignitionReliabilityEnd = 0.993220
 		cycleReliabilityStart = 0.982456
@@ -316,6 +313,7 @@
 		techTransfer = HM-7:50
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HM-7B] { %ratedBurnTime = #$/TESTFLIGHT[HM-7B]/ratedBurnTime$ } }
 }
 //Ariane-40 H10-3: 3 flights, 0 failures
 //Ariane-42P H10-3: 9 flights, 1 failure
@@ -329,7 +327,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7B+
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B+]/ratedBurnTime$
+		ratedBurnTime = 980
 		ignitionReliabilityStart = 0.986301
 		ignitionReliabilityEnd = 0.997260
 		cycleReliabilityStart = 0.986301
@@ -337,6 +335,7 @@
 		techTransfer = HM-7,HM-7B:50
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HM-7B+] { %ratedBurnTime = #$/TESTFLIGHT[HM-7B+]/ratedBurnTime$ } }
 }
 //Ariane-5ECA: 71 flights, 1 failure. 1 failure due to incorrect data entered
 //Ariane-5ECA+: 3 flights, 0 failures
@@ -346,7 +345,7 @@
 	TESTFLIGHT
 	{
 		name = HM-7B++
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B++]/ratedBurnTime$
+		ratedBurnTime = 980
 		ignitionReliabilityStart = 0.986667
 		ignitionReliabilityEnd = 0.997333
 		cycleReliabilityStart = 0.986667
@@ -354,4 +353,5 @@
 		techTransfer = HM-7,HM-7B,HM-7B+:50
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[HM-7B++] { %ratedBurnTime = #$/TESTFLIGHT[HM-7B++]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -80,7 +80,6 @@
 			name = J-2T-200K
 			maxThrust = 889.3
 			minThrust = 177.8
-			ratedBurnTime = 500
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -110,7 +109,6 @@
 			name = J-2T-250K
 			maxThrust = 1111.6
 			minThrust = 222.32
-			ratedBurnTime = 500
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -143,13 +141,14 @@
 	{
 		name = J-2T-200K
 		// Copied from J-2S, used J-2S turbomachinery
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2T-200K]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665
 		cycleReliabilityEnd = 0.9999
 		techTransfer = J-2-200K,J-2-225K,J-2-230K:30
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2T-200K] { %ratedBurnTime = #$/TESTFLIGHT[J-2T-200K]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[J-2T-250K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -157,11 +156,12 @@
 	{
 		name = J-2T-250K
 		// Copied from J-2S, used J-2S turbomachinery
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2T-250K]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665
 		cycleReliabilityEnd = 0.9999
 		techTransfer = J-2-200K,J-2-225K,J-2-230K,J-2T-200K:30
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2T-250K] { %ratedBurnTime = #$/TESTFLIGHT[J-2T-250K]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
@@ -63,7 +63,6 @@
 			name = J-2X
 			maxThrust = 1308
 			minThrust = 1072
-			ratedBurnTime = 500
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -98,10 +97,11 @@
 	{
 		name = J-2X
 		// Using J-2S data
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2X]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665
 		cycleReliabilityEnd = 0.9999
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2X] { %ratedBurnTime = #$/TESTFLIGHT[J-2X]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -116,7 +116,6 @@
 			description = This was the earliest variant of the J-2 that flew on the first 3 Saturn IB flights AS-201 to AS-203.
 			minThrust = 685.026
 			maxThrust = 889.644
-			ratedBurnTime = 500
 			heatProduction = 100
 			massMult = 1.00
 			PROPELLANT	// 5.0 Mixture Ratio
@@ -151,7 +150,6 @@
 			description = The uprated 225k variant was flown starting with SA-501 Saturn V.
 			minThrust = 770.654
 			maxThrust = 1000.850
-			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -185,7 +183,6 @@
 			description = The final version of the J-2 that flew on the Saturn, the 230k variant flew starting with Apollo 8, SA-208 and all subsequent flights.
 			minThrust = 787.780
 			maxThrust = 1023.091
-			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -219,7 +216,6 @@
 			description = The J-2S (J-2 Simplified) was a improvement on the J-2 Engine. It was completely tested and logged more than 30,000 seconds of static fire before the program was terminated.
 			minThrust = 196.463	// 6:1 throttling thanks to redesigned pumps and injectors
 			maxThrust = 1178.778
-			ratedBurnTime = 500
 			massMult = 1.036835 // All sources state the J-2S was heavier than J-2
 			heatProduction = 100
 			PROPELLANT
@@ -260,12 +256,13 @@
 	{
 		name = J-2-200K
 		// 3/3 successful flights, but still new technology
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2-200K]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.909091
 		cycleReliabilityEnd = 0.981818
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2-200K] { %ratedBurnTime = #$/TESTFLIGHT[J-2-200K]/ratedBurnTime$ } }
 }
 
 //Saturn 1B: 4 flights, 0 failures
@@ -279,13 +276,14 @@
 	{
 		name = J-2-225K
 		// Only failures (Apollo 6) but was caused more by F-1 POGO issues than J-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2-225K]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.909091
 		cycleReliabilityEnd = 0.981818
 		techTransfer = J-2-200K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2-225K] { %ratedBurnTime = #$/TESTFLIGHT[J-2-225K]/ratedBurnTime$ } }
 }
 
 //Saturn 1B: 2 flights, 0 failures
@@ -300,13 +298,14 @@
 	{
 		name = J-2-230K
 		// No failures, refined design (starts low as should have good data transfer)
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2-230K]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.987179
 		ignitionReliabilityEnd = 0.997436
 		cycleReliabilityStart = 0.985294
 		cycleReliabilityEnd = 0.997059
 		techTransfer = J-2-200K,J-2-225K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2-230K] { %ratedBurnTime = #$/TESTFLIGHT[J-2-230K]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[J-2S]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -314,11 +313,12 @@
 	{
 		name = J-2S
 		// Simplified version of a well-refined engine
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[J-2S]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.987
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.9995
 		techTransfer = J-2-200K,J-2-225K,J-2-230K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2S] { %ratedBurnTime = #$/TESTFLIGHT[J-2S]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -64,7 +64,6 @@
 			name = Juno45k
 			minThrust = 200.17
 			maxThrust = 200.17
-			ratedBurnTime = 135
 			heatProduction = 100
 			
 			PROPELLANT
@@ -104,10 +103,11 @@
 	TESTFLIGHT
 	{
 			name = Juno45k
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Juno45k]/ratedBurnTime$
+			ratedBurnTime = 135
 			ignitionReliabilityStart = 0.80	 // Guesses, but should be about the same as X-405H
 			ignitionReliabilityEnd = 0.94
 			cycleReliabilityStart = 0.86
 			cycleReliabilityEnd = 0.96
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Juno45k] { %ratedBurnTime = #$/TESTFLIGHT[Juno45k]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -64,7 +64,6 @@
 			name = Juno6k
 			minThrust = 26.68932
 			maxThrust = 26.68932
-			ratedBurnTime = 450
 			heatProduction = 100
 			
 			PROPELLANT
@@ -104,10 +103,11 @@
 	TESTFLIGHT
 	{
 			name = Juno6k
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Juno6k]/ratedBurnTime$
+			ratedBurnTime = 450
 			ignitionReliabilityStart = 0.85
 			ignitionReliabilityEnd = 0.95
 			cycleReliabilityStart = 0.79
 			cycleReliabilityEnd = 0.95
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Juno6k] { %ratedBurnTime = #$/TESTFLIGHT[Juno6k]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/KIWIA24_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KIWIA24_Config.cfg
@@ -51,7 +51,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 4.2				
 			maxThrust = 29.3				
-			ratedBurnTime = 360
 			massMult = 1			
 			ignitions = 2
 			%ullage = True
@@ -110,7 +109,7 @@
 	TESTFLIGHT
 	{
 		name = KIWIA24-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[KIWIA24-Hydrogen]/ratedBurnTime$ // 6 minutes
+		ratedBurnTime = 360 // 6 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -122,4 +121,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[KIWIA24-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[KIWIA24-Hydrogen]/ratedBurnTime$ } }
 } 

--- a/GameData/RealismOverhaul/Engine_Configs/KIWIB48_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KIWIB48_Config.cfg
@@ -40,7 +40,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 22
 			maxThrust = 220
-			ratedBurnTime = 750
 			massMult = 1			
 			ignitions = 4
 			%ullage = True
@@ -100,7 +99,7 @@
 	TESTFLIGHT
 	{
 		name = KIWIB48-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[KIWIB48-Hydrogen]/ratedBurnTime$ // 12 minutes
+		ratedBurnTime = 750 // 12 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -112,4 +111,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[KIWIB48-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[KIWIB48-Hydrogen]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
@@ -97,7 +97,6 @@
 			description = Developed for use as an N-1 upper stage. Cancelled with the N-1, but considered for use on Proton and Angara
 			minThrust = 69.6
 			maxThrust = 69.6
-			ratedBurnTime = 800
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -131,7 +130,6 @@
 			description = AKA RD-56M. Upgraded model of the RD-56. Never saw use in the USSR, but was sold to India, and later license built in India. Poor overall reliability
 			minThrust = 73.58
 			maxThrust = 73.58
-			ratedBurnTime = 800
 			heatProduction = 100
 			massMult = 0.585
 			PROPELLANT
@@ -166,7 +164,6 @@
 			description = Natively developed Indian upgrade of the KVD-1 following embargos and poor performance. Used for GSLV Mk.II.
 			minThrust = 69.55
 			maxThrust = 69.55
-			ratedBurnTime = 850
 			heatProduction = 100
 			massMult = 0.585
 			ignitions = 5
@@ -196,7 +193,7 @@
 	{
 		name = RD-56
 		//Never flew, guess based on performance of KVD-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-56]/ratedBurnTime$
+		ratedBurnTime = 800
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.5
@@ -204,6 +201,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-56] { %ratedBurnTime = #$/TESTFLIGHT[RD-56]/ratedBurnTime$ } }
 }
 //GSLV Mk.1 (1): 1 flight, 1 failure.
 //GSLV Mk.1 (2): 3 flights, 1 failure.
@@ -215,7 +213,7 @@
 	TESTFLIGHT
 	{
 		name = KVD-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[KVD-1]/ratedBurnTime$
+		ratedBurnTime = 800
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
 		cycleReliabilityStart = 0.500000
@@ -224,6 +222,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[KVD-1] { %ratedBurnTime = #$/TESTFLIGHT[KVD-1]/ratedBurnTime$ } }
 }
 //GSLV Mk.2 (1): 5 flights, 1 failure
 //GSLV Mk.2 (2): 1 flight, 0 failures
@@ -236,7 +235,7 @@
 	TESTFLIGHT
 	{
 		name = CE-7.5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CE-7.5]/ratedBurnTime$
+		ratedBurnTime = 850
 		ignitionReliabilityStart = 0.928571
 		ignitionReliabilityEnd = 0.985714
 		cycleReliabilityStart = 0.857143
@@ -245,4 +244,5 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[CE-7.5] { %ratedBurnTime = #$/TESTFLIGHT[CE-7.5]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Kestrel_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Kestrel_Config.cfg
@@ -78,7 +78,6 @@
 			name = Kestrel
 			minThrust = 30.5
 			maxThrust = 30.5
-			ratedBurnTime = 415
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -163,10 +162,11 @@
 	TESTFLIGHT
 	{
 			name = Kestrel
-			ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Kestrel]/ratedBurnTime$
+			ratedBurnTime = 415
 			ignitionReliabilityStart = 0.750000
 			ignitionReliabilityEnd = 0.950000
 			cycleReliabilityStart = 0.666667
 			cycleReliabilityEnd = 0.933333
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Kestrel] { %ratedBurnTime = #$/TESTFLIGHT[Kestrel]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LE7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LE7_Config.cfg
@@ -97,7 +97,6 @@
 			description = Developed as a first stage engine for the Japanese H-II.
 			maxThrust = 1078
 			minThrust = 1078
-			ratedBurnTime = 350
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -129,7 +128,6 @@
 			description = Simplified design for the H-IIA. Lower cost and better reliability, at the cost of lower performance. Intended to have a nozzle extension, but it had to be removed due to unexpected combustion instability issues.
 			maxThrust = 1074
 			minThrust = 773
-			ratedBurnTime = 400
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -162,7 +160,6 @@
 			description = A Redesigned nozzle extension allowed for the LE-7A to achieve its intended performance, at the cost of slightly more weight.
 			maxThrust = 1098
 			minThrust = 790
-			ratedBurnTime = 400
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -199,12 +196,13 @@
 	TESTFLIGHT
 	{
 		name = LE-7
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LE-7]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.857143
 		ignitionReliabilityEnd = 0.971429
 		cycleReliabilityStart = 0.857143
 		cycleReliabilityEnd = 0.971429
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LE-7] { %ratedBurnTime = #$/TESTFLIGHT[LE-7]/ratedBurnTime$ } }
 }
 //H-IIA: 41 flights, 1 failure. 1 Failure due to SRMs
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LE-7A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -212,13 +210,14 @@
 	TESTFLIGHT
 	{
 		name = LE-7A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LE-7A]/ratedBurnTime$
+		ratedBurnTime = 400
 		ignitionReliabilityStart = 0.976190
 		ignitionReliabilityEnd = 0.995238
 		cycleReliabilityStart = 0.976190
 		cycleReliabilityEnd = 0.995238
 		techTransfer = LE-7:25
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LE-7A] { %ratedBurnTime = #$/TESTFLIGHT[LE-7A]/ratedBurnTime$ } }
 }
 //H-IIB: 9 Flights, 0 failures
 //18 engines, 0 failures
@@ -227,11 +226,12 @@
 	TESTFLIGHT
 	{
 		name = LE-7A-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LE-7A-2]/ratedBurnTime$
+		ratedBurnTime = 400
 		ignitionReliabilityStart = 0.947368
 		ignitionReliabilityEnd = 0.989474
 		cycleReliabilityStart = 0.947368
 		cycleReliabilityEnd = 0.989474
 		techTransfer = LE-7A:75
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LE-7A-2] { %ratedBurnTime = #$/TESTFLIGHT[LE-7A-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -78,7 +78,6 @@
 			name = LMAE
 			minThrust = 15.57
 			maxThrust = 15.57
-			ratedBurnTime = 560
 			heatProduction = 20
 			massMult = 1.0
 			ullage = True
@@ -118,7 +117,6 @@
 			description = LMAE converted to run on Methalox for use on future manned Lunar and Martian landers. Developed and test fired, but cancelled in 2020 in favor of commercially developed landers.
 			minThrust = 24.5
 			maxThrust = 24.5
-			ratedBurnTime = 560
 			heatProduction = 20
 			massMult = 1.0
 			ullage = True
@@ -159,12 +157,13 @@
 	TESTFLIGHT
 	{
 		name = LMAE
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LMAE]/ratedBurnTime$
+		ratedBurnTime = 560
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LMAE] { %ratedBurnTime = #$/TESTFLIGHT[LMAE]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-18]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -173,10 +172,11 @@
 	{
 		//guess, based on LMAE
 		name = RS-18
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-18]/ratedBurnTime$
+		ratedBurnTime = 560
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-18] { %ratedBurnTime = #$/TESTFLIGHT[RS-18]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
@@ -109,7 +109,6 @@
 			description = Lunar Module Descent Engine used up to Apollo 15
 			minThrust = 4.67
 			maxThrust = 43.9
-			ratedBurnTime = 960
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -149,7 +148,6 @@
 			description = LMDE upgraded for J-class missions. Improved performance and more fuel allowed the LEM to carry rovers and extra scientific equipment to the surface.
 			minThrust = 4.67
 			maxThrust = 45.04
-			ratedBurnTime = 960
 			heatProduction = 36
 			massMult = 1.0
 			ullage = True
@@ -189,7 +187,6 @@
 			description = Simplifed LMDE used on Delta-P as an upper stage engine.
 			minThrust = 43.8
 			maxThrust = 43.8
-			ratedBurnTime = 360
 			heatProduction = 48
 			massMult = 0.7151 //mass is 0.113
 			ullage = True
@@ -236,7 +233,7 @@
 	TESTFLIGHT
 	{
 		name = LMDE-H
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LMDE-H]/ratedBurnTime$
+		ratedBurnTime = 960
 		ignitionReliabilityStart = 0.933333 // ignition chance will be this at 0 data
 		ignitionReliabilityEnd = 0.986667 // and this at 10000 data
 		
@@ -269,13 +266,14 @@
 		
 		// techTransfer determines what tech transfer, if any, applies. It is used as given.
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LMDE-H] { %ratedBurnTime = #$/TESTFLIGHT[LMDE-H]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LMDE-J]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LMDE-J
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LMDE-J]/ratedBurnTime$
+		ratedBurnTime = 960
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		ignitionDynPresFailMultiplier = 0.1
@@ -284,6 +282,7 @@
 		techTransfer = LMDE-H:75
 		reliabilityDataRateMultiplier = 2
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LMDE-J] { %ratedBurnTime = #$/TESTFLIGHT[LMDE-J]/ratedBurnTime$ } }
 }
 //Delta-1410: 1 flight, 0 failures
 //Delta 1910: 1 flight, 0 failures
@@ -306,7 +305,7 @@
 	TESTFLIGHT
 	{
 		name = TR-201
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[TR-201]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.989130
 		ignitionReliabilityEnd = 0.997826
 		ignitionDynPresFailMultiplier = 0.1
@@ -314,4 +313,5 @@
 		cycleReliabilityEnd = 0.996721
 		techTransfer = LMDE-H,LMDE-J:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[TR-201] { %ratedBurnTime = #$/TESTFLIGHT[TR-201]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -86,7 +86,6 @@
 			description = First production version. Used on Thor and Atlas as vernier engines
 			minThrust = 5.1144
 			maxThrust = 5.1144
-			ratedBurnTime = 360
 			heatProduction = 10
 
 			ullage = True
@@ -126,7 +125,6 @@
 			description = Developed for later, larger Thor variants, with improved performance
 			minThrust = 5.369
 			maxThrust = 5.369
-			ratedBurnTime = 360
 			heatProduction = 10
 
 			ullage = True
@@ -165,7 +163,6 @@
 			description = Downrated for later Atlas variants when studies showed much lower thrust could be used to maintain control
 			minThrust = 2.976
 			maxThrust = 2.976
-			ratedBurnTime = 360
 			heatProduction = 10
 			massMult = 0.8
 
@@ -207,12 +204,13 @@
 	TESTFLIGHT
 	{
 		name = LR101-NA-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-3]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.998
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR101-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR101-NA-3]/ratedBurnTime$ } }
 }
 // http://www.asi.org/adb/04/03/09/01/bna.html
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR101-NA-11]]]:BEFORE[zTestFlight]
@@ -220,7 +218,7 @@
 	TESTFLIGHT
 	{
 		name = LR101-NA-11
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-11]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
@@ -228,13 +226,14 @@
 		reliabilityDataRateMultiplier = 2
 		techTransfer = LR101-NA-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR101-NA-11] { %ratedBurnTime = #$/TESTFLIGHT[LR101-NA-11]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR101-NA-15]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR101-NA-15
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-15]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
@@ -242,4 +241,5 @@
 		techTransfer =	LR101-NA-3,LR101-NA-11:50
 		reliabilityDataRateMultiplier = 2
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR101-NA-15] { %ratedBurnTime = #$/TESTFLIGHT[LR101-NA-15]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -170,7 +170,6 @@
 			description = Prototype MA-1 Atlas sustainer sustainer. An XLR43 modified with vaccum optimzed nozzle and burning kerosene. Used on Atlas B (Atlas A had no sustainer)
 			minThrust = 240.2
 			maxThrust = 240.2
-			ratedBurnTime = 330
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True
@@ -213,7 +212,6 @@
 			description = MA-1 Atlas sustainer engine. Significantly upgraded and simplified, used on Atlas B/C
 			minThrust = 352.2
 			maxThrust = 352.2
-			ratedBurnTime = 330
 			heatProduction = 100
 			massMult = 1.0
 			ullage = True
@@ -255,7 +253,6 @@
 			description = MA-3 Atlas Sustainer engine. Developed for the USAF for Atlas D
 			minThrust = 366.1
 			maxThrust = 366.1
-			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
 			ullage = True
@@ -296,7 +293,6 @@
 			description = MA-3 Atlas sustainer engine. Slightly upgraded for Atlas E/F
 			minThrust = 373.2
 			maxThrust = 373.2
-			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 0.8978 // 413kg http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm for the LR105-5
 			ullage = True
@@ -337,7 +333,6 @@
 			description = MA-5.1 sustainer engine for Atlas-Agena launches
 			minThrust = 385.2
 			maxThrust = 385.2
-			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 1.02174 // 470kg engine, same source
 			ullage = True
@@ -378,7 +373,6 @@
 			description = MA-5.2 sustainer engine for Atlas-Centaur launches
 			minThrust = 386.4
 			maxThrust = 386.4
-			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 1.02174 // 470kg engine, same source
 			ullage = True
@@ -419,7 +413,6 @@
 			description = Atlas MA-5A sustainer engine. Upgraded with RS-27 components to reduce cost and improve performance. Used on Atlas II
 			minThrust = 386.4
 			maxThrust = 386.4
-			ratedBurnTime = 350
 			heatProduction = 100
 			massMult = 1.0 // total guess, lower than above because H-1 was lighter...?
 			ullage = True
@@ -475,13 +468,14 @@
 	TESTFLIGHT
 	{
 		name = LR43-NA-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR43-NA-5]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.826087
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
 		cycleReliabilityEnd = 0.965217
 		techTransfer = XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR43-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR43-NA-5]/ratedBurnTime$ } }
 }
 
 //Atlas-C: 6 flights, 3 failures
@@ -491,13 +485,14 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-3]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = XLR43-NA-3,LR43-NA-5:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-3]/ratedBurnTime$ } }
 }
 
 //Atlas-D: 116 flights, 25 failures
@@ -527,13 +522,14 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-5]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.956710
 		ignitionReliabilityEnd = 0.991342
 		cycleReliabilityStart = 0.956710
 		cycleReliabilityEnd = 0.991342
 		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-5]/ratedBurnTime$ } }
 }
 
 //Atlas-E: 34 flights, 13 failures
@@ -556,13 +552,14 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-6
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-6]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.939394
 		ignitionReliabilityEnd = 0.987879
 		cycleReliabilityStart = 0.939394
 		cycleReliabilityEnd = 0.987879
 		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-6] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-6]/ratedBurnTime$ } }
 }
 
 //Atlas-G Centaur-D1AR: 7 flights, 0 failures
@@ -573,13 +570,14 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-7.1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-7.1]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
 		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.1]/ratedBurnTime$ } }
 }
 
 //Atlas-H MSD: 5 flights, 0 failures
@@ -590,13 +588,14 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-7.2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-7.2]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
 		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6,LR105-NA-7.1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.2]/ratedBurnTime$ } }
 }
 
 //Atlas-2: 10 flights, 0 failures
@@ -608,11 +607,12 @@
 	TESTFLIGHT
 	{
 		name = RS-56-OSA
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-56-OSA]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.994737
 		ignitionReliabilityEnd = 0.998947
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-5,LR105-NA-6,LR105-NA-7.1,LR105-NA-7.2,RS-27,RS-27A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-56-OSA] { %ratedBurnTime = #$/TESTFLIGHT[RS-56-OSA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
@@ -99,7 +99,6 @@
 			description = Prototype for USAF ISINGLASS rocketplane
 			minThrust = 217.1
 			maxThrust = 1085.4
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -132,7 +131,6 @@
 			description = Production model for USAF ISINGLASS rocketplane
 			minThrust = 222.4
 			maxThrust = 1112.1
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -165,7 +163,6 @@
 			description = P&W proposal for Space Shuttle Main Engine
 			minThrust = 778.5
 			maxThrust = 1556.9
-			ratedBurnTime = 480
 			massMult = 1.25	//Guess
 			PROPELLANT
 			{
@@ -199,7 +196,6 @@
 			description = Speculative upgrade
 			minThrust = 809.6
 			maxThrust = 1619.2
-			ratedBurnTime = 480
 			massMult = 1.25	//Guess
 			//speculative = fictional
 			PROPELLANT
@@ -252,49 +248,53 @@
 	TESTFLIGHT
 	{
 		name = XLR129-P-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR129-P-1]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.8491
 		ignitionReliabilityEnd = 0.9091
 		cycleReliabilityStart = 0.8875
 		cycleReliabilityEnd = 0.9475
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR129-P-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR129-P-1]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR129-P-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR129-P-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-1]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.962
 		cycleReliabilityStart = 0.9468
 		cycleReliabilityEnd = 0.9995
 		techTransfer = XLR129-P-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR129-P-1] { %ratedBurnTime = #$/TESTFLIGHT[LR129-P-1]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR129-P-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR129-P-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-2]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.932
 		ignitionReliabilityEnd = 0.992
 		cycleReliabilityStart = 0.872
 		cycleReliabilityEnd = 0.932
 		techTransfer = XLR129-P-1,LR129-P-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR129-P-2] { %ratedBurnTime = #$/TESTFLIGHT[LR129-P-2]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR129-P-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR129-P-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-3]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.9415
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9415
 		cycleReliabilityEnd = 0.9995
 		techTransfer = XLR129-P-1,LR129-P-1,LR129-P-2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR129-P-3] { %ratedBurnTime = #$/TESTFLIGHT[LR129-P-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -145,7 +145,6 @@
 			minThrust = 696.6
 			// OLD REFERENCE-NO LONGER USED: https://forum.nasaspaceflight.com/index.php?PHPSESSID=br6ak5uvm7sfiqsbqv53ej40g4&topic=40733.0
 			maxThrust = 696.6
-			ratedBurnTime = 182
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -191,7 +190,6 @@
 			description = Main engine for the Jupiter / Juno II launch vehicle
 			minThrust = 766.34
 			maxThrust = 766.34
-			ratedBurnTime = 182
 			heatProduction = 100
 			massMult = 1.0
 
@@ -240,7 +238,6 @@
 			// 176,000 lbf * 0.00444822 = 782.88672 kN
 			// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 783
-			ratedBurnTime = 165
 			heatProduction = 100
 			// Linear steps from S-3 to LR79-NA-9 to LR79-NA-11 to LR79-NA-13
 			// Only known two masses are S-3 and LR79-NA-13
@@ -289,7 +286,6 @@
 			description = Main engine for MB-3-II propulsion system
 			minThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
-			ratedBurnTime = 165
 			heatProduction = 100
 			// Linear steps from S-3 to LR79-NA-9 to LR79-NA-11 to LR79-NA-13
 			// Only known two masses are S-3 and LR79-NA-13
@@ -338,7 +334,6 @@
 			description = Main engine for MB-3-III propulsion system
 			minThrust = 873	// Source #6
 			maxThrust = 873	// Source #6
-			ratedBurnTime = 260
 			heatProduction = 100
 			massMult = 0.965 // Source #7
 
@@ -394,13 +389,14 @@
 	TESTFLIGHT
 	{
 		name = S-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S-3]/ratedBurnTime$
+		ratedBurnTime = 182
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = XLR43-NA-3:40	//Direct derivative of LR43
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S-3] { %ratedBurnTime = #$/TESTFLIGHT[S-3]/ratedBurnTime$ } }
 }
 
 //Jupiter: 7 flights, 0 failures
@@ -411,13 +407,14 @@
 	TESTFLIGHT
 	{
 		name = S-3D
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S-3D]/ratedBurnTime$
+		ratedBurnTime = 182
 		ignitionReliabilityStart = 0.882353
 		ignitionReliabilityEnd = 0.976471
 		cycleReliabilityStart = 0.882353
 		cycleReliabilityEnd = 0.976471
 		techTransfer = XLR43-NA-3,S-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S-3D] { %ratedBurnTime = #$/TESTFLIGHT[S-3D]/ratedBurnTime$ } }
 }
 
 //Thor DM-18: 17 flights, 11 failures
@@ -447,13 +444,14 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-9
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-9]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.789773
 		ignitionReliabilityEnd = 0.957955
 		cycleReliabilityStart = 0.789773
 		cycleReliabilityEnd = 0.957955
 		techTransfer = XLR43-NA-3,S-3,S-3D:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-9] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-9]/ratedBurnTime$ } }
 }
 
 //Thor-DM18C: 3 flights, 0 failures
@@ -471,13 +469,14 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-11
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-11]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.936364
 		ignitionReliabilityEnd = 0.987273
 		cycleReliabilityStart = 0.936364
 		cycleReliabilityEnd = 0.987273
 		techTransfer = XLR43-NA-3,S-3,S-3D,LR79-NA-9:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-11] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-11]/ratedBurnTime$ } }
 }
 
 //Thor-SLV2A Agena-B: 2 flights, 0 failures
@@ -515,11 +514,12 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-13
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-13]/ratedBurnTime$
+		ratedBurnTime = 260
 		ignitionReliabilityStart = 0.964646
 		ignitionReliabilityEnd = 0.992929
 		cycleReliabilityStart = 0.964646
 		cycleReliabilityEnd = 0.992929
 		techTransfer = XLR43-NA-3,S-3,S-3D,LR79-NA-9,LR79-NA-11:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-13] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-13]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
@@ -65,7 +65,6 @@
 			name = XLR83-NA-1
 			minThrust = 2072
 			maxThrust = 2072
-			ratedBurnTime = 100
 			heatProduction = 100
 
 			PROPELLANT
@@ -103,11 +102,12 @@
 	{
 		//Cancelled before it could fly. Reliability assumed to be the same as LR43
 		name = XLR83-NA-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR83-NA-1]/ratedBurnTime$
+		ratedBurnTime = 100
 		ignitionReliabilityStart = 0.70
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.80
 		cycleReliabilityEnd = 0.90
 		techTransfer = XLR43-NA-1,XLR43-NA-3:50	//LR83 was an XLR43 modified to burn kerosene.
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR83-NA-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR83-NA-1]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
@@ -41,7 +41,6 @@
 			description = Developed for Titan C
 			minThrust = 667.0
 			maxThrust = 667.0
-			ratedBurnTime = 300
 			heatProduction = 175
 			ignitions = 1
 			PROPELLANT
@@ -67,7 +66,6 @@
 			description = Developed as Aerojets proposal for the Saturn V upper stage engines. It could be ready much earlier than its competition, but the J-2 was chosen due to its higher performance.
 			minThrust = 778.0
 			maxThrust = 778.0
-			ratedBurnTime = 360
 			heatProduction = 175
 			ignitions = 2
 			massMult = 1.14865
@@ -94,7 +92,6 @@
 			description = Speculative upgrade for Titan C
 			minThrust = 801 // 180 klbf
 			maxThrust = 801
-			ratedBurnTime = 480
 			heatProduction = 175
 			massMult = 1.08109
 			ignitions = 2
@@ -122,7 +119,6 @@
 			description = Speculative upgrade for use on later Saturn V missions
 			minThrust = 889.0
 			maxThrust = 889.0
-			ratedBurnTime = 480
 			heatProduction = 175
 			massMult = 1.18
 			ignitions = 3
@@ -151,7 +147,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-TitanC
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-TitanC]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.892
@@ -161,13 +157,14 @@
 
 		techTransfer = LR87-AJ-3:30
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-LH2-TitanC] { %ratedBurnTime = #$/TESTFLIGHT[LR87-LH2-TitanC]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR87-LH2-Vacuum]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR87-LH2-Vacuum
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-Vacuum]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.92
 		ignitionReliabilityEnd = 0.975
 		cycleReliabilityStart = 0.93
@@ -177,13 +174,14 @@
 
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-LH2-Vacuum] { %ratedBurnTime = #$/TESTFLIGHT[LR87-LH2-Vacuum]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR87-LH2-SustainerUpgrade]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR87-LH2-SustainerUpgrade
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-SustainerUpgrade]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
@@ -192,13 +190,14 @@
 
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-LH2-SustainerUpgrade] { %ratedBurnTime = #$/TESTFLIGHT[LR87-LH2-SustainerUpgrade]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LR87-LH2-VacuumUpgrade]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LR87-LH2-VacuumUpgrade
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-VacuumUpgrade]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.96
@@ -208,4 +207,5 @@
 
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-LH2-VacuumUpgrade] { %ratedBurnTime = #$/TESTFLIGHT[LR87-LH2-VacuumUpgrade]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -151,7 +151,6 @@
 			description = First stage engine for the Titan I ICBM
 			minThrust = 765.95
 			maxThrust = 765.95
-			ratedBurnTime = 137
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -188,7 +187,6 @@
 			description = First stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
 			minThrust = 1075.5
 			maxThrust = 1075.5
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -222,7 +220,6 @@
 			description = First stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
 			minThrust = 1097.2
 			maxThrust = 1097.2
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -257,7 +254,6 @@
 			description = First stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
 			minThrust = 1130
 			maxThrust = 1130
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -290,7 +286,6 @@
 			description = First stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Modified to light in midair, since the UA120x boosters used by Titan III could lift Titan without assistance. Ignited just before booster burnout.
 			minThrust = 1170
 			maxThrust = 1170
-			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -323,7 +318,6 @@
 			description = First stage engine for Titan IVA and IVB. Equipped with a nozzle extension to improve vacuum performance, since it was not needed at sea level.
 			minThrust = 1210.9
 			maxThrust = 1210.9
-			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -356,7 +350,6 @@
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design
 			minThrust = 1012
 			maxThrust = 1012
-			ratedBurnTime = 150
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -390,7 +383,6 @@
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design. Equipped with nozzle extensions to increase vacuum performance
 			minThrust = 1026
 			maxThrust = 1026
-			ratedBurnTime = 150
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -428,7 +420,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-3]/ratedBurnTime$
+		ratedBurnTime = 137
 		ignitionReliabilityStart = 0.898305
 		ignitionReliabilityEnd = 0.979661
 		cycleReliabilityStart = 0.898305
@@ -436,6 +428,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-3] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-3]/ratedBurnTime$ } }
 }
 
 //SM-68B: 81 flights, 7 failures
@@ -448,7 +441,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-5]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.962766
 		ignitionReliabilityEnd = 0.992553
 		cycleReliabilityStart = 0.962766
@@ -458,6 +451,7 @@
 
 		techTransfer = LR87-AJ-3:30
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-5] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-5]/ratedBurnTime$ } }
 }
 
 //Titan-2-GLV: 12 flights, 0 failures
@@ -467,7 +461,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-7
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-7]/ratedBurnTime$ // [1] Page 11.C-9, 147s rounded up to 150
+		ratedBurnTime = 150 // [1] Page 11.C-9, 147s rounded up to 150
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.960000
@@ -477,6 +471,7 @@
 
 		techTransfer = LR87-AJ-3,LR87-AJ-5:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-7] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-7]/ratedBurnTime$ } }
 }
 
 //Titan-3A: 4 flights, 0 failures
@@ -488,7 +483,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.975000
@@ -498,6 +493,7 @@
 
 		techTransfer = LR87-AJ-3,LR87-AJ-5,LR87-AJ-7:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-9] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-9]/ratedBurnTime$ } }
 }
 
 //no data, never flew. Using AJ-9 data
@@ -506,7 +502,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9-Kero-15AR
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9-Kero-15AR]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.975000
@@ -516,6 +512,7 @@
 
 		techTransfer = LR87-AJ-3,LR87-AJ-5,LR87-AJ-7:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-9-Kero-15AR] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-9-Kero-15AR]/ratedBurnTime$ } }
 }
 
 //no data, never flew. Using AJ-9 data
@@ -524,7 +521,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9-Kero
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9-Kero]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.975000
@@ -534,6 +531,7 @@
 
 		techTransfer = LR87-AJ-3,LR87-AJ-5,LR87-AJ-7:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-9-Kero] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-9-Kero]/ratedBurnTime$ } }
 }
 
 //Titan-3(23)B Agena-D: 9 flights, 0 failures
@@ -553,7 +551,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-11]/ratedBurnTime$ // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
+		ratedBurnTime = 300 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
 		ignitionReliabilityStart = 0.982143
 		ignitionReliabilityEnd = 0.996429
 		cycleReliabilityStart = 0.982143
@@ -563,6 +561,7 @@
 
 		techTransfer = LR87-AJ-3,LR87-AJ-5,LR87-AJ-7,LR87-AJ-9:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-11] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-11]/ratedBurnTime$ } }
 }
 
 //Commercial Titan 3: 4 flights, 0 failures
@@ -578,7 +577,7 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-11A]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.988372
 		ignitionReliabilityEnd = 0.997674
 		cycleReliabilityStart = 0.988372
@@ -588,4 +587,5 @@
 
 		techTransfer = LR87-AJ-3,LR87-AJ-5,LR87-AJ-7,LR87-AJ-9,LR87-AJ-11:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-11A] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-11A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -168,7 +168,6 @@
 			description = MA-0 and prototype MA-1 Atlas Booster engine. An XLR43 modified to burn kerosene. Used on Convair X12 and Atlas A
 			minThrust = 756.8
 			maxThrust = 756.8
-			ratedBurnTime = 135
 			heatProduction = 100
 			massMult = 1
 
@@ -214,7 +213,6 @@
 			description = MA-1 Atlas booster engine. Significantly upgraded and simplified, with both engines sharing turbopumps. Used on Atlas B/C
 			minThrust = 758.7
 			maxThrust = 758.7
-			ratedBurnTime = 135
 			heatProduction = 100
 			massMult = 0.89
 
@@ -260,7 +258,6 @@
 			description = MA-3 Atlas booster engine. Each engine had its own turbopump allow for engines to be quickly swapped. Developed for the USAF for Atlas D
 			minThrust = 831.4
 			maxThrust = 831.4
-			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 1.15		 // https://www.hq.nasa.gov/alsj/a12/Surveyor-III-MIssionRpt1967028267.pdf. With a 1.61t skirt, this should result in each booster weighing 0.828t resulting in a 3.266t total weight which includes residuals.
 
@@ -306,7 +303,6 @@
 			description = MA-3 Atlas booster engine. Slightly upgraded for Atlas E/F
 			minThrust = 846.6
 			maxThrust = 846.6
-			ratedBurnTime = 160
 			heatProduction = 100
 			massMult = 1.2264		// https://ia601201.us.archive.org/30/items/NASA_NTRS_Archive_19700011207/NASA_NTRS_Archive_19700011207.pdf. With a 1.61t skirt, this should result in each booster weighing 0.883t resulting in the 3.376t total weight (including residuals) of AC-13.
 
@@ -352,7 +348,6 @@
 			description = MA-5.1 booster engine. Both engines shared turbopumps due to NASA preferring that configuration. Used for Atlas-Agena launches
 			minThrust = 931.7
 			maxThrust = 931.7
-			ratedBurnTime = 165
 			heatProduction = 100
 			massMult = 1.414		// astronautix.com MA-5. With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
@@ -396,7 +391,6 @@
 			description = MA-5.2 booster engine. Both engines shared turbopumps due to NASA preferring that configuration. Used for Atlas-Centaur launches
 			minThrust = 950.8
 			maxThrust = 950.8
-			ratedBurnTime = 165
 			heatProduction = 100
 			massMult = 1.414		// astronautix.com MA-5.  With a 1.61t skirt, this should result in each booster weighing 1.018t resulting in a 3.646t total weight.
 
@@ -442,7 +436,6 @@
 			description = Atlas MA-5A booster engine. Upgraded with RS-27 components to reduce cost and improve performance. Used on Atlas II
 			minThrust = 1077.6
 			maxThrust = 1077.6
-			ratedBurnTime = 170
 			heatProduction = 100
 			massMult = 1.7896		// astronautix.com Atlas II.  With a 1.61t skirt, this should result in each booster weighing 1.289t resulting in a 4.187t total weight
 			//massMult = 1.11805	FIXME maybe revert to this value?
@@ -500,13 +493,14 @@
 	TESTFLIGHT
 	{
 		name = LR43-NA-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR43-NA-3]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.826087
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
 		cycleReliabilityEnd = 0.965217
 		techTransfer = XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR43-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR43-NA-3]/ratedBurnTime$ } }
 }
 
 //Atlas-C: 6 flights, 3 failures
@@ -516,13 +510,14 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-3]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = XLR43-NA-3,LR43-NA-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-3]/ratedBurnTime$ } }
 }
 
 //Atlas-D: 116 flights, 25 failures
@@ -552,13 +547,14 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-5]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.956710
 		ignitionReliabilityEnd = 0.991342
 		cycleReliabilityStart = 0.956710
 		cycleReliabilityEnd = 0.991342
 		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-5]/ratedBurnTime$ } }
 }
 
 //Atlas-E: 34 flights, 13 failures
@@ -581,13 +577,14 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-6
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-6]/ratedBurnTime$
+		ratedBurnTime = 160
 		ignitionReliabilityStart = 0.939394
 		ignitionReliabilityEnd = 0.987879
 		cycleReliabilityStart = 0.939394
 		cycleReliabilityEnd = 0.987879
 		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-6] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-6]/ratedBurnTime$ } }
 }
 
 //Atlas-G Centaur-D1AR: 7 flights, 0 failures
@@ -598,13 +595,14 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-7.1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-7.1]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
 		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-7.1]/ratedBurnTime$ } }
 }
 
 //Atlas-H MSD: 5 flights, 0 failures
@@ -615,13 +613,14 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-7.2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-7.2]/ratedBurnTime$
+		ratedBurnTime = 165
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
 		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6,LR89-NA-7.1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-7.2]/ratedBurnTime$ } }
 }
 
 //Atlas-2: 10 flights, 0 failures
@@ -633,11 +632,12 @@
 	TESTFLIGHT
 	{
 		name = RS-56-OBA
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-56-OBA]/ratedBurnTime$
+		ratedBurnTime = 170
 		ignitionReliabilityStart = 0.994737
 		ignitionReliabilityEnd = 0.998947
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-7.1,LR89-NA-7.2,RS-27,RS-27A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-56-OBA] { %ratedBurnTime = #$/TESTFLIGHT[RS-56-OBA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -145,7 +145,6 @@
 			description = Second stage engine for the Titan I ICBM.
 			minThrust = 362.87
 			maxThrust = 362.87 // added the Verniers back to the thrust
-			ratedBurnTime = 160
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -180,7 +179,6 @@
 			description = Second stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
 			minThrust = 448.2
 			maxThrust = 448.2 // added the Verniers back to the thrust
-			ratedBurnTime = 180
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -215,7 +213,6 @@
 			description = Second stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
-			ratedBurnTime = 190
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -249,7 +246,6 @@
 			description = Second stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
-			ratedBurnTime = 210
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -283,7 +279,6 @@
 			description = Second stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Slightly improved performance.
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
-			ratedBurnTime = 250
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -317,7 +312,6 @@
 			description = Second stage engine for Titan IVA and IVB. Slightly improved performance
 			minThrust = 474.6
 			maxThrust = 474.6 // added the Verniers back to the thrust
-			ratedBurnTime = 250
 			heatProduction = 160
 			PROPELLANT
 			{
@@ -360,7 +354,6 @@
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design
 			minThrust = 394.9
 			maxThrust = 394.9 // added the Verniers back to the thrust
-			ratedBurnTime = 210
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -399,12 +392,13 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-3]/ratedBurnTime$ // http://www.astronautix.com/engines/lr913.htm claims 225s but that makes no sense. Titan I-2 burn time was 155s, so let's round up to 180.
+		ratedBurnTime = 160 // http://www.astronautix.com/engines/lr913.htm claims 225s but that makes no sense. Titan I-2 burn time was 155s, so let's round up to 180.
 		ignitionReliabilityStart = 0.950000
 		ignitionReliabilityEnd = 0.990000
 		cycleReliabilityStart = 0.950000
 		cycleReliabilityEnd = 0.990000
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-3] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-3]/ratedBurnTime$ } }
 }
 
 //Titan-2: 78 flights, 4 failures
@@ -417,7 +411,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-5]/ratedBurnTime$ // Titan II SLV and Titan 23G.
+		ratedBurnTime = 180 // Titan II SLV and Titan 23G.
 		ignitionReliabilityStart = 0.956044
 		ignitionReliabilityEnd = 0.991209
 		cycleReliabilityStart = 0.956044
@@ -427,6 +421,7 @@
 
 		techTransfer = LR91-AJ-3:30
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-5] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-5]/ratedBurnTime$ } }
 }
 
 //Titan-2-GLV: 12 flights, 0 failures
@@ -436,7 +431,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-7
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-7]/ratedBurnTime$ // Titan II GLV, had a 9s stage stretch, round to 190s.
+		ratedBurnTime = 190 // Titan II GLV, had a 9s stage stretch, round to 190s.
 		ignitionReliabilityStart = 0.961165
 		ignitionReliabilityEnd = 0.992233
 		cycleReliabilityStart = 0.961165
@@ -446,6 +441,7 @@
 
 		techTransfer = LR91-AJ-5:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-7] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-7]/ratedBurnTime$ } }
 }
 
 //Titan-3A: 4 flights, 0 failures
@@ -457,7 +453,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-9
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-9]/ratedBurnTime$ // Titan III stretch
+		ratedBurnTime = 210 // Titan III stretch
 		ignitionReliabilityStart = 0.974359
 		ignitionReliabilityEnd = 0.994872
 		cycleReliabilityStart = 0.974359
@@ -467,6 +463,7 @@
 
 		techTransfer = LR91-AJ-5,LR91-AJ-7:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-9] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-9]/ratedBurnTime$ } }
 }
 
 //no data, never flew. Using AJ-9 data
@@ -475,7 +472,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-9-Kero
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-9-Kero]/ratedBurnTime$ // Titan III stretch
+		ratedBurnTime = 210 // Titan III stretch
 		ignitionReliabilityStart = 0.974359
 		ignitionReliabilityEnd = 0.994872
 		cycleReliabilityStart = 0.974359
@@ -485,6 +482,7 @@
 
 		techTransfer = LR91-AJ-5,LR91-AJ-7:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-9-Kero] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-9-Kero]/ratedBurnTime$ } }
 }
 
 //Titan-3(23)B Agena-D: 9 flights, 0 failures
@@ -504,7 +502,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-11
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-11]/ratedBurnTime$ // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
+		ratedBurnTime = 250 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
 		ignitionReliabilityStart = 0.972727
 		ignitionReliabilityEnd = 0.994545
 		cycleReliabilityStart = 0.972727
@@ -514,6 +512,7 @@
 
 		techTransfer = LR91-AJ-5,LR91-AJ-7,LR91-AJ-9:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-11] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-11]/ratedBurnTime$ } }
 }
 
 //Commercial Titan 3: 4 flights, 0 failures
@@ -529,7 +528,7 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-11A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-11A]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
 		cycleReliabilityStart = 0.975610
@@ -539,4 +538,5 @@
 
 		techTransfer = LR91-AJ-5,LR91-AJ-7,LR91-AJ-9,LR91-AJ-11:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-11A] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-11A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -132,7 +132,6 @@
 			description = Initial version of the M-1, generating 1.2 mlbf of thrust
 			minThrust = 5337.866
 			maxThrust = 5337.866
-			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -165,7 +164,6 @@
 			description = Production version of the M-1, generating 1.5 mlbf of thrust
 			minThrust = 6672.332
 			maxThrust = 6672.332
-			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -198,7 +196,6 @@
 			description = 1990s proposal to convert the M-1 into a sea level sustainer engine for super-heavy launch vehicles
 			minThrust = 6928
 			maxThrust = 6928
-			ratedBurnTime = 500
 			heatProduction = 100
 			massMult = 1.01
 			PROPELLANT
@@ -232,7 +229,6 @@
 			description = M-1, uprated to 1.8 mlbf. All M-1 components were designed to handle 1200 psi chamber to allow this upgrade.
 			minThrust = 8006.799
 			maxThrust = 8006.799
-			ratedBurnTime = 500
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -265,7 +261,6 @@
 			description = Sea level M-1, but running at 1200 psi chamber pressure.
 			minThrust = 7708.87
 			maxThrust = 7708.87
-			ratedBurnTime = 500
 			heatProduction = 100
 			//speculative = fictional
 			PROPELLANT
@@ -301,62 +296,67 @@
 	TESTFLIGHT
 	{
 		name = M-1-Spec
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1-Spec]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9182
 		ignitionReliabilityEnd = 0.9932
 		cycleReliabilityStart = 0.9182
 		cycleReliabilityEnd = 0.9932
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1-Spec] { %ratedBurnTime = #$/TESTFLIGHT[M-1-Spec]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[M-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = M-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9257
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9257
 		cycleReliabilityEnd = 0.9999
 		techTransfer = M-1-Spec:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1] { %ratedBurnTime = #$/TESTFLIGHT[M-1]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[M-1SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = M-1SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1SL]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
 		cycleReliabilityEnd = 0.9999
 		techTransfer = M-1-Spec,M-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1SL] { %ratedBurnTime = #$/TESTFLIGHT[M-1SL]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[M-1U]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = M-1U
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1U]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
 		cycleReliabilityEnd = 0.9999
 		techTransfer = M-1-Spec,M-1,M-1SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1U] { %ratedBurnTime = #$/TESTFLIGHT[M-1U]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[M-1U-SL]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = M-1U-SL
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M-1U-SL]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
 		cycleReliabilityEnd = 0.9999
 		techTransfer = M-1-Spec,M-1,M-1SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1U-SL] { %ratedBurnTime = #$/TESTFLIGHT[M-1U-SL]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/M55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M55_Config.cfg
@@ -74,7 +74,6 @@
 			name = M55
 			minThrust = 876
 			maxThrust = 876
-			ratedBurnTime = 75
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -114,7 +113,7 @@
 	TESTFLIGHT
 	{
 		name = M55
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[M55]/ratedBurnTime$
+		ratedBurnTime = 75
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999		//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.972315
@@ -123,4 +122,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[M55] { %ratedBurnTime = #$/TESTFLIGHT[M55]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/MB35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB35_Config.cfg
@@ -65,7 +65,6 @@
 			name = MB-35
 			maxThrust = 155.7
 			minThrust = 155.7
-			ratedBurnTime = 1130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -99,7 +98,7 @@
 	TESTFLIGHT
 	{
 		name = MB-35					//assume same as RL10-B2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-35]/ratedBurnTime$
+		ratedBurnTime = 1130
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -108,4 +107,6 @@
 		ignitionDynPresFailMultiplier = 0.05
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MB-35] { %ratedBurnTime = #$/TESTFLIGHT[MB-35]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/MB45_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB45_Config.cfg
@@ -65,7 +65,6 @@
 			name = MB-XX-Demo
 			maxThrust = 177.9
 			minThrust = 177.9
-			ratedBurnTime = 720
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -96,7 +95,6 @@
 			name = MB-45
 			maxThrust = 200.2
 			minThrust = 200.2
-			ratedBurnTime = 1130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -130,7 +128,7 @@
 	TESTFLIGHT
 	{
 		name = MB-XX-Demo					//assume same as RL10-B2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-XX-Demo]/ratedBurnTime$
+		ratedBurnTime = 720
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -139,6 +137,8 @@
 		ignitionDynPresFailMultiplier = 0.05
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MB-XX-Demo] { %ratedBurnTime = #$/TESTFLIGHT[MB-XX-Demo]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[MB-45]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -146,7 +146,7 @@
 	TESTFLIGHT
 	{
 		name = MB-45					//assume same as RL10-B2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-45]/ratedBurnTime$
+		ratedBurnTime = 1130
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.985
@@ -155,4 +155,6 @@
 		ignitionDynPresFailMultiplier = 0.05
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MB-45] { %ratedBurnTime = #$/TESTFLIGHT[MB-45]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/MB60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB60_Config.cfg
@@ -65,7 +65,6 @@
 			name = MB-60
 			maxThrust = 266.9
 			minThrust = 266.9
-			ratedBurnTime = 1130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -99,7 +98,7 @@
 	TESTFLIGHT
 	{
 		name = MB-60					//assume same as RL10-B2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MB-60]/ratedBurnTime$
+		ratedBurnTime = 1130
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -108,4 +107,6 @@
 		ignitionDynPresFailMultiplier = 0.05
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MB-60] { %ratedBurnTime = #$/TESTFLIGHT[MB-60]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
@@ -59,7 +59,6 @@
 			name = MR-80B
 			minThrust = 0.031
 			maxThrust = 3.603
-			ratedBurnTime = 350
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -90,11 +89,12 @@
 	{
 		name = MR-80B
 		//Extremely simple and reliable monopropellant engines
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MR-80B]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
 		cycleReliabilityEnd = 0.999
 		techTransfer = MR-80-TDE:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MR-80B] { %ratedBurnTime = #$/TESTFLIGHT[MR-80B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -217,7 +217,6 @@
 			description = Used on Falcon 1 first stage
 			minThrust = 369.2
 			maxThrust = 369.2
-			ratedBurnTime = 300
 			heatProduction = 58
 			massMult = 1.0
 
@@ -263,7 +262,6 @@
 			name = Merlin1B
 			minThrust = 394.6
 			maxThrust = 394.6
-			ratedBurnTime = 300
 			heatProduction = 64
 			massMult = 1.0			// From Wikipedia: turbopump weight was unchanged at 150 lbs.
 
@@ -309,7 +307,6 @@
 			name = Merlin1BVac
 			minThrust = 421.6
 			maxThrust = 421.6
-			ratedBurnTime = 345
 			heatProduction = 63
 			massMult = 1.2			// No good source but it should be heavier than the SL version.
 
@@ -356,7 +353,6 @@
 			description = Used on Falcon 9 Block 1 (v1.0)
 			minThrust = 482.63
 			maxThrust = 482.63
-			ratedBurnTime = 300
 			heatProduction = 96
 			massMult = 0.829
 
@@ -403,7 +399,6 @@
 			description = Used on Falcon 9 Block 1 (v1.0)
 			minThrust = 314.94
 			maxThrust = 524.9		// [9]
-			ratedBurnTime = 345
 			heatProduction = 76
 			massMult = 1.0
 
@@ -450,7 +445,6 @@
 			description = Used on Falcon 9 v1.1
 			minThrust = 290
 			maxThrust = 742.4
-			ratedBurnTime = 350
 			heatProduction = 196
 			massMult = 0.6184
 
@@ -497,7 +491,6 @@
 			description = Used on Falcon 9 v1.2 (Full Thrust)
 			minThrust = 330
 			maxThrust = 825			//[2]
-			ratedBurnTime = 350
 			heatProduction = 225
 			massMult = 0.6184
 
@@ -544,7 +537,6 @@
 			description = Used on Falcon 9 Block 5
 			minThrust = 330			// [5]
 			maxThrust = 914.12		// [3]
-			ratedBurnTime = 350
 			heatProduction = 248
 			massMult = 0.6184
 
@@ -591,7 +583,6 @@
 			description = Used on Falcon 9 v1.1
 			minThrust = 360
 			maxThrust = 805
-			ratedBurnTime = 375
 			heatProduction = 233
 			massMult = 0.6447
 
@@ -637,7 +628,6 @@
 			description = Used on Falcon 9 v1.2 (Full Thrust and Block 5)
 			minThrust = 360
 			maxThrust = 934.12		 // [2]
-			ratedBurnTime = 400
 			heatProduction = 225
 			massMult = 0.6447
 
@@ -697,12 +687,13 @@
 	TESTFLIGHT
 	{
 		name = Merlin1A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1A]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.800000
 		ignitionReliabilityEnd = 0.960000
 		cycleReliabilityStart = 0.800000
 		cycleReliabilityEnd = 0.960000
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1A] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1A]/ratedBurnTime$ } }
 }
 
 //Never flown?
@@ -711,13 +702,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1B]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 		techTransfer = Merlin1A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1B] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1B]/ratedBurnTime$ } }
 }
 
 //Never flown?
@@ -726,13 +718,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1BVac
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1BVac]/ratedBurnTime$
+		ratedBurnTime = 345
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 		techTransfer = Merlin1A,Merlin1B:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1BVac] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1BVac]/ratedBurnTime$ } }
 }
 
 //Falcon-9 v1.0: 5 flights, 1 failure
@@ -742,13 +735,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1C
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1C]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.977778
 		ignitionReliabilityEnd = 0.995556
 		cycleReliabilityStart = 0.977778
 		cycleReliabilityEnd = 0.995556
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1C] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1C]/ratedBurnTime$ } }
 }
 
 //Falcon 9 v1.0: 5 flights, 0 failures
@@ -758,13 +752,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1CVac
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1CVac]/ratedBurnTime$
+		ratedBurnTime = 345
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1CVac] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1CVac]/ratedBurnTime$ } }
 }
 //Falcon-9 v1.1: 7 flights, 1 failure
 //Falcon-9 v1.1(ex): 8 flights, 0 failures
@@ -775,13 +770,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.993711
 		ignitionReliabilityEnd = 0.998742
 		cycleReliabilityStart = 0.992593
 		cycleReliabilityEnd = 0.998519
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1D] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1D]/ratedBurnTime$ } }
 }
 
 //Falcon-9 v1.2: 28 flights, 0 failures
@@ -793,13 +789,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D+
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D+]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.997481
 		ignitionReliabilityEnd = 0.999496
 		cycleReliabilityStart = 0.996923
 		cycleReliabilityEnd = 0.999385
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1D+] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1D+]/ratedBurnTime$ } }
 }
 
 //Falcon-9FT: 28 flights, 1 failures
@@ -813,13 +810,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D++
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D++]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.998689
 		ignitionReliabilityEnd = 0.999738
 		cycleReliabilityStart = 0.998316
 		cycleReliabilityEnd = 0.999663
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D,Merlin1D+:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1D++] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1D++]/ratedBurnTime$ } }
 }
 
 //Falcon-9 v1.1: 6 flights, 0 failures
@@ -832,13 +830,14 @@
 	TESTFLIGHT
 	{
 		name = Merlin1DVac
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac]/ratedBurnTime$
+		ratedBurnTime = 375
 		ignitionReliabilityStart = 0.965517
 		ignitionReliabilityEnd = 0.993103
 		cycleReliabilityStart = 0.933333
 		cycleReliabilityEnd = 0.986667
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D,Merlin1D+,Merlin1D++:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1DVac] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1DVac]/ratedBurnTime$ } }
 }
 
 //Falcon-9FT: 28 flights, 0 failures
@@ -853,11 +852,12 @@
 	TESTFLIGHT
 	{
 		name = Merlin1DVac+
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac+]/ratedBurnTime$
+		ratedBurnTime = 400
 		ignitionReliabilityStart = 0.992481
 		ignitionReliabilityEnd = 0.998496
 		cycleReliabilityStart = 0.985075
 		cycleReliabilityEnd = 0.997015
 		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D,Merlin1D+,Merlin1D++,Merlin1DVac:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1DVac+] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1DVac+]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockA_Config.cfg
@@ -18,7 +18,6 @@
 			name = 30x_NK-15
 			maxThrust = 50308
 			minThrust = 10061// 6 engines
-			ratedBurnTime = 180
 			PROPELLANT
 			{
 				name = Kerosene
@@ -42,7 +41,6 @@
 			name = 30x_NK-33
 			minThrust = 10092// 6 engines
 			maxThrust = 50460
-			ratedBurnTime = 240
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -70,13 +68,14 @@
 	TESTFLIGHT
 	{
 		name = 30x_NK-15
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[30x_NK-15]/ratedBurnTime$
+		ratedBurnTime = 180
 		ignitionReliabilityStart = 0.6682  // Rate of NK-15 = 0.87, (Average of Rel and Rel^SQRT(30))
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.6303  // Rate of NK-15 = 0.85, (Average of Rel and Rel^SQRT(30))
 		cycleReliabilityEnd = 0.96
 		techTransfer = NK-15-Original-NoGimbal, NK-15:200  // since starting reliability so low, allow more tech transfer
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[30x_NK-15] { %ratedBurnTime = #$/TESTFLIGHT[30x_NK-15]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[30x_NK-33]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -84,11 +83,12 @@
 	TESTFLIGHT
 	{
 		name = 30x_NK-33
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[30x_NK-33]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.801  // Rate of NK-33 = 0.93, (Average of Rel and Rel^SQRT(30))
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.7767  // Rate of NK-33 = 0.93, (Average of Rel and Rel^SQRT(30))
 		cycleReliabilityEnd = 0.996
 		techTransfer = 30x_NK-15,NK-33,NK-33-Original-NoGimbal:200  // since starting reliability so low, allow more tech transfer
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[30x_NK-33] { %ratedBurnTime = #$/TESTFLIGHT[30x_NK-33]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockB_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockB_Config.cfg
@@ -18,7 +18,6 @@
 			name = 8x_NK-15V
 			maxThrust = 13184
 			minThrust = 13184
-			ratedBurnTime = 240
 			PROPELLANT
 			{
 				name = Kerosene
@@ -42,7 +41,6 @@
 			name = 8x_NK-43
 			minThrust = 7020
 			maxThrust = 14040
-			ratedBurnTime = 360
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -70,24 +68,26 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 8x_NK-15V
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[8x_NK-15V]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.7722  // Rate of NK-15V = 0.87, (Average of Rel and Rel^SQRT(8))
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.7407  // Rate of NK-15V = 0.85, (Average of Rel and Rel^SQRT(8))
 		cycleReliabilityEnd = 0.96
 		techTransfer = NK-15V, NK-15V-Original-NoGimbal:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[8x_NK-15V] { %ratedBurnTime = #$/TESTFLIGHT[8x_NK-15V]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[8x_NK-43]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 8x_NK-43
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[8x_NK-43]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.8722  // Rate of NK-43 = 0.93, (Average of Rel and Rel^SQRT(8))
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.855  // Rate of NK-43 = 0.92, (Average of Rel and Rel^SQRT(8))
 		cycleReliabilityEnd = 0.996
 		techTransfer = NK-43-Original-NoGimbal, NK-43, 8x_NK-15V:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[8x_NK-43] { %ratedBurnTime = #$/TESTFLIGHT[8x_NK-43]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockV_Config.cfg
@@ -18,7 +18,6 @@
 			name = 4x_NK-21
 			maxThrust = 1608
 			minThrust = 1608
-			ratedBurnTime = 450
 			PROPELLANT
 			{
 				name = Kerosene
@@ -42,7 +41,6 @@
 			name = 4x_NK-39
 			minThrust = 1628
 			maxThrust = 1628
-			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -70,13 +68,14 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 4x_NK-21
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[4x_NK-21]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.7863  // Rate of NK-21 = 0.9, (Average of Rel and Rel^SQRT(4))
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.7728  // Rate of NK-21 = 0.89, (Average of Rel and Rel^SQRT(4))
 		cycleReliabilityEnd = 0.975
 		techTransfer = NK-21:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[4x_NK-21] { %ratedBurnTime = #$/TESTFLIGHT[4x_NK-21]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[4x_NK-39]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -84,11 +83,12 @@
 	TESTFLIGHT  // Want to lower starting reliability, but allow clusters to get same reliability overall
 	{
 		name = 4x_NK-39
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[4x_NK-39]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.8272  // Rate of NK-39 = 0.93, (Average of Rel and Rel^SQRT(4))
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.8411  // Rate of NK-39 = 0.94, (Average of Rel and Rel^SQRT(4))
 		cycleReliabilityEnd = 0.985
 		techTransfer = NK-39, 4x_NK-21:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[4x_NK-39] { %ratedBurnTime = #$/TESTFLIGHT[4x_NK-39]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -96,7 +96,6 @@
 			name = A-6
 			minThrust = 395.9
 			maxThrust = 395.9
-			ratedBurnTime = 145
 			heatProduction = 41
 			massMult = 1.0
 			ullage = True
@@ -143,7 +142,6 @@
 			name = A-7
 			minThrust = 416.2
 			maxThrust = 416.2
-			ratedBurnTime = 155
 			heatProduction = 45
 			massMult = 1.0
 			ullage = True
@@ -203,13 +201,14 @@
 	TESTFLIGHT
 	{
 		name = A-6
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-6]/ratedBurnTime$
+		ratedBurnTime = 145
 		ignitionReliabilityStart = 0.879121
 		ignitionReliabilityEnd = 0.975824
 		cycleReliabilityStart = 0.879121
 		cycleReliabilityEnd = 0.975824
 		techTransfer = XLR41-NA-1,XLR43-NA-1:50			// A-4/V-2 derivative. Modified XLR43-NA-1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[A-6] { %ratedBurnTime = #$/TESTFLIGHT[A-6]/ratedBurnTime$ } }
 }
 
 //Jupiter-C: 3 flights, 1 failure
@@ -221,11 +220,12 @@
 	TESTFLIGHT
 	{
 		name = A-7
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[A-7]/ratedBurnTime$
+		ratedBurnTime = 155
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889
 		cycleReliabilityEnd = 0.977778
 		techTransfer = A-6,XLR41-NA-1,XLR43-NA-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[A-7] { %ratedBurnTime = #$/TESTFLIGHT[A-7]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NERVAII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVAII_Config.cfg
@@ -56,8 +56,6 @@
 			minThrust = 750 //a bit of throttle, no sources
 			maxThrust = 867 //195000 lbf of thrust
 			
-			ratedBurnTime = 36000
-			
 			ignitions = 60
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
@@ -149,7 +147,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA-II
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA-II]/ratedBurnTime$ // 10 hours
+		ratedBurnTime = 36000 // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -161,4 +159,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NERVA-II] { %ratedBurnTime = #$/TESTFLIGHT[NERVA-II]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NERVANRX_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVANRX_Config.cfg
@@ -51,7 +51,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 122
 			maxThrust = 243
-			ratedBurnTime = 3720
 			massMult = 1			
 			ignitions = 30
 			%ullage = True
@@ -111,7 +110,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA_NRX-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA_NRX-Hydrogen]/ratedBurnTime$ // ~1 hours
+		ratedBurnTime = 3720 // ~1 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -123,4 +122,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NERVA_NRX-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[NERVA_NRX-Hydrogen]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NERVAXE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVAXE_Config.cfg
@@ -51,7 +51,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 119
 			maxThrust = 239
-			ratedBurnTime = 36000
 			massMult = 1
 			ignitions = 60
 			%ullage = True
@@ -108,7 +107,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA_XE-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA_XE-Hydrogen]/ratedBurnTime$ // 10 hours
+		ratedBurnTime = 36000 // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -120,4 +119,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NERVA_XE-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[NERVA_XE-Hydrogen]/ratedBurnTime$ } }
 } 

--- a/GameData/RealismOverhaul/Engine_Configs/NERVA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVA_Config.cfg
@@ -54,8 +54,6 @@
 			minThrust = 222 //can't find a good source, just gonna go with this.
 			maxThrust = 334
 			
-			ratedBurnTime = 36000
-			
 			ignitions = 60
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
@@ -147,7 +145,7 @@
 	TESTFLIGHT
 	{
 		name = NERVA-I
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NERVA-I]/ratedBurnTime$ // 10 hours
+		ratedBurnTime = 36000 // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -159,4 +157,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NERVA-I] { %ratedBurnTime = #$/TESTFLIGHT[NERVA-I]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -102,7 +102,6 @@
 			description = Developed as the first stage engine of the N-1 moon rocket. Gimbal, differential throttle.
 			maxThrust = 1681 // 378,000 Ibf 
 			minThrust = 841
-			ratedBurnTime = 180
 			heatProduction = 100
 			massMult = 1.21812 // 1.020458 (NK-15, no gimbal) * 1.1937 (increase % for gimbal)
 			gimbalRange = 6
@@ -143,7 +142,6 @@
 			description = Developed as the first stage engine of the N-1 moon rocket. No gimbal, differential throttle.
 			maxThrust = 1681
 			minThrust = 841
-			ratedBurnTime = 180
 			heatProduction = 100
 			massMult = 1.020458
 			gimbalRange = 0
@@ -184,7 +182,6 @@
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. Gimbal, differential throttle.
 			maxThrust = 1766 //105% rated thrust
 			minThrust = 841
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.1937 // 1.459t, mass value from AJ26-59
 			gimbalRange = 6
@@ -225,7 +222,6 @@
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. No gimbal, differential throttle.
 			maxThrust = 1766
 			minThrust = 841
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1
 			gimbalRange = 0
@@ -266,7 +262,6 @@
 			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. Formerly used for the Antares-100 series
 			maxThrust = 1815
 			minThrust = 941.92
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.1937
 			ignitions = 2
@@ -324,7 +319,7 @@
 	TESTFLIGHT
 	{
 		name = NK-15
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15]/ratedBurnTime$
+		ratedBurnTime = 180
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -333,13 +328,14 @@
 		
 		reliabilityMidH = 0.65
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-15] { %ratedBurnTime = #$/TESTFLIGHT[NK-15]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-15-Original-NoGimbal]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = NK-15-Original-NoGimbal
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15-Original-NoGimbal]/ratedBurnTime$
+		ratedBurnTime = 180
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -348,6 +344,7 @@
 		
 		reliabilityMidH = 0.65
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-15-Original-NoGimbal] { %ratedBurnTime = #$/TESTFLIGHT[NK-15-Original-NoGimbal]/ratedBurnTime$ } }
 }
 
 //due to limited data, data from both the NK-33 and AJ26-62 is used
@@ -361,37 +358,40 @@
 	TESTFLIGHT
 	{
 		name = NK-33
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-33]/ratedBurnTime$ //based on Antares and Soyuz 2-1v burn times.
+		ratedBurnTime = 240 //based on Antares and Soyuz 2-1v burn times.
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		cycleReliabilityStart = 0.937500
 		cycleReliabilityEnd = 0.987500
 		techTransfer = NK-15,NK-15-Original-NoGimbal:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-33] { %ratedBurnTime = #$/TESTFLIGHT[NK-33]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-33-Original-NoGimbal]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = NK-33-Original-NoGimbal
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-33-Original-NoGimbal]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		cycleReliabilityStart = 0.937500
 		cycleReliabilityEnd = 0.987500
 		techTransfer = NK-15,NK-15-Original-NoGimbal:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-33-Original-NoGimbal] { %ratedBurnTime = #$/TESTFLIGHT[NK-33-Original-NoGimbal]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[AJ26-62]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = AJ26-62
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[AJ26-62]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		cycleReliabilityStart = 0.937500
 		cycleReliabilityEnd = 0.987500
 		techTransfer = NK-15,NK-15-Original-NoGimbal,NK-33,NK-33-Original-NoGimbal:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ26-62] { %ratedBurnTime = #$/TESTFLIGHT[AJ26-62]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -82,7 +82,6 @@
 			description = Developed as the second stage engine of the N-1 moon rocket. Gimbal, differential throttle.
 			maxThrust = 1755
 			minThrust = 877.5
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 1.15009 // 0.963467 (NK-15V, no gimbal) * 1.1937 (increase % for gimbal)
 			gimbalRange = 6
@@ -123,7 +122,6 @@
 			description = Developed as the second stage engine of the N-1 moon rocket. No gimbal, differential throttle.
 			maxThrust = 1755
 			minThrust = 877.5
-			ratedBurnTime = 240
 			heatProduction = 100
 			massMult = 0.963467
 			gimbalRange = 0
@@ -164,7 +162,6 @@
 			description =  Developed as an upgrade to the NK-15V, and then abandoned with the cancellation of the N-1. Gimbal, differential throttle.
 			minThrust = 877.5
 			maxThrust = 1755
-			ratedBurnTime = 360
 			heatProduction = 100
 			massMult = 1.1937 // 1 (NK-43, no gimbal) * 1.1937 (increase % for gimbal)
 			gimbalRange = 6
@@ -205,7 +202,6 @@
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. No gimbal, differential throttle.
 			maxThrust = 1755
 			minThrust = 877.5
-			ratedBurnTime = 360
 			heatProduction = 100
 			massMult = 1
 			gimbalRange = 0
@@ -255,7 +251,7 @@
 	TESTFLIGHT
 	{
 		name = NK-15V
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15V]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.85
@@ -264,13 +260,14 @@
 		
 		reliabilityMidH = 0.65
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-15V] { %ratedBurnTime = #$/TESTFLIGHT[NK-15V]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-15V-Original-NoGimbal]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = NK-15V-Original-NoGimbal
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-15V-Original-NoGimbal]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.85
@@ -279,30 +276,33 @@
 		
 		reliabilityMidH = 0.65
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-15V-Original-NoGimbal] { %ratedBurnTime = #$/TESTFLIGHT[NK-15V-Original-NoGimbal]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-43]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = NK-43
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-43]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.996
 		techTransfer = NK-15V,NK-15V-Original-NoGimbal,NK-43-Original-NoGimbal:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-43] { %ratedBurnTime = #$/TESTFLIGHT[NK-43]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[NK-43-Original-NoGimbal]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = NK-43-Original-NoGimbal
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-43-Original-NoGimbal]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.996
 		techTransfer = NK-15V,NK-15V-Original-NoGimbal,NK-43:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-43-Original-NoGimbal] { %ratedBurnTime = #$/TESTFLIGHT[NK-43-Original-NoGimbal]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
@@ -68,7 +68,6 @@
 			description = Developed for R-9 ICBM, and later used as the first stage engine for GR-1, the N-1 predecessor.
 			maxThrust = 421 // sources differ. Nautix says 441kN for the engine, but 421kN for the GR-1's stage. lpre.de also says 421 kn, so go with this
 			minThrust = 421
-			ratedBurnTime = 150
 			heatProduction = 205
 			PROPELLANT
 			{
@@ -107,7 +106,6 @@
 			description = Speculative upgrade, assuming technologies from the NK-15 were integrated back into the NK-9
 			maxThrust = 421
 			minThrust = 421
-			ratedBurnTime = 190
 			heatProduction = 205
 			// speculative = fictional
 			PROPELLANT
@@ -147,7 +145,6 @@
 			description = Speculative upgrade, assuming technologies from the NK-33 were integrated back into the NK-9
 			maxThrust = 436 // (for same TWR as NK-33 - (1766 / 1459) * 360)
 			minThrust = 436
-			ratedBurnTime = 240
 			heatProduction = 205
 			// speculative = fictional
 			PROPELLANT
@@ -187,7 +184,6 @@
 			description = Speculative upgrade, assuming Aerojet purchased and upgraded NK-9s for their own use.
 			maxThrust = 448 // (for same TWR as AJ26-62 - (1815 / (1222 * 1.1937)) * 360)
 			minThrust = 448
-			ratedBurnTime = 240
 			heatProduction = 205
 			// speculative = fictional
 			// 2.7 O/F mass ratio (Antares UG)
@@ -238,7 +234,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
@@ -247,6 +243,7 @@
 		
 		reliabilityMidH = 0.65
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9] { %ratedBurnTime = #$/TESTFLIGHT[NK-9]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -255,13 +252,14 @@
 	TESTFLIGHT
 	{
 		name = NK-9-1969
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9-1969]/ratedBurnTime$
+		ratedBurnTime = 190
 		ignitionReliabilityStart = 0.90
 		ignitionReliabilityEnd = 0.983
 		cycleReliabilityStart = 0.885
 		cycleReliabilityEnd = 0.978
 		techTransfer = NK-9-1972,NK-9V:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9-1969] { %ratedBurnTime = #$/TESTFLIGHT[NK-9-1969]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -270,13 +268,14 @@
 	TESTFLIGHT
 	{
 		name = NK-9-1972
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9-1972]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.996
 		techTransfer = NK-9-2009,NK-9V:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9-1972] { %ratedBurnTime = #$/TESTFLIGHT[NK-9-1972]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -285,11 +284,12 @@
 	TESTFLIGHT
 	{
 		name = NK-9-2009
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9-2009]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.996
 		techTransfer = NK-9V:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9-2009] { %ratedBurnTime = #$/TESTFLIGHT[NK-9-2009]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -128,7 +128,6 @@
 			description = Original vacuum version of NK-9 for the GR-1 rocket.
 			maxThrust = 451.1 // b14643
 			minThrust = 451.1
-			ratedBurnTime = 240
 			heatProduction = 205
 			massMult = 1
 			// 2.5 O/F mass ratio (b14643.de)
@@ -168,7 +167,6 @@
 			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
 			maxThrust = 400 // b14643
 			minThrust = 240 // assume 60% throttle.
-			ratedBurnTime = 450
 			heatProduction = 205
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -208,7 +206,6 @@
 			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
 			maxThrust = 400
 			minThrust = 240
-			ratedBurnTime = 450
 			heatProduction = 205
 			massMult = 1 // I...guess?
 			// 2.5 O/F mass ratio (b14643.de)
@@ -248,7 +245,6 @@
 			description = Improved for N1F Block V. No gimbal, differential throttle.
 			maxThrust = 400
 			minThrust = 240 //FIXME guessing 60% min throttle
-			ratedBurnTime = 600
 			heatProduction = 205
 			massMult = 1.09375 // 700kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
 			// 2.6 O/F mass ratio (b14643.de)
@@ -288,7 +284,6 @@
 			description = Improved for N1F Block G. Relightable. Gimbal, throttle.
 			maxThrust = 402 // b14643
 			minThrust = 240 // assume some level of throttle, engine design was capable, and LH2 replacement engine for this stage had throttle.
-			ratedBurnTime = 600
 			heatProduction = 205
 			massMult = 1.128125 // 722kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
 			// 2.6 O/F mass ratio (b14643.de)
@@ -350,7 +345,7 @@
 	TESTFLIGHT
 	{
 		name = NK-9V
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-9V]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.85
@@ -359,6 +354,7 @@
 		
 		reliabilityMidH = 0.65
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9V] { %ratedBurnTime = #$/TESTFLIGHT[NK-9V]/ratedBurnTime$ } }
 }
 
 //no data, all flights failed before NK-21 ignition
@@ -367,7 +363,7 @@
 	TESTFLIGHT
 	{
 		name = NK-21
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-21]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.89
@@ -376,6 +372,7 @@
 		
 		reliabilityMidH = 0.55
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-21] { %ratedBurnTime = #$/TESTFLIGHT[NK-21]/ratedBurnTime$ } }
 }
 
 //no data, all flights failed before NK-19 ignition
@@ -384,7 +381,7 @@
 	TESTFLIGHT
 	{
 		name = NK-19
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-19]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.89
@@ -393,6 +390,7 @@
 		
 		reliabilityMidH = 0.55
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-19] { %ratedBurnTime = #$/TESTFLIGHT[NK-19]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -401,13 +399,14 @@
 	TESTFLIGHT
 	{
 		name = NK-39
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-39]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
 		techTransfer = NK-9,NK-9V,NK-19,NK-21,NK-31:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-39] { %ratedBurnTime = #$/TESTFLIGHT[NK-39]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -416,11 +415,12 @@
 	TESTFLIGHT
 	{
 		name = NK-31
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[NK-31]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
 		techTransfer = NK-9V,NK-9,NK-19,NK-21,NK-39:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-31] { %ratedBurnTime = #$/TESTFLIGHT[NK-31]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -68,7 +68,6 @@
 			name = ORM-65
 			minThrust = 0.510
 			maxThrust = 1.785
-			ratedBurnTime = 80
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -98,7 +97,6 @@
 			description = Simplified ORM-65 for the RP-318 rocket planes
 			minThrust = 0.499
 			maxThrust = 1.460
-			ratedBurnTime = 200
 			massMult = 0.86
 			heatProduction = 100
 			PROPELLANT
@@ -133,7 +131,6 @@
 			description = Uprated RDA-1-300, to allow the RP-318 to take off under its own power. Test site was overrun by the German army before it could be tested.
 			minThrust = 0.499
 			maxThrust = 2.942
-			ratedBurnTime = 200
 			massMult = 0.86
 			heatProduction = 100
 			PROPELLANT
@@ -170,13 +167,14 @@
 	{
 		//reliability largley copied from aerobee, too few tests of ORM-65 to get accurate reliability info
 		name = ORM-65
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[ORM-65]/ratedBurnTime$
+		ratedBurnTime = 80
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.96
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
 		cycleReliabilityStart = 0.7
 		cycleReliabilityEnd = 0.9
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[ORM-65] { %ratedBurnTime = #$/TESTFLIGHT[ORM-65]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RDA-1-150]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -184,7 +182,7 @@
 	{
 		//was man rated and flew several times in rocket glider without major incident
 		name = RDA-1-150
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RDA-1-150]/ratedBurnTime$
+		ratedBurnTime = 200
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -192,6 +190,7 @@
 		cycleReliabilityEnd = 0.99
 		techTransfer = ORM-65:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RDA-1-150] { %ratedBurnTime = #$/TESTFLIGHT[RDA-1-150]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RDA-1-300]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -199,7 +198,7 @@
 	{
 		//same as RDA-1-150 due to lack of information
 		name = RDA-1-300
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RDA-1-300]/ratedBurnTime$
+		ratedBurnTime = 200
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -207,4 +206,5 @@
 		cycleReliabilityEnd = 0.99
 		techTransfer = ORM-65, RDA-1-150:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RDA-1-300] { %ratedBurnTime = #$/TESTFLIGHT[RDA-1-300]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/PEWEE100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/PEWEE100_Config.cfg
@@ -50,7 +50,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 22				
 			maxThrust = 111	
-			ratedBurnTime = 2400
 			massMult = 1
 			heatProduction = 12
 			
@@ -112,7 +111,7 @@
 	TESTFLIGHT
 	{
 		name = PEWEE100-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[PEWEE100-Hydrogen]/ratedBurnTime$ // 40 minutes
+		ratedBurnTime = 2400 // 40 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -124,4 +123,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[PEWEE100-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[PEWEE100-Hydrogen]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Phoebus1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Phoebus1_Config.cfg
@@ -51,7 +51,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 99				
 			maxThrust = 299				
-			ratedBurnTime = 2700
 			massMult = 1			
 			ignitions = 4
 			%ullage = True
@@ -110,7 +109,7 @@
 	TESTFLIGHT
 	{
 		name = Phoebus1N50-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Phoebus1N50-Hydrogen]/ratedBurnTime$ //45 minutes
+		ratedBurnTime = 2700 //45 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -122,4 +121,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Phoebus1N50-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[Phoebus1N50-Hydrogen]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Phoebus2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Phoebus2_Config.cfg
@@ -51,7 +51,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 228				
 			maxThrust = 913	
-			ratedBurnTime = 2700
 			massMult = 1			
 			ignitions = 8
 			%ullage = True
@@ -110,7 +109,7 @@
 	TESTFLIGHT
 	{
 		name = Phoebus2N100-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Phoebus2N100-Hydrogen]/ratedBurnTime$ //45 minutes (limited by hydrogen supply, assumed same as 1B)
+		ratedBurnTime = 2700 //45 minutes (limited by hydrogen supply, assumed same as 1B)
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -122,4 +121,5 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Phoebus2N100-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[Phoebus2N100-Hydrogen]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
@@ -100,7 +100,6 @@
 			description = 164:1 nozzle ratio version used on the Cassini probe
 			minThrust = 0.490
 			maxThrust = 0.490
-			ratedBurnTime = 12000
 			heatProduction = 10
 			massMult = 1.0
 			ullage = False
@@ -218,11 +217,12 @@
 	TESTFLIGHT
 	{
 		name = R-4D-11
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[R-4D-11]/ratedBurnTime$
+		ratedBurnTime = 12000
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.9985
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[R-4D-11] { %ratedBurnTime = #$/TESTFLIGHT[R-4D-11]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD-0410NTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD-0410NTR_Config.cfg
@@ -80,7 +80,6 @@
 			ignitionThreshold = 0.1
 			minThrust = 0
 			maxThrust = 35.3
-			ratedBurnTime = 36000
 			massMult = 1
 			ignitions = 10
 			%ullage = True
@@ -158,7 +157,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0410MID-Hydrogen
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0410MID-Hydrogen]/ratedBurnTime$ // 10 hours
+		ratedBurnTime = 36000 // 10 hours
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -170,6 +169,7 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0410MID-Hydrogen] { %ratedBurnTime = #$/TESTFLIGHT[RD-0410MID-Hydrogen]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0410MID-Methane]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {

--- a/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
@@ -87,7 +87,6 @@
 			description = Modified RD-107 vernier for use as an independent upper stage for the R-7. Used on Luna and early Vostok rockets
 			minThrust = 49.4
 			maxThrust = 49.4
-			ratedBurnTime = 440
 			heatProduction = 100
 			massMult = 1.0
 
@@ -132,7 +131,6 @@
 			description = RD-0105 upgraded with increase reliability and performance for manned flight. Used on Vostok
 			minThrust = 54.5
 			maxThrust = 54.5
-			ratedBurnTime = 440
 			heatProduction = 100
 			massMult = 0.9307
 
@@ -188,7 +186,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0105
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0105]/ratedBurnTime$
+		ratedBurnTime = 440
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		ignitionDynPresFailMultiplier = 0.1
@@ -196,6 +194,7 @@
 		cycleReliabilityEnd = 0.950000
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0105] { %ratedBurnTime = #$/TESTFLIGHT[RD-0105]/ratedBurnTime$ } }
 }
 
 //Vostok-K (8K72K): 13 flights, 2 failures
@@ -207,7 +206,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0109
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0109]/ratedBurnTime$
+		ratedBurnTime = 440
 		ignitionReliabilityStart = 0.966216
 		ignitionReliabilityEnd = 0.993243
 		ignitionDynPresFailMultiplier = 0.1
@@ -216,4 +215,5 @@
 		techTransfer = RD-0105:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0109] { %ratedBurnTime = #$/TESTFLIGHT[RD-0109]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
@@ -76,7 +76,6 @@
 			name = RD-0110R
 			minThrust = 68.3
 			maxThrust = 68.3
-			ratedBurnTime = 250
 			gimbalRange = 42.0
 			massMult = 1.0
 			ullage = True
@@ -134,7 +133,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0110R
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110R]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		ignitionDynPresFailMultiplier = 0.1
@@ -142,4 +141,5 @@
 		cycleReliabilityEnd = 0.992000
 		techTransfer = RD-0107,RD-0110:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0110R] { %ratedBurnTime = #$/TESTFLIGHT[RD-0110R]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
@@ -77,7 +77,6 @@
 			name = RD-0110-Vernier
 			minThrust = 6.0
 			maxThrust = 6.0
-			ratedBurnTime = 250
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
@@ -121,11 +120,12 @@
 	TESTFLIGHT
 	{
 		name = RD-0110-Vernier
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110-Vernier]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.984362
 		ignitionReliabilityEnd = 0.996872
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.984362
 		cycleReliabilityEnd = 0.996872
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0110-Vernier] { %ratedBurnTime = #$/TESTFLIGHT[RD-0110-Vernier]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
@@ -64,7 +64,6 @@
 			description = Upper stage for the R-7 developed from the RD-0106 booster engine. Used on Vostok and early Molniya rockets.
 			maxThrust = 297.9
 			minThrust = 269.69 //90.5%
-			ratedBurnTime = 250
 			massMult = 1.0
 			PROPELLANT
 			{
@@ -102,7 +101,6 @@
 			description = Developed for the upgraded Molniya-M, and later used on Soyuz.
 			maxThrust = 298.2
 			minThrust = 269.69 //90.5%
-			ratedBurnTime = 250
 			massMult = 1.0
 			PROPELLANT
 			{
@@ -164,13 +162,14 @@
 	TESTFLIGHT
 	{
 		name = RD-0107
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0107]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.937870
 		ignitionReliabilityEnd = 0.987574
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.937870
 		cycleReliabilityEnd = 0.987574
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0107] { %ratedBurnTime = #$/TESTFLIGHT[RD-0107]/ratedBurnTime$ } }
 }
 
 //Soyuz (11A511): 31 flights, 0 failures
@@ -189,7 +188,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0110
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.984362
 		ignitionReliabilityEnd = 0.996872
 		ignitionDynPresFailMultiplier = 0.1
@@ -197,4 +196,5 @@
 		cycleReliabilityEnd = 0.996872
 		techTransfer = RD-0107:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0110] { %ratedBurnTime = #$/TESTFLIGHT[RD-0110]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
@@ -78,7 +78,6 @@
 			name = RD-0120
 			minThrust = 882.45
 			maxThrust = 1961
-			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -111,7 +110,6 @@
 			name = RD-0120M
 			minThrust = 745.44
 			maxThrust = 1961.7
-			ratedBurnTime = 600
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -148,13 +146,14 @@
 	TESTFLIGHT
 	{
 		name = RD-0120
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0120]/ratedBurnTime$
+		ratedBurnTime = 600
 		//Rated to 1670 seconds, but based on SSME would probably only be able to complete 1 burn (600s) before overhaul
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889
 		cycleReliabilityEnd = 0.977778
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0120] { %ratedBurnTime = #$/TESTFLIGHT[RD-0120]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -163,11 +162,12 @@
 	TESTFLIGHT
 	{
 		name = RD-0120M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0120M]/ratedBurnTime$
+		ratedBurnTime = 600
 		//Rated to 1670 seconds, but based on SSME would probably only be able to complete 1 burn (600s) before overhaul
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.9
 		cycleReliabilityEnd = 0.98
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0120M] { %ratedBurnTime = #$/TESTFLIGHT[RD-0120M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
@@ -63,7 +63,6 @@
 			name = RD-0124
 			minThrust = 294.3
 			maxThrust = 294.3
-			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 1.0
 			PROPELLANT
@@ -120,7 +119,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0124
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0124]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.983607
 		ignitionReliabilityEnd = 0.996721
 		ignitionDynPresFailMultiplier = 0.1
@@ -128,4 +127,5 @@
 		cycleReliabilityEnd = 0.996721
 		techTransfer = RD-0110:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0124] { %ratedBurnTime = #$/TESTFLIGHT[RD-0124]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
@@ -81,7 +81,6 @@
 			description = High performance upper stage engine for Proton. Tested extensively by KB Khimavtomatika and P&W, but never flew.
 			minThrust = 98.1
 			maxThrust = 98.1
-			ratedBurnTime = 1100
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -114,7 +113,6 @@
 			description = Upgrade, intended for Angara.
 			minThrust = 73.5
 			maxThrust = 73.5
-			ratedBurnTime = 1100
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -150,7 +148,7 @@
 	{
 		name = RD-0146
 		//Copied from RL10A-4-1-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0146]/ratedBurnTime$
+		ratedBurnTime = 1100
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.94968
@@ -160,6 +158,7 @@
 
 		techTransfer = RL10A-4-1-2:30
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0146] { %ratedBurnTime = #$/TESTFLIGHT[RD-0146]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0146D]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -168,7 +167,7 @@
 	{
 		name = RD-0146D
 		//Copied from RL10A-4-1-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0146D]/ratedBurnTime$
+		ratedBurnTime = 1100
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.94968
@@ -178,4 +177,5 @@
 
 		techTransfer = RD-0146
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0146D] { %ratedBurnTime = #$/TESTFLIGHT[RD-0146D]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0162_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0162_Config.cfg
@@ -78,7 +78,6 @@
 			name = RD-0162
 			minThrust = 995							 //45%
 			maxThrust = 2210
-			ratedBurnTime = 360
 			heatProduction = 100
 			PROPELLANT								 //OF 3.5
 			{
@@ -116,7 +115,6 @@
 			description = Variant uprated for 136% thrust.
 			minThrust = 1355						 //45%
 			maxThrust = 3011
-			ratedBurnTime = 240
 			heatProduction = 100
 			PROPELLANT								 //OF 3.5
 			{
@@ -165,12 +163,13 @@
 	TESTFLIGHT
 	{
 		name = RD-0162
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0162]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991
 		cycleReliabilityEnd = 0.9995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0162] { %ratedBurnTime = #$/TESTFLIGHT[RD-0162]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -179,10 +178,11 @@
 	TESTFLIGHT
 	{
 		name = RD-0162A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0162A]/ratedBurnTime$
+		ratedBurnTime = 240
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991
 		cycleReliabilityEnd = 0.9995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0162A] { %ratedBurnTime = #$/TESTFLIGHT[RD-0162A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
@@ -64,7 +64,6 @@
 			name = RD-0164
 			minThrust = 1725		//45%
 			maxThrust = 3831
-			ratedBurnTime = 360
 			heatProduction = 100
 			PROPELLANT				//OF 3.5
 			{
@@ -113,10 +112,11 @@
 	TESTFLIGHT
 	{
 		name = RD-0164
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0164]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991
 		cycleReliabilityEnd = 0.9995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0164] { %ratedBurnTime = #$/TESTFLIGHT[RD-0164]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
@@ -63,7 +63,6 @@
 			name = RD-0169
 			minThrust = 716
 			maxThrust = 716
-			ratedBurnTime = 720
 			heatProduction = 100
 			PROPELLANT								//OF 3.5
 			{
@@ -111,10 +110,11 @@
 	TESTFLIGHT
 	{
 		name = RD-0169
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0169]/ratedBurnTime$
+		ratedBurnTime = 720
 		ignitionReliabilityStart = 0.991
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.991
 		cycleReliabilityEnd = 0.9995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0169] { %ratedBurnTime = #$/TESTFLIGHT[RD-0169]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -88,7 +88,6 @@
 			description = Used on the UR-500 second stage. AKA 8D411
 			minThrust = 574.05
 			maxThrust = 574.05
-			ratedBurnTime = 150
 			gimbalRange = 3.25
 			ullage = True
 			pressureFed = False
@@ -128,7 +127,6 @@
 			description = Slight upgrade for use on the Proton second stage. AKA 8D411K
 			minThrust = 584.77
 			maxThrust = 584.77
-			ratedBurnTime = 238
 			gimbalRange = 3.25
 			ullage = True
 			pressureFed = False
@@ -174,7 +172,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0208
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0208]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
 		ignitionDynPresFailMultiplier = 0.1
@@ -184,6 +182,7 @@
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0208] { %ratedBurnTime = #$/TESTFLIGHT[RD-0208]/ratedBurnTime$ } }
 }
 
 //Proton-K (8K82K): 28 flights, 1 failure
@@ -208,7 +207,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0210
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0210]/ratedBurnTime$
+		ratedBurnTime = 238
 		ignitionReliabilityStart = 0.992063
 		ignitionReliabilityEnd = 0.998413
 		ignitionDynPresFailMultiplier = 0.1
@@ -219,4 +218,5 @@
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0210] { %ratedBurnTime = #$/TESTFLIGHT[RD-0210]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -73,7 +73,6 @@
 			name = RD-0212
 			minThrust = 584.77
 			maxThrust = 584.77
-			ratedBurnTime = 250
 			gimbalRange = 45.0
 			ullage = True
 			pressureFed = False
@@ -134,7 +133,7 @@
 	TESTFLIGHT
 	{
 		name = RD-0212
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0212]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633
 		ignitionDynPresFailMultiplier = 0.1
@@ -145,4 +144,5 @@
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0212] { %ratedBurnTime = #$/TESTFLIGHT[RD-0212]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
@@ -66,7 +66,6 @@
 			name = RD-0213
 			minThrust = 582.1
 			maxThrust = 582.1
-			ratedBurnTime = 250
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -111,7 +110,7 @@
 	{
 		name = RD-0213
 		//Copied from RD-0212
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0213]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633
 		ignitionDynPresFailMultiplier = 0.1
@@ -121,4 +120,5 @@
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0213] { %ratedBurnTime = #$/TESTFLIGHT[RD-0213]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -48,7 +48,6 @@
 			name = RD-0214
 			minThrust = 30.98
 			maxThrust = 30.98
-			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -92,7 +91,7 @@
 	{
 		name = RD-0214
 		//Copied from RD-0212
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0214]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633
 		ignitionDynPresFailMultiplier = 0.1
@@ -102,4 +101,5 @@
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0214] { %ratedBurnTime = #$/TESTFLIGHT[RD-0214]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
@@ -68,7 +68,6 @@
 			name = RD-0242M2
 			minThrust = 30.0
 			maxThrust = 50.0
-			ratedBurnTime = 600
 			ullage = False
 			pressureFed = True
 			ignitions = 6
@@ -109,7 +108,7 @@
 	{
 		name = RD-0242M2
 		//Copied from RD-0212
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-0242M2]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.857
 		ignitionReliabilityEnd = 0.995
 		ignitionDynPresFailMultiplier = 0.1
@@ -117,4 +116,6 @@
 		cycleReliabilityEnd = 0.992
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0242M2] { %ratedBurnTime = #$/TESTFLIGHT[RD-0242M2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -144,7 +144,6 @@
 			name = RD-100
 			minThrust = 307.0
 			maxThrust = 307.0
-			ratedBurnTime = 70
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -191,7 +190,6 @@
 			name = RD-101
 			minThrust = 404.0
 			maxThrust = 404.0
-			ratedBurnTime = 85
 			heatProduction = 45
 			massMult = 1.0
 			ullage = True
@@ -238,7 +236,6 @@
 			name = RD-102
 			minThrust = 428.0
 			maxThrust = 428.0
-			ratedBurnTime = 83
 			heatProduction = 45
 			massMult = 0.9966
 			ullage = True
@@ -285,7 +282,6 @@
 			name = RD-103
 			minThrust = 490.33
 			maxThrust = 490.33
-			ratedBurnTime = 130
 			heatProduction = 55
 			massMult = 0.9797
 			ullage = True
@@ -331,7 +327,6 @@
 			name = RD-103M
 			minThrust = 500.14
 			maxThrust = 500.14
-			ratedBurnTime = 140
 			heatProduction = 57
 			massMult = 0.9763
 			ullage = True
@@ -384,7 +379,7 @@
 	TESTFLIGHT
 	{
 		name = RD-100
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-100]/ratedBurnTime$
+		ratedBurnTime = 70
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		ignitionDynPresFailMultiplier = 2.0
@@ -392,6 +387,7 @@
 		cycleReliabilityEnd = 0.94
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-100] { %ratedBurnTime = #$/TESTFLIGHT[RD-100]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-101]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -399,7 +395,7 @@
 	TESTFLIGHT
 	{
 		name = RD-101
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-101]/ratedBurnTime$
+		ratedBurnTime = 85
 		ignitionReliabilityStart = 0.86
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0
@@ -408,6 +404,7 @@
 		techTransfer = RD-100:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-101] { %ratedBurnTime = #$/TESTFLIGHT[RD-101]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-102]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -415,7 +412,7 @@
 	TESTFLIGHT
 	{
 		name = RD-102
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-102]/ratedBurnTime$
+		ratedBurnTime = 83
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
 		ignitionDynPresFailMultiplier = 2.0
@@ -424,6 +421,7 @@
 		techTransfer = RD-101:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-102] { %ratedBurnTime = #$/TESTFLIGHT[RD-102]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-103]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -431,7 +429,7 @@
 	TESTFLIGHT
 	{
 		name = RD-103
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-103]/ratedBurnTime$
+		ratedBurnTime = 130
 		ignitionReliabilityStart = 0.82
 		ignitionReliabilityEnd = 0.93
 		ignitionDynPresFailMultiplier = 2.0
@@ -440,6 +438,7 @@
 		techTransfer = RD-102:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-103] { %ratedBurnTime = #$/TESTFLIGHT[RD-103]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-103M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -447,7 +446,7 @@
 	TESTFLIGHT
 	{
 		name = RD-103M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-103M]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.84
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0
@@ -456,4 +455,5 @@
 		techTransfer = RD-103:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-103M] { %ratedBurnTime = #$/TESTFLIGHT[RD-103M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -203,7 +203,6 @@
 			description = Used on R-7 8K71
 			maxThrust = 1000.28
 			minThrust = 1000.28
-			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -256,7 +255,6 @@
 			description = Used on Sputnik 8K71PS
 			maxThrust = 972.3
 			minThrust = 972.3
-			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -309,7 +307,6 @@
 			description = Used on Sputnik 8A91
 			maxThrust = 972.8
 			minThrust = 972.8
-			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -362,7 +359,6 @@
 			description = Used on Luna 8K72
 			maxThrust = 996.4
 			minThrust = 996.4
-			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -415,7 +411,6 @@
 			description = Used on Vostok 8K72K
 			maxThrust = 996.4
 			minThrust = 996.4
-			ratedBurnTime = 140
 			massMult = 1.0
 
 			ullage = True
@@ -468,7 +463,6 @@
 			description = Used on Molniya 8K78 and Voskhod 11A57-1
 			maxThrust = 995.37
 			minThrust = 995.37
-			ratedBurnTime = 140
 			massMult = 0.9912
 
 			ullage = True
@@ -521,7 +515,6 @@
 			description = Used on Molniya-M 8K78M and Soyuz 11A511
 			maxThrust = 995.37
 			minThrust = 995.37
-			ratedBurnTime = 140
 			massMult = 0.9912
 
 			ullage = True
@@ -574,7 +567,6 @@
 			description = Used on Soyuz-U 11A511U (also known as RD-117)
 			maxThrust = 977.72
 			minThrust = 977.72
-			ratedBurnTime = 140
 			massMult = 1.0396
 
 			ullage = True
@@ -628,8 +620,6 @@
 			maxThrust = 996.4
 			minThrust = 996.4
 
-			ratedBurnTime = 140
-
 			ullage = True
 			pressureFed = False
 			ignitions = 0
@@ -680,7 +670,6 @@
 			description = Used on Soyuz-FG
 			maxThrust = 1019.89
 			minThrust = 1019.89
-			ratedBurnTime = 140
 			massMult = 0.9427
 
 			ullage = True
@@ -747,7 +736,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.915385
 		ignitionReliabilityEnd = 0.983077
 		cycleReliabilityStart = 0.915385
@@ -757,6 +746,7 @@
 		reliabilityMidH = 0.6
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D74] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D74]/ratedBurnTime$ } }
 }
 
 //Sputnik (8K71PS): 2 flights, 0 failed
@@ -766,7 +756,7 @@
 	TESTFLIGHT
 	{	
 		name = RD-107-8D74PS
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74PS]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
 		cycleReliabilityStart = 0.909091
@@ -776,6 +766,7 @@
 		reliabilityMidH = 0.55
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D74PS] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D74PS]/ratedBurnTime$ } }
 }
 
 //Sputnik (8A91): 2 flights, 1 failure
@@ -785,7 +776,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D76
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D76]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
@@ -794,6 +785,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D76] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D76]/ratedBurnTime$ } }
 }
 
 //Vostok-L (8K72): 9 flights, 3 failed
@@ -804,7 +796,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74-1958
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74-1958]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.938462
 		ignitionReliabilityEnd = 0.987692
 		cycleReliabilityStart = 0.938462
@@ -813,6 +805,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D74-1958] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D74-1958]/ratedBurnTime$ } }
 }
 
 //Vostok-K (8K72K): 13 flights, 0 failures
@@ -822,7 +815,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74-1959
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74-1959]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
 		cycleReliabilityStart = 0.984848
@@ -831,6 +824,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D74-1959] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D74-1959]/ratedBurnTime$ } }
 }
 
 //Molniya (8K78): 40 flights, 1 failures
@@ -841,7 +835,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74K]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.999410
 		ignitionReliabilityEnd = 0.999882
 		cycleReliabilityStart = 0.999410
@@ -850,6 +844,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D74K] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D74K]/ratedBurnTime$ } }
 }
 
 //Molniya-M (Blok-L) (8K78M): 10 flights, 0 failures
@@ -864,7 +859,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D728
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D728]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.999286
 		ignitionReliabilityEnd = 0.999857
 		cycleReliabilityStart = 0.999286
@@ -873,6 +868,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-8D728] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-8D728]/ratedBurnTime$ } }
 }
 
 //Soyuz-U (11A511U): 776 flights, 3 failures
@@ -882,7 +878,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-11D511
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-11D511]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.999227
 		ignitionReliabilityEnd = 0.999845
 		cycleReliabilityStart = 0.999227
@@ -891,6 +887,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-11D511] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-11D511]/ratedBurnTime$ } }
 }
 
 //Soyuz-U2 (11A511U2): 72 flights, 0 failures
@@ -900,7 +897,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107-11D511P
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-11D511P]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.997230
 		ignitionReliabilityEnd = 0.999446
 		cycleReliabilityStart = 0.997230
@@ -909,6 +906,7 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107-11D511P] { %ratedBurnTime = #$/TESTFLIGHT[RD-107-11D511P]/ratedBurnTime$ } }
 }
 
 //Soyuz-FG (11A511U-FG): 60 flights, 0 failures
@@ -920,7 +918,7 @@
 	TESTFLIGHT
 	{
 		name = RD-107A-14D22
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-107A-14D22]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.997732
 		ignitionReliabilityEnd = 0.999546
 		cycleReliabilityStart = 0.997732
@@ -929,4 +927,5 @@
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-107A-14D22] { %ratedBurnTime = #$/TESTFLIGHT[RD-107A-14D22]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -211,7 +211,6 @@
 			description = Used on R-7 8K71
 			maxThrust = 941.44
 			minThrust = 941.44
-			ratedBurnTime = 340
 			massMult = 1.0
 
 			ullage = True
@@ -264,7 +263,6 @@
 			description = Used on Sputnik 8K71PS
 			maxThrust = 918.3
 			minThrust = 918.3
-			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -317,7 +315,6 @@
 			description = Used on Sputnik 8A91
 			maxThrust = 803.2
 			minThrust = 803.2
-			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -370,7 +367,6 @@
 			description = Used on Luna 8K72
 			maxThrust = 945.4
 			minThrust = 945.4
-			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -423,7 +419,6 @@
 			description = Used on Vostok 8K72K
 			maxThrust = 941
 			minThrust = 941
-			ratedBurnTime = 340
 			massMult = 0.9774
 
 			ullage = True
@@ -476,7 +471,6 @@
 			description = Used on Molniya 8K78 and Voskhod 11A57-1
 			maxThrust = 941.47
 			minThrust = 941.47
-			ratedBurnTime = 340
 			massMult = 0.979
 
 			ullage = True
@@ -529,7 +523,6 @@
 			description = Used on Molniya-M 8K78M and Soyuz 11A511
 			maxThrust = 973.8
 			minThrust = 973.8
-			ratedBurnTime = 340
 			massMult = 0.9612
 
 			ullage = True
@@ -582,7 +575,6 @@
 			description = Used on Soyuz-U 11A511U (also known as RD-118)
 			maxThrust = 999.3
 			minThrust = 999.3
-			ratedBurnTime = 340
 			massMult = 1.0985
 
 			ullage = True
@@ -635,7 +627,6 @@
 			description = Used on Soyuz-U2 11A511U2 (also known as RD-118P)
 			maxThrust = 1011
 			minThrust = 1011
-			ratedBurnTime = 340
 			massMult = 1.0985
 
 			ullage = True
@@ -688,7 +679,6 @@
 			description = Used on Soyuz-FG
 			maxThrust = 990.47
 			minThrust = 990.47
-			ratedBurnTime = 340
 			massMult = 0.836
 
 			ullage = True
@@ -757,7 +747,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.915385
 		ignitionReliabilityEnd = 0.983077
 		cycleReliabilityStart = 0.915385
@@ -766,6 +756,7 @@
 		
 		reliabilityMidH = 0.6
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75]/ratedBurnTime$ } }
 }
 
 //Sputnik (8K71PS): 2 flights, 0 failed
@@ -775,7 +766,7 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75PS
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75PS]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
 		cycleReliabilityStart = 0.909091
@@ -784,6 +775,7 @@
 		
 		reliabilityMidH = 0.55
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75PS] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75PS]/ratedBurnTime$ } }
 }
 
 //Sputnik (8A91): 2 flights, 1 failure
@@ -793,13 +785,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D77
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D77]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
 		cycleReliabilityEnd = 0.980000
 		techTransfer = RD-200:25,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D77] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D77]/ratedBurnTime$ } }
 }
 
 //Vostok-L (8K72): 9 flights, 3 failed
@@ -810,13 +803,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75-1958
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75-1958]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.938462
 		ignitionReliabilityEnd = 0.987692
 		cycleReliabilityStart = 0.938462
 		cycleReliabilityEnd = 0.987692
 		techTransfer = RD-200:25,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75-1958] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75-1958]/ratedBurnTime$ } }
 }
 
 //Vostok-K (8K72K): 13 flights, 0 failures
@@ -826,13 +820,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75-1959
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75-1959]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
 		cycleReliabilityStart = 0.984848
 		cycleReliabilityEnd = 0.996970
 		techTransfer = RD-200:25,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75-1959] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75-1959]/ratedBurnTime$ } }
 }
 
 //Molniya (8K78): 40 flights, 1 failures
@@ -843,13 +838,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75K]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.999410
 		ignitionReliabilityEnd = 0.999882
 		cycleReliabilityStart = 0.999410
 		cycleReliabilityEnd = 0.999882
 		techTransfer = RD-200:25,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75K] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75K]/ratedBurnTime$ } }
 }
 
 //Molniya-M (Blok-L) (8K78M): 10 flights, 0 failures
@@ -864,13 +860,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D727
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D727]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.999286
 		ignitionReliabilityEnd = 0.999857
 		cycleReliabilityStart = 0.999286
 		cycleReliabilityEnd = 0.999857
 		techTransfer = RD-200:25,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D727] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D727]/ratedBurnTime$ } }
 }
 
 //Soyuz-U (11A511U): 776 flights, 3 failures
@@ -880,13 +877,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-11D512
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-11D512]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.999227
 		ignitionReliabilityEnd = 0.999845
 		cycleReliabilityStart = 0.999227
 		cycleReliabilityEnd = 0.999845
 		techTransfer = RD-200:25,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-11D512] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-11D512]/ratedBurnTime$ } }
 }
 
 //Soyuz-U2 (11A511U2): 72 flights, 0 failures
@@ -896,13 +894,14 @@
 	TESTFLIGHT
 	{
 		name = RD-108-11D512P
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-11D512P]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.997230
 		ignitionReliabilityEnd = 0.999446
 		cycleReliabilityStart = 0.997230
 		cycleReliabilityEnd = 0.999446
 		techTransfer = RD-200:25,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-11D512P] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-11D512P]/ratedBurnTime$ } }
 }
 
 //Soyuz-FG (11A511U-FG): 60 flights, 0 failures
@@ -914,11 +913,12 @@
 	TESTFLIGHT
 	{
 		name = RD-108A-14D21
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-108A-14D21]/ratedBurnTime$
+		ratedBurnTime = 340
 		ignitionReliabilityStart = 0.997732
 		ignitionReliabilityEnd = 0.999546
 		cycleReliabilityStart = 0.997732
 		cycleReliabilityEnd = 0.999546
 		techTransfer = RD-200:25,RD-108-11D512P,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108A-14D21] { %ratedBurnTime = #$/TESTFLIGHT[RD-108A-14D21]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -78,7 +78,6 @@
 			description = Prototype for the R-7 (8K73) project
 			minThrust = 101.6
 			maxThrust = 101.6
-			ratedBurnTime = 330
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -115,7 +114,6 @@
 			description = Upper stage for Kosmos-2 (11K63)
 			minThrust = 105.5
 			maxThrust = 105.5
-			ratedBurnTime = 260
 			massMult = 0.8	//168 kg
 			heatProduction = 100
 			PROPELLANT
@@ -155,12 +153,13 @@
 	TESTFLIGHT
 	{
 		name = RD-109-8D711
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-109-8D711]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.9
 		cycleReliabilityEnd = 0.95
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-109-8D711] { %ratedBurnTime = #$/TESTFLIGHT[RD-109-8D711]/ratedBurnTime$ } }
 }
 
 //Kosmos-2 (11K63): 125 flights, 6 failures
@@ -170,11 +169,12 @@
 	TESTFLIGHT
 	{
 		name = RD-119-8D710
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-119-8D710]/ratedBurnTime$
+		ratedBurnTime = 260
 		ignitionReliabilityStart = 0.952000
 		ignitionReliabilityEnd = 0.990400
 		cycleReliabilityStart = 0.952000
 		cycleReliabilityEnd = 0.990400
 		techTransfer = RD-109-8D711:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-119-8D710] { %ratedBurnTime = #$/TESTFLIGHT[RD-119-8D710]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
@@ -98,7 +98,6 @@
 			name = RD-120
 			minThrust = 583.49
 			maxThrust = 833.56
-			ratedBurnTime = 290
 			gimbalRange = 0
 			massMult = 1.0
 			ullage = True
@@ -143,7 +142,6 @@
 			name = RD-120F
 			minThrust = 583.49
 			maxThrust = 912.02
-			ratedBurnTime = 290
 			gimbalRange = 0
 			massMult = 1.0
 			ullage = True
@@ -188,7 +186,6 @@
 			name = RD-120K
 			minThrust = 416.78
 			maxThrust = 853.18
-			ratedBurnTime = 305
 			gimbalRange = 6.0
 			massMult = 0.96
 			ullage = True
@@ -248,12 +245,13 @@
 	TESTFLIGHT
 	{
 		name = RD-120
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-120]/ratedBurnTime$		//Only burned for ~300s, but rated for 2200s
+		ratedBurnTime = 290		//Only burned for ~300s, but rated for 2200s
 		ignitionReliabilityStart = 0.986111
 		ignitionReliabilityEnd = 0.997222
 		cycleReliabilityStart = 0.888889
 		cycleReliabilityEnd = 0.977778
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-120] { %ratedBurnTime = #$/TESTFLIGHT[RD-120]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -262,13 +260,14 @@
 	TESTFLIGHT
 	{
 		name = RD-120K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-120K]/ratedBurnTime$
+		ratedBurnTime = 305
 		ignitionReliabilityStart = 0.92		//not much is known about this
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.99
 		techTransfer = RD-120:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-120K] { %ratedBurnTime = #$/TESTFLIGHT[RD-120K]/ratedBurnTime$ } }
 }
 
 //Zenit-3SL: 16 flights, 1 failure
@@ -283,11 +282,12 @@
 	TESTFLIGHT
 	{
 		name = RD-120F
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-120F]/ratedBurnTime$
+		ratedBurnTime = 290
 		ignitionReliabilityStart = 0.988764
 		ignitionReliabilityEnd = 0.997753
 		cycleReliabilityStart = 0.977273
 		cycleReliabilityEnd = 0.995455
 		techTransfer = RD-120,RD-120F:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-120F] { %ratedBurnTime = #$/TESTFLIGHT[RD-120F]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
@@ -110,7 +110,6 @@
 			description = Used on Energia liquid rocket boosters
 			minThrust = 3953
 			maxThrust = 7904
-			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 1.02632
 			PROPELLANT
@@ -149,7 +148,6 @@
 			description = Used on Zenit, a rocket derived from Energia boosters
 			minThrust = 3953
 			maxThrust = 7904
-			ratedBurnTime = 150
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -187,7 +185,6 @@
 			description = Uprated RD-171 for the Vulkan ("Volcano"), baseline for the RD-180, RD-191 and it's derivatives.
 			minThrust = 3953
 			maxThrust = 8316 //[2]
-			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 1.07947
 			PROPELLANT
@@ -226,7 +223,6 @@
 			description = Modernized model for use on Zenit
 			minThrust = 3953
 			maxThrust = 7904
-			ratedBurnTime = 150
 			heatProduction = 100
 			massMult = 0.97894
 			PROPELLANT
@@ -277,13 +273,14 @@
 	TESTFLIGHT
 	{
 		name = RD-170
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-170]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889
 		cycleReliabilityEnd = 0.977778
 		techTransfer = RD-120:20	//Design incorporated lessons from the RD-120
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-170] { %ratedBurnTime = #$/TESTFLIGHT[RD-170]/ratedBurnTime$ } }
 }
 
 //Zenit-2: 36 flights, 2 failures
@@ -293,13 +290,14 @@
 	TESTFLIGHT
 	{
 		name = RD-171
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-171]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.944444
 		ignitionReliabilityEnd = 0.988889
 		cycleReliabilityStart = 0.944444
 		cycleReliabilityEnd = 0.988889
 		techTransfer = RD-170:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-171] { %ratedBurnTime = #$/TESTFLIGHT[RD-171]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -308,13 +306,14 @@
 	TESTFLIGHT
 	{
 		name = RD-172-173
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-172-173]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.9625
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9384
 		cycleReliabilityEnd = 0.9999
 		techTransfer = RD-170,RD-171:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-172-173] { %ratedBurnTime = #$/TESTFLIGHT[RD-172-173]/ratedBurnTime$ } }
 }
 
 //Zenit-2M/3: 48 flights, 0 failures
@@ -324,11 +323,12 @@
 	TESTFLIGHT
 	{
 		name = RD-171M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-171M]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979592
 		cycleReliabilityEnd = 0.995918
 		techTransfer = RD-170,RD-171,RD-172-173:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-171M] { %ratedBurnTime = #$/TESTFLIGHT[RD-171M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -67,7 +67,6 @@
 			name = RD-180
 			minThrust = 1951.44
 			maxThrust = 4152
-			ratedBurnTime = 255
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -120,11 +119,12 @@
 	TESTFLIGHT
 	{
 		name = RD-180
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-180]/ratedBurnTime$
+		ratedBurnTime = 255
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
 		cycleReliabilityEnd = 0.997778
 		techTransfer = RD-171M,RD-172-173,RD-171,RD-170:20
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-180] { %ratedBurnTime = #$/TESTFLIGHT[RD-180]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
@@ -94,7 +94,6 @@
 			name = RD-191
 			minThrust = 565
 			maxThrust = 2085
-			ratedBurnTime = 255
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -132,7 +131,6 @@
 			name = RD-151
 			minThrust = 565
 			maxThrust = 1918
-			ratedBurnTime = 255
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -170,7 +168,6 @@
 			description = Modified for the Antares to replace the NK-33.
 			minThrust = 980
 			maxThrust = 2085
-			ratedBurnTime = 255
 			heatProduction = 100
 			gimbalRange = 5
 			massMult = 0.9607
@@ -210,7 +207,6 @@
 			description = No gimbal, planned to replace the NK-33 on Soyuz 2-1v.
 			minThrust = 834
 			maxThrust = 2085
-			ratedBurnTime = 255
 			heatProduction = 100
 			gimbalRange = 0
 			massMult = 0.8297
@@ -264,13 +260,14 @@
 	{
 		name = RD-191
 		//Copied from RD-180
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-191]/ratedBurnTime$
+		ratedBurnTime = 255
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
 		cycleReliabilityEnd = 0.997778
 		techTransfer = RD-171M,RD-172-173,RD-171,RD-170,RD-180:20
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-191] { %ratedBurnTime = #$/TESTFLIGHT[RD-191]/ratedBurnTime$ } }
 }
 
 //Naro-1: 3 flights, 2 failures
@@ -280,13 +277,14 @@
 	{
 		name = RD-151
 		//Copied from RD-180
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-151]/ratedBurnTime$
+		ratedBurnTime = 255
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
 		cycleReliabilityEnd = 0.997778
 		techTransfer = RD-191:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-151] { %ratedBurnTime = #$/TESTFLIGHT[RD-151]/ratedBurnTime$ } }
 }
 
 //Antares-230: 5 flights, 0 failures
@@ -298,13 +296,14 @@
 	{
 		name = RD-181
 		//Copied from RD-180
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-181]/ratedBurnTime$
+		ratedBurnTime = 255
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
 		cycleReliabilityEnd = 0.997778
 		techTransfer = RD-191,RD-151:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-181] { %ratedBurnTime = #$/TESTFLIGHT[RD-181]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -314,11 +313,12 @@
 	{
 		name = RD-193
 		//Copied from RD-180
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-193]/ratedBurnTime$
+		ratedBurnTime = 255
 		ignitionReliabilityStart = 0.988889
 		ignitionReliabilityEnd = 0.997778
 		cycleReliabilityStart = 0.988889
 		cycleReliabilityEnd = 0.997778
 		techTransfer = RD-191,RD-151,RD-181:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-193] { %ratedBurnTime = #$/TESTFLIGHT[RD-193]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
@@ -54,7 +54,6 @@
 			description = 
 			minThrust = 12.6
 			maxThrust = 12.6
-			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -121,11 +120,13 @@
 	{
 		//Over 100 flights in the Pe-2RD. Early flights had difficulty with ignitions
 		name = RD-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-1]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.7
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.8
 		cycleReliabilityEnd = 0.867
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-1] { %ratedBurnTime = #$/TESTFLIGHT[RD-1]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
@@ -69,7 +69,6 @@
 			description = First multi-chamber engine designed by Glushko, basis of RD-107/108 and RD-214
 			minThrust = 98.51
 			maxThrust = 98.51
-			ratedBurnTime = 605
 			heatProduction = 100
 			massMult = 1.0
 
@@ -119,7 +118,7 @@
 	TESTFLIGHT
 	{
 		name = RD-200
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-200]/ratedBurnTime$		//Needs confirmation
+		ratedBurnTime = 605		//Needs confirmation
 		ignitionReliabilityStart = 0.86
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0
@@ -128,4 +127,5 @@
 		techTransfer = RD-100:25
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-200] { %ratedBurnTime = #$/TESTFLIGHT[RD-200]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -127,7 +127,6 @@
 			description = Prototype for the R-12 (8K63)
 			minThrust = 642.3
 			maxThrust = 642.3
-			ratedBurnTime = 122
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -176,7 +175,6 @@
 			description = Prototype for Buran cruise missile
 			minThrust = 437.0
 			maxThrust = 622.7
-			ratedBurnTime = 100
 			massMult = 1.01	//642 kg
 			heatProduction = 100
 			PROPELLANT
@@ -224,7 +222,6 @@
 			description = Prototype for Buran cruise missile
 			minThrust = 549.0
 			maxThrust = 749.2
-			ratedBurnTime = 110
 			massMult = 0.984	//625 kg
 			heatProduction = 100
 			PROPELLANT
@@ -272,7 +269,6 @@
 			description = Engine for the R-12 (8K63)
 			minThrust = 730.2
 			maxThrust = 730.2
-			ratedBurnTime = 140
 			massMult = 1.03	//625 kg
 			heatProduction = 100
 			PROPELLANT
@@ -320,7 +316,6 @@
 			description = Engine for the R-12U (8K63S) and Kosmos-2 (11K63)
 			minThrust = 730.6
 			maxThrust = 730.6
-			ratedBurnTime = 140
 			massMult = 1.03	//625 kg
 			heatProduction = 100
 			PROPELLANT
@@ -378,13 +373,14 @@
 	TESTFLIGHT
 	{
 		name = RD-211-8D57
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-211-8D57]/ratedBurnTime$
+		ratedBurnTime = 122
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.94
 		cycleReliabilityStart = 0.75
 		cycleReliabilityEnd = 0.94
 		techTransfer = RD-200:25
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-211-8D57] { %ratedBurnTime = #$/TESTFLIGHT[RD-211-8D57]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -393,13 +389,14 @@
 	TESTFLIGHT
 	{
 		name = RD-212-8D41
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-212-8D41]/ratedBurnTime$
+		ratedBurnTime = 100
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
 		cycleReliabilityStart = 0.8
 		cycleReliabilityEnd = 0.9
 		techTransfer = RD-200:25,RD-211-8D57:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-212-8D41] { %ratedBurnTime = #$/TESTFLIGHT[RD-212-8D41]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -408,13 +405,14 @@
 	TESTFLIGHT
 	{
 		name = RD-213-8D13
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-213-8D13]/ratedBurnTime$
+		ratedBurnTime = 110
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
 		cycleReliabilityStart = 0.8
 		cycleReliabilityEnd = 0.9
 		techTransfer = RD-200:25,RD-211-8D57,RD-212-8D41:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-213-8D13] { %ratedBurnTime = #$/TESTFLIGHT[RD-213-8D13]/ratedBurnTime$ } }
 }
 
 //R-12 R&D: 104 flights, 6 failed
@@ -423,7 +421,7 @@
 	TESTFLIGHT
 	{
 		name = RD-214-8D59
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-214-8D59]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.942308
 		ignitionReliabilityEnd = 0.988462
 		cycleReliabilityStart = 0.942308
@@ -431,6 +429,8 @@
 		techTransfer = RD-200:25,RD-211-8D57,RD-212-8D41,RD-213-8D13:50
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-214-8D59] { %ratedBurnTime = #$/TESTFLIGHT[RD-214-8D59]/ratedBurnTime$ } }
 }
 
 //Kosmos (63S1): 38 flights, 7 failures
@@ -441,11 +441,12 @@
 	TESTFLIGHT
 	{
 		name = RD-214U-8D59U
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-214U-8D59U]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.945455
 		ignitionReliabilityEnd = 0.989091
 		cycleReliabilityStart = 0.945455
 		cycleReliabilityEnd = 0.989091
 		techTransfer = RD-200:25,RD-211-8D57,RD-212-8D41,RD-213-8D13,RD-214-8D59:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-214U-8D59U] { %ratedBurnTime = #$/TESTFLIGHT[RD-214U-8D59U]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
@@ -151,7 +151,6 @@
 			description = Used on R-14 8K65 as RD-216
 			minThrust = 869.9
 			maxThrust = 869.9
-			ratedBurnTime = 146
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -188,7 +187,6 @@
 			description = Used on R-16 8K64 as RD-218
 			minThrust = 869.9
 			maxThrust = 869.9
-			ratedBurnTime = 90
 			massMult = 0.967	//653 kg
 			heatProduction = 100
 			PROPELLANT
@@ -224,7 +222,6 @@
 			description = Used on R-26 8K66 as RD-224
 			minThrust = 887.5
 			maxThrust = 887.5
-			ratedBurnTime = 120
 			massMult = 0.967	//653 kg
 			heatProduction = 100
 			PROPELLANT
@@ -260,7 +257,6 @@
 			description = Used on Kosmos-3M 8K65M as RD-216M
 			minThrust = 872.3
 			maxThrust = 872.3
-			ratedBurnTime = 146
 			massMult = 0.97		//655 kg
 			heatProduction = 100
 			PROPELLANT
@@ -296,7 +292,6 @@
 			description = Used on R-36 and Tsiklon-2 8K65M as RD-251
 			minThrust = 881.3
 			maxThrust = 881.3
-			ratedBurnTime = 120
 			heatProduction = 100
 			massMult = 0.853	//576 kg
 			PROPELLANT
@@ -332,7 +327,6 @@
 			description = Used on Tsiklon-2M and Tsiklon-3 11K68 as RD-261
 			minThrust = 882.6
 			maxThrust = 882.6
-			ratedBurnTime = 120
 			heatProduction = 100
 			massMult = 0.853	//576 kg
 			PROPELLANT
@@ -373,7 +367,7 @@
 	TESTFLIGHT
 	{
 		name = RD-215-8D513
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-215-8D513]/ratedBurnTime$
+		ratedBurnTime = 146
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.96
 		cycleReliabilityStart = 0.88
@@ -381,6 +375,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-215-8D513] { %ratedBurnTime = #$/TESTFLIGHT[RD-215-8D513]/ratedBurnTime$ } }
 }
 
 //R-16 R&D: 60 flights, 13 failures
@@ -390,7 +385,7 @@
 	TESTFLIGHT
 	{
 		name = RD-217-8D515
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-217-8D515]/ratedBurnTime$
+		ratedBurnTime = 90
 		ignitionReliabilityStart = 0.891667
 		ignitionReliabilityEnd = 0.978333
 		cycleReliabilityStart = 0.891667
@@ -399,6 +394,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-217-8D515] { %ratedBurnTime = #$/TESTFLIGHT[RD-217-8D515]/ratedBurnTime$ } }
 }
 
 //no data, prototype only
@@ -407,7 +403,7 @@
 	TESTFLIGHT
 	{
 		name = RD-225-8D721
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-225-8D721]/ratedBurnTime$
+		ratedBurnTime = 120
 		ignitionReliabilityStart = 0.928
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.928
@@ -416,6 +412,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-225-8D721] { %ratedBurnTime = #$/TESTFLIGHT[RD-225-8D721]/ratedBurnTime$ } }
 }
 
 //Kosmos-3M (11K65M): 445 flights, 4 failures
@@ -425,7 +422,7 @@
 	TESTFLIGHT
 	{
 		name = RD-215M-8D613
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-215M-8D613]/ratedBurnTime$
+		ratedBurnTime = 146
 		ignitionReliabilityStart = 0.995506
 		ignitionReliabilityEnd = 0.999101
 		cycleReliabilityStart = 0.995506
@@ -435,6 +432,8 @@
 		clusterMultiplier = #$../clusterMultiplier$
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-215M-8D613] { %ratedBurnTime = #$/TESTFLIGHT[RD-215M-8D613]/ratedBurnTime$ } }
 }
 
 //R-36-O (8K69): 23 flights, 3 failures
@@ -446,7 +445,7 @@
 	TESTFLIGHT
 	{
 		name = RD-250-8D518
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-250-8D518]/ratedBurnTime$
+		ratedBurnTime = 120
 		ignitionReliabilityStart = 0.992701
 		ignitionReliabilityEnd = 0.998540
 		cycleReliabilityStart = 0.992701
@@ -455,6 +454,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-250-8D518] { %ratedBurnTime = #$/TESTFLIGHT[RD-250-8D518]/ratedBurnTime$ } }
 }
 
 //Tsiklon-3 (11K68): 122 flights, 1 failures
@@ -464,7 +464,7 @@
 	TESTFLIGHT
 	{
 		name = RD-250PM
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-250PM]/ratedBurnTime$
+		ratedBurnTime = 120
 		ignitionReliabilityStart = 0.997268
 		ignitionReliabilityEnd = 0.999454
 		cycleReliabilityStart = 0.997268
@@ -473,4 +473,5 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-250PM] { %ratedBurnTime = #$/TESTFLIGHT[RD-250PM]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
@@ -100,7 +100,6 @@
 			description = Used on R-16 8K64
 			minThrust = 882.6
 			maxThrust = 882.6
-			ratedBurnTime = 125
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -136,7 +135,6 @@
 			description = Used on R-36 and Tsiklon-2 8K67
 			minThrust = 940.8
 			maxThrust = 940.8
-			ratedBurnTime = 160
 			heatProduction = 100
 			massMult = 0.941	//715 kg
 			PROPELLANT
@@ -172,7 +170,6 @@
 			description = Used on Tsiklon-2M and Tsiklon-3 11K68
 			minThrust = 941.4
 			maxThrust = 941.4
-			ratedBurnTime = 160
 			heatProduction = 100
 			massMult = 0.957	//728 kg
 			PROPELLANT
@@ -211,12 +208,13 @@
 	TESTFLIGHT
 	{
 		name = RD-219-8D713
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-219-8D713]/ratedBurnTime$
+		ratedBurnTime = 125
 		ignitionReliabilityStart = 0.980769
 		ignitionReliabilityEnd = 0.996154
 		cycleReliabilityStart = 0.980769
 		cycleReliabilityEnd = 0.996154
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-219-8D713] { %ratedBurnTime = #$/TESTFLIGHT[RD-219-8D713]/ratedBurnTime$ } }
 }
 
 //R-36-O (8K69): 23 flights, 1 failure
@@ -228,13 +226,14 @@
 	TESTFLIGHT
 	{
 		name = RD-252-8D724
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-252-8D724]/ratedBurnTime$
+		ratedBurnTime = 160
 		ignitionReliabilityStart = 0.985401
 		ignitionReliabilityEnd = 0.997080
 		cycleReliabilityStart = 0.985401
 		cycleReliabilityEnd = 0.997080
 		techTransfer = RD-219-8D713:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-252-8D724] { %ratedBurnTime = #$/TESTFLIGHT[RD-252-8D724]/ratedBurnTime$ } }
 }
 
 //Tsiklon-3 (11K68): 121 flights, 0 failures
@@ -244,7 +243,7 @@
 	TESTFLIGHT
 	{
 		name = RD-262-11D26
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-262-11D26]/ratedBurnTime$
+		ratedBurnTime = 160
 		ignitionReliabilityStart = 0.991803
 		ignitionReliabilityEnd = 0.998361
 		cycleReliabilityStart = 0.991803
@@ -252,4 +251,6 @@
 		techTransfer = RD-219-8D713,RD-252-8D724:50
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-262-11D26] { %ratedBurnTime = #$/TESTFLIGHT[RD-262-11D26]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
@@ -143,7 +143,6 @@
 			name = RD-253
 			minThrust = 1545
 			maxThrust = 1545
-			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -177,7 +176,6 @@
 			name = RD-253-Mk2
 			minThrust = 1635
 			maxThrust = 1635
-			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -212,7 +210,6 @@
 			name = RD-253-Mk3
 			minThrust = 1698
 			maxThrust = 1698
-			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -246,7 +243,6 @@
 			name = RD-253-Mk4
 			minThrust = 1748
 			maxThrust = 1748
-			ratedBurnTime = 148
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -281,7 +277,6 @@
 			description = Mid-90s upgrade to improve performance of Proton
 			minThrust = 1746
 			maxThrust = 1746
-			ratedBurnTime = 129
 			heatProduction = 100
 			massMult = 0.99074 // 1.07
 			PROPELLANT
@@ -317,7 +312,6 @@
 			description = Modern upgrade to improve performance of Proton. AKA RD-276
 			minThrust = 1830
 			maxThrust = 1830
-			ratedBurnTime = 129
 			heatProduction = 100
 			massMult = 0.99074 // 1.07
 			PROPELLANT
@@ -371,7 +365,7 @@
 	TESTFLIGHT
 	{
 		name = RD-253
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253]/ratedBurnTime$
+		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -381,13 +375,14 @@
 		
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-253] { %ratedBurnTime = #$/TESTFLIGHT[RD-253]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-253-Mk2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = RD-253-Mk2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk2]/ratedBurnTime$
+		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -398,13 +393,14 @@
 		
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-253-Mk2] { %ratedBurnTime = #$/TESTFLIGHT[RD-253-Mk2]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-253-Mk3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = RD-253-Mk3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk3]/ratedBurnTime$
+		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
@@ -415,19 +411,21 @@
 		
 		reliabilityDataRateMultiplier = 0.5
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-253-Mk3] { %ratedBurnTime = #$/TESTFLIGHT[RD-253-Mk3]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-253-Mk4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = RD-253-Mk4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk4]/ratedBurnTime$
+		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
 		cycleReliabilityEnd = 0.999143
 		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-253-Mk4] { %ratedBurnTime = #$/TESTFLIGHT[RD-253-Mk4]/ratedBurnTime$ } }
 }
 
 //Proton-M Blok-DM-2 (8K82K 11S861): 6 flights, 0 failures
@@ -441,13 +439,14 @@
 	TESTFLIGHT
 	{
 		name = RD-275
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-275]/ratedBurnTime$
+		ratedBurnTime = 129
 		ignitionReliabilityStart = 0.995261
 		ignitionReliabilityEnd = 0.999052
 		cycleReliabilityStart = 0.995261
 		cycleReliabilityEnd = 0.999052
 		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3,RD-253-Mk4:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-275] { %ratedBurnTime = #$/TESTFLIGHT[RD-275]/ratedBurnTime$ } }
 }
 
 //Proton-M Briz-M (8K82KM 14S43) (Phase I mod. 1): 2 flights, 0 failures
@@ -462,11 +461,12 @@
 	TESTFLIGHT
 	{
 		name = RD-275M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-275M]/ratedBurnTime$
+		ratedBurnTime = 129
 		ignitionReliabilityStart = 0.997753
 		ignitionReliabilityEnd = 0.999551
 		cycleReliabilityStart = 0.997753
 		cycleReliabilityEnd = 0.999551
 		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3,RD-253-Mk4,RD-275:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-275M] { %ratedBurnTime = #$/TESTFLIGHT[RD-275M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
@@ -64,7 +64,6 @@
 			name = RD-270M
 			minThrust = 6443.1
 			maxThrust = 7159
-			ratedBurnTime = 148
 			heatProduction = 225
 			PROPELLANT
 			{
@@ -101,11 +100,12 @@
 	TESTFLIGHT
 	{
 		name = RD-270M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-270M]/ratedBurnTime$
+		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
 		cycleReliabilityEnd = 0.999143
 		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-270M] { %ratedBurnTime = #$/TESTFLIGHT[RD-270M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
@@ -64,7 +64,6 @@
 			name = RD-270
 			minThrust = 5644.8
 			maxThrust = 6272
-			ratedBurnTime = 148
 			heatProduction = 205
 			PROPELLANT
 			{
@@ -101,11 +100,12 @@
 	TESTFLIGHT
 	{
 		name = RD-270
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-270]/ratedBurnTime$
+		ratedBurnTime = 148
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
 		cycleReliabilityStart = 0.995713
 		cycleReliabilityEnd = 0.999143
 		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-270] { %ratedBurnTime = #$/TESTFLIGHT[RD-270]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
@@ -81,7 +81,6 @@
 			name = RD-57
 			minThrust = 78.46
 			maxThrust = 392.3
-			ratedBurnTime = 800
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -114,7 +113,6 @@
 			name = RD-57M
 			minThrust = 79.4 // some sources suggest min throttle is 303.0, this sounds unlikely. 
 			maxThrust = 397
-			ratedBurnTime = 800
 			heatProduction = 100
 			
 			PROPELLANT
@@ -153,7 +151,7 @@
 	{
 		name = RD-57
 		//Never flew, guess based on performance of similar KVD-1/RD-56
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-57]/ratedBurnTime$
+		ratedBurnTime = 800
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
 		cycleReliabilityStart = 0.500000
@@ -161,6 +159,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-57] { %ratedBurnTime = #$/TESTFLIGHT[RD-57]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-57M]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -168,7 +167,7 @@
 	{
 		name = RD-57M
 		//Never flew, guess based on performance of similar KVD-1/RD-56
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-57M]/ratedBurnTime$
+		ratedBurnTime = 800
 		ignitionReliabilityStart = 0.928571
 		ignitionReliabilityEnd = 0.985714
 		cycleReliabilityStart = 0.857143
@@ -177,4 +176,5 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-57M] { %ratedBurnTime = #$/TESTFLIGHT[RD-57M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -176,7 +176,6 @@
 			description = Used on Molnyia (Blok L)
 			minThrust = 63.7
 			maxThrust = 63.7
-			ratedBurnTime = 250
 			heatProduction = 100
 			massMult = 1.02
 
@@ -218,7 +217,6 @@
 			description = Developed version of S1.5400 engine for the Blok ML and Blok MVL stage of the Molniya-M launch vehicle. Slightly better performance.
 			minThrust = 66.7
 			maxThrust = 66.7
-			ratedBurnTime = 270
 			heatProduction = 100
 			massMult = 1.02
 
@@ -259,7 +257,6 @@
 			description = The S1.5400A engine, as used on Block 2BLM of the Molniya launch vehicle. Further performance improvements.
 			minThrust = 67.3
 			maxThrust = 67.3
-			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 0.9867
 
@@ -300,7 +297,6 @@
 			description = Upgrade developed for use on the Blok D stage of the N-1, and later used on Proton. Significant upgrade over the S1.5400
 			maxThrust = 83.36
 			minThrust = 83.36
-			ratedBurnTime = 600
 			heatProduction = 100
 			massMult = 1.534
 
@@ -341,7 +337,6 @@
 			description = Modification of the RD-58 for use on Proton Blok DM, after the N-1 was cancelled. 
 			maxThrust = 83.36
 			minThrust = 83.36
-			ratedBurnTime = 720
 			heatProduction = 100
 			massMult = 1.534
 
@@ -382,7 +377,6 @@
 			description = Modification of the RD-58 burning Syntin instead of Kerosene. Used on Proton (Blok DM-2M)
 			maxThrust = 86.3
 			minThrust = 86.3
-			ratedBurnTime = 680
 			heatProduction = 100
 			massMult = 1.534
 
@@ -423,7 +417,6 @@
 			description = Modification of the RD-58M with a Carbon Composite Nozzle extension for better vacuum performance. Used on Zenit Blok DM-SL.
 			maxThrust = 85
 			minThrust = 85
-			ratedBurnTime = 1200
 			heatProduction = 100
 			massMult = 1.6824
 
@@ -463,7 +456,6 @@
 			description = OMS engine for the Buran orbiter
 			maxThrust = 86.24
 			minThrust = 86.24
-			ratedBurnTime = 680
 			heatProduction = 100
 			massMult = 1.5333		// 230 kg
 
@@ -517,13 +509,14 @@
 	TESTFLIGHT
 	{
 		name = S1_5400
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S1_5400]/ratedBurnTime$
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.952381
 		ignitionReliabilityEnd = 0.990476
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.866667
 		cycleReliabilityEnd = 0.973333
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S1_5400] { %ratedBurnTime = #$/TESTFLIGHT[S1_5400]/ratedBurnTime$ } }
 }
 
 //Molniya-M (Blok-ML) (8K78M): 163 flights, 1 failure. 5 ignition failures
@@ -537,7 +530,7 @@
 	TESTFLIGHT
 	{
 		name = 11D33
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[11D33]/ratedBurnTime$
+		ratedBurnTime = 270
 		ignitionReliabilityStart = 0.982405
 		ignitionReliabilityEnd = 0.996481
 		ignitionDynPresFailMultiplier = 0.1
@@ -545,6 +538,7 @@
 		cycleReliabilityEnd = 0.998830
 		techTransfer = S1_5400:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[11D33] { %ratedBurnTime = #$/TESTFLIGHT[11D33]/ratedBurnTime$ } }
 }
 
 //Molniya-M (Blok-2BL) (8K78M): 89 flights, 0 failures. 3 ignition failures
@@ -557,7 +551,7 @@
 	TESTFLIGHT
 	{
 		name = 11D33M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[11D33M]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
 		ignitionDynPresFailMultiplier = 0.1
@@ -565,6 +559,7 @@
 		cycleReliabilityEnd = 0.998000
 		techTransfer = S1_5400,11D33:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[11D33M] { %ratedBurnTime = #$/TESTFLIGHT[11D33M]/ratedBurnTime$ } }
 }
 
 //Proton-K Blok-D (8K82K 11S824): 34 flights, 2 failures. 3 ignition failures
@@ -576,7 +571,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58]/ratedBurnTime$
+		ratedBurnTime = 600
 		ignitionReliabilityStart = 0.954545
 		ignitionReliabilityEnd = 0.990909
 		ignitionDynPresFailMultiplier = 0.1
@@ -584,6 +579,7 @@
 		cycleReliabilityEnd = 0.988235
 		techTransfer = 11D33M:25
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58] { %ratedBurnTime = #$/TESTFLIGHT[RD-58]/ratedBurnTime$ } }
 }
 
 //Proton-K Blok-D-1 (8K82K 11S824M): 10 flights, 0 failures
@@ -602,7 +598,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58M
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58M]/ratedBurnTime$
+		ratedBurnTime = 720
 		ignitionReliabilityStart = 0.984733
 		ignitionReliabilityEnd = 0.996947
 		ignitionDynPresFailMultiplier = 0.1
@@ -610,6 +606,7 @@
 		cycleReliabilityEnd = 0.998985
 		techTransfer = RD-58:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58M] { %ratedBurnTime = #$/TESTFLIGHT[RD-58M]/ratedBurnTime$ } }
 }
 
 //Proton-K Blok-DM-2M (8K82K 11S861-01): 15 flights, 0 failures.
@@ -623,7 +620,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58S
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58S]/ratedBurnTime$
+		ratedBurnTime = 680
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
 		ignitionDynPresFailMultiplier = 0.1
@@ -631,6 +628,7 @@
 		cycleReliabilityEnd = 0.995238
 		techTransfer = RD-58,RD-58M:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58S] { %ratedBurnTime = #$/TESTFLIGHT[RD-58S]/ratedBurnTime$ } }
 }
 
 //Zenit-3SL (1): 16 flights, 1 failure.
@@ -644,7 +642,7 @@
 	TESTFLIGHT
 	{
 		name = RD-58M-CCN
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-58M-CCN]/ratedBurnTime$
+		ratedBurnTime = 1200
 		ignitionReliabilityStart = 0.987654
 		ignitionReliabilityEnd = 0.997531
 		ignitionDynPresFailMultiplier = 0.1
@@ -652,6 +650,7 @@
 		cycleReliabilityEnd = 0.995000
 		techTransfer = RD-58,RD-58M:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58M-CCN] { %ratedBurnTime = #$/TESTFLIGHT[RD-58M-CCN]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -660,7 +659,7 @@
 	TESTFLIGHT
 	{
 		name = 17D12
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[17D12]/ratedBurnTime$
+		ratedBurnTime = 680
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.998
 		ignitionDynPresFailMultiplier = 0.1
@@ -668,4 +667,5 @@
 		cycleReliabilityEnd = 0.998
 		techTransfer = RD-58,RD-58M:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[17D12] { %ratedBurnTime = #$/TESTFLIGHT[17D12]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
@@ -70,7 +70,6 @@
 			name = RD-805
 			minThrust = 19.6
 			maxThrust = 19.6
-			ratedBurnTime = 1100
 			heatProduction = 69
 			gimbalRange = 8.0
 			massMult = 1.0
@@ -131,11 +130,12 @@
 	TESTFLIGHT
 	{
 		name = RD-805
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-805]/ratedBurnTime$
+		ratedBurnTime = 1100
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.997
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.995
 		cycleReliabilityEnd = 0.997
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-805] { %ratedBurnTime = #$/TESTFLIGHT[RD-805]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
@@ -66,7 +66,6 @@
 			name = RD-855
 			maxThrust = 83
 			minThrust = 83
-			ratedBurnTime = 127
 			PROPELLANT
 			{
 				name = UDMH
@@ -101,10 +100,11 @@
 	{
 		name = RD-855
 		//Copied from RD-250
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-855]/ratedBurnTime$
+		ratedBurnTime = 127
 		ignitionReliabilityStart = 0.992701
 		ignitionReliabilityEnd = 0.998540
 		cycleReliabilityStart = 0.992701
 		cycleReliabilityEnd = 0.998540
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-855] { %ratedBurnTime = #$/TESTFLIGHT[RD-855]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
@@ -75,7 +75,6 @@
 			name = RD-856
 			minThrust = 13.55
 			maxThrust = 13.55
-			ratedBurnTime = 163
 			heatProduction = 55
 			ullage = True
 			pressureFed = False
@@ -122,10 +121,11 @@
 	TESTFLIGHT
 	{
 		name = RD-856
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-856]/ratedBurnTime$
+		ratedBurnTime = 163
 		ignitionReliabilityStart = 0.985401
 		ignitionReliabilityEnd = 0.997080
 		cycleReliabilityStart = 0.985401
 		cycleReliabilityEnd = 0.997080
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-856] { %ratedBurnTime = #$/TESTFLIGHT[RD-856]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
@@ -73,7 +73,6 @@
 			description = Vernier engine for the Zenit second stage.
 			minThrust = 78.44
 			maxThrust = 78.44
-			ratedBurnTime = 1100
 			gimbalRange = 33.0
 			massMult = 1.0
 			ullage = True
@@ -132,10 +131,11 @@
 	TESTFLIGHT
 	{
 		name = RD-8
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RD-8]/ratedBurnTime$
+		ratedBurnTime = 1100
 		ignitionReliabilityStart = 0.970588
 		ignitionReliabilityEnd = 0.994118
 		cycleReliabilityStart = 0.941176
 		cycleReliabilityEnd = 0.988235
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-8] { %ratedBurnTime = #$/TESTFLIGHT[RD-8]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -315,7 +315,6 @@
 			name = RL10A-1
 			minThrust = 65.6
 			maxThrust = 65.6
-			ratedBurnTime = 430
 			heatProduction = 100
 			description = Prototype. Used for Early Atlas-Centaur launches. Very unreliable
 			PROPELLANT
@@ -349,7 +348,6 @@
 			name = RL10A-3-1
 			minThrust = 68.05
 			maxThrust = 68.05
-			ratedBurnTime = 470
 			heatProduction = 100
 			description = First production model of the RL10. Used for Atlas-Centaur and Saturn 1 launches.
 			PROPELLANT
@@ -383,7 +381,6 @@
 			name = RL10A-3-3
 			minThrust = 70.05
 			maxThrust = 70.05
-			ratedBurnTime = 470
 			heatProduction = 100
 			description = Upgraded model with slightly higher performance. Used for the majority of Atlas-Centaur D Launches.
 			PROPELLANT
@@ -417,7 +414,6 @@
 			name = RL10A-3-3-Lunex
 			minThrust = 11.5	//6:1 throttling goal
 			maxThrust = 69.4	//Some performance loss from extra baffling and hydrogen bleed assumed
-			ratedBurnTime = 600
 			heatProduction = 100
 			description = Speculative throttling configuration for the USAF Lunex lander
 			PROPELLANT
@@ -451,7 +447,6 @@
 			name = RL10A-3-3A
 			minThrust = 73.4
 			maxThrust = 73.4
-			ratedBurnTime = 550
 			heatProduction = 100
 			description = Heavily reworked turbopumps for higher performance on Atlas-Centaur G and Titan-Centaur.
 			PROPELLANT
@@ -485,7 +480,6 @@
 			name = RL10A-4
 			minThrust = 91.2
 			maxThrust = 91.2
-			ratedBurnTime = 392
 			heatProduction = 100
 			description = Reworked turbopumps, nozzle extenstion and electric TVC to improve performance for Atlas II
 			PROPELLANT
@@ -519,7 +513,6 @@
 			name = RL10A-4-1-2
 			minThrust = 97.9
 			maxThrust = 97.9
-			ratedBurnTime = 850
 			heatProduction = 100
 			description = Reworked turbopumps and improved performance for usage in a single & dual engine configuration on Atlas II & Atlas III & single engine configuration on Atlas V
 			PROPELLANT
@@ -553,7 +546,6 @@
 			name = RL10A-4-2N
 			minThrust = 99.2
 			maxThrust = 99.2
-			ratedBurnTime = 850
 			heatProduction = 100
 			description = Reworked turbopumps, nozzle extenstion and improved performance for usage in a single engine configuration on Atlas V
 			PROPELLANT
@@ -587,7 +579,6 @@
 			name = RL10A-5
 			minThrust = 19.4
 			maxThrust = 64.75
-			ratedBurnTime = 430
 			gimbalRange = 8.5 //average of 8 and 9 from 2 sources.
 			heatProduction = 100
 			description = Sea level RL10 for use on the Delta Clipper (DC-X) project.
@@ -622,7 +613,6 @@
 			name = RL10B-2
 			minThrust = 109.4
 			maxThrust = 109.4
-			ratedBurnTime = 1130
 			heatProduction = 100
 			description = Extremely large nozzle extenstion developed for Delta III, and used on Delta IV
 			PROPELLANT
@@ -656,7 +646,6 @@
 			name = RL10C-1
 			minThrust = 101.85
 			maxThrust = 101.85
-			ratedBurnTime = 1130
 			heatProduction = 100
 			description = Cost reduced model with modern production techniques, used in single or double engine configurations on Atlas V.
 			PROPELLANT
@@ -690,7 +679,6 @@
 			name = RL10C-1-1
 			minThrust = 105.9
 			maxThrust = 105.9
-			ratedBurnTime = 1200
 			heatProduction = 100
 			description = Planned upgrade of RL10C-1 for use on Vulcan-Centaur, OmegA, and later Atlas V launches
 			PROPELLANT
@@ -724,7 +712,6 @@
 			name = RL10C-2-1	//Mentioned as identical to the B-2, probably a cost-reduced drop-in replacement for DCSS
 			minThrust = 111.2 
 			maxThrust = 111.2
-			ratedBurnTime = 1130
 			heatProduction = 100
 			description = RL10B-2 using RL10C-1 components to reduce cost.
 			PROPELLANT
@@ -758,7 +745,6 @@
 			name = RL10C-3
 			minThrust = 108.5
 			maxThrust = 108.5
-			ratedBurnTime = 1350
 			heatProduction = 100
 			description = Man-rated for use on the EUS for Lunar missions.
 			PROPELLANT
@@ -792,7 +778,6 @@
 			name = CECE-Base
 			minThrust = 4.5 //15:1, target was 10-20:1 throttling
 			maxThrust = 67
-			ratedBurnTime = 10000
 			heatProduction = 100
 			description = Technology demonstrator, with deep throttling capability
 			PROPELLANT
@@ -826,7 +811,6 @@
 			name = CECE-High
 			minThrust = 110
 			maxThrust = 110
-			ratedBurnTime = 10000
 			heatProduction = 100
 			description = Technology Demonstrator, with extremely high performance turbopumps
 			PROPELLANT
@@ -860,7 +844,6 @@
 			name = CECE-Methane
 			minThrust = 17 //4:1, target was 3-5:1
 			maxThrust = 67
-			ratedBurnTime = 10000
 			heatProduction = 100
 			description = Technology demonstrator, modified to burn methane
 			PROPELLANT
@@ -900,7 +883,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-1]/ratedBurnTime$
+		ratedBurnTime = 430
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -908,6 +891,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-1]/ratedBurnTime$ } }
 }
 
 //Atlas-LV3C Centaur-D: 7 flights, 0 failures
@@ -917,7 +901,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-1]/ratedBurnTime$
+		ratedBurnTime = 470
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -927,6 +911,7 @@
 
 		techTransfer = RL10A-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-1]/ratedBurnTime$ } }
 }
 
 //Atlas-SLV3C Centaur-D: 16 flights, 0 failures. 1 ignition failure
@@ -942,7 +927,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3]/ratedBurnTime$
+		ratedBurnTime = 470
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
 		cycleReliabilityStart = 0.989474
@@ -952,6 +937,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -961,7 +947,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3-Lunex
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3-Lunex]/ratedBurnTime$ //Longer burn time to account for throttling
+		ratedBurnTime = 600 //Longer burn time to account for throttling
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
 		cycleReliabilityStart = 0.989474
@@ -971,6 +957,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3-Lunex] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3-Lunex]/ratedBurnTime$ } }
 }
 
 //Atlas-G Centaur-D1AR: 6 flights, 0 failures
@@ -984,7 +971,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3A]/ratedBurnTime$
+		ratedBurnTime = 550
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
 		cycleReliabilityStart = 0.962963
@@ -994,6 +981,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3A] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3A]/ratedBurnTime$ } }
 }
 
 //Atlas-2A: 23 flights, 0 failures
@@ -1006,7 +994,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4]/ratedBurnTime$
+		ratedBurnTime = 392
 		ignitionReliabilityStart = 0.995305
 		ignitionReliabilityEnd = 0.999061
 		cycleReliabilityStart = 0.990654
@@ -1016,6 +1004,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4]/ratedBurnTime$ } }
 }
 
 //Atlas-3A: 2 flights, 0 failures
@@ -1038,7 +1027,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4-1-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-1-2]/ratedBurnTime$
+		ratedBurnTime = 850
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
 		cycleReliabilityStart = 0.980000
@@ -1048,6 +1037,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1-2] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1-2]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-2N]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -1055,7 +1045,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4-2N
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-2N]/ratedBurnTime$
+		ratedBurnTime = 850
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
 		cycleReliabilityStart = 0.980000
@@ -1065,6 +1055,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-2N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-2N]/ratedBurnTime$ } }
 }
 
 //DC-X: 7 flights, 1 failures(?)
@@ -1076,7 +1067,7 @@
 	TESTFLIGHT
 	{
 		name = RL10A-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-5]/ratedBurnTime$
+		ratedBurnTime = 430
 		ignitionReliabilityStart = 0.977273
 		ignitionReliabilityEnd = 0.995455
 		cycleReliabilityStart = 0.977273
@@ -1084,6 +1075,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-5] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-5]/ratedBurnTime$ } }
 }
 
 //Delta III: 2 flights, 1 failure
@@ -1104,7 +1096,7 @@
 	TESTFLIGHT
 	{
 		name = RL10B-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10B-2]/ratedBurnTime$
+		ratedBurnTime = 1130
 		ignitionReliabilityStart = 0.988235
 		ignitionReliabilityEnd = 0.997647
 		cycleReliabilityStart = 0.952381
@@ -1114,6 +1106,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10B-2] { %ratedBurnTime = #$/TESTFLIGHT[RL10B-2]/ratedBurnTime$ } }
 }
 
 //Atlas-5(401): 19 flights, 0 failures
@@ -1132,7 +1125,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-1]/ratedBurnTime$ //is modified RL10B-2
+		ratedBurnTime = 1130 //is modified RL10B-2
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1142,6 +1135,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -1151,7 +1145,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-1-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-1-1]/ratedBurnTime$ //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
+		ratedBurnTime = 1200 //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1161,6 +1155,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2,RL10C-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1-1]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -1170,7 +1165,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-2-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-2-1]/ratedBurnTime$ //is modified RL10B-2
+		ratedBurnTime = 1130 //is modified RL10B-2
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1180,6 +1175,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2,RL10C-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-2-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-2-1]/ratedBurnTime$ } }
 }
 
 //no data, never flown
@@ -1189,7 +1185,7 @@
 	TESTFLIGHT
 	{
 		name = RL10C-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-3]/ratedBurnTime$ //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
+		ratedBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
 		cycleReliabilityStart = 0.977273
@@ -1199,6 +1195,7 @@
 
 		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2,RL10C-1,RL10C-1-1,RL10C-2-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-3] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-3]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[CECE-Base]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -1206,7 +1203,7 @@
 	TESTFLIGHT
 	{
 		name = CECE-Base
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CECE-Base]/ratedBurnTime$
+		ratedBurnTime = 10000
 		ignitionReliabilityStart = 0.99975
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.99975 //total design reliability = 0.9995
@@ -1216,6 +1213,7 @@
 
 		techTransfer = CECE-High,CECE-Methane:70
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[CECE-Base] { %ratedBurnTime = #$/TESTFLIGHT[CECE-Base]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[CECE-High]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -1223,7 +1221,7 @@
 	TESTFLIGHT
 	{
 		name = CECE-High
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CECE-High]/ratedBurnTime$
+		ratedBurnTime = 10000
 		ignitionReliabilityStart = 0.99975
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.99975
@@ -1233,6 +1231,7 @@
 
 		techTransfer = CECE-Base,CECE-Methane:70
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[CECE-High] { %ratedBurnTime = #$/TESTFLIGHT[CECE-High]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[CECE-Methane]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -1240,7 +1239,7 @@
 	TESTFLIGHT
 	{
 		name = CECE-Methane
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[CECE-Methane]/ratedBurnTime$
+		ratedBurnTime = 10000
 		ignitionReliabilityStart = 0.99975
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.99975
@@ -1250,4 +1249,5 @@
 
 		techTransfer = CECE-High,CECE-Base:70
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[CECE-Methane] { %ratedBurnTime = #$/TESTFLIGHT[CECE-Methane]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
@@ -78,7 +78,6 @@
 			name = RL60
 			maxThrust = 267
 			minThrust = 267
-			ratedBurnTime = 4050
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -111,7 +110,6 @@
 			massMult = 1.100
 			maxThrust = 180
 			minThrust = 180
-			ratedBurnTime = 4050
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -147,7 +145,7 @@
 	TESTFLIGHT
 	{
 		name = RL60
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RL60]/ratedBurnTime$
+		ratedBurnTime = 4050
 		ignitionReliabilityStart = 0.98		//Copied from RL10B-2
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -157,6 +155,7 @@
 
 		techTransfer = RL10B-2:20	//loosley based on RL10
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL60] { %ratedBurnTime = #$/TESTFLIGHT[RL60]/ratedBurnTime$ } }
 }
 
 //no data, never flew
@@ -165,7 +164,7 @@
 	TESTFLIGHT
 	{
 		name = Vinci-180
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vinci-180]/ratedBurnTime$
+		ratedBurnTime = 4050
 		ignitionReliabilityStart = 0.98		//Copied from RL10B-2
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9643
@@ -175,4 +174,5 @@
 
 		techTransfer = RL60:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vinci-180] { %ratedBurnTime = #$/TESTFLIGHT[Vinci-180]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
@@ -65,7 +65,6 @@
 			name = RS-2100
 			maxThrust = 2399.5
 			minThrust = 1320
-			ratedBurnTime = 450
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -106,11 +105,12 @@
 	TESTFLIGHT
 	{
 		name = RS-2100
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-2100]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995
 		cycleReliabilityEnd = 0.99995
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-2100] { %ratedBurnTime = #$/TESTFLIGHT[RS-2100]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -121,7 +121,6 @@
 			name = RS-68
 			maxThrust = 3370
 			minThrust = 1890
-			ratedBurnTime = 330
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -159,7 +158,6 @@
 			name = RS-68A
 			maxThrust = 3570
 			minThrust = 1820
-			ratedBurnTime = 330
 			heatProduction = 91
 			ullage = True
 			pressureFed = False
@@ -197,7 +195,6 @@
 			description = RS-68 upgrade with regeneratively cooled nozzle, allowing the engine to burn hotter.
 			maxThrust = 3647
 			minThrust = 2006
-			ratedBurnTime = 450
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -235,7 +232,6 @@
 			descriptions = Proposed upgrade for Delta IV
 			maxThrust = 4110
 			minThrust = 2261
-			ratedBurnTime = 450
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -320,13 +316,14 @@
 	TESTFLIGHT
 	{
 		name = RS-68
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-68]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.976744
 		ignitionReliabilityEnd = 0.995349
 		cycleReliabilityStart = 0.976744
 		cycleReliabilityEnd = 0.995349
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-68] { %ratedBurnTime = #$/TESTFLIGHT[RS-68]/ratedBurnTime$ } }
 }
 
 //Delta-4M+(4,2) (upg.): 2 flights, 0 failures
@@ -339,7 +336,7 @@
 	TESTFLIGHT
 	{
 		name = RS-68A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-68A]/ratedBurnTime$
+		ratedBurnTime = 330
 		ignitionReliabilityStart = 0.976744
 		ignitionReliabilityEnd = 0.995349
 		cycleReliabilityStart = 0.976744
@@ -347,13 +344,14 @@
 		techTransfer = RS-68:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-68A] { %ratedBurnTime = #$/TESTFLIGHT[RS-68A]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-68K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = RS-68K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-68K]/ratedBurnTime$						 //burntime increase due to regen cooled nozzle
+		ratedBurnTime = 450						 //burntime increase due to regen cooled nozzle
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -361,13 +359,14 @@
 		techTransfer = RS-68:25
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-68K] { %ratedBurnTime = #$/TESTFLIGHT[RS-68K]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RS-800]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = RS-800
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-800]/ratedBurnTime$
+		ratedBurnTime = 450
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -375,4 +374,5 @@
 		techTransfer = RS-68K:50
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-800] { %ratedBurnTime = #$/TESTFLIGHT[RS-800]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
@@ -67,7 +67,6 @@
 			name = RS-76
 			maxThrust = 4378.81
 			minThrust = 2846.23
-			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -167,7 +166,7 @@
 	TESTFLIGHT
 	{
 		name = RS-76
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-76]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -175,4 +174,5 @@
 
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-76] { %ratedBurnTime = #$/TESTFLIGHT[RS-76]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RS83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS83_Config.cfg
@@ -69,7 +69,6 @@
 			name = RS-83
 			maxThrust = 3300
 			minThrust = 1650
-			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -114,7 +113,7 @@
 	TESTFLIGHT
 	{
 		name = RS-83
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-83]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -122,4 +121,5 @@
 		techTransfer = RS-68A:30	//Based on RS-68
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-83] { %ratedBurnTime = #$/TESTFLIGHT[RS-83]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RS84_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS84_Config.cfg
@@ -68,7 +68,6 @@
 			name = RS-84
 			maxThrust = 5026.49
 			minThrust = 3267.22
-			ratedBurnTime = 500
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -125,7 +124,7 @@
 	TESTFLIGHT
 	{
 		name = RS-84
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-84]/ratedBurnTime$
+		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -133,4 +132,5 @@
 
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-84] { %ratedBurnTime = #$/TESTFLIGHT[RS-84]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
@@ -85,7 +85,6 @@
 			name = RSRMV
 			minThrust = 15800 //Checked, 3550 klbf
 			maxThrust = 15800
-			ratedBurnTime = 126
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -321,7 +320,7 @@
 	TESTFLIGHT
 	{
 		name = RSRMV
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RSRMV]/ratedBurnTime$
+		ratedBurnTime = 126
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995392
@@ -330,4 +329,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RSRMV] { %ratedBurnTime = #$/TESTFLIGHT[RSRMV]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -96,7 +96,6 @@
 			description = Original version of the RSRM, used on early shuttle launches
 			minThrust = 14819
 			maxThrust = 14819
-			ratedBurnTime = 138
 			heatProduction = 100
 			curveResource = PBAN
 			gimbalRange = 5.0
@@ -248,7 +247,6 @@
 			description = Redesigned RSRM, after Challenger disaster
 			minThrust = 14819
 			maxThrust = 14819
-			ratedBurnTime = 138
 			heatProduction = 100
 			curveResource = PBAN
 			gimbalRange = 5.0
@@ -402,7 +400,7 @@
 	TESTFLIGHT
 	{
 		name = RSRM-1981
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RSRM-1981]/ratedBurnTime$
+		ratedBurnTime = 138
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.958333
@@ -410,6 +408,7 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RSRM-1981] { %ratedBurnTime = #$/TESTFLIGHT[RSRM-1981]/ratedBurnTime$ } }
 }
 
 //Redsigned RSRM: 216 flown, 0 failures
@@ -418,7 +417,7 @@
 	TESTFLIGHT
 	{
 		name = RSRM-1986
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RSRM-1986]/ratedBurnTime$
+		ratedBurnTime = 138
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995392
@@ -426,4 +425,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RSRM-1986] { %ratedBurnTime = #$/TESTFLIGHT[RSRM-1986]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -83,7 +83,6 @@
 			name = RZ20-Mk1
 			minThrust = 70 //16 klbf
 			maxThrust = 70
-			ratedBurnTime = 470
 			description = Prototype developed by Rolls-Royce
 			heatProduction = 100
 			PROPELLANT
@@ -116,7 +115,6 @@
 			name = RZ20-Mk2
 			minThrust = 72.56
 			maxThrust = 72.56
-			ratedBurnTime = 470
 			description = Increased expansion ratio proposal
 			heatProduction = 100
 			PROPELLANT
@@ -154,7 +152,7 @@
 	TESTFLIGHT
 	{
 		name = RZ20-Mk1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ20-Mk1]/ratedBurnTime$
+		ratedBurnTime = 470
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
 		cycleReliabilityStart = 0.933333
@@ -162,6 +160,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RZ20-Mk1] { %ratedBurnTime = #$/TESTFLIGHT[RZ20-Mk1]/ratedBurnTime$ } }
 }
 //No Data, never flew
 //Using RL10A-3-3 data, as the gas generator design was simple, and British engineers had access to RL10 data from P&W
@@ -170,7 +169,7 @@
 	TESTFLIGHT
 	{
 		name = RZ20-Mk2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ20-Mk2]/ratedBurnTime$
+		ratedBurnTime = 470
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
 		cycleReliabilityStart = 0.989474
@@ -178,4 +177,5 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RZ20-Mk2] { %ratedBurnTime = #$/TESTFLIGHT[RZ20-Mk2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -93,7 +93,6 @@
 			description = License-Built version of the Rocketdyne S-3
 			minThrust = 696.6
 			maxThrust = 696.6
-			ratedBurnTime = 156
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -139,7 +138,6 @@
 			description = Production engine for the Blue Streak missile, based on the rocketdyne S-3D
 			minThrust = 763
 			maxThrust = 763
-			ratedBurnTime = 156
 			heatProduction = 100
 			massMult = 1.0
 
@@ -185,7 +183,6 @@
 			description = Uprated for Europa I and II
 			minThrust = 791.2
 			maxThrust = 791.2
-			ratedBurnTime = 156
 			heatProduction = 100
 			massMult = 1.0
 
@@ -244,13 +241,14 @@
 	TESTFLIGHT
 	{
 		name = RZ.1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ.1]/ratedBurnTime$
+		ratedBurnTime = 156
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = XLR43-NA-3,S-3:50	//Direct derivative of S-3
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RZ.1] { %ratedBurnTime = #$/TESTFLIGHT[RZ.1]/ratedBurnTime$ } }
 }
 
 //Blue Streak: 4 successes, 1 failures. 9 engines succeeded, 1 failed
@@ -260,13 +258,14 @@
 	{
 
 		name = RZ.2-Mk3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ.2-Mk3]/ratedBurnTime$
+		ratedBurnTime = 156
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.888889
 		cycleReliabilityEnd = 0.977778
 		techTransfer = XLR43-NA-3,S-3,S-3D,RZ.1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RZ.2-Mk3] { %ratedBurnTime = #$/TESTFLIGHT[RZ.2-Mk3]/ratedBurnTime$ } }
 }
 
 //Europa I & II: 6 launches, no first stage failures. 12 engines succeeded, 0 failed
@@ -275,11 +274,12 @@
 	TESTFLIGHT
 	{
 		name = RZ.2-Mk4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RZ.2-Mk4]/ratedBurnTime$
+		ratedBurnTime = 156
 		ignitionReliabilityStart = 0.923077
 		ignitionReliabilityEnd = 0.984615
 		cycleReliabilityStart = 0.923077
 		cycleReliabilityEnd = 0.984615
 		techTransfer = XLR43-NA-3,S-3,S-3D,RZ.1,RZ.2-Mk3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RZ.2-Mk4] { %ratedBurnTime = #$/TESTFLIGHT[RZ.2-Mk4]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
@@ -105,7 +105,6 @@
 			name = Raptor //[6]
 			maxThrust = 1650
 			minThrust = 660 // 40% throttle [3]
-			ratedBurnTime = 1800
 			heatProduction = 100
 			PROPELLANT // Ratio = 3.55 [1]
 			{
@@ -152,7 +151,6 @@
 			name = Raptor Non-Throttleable // [7]
 			maxThrust = 3000
 			minThrust = 3000
-			ratedBurnTime = 1800
 			heatProduction = 100
 			PROPELLANT // Ratio = 3.55 [1]
 			{
@@ -199,7 +197,6 @@
 			name = Raptor Vacuum
 			maxThrust = 2240.0 // ~ Guess
 			minThrust = 896.0 // 40% throttle [3]
-			ratedBurnTime = 3600
 			heatProduction = 100
 			PROPELLANT // Ratio = 3.55 [1]
 			{
@@ -253,12 +250,13 @@
 	TESTFLIGHT
 	{
 		name = Raptor
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Raptor]/ratedBurnTime$ // ~ Guess to Allow it to Burn For 30 Minutes
+		ratedBurnTime = 1800 // ~ Guess to Allow it to Burn For 30 Minutes
 		ignitionReliabilityStart = 0.98 // ~ Slight Chance of the Torch-lit system failing
 		ignitionReliabilityEnd = 0.995 // ~ Slight Chance of the Torch-lit system failing
 		cycleReliabilityStart = 0.99975
 		cycleReliabilityEnd = 0.99995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Raptor] { %ratedBurnTime = #$/TESTFLIGHT[Raptor]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Raptor?Non-Throttleable]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -266,12 +264,13 @@
 	TESTFLIGHT
 	{
 		name = Raptor Non-Throttleable
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Raptor Non-Throttleable]/ratedBurnTime$ // ~ Guess to Allow it to Burn For 30 Minutes
+		ratedBurnTime = 1800 // ~ Guess to Allow it to Burn For 30 Minutes
 		ignitionReliabilityStart = 0.98 // ~ Slight Chance of the Torch-lit system failing
 		ignitionReliabilityEnd = 0.995 // ~ Slight Chance of the Torch-lit system failing
 		cycleReliabilityStart = 0.99975
 		cycleReliabilityEnd = 0.99995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Raptor?Non-Throttleable] { %ratedBurnTime = #$/TESTFLIGHT[Raptor?Non-Throttleable]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Raptor?Vacuum]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -279,10 +278,11 @@
 	TESTFLIGHT
 	{
 		name = Raptor Vacuum
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Raptor Vacuum]/ratedBurnTime$ // ~ Guess to Allow it to Burn For 1 Hour
+		ratedBurnTime = 3600 // ~ Guess to Allow it to Burn For 1 Hour
 		ignitionReliabilityStart = 0.98 // ~ Slight Chance of the Torch-lit system failing
 		ignitionReliabilityEnd = 0.995 // ~ Slight Chance of the Torch-lit system failing
 		cycleReliabilityStart = 0.99975
 		cycleReliabilityEnd = 0.99995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Raptor?Vacuum] { %ratedBurnTime = #$/TESTFLIGHT[Raptor?Vacuum]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
@@ -78,7 +78,6 @@
 			name = Rubis
 			minThrust = 53
 			maxThrust = 53
-			ratedBurnTime = 45
 			heatProduction = 100
 
 			PROPELLANT
@@ -118,7 +117,7 @@
 	TESTFLIGHT
 	{
 		name = Rubis
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Rubis]/ratedBurnTime$
+		ratedBurnTime = 45
 		ignitionReliabilityStart = 0.75
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.75
@@ -126,4 +125,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Rubis] { %ratedBurnTime = #$/TESTFLIGHT[Rubis]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -63,7 +63,6 @@
 			name = Rutherford-SL
 			minThrust = 17.05	//Guess
 			maxThrust = 24.91
-			ratedBurnTime = 150
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -119,11 +118,12 @@
 	{
 		name = Rutherford-SL
 		//Simple and reliable engine, all failures due to other parts
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Rutherford-SL]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
 		cycleReliabilityStart = 0.990826
 		cycleReliabilityEnd = 0.998165
 		techTransfer = RutherfordVac:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Rutherford-SL] { %ratedBurnTime = #$/TESTFLIGHT[Rutherford-SL]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -63,7 +63,6 @@
 			name = RutherfordVac
 			minThrust = 17.5	//guess
 			maxThrust = 25.79
-			ratedBurnTime = 288
 			heatProduction = 90
 			PROPELLANT
 			{
@@ -117,11 +116,12 @@
 	{
 		name = RutherfordVac
 		//Simple and reliable engine, all failures due to other parts
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RutherfordVac]/ratedBurnTime$
+		ratedBurnTime = 288
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
 		cycleReliabilityStart = 0.990826
 		cycleReliabilityEnd = 0.998165
 		techTransfer = Rutherford-SL:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RutherfordVac] { %ratedBurnTime = #$/TESTFLIGHT[RutherfordVac]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/S155.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S155.cfg
@@ -52,7 +52,6 @@
 			name = S-155
 			minThrust = 19.5
 			maxThrust = 39
-			ratedBurnTime = 1200
 			massMult = 1.0
 			heatProduction = 100
 			PROPELLANT
@@ -93,11 +92,12 @@
 	TESTFLIGHT
 	{
 		name = S-155
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S-155]/ratedBurnTime$	//Ye-50/3 contained 20 minutes of fuel
+		ratedBurnTime = 1200	//Ye-50/3 contained 20 minutes of fuel
 		ignitionReliabilityStart = 0.857143
 		ignitionReliabilityEnd = 0.971429
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
 		cycleReliabilityStart = 0.875000
 		cycleReliabilityEnd = 0.975000
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S-155] { %ratedBurnTime = #$/TESTFLIGHT[S-155]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -117,7 +117,6 @@
 			description = Derived from the German Wasserfall engine, used on the R-11 (Scud-A)
 			minThrust = 93.3
 			maxThrust = 93.3
-			ratedBurnTime = 95
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -162,7 +161,6 @@
 			description = Pump-fed upgrade, used on the R-11MU and some R-17 prototypes. Never entered service
 			minThrust = 127.5
 			maxThrust = 127.5
-			ratedBurnTime = 65
 			heatProduction = 35
 			massMult = 0.53
 			ullage = True
@@ -207,7 +205,6 @@
 			description = Upgrade, used on the Production R-17 and R-17M missile, A.K.A Scud-B and Scud-C. This was the most heavily exported variant, and copies were built by many countries.
 			minThrust = 146.3
 			maxThrust = 146.3
-			ratedBurnTime = 75
 			heatProduction = 35
 			massMult = 0.53
 			ullage = True
@@ -252,7 +249,6 @@
 			description = Upgrade used for the R-17MU, A.K.A Scud-D. It saw very little use in the Soviet Union due to mediocore performance, so the remaining missiles were sold to North Korea, providing the basis for North Korean missile development.
 			minThrust = 165.5
 			maxThrust = 165.5
-			ratedBurnTime = 90
 			heatProduction = 35
 			massMult = 0.53
 			ullage = True
@@ -305,7 +301,7 @@
 	{
 		//R-11A Sounding Rocket. 26 successes, 0 failures 
 		name = S2.253
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S2.253]/ratedBurnTime$
+		ratedBurnTime = 95
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -314,6 +310,7 @@
 		reliabilityDataRateMultiplier = 1
 		techTransfer = RD-100:20
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S2.253] { %ratedBurnTime = #$/TESTFLIGHT[S2.253]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S3.42T]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -321,7 +318,7 @@
 	{
 		//no data, assumed same as S5.2
 		name = S3.42T
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S3.42T]/ratedBurnTime$
+		ratedBurnTime = 65
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -330,6 +327,7 @@
 		reliabilityDataRateMultiplier = 1
 		techTransfer = S2.253:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S3.42T] { %ratedBurnTime = #$/TESTFLIGHT[S3.42T]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5.2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -337,7 +335,7 @@
 	{
 		//R-17 acceptance trials. 20 launches, 5 failures
 		name = S5.2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[S5.2]/ratedBurnTime$
+		ratedBurnTime = 75
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -346,6 +344,7 @@
 		reliabilityDataRateMultiplier = 1
 		techTransfer = S2.253,S3.42T:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[S5.2] { %ratedBurnTime = #$/TESTFLIGHT[S5.2]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Isayev-R17]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -353,7 +352,7 @@
 	{
 		//no data, assumed same as S5.2
 		name = Isayev-R17
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Isayev-R17]/ratedBurnTime$
+		ratedBurnTime = 90
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		ignitionDynPresFailMultiplier = 1.5
@@ -362,5 +361,6 @@
 		reliabilityDataRateMultiplier = 1
 		techTransfer = S2.253,S3.42T,S5.2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Isayev-R17] { %ratedBurnTime = #$/TESTFLIGHT[Isayev-R17]/ratedBurnTime$ } }
 }
 

--- a/GameData/RealismOverhaul/Engine_Configs/SNTPPFE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SNTPPFE_Config.cfg
@@ -68,7 +68,6 @@
 			description = LV-03/DE-01 technology demonstrator
 			minThrust = 41.2
 			maxThrust = 206
-			ratedBurnTime = 600
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			massMult = 1			
@@ -103,7 +102,6 @@
 			description = Production engine predicted performance. Increased core temperature to 3000K and Carbon-Carbon turbopumps to handle higher flow rates and inlet temperatures
 			minThrust = 49
 			maxThrust = 245.2
-			ratedBurnTime = 1050
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			massMult = 1
@@ -164,7 +162,7 @@
 	TESTFLIGHT
 	{
 		name = SNTPPFE100-Prototype
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SNTPPFE100-Prototype]/ratedBurnTime$ // 10 minutes
+		ratedBurnTime = 600 // 10 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -176,13 +174,14 @@
 		reliabilityMidTangentWeight = 0
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[SNTPPFE100-Prototype] { %ratedBurnTime = #$/TESTFLIGHT[SNTPPFE100-Prototype]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[SNTPPFE100]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = SNTPPFE100
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SNTPPFE100]/ratedBurnTime$ // 17.5 minutes
+		ratedBurnTime = 1050 // 17.5 minutes
 		explicitDataRate = True
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999997
@@ -195,4 +194,5 @@
 		reliabilityDataRateMultiplier = 100 // due to the burn time
 		techTransfer = SNTPPFE100-Hydrogen:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[SNTPPFE100] { %ratedBurnTime = #$/TESTFLIGHT[SNTPPFE100]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
@@ -78,7 +78,6 @@
 			name = SRMU
 			minThrust = 8233.777
 			maxThrust = 8233.777
-			ratedBurnTime = 145
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -165,7 +164,7 @@
 	TESTFLIGHT
 	{
 		name = SRMU
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SRMU]/ratedBurnTime$
+		ratedBurnTime = 145
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.971429
@@ -174,4 +173,5 @@
 		
 		isSolid = true
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[SRMU] { %ratedBurnTime = #$/TESTFLIGHT[SRMU]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -114,7 +114,6 @@
 			description = Phase I SSME
 			minThrust = 1358.5
 			maxThrust = 2090
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -147,7 +146,6 @@
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
 			minThrust = 1358.5
 			maxThrust = 2173.6
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -180,7 +178,6 @@
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
 			minThrust = 1358.5
 			maxThrust = 2278.1
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -213,7 +210,6 @@
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
 			minThrust = 1358.5
 			maxThrust = 2319.9
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -250,12 +246,13 @@
 	TESTFLIGHT
 	{
 		name = RS-25
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.966667
 		ignitionReliabilityEnd = 0.993333
 		cycleReliabilityStart = 0.983333
 		cycleReliabilityEnd = 0.996667
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25] { %ratedBurnTime = #$/TESTFLIGHT[RS-25]/ratedBurnTime$ } }
 }
 
 //	RS-25A(B) flew on 63 flights with 3 ignition failures
@@ -265,13 +262,14 @@
 	TESTFLIGHT
 	{
 		name = RS-25A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25A]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.984127
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = RS-25:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25A] { %ratedBurnTime = #$/TESTFLIGHT[RS-25A]/ratedBurnTime$ } }
 }
 
 //	RS-25C flew on 16 flights with 1 failure
@@ -281,13 +279,14 @@
 	TESTFLIGHT
 	{
 		name = RS-25C
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25C]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979167
 		cycleReliabilityEnd = 0.995833
 		techTransfer = RS-25,RS-25A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25C] { %ratedBurnTime = #$/TESTFLIGHT[RS-25C]/ratedBurnTime$ } }
 }
 
 //	RS-25D-E flew on 31 flights with no failures
@@ -297,11 +296,12 @@
 	TESTFLIGHT
 	{
 		name = RS-25D-E
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[RS-25D-E]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.989362
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
 		techTransfer = RS-25,RS-25A,RS-25C:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25D-E] { %ratedBurnTime = #$/TESTFLIGHT[RS-25D-E]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/STBE1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STBE1_Config.cfg
@@ -92,7 +92,6 @@
 			name = STBE-1A
 			minThrust = 1475				//45%
 			maxThrust = 3275
-			ratedBurnTime = 300
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -129,7 +128,6 @@
 			name = STBE-1B
 			minThrust = 1475					//45%
 			maxThrust = 3273
-			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 1.001
 			PROPELLANT
@@ -167,7 +165,6 @@
 			name = STBE-3
 			minThrust = 1428						//45%
 			maxThrust = 3172
-			ratedBurnTime = 300
 			heatProduction = 100
 			massMult = 0.985
 			PROPELLANT								//OF 3.5
@@ -217,12 +214,13 @@
 	TESTFLIGHT
 	{
 		name = STBE-1A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE-1A]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995
 		cycleReliabilityEnd = 0.99995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STBE-1A] { %ratedBurnTime = #$/TESTFLIGHT[STBE-1A]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[STBE-1B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -230,12 +228,13 @@
 	TESTFLIGHT
 	{
 		name = STBE-1B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE-1B]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995
 		cycleReliabilityEnd = 0.99995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STBE-1B] { %ratedBurnTime = #$/TESTFLIGHT[STBE-1B]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[STBE-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -243,10 +242,11 @@
 	TESTFLIGHT
 	{
 		name = STBE-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE-3]/ratedBurnTime$
+		ratedBurnTime = 300
 		ignitionReliabilityStart = 0.995
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.995
 		cycleReliabilityEnd = 0.99995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STBE-3] { %ratedBurnTime = #$/TESTFLIGHT[STBE-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/STBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STBE_Config.cfg
@@ -64,7 +64,6 @@
 			name = STBE
 			minThrust = 8896.4
 			maxThrust = 8896.4
-			ratedBurnTime = 315
 			PROPELLANT
 			{
 				name = Kerosene
@@ -110,10 +109,11 @@
 	TESTFLIGHT
 	{
 		name = STBE
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STBE]/ratedBurnTime$
+		ratedBurnTime = 315
 		ignitionReliabilityStart = 0.9371
 		ignitionReliabilityEnd = 0.9971
 		cycleReliabilityStart = 0.9371
 		cycleReliabilityEnd = 0.9971
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STBE] { %ratedBurnTime = #$/TESTFLIGHT[STBE]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
@@ -64,7 +64,6 @@
 			name = STME
 			minThrust = 2023.9
 			maxThrust = 2891.3
-			ratedBurnTime = 480
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -100,11 +99,12 @@
 	TESTFLIGHT
 	{
 		name = STME
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STME]/ratedBurnTime$
+		ratedBurnTime = 480
 		ignitionReliabilityStart = 0.932
 		ignitionReliabilityEnd = 0.992
 		cycleReliabilityStart = 0.9415
 		cycleReliabilityEnd = 0.9995
 		techTransfer = RS-25A:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STME] { %ratedBurnTime = #$/TESTFLIGHT[STME]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-13B
 			minThrust = 9.61
 			maxThrust = 9.61
-			ratedBurnTime = 16
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +312,7 @@
 	TESTFLIGHT
 	{
 		name = Star-13B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-13B]/ratedBurnTime$
+		ratedBurnTime = 16
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -321,4 +320,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-13B] { %ratedBurnTime = #$/TESTFLIGHT[Star-13B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-15G
 			minThrust = 12.5
 			maxThrust = 12.5
-			ratedBurnTime = 36
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +312,7 @@
 	TESTFLIGHT
 	{
 		name = Star-15G
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-15G]/ratedBurnTime$
+		ratedBurnTime = 36
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -321,4 +320,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-15G] { %ratedBurnTime = #$/TESTFLIGHT[Star-15G]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-17A
 			minThrust = 17.4
 			maxThrust = 17.4
-			ratedBurnTime = 25
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -312,7 +311,7 @@
 	TESTFLIGHT
 	{
 		name = Star-17A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-17A]/ratedBurnTime$
+		ratedBurnTime = 25
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -320,4 +319,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-17A] { %ratedBurnTime = #$/TESTFLIGHT[Star-17A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-20
 			minThrust = 28.9
 			maxThrust = 28.9
-			ratedBurnTime = 31
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -314,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-20
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-20]/ratedBurnTime$
+		ratedBurnTime = 31
 		ignitionReliabilityStart = 0.972973
 		ignitionReliabilityEnd = 0.994595
 		cycleReliabilityStart = 0.972973
@@ -324,4 +323,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-20] { %ratedBurnTime = #$/TESTFLIGHT[Star-20]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
@@ -86,7 +86,6 @@
 			name = STAR-24C
 			minThrust = 21.35
 			maxThrust = 21.35
-			ratedBurnTime = 30
 			heatProduction = 123
 			gimbalRange = 0
 			masMult = 1.0
@@ -335,10 +334,11 @@
 	{
 		name = STAR-24C
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-24C]/ratedBurnTime$
+		ratedBurnTime = 30
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.9999
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STAR-24C] { %ratedBurnTime = #$/TESTFLIGHT[STAR-24C]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
@@ -92,7 +92,6 @@
 			name = Star-27
 			minThrust = 28.2
 			maxThrust = 28.2
-			ratedBurnTime = 47
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -560,7 +559,7 @@
 	TESTFLIGHT
 	{
 		name = Star-27
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-27]/ratedBurnTime$
+		ratedBurnTime = 47
 		ignitionReliabilityStart = 0.983333
 		ignitionReliabilityEnd = 0.996667
 		cycleReliabilityStart = 0.983333
@@ -568,4 +567,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-27] { %ratedBurnTime = #$/TESTFLIGHT[Star-27]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-30BP
 			minThrust = 30.9
 			maxThrust = 30.9
-			ratedBurnTime = 55
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +312,7 @@
 	TESTFLIGHT
 	{
 		name = Star-30BP
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-30BP]/ratedBurnTime$
+		ratedBurnTime = 55
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
 		cycleReliabilityStart = 0.960000
@@ -321,4 +320,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-30BP] { %ratedBurnTime = #$/TESTFLIGHT[Star-30BP]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
@@ -78,7 +78,6 @@
 			name = Star-31
 			minThrust = 95.6
 			maxThrust = 95.6
-			ratedBurnTime = 51
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -314,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-31
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-31]/ratedBurnTime$
+		ratedBurnTime = 51
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.90
@@ -324,4 +323,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-31] { %ratedBurnTime = #$/TESTFLIGHT[Star-31]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -90,7 +90,6 @@
 			name = STAR-37E
 			minThrust = 68.8
 			maxThrust = 68.8
-			ratedBurnTime = 42
 			heatProduction = 95
 			gimbalRange = 0
 			masMult = 1.0
@@ -338,11 +337,12 @@
 	{
 		name = STAR-37E
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-37E]/ratedBurnTime$
+		ratedBurnTime = 42
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.9999
 		techTransfer = STAR-37:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STAR-37E] { %ratedBurnTime = #$/TESTFLIGHT[STAR-37E]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -86,7 +86,6 @@
 			name = STAR-37FM
 			minThrust = 54.8
 			maxThrust = 54.8
-			ratedBurnTime = 64
 			gimbalRange = 0
 			masMult = 1.0
 			ullage = False
@@ -332,11 +331,12 @@
 	{
 		name = STAR-37FM
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-37FM]/ratedBurnTime$
+		ratedBurnTime = 64
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.9999
 		techTransfer = STAR-37,Star-37E:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STAR-37FM] { %ratedBurnTime = #$/TESTFLIGHT[STAR-37FM]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -92,7 +92,6 @@
 			name = STAR-37
 			minThrust = 43.5
 			maxThrust = 43.5
-			ratedBurnTime = 42
 			heatProduction = 73
 			gimbalRange = 0
 			massMult = 1.0
@@ -340,10 +339,11 @@
 	{
 		name = STAR-37
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[STAR-37]/ratedBurnTime$
+		ratedBurnTime = 42
 		ignitionReliabilityStart = 0.958
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.9999
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[STAR-37] { %ratedBurnTime = #$/TESTFLIGHT[STAR-37]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
@@ -76,7 +76,6 @@
 			name = Star-3
 			minThrust = 2
 			maxThrust = 2
-			ratedBurnTime = 5
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -209,7 +208,7 @@
 	TESTFLIGHT
 	{
 		name = Star-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-3]/ratedBurnTime$
+		ratedBurnTime = 5
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -217,4 +216,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-3] { %ratedBurnTime = #$/TESTFLIGHT[Star-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
@@ -112,7 +112,6 @@
 			name = Star-48B/Short
 			minThrust = 76.1
 			maxThrust = 76.1
-			ratedBurnTime = 90
 			heatProduction = 100
 			massMult = 0.9521
 			PROPELLANT
@@ -345,7 +344,6 @@
 			name = Star-48B/Long
 			minThrust = 78
 			maxThrust = 78
-			ratedBurnTime = 90
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -576,7 +574,6 @@
 		{
 			name = Star-48BV
 			maxThrust = 78
-			ratedBurnTime = 90
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -816,13 +813,14 @@
 	{
 		name = Star-48B/Short
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-48B?Short]/ratedBurnTime$
+		ratedBurnTime = 90
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.995
 		techTransfer = STAR-37,Star-37E:50 & Star-48B/Long,Star-48BV:100
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-48B?Short] { %ratedBurnTime = #$/TESTFLIGHT[Star-48B?Short]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-48B/Long]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -830,13 +828,14 @@
 	{
 		name = Star-48B/Long
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-48B?Long]/ratedBurnTime$
+		ratedBurnTime = 90
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.995
 		techTransfer = STAR-37,Star-37E:50 & Star-48B/Short,Star-48BV:100
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-48B?Long] { %ratedBurnTime = #$/TESTFLIGHT[Star-48B?Long]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Star-48BV]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -844,11 +843,12 @@
 	{
 		name = Star-48BV
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-48BV]/ratedBurnTime$
+		ratedBurnTime = 90
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.995
 		techTransfer = STAR-37,Star-37E:50 & Star-48B/Short,Star-48/Long:100
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-48BV] { %ratedBurnTime = #$/TESTFLIGHT[Star-48BV]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star4G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star4G_Config.cfg
@@ -76,7 +76,6 @@
 			name = Star-4G
 			minThrust = 0.3
 			maxThrust = 0.3
-			ratedBurnTime = 10
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -312,7 +311,7 @@
 	TESTFLIGHT
 	{
 		name = Star-4G
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-4G]/ratedBurnTime$
+		ratedBurnTime = 10
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -320,4 +319,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-4G] { %ratedBurnTime = #$/TESTFLIGHT[Star-4G]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
@@ -76,7 +76,6 @@
 			name = Star-5C
 			minThrust = 2.468
 			maxThrust = 2.468
-			ratedBurnTime = 3
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -311,7 +310,7 @@
 	TESTFLIGHT
 	{
 		name = Star-5C
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-5C]/ratedBurnTime$
+		ratedBurnTime = 3
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -319,4 +318,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-5C] { %ratedBurnTime = #$/TESTFLIGHT[Star-5C]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-5D
 			minThrust = 6.272
 			maxThrust = 6.272
-			ratedBurnTime = 4
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -105,7 +104,7 @@
 	TESTFLIGHT
 	{
 		name = Star-5D
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-5D]/ratedBurnTime$
+		ratedBurnTime = 4
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.99
@@ -113,4 +112,5 @@
 		techTransfer = Star-5C:50
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-5D] { %ratedBurnTime = #$/TESTFLIGHT[Star-5D]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
@@ -76,7 +76,6 @@
 			name = Star-63D
 			minThrust = 119
 			maxThrust = 119
-			ratedBurnTime = 120
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -315,11 +314,12 @@
 	{
 		name = Star-63D
 		isSolid = True
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-63D]/ratedBurnTime$
+		ratedBurnTime = 120
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.9999
 		techTransfer = Star-48/Short,Star-48B/Long,Star-48BV:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-63D] { %ratedBurnTime = #$/TESTFLIGHT[Star-63D]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star6B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star6B_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-6B
 			minThrust = 2.82
 			maxThrust = 2.82
-			ratedBurnTime = 8
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -313,7 +312,7 @@
 	TESTFLIGHT
 	{
 		name = Star-6B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-6B]/ratedBurnTime$
+		ratedBurnTime = 8
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -321,4 +320,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-6B] { %ratedBurnTime = #$/TESTFLIGHT[Star-6B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
@@ -77,7 +77,6 @@
 			name = Star-8
 			minThrust = 7.749
 			maxThrust = 7.749
-			ratedBurnTime = 5
 			heatProduction = 100
 			curveResource = HTPB
 			ullage = False
@@ -105,7 +104,7 @@
 	TESTFLIGHT
 	{
 		name = Star-8
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-8]/ratedBurnTime$
+		ratedBurnTime = 5
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -113,4 +112,5 @@
 		techTransfer = Star-5C,Star-5D:50
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-8] { %ratedBurnTime = #$/TESTFLIGHT[Star-8]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star9_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star9_Config.cfg
@@ -78,7 +78,6 @@
 			name = Star-9
 			minThrust = 5.83
 			maxThrust = 5.83
-			ratedBurnTime = 10
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -314,7 +313,7 @@
 	TESTFLIGHT
 	{
 		name = Star-9
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Star-9]/ratedBurnTime$
+		ratedBurnTime = 10
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.98
@@ -322,4 +321,5 @@
 
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-9] { %ratedBurnTime = #$/TESTFLIGHT[Star-9]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
@@ -66,7 +66,6 @@
 			description = Booster for the Blue Steel missile
 			minThrust = 110
 			maxThrust = 110
-			ratedBurnTime = 60
 			heatProduction = 100
 			massMult = 1.0
 
@@ -108,11 +107,12 @@
 	TESTFLIGHT
 	{
 		name = Stentor
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Stentor]/ratedBurnTime$
+		ratedBurnTime = 60
 
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
 		cycleReliabilityStart = 0.931034
 		cycleReliabilityEnd = 0.986207
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Stentor] { %ratedBurnTime = #$/TESTFLIGHT[Stentor]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
@@ -65,7 +65,6 @@
 			name = SuperDraco
 			minThrust = 17.0
 			maxThrust = 85.0
-			ratedBurnTime = 350
 			heatProduction = 54
 
 			PROPELLANT
@@ -111,10 +110,11 @@
 	TESTFLIGHT
 	{
 		name = SuperDraco
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[SuperDraco]/ratedBurnTime$
+		ratedBurnTime = 350
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[SuperDraco] { %ratedBurnTime = #$/TESTFLIGHT[SuperDraco]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
@@ -70,7 +70,6 @@
 			name = TD-339
 			minThrust = 0.133
 			maxThrust = 0.462
-			ratedBurnTime = 495
 			heatProduction = 100
 			ullage = False
 			pressureFed = True
@@ -110,10 +109,11 @@
 	TESTFLIGHT
 	{
 		name = TD-339
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[TD-339]/ratedBurnTime$		//Enough to deplete fuel tanks at low throttle
+		ratedBurnTime = 495		//Enough to deplete fuel tanks at low throttle
 		ignitionReliabilityStart = 0.984127
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.954545
 		cycleReliabilityEnd = 0.990909
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[TD-339] { %ratedBurnTime = #$/TESTFLIGHT[TD-339]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
@@ -62,7 +62,6 @@
 			name = MR-80-TDE
 			minThrust = 0.276
 			maxThrust = 2.811
-			ratedBurnTime = 215
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -94,10 +93,11 @@
 	{
 		name = MR-80-TDE
 		//Extremely simple and reliable monopropellant engines
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[MR-80-TDE]/ratedBurnTime$
+		ratedBurnTime = 215
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99
 		cycleReliabilityEnd = 0.999
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[MR-80-TDE] { %ratedBurnTime = #$/TESTFLIGHT[MR-80-TDE]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/TR107_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TR107_Config.cfg
@@ -66,7 +66,6 @@
 			name = TR-107
 			maxThrust = 5323
 			minThrust = 3460
-			ratedBurnTime = 3600
 			heatProduction = 86
 			ullage = True
 			pressureFed = False
@@ -122,7 +121,7 @@
 	TESTFLIGHT
 	{
 		name = TR-107
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[TR-107]/ratedBurnTime$
+		ratedBurnTime = 3600
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -130,4 +129,5 @@
 
 		reliabilityDataRateMultiplier = 1
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[TR-107] { %ratedBurnTime = #$/TESTFLIGHT[TR-107]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
@@ -85,7 +85,6 @@
 			name = UA1204
 			minThrust = 4151.3
 			maxThrust = 4151.3
-			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -154,11 +153,12 @@
 	TESTFLIGHT
 	{
 		name = UA1204
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1204]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = UA1205,UA1206,UA1207,UA1208:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[UA1204] { %ratedBurnTime = #$/TESTFLIGHT[UA1204]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
@@ -84,7 +84,6 @@
 			name = UA1205
 			minThrust = 5338
 			maxThrust = 5338
-			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -152,11 +151,12 @@
 	TESTFLIGHT
 	{
 		name = UA1205
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1205]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = UA1204,UA1206,UA1207,UA1208:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[UA1205] { %ratedBurnTime = #$/TESTFLIGHT[UA1205]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
@@ -86,7 +86,6 @@
 			name = UA1206
 			minThrust = 6227
 			maxThrust = 6227
-			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -154,11 +153,12 @@
 	TESTFLIGHT
 	{
 		name = UA1206
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1206]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = UA1204,UA1205,UA1207,UA1208:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[UA1206] { %ratedBurnTime = #$/TESTFLIGHT[UA1206]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
@@ -86,7 +86,6 @@
 			name = UA1207
 			minThrust = 7450
 			maxThrust = 7450
-			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -148,11 +147,12 @@
 	TESTFLIGHT
 	{
 		name = UA1207
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1207]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = UA1204,UA1205,UA1206,UA1208:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[UA1207] { %ratedBurnTime = #$/TESTFLIGHT[UA1207]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
@@ -86,7 +86,6 @@
 			name = UA1208
 			minThrust = 7450
 			maxThrust = 7450
-			ratedBurnTime = 135
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -148,11 +147,12 @@
 	TESTFLIGHT
 	{
 		name = UA1208
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[UA1208]/ratedBurnTime$
+		ratedBurnTime = 135
 		ignitionReliabilityStart = 0.999
 		ignitionReliabilityEnd = 1.0	//This isn't really a possible failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
 		techTransfer = UA1204,UA1205,UA1206,UA1207:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[UA1208] { %ratedBurnTime = #$/TESTFLIGHT[UA1208]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
@@ -101,7 +101,6 @@
 			description = Prototype, used for early tests
 			minThrust = 44.4
 			maxThrust = 44.4
-			ratedBurnTime = 6.5
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -147,7 +146,6 @@
 			description = Production Engine
 			minThrust = 44.4
 			maxThrust = 44.4
-			ratedBurnTime = 45
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -193,7 +191,6 @@
 			description = Turpentine fuel for increased performance
 			minThrust = 43.6
 			maxThrust = 43.6
-			ratedBurnTime = 49
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -239,7 +236,6 @@
 			description = Uprated version
 			minThrust = 65.3
 			maxThrust = 65.3
-			ratedBurnTime = 56
 			heatProduction = 100
 			massMult = 1.0
 			
@@ -298,13 +294,15 @@
 	{
 		//7 successes, 1 failure
 		name = VeroniqueR
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[VeroniqueR]/ratedBurnTime$
+		ratedBurnTime = 6.5
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.875000
 		cycleReliabilityEnd = 0.975000
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[VeroniqueR] { %ratedBurnTime = #$/TESTFLIGHT[VeroniqueR]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Veronique]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -312,13 +310,14 @@
 	{
 		//35 successes, 19 failures
 		name = Veronique
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Veronique]/ratedBurnTime$
+		ratedBurnTime = 45
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.648148
 		cycleReliabilityEnd = 0.929630
 		techTransfer = VeroniqueR:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Veronique] { %ratedBurnTime = #$/TESTFLIGHT[Veronique]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[VeroniqueAGI]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -326,13 +325,14 @@
 	{
 		//8 successes, 1 failure
 		name = VeroniqueAGI
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[VeroniqueAGI]/ratedBurnTime$
+		ratedBurnTime = 49
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.888889
 		cycleReliabilityEnd = 0.977778
 		techTransfer = VeroniqueR,Veronique:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[VeroniqueAGI] { %ratedBurnTime = #$/TESTFLIGHT[VeroniqueAGI]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Veronique61]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -340,11 +340,12 @@
 	{
 		//21 successes, 0 failure
 		name = Veronique61
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Veronique61]/ratedBurnTime$
+		ratedBurnTime = 56
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.954545
 		cycleReliabilityEnd = 0.990909
 		techTransfer = VeroniqueR,Veronique,VeroniqueAGI:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Veronique61] { %ratedBurnTime = #$/TESTFLIGHT[Veronique61]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
@@ -125,7 +125,6 @@
 			description = Used for the "Super-Veronique" Vesta sounding rocket. Has no gimbal
 			minThrust = 153.7
 			maxThrust = 153.7
-			ratedBurnTime = 56
 			heatProduction = 100
 			massMult = 1.0
 
@@ -169,7 +168,6 @@
 			description = First stage engine for the "precious stones" series of sounding rockets, culminating in the Diamant Launch Vehicle.
 			minThrust = 310.1
 			maxThrust = 310.1
-			ratedBurnTime = 96
 			heatProduction = 100
 			massMult = 1.0
 
@@ -213,7 +211,6 @@
 			description = Modified for vaccuum use and converted to UDMH/NTO as the second stage of the Europa Launch Vehicle.
 			minThrust = 262
 			maxThrust = 262
-			ratedBurnTime = 96
 			heatProduction = 100
 			massMult = 1.0
 
@@ -251,7 +248,6 @@
 			description = Upgraded version of Vexin, used in the first stage of the Amethyste sounding rocket and Diamant-B launch vehicle.
 			minThrust = 407.7
 			maxThrust = 407.7
-			ratedBurnTime = 110
 			heatProduction = 100
 			massMult = 1.0
 
@@ -291,7 +287,6 @@
 			description = Engine for the Diamant-BP first stage
 			minThrust = 373.5
 			maxThrust = 373.5
-			ratedBurnTime = 110
 			heatProduction = 100
 			massMult = 1.0
 
@@ -333,13 +328,14 @@
 	{
 		//5 successes, 0 failures
 		name = Vesta
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vesta]/ratedBurnTime$
+		ratedBurnTime = 56
 		ignitionReliabilityStart = 0.8
 		ignitionReliabilityEnd = 0.9
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = VeroniqueR,Veronique,VeroniqueAGI:40
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vesta] { %ratedBurnTime = #$/TESTFLIGHT[Vesta]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vexin]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -349,13 +345,14 @@
 		//Emeraude: 2 successes, 3 failures
 		//Diamant: 4 successes, 0 failures
 		name = Vexin
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vexin]/ratedBurnTime$
+		ratedBurnTime = 96
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.666667
 		cycleReliabilityEnd = 0.933333
 		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta:40
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vexin] { %ratedBurnTime = #$/TESTFLIGHT[Vexin]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vexin-A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -365,13 +362,14 @@
 		//Europa I: 3 successes, 2 failures
 		//Europa II: 1 success, 0 failures
 		name = Vexin-A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vexin-A]/ratedBurnTime$
+		ratedBurnTime = 96
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.666667
 		cycleReliabilityEnd = 0.933333
 		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin:40
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vexin-A] { %ratedBurnTime = #$/TESTFLIGHT[Vexin-A]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Valois-A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -380,13 +378,14 @@
 	{
 		//Diamant-B: 5 successes, 0 failures
 		name = Valois-A
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Valois-A]/ratedBurnTime$
+		ratedBurnTime = 110
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
 		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin,Vexin-A:40
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Valois-A] { %ratedBurnTime = #$/TESTFLIGHT[Valois-A]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Valois-B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -395,11 +394,12 @@
 	{
 		//Diamant-BP.4: 3 successes, 0 failures
 		name = Valois-B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Valois-B]/ratedBurnTime$
+		ratedBurnTime = 110
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.950000
 		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin,Vexin-A,Valois-A:40
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Valois-B] { %ratedBurnTime = #$/TESTFLIGHT[Valois-B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
@@ -44,7 +44,6 @@
 			description = License built copy of the European Viking-5 engine.
             minThrust = 680.5
             maxThrust = 680.5
-            ratedBurnTime = 154
             heatProduction = 100
             massMult = 0.9178
 
@@ -93,7 +92,6 @@
 			description = Uprated version of the Vikas-1.
             minThrust = 765.5
             maxThrust = 765.5
-            ratedBurnTime = 154
             heatProduction = 100
             massMult = 0.9178
 
@@ -142,7 +140,6 @@
 			description = License built copy of the Viking-4 vacuum engine.
             minThrust = 725
             maxThrust = 725
-            ratedBurnTime = 133
             heatProduction = 100
             massMult = 1.0
 
@@ -191,7 +188,6 @@
 			description = Uprated version of the Vikas-2.
             minThrust = 804.5
             maxThrust = 804.5
-            ratedBurnTime = 140
             heatProduction = 100
             massMult = 1.0
 
@@ -251,48 +247,52 @@
 	TESTFLIGHT
 	{
 		name = Vikas-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-1]/ratedBurnTime$
+		ratedBurnTime = 154
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vikas-1] { %ratedBurnTime = #$/TESTFLIGHT[Vikas-1]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vikas-1+]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Vikas-1+
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-1+]/ratedBurnTime$
+		ratedBurnTime = 154
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9965
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 		techTransfer = Vikas-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vikas-1+] { %ratedBurnTime = #$/TESTFLIGHT[Vikas-1+]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vikas-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Vikas-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-2]/ratedBurnTime$
+		ratedBurnTime = 133
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vikas-2] { %ratedBurnTime = #$/TESTFLIGHT[Vikas-2]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Vikas-2B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = Vikas-2B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-2B]/ratedBurnTime$
+		ratedBurnTime = 140
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9965
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
 		techTransfer = Vikas-1:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vikas-2B] { %ratedBurnTime = #$/TESTFLIGHT[Vikas-2B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -135,7 +135,6 @@
 			description = First stage engine for Ariane 1
 			minThrust = 690
 			maxThrust = 690
-			ratedBurnTime = 145
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -184,7 +183,6 @@
 			description = Second stage engine for Ariane 1
 			minThrust = 713
 			maxThrust = 713
-			ratedBurnTime = 132
 			heatProduction = 100
 			massMult = 1.064
 			gimbalRange = 5.0
@@ -233,7 +231,6 @@
 			description = First stage engine for Ariane 2/3. Uses UH25 for extra performance.
 			minThrust = 720
 			maxThrust = 720
-			ratedBurnTime = 205
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -282,7 +279,6 @@
 			description = Second stage engine for Ariane 2/3/4. Uses UH25 for extra performance.
 			minThrust = 805
 			maxThrust = 805
-			ratedBurnTime = 125
 			heatProduction = 100
 			massMult = 1.064
 			gimbalRange = 5.0
@@ -331,7 +327,6 @@
 			description = First stage engine for Ariane 4
 			minThrust = 758
 			maxThrust = 758
-			ratedBurnTime = 205
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -380,7 +375,6 @@
 			description = Booster engine for Ariane 4
 			minThrust = 758
 			maxThrust = 758
-			ratedBurnTime = 142
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 0.0
@@ -435,13 +429,14 @@
 	{
 		//10 1st stage successes, 1 failure. 43 engines succeeded, 1 failed
 		name = Viking-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-2]/ratedBurnTime$
+		ratedBurnTime = 145
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.976744
 		cycleReliabilityEnd = 0.995349
 		techTransfer = Viking-4:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Viking-2] { %ratedBurnTime = #$/TESTFLIGHT[Viking-2]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -449,13 +444,14 @@
 	{
 		//9 2nd stage successes, 0 failure. 9 engines succeeded, 0 failed
 		name = Viking-4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4]/ratedBurnTime$
+		ratedBurnTime = 132
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.9
 		cycleReliabilityEnd = 0.98
 		techTransfer = Viking-2:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Viking-4] { %ratedBurnTime = #$/TESTFLIGHT[Viking-4]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-2B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -464,13 +460,14 @@
 		//Ariane 2: 6 1st stage successes, 0 failure. 24 engines succeeded, 0 failed
 		//Ariane 3: 11 1st stage successes, 0 failure. 44 engines succeeded, 0 failed
 		name = Viking-2B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-2B]/ratedBurnTime$
+		ratedBurnTime = 205
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.997
 		cycleReliabilityStart = 0.985294
 		cycleReliabilityEnd = 0.997059
 		techTransfer = Viking-2,Viking-4,Viking-4B:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Viking-2B] { %ratedBurnTime = #$/TESTFLIGHT[Viking-2B]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-4B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -480,13 +477,14 @@
 		//Ariane 3: 11 2nd stage successes, 0 failure. 11 engines succeeded, 0 failed
 		//Ariane 4: 115 2nd stage successes, 0 failures. 115 engines succeeded, 0 failed
 		name = Viking-4B
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4B]/ratedBurnTime$
+		ratedBurnTime = 125
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.992424
 		cycleReliabilityEnd = 0.998485
 		techTransfer = Viking-2,Viking-4,Viking-2B:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Viking-4B] { %ratedBurnTime = #$/TESTFLIGHT[Viking-4B]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-5C]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -494,13 +492,14 @@
 	{
 		//Ariane 4: 115 1st stage successes, 1 failures. 463 engines succeeded, 1 failed
 		name = Viking-5C
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-5C]/ratedBurnTime$
+		ratedBurnTime = 205
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.997840
 		cycleReliabilityEnd = 0.999568
 		techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Viking-5C] { %ratedBurnTime = #$/TESTFLIGHT[Viking-5C]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Viking-6]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -508,11 +507,12 @@
 	{
 		//Ariane 4: 238 booster stage successes, 0 failures. 238 engines succeeded, 0 failed
 		name = Viking-6
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Viking-6]/ratedBurnTime$
+		ratedBurnTime = 142
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.995798
 		cycleReliabilityEnd = 0.999160
 		techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B,Viking-5C:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Viking-6] { %ratedBurnTime = #$/TESTFLIGHT[Viking-6]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vulcain_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vulcain_Config.cfg
@@ -80,7 +80,6 @@
 			name = Vulcain
 			maxThrust = 1113
 			minThrust = 1113
-			ratedBurnTime = 580
 			massMult = 0.72
 			PROPELLANT
 			{
@@ -113,7 +112,6 @@
 			description = Upgrade, utilizing flim cooling and new turbopumps for higher thrust.
 			maxThrust = 1359
 			minThrust = 1359
-			ratedBurnTime = 580
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -147,13 +145,15 @@
 	TESTFLIGHT
 	{
 		name = Vulcain
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vulcain]/ratedBurnTime$
+		ratedBurnTime = 580
 		ignitionReliabilityStart = 0.961538
 		ignitionReliabilityEnd = 0.992308
 		cycleReliabilityStart = 0.961538
 		cycleReliabilityEnd = 0.992308
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vulcain] { %ratedBurnTime = #$/TESTFLIGHT[Vulcain]/ratedBurnTime$ } }
 }
 
 //Ariane 5 ES/ECA: 83 flights, 1 failures
@@ -162,11 +162,13 @@
 	TESTFLIGHT
 	{
 		name = Vulcain-2
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Vulcain-2]/ratedBurnTime$
+		ratedBurnTime = 580
 		ignitionReliabilityStart = 0.987952
 		ignitionReliabilityEnd = 0.997590
 		cycleReliabilityStart = 0.987952
 		cycleReliabilityEnd = 0.997590
 
 	}
+
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Vulcain-2] { %ratedBurnTime = #$/TESTFLIGHT[Vulcain-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
@@ -71,7 +71,6 @@
 			name = Waxwing
 			minThrust = 34.35
 			maxThrust = 34.35
-			ratedBurnTime = 30
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -176,7 +175,7 @@
 	TESTFLIGHT
 	{
 		name = Waxwing
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[Waxwing]/ratedBurnTime$
+		ratedBurnTime = 30
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.97
@@ -185,4 +184,5 @@
 		
 		isSolid = True
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Waxwing] { %ratedBurnTime = #$/TESTFLIGHT[Waxwing]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -119,7 +119,6 @@
 			name = X-405
 			minThrust = 135.5
 			maxThrust = 135.5 // 27835lbf at sea level
-			ratedBurnTime = 145
 			heatProduction = 78
 			massMult = 1.0
 			ullage = True
@@ -172,7 +171,6 @@
 			name = X-405H
 			minThrust = 156.3
 			maxThrust = 156.3
-			ratedBurnTime = 245
 			heatProduction = 78
 			massMult = 1.141
 			ullage = True
@@ -227,7 +225,6 @@
 			description = Speculative upgrade configuration with increased expansion ratio
 			minThrust = 161.86
 			maxThrust = 161.86
-			ratedBurnTime = 245
 			heatProduction = 78
 			massMult = 1.15
 			ullage = True
@@ -282,7 +279,6 @@
 			description = Speculative upgrade configuration with increased chamber pressure and upgrades with late 1960s technology.
 			minThrust = 186.42
 			maxThrust = 186.42
-			ratedBurnTime = 245
 			heatProduction = 78
 			massMult = 1.15
 			ullage = True
@@ -349,26 +345,28 @@
 	TESTFLIGHT
 	{
 		name = X-405
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405]/ratedBurnTime$
+		ratedBurnTime = 145
 		ignitionReliabilityStart = 0.70
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.86
 		cycleReliabilityEnd = 0.94
 		techTransfer = A-4:10
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[X-405] { %ratedBurnTime = #$/TESTFLIGHT[X-405]/ratedBurnTime$ } }
 }
 @PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405H]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = X-405H
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405H]/ratedBurnTime$
+		ratedBurnTime = 245
 		ignitionReliabilityStart = 0.80
 		ignitionReliabilityEnd = 0.94
 		cycleReliabilityStart = 0.86
 		cycleReliabilityEnd = 0.96
 		techTransfer = X-405:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[X-405H] { %ratedBurnTime = #$/TESTFLIGHT[X-405H]/ratedBurnTime$ } }
 }
 @PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405H-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -376,13 +374,14 @@
 	{
 		// Copied from H-1.
 		name = X-405H-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405H-3]/ratedBurnTime$
+		ratedBurnTime = 245
 		ignitionReliabilityStart = 0.89
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.93
 		cycleReliabilityEnd = 0.988
 		techTransfer = X-405,X-405H:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[X-405H-3] { %ratedBurnTime = #$/TESTFLIGHT[X-405H-3]/ratedBurnTime$ } }
 }
 @PART:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[X-405H-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
@@ -390,11 +389,12 @@
 	{
 		// Copied from H-1b.
 		name = X-405H-4
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[X-405H-4]/ratedBurnTime$
+		ratedBurnTime = 245
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.994
 		techTransfer = X-405,X-405H,X-405H-3:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[X-405H-4] { %ratedBurnTime = #$/TESTFLIGHT[X-405H-4]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
@@ -114,7 +114,6 @@
 			name = XLR11-RM-3
 			minThrust = 7.2
 			maxThrust = 28.80
-			ratedBurnTime = 150
 			massMult = 0.61
 			heatProduction = 100
 			pressureFed = True
@@ -141,7 +140,6 @@
 			name = XLR11-RM-5
 			minThrust = 7.2
 			maxThrust = 28.80
-			ratedBurnTime = 360
 			massMult = 1.0
 			heatProduction = 100
 			%pressureFed = False
@@ -175,7 +173,6 @@
 			name = XLR11-RM-13-8K
 			minThrust = 9.6125
 			maxThrust = 38.45
-			ratedBurnTime = 360
 			massMult = 1.0
 			heatProduction = 100
 			%pressureFed = False
@@ -209,7 +206,6 @@
 			name = XLR11-RM-13-10K	//Uprated version used in X-24B
 			minThrust = 11.77
 			maxThrust = 47.08
-			ratedBurnTime = 360
 			massMult = 1.0
 			heatProduction = 100
 			%pressureFed = False
@@ -245,20 +241,21 @@
 	TESTFLIGHT
 	{
 		name = XLR11-RM-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-3]/ratedBurnTime$
+		ratedBurnTime = 150
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.987
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
 		cycleReliabilityStart = 0.93
 		cycleReliabilityEnd = 0.998
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR11-RM-3] { %ratedBurnTime = #$/TESTFLIGHT[XLR11-RM-3]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR11-RM-5]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = XLR11-RM-5
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-5]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.987
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -266,13 +263,14 @@
 		cycleReliabilityEnd = 0.998
 		techTransfer = XLR11-RM-3:30	//Added turbopumps, fairly different from -3
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR11-RM-5] { %ratedBurnTime = #$/TESTFLIGHT[XLR11-RM-5]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR11-RM-13-8K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = XLR11-RM-13-8K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-13-8K]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99	//Never failed to ignite on X-15
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -280,13 +278,14 @@
 		cycleReliabilityEnd = 0.998 //1 engine failiure on X-15
 		techTransfer = XLR11-RM-5:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR11-RM-13-8K] { %ratedBurnTime = #$/TESTFLIGHT[XLR11-RM-13-8K]/ratedBurnTime$ } }
 }
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR11-RM-13-10K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = XLR11-RM-13-10K
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-13-10K]/ratedBurnTime$
+		ratedBurnTime = 360
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
@@ -294,4 +293,5 @@
 		cycleReliabilityEnd = 0.998
 		techTransfer = XLR-RM-5,XLR11-RM-13-8K:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR11-RM-13-10K] { %ratedBurnTime = #$/TESTFLIGHT[XLR11-RM-13-10K]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -60,7 +60,6 @@
 			name = XLR25-CW-1
 			minThrust = 12.02
 			maxThrust = 72.17
-			ratedBurnTime = 650
 			massMult = 1.0
 
 			%ullage = False
@@ -100,7 +99,7 @@
 	TESTFLIGHT
 	{
 		name = XLR25-CW-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR25-CW-1]/ratedBurnTime$ //175 at full thrust
+		ratedBurnTime = 650 //175 at full thrust
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
 		ignitionDynPresFailMultiplier = 50.0
@@ -109,4 +108,5 @@
 		
 		techTransfer = XLR-RM-5,XLR11-RM-13-8K:50	//Used a similar turbopump to the late-model XLR11, and was developed at around the same time
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR25-CW-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR25-CW-1]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
@@ -75,7 +75,6 @@
 			chamberNominalTemp = 2923
 			minThrust = 333
 			maxThrust = 333
-			ratedBurnTime = 70
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
@@ -127,11 +126,12 @@
 	TESTFLIGHT
 	{
 		name = XLR41-NA-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR41-NA-1]/ratedBurnTime$
+		ratedBurnTime = 70
 		ignitionReliabilityStart = 0.89	//Almost identical to A-4. Never flew, so no data is availible
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.75
 		cycleReliabilityEnd = 0.95
 		techTransfer = A-4:50			// A-4/V-2 derivative.
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR41-NA-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR41-NA-1]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
@@ -92,7 +92,6 @@
 			chamberNominalTemp = 2923
 			minThrust = 392.6
 			maxThrust = 392.6
-			ratedBurnTime = 60
 			massMult = 1.0
 			ullage = True
 			pressureFed = False
@@ -137,7 +136,6 @@
 			name = XLR43-NA-3
 			minThrust = 617.4
 			maxThrust = 617.4
-			ratedBurnTime = 65
 			massMult = 0.73
 			ullage = True
 			pressureFed = False
@@ -183,13 +181,14 @@
 	TESTFLIGHT
 	{
 		name = XLR43-NA-1
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR43-NA-1]/ratedBurnTime$
+		ratedBurnTime = 60
 		ignitionReliabilityStart = 0.70	//Broadly the same performance of Redstone, slightly worse because it was first large single chamber engine
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.75
 		cycleReliabilityEnd = 0.90
 		techTransfer = XLR41-NA-1:50			// A-4/V-2 derivative.
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR43-NA-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR43-NA-1]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR43-NA-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -197,11 +196,12 @@
 	TESTFLIGHT
 	{
 		name = XLR43-NA-3
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR43-NA-3]/ratedBurnTime$
+		ratedBurnTime = 65
 		ignitionReliabilityStart = 0.80
 		ignitionReliabilityEnd = 0.90
 		cycleReliabilityStart = 0.80
 		cycleReliabilityEnd = 0.90	//By the end of the Navaho program, LR71 booster (two LR43s) performed perfectly for 6 out of last 7 launches
 		techTransfer = XLR41-NA-1,XLR43-NA-1,NAA75_110:50
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR43-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[XLR43-NA-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
@@ -58,7 +58,6 @@
 			name = XLR99
 			minThrust = 131.2
 			maxThrust = 262.4
-			ratedBurnTime = 2700
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -100,7 +99,7 @@
 	TESTFLIGHT
 	{
 		name = XLR99
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[XLR99]/ratedBurnTime$ // "after one hour of operation, it required an overhaul" - but let's underspec a bit
+		ratedBurnTime = 2700 // "after one hour of operation, it required an overhaul" - but let's underspec a bit
 		// static-fired for long periods between refurb.
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.996 // pretty much all flights were successful, but ground tests failed
@@ -109,4 +108,5 @@
 		cycleReliabilityEnd = 0.99 // very low chance early on, but 1% chance of failing after 2700s
 		reliabilityDataRateMultiplier = 20
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR99] { %ratedBurnTime = #$/TESTFLIGHT[XLR99]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/YF-77.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/YF-77.cfg
@@ -47,7 +47,6 @@
 			name = YF-77
 			minThrust = 700
 			maxThrust = 700
-			ratedBurnTime = 485
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -76,11 +75,12 @@
 	TESTFLIGHT
 	{
 		name = YF-77
-		ratedBurnTime = #$/MODULE[ModuleEngineConfigs]/CONFIG[YF-77]/ratedBurnTime$ //20 extra for padding
+		ratedBurnTime = 485 //20 extra for padding
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
 		cycleReliabilityStart = 0.875000
 		cycleReliabilityEnd = 0.975000
 	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[YF-77] { %ratedBurnTime = #$/TESTFLIGHT[YF-77]/ratedBurnTime$ } }
 }


### PR DESCRIPTION
Previous version created errors with engines that didn't use the global configs and defined their own inside the part definition.