### PR TITLE
Give consistent compressors to AJE turbojets

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -9,6 +9,12 @@
 			@name=Kerosene
 		}
 	}
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.2, 1.6, 1.2
+	}
 }
 @PART[aje_j85]:FOR[RealismOverhaul]
 {
@@ -20,21 +26,83 @@
 {
 	%RSSROConfig = True
 	%title = J57-P-21 Turbojet
+
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.2, 1.32, 1.2
+	}
+}
+@PART[turboFanEngine]:FOR[RealismOverhaul] // j58
+{
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.6, 2.5, 1.6
+		position = 0.0, 1.4, 0.0
+	}
+}
+@PART[aje_j75]:FOR[RealismOverhaul]
+{
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.6, 1.8, 1.6
+	}
 }
 @PART[aje_j79]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%title = J79-GE-17 Turbojet
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.28, 1.6, 1.28
+	}
+}
+@PART[aje_al31]:FOR[RealismOverhaul]
+{
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.6, 2.2, 1.6
+	}
 }
 @PART[aje_atar]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%title = Atar 9K-50 Turbojet
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.2, 1.32, 1.2
+	}
 }
 @PART[aje_avon]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%title = Avon RB-146 Mk.302 Turbojet
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.152, 1.25, 1.152
+	}
+}
+@PART[turboJet]:FOR[RealismOverhaul] // F100
+{
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.6, 2.2, 1.6
+	}
 }
 
 // Clone aje_j75 to be J48


### PR DESCRIPTION
Ven's Stock Revamp adds compressors if it's installed, which
AJE rescales. But without VSR, we only get nozzles.

So remove the VSR-added compressor and add RO's version instead,
using the same scaling

Scaling matches what AJE uses, and visually matches the VSR-installed version; but for maybe half the engines, that looks wrong: CoM is still in front of the compressor. Could use a revisit by someone knowledgeable enough to know how to map real-world sizes to compressor+nozzle models.