### PR TITLE
Basic support for CarnationRED Flexible Parts

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels_PartConfigs.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels_PartConfigs.cfg
@@ -1,0 +1,132 @@
+// Populates fuel tank parts with appropriate ModuleFuelTanks tank types,
+// (as defined by TANK_DEFINITIONs), based on a tag identifying a family
+// of related types.
+//
+// FIXME this file uses AFTER[RO] so it runs after the files that apply
+// roTankType. Maybe a FOR[RealismOverhaulTankType] would be better?
+
+@PART:HAS[#roTankType]:AFTER[RealismOverhaul]
+{
+    !MODULE[ModuleFuelTanks] {}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 1060 // FIXME: carried over from refactoring, no idea if this does anything
+        utilizationTweakable = true
+
+        // actual types will limit this further, this just
+        // makes sure the slider will default to maximum allowed
+        maxUtilization = 100
+        utilization = 100
+    }
+}
+
+@PART:HAS[#roTankType[legacy]]:AFTER[RealismOverhaul]
+{
+    @MODULE[ModuleFuelTanks]
+    {
+        type = Default
+        typeAvailable = Default
+        typeAvailable = Cryogenic
+        typeAvailable = ServiceModule
+        typeAvailable = Fuselage
+        typeAvailable = Balloon
+        typeAvailable = BalloonCryo
+        typeAvailable = Structural
+        typeAvailable = ElectricPropulsion
+        typeAvailable = LifeSupport
+    }
+}
+
+@PART:HAS[#roTankType[conventional]]:AFTER[RealismOverhaul]
+{
+    @description = The most basic form of fuel tank. Conventional structure tanks consist of two parts, a support structure (also known as stringers) and a fuel tank. Earlier iterations also had a separate skin surrounding them, but later tanks moved the structure inside the fuel tanks. This makes them cheap and easy to produce.
+
+    @MODULE[ModuleFuelTanks]
+    {
+        type = Tank-Sep-Steel
+        typeAvailable = Tank-Sep-Steel
+        typeAvailable = Tank-Sep-Steel-HP
+        typeAvailable = Tank-Sep-Al
+        typeAvailable = Tank-Sep-Al-HP
+        typeAvailable = Tank-Sep-Al2
+        typeAvailable = Tank-Sep-Al2-HP
+        typeAvailable = Tank-Sep-AlCu
+        typeAvailable = Tank-Sep-AlCu-HP
+        typeAvailable = Tank-Sep-AlLi
+        typeAvailable = Tank-Sep-AlLi-HP
+        typeAvailable = Tank-Sep-Stir
+        typeAvailable = Tank-Sep-Stir-HP
+        typeAvailable = Tank-Sep-Starship
+        typeAvailable = Tank-Sep-Starship-HP
+    }
+}
+
+@PART:HAS[#roTankType[integral]]:AFTER[RealismOverhaul]
+{
+    @description = A more complex, but lightweight tank. Integral structure tanks use machined walls that are also load-bearing and form the entire structure of the tank, so no additional structure is needed to maintain rigidity. Manufacturing them can be difficult, however.
+
+    @MODULE[ModuleFuelTanks]
+    {
+        type = Tank-Int-Al
+        typeAvailable = Tank-Int-Al
+        typeAvailable = Tank-Int-Al-HP
+        typeAvailable = Tank-Int-AlCu
+        typeAvailable = Tank-Int-AlCu-HP
+        typeAvailable = Tank-Int-AlLi
+        typeAvailable = Tank-Int-AlLi-HP
+        typeAvailable = Tank-Int-Comp
+        typeAvailable = Tank-Int-Magic
+    }
+}
+
+@PART:HAS[#roTankType[balloon]]:AFTER[RealismOverhaul]
+{
+    @description = A very expensive and fragile, but also very light tank. Balloon tanks are expensive and complex as they need to be pressurized at all times, but they are much lighter than regular tanks. These are similar to tanks used on the Atlas and Centaur stages. <b><color=green>Min Utilization: 99% - Max Utilization: 100%</color></b>
+
+    @MODULE[ModuleFuelTanks]
+    {
+        type = Tank-Balloon-SteelAl
+        typeAvailable = Tank-Balloon-SteelAl
+        typeAvailable = Tank-Balloon-SteelAlCu
+        typeAvailable = Tank-Balloon-SteelAlLi
+    }
+}
+
+@PART:HAS[#roTankType[spaceplane]]:AFTER[RealismOverhaul]
+{
+    @description = Heat-resistant switchable procedural tank. Includes normal (Structural) and highly pressurized (Fuselage) options. Rated for LEO reentries on a spaceplane.
+
+    @MODULE[ModuleFuelTanks]
+    {
+        type = Structural
+        typeAvailable = Structural
+        typeAvailable = Fuselage
+    }
+}
+
+@PART:HAS[#roTankType[service]]:AFTER[RealismOverhaul]
+{
+    @description = <b><color=red>Not intended to hold fuel</color></b>, these specialized tanks are for batteries, payloads and life support. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
+
+    @MODULE[ModuleFuelTanks]
+    {
+        type = SM-I
+        typeAvailable = SM-I
+        typeAvailable = SM-II
+        typeAvailable = SM-III
+        typeAvailable = SM-IV
+    }
+}
+
+@PART:HAS[#roTankTypeDescription]:AFTER[RealismOverhaul]
+{
+    @description = #$roTankTypeDescription$
+    !roTankTypeDescription = delete
+}
+
+// cleanup
+@PART:HAS[roTankType]:AFTER[RealismOverhaul]
+{
+    !roTankType = delete
+}

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -218,20 +218,11 @@
 	@name = RO-ProcTankSpaceplane
 
 	@title = Tank [Procedural, Shielded]
-	@description = Heat-resistant switchable procedural tank. Includes normal (Structural) and highly pressurized (Fuselage) options. Rated for LEO reentries on a spaceplane.
 
 	@maxTemp = 1473.14
 	%skinMaxTemp = 2473.15
 
-	@MODULE[ModuleFuelTanks]
-	{
-		%maxUtilization = 92
-		%utilization = 92
-		@type = Structural
-		!typeAvailable,* = DEL
-		typeAvailable = Fuselage
-		typeAvailable = Structural
-	}
+	roTankType = spaceplane
 }
 
 +PART[proceduralTankRealFuels]:FOR[RealismOverhaul]
@@ -294,32 +285,7 @@
 	%RSSROConfig = True
 
 	@title = Procedural Tank (Conventional Structure)
-	@description = The most basic form of fuel tank. Conventional structure tanks consist of two parts, a support structure (also known as stringers) and a fuel tank. Earlier iterations also had a separate skin surrounding them, but later tanks moved the structure inside the fuel tanks. This makes them cheap and easy to produce.
-
-	!MODULE[ModuleFuelTanks] {}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 1060
-		utilizationTweakable = true
-		maxUtilization = 88
-		utilization = 88
-		type = Tank-Sep-Steel
-		typeAvailable = Tank-Sep-Steel
-		typeAvailable = Tank-Sep-Steel-HP
-		typeAvailable = Tank-Sep-Al
-		typeAvailable = Tank-Sep-Al-HP
-		typeAvailable = Tank-Sep-Al2
-		typeAvailable = Tank-Sep-Al2-HP
-		typeAvailable = Tank-Sep-AlCu
-		typeAvailable = Tank-Sep-AlCu-HP
-		typeAvailable = Tank-Sep-AlLi
-		typeAvailable = Tank-Sep-AlLi-HP
-		typeAvailable = Tank-Sep-Stir
-		typeAvailable = Tank-Sep-Stir-HP
-		typeAvailable = Tank-Sep-Starship
-		typeAvailable = Tank-Sep-Starship-HP
-	}
+	roTankType = conventional
 }
 
 +PART[proceduralTankRealFuels]:FOR[RealismOverhaul]
@@ -328,26 +294,7 @@
 	%RSSROConfig = True
 
 	@title = Procedural Tank (Integral Structure)
-	@description = A more complex, but lightweight tank. Integral structure tanks use machined walls that are also load-bearing and form the entire structure of the tank, so no additional structure is needed to maintain rigidity. Manufacturing them can be difficult, however.
-
-	!MODULE[ModuleFuelTanks] {}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 1060
-		utilizationTweakable = true
-		maxUtilization = 88
-		utilization = 88
-		type = Tank-Int-Al
-		typeAvailable = Tank-Int-Al
-		typeAvailable = Tank-Int-Al-HP
-		typeAvailable = Tank-Int-AlCu
-		typeAvailable = Tank-Int-AlCu-HP
-		typeAvailable = Tank-Int-AlLi
-		typeAvailable = Tank-Int-AlLi-HP
-		typeAvailable = Tank-Int-Comp
-		typeAvailable = Tank-Int-Magic
-	}
+	roTankType = integral
 }
 
 +PART[proceduralTankRealFuels]:FOR[RealismOverhaul]
@@ -356,21 +303,7 @@
 	%RSSROConfig = True
 
 	@title = Procedural Tank (Balloon)
-	@description = A very expensive and fragile, but also very light tank. Balloon tanks are expensive and complex as they need to be pressurized at all times, but they are much lighter than regular tanks. These are similar to tanks used on the Atlas and Centaur stages. <b><color=green>Min Utilization: 99% - Max Utilization: 100%</color></b>
-
-	!MODULE[ModuleFuelTanks] {}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 1060
-		utilizationTweakable = true
-		minUtilization = 99
-		utilization = 100
-		type = Tank-Balloon-SteelAl
-		typeAvailable = Tank-Balloon-SteelAl
-		typeAvailable = Tank-Balloon-SteelAlCu
-		typeAvailable = Tank-Balloon-SteelAlLi
-	}
+	roTankType = balloon
 }
 
 +PART[proceduralTankRealFuels]:FOR[RealismOverhaul]
@@ -379,22 +312,7 @@
 	%RSSROConfig = True
 
 	@title = Procedural Service Module
-	@description = <b><color=red>Not intended to hold fuel</color></b>, these specialized tanks are for batteries, payloads and life support. There are different levels of service modules that you can unlock. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. These are the only types of tanks that can have life support resources added to them.
-
-	!MODULE[ModuleFuelTanks] {}
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 1060
-		utilizationTweakable = true
-		maxUtilization = 88
-		utilization = 88
-		type = SM-I
-		typeAvailable = SM-I
-		typeAvailable = SM-II
-		typeAvailable = SM-III
-		typeAvailable = SM-IV
-	}
+	roTankType = service
 }
 
 @PART:HAS[@MODULE[ProceduralPart]]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
@@ -59,3 +59,38 @@
     %skinMaxTemp = 2473
 }
 
+// CRFP imposes stock-style tech-based size limits.
+// RO will wipe the slate; RP-1 can add some limits back in
+// if it wants (it won't)
+// Mostly, we do this so someone can play with the parts without
+// being forced to use a sandbox save.
+@CRFPTechLimits:FOR[RealismOverhaul]
+{
+    !TechLimit,* {}
+
+    // At least one config MUST exist. Let's make it high enough
+    // for most people, but low enough for sliders to be usable.
+    TechLimit
+    {
+        level = start
+        maxSize = 30    // wider than sea dragon
+        maxLength = 100 // taller than SLS. can always stack multiple to go taller
+    }
+}
+
+@CRFPSettings:FOR[RealismOverhaul]
+{
+    // Default is a bizarre 1000.43769149
+    // We'll assume someone knew what they were doing and leave
+    // it alone for now, but let this serve as a reminder.
+    // @RealFuelVolumeFactor = 1000
+}
+
+
+@CRFPTextureDefinition:FOR[RealismOverhaul]
+{
+    // Would LIKE to add some less stockalike textures, but it looks like
+    // the mod is hardwired to only look for files under 
+    // GameData/CarnationREDFlexiblePart/Texture/
+}
+

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
@@ -18,7 +18,18 @@
     // available volume even less realistic than procparts
     // "the whole part volume". Probably nothing that can be fixed
     // from outside CRFP itself, however.
+
+    MODULE
+    {
+        name = ModuleToggleCrossfeed
+        crossfeedStatus = True
+        toggleEditor = True
+        toggleFlight = True
+        enableText = Enable Crossfeed
+        disableText = Disable Crossfeed
+    }
 }
+
 +PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
 {
     %name = RO-CRFPTank-Conventional

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
@@ -94,3 +94,112 @@
     // GameData/CarnationREDFlexiblePart/Texture/
 }
 
+@CRFPSectionCornerDefinitions:FOR[RealismOverhaul]
+{
+    // let's build a semicircle!
+    // We have 7 points per "corner"
+    // To build a half circle out of all 4, we use 2 corners to build a quarter circle
+    // That means 13 points (1 point is shared).
+    // That's 13 points out of a 48-point full circle.
+    // We'll use a target radius of 2x the part radius: the top and bottom will stay
+    // lined up with the plain cylinder's, the sides will flare out. Arbitrary, but
+    // made the math easier.
+    //
+    // x = 2*cos(k*2pi/n), y = 2*sin(k*2pi/n) is the k'th point of a circle with 48 points
+    // k = 0,  x = 2,        y = 0
+    // k = 1,  x = 1.98289,  y = 0.261052
+    // k = 2,  x = 1.93185,  y = 0.517638
+    // k = 3,  x = 1.84776,  y = 0.765367
+    // k = 4,  x = 1.73205,  y = 1
+    // k = 5,  x = 1.58671,  y = 1.21752
+    // k = 6,  x = 1.41421,  y = 1.41421
+    // k = 7,  x = 1.21752,  y = 1.58671
+    // k = 8,  x = 1,        y = 1.73205
+    // k = 9,  x = 0.765367, y = 1.84776
+    // k = 10, x = 0.517638, y = 1.93185
+    // k = 11, x = 0.261052, y = 1.98289
+    // k = 12, x = 0,        y = 2
+    //
+    // All those coordinates are with the origin at
+    // x = between the 2 left corners and 2 right corners, and
+    // y = BELOW the 2 bottom corners.
+    // Besides which, each corner has its own frame of reference for extra fun
+
+    // top-right corner's 0, 1 is big circle's 0, 2.
+    // it gets points 12->6, with x=x, y = y-1
+    SectionCorner
+    {
+        name = ro-TR
+        vertex1 = 0, 1
+        vertex2 = 0.262052, 0.98289
+        vertex3 = 0.517638, 0.93185
+        vertex4 = 0.76537, 0.84776
+        vertex5 = 1, 0.73205
+        vertex6 = 1.21752, 0.58671
+        vertex7 = 1.41421, 0.41421
+
+        // These two determine how textures get stretched. But since we're spending
+        // all our vertices on the curves and none on the cylinder base, we're going
+        // to get uneven texture distribution no matter what values we set.
+        // So no sense in trying to finetune them. Should look ok so long as
+        // non-greeble, mostly uniform textures are used.
+        cornerPerimeter = 1
+        cornerArea = 1
+    }
+    
+    // bottom-right corner's 0, 1 is big circle's 1, 1; 1, 0 is 0, 0 (a 90 degrees rotation)
+    //  it gets points 6->0, with x = 1-y, y = x
+    SectionCorner
+    {
+        name = ro-BR
+        vertex1 = -0.41421, 1.41421
+        vertex2 = -0.21752, 1.58671
+        vertex3 = 0, 1.73205
+        vertex4 = 0.234633, 1.84776
+        vertex5 = 0.482362, 1.93185
+        vertex6 = 0.738948, 1.98289
+        vertex7 = 1, 2
+        cornerPerimeter = 1
+        cornerArea = 1
+    }
+
+    // top-left is the mirror of top-right, but the frame of reference is also rotated
+    // 90 degrees. Somehow that works out to just swapping x and y,
+    // and placing the points in reverse order
+    SectionCorner
+    {
+        name = ro-TL
+        vertex7 = 1, 0
+        vertex6 = 0.98289, 0.262052
+        vertex5 = 0.93185, 0.517638
+        vertex4 = 0.84776, 0.76537
+        vertex3 = 0.73205, 1
+        vertex2 = 0.58671, 1.21752
+        vertex1 = 0.41421, 1.41421
+        cornerPerimeter = 1
+        cornerArea = 1
+    }
+
+    //ditto bottom-left
+    SectionCorner
+    {
+        name = ro-BL
+        vertex7 = 1.41421, -0.41421
+        vertex6 = 1.58671, -0.21752
+        vertex5 = 1.73205, 0
+        vertex4 = 1.84776, 0.234633
+        vertex3 = 1.93185, 0.482362
+        vertex2 = 1.98289, 0.738948
+        vertex1 = 2, 1
+        cornerPerimeter = 1
+        cornerArea = 1
+    }
+
+    // The half-circle shape has 4 possible permutation, the obvious being
+    // Radius 1 = ro-TR, Radius 2 = ro-BR, Radius 3 = ro-BL, Radius 4 = ro-TL
+    // Other permutations will give a bunch of different shapes, some broken, some interesting
+
+    // TODO: add more shapes (though not too many, the selector isn't great).
+    // This one is just for demo purposes, and has very little to do with RO.
+    // What shapes would specifically make sense to have in a RO context?
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CRFP/CRFPTanks.cfg
@@ -1,0 +1,61 @@
+@PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = true
+    %skinMaxTemp = 873
+    %maxTemp = 773
+
+    // CRFP has RF support out of the box, but only exposes the
+    // Default tank type. Let's expose all the classic RF tanks.
+    roTankType = legacy 
+
+    // CRFP's "how to use this mod" description is more useful
+    // than RO's tank type description, so let's preserve it
+    roTankTypeDescription = #$description$
+
+    // FIXME: available volume seems to be strictly based on
+    // height/width/depth + corner fillets, with no consideration
+    // for the distortions of all the other sliders. This makes
+    // available volume even less realistic than procparts
+    // "the whole part volume". Probably nothing that can be fixed
+    // from outside CRFP itself, however.
+}
++PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
+{
+    %name = RO-CRFPTank-Conventional
+    %title = Flexible Tank (Conventional Structure)
+    %roTankType = conventional
+}
+
++PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
+{
+    %name = RO-CRFPTank-Integral
+    %title = Flexible Tank (Integral Structure)
+    %roTankType = integral
+}
+
++PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
+{
+    %name = RO-CRFPTank-Balloon
+    %title = Flexible Balloon Tank // for making balloon animals, clearly
+    %roTankType = balloon
+
+    // Balloon makes very little sense for some of the fancy shapes
+    // CRFP can make, but let's let the player decide what makes sense
+}
+
++PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
+{
+    %name = RO-CRFPTank-SM
+    %title = Flexible Service Module Tank
+    %roTankType = service
+}
+
++PART[CarnationREDFlexibleFuelTank]:FOR[RealismOverhaul]
+{
+    %name = RO-CRFPTank-Spaceplane
+    %title = Flexible Shielded Tank
+    %roTankType = spaceplane
+    %maxTemp = 1473
+    %skinMaxTemp = 2473
+}
+


### PR DESCRIPTION
- extract proctanks "set availableTypes" into reuable helper
- configure the core CRFP part to expose the classic
  Default/Fuselage/etc realfuel tank types
- add additional parts corresponding to procparts Conventional,
  Integral, etc types

For cylinders, dry mass and available volume seem to match procparts
equivalents in all cases. For more exotic shapes, we get what we get.

One omission: a pure, tankless "structural" part. Not a priority,
and couldn't quite see how to use this to configure mass scaling:
https://github.com/CarnationRED/CarnationREDFlexibleParts/blob/c5bad4fa060b07ff6dc0cd3bcd126acd0ddede2a/Main/ModuleCarnationVariablePart.cs#L809-L810