### PR TITLE
Update RO_HabTech2.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/HabTech2/RO_HabTech2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/HabTech2/RO_HabTech2.cfg
@@ -1,157 +1,804 @@
-//	Leonardo Permanent Multipurpose Module (PMM)
-//	Diameter: 4.57m
-//	Length: 6.6m
-//	Mass: 4.437944128t
-//	Source: https://en.wikipedia.org/wiki/Leonardo_(ISS_module)
 
-@PART[ht2_MPLM]:FOR[RealismOverhaul]
+@PART[ht2_handrail]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	
-	@MODEL
-	{
-		%scale = 1.828, 1.9, 1.828
-	}
-	@scale = 1
-	@rescaleFactor = 1
-	
-	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-    @attachRules = 1,0,1,1,0
-	
-	@title = Leonardo Permanent Multipurpose Module (PMM)
-	@manufacturer = Italian Space Agency
-	@description = Leonardo is primarily used for storage of spares, supplies and waste on the ISS, which was until then stored in many different places within the space station.
-	
-	@mass = 4.4379
-	
-	// fixme
-	// @CrewCapacity = 0
-	
-	@category = Utility
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 8
-	
-	@MODULE[ModuleB9PartSwitch]
-	{
-		@SUBTYPE[Bulkhead]
-		{
-			@NODE[nodeTop]
-			{
-				@position = 0.0, 3.2775, 0.0
-			}
-		}
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@title = ISS EVA/Service handrail
+	@manufacturer = NASA
+	@description = Handrails serve as mobility and stability aids for astronauts during extravehicular activity. Handrails are installed to define a safe path and provide sturdy anchors for the astronauts to use while they are working outside the spacecraft.
+	@mass = 0.001
+}
+
+@PART[ht2_CBM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 0.05 
+	@title = ISS CBM
+	@manufacturer = Boeing
+	@description = The common berthing mechanism (CBM) is a berthing mechanism used to connect all non-Russian pressurized modules of the International Space Station. It was developed by Boeing at the Marshall Space Flight Center (MSFC) in Huntsville, Alabama while under contract to the National Aeronautics and Space Administration (NASA). 
+	@maxTemp = 1073.15
+	@MODULE[ModuleDockingNode]
+	{ 
+		@nodeType = ht2_CBM
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1 
 	}
 }
 
-// 	TACLS Compatibility
-//	20,000 lbs of Storage = 9.07184t
-@PART[ht2_MPLM]:FOR[RealismOverhaulTACLS]:NEEDS[TacLifeSupport]
+@PART[ht2_solarArray_duo]:FOR[RealismOverhaul]
 {
-	@description ^= :$: Can store Life Support inventory.
-	
-	!MODULE[ModuleFuelTanks] {}
-	
-	MODULE
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 15.865
+	@title = ISS P4-P6/S4-S6
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@maxTemp = 1073.15 
+	@MODULE[ModuleDeployableSolarPanel]
+	{	
+		@chargeRate = 70
+	}
+}
+
+@PART[ht2_truss_S0]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 10.785
+	@title = ISS S0 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The S0 truss, (also called the Center Integrated Truss Assembly Starboard 0 Truss) forms the center backbone of the Space Station. It was attached on the top of the Destiny Laboratory Module during STS-110 in April 2002. S0 is used to route power to the pressurized station modules and conduct heat away from the modules to the S1 and P1 Trusses. 
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 3000
+		%maxAmount = 3000
+	}
+}
+
+@PART[ht2_truss_S1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 12.4
+	@title = ISS S1/P1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The P1 and S1 trusses (also called the Port and Starboard Side Thermal Radiator Trusses) are attached to the S0 truss, and contain carts to transport the Canadarm2 and astronauts to worksites along the space station. They each flow 290 kg (637 lb) of anhydrous ammonia through three heat rejection radiators. The S1 truss was launched on STS-112 in October 2002 and the P1 truss was launched on STS-113 in November 2002. 
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 2500
+		%maxAmount = 2500
+	}
+}
+
+@PART[ht2_radiatorTriple]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 3.4
+	@title = Triple HRS radiators
+	@manufacturer = Lockheed Martin 
+	@description = The three HRS radiators on S1 weigh approximately 7,500 pounds, which is almost 30 percent of the payload on the Space Shuttle Atlantis.
+	%breakingForce = 250
+	%breakingTorque = 250	
+	%fuelCrossFeed = False
+	%radiatorHeadroom = 0.29 // 0.2702 sets the limit to 17C, or 290K
+	@maxTemp = 1073.15
+
+	@MODULE[ModuleActiveRadiator]
+	{
+        	@maxEnergyTransfer = 1750
+        	@overcoolFactor = 0.0186367
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 1.545
+        } 
+}
+
+@PART[ht2_PMA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 1.25
+	@title = ISS Pressurized Mating Adapter
+	@manufacturer = Boeing
+	@description = The International Space Station (ISS) uses three Pressurized Mating Adapters (PMAs) to interconnect spacecraft and modules with different docking mechanisms. The first two PMAs were launched with the Unity module in 1998 aboard STS-88. The third was launched in 2000 aboard STS-92. 
+	@maxTemp = 1073.15	
+
+}
+
+@PART[ht2_JEM_EF]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 3.5
+	@title = JEM-EF 
+	@manufacturer = ??? 
+	@description = The JEM-EF is an external platform for conducting scientific observations, Earth observations, and experiments in an environment exposed to space. 
+	@maxTemp = 1073.15 
+}
+
+@PART[ht2_moduleColumbus]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 10.25
+	@title = ISS Columbus
+	@manufacturer = Thales Alenia Space/ EADS 
+	@description = Columbus is a science laboratory that is part of the International Space Station (ISS) and is the largest single contribution to the ISS made by the European Space Agency (ESA). Like the Harmony and Tranquility modules, the Columbus laboratory was constructed in Turin, Italy by Rome based Alcatel Alenia Space with respect to structures and thermal control. The functional architecture (including software) of the lab was designed by EADS in Bremen, Germany where it was also integrated before being flown to the Kennedy Space Center (KSC) in Florida in an Airbus Beluga. It was launched aboard Space Shuttle Atlantis on February 7, 2008 on flight STS-122. It is designed for ten years of operation. The module is controlled by the Columbus Control Centre, located at the German Space Operations Centre, part of the German Aerospace Center in Oberpfaffenhofen near Munich, Germany.
+	@maxTemp = 1073.15  
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 8.0
+		}
+	}
+         	MODULE
 	{
 		name = ModuleFuelTanks
-		type = ServiceModule
+		volume = 20000
 		basemass = -1
-		volume = 27300
-		
+		type = ServiceModule
 		TANK
 		{
-			name = Food
-			amount = 0
-			maxAmount = 8438.43
+			name = ElectricCharge
+			amount = 50000
+			maxAmount = 50000
 		}
-		
-		TANK
-		{
-			name = Water
-			amount = 0
-			maxAmount = 5577.39
-		}
-		
-		TANK
-		{
-			name = Oxygen
-			amount = 0
-			maxAmount = 772590
-		}
-		
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 310128
+			maxAmount = 10000
 		}
-		
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
+}
+
+@PART[ht2_moduleCupola]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 1.83
+	@category = Utility
+	@title = ISS Cupola
+	@manufacturer = Boeing/ ASI
+	@description = The Cupola is an ESA-built observatory module of the International Space Station (ISS). Its seven windows are used to conduct experiments, dockings and observations of Earth. It was launched aboard Space Shuttle mission STS-130 on 8 February 2010 and attached to the Tranquility (Node 3) module. With the Cupola attached, ISS assembly reached 85 percent completion. The Cupolas 80 cm (31 in) window is the largest ever used in space.
+	@maxTemp = 1073.15
+	@vesselType = Station
+	@CrewCapacity = 1 
+	@MODULE[ModuleCommand]
+	{
+		%CrewCapacity = 1
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 5.5
+		}
+	}
+
+	!MODULE[ModuleCommand]
+	{
+        }
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 5000
+			maxAmount = 5000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 767.13
+			maxAmount = 300
 		}
-		
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 7103.46
+			maxAmount = 600
+		}
+		TANK
+		{
+			name = Food
+			amount = 500
+			maxAmount = 500
+		}
+		TANK
+		{
+			name = Water
+			amount = 500
+			maxAmount = 500
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 1200
+			maxAmount = 1200
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
 		}
 	}
 }
 
-// 	Kerbalism Compatibility
-//	20,000 lbs of Storage = 9.07184t
-@PART[ht2_MPLM]:FOR[RealismOverhaulTACLS]:NEEDS[Kerbalism]
+@PART[ht2_moduleDestiny]:FOR[RealismOverhaul]
 {
-	@description ^= :$: Can store Life Support inventory.
-	
-	!MODULE[ModuleFuelTanks] {}
-	
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 14.415
+	@title = ISS Destiny
+	@manufacturer = Boeing
+	@description = The Destiny module is the primary operating facility for U.S. research payloads aboard the International Space Station (ISS). It was berthed to the Unity module and activated over a period of five days in February, 2001. Destiny is NASAs first permanent operating orbital research station since Skylab was vacated in February 1974. 
+	@maxTemp = 1073.15 
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 9.8
+		}
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
-		type = ServiceModule
+		volume = 20000
 		basemass = -1
-		volume = 25749.36
-		
+		type = ServiceModule
 		TANK
 		{
-			name = Food
-			amount = 0
-			maxAmount = 8438.43
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
 		}
-		
 		TANK
 		{
-			name = Water
+			name = CarbonDioxide
 			amount = 0
-			maxAmount = 5577.39
+			maxAmount = 10000
 		}
-		
 		TANK
 		{
 			name = Oxygen
-			amount = 0
-			maxAmount = 772590
+			amount = 10000
+			maxAmount = 10000
 		}
-		
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+}
+
+@PART[ht2_moduleHarmony]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 13.888
+	@title = ISS Harmony (Node 2)
+	@manufacturer = Thales Alenia Space 
+	@description = Harmony, also known as Node 2, is the "utility hub" of the International Space Station. The hub contains four racks that provide electrical power, plus electronic data, and act as a central connecting point for several other components via its six Common Berthing Mechanisms (CBMs). Harmony added 2,666 cubic feet (75.5 m3) to the station's living volume, an increase of almost 20 percent, from 15,000 cu ft (420 m3) to 17,666 cu ft (500.2 m3) The successful installation of Harmony meant that from NASA's perspective, the station was "U.S. Core Complete". Harmony was successfully launched into space aboard Space Shuttle flight STS-120 on October 23, 2007. After temporarily being attached to the port side of the Unity node, it was moved to its permanent location on the forward end of the Destiny laboratory on November 14, 2007.
+	@maxTemp = 1073.15 
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
 		TANK
 		{
-			name = Waste
-			amount = 0
-			maxAmount = 767.13
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
 		}
-		
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
+}
+
+@PART[ht2_moduleJEMlogistics]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 8.336
+	@title = ISS JEM ELM-PS
+	@manufacturer = IHI AEROSPACE
+	@description = The Japanese Experiment Logistics Module, Pressurized Section (ELM-PS), also called the JLP, is a pressurized addition to the PM. The module is a storage facility that provides storage space for experiment payloads, samples and spare items.
+	@maxTemp = 1073.15 
+        MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Food
+			amount = 1300
+			maxAmount = 1300
+		}
+		TANK
+		{
+			name = Water
+			amount = 750
+			maxAmount = 750
+		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 7103.46
+			maxAmount = 750
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 1000
+		}
+
+	}
+
+}
+
+@PART[ht2_moduleKibo]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 14.7
+	@title = ISS Kibo (JEM Pressurized Module)
+	@manufacturer =  Mitsubishi Heavy Industries 
+	@description = The Japanese Experiment Module (JEM), also known with the nickname Kibo (Hope), is a Japanese science module for the International Space Station (ISS) developed by JAXA. It is the largest single ISS module. The first two pieces of the module were launched on Space Shuttle missions STS-123 and STS-124. The third and final components were launched on STS-127. The Pressurized Module (PM) is the core component connected to the port hatch of the Node 2 Module. It is cylindrical in shape and contains twenty-three International Standard Payload Racks (ISPRs), ten of which are dedicated to science experiments while the remaining 13 are dedicated to Kibos systems and storage. The racks are placed 6-6-6-5 along the four walls of the module. The end of the JEM-PM has an airlock and two window hatches. The Exposed Facility, Experiment Logistics Module and the Remote Manipulator System all connect to the pressurized module. Kibo is also the location for many of the press conferences that take place on board the station.
+	@maxTemp = 1073.15  
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 10.2
 		}
 	}
+
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Food
+			amount = 350
+			maxAmount = 350
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 250
+		}
+
+	}
+
+}
+
+@PART[ht2_MPLM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 4.082
+	@title = ISS Leonardo PMM 
+	@manufacturer = ASI 
+	@description = The Leonardo Permanent Multipurpose Module (PMM) is a module of the International Space Station. It was flown into space aboard the Space Shuttle on STS-133 on 24 February 2011 and installed on 1 March. Leonardo is primarily used for storage of spares, supplies and waste on the ISS, which is currently stored in many different places within the space station. The Leonardo PMM was a Multi-Purpose Logistics Module (MPLM) before 2011, but was modified into its current configuration. It was formerly one of three MPLM used for bringing cargo to and from the ISS with the Space Shuttle. The module was named for Italian polymath Leonardo da Vinci.
+	@maxTemp = 1073.15 
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Food
+			amount = 350
+			maxAmount = 350
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 250
+		}
+	}
+}
+
+@PART[ht2_moduleQuest]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 6.014
+	@title = ISS Quest Joint Airlock
+	@manufacturer = Boeing 
+	@description = The Quest Joint Airlock, previously known as the Joint Airlock Module, is the primary airlock for the International Space Station. Quest was designed to host spacewalks with both Extravehicular Mobility Unit (EMU) spacesuits and Orlan space suits. The airlock was launched on STS-104 on July 14, 2001. Before Quest was attached, Russian spacewalks using Orlan suits could only be done from the Zvezda service module and American spacewalks using EMUs were only possible when a Space Shuttle was docked. The arrival of Pirs docking compartment on September 16, 2001 provided another airlock from which Orlan spacewalks can be conducted.
+	@maxTemp = 1073.15 
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 100000
+			maxAmount = 100000
+		}
+	}
+
+}
+
+@PART[ht2_moduleUnity]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@module = Part
+	%rescaleFactor = 1.5625
+	@category = Utility
+	@mass = 11.312
+	@title = ISS Unity (Node 1)
+	@manufacturer = Boeing
+	@description = The Unity connecting module was the first U.S.-built component of the International Space Station. It is cylindrical in shape, with six berthing locations (forward, aft, port, starboard, zenith, and nadir) facilitating connections to other modules. Unity was built for NASA by Boeing in a manufacturing facility at the Marshall Space Flight Center in Huntsville, Alabama. Sometimes referred to as Node 1, Unity was the first of the three connecting modules; the other two are Harmony and Tranquility.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	@vesselType = Station
+	!RESOURCE,* {}
+	!MODULE[ModuleCommand] {}
+	!MODULE[ModuleFuelTanks],* {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 200
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+}
+
+@PART[ht2_radialTrussPort]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@title = S0 radial truss connector
+	@manufacturer = Boeing
+	@description = A radially-attachable mechanism designed for connecting the S0 truss to the ISS.
+}
+
+@PART[ht2_truss_S2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 0.28
+	@title = ISS P3 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The P3/S3 primary structure is made of a hexagonal shaped aluminum structure and includes four bulkheads and six longerons. 
+	@maxTemp = 1073.15	
+}
+
+@PART[ht2_truss_Z1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 8.83
+	@title = ISS Z1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The first truss piece, the Z1 truss, launched aboard STS-92 in October 2000. It contains the control moment gyroscope (CMG) assemblies, electrical wiring, communications equipment, and two plasma contactors designed to neutralize the static electrical charge of the space station. Another objective of the Z1 truss was to serve as a temporary mounting position for the "P6 truss and solar array" until its relocation to the end of the P5 truss during STS-120. Though not a part of the main truss, the Z1 truss was the first permanent lattice-work structure for the ISS, very much like a girder, setting the stage for the future addition of the stations major trusses or backbones.
+	@maxTemp = 1073.15 
+	@MODULE[ModuleReactionWheel]
+    {
+		name = ModuleReactionWheel
+	
+		PitchTorque = 5
+		YawTorque = 5
+		RollTorque = 5
+	
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.8
+		}
+    }
+    MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 100
+		}
+	}
+}
+
+@PART[ht2_trussPort]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.5625
+	@mass = 0.5
+	@title = ISS Truss Docking Port 
+	@manufacturer = Boeing 
+	@description = Docking port to connect the truss segments for the Integrated Truss Structure which contains the large solar arrays and radiators for the International Space Station.
+	@maxTemp = 1073.15 
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/HabTech2/RO_HabTech2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/HabTech2/RO_HabTech2.cfg
@@ -12,7 +12,8 @@
 @PART[ht2_CBM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
+	!rescaleFactor{}
+	%rescaleFactor = 1.5625
 	@mass = 0.05 
 	@title = ISS CBM
 	@manufacturer = Boeing
@@ -719,7 +720,8 @@
 @PART[ht2_radialTrussPort]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
+	!rescaleFactor{}
+	%rescaleFactor = 1.5625
 	@title = S0 radial truss connector
 	@manufacturer = Boeing
 	@description = A radially-attachable mechanism designed for connecting the S0 truss to the ISS.
@@ -795,7 +797,8 @@
 @PART[ht2_trussPort]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
+	!rescaleFactor{}
+	%rescaleFactor = 1.5625
 	@mass = 0.5
 	@title = ISS Truss Docking Port 
 	@manufacturer = Boeing 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/HabTech2/RO_HabTech2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/HabTech2/RO_HabTech2.cfg
@@ -1,259 +1,124 @@
+//	================================================
+//	HABTECH2 - RealismOverhaul configurations (WIP)
+//	================================================
+//	Configures all Habtech2 parts that are neccessary to construct the ISS.
+//	Parts included true to life masses,close to life scale and module life support systems.
+//	With these configurations, regular re-supply missions will be necessary!
+//	Configurations come with part specifications and the source of compiled research.
+//	Fully compatible with SpaceShuttleSystem and S.O.C.K (managed by Aviation & StonesmileGit)
+//	==========================================================================================
 
-@PART[ht2_handrail]:FOR[RealismOverhaul]
+//	Leonardo Permanent Multipurpose Module (PMM)
+//	Diameter: 4.57m (15ft)
+//	Length: 6.6m (22ft)
+//	Mass: 4,082kg (8,999lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+
+@PART[ht2_MPLM]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@title = ISS EVA/Service handrail
-	@manufacturer = NASA
-	@description = Handrails serve as mobility and stability aids for astronauts during extravehicular activity. Handrails are installed to define a safe path and provide sturdy anchors for the astronauts to use while they are working outside the spacecraft.
-	@mass = 0.001
-}
-
-@PART[ht2_CBM]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	!rescaleFactor{}
-	%rescaleFactor = 1.5625
-	@mass = 0.05 
-	@title = ISS CBM
-	@manufacturer = Boeing
-	@description = The common berthing mechanism (CBM) is a berthing mechanism used to connect all non-Russian pressurized modules of the International Space Station. It was developed by Boeing at the Marshall Space Flight Center (MSFC) in Huntsville, Alabama while under contract to the National Aeronautics and Space Administration (NASA). 
-	@maxTemp = 1073.15
-	@MODULE[ModuleDockingNode]
-	{ 
-		@nodeType = ht2_CBM
-		%acquireForce = 0.5
-		%acquireMinFwdDot = 0.8
-		%acquireminRollDot = -3.40282347E+38
-		%acquireRange = 0.25
-		%acquireTorque = 0.5
-		%captureMaxRvel = 0.1
-		%captureMinFwdDot = 0.998
-		%captureMinRollDot = -3.40282347E+38
-		%captureRange = 0.05
-		%minDistanceToReEngage = 0.25
-		%undockEjectionForce = 0.1 
-	}
-}
-
-@PART[ht2_solarArray_duo]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 15.865
-	@title = ISS P4-P6/S4-S6
-	@manufacturer = Boeing 
-	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@rescaleFactor = 1.81
+	@mass = 4.082
+	@title = ISS Leonardo PMM 
+	@manufacturer = ASI 
+	@description = The Leonardo Permanent Multipurpose Module (PMM) is a module of the International Space Station. It was flown into space aboard the Space Shuttle on STS-133 on 24 February 2011 and installed on 1 March. Leonardo is primarily used for storage of spares, supplies and waste on the ISS, which is currently stored in many different places within the space station. The Leonardo PMM was a Multi-Purpose Logistics Module (MPLM) before 2011, but was modified into its current configuration. It was formerly one of three MPLM used for bringing cargo to and from the ISS with the Space Shuttle. The module was named for Italian polymath Leonardo da Vinci.
 	@maxTemp = 1073.15 
-	@MODULE[ModuleDeployableSolarPanel]
-	{	
-		@chargeRate = 70
-	}
-}
-
-@PART[ht2_truss_S0]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 10.785
-	@title = ISS S0 Truss Segment 
-	@manufacturer = Boeing 
-	@description = The S0 truss, (also called the Center Integrated Truss Assembly Starboard 0 Truss) forms the center backbone of the Space Station. It was attached on the top of the Destiny Laboratory Module during STS-110 in April 2002. S0 is used to route power to the pressurized station modules and conduct heat away from the modules to the S1 and P1 Trusses. 
-	@maxTemp = 1073.15 
-	@RESOURCE[ElectricCharge]
-	{
-		@name = ElectricCharge
-		%amount = 3000
-		%maxAmount = 3000
-	}
-}
-
-@PART[ht2_truss_S1]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 12.4
-	@title = ISS S1/P1 Truss Segment 
-	@manufacturer = Boeing 
-	@description = The P1 and S1 trusses (also called the Port and Starboard Side Thermal Radiator Trusses) are attached to the S0 truss, and contain carts to transport the Canadarm2 and astronauts to worksites along the space station. They each flow 290 kg (637 lb) of anhydrous ammonia through three heat rejection radiators. The S1 truss was launched on STS-112 in October 2002 and the P1 truss was launched on STS-113 in November 2002. 
-	@maxTemp = 1073.15 
-	@RESOURCE[ElectricCharge]
-	{
-		@name = ElectricCharge
-		%amount = 2500
-		%maxAmount = 2500
-	}
-}
-
-@PART[ht2_radiatorTriple]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 3.4
-	@title = Triple HRS radiators
-	@manufacturer = Lockheed Martin 
-	@description = The three HRS radiators on S1 weigh approximately 7,500 pounds, which is almost 30 percent of the payload on the Space Shuttle Atlantis.
-	%breakingForce = 250
-	%breakingTorque = 250	
-	%fuelCrossFeed = False
-	%radiatorHeadroom = 0.29 // 0.2702 sets the limit to 17C, or 290K
-	@maxTemp = 1073.15
-
-	@MODULE[ModuleActiveRadiator]
-	{
-        	@maxEnergyTransfer = 1750
-        	@overcoolFactor = 0.0186367
-
-        @RESOURCE[ElectricCharge]
-        {
-            @rate = 1.545
-        } 
-}
-
-@PART[ht2_PMA]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 1.25
-	@title = ISS Pressurized Mating Adapter
-	@manufacturer = Boeing
-	@description = The International Space Station (ISS) uses three Pressurized Mating Adapters (PMAs) to interconnect spacecraft and modules with different docking mechanisms. The first two PMAs were launched with the Unity module in 1998 aboard STS-88. The third was launched in 2000 aboard STS-92. 
-	@maxTemp = 1073.15	
-
-}
-
-@PART[ht2_JEM_EF]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 3.5
-	@title = JEM-EF 
-	@manufacturer = ??? 
-	@description = The JEM-EF is an external platform for conducting scientific observations, Earth observations, and experiments in an environment exposed to space. 
-	@maxTemp = 1073.15 
-}
-
-@PART[ht2_moduleColumbus]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 10.25
-	@title = ISS Columbus
-	@manufacturer = Thales Alenia Space/ EADS 
-	@description = Columbus is a science laboratory that is part of the International Space Station (ISS) and is the largest single contribution to the ISS made by the European Space Agency (ESA). Like the Harmony and Tranquility modules, the Columbus laboratory was constructed in Turin, Italy by Rome based Alcatel Alenia Space with respect to structures and thermal control. The functional architecture (including software) of the lab was designed by EADS in Bremen, Germany where it was also integrated before being flown to the Kennedy Space Center (KSC) in Florida in an Airbus Beluga. It was launched aboard Space Shuttle Atlantis on February 7, 2008 on flight STS-122. It is designed for ten years of operation. The module is controlled by the Columbus Control Centre, located at the German Space Operations Centre, part of the German Aerospace Center in Oberpfaffenhofen near Munich, Germany.
-	@maxTemp = 1073.15  
-	%MODULE[ModuleCommand]
-	{
-		%RESOURCE[ElectricCharge]
-		{
-			%rate = 8.0
-		}
-	}
-         	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 20000
-		basemass = -1
-		type = ServiceModule
-		TANK
-		{
-			name = ElectricCharge
-			amount = 50000
-			maxAmount = 50000
-		}
-		TANK
-		{
-			name = CarbonDioxide
-			amount = 0
-			maxAmount = 10000
-		}
-		TANK
-		{
-			name = Oxygen
-			amount = 10000
-			maxAmount = 10000
-		}
-	}
-
-}
-
-@PART[ht2_moduleCupola]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 1.83
-	@category = Utility
-	@title = ISS Cupola
-	@manufacturer = Boeing/ ASI
-	@description = The Cupola is an ESA-built observatory module of the International Space Station (ISS). Its seven windows are used to conduct experiments, dockings and observations of Earth. It was launched aboard Space Shuttle mission STS-130 on 8 February 2010 and attached to the Tranquility (Node 3) module. With the Cupola attached, ISS assembly reached 85 percent completion. The Cupolas 80 cm (31 in) window is the largest ever used in space.
-	@maxTemp = 1073.15
-	@vesselType = Station
-	@CrewCapacity = 1 
-	@MODULE[ModuleCommand]
-	{
-		%CrewCapacity = 1
-		%RESOURCE[ElectricCharge]
-		{
-			%rate = 5.5
-		}
-	}
-
-	!MODULE[ModuleCommand]
-	{
-        }
+        
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20000
+		type = SeviceModule
 		basemass = -1
-		type = ServiceModule
+		volume = 31000
 		TANK
 		{
 			name = ElectricCharge
-			amount = 5000
-			maxAmount = 5000
+			amount = 11000
+			maxAmount = 11000
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 1000
+			maxAmount = 4000
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 1000
-			maxAmount = 1000
+			amount = 4000
+			maxAmount = 4000
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 300
+			maxAmount = 10
 		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 600
+			maxAmount = 60
 		}
 		TANK
 		{
 			name = Food
-			amount = 500
-			maxAmount = 500
+			amount = 100
+			maxAmount = 100
 		}
 		TANK
 		{
 			name = Water
-			amount = 500
-			maxAmount = 500
+			amount = 75
+			maxAmount = 75
 		}
 		TANK
 		{
 			name = LithiumHydroxide 
-			amount = 1200
-			maxAmount = 1200
+			amount = 200
+			maxAmount = 200
+		}
+	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
 		}
 	}
 	MODULE:NEEDS[TacLifeSupport]
@@ -346,48 +211,317 @@
 	}
 }
 
-@PART[ht2_moduleDestiny]:FOR[RealismOverhaul]
+@PART[ht2_handrail]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 14.415
-	@title = ISS Destiny
+	@rescaleFactor = 1.81
+	@title = ISS EVA/Service handrail
+	@manufacturer = NASA
+	@description = Handrails serve as mobility and stability aids for astronauts during extravehicular activity. Handrails are installed to define a safe path and provide sturdy anchors for the astronauts to use while they are working outside the spacecraft.
+	@mass = 0.001
+}
+
+//	Common Berthing Mechanism
+//	Diameter: 1.8m
+//	Length: 0.4m
+//	Mass: 200kg (440lb)
+//	Source: https://en.wikipedia.org/wiki/Common_Berthing_Mechanism#:~:text=The%20Common%20Berthing%20Mechanism%20(CBM,a%20cylindrical%20vestibule%20between%20modules.
+@PART[ht2_CBM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	!rescaleFactor,* = DEL
+	%rescaleFactor = 1.81
+	@mass = 0.2 
+	@title = ISS CBM
 	@manufacturer = Boeing
-	@description = The Destiny module is the primary operating facility for U.S. research payloads aboard the International Space Station (ISS). It was berthed to the Unity module and activated over a period of five days in February, 2001. Destiny is NASAs first permanent operating orbital research station since Skylab was vacated in February 1974. 
+	@description = The common berthing mechanism (CBM) is a berthing mechanism used to connect all non-Russian pressurized modules of the International Space Station. It was developed by Boeing at the Marshall Space Flight Center (MSFC) in Huntsville, Alabama while under contract to the National Aeronautics and Space Administration (NASA). 
+	@maxTemp = 1073.15
+	
+	@MODULE[ModuleDockingNode]
+	{ 
+		@nodeType = ht2_CBM
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1 
+	}
+}
+
+//	ISS Solar arrays & trusses (P4/S4 - P6/S6)
+//	(P3/S3 truss is a seperate part in HT2 so isn't factored into the solar array config)
+//	Diameter: 10.7m (35ft)
+//	Length: 73.2m (240.2ft)
+//	Mass: 15,900kg //15900kg (#P3/4); 16183kg (#S3/4) split the difference for the mass of the two S3/P3 trusses
+//	Source: https://space.skyrocket.de/doc_sdat/its-s3-4.htm
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_solarArray_duo]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 15.900
+	@title = ISS P4-P6/S4-S6
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
 	@maxTemp = 1073.15 
-	%MODULE[ModuleCommand]
+	!MODULE[ModuleDeployableSolarPanel],1 {}
+	!MODULE[ModuleDeployableSolarPanel],2 {}
+	!MODULE[ModuleDeployableSolarPanel],3 {}
+
+	MODULE
 	{
-		%RESOURCE[ElectricCharge]
-		{
-			%rate = 9.8
-		}
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 15	// Solar arrays capable of upto 120KW- 120/4=30 divide by two Modules = 15
+		retractable = true
+		isBreakable = true
+		animationName = SAW_array2Deploy
+		impactResistance = 4
+		impactResistanceRetracted = 20
+		pivotName = array1_solarPivot
+		raycastTransformName = array1_sunCatcher
+		extendActionName = Extend Solar Array 1
+		retractActionName = Retract Solar Array 1
+		extendpanelsActionName = Toggle Solar Array 1
 	}
 
 	MODULE
 	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 15
+		retractable = true
+		isBreakable = true
+		animationName = SAW_array1Deploy
+		impactResistance = 4
+		impactResistanceRetracted = 20
+		pivotName = array2_solarPivot
+		raycastTransformName = array2_sunCatcher
+		extendActionName = Extend Solar Array 2
+		retractActionName = Retract Solar Array 2
+		extendpanelsActionName = Toggle Solar Array 2
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		isBreakable = false
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 0
+		retractable = true
+		animationName = SAW_duo_TrackingDeploy
+		pivotName = SARJ
+		isBreakable = false
+		impactResistance = 100
+		impactResistanceRetracted = 100
+		raycastTransformName = trackingCatcher
+		extendActionName = Enable Secondary Axis
+		retractActionName = Disable Secondary Axis
+		extendpanelsActionName = Toggle Secondary Axis
+	}
+}
+
+//	ISS S0 truss
+//	Diameter: 4.6m
+//	Length: 13.4m
+//	Mass: 13,970kg (30,800lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_truss_S0]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 13.970
+	@title = ISS S0 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The S0 truss, (also called the Center Integrated Truss Assembly Starboard 0 Truss) forms the center backbone of the Space Station. It was attached on the top of the Destiny Laboratory Module during STS-110 in April 2002. S0 is used to route power to the pressurized station modules and conduct heat away from the modules to the S1 and P1 Trusses. 
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 3000
+		%maxAmount = 3000
+	}
+}
+
+//	ISS S1/P1 truss
+//	Diameter: 4.6m
+//	Length: 13.7m
+//	Mass: 9,124kg // 12,524kg (27,611lb) inc triple HRS (seperate part)
+//	Source: https://space.skyrocket.de/doc_sdat/its-s1.htm
+@PART[ht2_truss_S1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 9.124
+	@title = ISS S1/P1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The P1 and S1 trusses (also called the Port and Starboard Side Thermal Radiator Trusses) are attached to the S0 truss, and contain carts to transport the Canadarm2 and astronauts to worksites along the space station. They each flow 290 kg (637 lb) of anhydrous ammonia through three heat rejection radiators. The S1 truss was launched on STS-112 in October 2002 and the P1 truss was launched on STS-113 in November 2002. 
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 2500
+		%maxAmount = 2500
+	}
+	
+	MODULE
+	{
+		name = ModuleRealAntenna
+        	antennaDiameter = 1.0
+	}
+}
+
+//	ISS Triple HRS
+//	Diameter: ?
+//	Length: 22.86m (75ft)
+//	Mass: 3,400kg (7496lb)
+//	Source: http://www.defense-aerospace.com/article-view/release/12155/lockheed-hrs-radiators-on-board-atlantis-(oct.-10).html
+@PART[ht2_radiatorTriple]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 3.4
+	@title = Triple HRS radiators
+	@manufacturer = Lockheed Martin 
+	@description = The three HRS radiators on S1 weigh approximately 7,500 pounds, which is almost 30 percent of the payload on the Space Shuttle Atlantis.
+	%breakingForce = 200
+	%breakingTorque = 200	
+	%fuelCrossFeed = False
+	%radiatorHeadroom = 0.29 // 0.2702 sets the limit to 17C, or 290K
+	@maxTemp = 1073.15
+
+	@MODULE[ModuleActiveRadiator]
+	{
+        	@maxEnergyTransfer = 1750
+        	@overcoolFactor = 0.0186367
+
+        	@RESOURCE[ElectricCharge]
+        	{
+            		@rate = 1.545
+        	}
+	}
+}
+
+//	Pressurized mating adapter
+//	Width: 19.m - 1.37m
+//	Length: 1.86m (6.1ft)
+//	Mass: 1376kg minus weight for seperate APAS port (APAS-95 = 526kg)
+//	Source: https://www.turbosquid.com/3d-models/iss-pressurized-mating-adapter-3d-model/1136389
+@PART[ht2_PMA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 0.850
+	@title = ISS Pressurized Mating Adapter
+	@manufacturer = Boeing
+	@description = The International Space Station (ISS) uses three Pressurized Mating Adapters (PMAs) to interconnect spacecraft and modules with different docking mechanisms. The first two PMAs were launched with the Unity module in 1998 aboard STS-88. The third was launched in 2000 aboard STS-92. 
+	@maxTemp = 1073.15	
+}
+
+//	JEM Exposed facility
+//	Width: 5m
+//	Length: 5.6m
+//	Mass: 4,100kg (13,450lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_JEM_EF]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 4.1
+	@title = JEM-EF 
+	@manufacturer = JAXA 
+	@description = The JEM-EF is an external platform for conducting scientific observations, Earth observations, and experiments in an environment exposed to space. 
+	@maxTemp = 1073.15 
+}
+
+//	ISS Columbus module
+//	Diameter: 4.5m
+//	Length: 7m
+//	Mass: 10,300kg (22,708lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_moduleColumbus]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 10.3
+	@title = ISS Columbus module
+	@manufacturer = Thales Alenia Space/ EADS 
+	@description = Columbus is a science laboratory that is part of the International Space Station (ISS) and is the largest single contribution to the ISS made by the European Space Agency (ESA). Like the Harmony and Tranquility modules, the Columbus laboratory was constructed in Turin, Italy by Rome based Alcatel Alenia Space with respect to structures and thermal control. The functional architecture (including software) of the lab was designed by EADS in Bremen, Germany where it was also integrated before being flown to the Kennedy Space Center (KSC) in Florida in an Airbus Beluga. It was launched aboard Space Shuttle Atlantis on February 7, 2008 on flight STS-122. It is designed for ten years of operation. The module is controlled by the Columbus Control Centre, located at the German Space Operations Centre, part of the German Aerospace Center in Oberpfaffenhofen near Munich, Germany.
+	@maxTemp = 1073.15  
+	
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 8.0
+		}
+	}
+        
+	MODULE
+	{
 		name = ModuleFuelTanks
-		volume = 20000
+		volume = 78490
 		basemass = -1
 		type = ServiceModule
 		TANK
 		{
 			name = ElectricCharge
-			amount = 200000
-			maxAmount = 200000
+			amount = 250000
+			maxAmount = 250000
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 10000
+			maxAmount = 17500
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 10000
-			maxAmount = 10000
+			amount = 18000
+			maxAmount = 18000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Food
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Water
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 240
+			maxAmount = 240
 		}
 	}
+	
 	MODULE:NEEDS[TacLifeSupport]
 	{
 		name = TacGenericConverter
@@ -429,116 +563,938 @@
 			DumpExcess = True
 		}
 	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
 }
 
-@PART[ht2_moduleHarmony]:FOR[RealismOverhaul]
+//	The Cupola
+//	Diameter: 2.95m (9.68ft)
+//	Height: 1.5m (4.9ft)
+//	Mass: 1,880kg (4,145lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_moduleCupola]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 13.888
-	@title = ISS Harmony (Node 2)
-	@manufacturer = Thales Alenia Space 
-	@description = Harmony, also known as Node 2, is the "utility hub" of the International Space Station. The hub contains four racks that provide electrical power, plus electronic data, and act as a central connecting point for several other components via its six Common Berthing Mechanisms (CBMs). Harmony added 2,666 cubic feet (75.5 m3) to the station's living volume, an increase of almost 20 percent, from 15,000 cu ft (420 m3) to 17,666 cu ft (500.2 m3) The successful installation of Harmony meant that from NASA's perspective, the station was "U.S. Core Complete". Harmony was successfully launched into space aboard Space Shuttle flight STS-120 on October 23, 2007. After temporarily being attached to the port side of the Unity node, it was moved to its permanent location on the forward end of the Destiny laboratory on November 14, 2007.
-	@maxTemp = 1073.15 
-	MODULE
+	%RSSROConfig = False	
+	@rescaleFactor = 2
+	@mass = 1.88
+	@category = Utility
+	@title = ISS Cupola
+	@manufacturer = Thales Alenia Space
+	@description = The Cupola is an ESA-built observatory module of the International Space Station (ISS). Its seven windows are used to conduct experiments, dockings and observations of Earth. It was launched aboard Space Shuttle mission STS-130 on 8 February 2010 and attached to the Tranquility (Node 3) module. With the Cupola attached, ISS assembly reached 85 percent completion. The Cupolas 80 cm (31 in) window is the largest ever used in space.
+	@maxTemp = 1073.15
+	@vesselType = Station
+	
+	@MODULE[ModuleCommand]
 	{
-		name = ModuleFuelTanks
-		volume = 20000
-		basemass = -1
-		type = ServiceModule
-		TANK
+		%RESOURCE[ElectricCharge]
 		{
-			name = ElectricCharge
-			amount = 200000
-			maxAmount = 200000
-		}
-		TANK
-		{
-			name = CarbonDioxide
-			amount = 0
-			maxAmount = 10000
-		}
-		TANK
-		{
-			name = Oxygen
-			amount = 10000
-			maxAmount = 10000
+			%rate = 5.5
 		}
 	}
 
-}
-
-@PART[ht2_moduleJEMlogistics]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 8.336
-	@title = ISS JEM ELM-PS
-	@manufacturer = IHI AEROSPACE
-	@description = The Japanese Experiment Logistics Module, Pressurized Section (ELM-PS), also called the JLP, is a pressurized addition to the PM. The module is a storage facility that provides storage space for experiment payloads, samples and spare items.
-	@maxTemp = 1073.15 
-        MODULE
+	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20000
+		volume = 3350
 		basemass = -1
 		type = ServiceModule
 		TANK
 		{
 			name = ElectricCharge
-			amount = 1000
-			maxAmount = 1000
+			amount = 11000
+			maxAmount = 11000
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 1000
+			maxAmount = 4000
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 1000
-			maxAmount = 1000
-		}
-		TANK
-		{
-			name = Food
-			amount = 1300
-			maxAmount = 1300
-		}
-		TANK
-		{
-			name = Water
-			amount = 750
-			maxAmount = 750
-		}
-		TANK
-		{
-			name = WasteWater
-			amount = 0
-			maxAmount = 750
+			amount = 4000
+			maxAmount = 4000
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 1000
+			maxAmount = 10
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 60
+		}
+		TANK
+		{
+			name = Food
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Water
+			amount = 75
+			maxAmount = 75
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 200
+			maxAmount = 200
+		}
+	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
 		}
 
-	}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
 
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
 }
 
+//	Destiny module
+//	Diameter: 4.2m (14ft)
+//	Length: 8.4m (28ft)
+//	Mass: 14,515kg (32,000lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_moduleDestiny]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 14.515
+	@title = ISS Destiny
+	@manufacturer = Boeing
+	@description = The Destiny module is the primary operating facility for U.S. research payloads aboard the International Space Station (ISS). It was berthed to the Unity module and activated over a period of five days in February, 2001. Destiny is NASAs first permanent operating orbital research station since Skylab was vacated in February 1974. 
+	@maxTemp = 1073.15 
+	
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 9.8
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 104770
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 17500
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 20000
+			maxAmount = 20000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 210
+		}
+		TANK
+		{
+			name = Food
+			amount = 200
+			maxAmount = 200
+		}
+		TANK
+		{
+			name = Water
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 250
+			maxAmount = 250
+		}
+	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
+}
+
+//	Harmony/Tranquility module
+//	Diameter: 4.4m (14ft)/4.48m (14.7ft)
+//	Length: 7.2m (24ft)/6.71m (22ft)
+//	Mass: 14,288kg (31,500lb)/19,000kg (42,000lb) - adjusted mass of part to be equal.
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+//	Source: https://space.skyrocket.de/doc_sdat/node-2.htm
+@PART[ht2_moduleHarmony]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 16.644
+	@title = ISS Harmony/Tranquility (Node 2/3)
+	@manufacturer = Thales Alenia Space 
+	@description = Harmony/Tranquility, also known as Node 2 and 3 respectively.Node 2 provides a passageway between four station science experiment facilities: the U.S. Destiny Laboratory, the Kibo Japanese Experiment Module, the European Columbus Laboratory and the Centrifuge Accommodation Module. Node 3 contains advanced life support systems. These systems will recycle waste water for crew use and generate oxygen for the crew to breathe.
+	@maxTemp = 1073.15 
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 70000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 17500
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 20000
+			maxAmount = 20000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 210
+		}
+		TANK
+		{
+			name = Food
+			amount = 200
+			maxAmount = 200
+		}
+		TANK
+		{
+			name = Water
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 250
+			maxAmount = 250
+		}
+	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
+}
+
+//	ISS JEM ELM-PS
+//	Diameter: 4.4m (14ft)
+//	Length: 4.2m (13.8ft)
+//	Mass: 8,386kg (18,488lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+@PART[ht2_moduleJEMlogistics]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 8.386
+	@title = ISS JEM ELM-PS
+	@manufacturer = IHI AEROSPACE
+	@description = The Japanese Experiment Logistics Module, Pressurized Section (ELM-PS), also called the JLP, is a pressurized addition to the PM. The module is a storage facility that provides storage space for experiment payloads, samples and spare items.
+	@maxTemp = 1073.15 
+        
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 63642
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 11000
+			maxAmount = 11000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 4000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 4000
+			maxAmount = 4000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 10
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 60
+		}
+		TANK
+		{
+			name = Food
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Water
+			amount = 75
+			maxAmount = 75
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 200
+			maxAmount = 200
+		}
+	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
+}
+
+//	ISS JEM PM
+//	Diameter: 4.4m (14ft)
+//	Length: 11.2m (36.7ft)
+//	Mass: 15,900kg (35,100lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
 @PART[ht2_moduleKibo]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 14.7
+	@rescaleFactor = 1.81
+	@mass = 15.9
 	@title = ISS Kibo (JEM Pressurized Module)
 	@manufacturer =  Mitsubishi Heavy Industries 
 	@description = The Japanese Experiment Module (JEM), also known with the nickname Kibo (Hope), is a Japanese science module for the International Space Station (ISS) developed by JAXA. It is the largest single ISS module. The first two pieces of the module were launched on Space Shuttle missions STS-123 and STS-124. The third and final components were launched on STS-127. The Pressurized Module (PM) is the core component connected to the port hatch of the Node 2 Module. It is cylindrical in shape and contains twenty-three International Standard Payload Racks (ISPRs), ten of which are dedicated to science experiments while the remaining 13 are dedicated to Kibos systems and storage. The racks are placed 6-6-6-5 along the four walls of the module. The end of the JEM-PM has an airlock and two window hatches. The Exposed Facility, Experiment Logistics Module and the Remote Manipulator System all connect to the pressurized module. Kibo is also the location for many of the press conferences that take place on board the station.
 	@maxTemp = 1073.15  
+	
 	%MODULE[ModuleCommand]
 	{
 		%RESOURCE[ElectricCharge]
@@ -547,261 +1503,724 @@
 		}
 	}
 
-         	MODULE
+    	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20000
+		volume = 169250
 		basemass = -1
 		type = ServiceModule
 		TANK
 		{
 			name = ElectricCharge
-			amount = 10000
-			maxAmount = 10000
+			amount = 15000
+			maxAmount = 15000
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 10000
+			maxAmount = 30500
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 10000
-			maxAmount = 10000
+			amount = 35000
+			maxAmount = 35000
 		}
 		TANK
 		{
 			name = Food
-			amount = 350
-			maxAmount = 350
+			amount = 400
+			maxAmount = 400
 		}
-
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 250
+			maxAmount = 35
 		}
-
+		TANK
+		{
+			name = Water
+			amount = 280
+			maxAmount = 280
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 280
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 300
+			maxAmount = 300
+		}
 	}
-
-}
-
-@PART[ht2_MPLM]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 4.082
-	@title = ISS Leonardo PMM 
-	@manufacturer = ASI 
-	@description = The Leonardo Permanent Multipurpose Module (PMM) is a module of the International Space Station. It was flown into space aboard the Space Shuttle on STS-133 on 24 February 2011 and installed on 1 March. Leonardo is primarily used for storage of spares, supplies and waste on the ISS, which is currently stored in many different places within the space station. The Leonardo PMM was a Multi-Purpose Logistics Module (MPLM) before 2011, but was modified into its current configuration. It was formerly one of three MPLM used for bringing cargo to and from the ISS with the Space Shuttle. The module was named for Italian polymath Leonardo da Vinci.
-	@maxTemp = 1073.15 
-         	MODULE
+	
+	MODULE:NEEDS[TacLifeSupport]
 	{
-		name = ModuleFuelTanks
-		volume = 20000
-		basemass = -1
-		type = ServiceModule
-		TANK
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
 		{
-			name = ElectricCharge
-			amount = 1000
-			maxAmount = 1000
+			ResourceName = Water
+			Ratio = 0.0000053129
 		}
-		TANK
+
+		INPUT_RESOURCE
 		{
-			name = CarbonDioxide
-			amount = 0
-			maxAmount = 10000
+			ResourceName = ElectricCharge
+			Ratio = 0.5
 		}
-		TANK
+
+		OUTPUT_RESOURCE
 		{
-			name = Oxygen
-			amount = 10000
-			maxAmount = 10000
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
 		}
-		TANK
+
+		OUTPUT_RESOURCE
 		{
-			name = Food
-			amount = 350
-			maxAmount = 350
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
 		}
-		TANK
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
 		{
-			name = Waste
-			amount = 0
-			maxAmount = 250
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
 		}
 	}
 }
 
+//	ISS Quest joint airlock
+//	Diameter: 4m (13ft)
+//	Length: 5.5m (18ft)
+//	Mass: 6,064kg (13,369lb) //9,923kg inc 4x N & O2 tanks
+//	Source: https://space.skyrocket.de/doc_sdat/jam.htm
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
 @PART[ht2_moduleQuest]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 6.014
+	@rescaleFactor = 1.81
+	@mass = 6.064
 	@title = ISS Quest Joint Airlock
 	@manufacturer = Boeing 
 	@description = The Quest Joint Airlock, previously known as the Joint Airlock Module, is the primary airlock for the International Space Station. Quest was designed to host spacewalks with both Extravehicular Mobility Unit (EMU) spacesuits and Orlan space suits. The airlock was launched on STS-104 on July 14, 2001. Before Quest was attached, Russian spacewalks using Orlan suits could only be done from the Zvezda service module and American spacewalks using EMUs were only possible when a Space Shuttle was docked. The arrival of Pirs docking compartment on September 16, 2001 provided another airlock from which Orlan spacewalks can be conducted.
 	@maxTemp = 1073.15 
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20000
+		volume = 34000
 		basemass = -1
 		type = ServiceModule
 		TANK
 		{
 			name = ElectricCharge
-			amount = 1000
-			maxAmount = 1000
+			amount = 25000
+			maxAmount = 25000
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 10000
+			maxAmount = 17500
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 100000
-			maxAmount = 100000
+			amount = 18000
+			maxAmount = 18000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Food
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Water
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 240
+			maxAmount = 240
 		}
 	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
 
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
 }
 
+//	ISS Unity (Node 1)
+//	Diameter: 4.57m (15ft)
+//	Length: 5.47m (17.9ft)
+//	Mass: 11,612kg (25,600lb)
+//	Source: http://spacecraftearth.com/wp-content/uploads/2017/06/Unity-Node-1.jpg
 @PART[ht2_moduleUnity]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	@module = Part
-	%rescaleFactor = 1.5625
-	@category = Utility
-	@mass = 11.312
+	@rescaleFactor = 1.81
+	@mass = 11.612
 	@title = ISS Unity (Node 1)
 	@manufacturer = Boeing
 	@description = The Unity connecting module was the first U.S.-built component of the International Space Station. It is cylindrical in shape, with six berthing locations (forward, aft, port, starboard, zenith, and nadir) facilitating connections to other modules. Unity was built for NASA by Boeing in a manufacturing facility at the Marshall Space Flight Center in Huntsville, Alabama. Sometimes referred to as Node 1, Unity was the first of the three connecting modules; the other two are Harmony and Tranquility.
 	@maxTemp = 1073.15
 	@CrewCapacity = 1
-	@vesselType = Station
 	!RESOURCE,* {}
 	!MODULE[ModuleCommand] {}
 	!MODULE[ModuleFuelTanks],* {}
+	
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 200
+		volume = 89566
 		basemass = -1
 		type = ServiceModule
 		TANK
 		{
 			name = ElectricCharge
-			amount = 200000
-			maxAmount = 200000
+			amount = 11000
+			maxAmount = 11000
 		}
 		TANK
 		{
 			name = CarbonDioxide
 			amount = 0
-			maxAmount = 10000
+			maxAmount = 4000
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 10000
-			maxAmount = 10000
-		}
-	}
-}
-
-@PART[ht2_radialTrussPort]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	!rescaleFactor{}
-	%rescaleFactor = 1.5625
-	@title = S0 radial truss connector
-	@manufacturer = Boeing
-	@description = A radially-attachable mechanism designed for connecting the S0 truss to the ISS.
-}
-
-@PART[ht2_truss_S2]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 0.28
-	@title = ISS P3 Truss Segment 
-	@manufacturer = Boeing 
-	@description = The P3/S3 primary structure is made of a hexagonal shaped aluminum structure and includes four bulkheads and six longerons. 
-	@maxTemp = 1073.15	
-}
-
-@PART[ht2_truss_Z1]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = False
-	@rescaleFactor = 1.5625
-	@mass = 8.83
-	@title = ISS Z1 Truss Segment 
-	@manufacturer = Boeing 
-	@description = The first truss piece, the Z1 truss, launched aboard STS-92 in October 2000. It contains the control moment gyroscope (CMG) assemblies, electrical wiring, communications equipment, and two plasma contactors designed to neutralize the static electrical charge of the space station. Another objective of the Z1 truss was to serve as a temporary mounting position for the "P6 truss and solar array" until its relocation to the end of the P5 truss during STS-120. Though not a part of the main truss, the Z1 truss was the first permanent lattice-work structure for the ISS, very much like a girder, setting the stage for the future addition of the stations major trusses or backbones.
-	@maxTemp = 1073.15 
-	@MODULE[ModuleReactionWheel]
-    {
-		name = ModuleReactionWheel
-	
-		PitchTorque = 5
-		YawTorque = 5
-		RollTorque = 5
-	
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = 0.8
-		}
-    }
-    MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 20000
-		basemass = -1
-		type = ServiceModule
-		TANK
-		{
-			name = ElectricCharge
-			amount = 1000
-			maxAmount = 1000
-		}
-		TANK
-		{
-			name = CarbonDioxide
-			amount = 0
-			maxAmount = 1000
-		}
-		TANK
-		{
-			name = Oxygen
-			amount = 1000
-			maxAmount = 1000
+			amount = 4000
+			maxAmount = 4000
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
+			maxAmount = 10
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 60
+		}
+		TANK
+		{
+			name = Food
+			amount = 100
 			maxAmount = 100
+		}
+		TANK
+		{
+			name = Water
+			amount = 75
+			maxAmount = 75
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 200
+			maxAmount = 200
+		}
+	}
+	
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
 		}
 	}
 }
 
+@PART[ht2_questRack]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@title = Quest Resource pod rack
+	@manufacturer = Boeing
+	@description = A specially designed rack to hold the Quest resource pod.
+	@mass = 0.005
+}
+
+//	Quest airlock Nitrogen/Oxygen tank
+//	Diameter: ???
+//	Length: ???
+//	Mass: 965kg (2,127lb) // split the difference in mass of the the sources and divided by 4.
+//	Source: https://space.skyrocket.de/doc_sdat/jam.htm
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+//	Source: https://www.nasa.gov/pdf/167129main_Systems.pdf
+@PART[ht2_questPod]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@title = Quest Nitrogen/Oxygen pod
+	@manufacturer = Boeing
+	@description = Nitrogen filled resource pods used to maintain total pressure within the cabin. Nitrogen is also required to support on-board experiments and medical equipment.
+	@mass = 0.965
+	@maxTemp = 1073.15
+	!MODULE[ModuleB9PartSwitch],2 {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Nitrogen
+			amount = 1000
+			maxAmount = 1000
+		}
+	}
+}
+
+//	Radial truss port to secure S0 to Destiny module
+@PART[ht2_radialTrussPort]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	!rescaleFactor,* = DEL
+	%rescaleFactor = 1.81
+	@title = S0 radial truss connector
+	@manufacturer = Boeing
+	@description = A radially-attachable mechanism designed for connecting the S0 truss to the ISS.
+}
+
+//	P3/S3 truss
+//	Seperate part in HT2, Originally apart of P4/S4. 
+//	Mass: 141.5kg
+@PART[ht2_truss_S2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 0.1415
+	@title = ISS P3/S3 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The P3/S3 primary structure is made of a hexagonal shaped aluminum structure and includes four bulkheads and six longerons. Used to connect P4/S4, don't forget your dockable truss port! 
+	@maxTemp = 1073.15	
+}
+
+//	ITS-Z1 
+//	Diameter: 4.2m (13.8ft)
+//	Length: 4.9m (16ft)
+//	Mass: 8,755kg (19,300lb)
+//	Source: http://spacecraftearth.com/#smoothscroll-portfolio-module
+//	Source: https://space.skyrocket.de/doc_sdat/its-z1.htm
+@PART[ht2_truss_Z1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	@rescaleFactor = 1.81
+	@mass = 8.755
+	@title = ISS Z1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The first truss piece, the Z1 truss, launched aboard STS-92 in October 2000. It contains the control moment gyroscope (CMG) assemblies, electrical wiring, communications equipment, and two plasma contactors designed to neutralize the static electrical charge of the space station. Another objective of the Z1 truss was to serve as a temporary mounting position for the "P6 truss and solar array" until its relocation to the end of the P5 truss during STS-120. Though not a part of the main truss, the Z1 truss was the first permanent lattice-work structure for the ISS, very much like a girder, setting the stage for the future addition of the stations major trusses or backbones.
+	@maxTemp = 1073.15 
+	
+	@MODULE[ModuleReactionWheel]
+    	{
+		@PitchTorque = 5
+		@YawTorque = 5
+		@RollTorque = 5
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.8
+		}
+    	}
+    	
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 1000
+		@maxAmount = 1000
+	}
+}
+
+//	Part switchable truss docking port for all ITS and docking to the radial truss connector on the top of Destiny.
 @PART[ht2_trussPort]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = False
-	!rescaleFactor{}
-	%rescaleFactor = 1.5625
-	@mass = 0.5
+	!rescaleFactor,* = DEL
+	%rescaleFactor = 1.81
+	@mass = 0.05
 	@title = ISS Truss Docking Port 
 	@manufacturer = Boeing 
 	@description = Docking port to connect the truss segments for the Integrated Truss Structure which contains the large solar arrays and radiators for the International Space Station.
 	@maxTemp = 1073.15 
+}
+
+@PART[ht2_MPLM_half]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = False
+	!rescaleFactor,* = DEL
+	@rescaleFactor = 1.81
+	@mass = 2
+	@maxTemp = 1073.15
+	@title = Leonardo half module
 }


### PR DESCRIPTION
Adds all Habtech2 parts configured for RO, in order to build ISS to scale. Does require a few parts in original Habtech2 mod to have duplicate 'rescaleFactor' instructions deleted from their files configurations.