### PR TITLE
Fairing base mass PFv6 compatibility

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_Remass.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_PF_Remass.cfg
@@ -19,12 +19,31 @@
 		%specificMass = 0.0008, 0.03, 0.02, 0
 	}
 }
+// the above for pre-v6 PF; the below for v6
+@PART:HAS[@MODULE[ProceduralFairingBase]]:FOR[zaPFRemass]
+{
+	@MODULE[ProceduralFairingBase]:HAS[#mode[Adapter]]
+	{
+		%specificMass = 0.0008, 0.03, 0.02, 0
+	}
+	@MODULE[ProceduralFairingBase]:HAS[#mode[Payload]]
+	{
+		%specificMass = 0.0008, 0.03, 0.02, 0
+	}
+}
 
 // however, boattail adapters ARE mechanically different. Without a decoupler,
 // they get to be much lighter
 @PART:HAS[@MODULE[ProceduralFairingAdapter],!MODULE[ModuleDecouple]]:FOR[zaPFRemass]
 {
 	@MODULE[ProceduralFairingAdapter]
+	{
+		%specificMass = 0.0002, 0.01, 0.005, 0
+	}
+}
+@PART:HAS[@MODULE[ProceduralFairingBase],!MODULE[ModuleDecouple]]:FOR[zaPFRemass]
+{
+	@MODULE[ProceduralFairingBase]:HAS[#mode[Adapter]]
 	{
 		%specificMass = 0.0002, 0.01, 0.005, 0
 	}


### PR DESCRIPTION
ProceduralFairingAdapter doesn't exist anymore, it's been folded
into ProceduralFairingBase

per https://discord.com/channels/319857228905447436/845457276641738782/855078235033174066
