### PR TITLE
Move pylon and hardpoint to the Coupling category

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Structural.cfg
@@ -83,6 +83,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.01
+	%category = Coupling
 }
 @PART[stationHub]:FOR[RealismOverhaul]
 {
@@ -127,6 +128,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.075
+	%category = Coupling
 }
 @PART[strutConnector]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Because they have a decoupler, and hiding them in the Structural
category seems to be stopping people from finding them