### PR TITLE
Set Nike dry mass

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Nike_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nike_Config.cfg
@@ -79,6 +79,7 @@
 	{
 		name = ModuleEngineConfigs
 		configuration = Nike-M5E1
+		origMass = 0.195
 		modded = false
 		CONFIG
 		{


### PR DESCRIPTION
docs at top say 195kg, but actual config neglected to set it.
ROEngines version somehow ended up with 2t dry mass for 350kg fuel