### PR TITLE
Fix Gimbals on NK33/43 and RD120

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -104,7 +104,7 @@
 			minThrust = 841
 			heatProduction = 100
 			massMult = 1.21812 // 1.020458 (NK-15, no gimbal) * 1.1937 (increase % for gimbal)
-			gimbalRange = 6
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
 			{
@@ -184,7 +184,7 @@
 			minThrust = 841
 			heatProduction = 100
 			massMult = 1.1937 // 1.459t, mass value from AJ26-59
-			gimbalRange = 6
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			// 2.6 O/F mass ratio (b14643.de)
 			PROPELLANT
 			{
@@ -265,7 +265,7 @@
 			heatProduction = 100
 			massMult = 1.1937
 			ignitions = 2
-			gimbalRange = 6
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			// 2.7 O/F mass ratio (Antares UG)
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -84,7 +84,7 @@
 			minThrust = 877.5
 			heatProduction = 100
 			massMult = 1.15009 // 0.963467 (NK-15V, no gimbal) * 1.1937 (increase % for gimbal)
-			gimbalRange = 6
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
 			{
@@ -164,7 +164,7 @@
 			maxThrust = 1755
 			heatProduction = 100
 			massMult = 1.1937 // 1 (NK-43, no gimbal) * 1.1937 (increase % for gimbal)
-			gimbalRange = 6
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			// 2.8 O/F mass ratio (b14643.de)
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
@@ -186,7 +186,7 @@
 			name = RD-120K
 			minThrust = 416.78
 			maxThrust = 853.18
-			gimbalRange = 6.0
+			gimbalRange = #$../../MODULE[ModuleGimbal]/gimbalRange$
 			massMult = 0.96
 			ullage = True
 			pressureFed = False


### PR DESCRIPTION
Fix Gimbals for these engines which have `gimbalRange = 0` configs, using methodology from #2380 