### PR TITLE
Fix typo in SSPX 4.15m airlock docking node

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Adapters_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Adapters_Utility.cfg
@@ -132,7 +132,7 @@
 	
 	@MODULE[ModuleDockingNode]
 	{
-		@nodeType = NASA
+		@nodeType = NASADock
 	}
 	
 	@MODULE[ModuleAnimateGeneric]


### PR DESCRIPTION
The node type 'NASA' does not exist anywhere else. I assume that the type should be 'NASADock'