### PR TITLE
Change the RD-200 burn time

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
@@ -118,7 +118,7 @@
 	TESTFLIGHT
 	{
 		name = RD-200
-		ratedBurnTime = 605		//Needs confirmation
+		ratedBurnTime = 85		//In keeping with "Using RD-101 data" above, using the same data for burn time as well
 		ignitionReliabilityStart = 0.86
 		ignitionReliabilityEnd = 0.94
 		ignitionDynPresFailMultiplier = 2.0


### PR DESCRIPTION
The previous value was a very suspicious 10 minutes sourced from astronautix.
As this engine was never flown, I suspect that is total burn time in test stands, so I'm following the fact that the reliability data was copied from the RD-101and using also its burn time.