### PR TITLE
Make J48 restock-compatible

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -43,15 +43,23 @@
 	%RSSROConfig = True
 	@name = RO-J48
 
-	!MODEL,* {}
-
-	MODEL:NEEDS[VenStockRevamp/Squad]
+	// AJE replaces the original model IF VenStockRevamp is detected.
+	// We like the replacement model, but need to resize it.
+	// TODO: change the NEEDS to reference Ven's New Parts, when that becomes possible
+	// AND AJE is changed accordingly. Right now, if Ven's Core exists but not VNP, AJE
+	// replaces a presumably-fine model by a non-existent one)
+	@MODEL,0:NEEDS[VenStockRevamp]
 	{
-		model = VenStockRevamp/Part Bin/NewParts/JetEngines/HighBypassJet
-		position = 0, -1.383335, 0
-		scale = 0.6217, 0.6217, 0.6217
+		@scale = 0.6217, 0.6217, 0.6217
 	}
+	// TODO: find out how the model should be resized if AJE does NOT replace it
 
+	// Remove the ven-added, AJE-resized compressor model, if any
+	!MODEL,1 {}
+
+	// Add our own multi-model compressor, if Ven's Stock Revamp is there
+	// to provide the models.
+	// If it isn't, the engine will be just a nozzle, but it will work.
 	MODEL:NEEDS[VenStockRevamp/Squad]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/EngineCore-Medium


### PR DESCRIPTION
Main problem was wiping out all models, then using a NEEDS[VSR/Squad]
(which means the restock-incompatible bits) to install replacement
models, including one that lives in Ven's New Parts (the
restock-compatible bits). End result was a part with no MODELs at all
in a vnp+restock install.