### PR TITLE
Add new early thrusters

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/KDU414_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KDU414_Config.cfg
@@ -1,0 +1,127 @@
+//	==================================================
+//	KDU-414
+//
+//	Manufacturer: Isayev Design Bureau (Khimmash)
+//
+//	=================================================================================
+//	KDU-414
+//	11D414, S5.19
+//	Venera 1, Mars 1, Molnyia 1
+//
+//	Dry Mass: 61 Kg		//including tankage mass
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1.96 kN	//200 kgf?
+//	ISP: ??? SL / 272 Vac
+//	Burn Time: 40
+//	Chamber Pressure: 1.18 MPa
+//	Propellant: AK20F / UDMH
+//	Prop Ratio: 2.6
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: ???
+//	=================================================================================
+
+//	Sources:
+
+//	Encyclopedia Astronautica - KTDU-414 engine:		http://www.astronautix.com/k/kdu-414.html
+//	https://www.mediafire.com/file/5b3cy43y76ywnd8/ychebnikiav597.pdf/file
+
+//	Used by:
+
+//
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[KDU414]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = KDU-414
+	%manufacturer = Isayev Design Bureau (Khimmash)
+	%description = A small manuevering engine used on the Soviet 1MV and 2MV spacecraft busses, and KAUR-2 comsat bus. Used on early Venera, Mars, Zond and Molnyia satellites.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = KDU-414
+		origMass = 0.0457	//Subtract 10.3 kg for tankage, 5 kg for structure
+
+		CONFIG
+		{
+			name = KDU-414
+			description = a.k.a. 11D414, S5.19
+			minThrust = 1.96
+			maxThrust = 1.96
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = True
+			ignitions = 3	//Unknown, guess 3 needed for course corrections
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.01
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4216
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = AK20
+				ratio = 0.5784
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 272
+				key = 1 100
+			}
+		}
+	}
+}
+
+//	==================================================
+//	TestFlight compatibility.
+//	==================================================
+
+//Mars 1: 1(?) burn completed before computer failure
+//Venera 1: 1 burn completed before computer failure
+//Zond 1: 1 burn completed before computer failure
+//Zond 2: 2(?) burns completed before computer failure
+//Zond 3: 2(?) burns completed before computer failure
+//Molnyia-1 series: 34 flights, 1(?) failure
+//41 Burns completed, 1 failure
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[KDU-414]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = KDU-414
+		ratedBurnTime = 40
+		ignitionReliabilityStart = 0.975610
+		ignitionReliabilityEnd = 0.995122
+		cycleReliabilityStart = 0.975610
+		cycleReliabilityEnd = 0.995122
+		
+		@MODULE[ModuleEngineConfigs] { @CONFIG[KDU-414] { %ratedBurnTime = #$/TESTFLIGHT[KDU-414]/ratedBurnTime$ } }
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU35.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU35.cfg
@@ -177,11 +177,24 @@
 //	==================================================
 
 //Data unavailble
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[KTDU-35]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5_60]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = KTDU-35
+		name = S5_60
+		ratedBurnTime = 500
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.98
+		cycleReliabilityEnd = 0.995
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5_35]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = S5_35
 		ratedBurnTime = 500
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU417_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU417_Config.cfg
@@ -1,0 +1,221 @@
+//	==================================================
+//	KTDU-417
+//
+//	Manufacturer: Isayev Design Bureau (Khimmash)
+//
+//	=================================================================================
+//	KTDU-417
+//	11D417
+//	Main Engine
+//
+//	Dry Mass: 81 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 18.92 kN	//1929 kgf?
+//	ISP: ??? SL / 314 Vac
+//	Burn Time: 650
+//	Chamber Pressure: 8.3 MPa
+//	Propellant: AK27I / UDMH
+//	Prop Ratio: 1.8
+//	Throttle: Throttle down to 7.35 kN
+//	Nozzle Ratio: ???
+//	Ignitions: 11
+//	=================================================================================
+//	KTDU-417B
+//	11D417B
+//	Secondary Engine
+//
+//	Dry Mass: N/A Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 3.43 kN	//350 kgf?
+//	ISP: ??? SL / 254 Vac
+//	Burn Time: 30
+//	Chamber Pressure: 0.89 MPa
+//	Propellant: AK27I / UDMH
+//	Prop Ratio: 2.4
+//	Throttle: Throttle down to 2.06 kN
+//	Nozzle Ratio: ???
+//	Ignitions: 11
+//	=================================================================================
+
+//	Sources:
+
+//	Encyclopedia Astronautica - KTDU-417 engine:		http://www.astronautix.com/k/ktdu-417.html
+//	https://www.mediafire.com/file/5b3cy43y76ywnd8/ychebnikiav597.pdf/file
+
+//	Used by:
+
+//
+
+//	Notes:
+
+//	Secondary engine probably could gimbal.
+//	==================================================
+@PART[*]:HAS[#engineType[KTDU417]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = KTDU-417
+	%manufacturer = Isayev Design Bureau (Khimmash)
+	%description = The landing engine for Luna 15-24. The main gas generator engine was used for orbital manuevering and descent, and then switched over to a secondary pressurefed engine for terminal descent. Use an action group to toggle between the main and secondary engines quickly to make landing easier.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal],*		//Secondary "verniers" could probably gimbal, based on pictures of KTDU-417 and Ye-8 bus
+	{
+		@gimbalRange = 5.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 11D417
+		engineID = MainEngine
+		isMaster = True
+		origMass = 0.081
+
+		CONFIG
+		{
+			name = 11D417
+			minThrust = 7.35
+			maxThrust = 18.92
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = False
+			pressureFed = False
+			ignitions = 11
+
+			OtherModules
+			{
+				BackupEngine = 11D417B
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.01
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.5120
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = AK27
+				ratio = 0.4880
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 314
+				key = 1 100
+			}
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 11D417B
+		engineID = BackupEngine
+		isMaster = False
+		
+		CONFIG
+		{
+			name = 11D417B
+			minThrust = 2.06
+			maxThrust = 3.43
+			heatProduction = 1
+			massMult = 1.0
+			ullage = False
+			pressureFed = True
+			ignitions = 11
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+			
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4404
+				DrawGauge = True
+			}
+			
+			PROPELLANT
+			{
+				name = AK27
+				ratio = 0.5596
+				DrawGauge = False
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 254
+				key = 1 100
+			}
+		}
+	}
+}
+
+//	==================================================
+//	TestFlight compatibility.
+//	==================================================
+
+//Luna 15: 5 Burns completed before computer failure
+//Luna 16: 6 Burns completed. 0 Failures
+//Luna 17: 6(?) Burns completed. 0 Failures
+//Luna 18: 6 Burns completed. 1 Failures (maybe, hard landed either due to engine issues or terrain)
+//Luna 19: 5(?) Burns completed. 0 Failures
+//Luna 20: 6(?) Burns completed. 0 Failures
+//Luna 21: 6 Burns completed. 0 Failures
+//Luna 22: 10(?) Burns completed. 0 Failures
+//Luna 23: 6(?) Burns completed. 0 Failures
+//Luna 24: 6 Burns completed. 0 Failures
+//62 Burns completed, 1 (possible) failure
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[11D417]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = 11D417
+		ratedBurnTime = 650
+		ignitionReliabilityStart = 0.983871
+		ignitionReliabilityEnd = 0.996774
+		cycleReliabilityStart = 0.983871
+		cycleReliabilityEnd = 0.996774
+		
+		@MODULE[ModuleEngineConfigs] { @CONFIG[11D417] { %ratedBurnTime = #$/TESTFLIGHT[11D417]/ratedBurnTime$ } }
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[11D417B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = 11D417B
+		ratedBurnTime = 30
+		ignitionReliabilityStart = 0.983871
+		ignitionReliabilityEnd = 0.996774
+		cycleReliabilityStart = 0.983871
+		cycleReliabilityEnd = 0.996774
+		
+		@MODULE[ModuleEngineConfigs] { @CONFIG[11D417B] { %ratedBurnTime = #$/TESTFLIGHT[11D417B]/ratedBurnTime$ } }
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU425A.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU425A.cfg
@@ -4,8 +4,23 @@
 //	Manufacturer: Isayev Design Bureau
 //
 //	=================================================================================
+//	KTDU-425
+//	Main Engine (1970)
+//
+//	Dry Mass: 70 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 18.85 kN
+//	ISP: ??? SL / 312 Vac
+//	Burn Time: 560
+//	Chamber Pressure: 13.32 MPa
+//	Propellant: AK-27 / UDMH
+//	Prop Ratio: 2.0
+//	Throttle: Could throttle to 7.05 kN
+//	Nozzle Ratio: ???
+//	Ignitions: 50
+//	=================================================================================
 //	KTDU-425A
-//	Main Engine
+//	Main Engine (1973)
 //
 //	Dry Mass: 70 Kg
 //	Thrust (SL): ??? kN
@@ -24,6 +39,7 @@
 
 //	Norbert Brügge - Spacecraft-propulsion blocks (KDU): http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
 //	Encyclopedia Astronautica - KTDU-425A engine:		 http://www.astronautix.com/k/ktdu-425a.html
+//	https://www.mediafire.com/file/5b3cy43y76ywnd8/ychebnikiav597.pdf/file
 
 //	Used by:
 
@@ -31,7 +47,6 @@
 
 //	Notes:
 
-//	* No reliability data defined yet.
 //	==================================================
 
 @PART[*]:HAS[#engineType[KTDU425A]]:FOR[RealismOverhaulEngines]
@@ -39,7 +54,7 @@
 	%category = Engine
 	%title = KTDU-425A
 	%manufacturer = Isayev Design Bureau (Khimmash)
-	%description = A gas generator hypergolic vacuum engine. Designed for use in the propulsion systems of the Mars and Venera 3MV, 4MV and 5MV spacecraft buses.
+	%description = A Soviet gas generator hypergolic vacuum engine. Designed for use in the propulsion systems of the Mars and Venera 3MV, 4MV and 5MV spacecraft buses.
 
 	@MODULE[ModuleEngines*]
 	{
@@ -62,8 +77,47 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = KTDU-425A
+		configuration = KTDU-425
 		origMass = 0.07
+
+		CONFIG
+		{
+			name = KTDU-425
+			minThrust = 7.05
+			maxThrust = 18.85
+			heatProduction = 35
+			gimbalRange = 5.0
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 50
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.01
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4782
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5218
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 312
+				key = 1 263
+			}
+		}
 
 		CONFIG
 		{
@@ -103,5 +157,60 @@
 				key = 1 263
 			}
 		}
+	}
+}
+
+//	==================================================
+//	TestFlight compatibility.
+//	==================================================
+
+//Same as below due to lack of data
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[KTDU-425]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = KTDU-425
+		ratedBurnTime = 560
+		ignitionReliabilityStart = 0.976744
+		ignitionReliabilityEnd = 0.995349
+		cycleReliabilityStart = 0.976744
+		cycleReliabilityEnd = 0.995349
+		
+		techTransfer = KDU-414:20	//Loosely related
+		
+		@MODULE[ModuleEngineConfigs] { @CONFIG[KTDU-425] { %ratedBurnTime = #$/TESTFLIGHT[KTDU-425]/ratedBurnTime$ } }
+	}
+}
+//Mars 4: 1 Burn completed before computer failure
+//Mars 5: 2 Burns completed. 0 Failures
+//Mars 6: 1 Burn completed. 0 Failures
+//Mars 7: 1 Burn completed. 0 Failures
+//Venera 9: 2 Burns completed. 0 Failures
+//Venera 10: 2 Burns completed. 0 Failures
+//Venera 11: 3(?) Burns completed. 0 Failures
+//Venera 12: 3(?) Burns completed. 0 Failures
+//Venera 13: 3(?) Burns completed. 0 Failures
+//Venera 14: 3(?) Burns completed. 0 Failures
+//Venera 15: 3(?) Burns completed. 0 Failures
+//Venera 16: 3(?) Burns completed. 0 Failures
+//Vega 1: 4(?) Burns completed. 0 Failures
+//Vega 2: 5 Burns completed. 0 failures
+//Fobos 1: 1 Burn completed before computer failure
+//Fobos 2: 5 Burns completed before computer failure
+//42 Burns completed, 0 engine failures
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[KTDU-425A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = KTDU-425A
+		ratedBurnTime = 560
+		ignitionReliabilityStart = 0.976744
+		ignitionReliabilityEnd = 0.995349
+		cycleReliabilityStart = 0.976744
+		cycleReliabilityEnd = 0.995349
+		
+		techTransfer = KDU-425:50
+		
+		@MODULE[ModuleEngineConfigs] { @CONFIG[KTDU-425A] { %ratedBurnTime = #$/TESTFLIGHT[KTDU-425A]/ratedBurnTime$ } }
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
@@ -7,7 +7,7 @@
 //	Ranger/Mariner Propulsion System
 //	
 //
-//	Dry Mass: 16.8 Kg
+//	Dry Mass: 16.8 Kg	//Including tankage and fuel
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 225 N		//50 lbf
 //	ISP: 112 SL / 234.97 Vac
@@ -51,7 +51,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 0.0168
+		origMass = 0.0084	//Subtract 8.4 kg for fuel and tankage mass (assuming SM-II)
 		configuration = RangerRetro
 		modded = false
 

--- a/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
@@ -57,7 +57,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 0.0084	//Subtract 8.4 kg for fuel and tankage mass (assuming SM-II)
+		origMass = 0.0098	//Subtract 7.0 kg for fuel and tankage mass (assuming SM-II)
 		configuration = RangerRetro
 		modded = false
 

--- a/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
@@ -1,0 +1,128 @@
+//	==================================================
+//	Ranger/Mariner Propulsion System
+//
+//	Manufacturer: JPL
+//
+//	=================================================================================
+//	Ranger/Mariner Propulsion System
+//	
+//
+//	Dry Mass: 16.8 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 225 N		//50 lbf
+//	ISP: 112 SL / 234.97 Vac
+//	Burn Time: 57
+//	Chamber Pressure: ??? MPa
+//	Propellant: Hydrazine
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 2
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.gutenberg.org/files/54585/54585-h/54585-h.htm
+//	https://ntrs.nasa.gov/citations/19680006875
+
+//	Used by:
+
+//	Notes:
+
+//	===============================================================
+
+@PART[*]:HAS[#engineType[RangerRetro]]:FOR[RealismOverhaulEngines]
+{
+	%title = Ranger/Mariner Propulsion System
+	%manufacturer = JPL
+	%description = 225 N Hydrazine thruster, used on all Ranger and early Mariner spacecraft for midcourse corrections. Since reliable Hydrazine catalysts had not yet been developed, the engines were only capable of two starts.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleGimbal] {}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.0168
+		configuration = RangerRetro
+		modded = false
+
+		CONFIG
+		{
+			name = RangerRetro
+			maxThrust = 0.255
+			minThrust = 0.255
+			heatProduction = 40
+
+			PROPELLANT
+			{
+				name = Hydrazine
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = NTO
+				amount = 0.015	//15 cm3 start slug
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Alumina
+				amount = 0.015	//Aluminum Oxide catalyst pellet
+			}
+
+			atmosphereCurve
+			{
+				key = 0 234.97
+				key = 1 112
+			}
+
+			massMult = 1
+
+			ullage = False	//bladder fed
+			ignitions = 2
+			pressureFed = True
+		}
+	}
+
+	RESOURCE
+	{
+		name = NTO
+		amount = 0.03
+		maxAmount = 0.03
+	}
+
+	RESOURCE
+	{
+		name = Alumina
+		amount = 0.03
+		maxAmount = 0.03
+	}
+}
+// Ranger Program: 5 Flights, 0 Failures 
+// Mariner Program: 5 Flights, 0 Failures
+// Assuming 2 burns per mission, 20 ignitions, 0 failures
+// Extremely simple, dual redundant design, fudge reliability numbers upwards to account for low sample size
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RangerRetro]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+			name = RangerRetro
+			ratedBurnTime = 57
+			ignitionReliabilityStart = 0.995238
+			ignitionReliabilityEnd = 0.999048
+			cycleReliabilityStart = 0.995238
+			cycleReliabilityEnd = 0.999048
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RangerRetro] { %ratedBurnTime = #$/TESTFLIGHT[RangerRetro]/ratedBurnTime$ } }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
@@ -43,9 +43,15 @@
 	}
 
 	!MODULE[ModuleEngineConfigs],*{}
-	!MODULE[ModuleGimbal] {}
 	!MODULE[ModuleAlternator],*{}
 	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal],*		//Thrust vanes
+	{
+		@gimbalRange = 2.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -446,10 +446,10 @@
 	%rescaleFactor = 0.56
 }
 
-//2.6 in diameter, 10.26 inch length (0.066 m x 0.26 m). (see sources in engineConfig)
+//2.6 in (inner) diameter, 10.26 inch length (0.066 m x 0.26 m). (see sources in engineConfig)
 @PART[RO-RangerRetro]:BEFORE[RealismOverhaul]
 {
-	%rescaleFactor = 0.0825
+	%rescaleFactor = 0.11	//Nozzle wall and thrust vanes added some length
 }
 
 @PART[RO_KVD1]:BEFORE[RealismOverhaul]:NEEDS[!ReStock]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -31,6 +31,8 @@
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = ROAJ10-137 }
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = ROAerobeeSustainer }
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = RO-2kN-Thruster }
++PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = RO-RangerRetro }
++PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = RO-KDU414 }
 
 +PART[solidBooster_sm_v2]:BEFORE[RealismOverhaul] { @name = RO-GCRC }
 +PART[solidBooster_sm_v2]:BEFORE[RealismOverhaul] { @name = RO-X-248 }
@@ -54,6 +56,9 @@
 
 +PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO_KVD1 }
 +PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[!ReStock] { @name = RO_KVD1 }
+
++PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO-KTDU417 }
++PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[!ReStock] { @name = RO-KTDU417 }
 
 
 // Phase 2: Model Patching
@@ -172,6 +177,12 @@
 {
 	// default model = Squad/Parts/Engine/liquidEnginePoodle/model
 	%rescaleFactor = 1.2
+}
+
+//  KDU414 (vacuum engine).
+@PART[RO-KDU414]:HAS[#mesh]:BEFORE[RealismOverhaul]
+{
+	%rescaleFactor = 0.51		//Actual size unknown, tankage included in dimensions. Just set to same size as 2kN generic
 }
 
 //  RD-0105/0109 (vacuum engine).
@@ -435,6 +446,12 @@
 	%rescaleFactor = 0.56
 }
 
+//2.6 in diameter, 10.26 inch length (0.066 m x 0.26 m). (see sources in engineConfig)
+@PART[RO-RangerRetro]:BEFORE[RealismOverhaul]
+{
+	%rescaleFactor = 0.0825
+}
+
 @PART[RO_KVD1]:BEFORE[RealismOverhaul]:NEEDS[!ReStock]
 {
 	@MODEL
@@ -479,11 +496,55 @@
 	}
 }
 
+@PART[RO-KTDU417]:BEFORE[RealismOverhaul]:NEEDS[!ReStock]
+{
+	@MODEL
+	{
+		%scale = 1.0, 1.73, 1.0
+	}
+
+	MODEL
+	{
+		model = Squad/Parts/Structural/strutOcto/model
+		scale = 1.0, 1.0, 1.0
+		position = 0.0, 0.0, 0.0
+		rotation = 0.0, 22.5, 0.0
+	}
+
+	@scale = 1.0
+	%rescaleFactor = 0.7
+
+	%node_stack_top = 0.0, 0.775, 0.0, 0.0, 1.0, 0.0, 1
+	%node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
+}
+
+@PART[RO-KTDU417]:BEFORE[RealismOverhaul]
+{
+	// Model common patches?
+	MODEL
+	{
+		model = RealismOverhaul/Models/KVDvernStock
+		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
+		scale = 1.0, 1.0, 1.0
+		position = 0.0, -0.65, -0.15
+		rotation = 12.0, 0.0, 0.0
+	}
+
+	MODEL
+	{
+		model = RealismOverhaul/Models/KVDvernStock
+		texture = ksp_r_microEngine_diff, Squad/Parts/Engine/liquidEngineLV-1R/ksp_r_microEngine_diff
+		scale = 1.0, 1.0, 1.0
+		position = 0.0, -0.65, 0.15
+		rotation = 12.0, 180, 0.0
+	}
+}
+
 
 // Phase 3: Configuration
 
 // Commons
-@PART[RO-RD-253|engineLargeSkipper|ionEngine|RO-LR105|RO-LR79|RO-E1|RO-H1-RS27|RO-LR-89|RO-RD58|RO-RD-0210|RO-LMDE|RO-LMAE|RO-RD-0105|RO-SurveyorVernier]:FOR[RealismOverhaul]
+@PART[RO-RD-253|engineLargeSkipper|ionEngine|RO-LR105|RO-LR79|RO-E1|RO-H1-RS27|RO-LR-89|RO-RD58|RO-RD-0210|RO-LMDE|RO-LMAE|RO-RD-0105|RO-SurveyorVernier|RO-KDU414]:FOR[RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -520,7 +581,7 @@
 	%ignoreMass = False
 }
 
-@PART[solidBooster_v2|solidBooster1-1|toroidalAerospike|RO-GCRC|RO-X-248|RO-X-258|RO-AltairIII|RO-STAR-37|solidBooster_sm_v2|RO_KVD1]:FOR[RealismOverhaul]
+@PART[solidBooster_v2|solidBooster1-1|toroidalAerospike|RO-GCRC|RO-X-248|RO-X-258|RO-AltairIII|RO-STAR-37|solidBooster_sm_v2|RO_KVD1|RO-KTDU417]:FOR[RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -610,6 +671,12 @@
 {
 	%RSSROConfig = True
 	%engineType = LMDE
+}
+
+@PART[RO-KDU414]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = KDU414
 }
 
 @PART[RO-LMAE]:FOR[RealismOverhaul]
@@ -826,6 +893,39 @@
 		%gimbalRangeYP = 15
 		%gimbalRangeYN = 15
 	}
+}
+@PART[RO-KTDU417]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = KTDU417
+
+	@MODULE[ModuleEngines*]
+	{
+		engineID = MainEngine
+	}
+
+	MODULE
+	{
+		name = ModuleEnginesRF
+		engineID = BackupEngine
+		thrustVectorTransformName = vern01Transform
+	}
+
+	// Verniers gimbal setup.
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalTransformName = vern01Transform
+	}
+}
+
+//Ranger/Mariner Propulsion System
+@PART[RO-RangerRetro]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = RangerRetro
+
+	//thrust vanes
+	%MODULE[ModuleGimbal] { %gimbalTransformName = thrustTransform }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-KDU414.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-KDU414.cfg
@@ -1,0 +1,14 @@
+//	==================================================
+//	KDU-414 thruster plume setup.
+//	==================================================
+
+@PART[RO-KDU414]:BEFORE[RealPlume]
+{
+	PLUME_TEMPLATE
+	{
+		name = Hypergolic_UpperWhite
+		transformName = thrustTransform
+		scale = 0.15
+		offset = -0.13
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-KTDU417.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/RO-KTDU417.cfg
@@ -1,0 +1,74 @@
+//	==================================================
+//	KTDU-417 thruster plume setup.
+//	==================================================
+
+@PART[RO-KTDU417]:BEFORE[RealPlume]
+{
+	PLUME
+	{
+		name = Hypergolic_UpperWhite
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		energy = 1
+		speed = 1
+		emissionMult = 0.5
+
+		flarePosition = 0,0,-0.05
+		flareScale = 0.09
+
+		corePosition = 0,0,0.1
+		coreScale = 0.8
+
+		plumePosition = 0,0,-0.3
+		plumeScale = 0.5
+	}
+	
+	PLUME
+	{
+		name = Hypergolic_UpperYellow
+		transformName = vern01Transform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		energy = 1
+		speed = 1
+
+		flarePosition = 0,0,-0.02
+		flareScale = 0.025
+
+		fumePosition = 0,0,0.05
+		fumeScale = 0.1
+
+		streamPosition = 0,0,0.05
+		streamScale = 0.1
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[MainEngine]]
+	{
+		%powerEffectName = Hypergolic_UpperWhite
+		!runningEffectName = DELETE
+	}
+
+	@MODULE[ModuleEngines*]:HAS[#engineID[BackupEngine]]
+	{
+		%powerEffectName = Hypergolic_UpperYellow
+		!runningEffectName = DELETE
+	}
+	
+
+	@MODULE[ModuleEngineConfigs]:HAS[#engineID[MainEngine]]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_UpperWhite
+		}
+	}
+
+	@MODULE[ModuleEngineConfigs]:HAS[#engineID[BackupEngine]]
+	{
+		@CONFIG,*
+		{
+			%powerEffectName = Hypergolic_UpperYellow
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/RangerRetro.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/RangerRetro.cfg
@@ -1,0 +1,14 @@
+//	==================================================
+//	Ranger Retro thruster plume setup.
+//	==================================================
+
+@PART[RO-RangerRetro]:BEFORE[RealPlume]
+{
+	PLUME_TEMPLATE
+	{
+		name = Hypergolic_UpperWhite
+		transformName = thrustTransform
+		scale = 0.03
+		offset = -0.13
+	}
+}


### PR DESCRIPTION
Add the Ranger/Mariner Propulsion system, KDU-414, KTDU-425 and KTDU-417 engine configs to RO, as well as RO-supplied parts for the Ranger/Mariner Propulsion system, KDU-414 and KTDU-417.

Intended to accompany https://github.com/KSP-RO/RP-0/pull/1470, it gives something to replace the lack of Hydrazine generics, as well as adding a Soviet equivalent to the Surveyor Vernier.