### PR TITLE
Add support for lights introduced in 1.11

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -439,6 +439,60 @@
 		@resourceAmount = 0.015
 	}
 }
+@PART[spotLight1_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.0035
+	@MODULE[ModuleLight]
+	{
+		@resourceAmount = 0.03
+	}
+}
+@PART[spotLight2_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.0035
+	@MODULE[ModuleLight]
+	{
+		@resourceAmount = 0.015
+	}
+}
+@PART[domeLight1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.001
+	@MODULE[ModuleLight]
+	{
+		@resourceAmount = 0.015
+	}
+}
+@PART[stripLight1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.001
+	@MODULE[ModuleLight]
+	{
+		@resourceAmount = 0.015
+	}
+}
+@PART[navLight1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.0015
+	@MODULE[ModuleLight]
+	{
+		@resourceAmount = 0.02
+	}
+}
+@PART[spotLight3]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.0015
+	@MODULE[ModuleLight]
+	{
+		@resourceAmount = 0.02
+	}
+}
 @PART[stackBiCoupler_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -420,8 +420,7 @@
 @PART[sensorThermometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-}
-@PART[spotLight1]:FOR[RealismOverhaul]
+}@PART[spotLight1|spotLight1_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.0035
@@ -430,7 +429,7 @@
 		@resourceAmount = 0.03
 	}
 }
-@PART[spotLight2]:FOR[RealismOverhaul]
+@PART[spotLight2|spotLight2_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.0035
@@ -439,25 +438,7 @@
 		@resourceAmount = 0.015
 	}
 }
-@PART[spotLight1_v2]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.0035
-	@MODULE[ModuleLight]
-	{
-		@resourceAmount = 0.03
-	}
-}
-@PART[spotLight2_v2]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.0035
-	@MODULE[ModuleLight]
-	{
-		@resourceAmount = 0.015
-	}
-}
-@PART[domeLight1]:FOR[RealismOverhaul]
+@PART[domeLight1|stripLight1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.001
@@ -466,31 +447,13 @@
 		@resourceAmount = 0.015
 	}
 }
-@PART[stripLight1]:FOR[RealismOverhaul]
+@PART[navLight1|spotLight3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.001
+	@mass = 0.0015
 	@MODULE[ModuleLight]
 	{
 		@resourceAmount = 0.015
-	}
-}
-@PART[navLight1]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.0015
-	@MODULE[ModuleLight]
-	{
-		@resourceAmount = 0.02
-	}
-}
-@PART[spotLight3]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.0015
-	@MODULE[ModuleLight]
-	{
-		@resourceAmount = 0.02
 	}
 }
 @PART[stackBiCoupler_v2]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -420,7 +420,8 @@
 @PART[sensorThermometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-}@PART[spotLight1|spotLight1_v2]:FOR[RealismOverhaul]
+}
+@PART[spotLight1|spotLight1_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@mass = 0.0035
@@ -455,6 +456,10 @@
 	{
 		@resourceAmount = 0.015
 	}
+}
+@PART[groundLight1|groundLight2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
 }
 @PART[stackBiCoupler_v2]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Patch 1.11 introduced some new illumination parts into the game, including a reworked version of existing Mk1 and Mk2 illuminators (the old parts were left in the game, probably for backward-compatibility, but hidden). Since the part names have changed for the old illuminators (`spotLight1` -> `spotLight1_v2`, `spotLight2` -> `spotLight2_v2`), RO currently does not support them.

This PR adds support for the reworked parts (by simply copying the existing config patch) and extends it onto the new parts (`domeLight1`, `stripLight1`, `navLight1`, `spotLight3`). I tried to maintain consistency between the old and new parts both in terms of mass and power consumption; the new parts are smaller so they should weigh less than the old Illuminators, but they seem to shine pretty much as brightly as the Mk2, so the values for `resourceAmount` I proposed is roughly similar as well. Of course, discussion is welcome and I'm ready to revisit this with better values.

Please let me know your thoughts, is there anything I might have missed - just tell me where to look and I'll try to figure it out. One thing I can already tell you I haven't done is `groundLight1` and `groundLight2` - new type of lamps that work like cargo parts. I did not change them as their values seem pretty reasonable already. If there's anything that should be done with them anyway then let me know, hopefully we can have all the stuff in this one PR.