### PR TITLE
Increase radar weight

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SCANSat/RO_SCANsat.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SCANSat/RO_SCANsat.cfg
@@ -121,7 +121,7 @@
 {
 	%RSSROConfig = True
 	
-	@mass = 0.003	//6.5 lbs
+	@mass = 0.006	//6.5 lbs electronics, add ~6.5 lbs for antenna
 	
 	@title = Early Radar Altimeter
 	@description = An early RADAR altimeter, based on those carried by the Block II Ranger and Mariner spacecraft. This radar set can provide low-resolution altimetry data. Best with low altitude orbits.


### PR DESCRIPTION
The weight of the Ranger radar only appears to include the electronics mass. Add 3 kilograms of antenna mass (estimated)