### PR TITLE
Center the Small Sep Motor thrust transform

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
@@ -17,11 +17,20 @@
 	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others. Smaller and less advanced than the radial separation motor.
 	@mass = 0.008
 	@maxTemp = 1973.15
+
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = 0.0, 0.0, 0.0
+		rotation = -90.0, 0.0, 0.0
+	}
+
 	@MODULE[ModuleEngines*]
 	{
 		@maxThrust = 18
 		@heatProduction = 17.5
 		%exhaustDamage = False
+		%thrustVectorTransformName = newThrustTransform
 		@atmosphereCurve
 		{
 			@key,0 = 0 230
@@ -74,12 +83,14 @@
 	%RSSROConfig = True
 	%scale = 1
 	%rescaleFactor = 1
-	%MODEL
+
+	@MODEL:HAS[#model[*Snubotron]]
 	{
 		%scale = 1.2, 1.2, 2.0
 		%position = 0.0, -0.37, 0.0
 		%rotation = 90, 0, 0
 	}
+
 	MODEL:NEEDS[VenStockRevamp/Squad]
 	{
 		model = VenStockRevamp/Squad/Parts/Propulsion/RCSFuelTankR10
@@ -87,12 +98,12 @@
 		position = 0.0, 0.05625, 0.0
 	}
 
-	MODEL
+	@MODEL:HAS[#model[*emptyengine]]
 	{
-		model = RealismOverhaul/emptyengine
-		position = 0.0, -0.575, 0.0
-		rotation = 0.0, 0.0, 0.0
+		%position = 0.0, -0.575, 0.0
+		%rotation = 0.0, 0.0, 0.0
 	}
+
 	%node_stack_top = 0.0, 0.525, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -0.69, 0.0, 0.0, -1.0, 0.0, 0
 	@node_attach = 0.0, 0.0, -0.0762, 0.0, 0.0, 1.0, 1
@@ -104,8 +115,6 @@
 
 	%engineType = BabySergeant
 	%engineTypeMult = 1
-
-	@MODULE[ModuleEngines*] { @thrustVectorTransformName = newThrustTransform }
 
 	!MODULE[ModuleFuelTanks],*{}
 	%MODULE[ModuleFuelTanks]


### PR DESCRIPTION
VNP model looks symmetrical, but has thrust transform slightly offset
from the CoM. Use emptyengine to give it a centered transform.

And then make sure this doesn't break the snubotron-derived baby sergeant.