### PR TITLE
Remove additional comma from RealismOverhaul.netkan

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -40,7 +40,7 @@
             { "name" : "Kerbalism-Config-RO" },
             { "name" : "TACLS" }
         ] },
-        { "name" : "TexturesUnlimited" },
+        { "name" : "TexturesUnlimited" }
     ],
     "suggests"   : [
         { "name" : "RealismOverhaulCraftFiles" },


### PR DESCRIPTION
## Problem
The CKAN download counter fails to process RealismOverhaul since a few days, caused by [this change](https://github.com/KSP-RO/RealismOverhaul/commit/753645e4accc8c0930eaf3718acebaf9daf50ed5#diff-9667970026e55def385bb9a8a16032db2b9c1905b324b8e1bd708303705396b6) from https://github.com/KSP-RO/RealismOverhaul/pull/2414.

It leaves behind a comma after the last element of an array, which is not valid JSON by strict rules.
This makes the download counter that uses Python's `json` module unable to load the netkan file and thus to fetch the download counts:
> Failed decoding count for RealismOverhaul: Expecting value: line 44 column 5 (char 1628)
![image](https://user-images.githubusercontent.com/28812678/112638153-3a78a100-8e3f-11eb-9e65-7489990e2258.png)


Inflation however still works fine, since the JSON library we use in the NetKAN code is more permissive.

## Changes
Remove that comma, should make download counts for RO reappear in CKAN.

---

I want to point to https://github.com/KSP-CKAN/xKAN-meta_testing on this occasion, which is the validation tool the CKAN team itself uses in the main CKAN-meta and NetKAN repositories to check PRs before merging them.
We've recently redone it to a GitHub Action to allow it to be used by other repositories hosting metanetkans themselves, too.
It can catch errors like this during the pull requests or when commits are pushed:
* https://github.com/DasSkelett/RealismOverhaul/runs/2195480100
* https://github.com/DasSkelett/RealismOverhaul/pull/1/files#diff-9667970026e55def385bb9a8a16032db2b9c1905b324b8e1bd708303705396b6
* https://github.com/DasSkelett/RealismOverhaul/pull/1
![image](https://user-images.githubusercontent.com/28812678/112519572-cab0da80-8d9a-11eb-886d-3a4d7d51fba3.png)

Would you be interested in using this in your repository (and maybe the other repos as well)?
If that's the case, we would polish the workflow file and do a PR to add it to this repository.