### PR TITLE
RealAntennas configs for restockplus dishes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RO_RestockPlus_Communications_Parts_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RO_RestockPlus_Communications_Parts_Config.cfg
@@ -32,6 +32,11 @@
         @packetResourceCost = 0.01
     }
 }
+@PART[restock-antenna-stack-2]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+    %mass = 0.004
+    @MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
+}
 
 // Communotron HG-61, 1.22m dish
 @PART[restock-antenna-stack-3]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
@@ -51,6 +56,12 @@
         @packetResourceCost = 0.01
     }
 }
+@PART[restock-antenna-stack-3]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+    %mass = 0.00625
+    @MODULE[ModuleRealAntenna] { %antennaDiameter = 1.25 }
+}
+
 
 // 4x 0.5m dishes in array, effective diameter 1m
 @PART[restock-relay-radial-2]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
@@ -70,3 +81,9 @@
         @packetResourceCost = 0.01
     }
 }
+@PART[restock-relay-radial-2]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+    %mass = 0.004
+    @MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
+}
+


### PR DESCRIPTION
Model diameters of the -stack-2 and -stack-3 match the stock 1m and
1.25m dishes (RelayAntenna5 & HighGainAntenna), so give them the same stats.

Same for -radial-2, basically being an array of 4 0.5m dishes
(HighGainAntenna5)