### PR TITLE
Correct some numbers for the M5E1 (Nike) SRM

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Nike_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nike_Config.cfg
@@ -8,15 +8,15 @@
 //	Nike
 //
 //	Dry Mass: 195 Kg
-//	Thrust (SL): 195.6 kN
-//	Thrust (Vac): ??? kN
-//	ISP: 195 SL / ??? Vac
-//	Burn Time: 3.4
+//	Thrust (SL): 193.05 kN, calculated from total impulse / total burn time
+//	Thrust (Vac): 224.46 kN
+//	ISP: 196 SL / 228 Vac, calculated from typo'd vac thrust, and total impulse/burn time.
+//	Burn Time: 3.4 // M5 is 3.5s, with other numbers scaled as such (42143 lbf sea level, etc)
 //	Chamber Pressure: ??? MPa
-//	Propellant: IRFNA-III / UDMH
+//	Propellant: NGNC (Ajax: IRFNA-III / UDMH)
 //	Prop Ratio: ???
 //	Throttle: N/A
-//	Nozzle Ratio: 40
+//	Nozzle Ratio: ???
 //	Ignitions: Infinite
 //	=================================================================================
 
@@ -32,15 +32,19 @@
 //			https://www.osti.gov/servlets/purl/4637852
 //			"Final Environmental Impact Statement for NASA Sounding Rocket Program"
 //			https://apps.dtic.mil/dtic/tr/fulltext/u2/a338963.pdf
+//			"Nike-Hercules Technical Data"
+//			http://ed-thelen.org/WesternElectricNikeHerculesBrown.pdf
 
-//	Used by:
+//	Used by: every sounding rocket ever, basically. And originally Nike-Ajax, Nike-Hercules, and all the other Nike-based SAMs/ABMs.
 
 //	Notes:
 //	Length: 134.8 in
 //	Diameter: 16.5 in
 //	Mass: 1180 lb
 //	Dry Mass: 430 lb
-//	Thrust: 49,000 lb
+//	Thrust: 50,461.5 lb vac -- the technical data reference mentions 59klbf vac thrust for M5, which is likely a typo for 49klbf. Later it mentions 43.4klbf "vac" thrust for M5E1 but that does not jibe with other references reporting 43.4klbf takeoff thrust (technically x4, since clustered)
+// The NASA sources mention 42.5klbf, which again seems correct for liftoff thrust rather than vac thrust given the thing only burns 3.4-3.5s.
+// So use 3.5/3.4 (which equates to 43.4/42.143) * 49,000 = 50,461.5 lbf
 
 //	==================================================
 @PART[*]:HAS[#engineType[Nike-M5E1]]:FOR[RealismOverhaulEngines]
@@ -84,8 +88,8 @@
 		CONFIG
 		{
 			name = Nike-M5E1
-			maxThrust = 195.6
-			minThrust = 195.6
+			maxThrust = 224.46
+			minThrust = 224.46
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -95,10 +99,9 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 195
-				key = 1 195
+				key = 0 196
+				key = 1 228
 			}
 		}
 	}
 }
-


### PR DESCRIPTION
Another one of those "vacuum Isp = SL Isp" configs. Did some more research, found I think where some of the numbers came from, and found differences between M5 and M5E1. The vac thrust is conjecture based on a plausible typo in a data document; other numbers calculated from known data.