### PR TITLE
Add small radial sep motor

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -977,6 +977,11 @@
 
 	@mass = 0.044
 
+	@MODULE[ModuleEngines*]
+	{
+		%exhaustDamage = False
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1041,6 +1041,7 @@
 
 //  ==================================================
 //  Radial Separation motor (small).
+//  Rescale and Volume dont align because volume was set to match snubotron for balance reasons and size for visuals
 //  ==================================================
 
 +PART[sepMotor1]:AFTER[RealismOverhaul]
@@ -1066,7 +1067,8 @@
 	}
 }
 
-@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLarge|sepMotorSmall]:FOR[RealismOverhaul]
+// sepMotorSmall and sepMotorLarge get this through the copy not directly
+@PART[sepMotor1|ROSmallSpinMotor|SnubOtron]:FOR[RealismOverhaul]
 {
 	@manufacturer = Generic
 	@crashTolerance = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -966,13 +966,13 @@
 }
 
 //  ==================================================
-//  Separation motor (medium).
+//  Radial Separation motor (medium).
 //  ==================================================
 
 @PART[sepMotor1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@title = Separation Motor (Medium)
+	@title = Radial Separation Motor (Medium)
 	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others.
 
 	@mass = 0.044
@@ -1016,13 +1016,13 @@
 }
 
 //  ==================================================
-//  Separation motor (large).
+//  Radial Separation motor (large).
 //  ==================================================
 
 +PART[sepMotor1]:AFTER[RealismOverhaul]
 {
 	@name = sepMotorLarge
-	@title = Separation Motor (Large)
+	@title = Radial Separation Motor (Large)
 	@description = Larger solid motor use to help separate one stage from another or perform ullage. Best used with others.
 
 	%rescaleFactor = 2.0
@@ -1047,7 +1047,39 @@
 	}
 }
 
-@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLarge]:FOR[RealismOverhaul]
+//  ==================================================
+//  Radial Separation motor (small).
+//  ==================================================
+
++PART[sepMotor1]:AFTER[RealismOverhaul]
+{
+	@name = sepMotorSmall
+	@title = Radial Separation Motor (Small)
+	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others.
+
+	%rescaleFactor = 0.5
+	@mass = 0.008
+
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust *= 0.18
+	}
+
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume *= 0.25
+	}
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG[SolidFuel]
+		{
+			@maxThrust *= 0.18
+		}
+	}
+}
+
+@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLarge|sepMotorSmall]:FOR[RealismOverhaul]
 {
 	@manufacturer = Generic
 	@crashTolerance = 10
@@ -1083,7 +1115,7 @@
 //  TestFlight compatibility.
 //  ==================================================
 
-@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLarge]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLargeLsepMotorSmall]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1055,7 +1055,7 @@
 
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 0.25
+		@volume *= 0.25		// Should be *.125, but balancing vs snubOtron, which has volume=5.
 	}
 
 	@MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -977,14 +977,6 @@
 
 	@mass = 0.044
 
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		@maxThrust = 98
-		@heatProduction = 17.5
-		%exhaustDamage = False
-	}
-
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -1028,11 +1020,6 @@
 	%rescaleFactor = 2.0
 	@mass = 0.25
 
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust *= 4
-	}
-
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume *= 8
@@ -1059,11 +1046,6 @@
 
 	%rescaleFactor = 0.5
 	@mass = 0.008
-
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust *= 0.18
-	}
 
 	@MODULE[ModuleFuelTanks]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1115,7 +1115,7 @@
 //  TestFlight compatibility.
 //  ==================================================
 
-@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLargeLsepMotorSmall]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[sepMotor1|ROSmallSpinMotor|SnubOtron|sepMotorLarge|sepMotorSmall]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{


### PR DESCRIPTION
This patch duplicates the existing Medium radial separation motor (sepMotor1) and makes a smaller version of it, in the same fashion that a larger one is made.  This expands the Medium & Large range to Small, Medium, and Large.

Also slightly renames the three to "Radial Separation Motor (Size)" to avoid confusion with the existing "Separation Motor (Small)" which is a different model entirely and most often (though not exclusively) mounted inline with a tank (on the ends) rather than on the sides.