### PR TITLE
Increase LMAE, LMDE reliability

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -152,16 +152,28 @@
 	}
 }
 
+//Apollo 5: 2 burns, 0 failures
+//Apollo 9: 1 burn, 0 failures
+//Apollo 10: 2 burns, 0 failures
+//Apollo 11: 2 burns(?), 0 failures
+//Apollo 12: 3 burns completed, 0 failures
+//Apollo 14: 2 burns completed, 0 failures
+//Apollo 15: 2 burns completed, 0 failures
+//Apollo 16: 1 burn completed, 0 failures
+//Apollo 17: 2 burns completed, 0 failures
+//9 engines, 0 failures
+//17 ignitions, 0 failures
+//Due to small sample size and very high design reliability, fudge numbers upwards
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LMAE]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LMAE
 		ratedBurnTime = 560
-		ignitionReliabilityStart = 0.985
-		ignitionReliabilityEnd = 0.995
-		cycleReliabilityStart = 0.833333
-		cycleReliabilityEnd = 0.966667
+		ignitionReliabilityStart = 0.994444
+		ignitionReliabilityEnd = 0.998889
+		cycleReliabilityStart = 0.988889
+		cycleReliabilityEnd = 0.997778
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LMAE] { %ratedBurnTime = #$/TESTFLIGHT[LMAE]/ratedBurnTime$ } }
 }
@@ -173,10 +185,10 @@
 		//guess, based on LMAE
 		name = RS-18
 		ratedBurnTime = 560
-		ignitionReliabilityStart = 0.985
-		ignitionReliabilityEnd = 0.995
-		cycleReliabilityStart = 0.985
-		cycleReliabilityEnd = 0.995
+		ignitionReliabilityStart = 0.994444
+		ignitionReliabilityEnd = 0.998889
+		cycleReliabilityStart = 0.988889
+		cycleReliabilityEnd = 0.997778
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-18] { %ratedBurnTime = #$/TESTFLIGHT[RS-18]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
@@ -228,17 +228,18 @@
 //Apollo 17: 1 ignition, 0 failures
 //10 engines, 0 failures
 //15 ignitions, 1 failure
+//Due to small sample size and very high design reliability, fudge numbers upwards
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[LMDE-H]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
 		name = LMDE-H
 		ratedBurnTime = 960
-		ignitionReliabilityStart = 0.933333 // ignition chance will be this at 0 data
-		ignitionReliabilityEnd = 0.986667 // and this at 10000 data
+		ignitionReliabilityStart = 0.989130 // ignition chance will be this at 0 data
+		ignitionReliabilityEnd = 0.997826 // and this at 10000 data
 		
-		cycleReliabilityStart = 0.909091 // the chance of completing its burn time successfully at 0 data
-		cycleReliabilityEnd = 0.981818 // and at 10000 data. The fail chance any second, except during the
+		cycleReliabilityStart = 0.983607 // the chance of completing its burn time successfully at 0 data
+		cycleReliabilityEnd = 0.996721 // and at 10000 data. The fail chance any second, except during the
 		// first few seconds of operation when failure is much more likely, will be
 		// (1 - this) / ratedBurnTime. It will also climb after rated burn time has elapsed.
 		
@@ -274,11 +275,11 @@
 	{
 		name = LMDE-J
 		ratedBurnTime = 960
-		ignitionReliabilityStart = 0.933333
-		ignitionReliabilityEnd = 0.986667
+		ignitionReliabilityStart = 0.989130
+		ignitionReliabilityEnd = 0.997826
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.909091
-		cycleReliabilityEnd = 0.981818
+		cycleReliabilityStart = 0.983607
+		cycleReliabilityEnd = 0.996721
 		techTransfer = LMDE-H:75
 		reliabilityDataRateMultiplier = 2
 	}


### PR DESCRIPTION
Increase LMAE and LMDE reliability. Both engines were designed to be as reliable as possible, and their current failure rates due to small sample size don't really make sense. Increase reliability on both engines