### PR TITLE
Unhide KTDU417, KVD1, RD256

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -476,6 +476,8 @@
 
 @PART[RO_KVD1]:BEFORE[RealismOverhaul]
 {
+	!TechHidden = delete
+
 	// Model common patches?
 	MODEL
 	{
@@ -520,6 +522,8 @@
 
 @PART[RO-KTDU417]:BEFORE[RealismOverhaul]
 {
+	!TechHidden = delete
+
 	// Model common patches?
 	MODEL
 	{
@@ -772,6 +776,7 @@
 {
 	%RSSROConfig = True
 	%engineType = RD856
+	!TechHidden = delete
 }
 
 //  Castor 30XL.


### PR DESCRIPTION
The base parts used to clone these have TechHidden=true
(at least with restock), causing the parts not to show up in r&d.
Unhide them.

Should eventually look into switching to restock's replacement parts,
but this will keep restock/notrestock parity until then.

(I spotted a few more, but they have ROE counterparts, so less important)