### PR TITLE
TF patches fixes

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -345,8 +345,8 @@
 	TESTFLIGHT
 	{
 			name = AJ10-37
-			ratedBurnTime = 150
-			ratedContinuousBurnTime = 115		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
+			testedBurnTime = 150
+			ratedBurnTime = 115		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
 			safeOverburn = true
 			ignitionReliabilityStart = 0.888889
 			ignitionReliabilityEnd = 0.977778
@@ -363,8 +363,8 @@
 	TESTFLIGHT
 	{
 			name = AJ10-42
-			ratedBurnTime = 195
-			ratedContinuousBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
+			testedBurnTime = 195
+			ratedBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
 			safeOverburn = true
 			ignitionReliabilityStart = 0.928571
 			ignitionReliabilityEnd = 0.985714
@@ -382,8 +382,8 @@
 	TESTFLIGHT
 	{
 			name = AJ10-142
-			ratedBurnTime = 195
-			ratedContinuousBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
+			testedBurnTime = 195
+			ratedBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
 			safeOverburn = true
 			ignitionReliabilityStart = 0.916667
 			ignitionReliabilityEnd = 0.983333
@@ -402,8 +402,8 @@
 	TESTFLIGHT
 	{
 			name = AJ10-101A
-			ratedBurnTime = 195
-			ratedContinuousBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
+			testedBurnTime = 195
+			ratedBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
 			safeOverburn = true
 			ignitionReliabilityStart = 0.916667
 			ignitionReliabilityEnd = 0.983333
@@ -421,8 +421,8 @@
 	TESTFLIGHT
 	{
 			name = AJ10-118
-			ratedBurnTime = 195
-			ratedContinuousBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
+			testedBurnTime = 195
+			ratedBurnTime = 150		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
 			safeOverburn = true
 			ignitionReliabilityStart = 0.9398
 			ignitionReliabilityEnd = 0.9879
@@ -445,8 +445,8 @@
 	TESTFLIGHT
 	{
 			name = AJ10-118D
-			ratedBurnTime = 195
-			ratedContinuousBurnTime = 180		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
+			testedBurnTime = 195
+			ratedBurnTime = 180		//AJ10 early seems to be aluminum tube AJ10s, which were prone to burnthrough and only rated to 130%
 			safeOverburn = true
 			ignitionReliabilityStart = 0.962963
 			ignitionReliabilityEnd = 0.992593

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
@@ -162,8 +162,8 @@
 	TESTFLIGHT
 	{
 		name = AJ10-104
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 300		//Ablestar switched to stainless steel tube design for better durability
+		testedBurnTime = 450
+		ratedBurnTime = 300		//Ablestar switched to stainless steel tube design for better durability
 		safeOverburn = true
 		ignitionReliabilityStart = 0.967742
 		ignitionReliabilityEnd = 0.993548
@@ -196,8 +196,8 @@
 	TESTFLIGHT
 	{
 		name = AJ10-118E
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 400		//Ablestar switched to stainless steel tube design for better durability
+		testedBurnTime = 450
+		ratedBurnTime = 400		//Ablestar switched to stainless steel tube design for better durability
 		safeOverburn = true
 		ignitionReliabilityStart = 0.986301
 		ignitionReliabilityEnd = 0.997260

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -635,7 +635,7 @@
 			minThrust		= 17.7 //3.98 klbf
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
-			pressureFed		= False	//Because engine was intended to be used mostly in pump-fed mode, pressureization system is included in engine mass
+			pressureFed		= False	//Because engine was intended to be used mostly in pump-fed mode, pressurization system is included in engine mass
 			ignitions		= 15
 			massMult		= 1.1811	//Including mass of pressurization system that allowed it to function in HP mode
 			gimbalRange		= 5
@@ -675,8 +675,8 @@
 	TESTFLIGHT
 	{
 		name = Model117
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 60		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 120
+		ratedBurnTime = 60		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.8
@@ -696,8 +696,8 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-3
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 100		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 150
+		ratedBurnTime = 100		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		//Identical to XLR81-BA-5 other than nozzle, give same reliability since only two were launched
@@ -720,8 +720,8 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-5
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 120		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 180
+		ratedBurnTime = 120		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
 		{
@@ -752,8 +752,8 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-7
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 480
+		ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
 		{
@@ -788,8 +788,8 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-11
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 640
+		ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
 		{
@@ -816,8 +816,8 @@
 	TESTFLIGHT
 	{
 		name = XLR81-BA-13
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 640
+		ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
 		{
@@ -851,8 +851,8 @@
 	TESTFLIGHT
 	{
 		name = Model8096-39
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 640
+		ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
 		{
@@ -879,8 +879,8 @@
 	TESTFLIGHT
 	{
 		name = Model8096A
-		ratedBurnTime = 640
-		ratedContinuousBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
+		testedBurnTime = 640
+		ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 		safeOverburn = true
 		restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
 		{
@@ -949,6 +949,7 @@
 	TESTFLIGHT
 	{
 		name = Agena-2000
+		testedBurnTime = 1200 // guess
 		ratedBurnTime = 700		//683 seconds required for propellant depletion.
 		// pump-fed, so failure is as likely to be ignition as during runtime
 		ignitionReliabilityStart = 0.97
@@ -968,13 +969,17 @@
 	TESTFLIGHT
 	{
 		name = XLR81-LF2-SPS
-		ratedBurnTime = 360	//No burn time listed. Time assumed to allow for mission completion even with single engine failiure, with margin.
+		testedBurnTime = 480 // guess, but probably lower than regular due to LF2
+		ratedBurnTime = 360	//No burn time listed. Time assumed to allow for mission completion even with single engine failure, with margin.
 		// pump-fed pressure fed hybrid. Allegedly only 1% worse reliability than pure pressurefed engine
-		ignitionReliabilityStart = 0.995305
-		ignitionReliabilityEnd = 0.999061
+		safeOverburn = true
+		// uses XLR81-BA-13 stats, but without restart penalty
+		// and with increaed upper end for human-rating
+		ignitionReliabilityStart = 0.958763
+		ignitionReliabilityEnd = 0.994
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.990654
-		cycleReliabilityEnd = 0.998131
+		cycleReliabilityStart = 0.958763
+		cycleReliabilityEnd = 0.995
 		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
@@ -274,8 +274,8 @@
 	TESTFLIGHT
 	{
 		name = E-1
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.995
@@ -292,8 +292,8 @@
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 210
+		testedBurnTime = 350
+		ratedBurnTime = 210
 		safeOverburn = true
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.995
@@ -310,8 +310,8 @@
 	TESTFLIGHT
 	{
 		name = E-1-Upgrade2
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 350
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998
@@ -329,8 +329,8 @@
 	TESTFLIGHT
 	{
 		name = E-1A_KS
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 350
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998

--- a/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
@@ -113,8 +113,8 @@
 	TESTFLIGHT
 	{
 		name = F-1B
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 315
+		testedBurnTime = 350
+		ratedBurnTime = 315
 		safeOverburn = true
 		//Copied from F-1A, used mostly unmodified F-1A turbomachinery
 		ignitionReliabilityStart = 0.985

--- a/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
@@ -219,8 +219,8 @@
 	TESTFLIGHT
 	{
 		name = F-1-1.5M
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.984615
 		ignitionReliabilityEnd = 0.996923
@@ -235,8 +235,8 @@
 	TESTFLIGHT
 	{
 		name = F-1-1.52M
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.984615
 		ignitionReliabilityEnd = 0.996923
@@ -254,8 +254,8 @@
 	TESTFLIGHT
 	{
 		name = F-1A
-		ratedBurnTime = 350					// Was proposed as a Sustainer engine like the LR105
-		ratedContinuousBurnTime = 315
+		testedBurnTime = 350					// Was proposed as a Sustainer engine like the LR105
+		ratedBurnTime = 315
 		safeOverburn = true
 		ignitionReliabilityStart = 0.985
 		ignitionReliabilityEnd = 0.998

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
@@ -105,8 +105,8 @@
 	TESTFLIGHT
 	{
 		name = Gamma-2
-		ratedBurnTime = 330
-		ratedContinuousBurnTime = 140		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		testedBurnTime = 330
+		ratedBurnTime = 140		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
 		safeOverburn = true
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
@@ -152,8 +152,8 @@
 	TESTFLIGHT
 	{
 		name = Gamma-201
-		ratedBurnTime = 330
-		ratedContinuousBurnTime = 145		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		testedBurnTime = 330
+		ratedBurnTime = 145		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
 		safeOverburn = true
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207
@@ -168,8 +168,8 @@
 	TESTFLIGHT
 	{
 		name = Gamma-301
-		ratedBurnTime = 330
-		ratedContinuousBurnTime = 145		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		testedBurnTime = 330
+		ratedBurnTime = 145		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
 		safeOverburn = true
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
@@ -104,8 +104,8 @@
 	TESTFLIGHT
 	{
 		name = Gamma-8
-		ratedBurnTime = 330
-		ratedContinuousBurnTime = 140		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		testedBurnTime = 330
+		ratedBurnTime = 140		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
 		safeOverburn = true
 		ignitionReliabilityStart = 0.931034
 		ignitionReliabilityEnd = 0.986207

--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -434,8 +434,8 @@
 	TESTFLIGHT
 	{
 		name = H-1-165K
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 155
+		testedBurnTime = 350
+		ratedBurnTime = 155
 		safeOverburn = true
 		ignitionReliabilityStart = 0.969697
 		ignitionReliabilityEnd = 0.993939
@@ -452,8 +452,8 @@
 	TESTFLIGHT
 	{
 		name = H-1-188K
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 155
+		testedBurnTime = 350
+		ratedBurnTime = 155
 		safeOverburn = true
 		ignitionReliabilityStart = 0.979592
 		ignitionReliabilityEnd = 0.995918
@@ -470,8 +470,8 @@
 	TESTFLIGHT
 	{
 		name = H-1-200K
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 155
+		testedBurnTime = 350
+		ratedBurnTime = 155
 		safeOverburn = true
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122
@@ -488,8 +488,8 @@
 	TESTFLIGHT
 	{
 		name = H-1-205K
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 155
+		testedBurnTime = 350
+		ratedBurnTime = 155
 		safeOverburn = true
 		ignitionReliabilityStart = 0.969697
 		ignitionReliabilityEnd = 0.993939
@@ -520,8 +520,8 @@
 	TESTFLIGHT
 	{
 		name = RS-27
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 350
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.990000
 		ignitionReliabilityEnd = 0.998000
@@ -547,8 +547,8 @@
 	TESTFLIGHT
 	{
 		name = RS-27A
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 285
+		testedBurnTime = 350
+		ratedBurnTime = 285
 		safeOverburn = true
 		ignitionReliabilityStart = 0.992958
 		ignitionReliabilityEnd = 0.998592

--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -318,8 +318,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 600
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
@@ -333,8 +333,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3-SL
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 600
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
@@ -348,8 +348,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3A
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 600
 		safeOverburn = true
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
@@ -364,8 +364,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3A-SL
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 600
 		safeOverburn = true
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
@@ -380,8 +380,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3B
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 750
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 750
 		safeOverburn = true
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.99
@@ -396,8 +396,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3B-SL
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 750
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 750
 		safeOverburn = true
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.99
@@ -412,8 +412,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3B-2
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 750
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 750
 		safeOverburn = true
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97
@@ -428,8 +428,8 @@
 	TESTFLIGHT
 	{
 		name = HG-3B-SL-2
-		ratedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
-		ratedContinuousBurnTime = 750
+		testedBurnTime = 3600		//J-2 derived and basis for RS-25, both of which demostrated very long life
+		ratedBurnTime = 750
 		safeOverburn = true
 		ignitionReliabilityStart = 0.902
 		ignitionReliabilityEnd = 0.97

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -141,8 +141,8 @@
 	{
 		name = J-2T-200K
 		// Copied from J-2S, used J-2S turbomachinery
-		ratedBurnTime = 2500
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999
@@ -158,8 +158,8 @@
 	{
 		name = J-2T-250K
 		// Copied from J-2S, used J-2S turbomachinery
-		ratedBurnTime = 2500
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999

--- a/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
@@ -97,8 +97,8 @@
 	{
 		name = J-2X
 		// Using J-2S data
-		ratedBurnTime = 1350		//Tested to 1350 second single burn
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 1350		//Tested to 1350 second single burn
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9665
 		ignitionReliabilityEnd = 0.9999

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -255,8 +255,8 @@
 	TESTFLIGHT
 	{
 		name = J-2-200K
-		ratedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
+		ratedBurnTime = 500
 		safeOverburn = true
 		restartWindowPenalty		//Intended to restart after between 1.5 and 6 hours
 		{
@@ -286,8 +286,8 @@
 	{
 		name = J-2-225K
 		// Only failures (Apollo 6) but was caused more by F-1 POGO issues than J-2
-		ratedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
+		ratedBurnTime = 500
 		safeOverburn = true
 		restartWindowPenalty		//Intended to restart after between 1.5 and 6 hours
 		{
@@ -317,8 +317,8 @@
 	{
 		name = J-2-230K
 		// No failures, refined design (starts low as should have good data transfer)
-		ratedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
+		ratedBurnTime = 500
 		safeOverburn = true
 		restartWindowPenalty		//Intended to restart after between 1.5 and 6 hours
 		{
@@ -341,8 +341,8 @@
 	{
 		name = J-2S
 		// Simplified version of a well-refined engine
-		ratedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//During qualification, one engine completed 5 full duration tests. Engines were also tested for a full burn, sometimes repeatedly, before delivery
+		ratedBurnTime = 500
 		safeOverburn = true
 		restartWindowPenalty		//Intended to restart after between 1.5 and 6 hours
 		{

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -103,8 +103,8 @@
 	TESTFLIGHT
 	{
 			name = Juno45k
-			ratedBurnTime = 180		//Assuming built to same 130% margin as early AJ10
-			ratedContinuousBurnTime = 135
+			testedBurnTime = 180		//Assuming built to same 130% margin as early AJ10
+			ratedBurnTime = 135
 			safeOverburn = true
 			ignitionReliabilityStart = 0.80	 // Guesses, but should be about the same as X-405H
 			ignitionReliabilityEnd = 0.94

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -103,8 +103,8 @@
 	TESTFLIGHT
 	{
 			name = Juno6k
-			ratedBurnTime = 585		//Assuming built to same 130% margin as early AJ10
-			ratedContinuousBurnTime = 450
+			testedBurnTime = 585		//Assuming built to same 130% margin as early AJ10
+			ratedBurnTime = 450
 			safeOverburn = true
 			ignitionReliabilityStart = 0.85
 			ignitionReliabilityEnd = 0.95

--- a/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
@@ -193,8 +193,8 @@
 	{
 		name = RD-56
 		//Never flew, guess based on performance of KVD-1
-		ratedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56 overall reliability was poor. Give double time
-		ratedContinuousBurnTime = 800
+		testedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56 overall reliability was poor. Give double time
+		ratedBurnTime = 800
 		safeOverburn = true
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.97
@@ -215,8 +215,8 @@
 	TESTFLIGHT
 	{
 		name = KVD-1
-		ratedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56 overall reliability was poor. Give double time
-		ratedContinuousBurnTime = 800
+		testedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56 overall reliability was poor. Give double time
+		ratedBurnTime = 800
 		safeOverburn = true
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
@@ -239,8 +239,8 @@
 	TESTFLIGHT
 	{
 		name = CE-7.5
-		ratedBurnTime = 1700		//Hydrogen engines tend to be very tolerant of overburns, but RD-56 overall reliability was poor. Give double time
-		ratedContinuousBurnTime = 850
+		testedBurnTime = 1700		//Hydrogen engines tend to be very tolerant of overburns, but RD-56 overall reliability was poor. Give double time
+		ratedBurnTime = 850
 		safeOverburn = true
 		ignitionReliabilityStart = 0.928571
 		ignitionReliabilityEnd = 0.985714

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -468,9 +468,10 @@
 	TESTFLIGHT
 	{
 		name = LR43-NA-5
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 330
+		testedBurnTime = 350
+		ratedBurnTime = 330
 		safeOverburn = true
+		overburnPenalty = 1
 		ignitionReliabilityStart = 0.826087
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
@@ -487,9 +488,10 @@
 	TESTFLIGHT
 	{
 		name = LR105-NA-3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 330
+		testedBurnTime = 350
+		ratedBurnTime = 330
 		safeOverburn = true
+		overburnPenalty = 1
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -391,8 +391,8 @@
 	TESTFLIGHT
 	{
 		name = S-3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 182
+		testedBurnTime = 350
+		ratedBurnTime = 182
 		safeOverburn = true
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
@@ -411,8 +411,8 @@
 	TESTFLIGHT
 	{
 		name = S-3D
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 182
+		testedBurnTime = 350
+		ratedBurnTime = 182
 		safeOverburn = true
 		ignitionReliabilityStart = 0.882353
 		ignitionReliabilityEnd = 0.976471
@@ -450,8 +450,8 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-9
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.789773
 		ignitionReliabilityEnd = 0.957955
@@ -477,8 +477,8 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-11
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.936364
 		ignitionReliabilityEnd = 0.987273
@@ -524,8 +524,8 @@
 	TESTFLIGHT
 	{
 		name = LR79-NA-13
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 260
+		testedBurnTime = 350
+		ratedBurnTime = 260
 		safeOverburn = true
 		ignitionReliabilityStart = 0.964646
 		ignitionReliabilityEnd = 0.992929

--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
@@ -147,8 +147,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-TitanC
-		ratedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
-		ratedContinuousBurnTime = 300
+		testedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
+		ratedBurnTime = 300
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.95
@@ -166,8 +166,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-Vacuum
-		ratedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.92
 		ignitionReliabilityEnd = 0.975
@@ -185,8 +185,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-SustainerUpgrade
-		ratedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99
@@ -203,8 +203,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-LH2-VacuumUpgrade
-		ratedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//Navaho derivatives were pretty durable. Give same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -420,8 +420,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 137
+		testedBurnTime = 350
+		ratedBurnTime = 137
 		safeOverburn = true
 		ignitionReliabilityStart = 0.898305
 		ignitionReliabilityEnd = 0.979661
@@ -443,8 +443,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-5
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 350
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.962766
 		ignitionReliabilityEnd = 0.992553
@@ -465,8 +465,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-7
-		ratedBurnTime = 350 // [1] Page 11.C-9, 147s rounded up to 150
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 350 // [1] Page 11.C-9, 147s rounded up to 150
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.960000
 		ignitionReliabilityEnd = 0.992000
@@ -489,8 +489,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 350
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
@@ -510,8 +510,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9-Kero-15AR
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 350
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
@@ -531,8 +531,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-9-Kero
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 350
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.975000
 		ignitionReliabilityEnd = 0.995000
@@ -563,8 +563,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11
-		ratedBurnTime = 350 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
-		ratedContinuousBurnTime = 190
+		testedBurnTime = 350 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
+		ratedBurnTime = 190
 		safeOverburn = true
 		ignitionReliabilityStart = 0.982143
 		ignitionReliabilityEnd = 0.996429
@@ -591,8 +591,8 @@
 	TESTFLIGHT
 	{
 		name = LR87-AJ-11A
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 190
+		testedBurnTime = 350
+		ratedBurnTime = 190
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988372
 		ignitionReliabilityEnd = 0.997674

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -493,8 +493,8 @@
 	TESTFLIGHT
 	{
 		name = LR43-NA-3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 135
+		testedBurnTime = 350
+		ratedBurnTime = 135
 		safeOverburn = true
 		ignitionReliabilityStart = 0.826087
 		ignitionReliabilityEnd = 0.965217
@@ -512,8 +512,8 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 135
+		testedBurnTime = 350
+		ratedBurnTime = 135
 		safeOverburn = true
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
@@ -551,8 +551,8 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-5
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 350
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.956710
 		ignitionReliabilityEnd = 0.991342
@@ -583,8 +583,8 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-6
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 160
+		testedBurnTime = 350
+		ratedBurnTime = 160
 		safeOverburn = true
 		ignitionReliabilityStart = 0.939394
 		ignitionReliabilityEnd = 0.987879
@@ -603,8 +603,8 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-7.1
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
@@ -623,8 +623,8 @@
 	TESTFLIGHT
 	{
 		name = LR89-NA-7.2
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 165
+		testedBurnTime = 350
+		ratedBurnTime = 165
 		safeOverburn = true
 		ignitionReliabilityStart = 0.981481
 		ignitionReliabilityEnd = 0.996296
@@ -644,8 +644,8 @@
 	TESTFLIGHT
 	{
 		name = RS-56-OBA
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 170
+		testedBurnTime = 350
+		ratedBurnTime = 170
 		safeOverburn = true
 		ignitionReliabilityStart = 0.994737
 		ignitionReliabilityEnd = 0.998947

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -392,8 +392,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-3
-		ratedBurnTime = 350 // http://www.astronautix.com/engines/lr913.htm claims 225s but that makes no sense. Titan I-2 burn time was 155s, so let's round up to 180.
-		ratedContinuousBurnTime = 160
+		testedBurnTime = 350
+		ratedBurnTime = 160 // http://www.astronautix.com/engines/lr913.htm claims 225s but that makes no sense. Titan I-2 burn time was 155s, so let's round up to 180.
 		safeOverburn = true
 		ignitionReliabilityStart = 0.950000
 		ignitionReliabilityEnd = 0.990000
@@ -413,8 +413,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-5
-		ratedBurnTime = 350 // Titan II SLV and Titan 23G.
-		ratedContinuousBurnTime = 180
+		testedBurnTime = 350 // Titan II SLV and Titan 23G.
+		ratedBurnTime = 180
 		safeOverburn = true
 		ignitionReliabilityStart = 0.956044
 		ignitionReliabilityEnd = 0.991209
@@ -435,8 +435,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-7
-		ratedBurnTime = 350 // Titan II GLV, had a 9s stage stretch, round to 190s.
-		ratedContinuousBurnTime = 190
+		testedBurnTime = 350 // Titan II GLV, had a 9s stage stretch, round to 190s.
+		ratedBurnTime = 190
 		safeOverburn = true
 		ignitionReliabilityStart = 0.961165
 		ignitionReliabilityEnd = 0.992233
@@ -459,8 +459,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-9
-		ratedBurnTime = 350 // Titan III stretch
-		ratedContinuousBurnTime = 210
+		testedBurnTime = 350 // Titan III stretch
+		ratedBurnTime = 210
 		safeOverburn = true
 		ignitionReliabilityStart = 0.974359
 		ignitionReliabilityEnd = 0.994872
@@ -480,8 +480,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-9-Kero
-		ratedBurnTime = 350 // Titan III stretch
-		ratedContinuousBurnTime = 210
+		testedBurnTime = 350 // Titan III stretch
+		ratedBurnTime = 210
 		safeOverburn = true
 		ignitionReliabilityStart = 0.974359
 		ignitionReliabilityEnd = 0.994872
@@ -512,8 +512,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-11
-		ratedBurnTime = 350 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
-		ratedContinuousBurnTime = 232
+		testedBurnTime = 350 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
+		ratedBurnTime = 232
 		safeOverburn = true
 		ignitionReliabilityStart = 0.972727
 		ignitionReliabilityEnd = 0.994545
@@ -540,8 +540,8 @@
 	TESTFLIGHT
 	{
 		name = LR91-AJ-11A
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 250
+		testedBurnTime = 350
+		ratedBurnTime = 250
 		safeOverburn = true
 		ignitionReliabilityStart = 0.975610
 		ignitionReliabilityEnd = 0.995122

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -296,8 +296,8 @@
 	TESTFLIGHT
 	{
 		name = M-1-Spec
-		ratedBurnTime = 2500		//same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9182
 		ignitionReliabilityEnd = 0.9932
@@ -311,8 +311,8 @@
 	TESTFLIGHT
 	{
 		name = M-1
-		ratedBurnTime = 2500		//same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9257
 		ignitionReliabilityEnd = 0.9999
@@ -327,8 +327,8 @@
 	TESTFLIGHT
 	{
 		name = M-1SL
-		ratedBurnTime = 2500		//same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
@@ -343,8 +343,8 @@
 	TESTFLIGHT
 	{
 		name = M-1U
-		ratedBurnTime = 2500		//same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999
@@ -359,8 +359,8 @@
 	TESTFLIGHT
 	{
 		name = M-1U-SL
-		ratedBurnTime = 2500		//same overburn as J-2
-		ratedContinuousBurnTime = 500
+		testedBurnTime = 2500		//same overburn as J-2
+		ratedBurnTime = 500
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9440
 		ignitionReliabilityEnd = 0.9999

--- a/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
@@ -89,8 +89,8 @@
 	{
 		name = MR-80B
 		//Extremely simple and reliable monopropellant engines
-		ratedBurnTime = 1000		//tested over 800 seconds, round up to 1000
-		ratedContinuousBurnTime = 215		//longest single burn
+		testedBurnTime = 1000		//tested over 800 seconds, round up to 1000
+		ratedBurnTime = 215		//longest single burn
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -687,7 +687,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1A
-		ratedBurnTime = 300		//ablative, no extra time
+		testedBurnTime = 300		//ablative, no extra time
 		ignitionReliabilityStart = 0.800000
 		ignitionReliabilityEnd = 0.960000
 		cycleReliabilityStart = 0.800000
@@ -702,7 +702,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1B
-		ratedBurnTime = 300		//non reusable
+		testedBurnTime = 300		//non reusable
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -718,7 +718,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1BVac
-		ratedBurnTime = 345		//non reusable
+		testedBurnTime = 345		//non reusable
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -735,10 +735,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1C
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 300
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 300
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		//Actually intended to run for this long
 		ignitionReliabilityStart = 0.977778
 		ignitionReliabilityEnd = 0.995556
 		cycleReliabilityStart = 0.977778
@@ -755,10 +755,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1CVac
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 345
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 345
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		// Actually intended to run for this long
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
@@ -776,10 +776,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 350
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 350
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		// Actually intended to run for this long
 		ignitionReliabilityStart = 0.993711
 		ignitionReliabilityEnd = 0.998742
 		cycleReliabilityStart = 0.992593
@@ -798,10 +798,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D+
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 350
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 350
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		// Actually intended to run for this long
 		ignitionReliabilityStart = 0.997481
 		ignitionReliabilityEnd = 0.999496
 		cycleReliabilityStart = 0.996923
@@ -822,10 +822,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1D++
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 350
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 350
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		// Actually intended to run for this long
 		ignitionReliabilityStart = 0.998689
 		ignitionReliabilityEnd = 0.999738
 		cycleReliabilityStart = 0.998316
@@ -845,10 +845,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1DVac
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 375
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 375
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		// Actually intended to run for this long
 		ignitionReliabilityStart = 0.965517
 		ignitionReliabilityEnd = 0.993103
 		cycleReliabilityStart = 0.933333
@@ -870,10 +870,10 @@
 	TESTFLIGHT
 	{
 		name = Merlin1DVac+
-		ratedBurnTime = 1620		//rated for 10 flights 
-		ratedContinuousBurnTime = 400
+		testedBurnTime = 1620		//rated for 10 flights 
+		ratedBurnTime = 400
 		safeOverburn = true
-		overburnPenalty = 1		Actually intended to run for this long
+		overburnPenalty = 1		// Actually intended to run for this long
 		ignitionReliabilityStart = 0.992481
 		ignitionReliabilityEnd = 0.998496
 		cycleReliabilityStart = 0.985075

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -687,7 +687,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1A
-		testedBurnTime = 300		//ablative, no extra time
+		ratedBurnTime = 300		//ablative, no extra time
 		ignitionReliabilityStart = 0.800000
 		ignitionReliabilityEnd = 0.960000
 		cycleReliabilityStart = 0.800000
@@ -702,7 +702,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1B
-		testedBurnTime = 300		//non reusable
+		ratedBurnTime = 300		//non reusable
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
@@ -718,7 +718,7 @@
 	TESTFLIGHT
 	{
 		name = Merlin1BVac
-		testedBurnTime = 345		//non reusable
+		ratedBurnTime = 345		//non reusable
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -319,8 +319,8 @@
 	TESTFLIGHT
 	{
 		name = NK-15
-		ratedBurnTime = 450		//Tested to 450 seconds
-		ratedContinuousBurnTime = 180
+		testedBurnTime = 450		//Tested to 450 seconds
+		ratedBurnTime = 180
 		safeOverburn = true
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
@@ -337,8 +337,8 @@
 	TESTFLIGHT
 	{
 		name = NK-15-Original-NoGimbal
-		ratedBurnTime = 450		//Tested to 450 seconds
-		ratedContinuousBurnTime = 180
+		testedBurnTime = 450		//Tested to 450 seconds
+		ratedBurnTime = 180
 		safeOverburn = true
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
@@ -362,8 +362,8 @@
 	TESTFLIGHT
 	{
 		name = NK-33
-		ratedBurnTime = 450		//Tested to 450 seconds
-		ratedContinuousBurnTime = 240 //based on Antares and Soyuz 2-1v burn times.
+		testedBurnTime = 450		//Tested to 450 seconds
+		ratedBurnTime = 240 //based on Antares and Soyuz 2-1v burn times.
 		safeOverburn = true
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
@@ -378,8 +378,8 @@
 	TESTFLIGHT
 	{
 		name = NK-33-Original-NoGimbal
-		ratedBurnTime = 450		//Tested to 450 seconds
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 450		//Tested to 450 seconds
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
@@ -394,8 +394,8 @@
 	TESTFLIGHT
 	{
 		name = AJ26-62
-		ratedBurnTime = 2400		//Tested to 450 seconds. Upgraded for reuse in K-1, with many modifications to increase reliability. Rate for 10 flights?
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 2400		//Tested to 450 seconds. Upgraded for reuse in K-1, with many modifications to increase reliability. Rate for 10 flights?
+		ratedBurnTime = 240
 		safeOverburn = true
 		overburnPenalty = 1.5		//rated for reuse, but wasn't terribly reliable
 		ignitionReliabilityStart = 0.937500

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -251,8 +251,8 @@
 	TESTFLIGHT
 	{
 		name = NK-15V
-		ratedBurnTime = 450		//Tested to 450 seconds, same as NK-15
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 450		//Tested to 450 seconds, same as NK-15
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.974
@@ -269,8 +269,8 @@
 	TESTFLIGHT
 	{
 		name = NK-15V-Original-NoGimbal
-		ratedBurnTime = 450		//Tested to 450 seconds, same as NK-15
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 450		//Tested to 450 seconds, same as NK-15
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.974
@@ -287,8 +287,8 @@
 	TESTFLIGHT
 	{
 		name = NK-43
-		ratedBurnTime = 450		//Tested to 450 seconds, same as NK-33
-		ratedContinuousBurnTime = 360
+		testedBurnTime = 450		//Tested to 450 seconds, same as NK-33
+		ratedBurnTime = 360
 		safeOverburn = true
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
@@ -303,8 +303,8 @@
 	TESTFLIGHT
 	{
 		name = NK-43-Original-NoGimbal
-		ratedBurnTime = 450		//Tested to 450 seconds, same as NK-33
-		ratedContinuousBurnTime = 360
+		testedBurnTime = 450		//Tested to 450 seconds, same as NK-33
+		ratedBurnTime = 360
 		safeOverburn = true
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996

--- a/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
@@ -234,8 +234,8 @@
 	TESTFLIGHT
 	{
 		name = NK-9
-		ratedBurnTime = 450		//Assume same as NK-33
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 450		//Assume same as NK-33
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
@@ -254,8 +254,8 @@
 	TESTFLIGHT
 	{
 		name = NK-9-1969
-		ratedBurnTime = 450		//Assume same as NK-33
-		ratedContinuousBurnTime = 190
+		testedBurnTime = 450		//Assume same as NK-33
+		ratedBurnTime = 190
 		safeOverburn = true
 		ignitionReliabilityStart = 0.90
 		ignitionReliabilityEnd = 0.983
@@ -272,8 +272,8 @@
 	TESTFLIGHT
 	{
 		name = NK-9-1972
-		ratedBurnTime = 450		//Assume same as NK-33
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 450		//Assume same as NK-33
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.996
@@ -290,8 +290,8 @@
 	TESTFLIGHT
 	{
 		name = NK-9-2009
-		ratedBurnTime = 450		//Assume same as NK-33
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 450		//Assume same as NK-33
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.996

--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -345,8 +345,8 @@
 	TESTFLIGHT
 	{
 		name = NK-9V
-		ratedBurnTime = 450		//Assume same as NK-33
-		ratedContinuousBurnTime = 240
+		testedBurnTime = 450		//Assume same as NK-33
+		ratedBurnTime = 240
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.97
@@ -365,8 +365,8 @@
 	TESTFLIGHT
 	{
 		name = NK-21
-		ratedBurnTime = 600
-		ratedContinuousBurnTime = 450
+		testedBurnTime = 600
+		ratedBurnTime = 450
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
@@ -385,8 +385,8 @@
 	TESTFLIGHT
 	{
 		name = NK-19
-		ratedBurnTime = 650
-		ratedContinuousBurnTime = 450
+		testedBurnTime = 650
+		ratedBurnTime = 450
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
@@ -405,8 +405,8 @@
 	TESTFLIGHT
 	{
 		name = NK-39
-		ratedBurnTime = 650
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 650
+		ratedBurnTime = 600
 		safeOverburn = true
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.99
@@ -423,8 +423,8 @@
 	TESTFLIGHT
 	{
 		name = NK-31
-		ratedBurnTime = 650
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 650
+		ratedBurnTime = 600
 		safeOverburn = true
 		ignitionReliabilityStart = 0.93
 		ignitionReliabilityEnd = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
@@ -186,8 +186,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0105
-		ratedBurnTime = 1320		//Tested to 3 times rated burn time?
-		ratedContinuousBurnTime = 440
+		testedBurnTime = 1320		//Tested to 3 times rated burn time?
+		ratedBurnTime = 440
 		safeOverburn = true
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
@@ -208,8 +208,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0109
-		ratedBurnTime = 1320		//Tested to 3 times rated burn time?
-		ratedContinuousBurnTime = 440
+		testedBurnTime = 1320		//Tested to 3 times rated burn time?
+		ratedBurnTime = 440
 		safeOverburn = true
 		ignitionReliabilityStart = 0.966216
 		ignitionReliabilityEnd = 0.993243

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
@@ -120,8 +120,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0110-Vernier
-		ratedBurnTime = 750		//Tested to 3 times rated burn time?
-		ratedContinuousBurnTime = 250
+		testedBurnTime = 750		//Tested to 3 times rated burn time?
+		ratedBurnTime = 250
 		ignitionReliabilityStart = 0.984362
 		ignitionReliabilityEnd = 0.996872
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
@@ -162,8 +162,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0107
-		ratedBurnTime = 750		//Tested to 3 times rated burn time?
-		ratedContinuousBurnTime = 250
+		testedBurnTime = 750		//Tested to 3 times rated burn time?
+		ratedBurnTime = 250
 		safeOverburn = true
 		ignitionReliabilityStart = 0.937870
 		ignitionReliabilityEnd = 0.987574
@@ -190,8 +190,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0110
-		ratedBurnTime = 750		//Tested to 3 times rated burn time?
-		ratedContinuousBurnTime = 250
+		testedBurnTime = 750		//Tested to 3 times rated burn time?
+		ratedBurnTime = 250
 		safeOverburn = true
 		ignitionReliabilityStart = 0.984362
 		ignitionReliabilityEnd = 0.996872

--- a/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
@@ -146,8 +146,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0120
-		ratedBurnTime = 1670		//Rated to 1670 seconds
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 1670		//Rated to 1670 seconds
+		ratedBurnTime = 600
 		overburnPenalty = 1.25
 		safeOverburn = true
 		ignitionReliabilityStart = 0.888889
@@ -164,8 +164,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0120M
-		ratedBurnTime = 1670		//Rated to 1670 seconds
-		ratedContinuousBurnTime = 600
+		testedBurnTime = 1670		//Rated to 1670 seconds
+		ratedBurnTime = 600
 		overburnPenalty = 1.25
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9

--- a/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
@@ -119,8 +119,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0124
-		ratedBurnTime = 900		//Tested to 3 times rated burn time?
-		ratedContinuousBurnTime = 300
+		testedBurnTime = 900		//Tested to 3 times rated burn time?
+		ratedBurnTime = 300
 		safeOverburn = true
 		ignitionReliabilityStart = 0.983607
 		ignitionReliabilityEnd = 0.996721

--- a/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
@@ -148,8 +148,8 @@
 	{
 		name = RD-0146
 		//Copied from RL10A-4-1-2
-		ratedBurnTime = 3600
-		ratedContinuousBurnTime = 1100
+		testedBurnTime = 3600
+		ratedBurnTime = 1100
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995
@@ -169,8 +169,8 @@
 	{
 		name = RD-0146D
 		//Copied from RL10A-4-1-2
-		ratedBurnTime = 3600
-		ratedContinuousBurnTime = 1100
+		testedBurnTime = 3600
+		ratedBurnTime = 1100
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9995

--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -172,8 +172,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0208
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 450
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.937500
 		ignitionReliabilityEnd = 0.987500
@@ -209,8 +209,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0210
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 238
+		testedBurnTime = 450
+		ratedBurnTime = 238
 		safeOverburn = true
 		ignitionReliabilityStart = 0.992063
 		ignitionReliabilityEnd = 0.998413

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -133,8 +133,8 @@
 	TESTFLIGHT
 	{
 		name = RD-0212
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 250
+		testedBurnTime = 450
+		ratedBurnTime = 250
 		safeOverburn = true
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633

--- a/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
@@ -110,8 +110,8 @@
 	{
 		name = RD-0213
 		//Copied from RD-0212
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 250
+		testedBurnTime = 450
+		ratedBurnTime = 250
 		safeOverburn = true
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -91,8 +91,8 @@
 	{
 		name = RD-0214
 		//Copied from RD-0212
-		ratedBurnTime = 450
-		ratedContinuousBurnTime = 300
+		testedBurnTime = 450
+		ratedBurnTime = 300
 		safeOverburn = true
 		ignitionReliabilityStart = 0.983165
 		ignitionReliabilityEnd = 0.996633

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -737,8 +737,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.915385
 		ignitionReliabilityEnd = 0.983077
@@ -759,8 +759,8 @@
 	TESTFLIGHT
 	{	
 		name = RD-107-8D74PS
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
@@ -781,8 +781,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D76
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
@@ -803,8 +803,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74-1958
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.938462
 		ignitionReliabilityEnd = 0.987692
@@ -824,8 +824,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74-1959
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
@@ -846,8 +846,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D74K
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.999410
 		ignitionReliabilityEnd = 0.999882
@@ -872,8 +872,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-8D728
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.999286
 		ignitionReliabilityEnd = 0.999857
@@ -893,8 +893,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-11D511
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.999227
 		ignitionReliabilityEnd = 0.999845
@@ -914,8 +914,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107-11D511P
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.997230
 		ignitionReliabilityEnd = 0.999446
@@ -937,8 +937,8 @@
 	TESTFLIGHT
 	{
 		name = RD-107A-14D22
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.997732
 		ignitionReliabilityEnd = 0.999546

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -748,8 +748,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.915385
 		ignitionReliabilityEnd = 0.983077
@@ -769,8 +769,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75PS
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.909091
 		ignitionReliabilityEnd = 0.981818
@@ -790,8 +790,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D77
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.900000
 		ignitionReliabilityEnd = 0.980000
@@ -810,8 +810,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75-1958
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.938462
 		ignitionReliabilityEnd = 0.987692
@@ -829,8 +829,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75-1959
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.984848
 		ignitionReliabilityEnd = 0.996970
@@ -849,8 +849,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D75K
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.999410
 		ignitionReliabilityEnd = 0.999882
@@ -873,8 +873,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-8D727
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.999286
 		ignitionReliabilityEnd = 0.999857
@@ -892,8 +892,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-11D512
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.999227
 		ignitionReliabilityEnd = 0.999845
@@ -911,8 +911,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108-11D512P
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.997230
 		ignitionReliabilityEnd = 0.999446
@@ -932,8 +932,8 @@
 	TESTFLIGHT
 	{
 		name = RD-108A-14D21
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 340
+		testedBurnTime = 400
+		ratedBurnTime = 340
 		safeOverburn = true
 		ignitionReliabilityStart = 0.997732
 		ignitionReliabilityEnd = 0.999546

--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -153,8 +153,8 @@
 	TESTFLIGHT
 	{
 		name = RD-109-8D711
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 330
+		testedBurnTime = 400
+		ratedBurnTime = 330
 		safeOverburn = true
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.95
@@ -172,8 +172,8 @@
 	TESTFLIGHT
 	{
 		name = RD-119-8D710
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 260
+		testedBurnTime = 400
+		ratedBurnTime = 260
 		safeOverburn = true
 		ignitionReliabilityStart = 0.952000
 		ignitionReliabilityEnd = 0.990400

--- a/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
@@ -245,8 +245,8 @@
 	TESTFLIGHT
 	{
 		name = RD-120
-		ratedBurnTime = 2200
-		ratedContinuousBurnTime = 290		//Only burned for ~300s, but rated for 2200s
+		testedBurnTime = 2200
+		ratedBurnTime = 290		//Only burned for ~300s, but rated for 2200s
 		safeOverburn = true
 		ignitionReliabilityStart = 0.986111
 		ignitionReliabilityEnd = 0.997222
@@ -262,8 +262,8 @@
 	TESTFLIGHT
 	{
 		name = RD-120K
-		ratedBurnTime = 2200
-		ratedContinuousBurnTime = 305
+		testedBurnTime = 2200
+		ratedBurnTime = 305
 		safeOverburn = true
 		ignitionReliabilityStart = 0.92		//not much is known about this
 		ignitionReliabilityEnd = 0.99
@@ -286,8 +286,8 @@
 	TESTFLIGHT
 	{
 		name = RD-120F
-		ratedBurnTime = 2200
-		ratedContinuousBurnTime = 290
+		testedBurnTime = 2200
+		ratedBurnTime = 290
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988764
 		ignitionReliabilityEnd = 0.997753

--- a/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
@@ -273,8 +273,8 @@
 	TESTFLIGHT
 	{
 		name = RD-170
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 150
 		safeOverburn = true
 		overburnPenalty = 1.5		//intended to be reused on later energia versions, but capability was never realized
 		ignitionReliabilityStart = 0.888889
@@ -293,8 +293,8 @@
 	TESTFLIGHT
 	{
 		name = RD-171
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 150
 		safeOverburn = true
 		overburnPenalty = 1.5		//intended to be reused on later energia versions, but capability was never realized
 		ignitionReliabilityStart = 0.944444
@@ -312,8 +312,8 @@
 	TESTFLIGHT
 	{
 		name = RD-172-173
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 150
 		safeOverburn = true
 		overburnPenalty = 1.5		//intended to be reused on later energia versions, but capability was never realized
 		ignitionReliabilityStart = 0.9625
@@ -332,8 +332,8 @@
 	TESTFLIGHT
 	{
 		name = RD-171M
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 150
 		safeOverburn = true
 		overburnPenalty = 1.5		//intended to be reused on later energia versions, but capability was never realized
 		ignitionReliabilityStart = 0.979592

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -119,8 +119,8 @@
 	TESTFLIGHT
 	{
 		name = RD-180
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 255
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 255
 		safeOverburn = true
 		overburnPenalty = 1.5
 		ignitionReliabilityStart = 0.988889

--- a/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
@@ -260,8 +260,8 @@
 	{
 		name = RD-191
 		//Copied from RD-180
-		ratedBurnTime = 255
-		ratedContinuousBurnTime = 1590		//tested up to 1590 seconds
+		testedBurnTime = 255
+		ratedBurnTime = 1590		//tested up to 1590 seconds
 		safeOverburn = true
 		overburnPenalty = 1.5
 		ignitionReliabilityStart = 0.988889
@@ -280,8 +280,8 @@
 	{
 		name = RD-151
 		//Copied from RD-180
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 255
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 255
 		safeOverburn = true
 		overburnPenalty = 1.5
 		ignitionReliabilityStart = 0.988889
@@ -302,8 +302,8 @@
 	{
 		name = RD-181
 		//Copied from RD-180
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 255
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 255
 		safeOverburn = true
 		overburnPenalty = 1.5
 		ignitionReliabilityStart = 0.988889
@@ -322,8 +322,8 @@
 	{
 		name = RD-193
 		//Copied from RD-180
-		ratedBurnTime = 1590		//tested up to 1590 seconds
-		ratedContinuousBurnTime = 255
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 255
 		safeOverburn = true
 		overburnPenalty = 1.5
 		ignitionReliabilityStart = 0.988889

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -373,8 +373,8 @@
 	TESTFLIGHT
 	{
 		name = RD-211-8D57
-		ratedBurnTime = 400		//same as RD107/108
-		ratedContinuousBurnTime = 122
+		testedBurnTime = 400		//same as RD107/108
+		ratedBurnTime = 122
 		safeOverburn = true
 		ignitionReliabilityStart = 0.85
 		ignitionReliabilityEnd = 0.94
@@ -391,8 +391,8 @@
 	TESTFLIGHT
 	{
 		name = RD-212-8D41
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 100
+		testedBurnTime = 400
+		ratedBurnTime = 100
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
@@ -409,8 +409,8 @@
 	TESTFLIGHT
 	{
 		name = RD-213-8D13
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 110
+		testedBurnTime = 400
+		ratedBurnTime = 110
 		safeOverburn = true
 		ignitionReliabilityStart = 0.87
 		ignitionReliabilityEnd = 0.93
@@ -427,8 +427,8 @@
 	TESTFLIGHT
 	{
 		name = RD-214-8D59
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.942308
 		ignitionReliabilityEnd = 0.988462
@@ -449,8 +449,8 @@
 	TESTFLIGHT
 	{
 		name = RD-214U-8D59U
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.945455
 		ignitionReliabilityEnd = 0.989091

--- a/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
@@ -367,8 +367,8 @@
 	TESTFLIGHT
 	{
 		name = RD-215-8D513
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 146
+		testedBurnTime = 400
+		ratedBurnTime = 146
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.96
@@ -387,8 +387,8 @@
 	TESTFLIGHT
 	{
 		name = RD-217-8D515
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 90
+		testedBurnTime = 400
+		ratedBurnTime = 90
 		safeOverburn = true
 		ignitionReliabilityStart = 0.891667
 		ignitionReliabilityEnd = 0.978333
@@ -407,8 +407,8 @@
 	TESTFLIGHT
 	{
 		name = RD-225-8D721
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 120
+		testedBurnTime = 400
+		ratedBurnTime = 120
 		safeOverburn = true
 		ignitionReliabilityStart = 0.928
 		ignitionReliabilityEnd = 0.998
@@ -428,8 +428,8 @@
 	TESTFLIGHT
 	{
 		name = RD-215M-8D613
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 146
+		testedBurnTime = 400
+		ratedBurnTime = 146
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995506
 		ignitionReliabilityEnd = 0.999101
@@ -453,8 +453,8 @@
 	TESTFLIGHT
 	{
 		name = RD-250-8D518
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 120
+		testedBurnTime = 400
+		ratedBurnTime = 120
 		safeOverburn = true
 		ignitionReliabilityStart = 0.992701
 		ignitionReliabilityEnd = 0.998540
@@ -474,8 +474,8 @@
 	TESTFLIGHT
 	{
 		name = RD-250PM
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 120
+		testedBurnTime = 400
+		ratedBurnTime = 120
 		safeOverburn = true
 		ignitionReliabilityStart = 0.997268
 		ignitionReliabilityEnd = 0.999454

--- a/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
@@ -208,8 +208,8 @@
 	TESTFLIGHT
 	{
 		name = RD-219-8D713
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 125
+		testedBurnTime = 400
+		ratedBurnTime = 125
 		safeOverburn = true
 		ignitionReliabilityStart = 0.980769
 		ignitionReliabilityEnd = 0.996154
@@ -228,8 +228,8 @@
 	TESTFLIGHT
 	{
 		name = RD-252-8D724
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 160
+		testedBurnTime = 400
+		ratedBurnTime = 160
 		safeOverburn = true
 		ignitionReliabilityStart = 0.985401
 		ignitionReliabilityEnd = 0.997080
@@ -247,8 +247,8 @@
 	TESTFLIGHT
 	{
 		name = RD-262-11D26
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 160
+		testedBurnTime = 400
+		ratedBurnTime = 160
 		safeOverburn = true
 		ignitionReliabilityStart = 0.991803
 		ignitionReliabilityEnd = 0.998361

--- a/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
@@ -365,8 +365,8 @@
 	TESTFLIGHT
 	{
 		name = RD-253
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 148
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 148
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
@@ -384,8 +384,8 @@
 	TESTFLIGHT
 	{
 		name = RD-253-Mk2
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 148
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 148
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
@@ -404,8 +404,8 @@
 	TESTFLIGHT
 	{
 		name = RD-253-Mk3
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 148
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 148
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
@@ -424,8 +424,8 @@
 	TESTFLIGHT
 	{
 		name = RD-253-Mk4
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 148
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 148
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143
@@ -447,8 +447,8 @@
 	TESTFLIGHT
 	{
 		name = RD-275
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 129
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 129
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995261
 		ignitionReliabilityEnd = 0.999052
@@ -471,8 +471,8 @@
 	TESTFLIGHT
 	{
 		name = RD-275M
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 129
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 129
 		safeOverburn = true
 		ignitionReliabilityStart = 0.997753
 		ignitionReliabilityEnd = 0.999551

--- a/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
@@ -100,8 +100,8 @@
 	TESTFLIGHT
 	{
 		name = RD-270M
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 148
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 148
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143

--- a/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
@@ -101,8 +101,8 @@
 	TESTFLIGHT
 	{
 		name = RD-270
-		ratedBurnTime = 450		//same as Proton Uppers
-		ratedContinuousBurnTime = 148
+		testedBurnTime = 450		//same as Proton Uppers
+		ratedBurnTime = 148
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995713
 		ignitionReliabilityEnd = 0.999143

--- a/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
@@ -151,8 +151,8 @@
 	{
 		name = RD-57
 		//Never flew, guess based on performance of similar KVD-1/RD-56
-		ratedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56/57 overall reliability was poor. Give double time
-		ratedContinuousBurnTime = 800
+		testedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56/57 overall reliability was poor. Give double time
+		ratedBurnTime = 800
 		safeOverburn = true
 		ignitionReliabilityStart = 0.875000
 		ignitionReliabilityEnd = 0.975000
@@ -169,8 +169,8 @@
 	{
 		name = RD-57M
 		//Never flew, guess based on performance of similar KVD-1/RD-56
-		ratedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56/57 overall reliability was poor. Give double time
-		ratedContinuousBurnTime = 800
+		testedBurnTime = 1600		//Hydrogen engines tend to be very tolerant of overburns, but RD-56/57 overall reliability was poor. Give double time
+		ratedBurnTime = 800
 		safeOverburn = true
 		ignitionReliabilityStart = 0.928571
 		ignitionReliabilityEnd = 0.985714

--- a/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
@@ -100,8 +100,8 @@
 	{
 		name = RD-855
 		//Copied from RD-250
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 127
+		testedBurnTime = 400
+		ratedBurnTime = 127
 		safeOverburn = true
 		ignitionReliabilityStart = 0.992701
 		ignitionReliabilityEnd = 0.998540

--- a/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
@@ -121,8 +121,8 @@
 	TESTFLIGHT
 	{
 		name = RD-856
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 163
+		testedBurnTime = 400
+		ratedBurnTime = 163
 		safeOverburn = true
 		ignitionReliabilityStart = 0.985401
 		ignitionReliabilityEnd = 0.997080

--- a/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
@@ -131,8 +131,8 @@
 	TESTFLIGHT
 	{
 		name = RD-8
-		ratedBurnTime = 2200		//Same as RD-120
-		ratedContinuousBurnTime = 1100
+		testedBurnTime = 2200		//Same as RD-120
+		ratedBurnTime = 1100
 		safeOverburn = true
 		ignitionReliabilityStart = 0.970588
 		ignitionReliabilityEnd = 0.994118

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -884,8 +884,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-1
-		ratedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
-		ratedContinuousBurnTime = 430
+		testedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
+		ratedBurnTime = 430
 		safeOverburn = true
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
@@ -904,8 +904,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-1
-		ratedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
-		ratedContinuousBurnTime = 470
+		testedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
+		ratedBurnTime = 470
 		safeOverburn = true
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
@@ -932,8 +932,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3
-		ratedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
-		ratedContinuousBurnTime = 470
+		testedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
+		ratedBurnTime = 470
 		safeOverburn = true
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
@@ -954,8 +954,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3-Lunex
-		ratedBurnTime = 1680		//RL10s tested to 28 minites (only limited by test stand propellant tanks)
-		ratedContinuousBurnTime = 620 //Longer burn time to account for throttling
+		testedBurnTime = 1680		//RL10s tested to 28 minites (only limited by test stand propellant tanks)
+		ratedBurnTime = 620 //Longer burn time to account for throttling
 		safeOverburn = true
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936
@@ -980,8 +980,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3A
-		ratedBurnTime = 1680		//RL10s tested to 28 minites (only limited by test stand propellant tanks)
-		ratedContinuousBurnTime = 620
+		testedBurnTime = 1680		//RL10s tested to 28 minites (only limited by test stand propellant tanks)
+		ratedBurnTime = 620
 		safeOverburn = true
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
@@ -1005,8 +1005,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4
-		ratedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedContinuousBurnTime = 392
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 392
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995305
 		ignitionReliabilityEnd = 0.999061
@@ -1040,8 +1040,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4-1-2
-		ratedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedContinuousBurnTime = 850
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 850
 		safeOverburn = true
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
@@ -1060,8 +1060,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-4-2N
-		ratedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedContinuousBurnTime = 850
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 850
 		safeOverburn = true
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
@@ -1084,8 +1084,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-5
-		ratedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedContinuousBurnTime = 430
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 430
 		safeOverburn = true
 		ignitionReliabilityStart = 0.977273
 		ignitionReliabilityEnd = 0.995455
@@ -1115,8 +1115,8 @@
 	TESTFLIGHT
 	{
 		name = RL10B-2
-		ratedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedContinuousBurnTime = 1130
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 1130
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988235
 		ignitionReliabilityEnd = 0.997647
@@ -1146,8 +1146,8 @@
 	TESTFLIGHT
 	{
 		name = RL10C-1
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1130 //is modified RL10B-2
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1130 //is modified RL10B-2
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
@@ -1168,8 +1168,8 @@
 	TESTFLIGHT
 	{
 		name = RL10C-1-1
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1200 //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1200 //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
@@ -1190,8 +1190,8 @@
 	TESTFLIGHT
 	{
 		name = RL10C-2-1
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1130 //is modified RL10B-2
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1130 //is modified RL10B-2
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
@@ -1212,8 +1212,8 @@
 	TESTFLIGHT
 	{
 		name = RL10C-3
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
@@ -1232,8 +1232,8 @@
 	TESTFLIGHT
 	{
 		name = CECE-Base
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1200
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1200
 		safeOverburn = true
 		overburnPenalty = 1		//actually theoretically designed for burns of this length, so don't penalize
 		ignitionReliabilityStart = 0.99975
@@ -1253,8 +1253,8 @@
 	TESTFLIGHT
 	{
 		name = CECE-High
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1200
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1200
 		safeOverburn = true
 		overburnPenalty = 1		//actually theoretically designed for burns of this length, so don't penalize
 		ignitionReliabilityStart = 0.99975
@@ -1274,8 +1274,8 @@
 	TESTFLIGHT
 	{
 		name = CECE-Methane
-		ratedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedContinuousBurnTime = 1200
+		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+		ratedBurnTime = 1200
 		safeOverburn = true
 		overburnPenalty = 1		//actually theoretically designed for burns of this length, so don't penalize
 		ignitionReliabilityStart = 0.99975

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -351,8 +351,8 @@
 	TESTFLIGHT
 	{
 		name = RS-68K
-		ratedBurnTime = 2500		//Hydrolox and fairly understressed
-		ratedContinuousBurnTime = 450		//burntime increase due to regen cooled nozzle
+		testedBurnTime = 2500		//Hydrolox and fairly understressed
+		ratedBurnTime = 450		//burntime increase due to regen cooled nozzle
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
@@ -368,8 +368,8 @@
 	TESTFLIGHT
 	{
 		name = RS-800
-		ratedBurnTime = 2500		//Hydrolox and fairly understressed
-		ratedContinuousBurnTime = 450
+		testedBurnTime = 2500		//Hydrolox and fairly understressed
+		ratedBurnTime = 450
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -152,8 +152,8 @@
 	TESTFLIGHT
 	{
 		name = RZ20-Mk1
-		ratedBurnTime = 1680		//Same as RL10
-		ratedContinuousBurnTime = 470
+		testedBurnTime = 1680		//Same as RL10
+		ratedBurnTime = 470
 		safeOverburn = true
 		ignitionReliabilityStart = 0.933333
 		ignitionReliabilityEnd = 0.986667
@@ -171,8 +171,8 @@
 	TESTFLIGHT
 	{
 		name = RZ20-Mk2
-		ratedBurnTime = 1680		//same as RL10
-		ratedContinuousBurnTime = 470
+		testedBurnTime = 1680		//same as RL10
+		ratedBurnTime = 470
 		safeOverburn = true
 		ignitionReliabilityStart = 0.994681
 		ignitionReliabilityEnd = 0.998936

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -241,8 +241,8 @@
 	TESTFLIGHT
 	{
 		name = RZ.1
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 156
+		testedBurnTime = 350
+		ratedBurnTime = 156
 		safeOverburn = true
 		ignitionReliabilityStart = 0.833333
 		ignitionReliabilityEnd = 0.966667
@@ -260,8 +260,8 @@
 	{
 
 		name = RZ.2-Mk3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 156
+		testedBurnTime = 350
+		ratedBurnTime = 156
 		safeOverburn = true
 		ignitionReliabilityStart = 0.888889
 		ignitionReliabilityEnd = 0.977778
@@ -278,8 +278,8 @@
 	TESTFLIGHT
 	{
 		name = RZ.2-Mk4
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 156
+		testedBurnTime = 350
+		ratedBurnTime = 156
 		safeOverburn = true
 		ignitionReliabilityStart = 0.923077
 		ignitionReliabilityEnd = 0.984615

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -118,8 +118,8 @@
 	{
 		name = Rutherford-SL
 		//Simple and reliable engine, all failures due to other parts
-		ratedBurnTime = 300
-		ratedContinuousBurnTime = 150
+		testedBurnTime = 300
+		ratedBurnTime = 150
 		safeOverburn = true
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -116,8 +116,8 @@
 	{
 		name = RutherfordVac
 		//Simple and reliable engine, all failures due to other parts
-		ratedBurnTime = 300
-		ratedContinuousBurnTime = 288
+		testedBurnTime = 300
+		ratedBurnTime = 288
 		safeOverburn = true
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165

--- a/GameData/RealismOverhaul/Engine_Configs/S155.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S155.cfg
@@ -92,8 +92,8 @@
 	TESTFLIGHT
 	{
 		name = S-155
-		ratedBurnTime = 3600		//intended to be used operationally
-		ratedContinuousBurnTime = 1200	//Ye-50/3 contained 20 minutes of fuel
+		testedBurnTime = 3600		//intended to be used operationally
+		ratedBurnTime = 1200	//Ye-50/3 contained 20 minutes of fuel
 		safeOverburn = true
 		overburnPenalty = 1		//No penalty
 		ignitionReliabilityStart = 0.857143

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -246,8 +246,8 @@
 	TESTFLIGHT
 	{
 		name = RS-25
-		ratedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
-		ratedContinuousBurnTime = 480
+		testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+		ratedBurnTime = 480
 		overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 		safeOverburn = true
 		ignitionReliabilityStart = 0.966667
@@ -265,8 +265,8 @@
 	TESTFLIGHT
 	{
 		name = RS-25A
-		ratedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
-		ratedContinuousBurnTime = 480
+		testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+		ratedBurnTime = 480
 		overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 		safeOverburn = true
 		ignitionReliabilityStart = 0.984127
@@ -285,8 +285,8 @@
 	TESTFLIGHT
 	{
 		name = RS-25C
-		ratedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
-		ratedContinuousBurnTime = 480
+		testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+		ratedBurnTime = 480
 		overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 		safeOverburn = true
 		ignitionReliabilityStart = 0.979592
@@ -305,8 +305,8 @@
 	TESTFLIGHT
 	{
 		name = RS-25D-E
-		ratedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
-		ratedContinuousBurnTime = 480
+		testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+		ratedBurnTime = 480
 		overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 		safeOverburn = true
 		ignitionReliabilityStart = 0.989362

--- a/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
@@ -107,8 +107,8 @@
 	TESTFLIGHT
 	{
 		name = Stentor
-		ratedBurnTime = 330
-		ratedContinuousBurnTime = 60		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		testedBurnTime = 330
+		ratedBurnTime = 60		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
 		safeOverburn = true
 
 		ignitionReliabilityStart = 0.931034

--- a/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
@@ -247,8 +247,8 @@
 	TESTFLIGHT
 	{
 		name = Vikas-1
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 154
+		testedBurnTime = 400
+		ratedBurnTime = 154
 		safeOverburn = true
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
@@ -262,8 +262,8 @@
 	TESTFLIGHT
 	{
 		name = Vikas-1+
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 154
+		testedBurnTime = 400
+		ratedBurnTime = 154
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9965
@@ -278,8 +278,8 @@
 	TESTFLIGHT
 	{
 		name = Vikas-2
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 133
+		testedBurnTime = 400
+		ratedBurnTime = 133
 		safeOverburn = true
 		ignitionReliabilityStart = 0.95
 		ignitionReliabilityEnd = 0.98
@@ -293,8 +293,8 @@
 	TESTFLIGHT
 	{
 		name = Vikas-2B
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 140
+		testedBurnTime = 400
+		ratedBurnTime = 140
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.9965

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -429,8 +429,8 @@
 	{
 		//10 1st stage successes, 1 failure. 43 engines succeeded, 1 failed
 		name = Viking-2
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 145
+		testedBurnTime = 400
+		ratedBurnTime = 145
 		safeOverburn = true
 		ignitionReliabilityStart = 0.97
 		ignitionReliabilityEnd = 0.995
@@ -446,8 +446,8 @@
 	{
 		//9 2nd stage successes, 0 failure. 9 engines succeeded, 0 failed
 		name = Viking-4
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 132
+		testedBurnTime = 400
+		ratedBurnTime = 132
 		safeOverburn = true
 		ignitionReliabilityStart = 0.9
 		ignitionReliabilityEnd = 0.98
@@ -464,8 +464,8 @@
 		//Ariane 2: 6 1st stage successes, 0 failure. 24 engines succeeded, 0 failed
 		//Ariane 3: 11 1st stage successes, 0 failure. 44 engines succeeded, 0 failed
 		name = Viking-2B
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 205
+		testedBurnTime = 400
+		ratedBurnTime = 205
 		safeOverburn = true
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.997
@@ -483,8 +483,8 @@
 		//Ariane 3: 11 2nd stage successes, 0 failure. 11 engines succeeded, 0 failed
 		//Ariane 4: 115 2nd stage successes, 0 failures. 115 engines succeeded, 0 failed
 		name = Viking-4B
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 125
+		testedBurnTime = 400
+		ratedBurnTime = 125
 		safeOverburn = true
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.998
@@ -500,8 +500,8 @@
 	{
 		//Ariane 4: 115 1st stage successes, 1 failures. 463 engines succeeded, 1 failed
 		name = Viking-5C
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 205
+		testedBurnTime = 400
+		ratedBurnTime = 205
 		safeOverburn = true
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999
@@ -517,8 +517,8 @@
 	{
 		//Ariane 4: 238 booster stage successes, 0 failures. 238 engines succeeded, 0 failed
 		name = Viking-6
-		ratedBurnTime = 400
-		ratedContinuousBurnTime = 142
+		testedBurnTime = 400
+		ratedBurnTime = 142
 		safeOverburn = true
 		ignitionReliabilityStart = 0.99
 		ignitionReliabilityEnd = 0.999

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -345,8 +345,8 @@
 	TESTFLIGHT
 	{
 		name = X-405
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 145
+		testedBurnTime = 350
+		ratedBurnTime = 145
 		safeOverburn = true
 		ignitionReliabilityStart = 0.70
 		ignitionReliabilityEnd = 0.90
@@ -361,8 +361,8 @@
 	TESTFLIGHT
 	{
 		name = X-405H
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 245
+		testedBurnTime = 350
+		ratedBurnTime = 245
 		safeOverburn = true
 		ignitionReliabilityStart = 0.80
 		ignitionReliabilityEnd = 0.94
@@ -378,8 +378,8 @@
 	{
 		// Copied from H-1.
 		name = X-405H-3
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 245
+		testedBurnTime = 350
+		ratedBurnTime = 245
 		safeOverburn = true
 		ignitionReliabilityStart = 0.89
 		ignitionReliabilityEnd = 0.97
@@ -395,8 +395,8 @@
 	{
 		// Copied from H-1b.
 		name = X-405H-4
-		ratedBurnTime = 350
-		ratedContinuousBurnTime = 245
+		testedBurnTime = 350
+		ratedBurnTime = 245
 		safeOverburn = true
 		ignitionReliabilityStart = 0.94
 		ignitionReliabilityEnd = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR43_Config.cfg
@@ -181,8 +181,8 @@
 	TESTFLIGHT
 	{
 		name = XLR43-NA-1
-		ratedBurnTime = 145		//same as NAA75-110. No longer, double walled design had heat issues
-		ratedContinuousBurnTime = 60
+		testedBurnTime = 145		//same as NAA75-110. No longer, double walled design had heat issues
+		ratedBurnTime = 60
 		safeOverburn = true
 		ignitionReliabilityStart = 0.70	//Broadly the same performance of Redstone, slightly worse because it was first large single chamber engine
 		ignitionReliabilityEnd = 0.90
@@ -198,8 +198,8 @@
 	TESTFLIGHT
 	{
 		name = XLR43-NA-3
-		ratedBurnTime = 200		//switched to spaghetti tube design, can probably safely make longer burns
-		ratedContinuousBurnTime = 65
+		testedBurnTime = 200		//switched to spaghetti tube design, can probably safely make longer burns
+		ratedBurnTime = 65
 		safeOverburn = true
 		ignitionReliabilityStart = 0.80
 		ignitionReliabilityEnd = 0.90

--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -68,14 +68,6 @@
 		&overburnPenalty = 2.0
 	}
 
-	// If we are not setting an explicit data rate,
-	// then we normalize it based on the burn time.
-	@TESTFLIGHT:HAS[~explicitDataRate[?rue]]
-	{
-		@reliabilityDataRateMultiplier *= 640 // normalized to rate=4 at 160s burntime
-		@reliabilityDataRateMultiplier /= #$ratedBurnTime$
-	}
-
 	// Now we create the actual curves for TestFlight.
 	@TESTFLIGHT,*
 	{
@@ -301,6 +293,14 @@
 	@TESTFLIGHT:HAS[~ratedContinuousBurnTime]
 	{
 		ratedContinuousBurnTime = #$ratedBurnTime$
+	}
+	
+	// If we are not setting an explicit data rate,
+	// then we normalize it based on the burn time.
+	@TESTFLIGHT:HAS[~explicitDataRate[?rue]]
+	{
+		@reliabilityDataRateMultiplier *= 640 // normalized to rate=4 at 160s burntime
+		@reliabilityDataRateMultiplier /= #$ratedContinuousBurnTime$
 	}
 
 	//create curve with gentle failure curve instead, for engines that can be safely overburned

--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -85,7 +85,7 @@
 		// multiplying by -1 and then adding 1 gives us
 		// the failure chance rather than the ignition chance.
 		// With that we multiply the failure chance by the
-		// cluter mult, then transform back.
+		// cluster mult, then transform back.
 		@ignitionReliabilityStart *= -1
 		@ignitionReliabilityStart += 1
 		@ignitionReliabilityStart *= #$clusterMultiplier$

--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -49,14 +49,6 @@
 		// Default value for ignition failure chance on additional ignitions
 		&additionalIgnitionFailureChance = 0.2
 
-		//Create placeholder flat curve for cont burn time. 3 keys needed?
-		&continuousCycle
-		{
-			key = 0 1
-			key = 1 1
-			key = 2 1
-		}
-
 		//Create placeholder flat curve
 		&restartWindowPenalty
 		{
@@ -66,6 +58,37 @@
 
 		//create placeholder
 		&overburnPenalty = 2.0
+		overburnContinuousPenalty = 100.0
+		cycleBurnTime = #$ratedBurnTime$
+	}
+	
+	// In this case we will have either a rated burn time or a tested burn time
+	// and two cycle curves, so the continuous cycle curve gets a lower penalty
+	@TESTFLIGHT:HAS[#safeOverburn[?rue]]
+	{
+		@overburnContinuousPenalty = #$overburnPenalty$
+	}
+	
+	// Compatibility with engines that define only ratedBurnTime
+	@TESTFLIGHT:HAS[~ratedContinuousBurnTime]
+	{
+		// default cycle curve -- might only need 1 key, but adding 3
+		cycle
+		{
+			key = 0 1
+			key = 1 1
+			key = 2 1
+		}
+		ratedContinuousBurnTime = #$ratedBurnTime$
+	}
+	
+	// If we have a tested burn time, we will use that for our cycle curve
+	// and (if only ratedBurnTime is specified) ratedBurnTime for
+	// our continuous cycle curve
+	@TESTFLIGHT:HAS[#testedBurnTime]
+	{
+		!cycle {}
+		@cycleBurnTime = #$testedBurnTime$
 	}
 
 	// Now we create the actual curves for TestFlight.
@@ -176,31 +199,7 @@
 			!key221 = DEL
 			!key222 = DEL
 		}
-		// Let's put the engine cycle curve magic in here, too.
-		cycle
-		{
-			key = 0.00 10.00
-			key = 5.00 1.00 -0.8 0
-
-			btPlus = #$../ratedBurnTime$
-			@btPlus += 5 // cushion
-			bt25 = #$../ratedBurnTime$
-			@bt25 *= 2.5
-			@bt25 += 5
-			timeDelta = #$bt25$
-			@timeDelta -= #$btPlus$
-			slope = 292.8
-			@slope /= #$timeDelta$
-
-			key = #$btPlus$ 1 0 0
-			key = #$bt25$ 100 $slope$ 0
-
-			!btPlus = DEL
-			!bt25 = DEL
-			!timeDelta = DEL
-			!slope = DEL
-		}
-		// Let's put the engine ignition curve magic in here, too.
+		
 		baseIgnitionChance
 		{
 			// Create first key
@@ -258,17 +257,15 @@
 			!key31 = DEL
 			!key32 = DEL
 		}
-	}
-
-	@TESTFLIGHT:HAS[#ratedContinuousBurnTime]
-	{
-		@continuousCycle
+		
+		// Apply the cycle curve. By default all engines have a continuousCycle curve
+		// because they all fire at least once.
+		// But some will also have a cycle curve, because they can reignite and have
+		// a rated burn time longer than their single-run time.
+		continuousCycle
 		{
-			//delete placeholder keys
-			!key,* = DEL
-
-			key = 0.00 1.00		//No ignition penalty, don't wanna overcharge
-			key = 1.00 1.00
+			key = 0.00 10.00
+			key = 5.00 1.00 -0.8 0
 
 			btPlus = #$../ratedContinuousBurnTime$
 			@btPlus += 5 // cushion
@@ -277,11 +274,14 @@
 			@bt25 += 5
 			timeDelta = #$bt25$
 			@timeDelta -= #$btPlus$
-			slope = 292.8
+			slope = 292.8 // good value for default (100)
 			@slope /= #$timeDelta$
+			// scale by actual penalty
+			@slope *= #$../overburnContinuousPenalty$
+			@slope /= 100
 
 			key = #$btPlus$ 1 0 0
-			key = #$bt25$ 100 $slope$ 0		//Keep the same 100x penalty, 2.5 times rated burn is still pretty generous
+			key = #$bt25$ $../overburnContinuousPenalty$ $slope$ 0
 
 			!btPlus = DEL
 			!bt25 = DEL
@@ -289,10 +289,31 @@
 			!slope = DEL
 		}
 	}
-	//Set ratedContinuousBurnTime to ratedBurnTime if it isn't explicitly set
-	@TESTFLIGHT:HAS[~ratedContinuousBurnTime]
+	
+	// If we don't have a cycle curve, that means we have both a ratedBurnTime *and*
+	// a ratedContinuousBurnTime. So we need to define both curves.
+	@TESTFLIGHT:HAS[!cycle[]]
 	{
-		ratedContinuousBurnTime = #$ratedBurnTime$
+		cycle
+		{
+			key = 0.00 1.00
+
+			btPlus = #$../cycleBurnTime$
+			bt25 = #$../cycleBurnTime$
+			@bt25 *= 2.5
+			timeDelta = #$bt25$
+			@timeDelta -= #$btPlus$
+			slope = 292.8
+			@slope /= #$timeDelta$
+
+			key = #$btPlus$ 1 0 0
+			key = #$bt25$ 100 $slope$ 0
+
+			!btPlus = DEL
+			!bt25 = DEL
+			!timeDelta = DEL
+			!slope = DEL
+		}
 	}
 	
 	// If we are not setting an explicit data rate,
@@ -301,39 +322,6 @@
 	{
 		@reliabilityDataRateMultiplier *= 640 // normalized to rate=4 at 160s burntime
 		@reliabilityDataRateMultiplier /= #$ratedContinuousBurnTime$
-	}
-
-	//create curve with gentle failure curve instead, for engines that can be safely overburned
-	//This can probably be done by just editing key indexes, but I don't know how to do that
-	@TESTFLIGHT:HAS[#safeOverburn[?rue]]
-	{
-		@cycle
-		{
-			//delete existing keys
-			!key,* = DEL
-
-			//Rerun, but with new key values
-			key = 0.00 10.00
-			key = 5.00 1.00 -0.8 0
-
-			btPlus = #$../ratedBurnTime$
-			@btPlus += 5 // cushion
-			bt25 = #$../ratedBurnTime$
-			@bt25 *= 2.5
-			@bt25 += 5
-			//timeDelta = #$bt25$		//cant get slope to cooperate, just use 0 for tangent
-			//@timeDelta -= #$btPlus$
-			//slope = 5.8
-			//@slope /= #$timeDelta$
-
-			key = #$btPlus$ 1 0 0
-			key = #$bt25$ $../overburnPenalty$ 0 0		//2 times penalty instead. continuousCycle will apply the big penalty instead
-
-			!btPlus = DEL
-			!bt25 = DEL
-			!timeDelta = DEL
-			!slope = DEL
-		}
 	}
 }
 


### PR DESCRIPTION
Redo the configurer to use ratedBurnTime, ratedContinuousBurnTime, and testedBurnTime. In normal use, leave ratedBurnTime as the stage burn time, and use testedBurnTime of the longer burn time for which the engine was tested. You must use safeOverburn=true in that case. Only for cases where an engine is used as a taxi engine with many relights during a single life cycle should the actual ratedBurnTime and ratedContinuousBurnTime keys in the TESTFLIGHT node be used.

Internally, what will be created are two curves, as before.