### PR TITLE
Rework TF cycle curve generation again

### DIFF
--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -233,7 +233,7 @@
 	//     engines whose full burn time is split across multiple small burns. In this case,
 	//     create a `cycle` curve as with (a) but also a `continuousCycle` curve with the
 	//     same rules (100 at 2.5x `ratedContinuousBurnTime`).
-	// (c) ``ratedBurnTime` and `testedBurnTime` are specified. This is for engines that have
+	// (c) `ratedBurnTime` and `testedBurnTime` are specified. This is for engines that have
 	//     been tested for a longer duration on the test stand than what they have been 'rated'
 	//     for. In this case, Create only a `cycle` curve, but use more keys. After the
 	//     (`ratedBurnTime` + 5, 1) point, the next point is (`testedBurnTime`, `overburnPenalty`).
@@ -349,7 +349,7 @@
 	// Create placeholder continuous curves for engines that don't have them. This would normally be
 	// done by TF (see https://github.com/KSP-RO/TestFlight/blob/c2a4fc999e827a6a8b98d9b2746d1bc9256d18c7/TestFlightReliability_EngineCycle.cs#L153-L172)
 	// but we need to do it ourselves here because we need to paste them in an `MM_PATCH_LOOP` later
-	// and there's no easy way to do so unconditionally.
+	// and there's no easy way to do so conditionally.
 	@TESTFLIGHT:HAS[~ratedContinuousBurnTime]
 	{
 		ratedContinuousBurnTime = #$ratedBurnTime$

--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -22,8 +22,7 @@
 		&name = TFGenericMissingName
 
 		// First, set the 'mainConfiguration' to be the name of the engine config we will bind to.
-		&mainConfiguration = #$name$:$name$__tfDefault
-		@mainConfiguration ^= :^(.+)__tfDefault$:engineConfig = $1:
+		&mainConfiguration = #engineConfig = $name$:$name$
 
 		// Set default parameters for the curve.
 		// TF configs generally have a "kink" in their du->reliability curve,
@@ -56,39 +55,8 @@
 			key = 1 1
 		}
 
-		//create placeholder
+		// Default overburn penalty. This is the value of the `cycle` curve at `testedBurnTime`.
 		&overburnPenalty = 2.0
-		overburnContinuousPenalty = 100.0
-		cycleBurnTime = #$ratedBurnTime$
-	}
-	
-	// In this case we will have either a rated burn time or a tested burn time
-	// and two cycle curves, so the continuous cycle curve gets a lower penalty
-	@TESTFLIGHT:HAS[#safeOverburn[?rue]]
-	{
-		@overburnContinuousPenalty = #$overburnPenalty$
-	}
-	
-	// Compatibility with engines that define only ratedBurnTime
-	@TESTFLIGHT:HAS[~ratedContinuousBurnTime]
-	{
-		// default cycle curve -- might only need 1 key, but adding 3
-		cycle
-		{
-			key = 0 1
-			key = 1 1
-			key = 2 1
-		}
-		ratedContinuousBurnTime = #$ratedBurnTime$
-	}
-	
-	// If we have a tested burn time, we will use that for our cycle curve
-	// and (if only ratedBurnTime is specified) ratedBurnTime for
-	// our continuous cycle curve
-	@TESTFLIGHT:HAS[#testedBurnTime]
-	{
-		!cycle {}
-		@cycleBurnTime = #$testedBurnTime$
 	}
 
 	// Now we create the actual curves for TestFlight.
@@ -142,7 +110,6 @@
 		@failChanceEnd += 1
 		@failChanceEnd /= #$ratedBurnTime$
 
-		// Let's put the reliability curve magic in here to simplify the iteration copies below.
 		reliabilityCurve
 		{
 			// Create first key
@@ -199,7 +166,7 @@
 			!key221 = DEL
 			!key222 = DEL
 		}
-		
+
 		baseIgnitionChance
 		{
 			// Create first key
@@ -257,65 +224,138 @@
 			!key31 = DEL
 			!key32 = DEL
 		}
-		
-		// Apply the cycle curve. By default all engines have a continuousCycle curve
-		// because they all fire at least once.
-		// But some will also have a cycle curve, because they can reignite and have
-		// a rated burn time longer than their single-run time.
-		continuousCycle
-		{
-			key = 0.00 10.00
-			key = 5.00 1.00 -0.8 0
-
-			btPlus = #$../ratedContinuousBurnTime$
-			@btPlus += 5 // cushion
-			bt25 = #$../ratedContinuousBurnTime$
-			@bt25 *= 2.5
-			@bt25 += 5
-			timeDelta = #$bt25$
-			@timeDelta -= #$btPlus$
-			slope = 292.8 // good value for default (100)
-			@slope /= #$timeDelta$
-			// scale by actual penalty
-			@slope *= #$../overburnContinuousPenalty$
-			@slope /= 100
-
-			key = #$btPlus$ 1 0 0
-			key = #$bt25$ $../overburnContinuousPenalty$ $slope$ 0
-
-			!btPlus = DEL
-			!bt25 = DEL
-			!timeDelta = DEL
-			!slope = DEL
-		}
 	}
-	
-	// If we don't have a cycle curve, that means we have both a ratedBurnTime *and*
-	// a ratedContinuousBurnTime. So we need to define both curves.
-	@TESTFLIGHT:HAS[!cycle[]]
+
+	// Generation of cycle curves. There are three cases:
+	// (a) Only `ratedBurnTime` is specified. This is the pre-TF v2.1 behavior (only a `cycle`
+	//     curve, 100 at 2.5x `ratedBurnTime`).
+	// (b) `ratedBurnTime` and `ratedContinuousBurnTime` are specified. This is for 'space taxi'
+	//     engines whose full burn time is split across multiple small burns. In this case,
+	//     create a `cycle` curve as with (a) but also a `continuousCycle` curve with the
+	//     same rules (100 at 2.5x `ratedContinuousBurnTime`).
+	// (c) ``ratedBurnTime` and `testedBurnTime` are specified. This is for engines that have
+	//     been tested for a longer duration on the test stand than what they have been 'rated'
+	//     for. In this case, Create only a `cycle` curve, but use more keys. After the
+	//     (`ratedBurnTime` + 5, 1) point, the next point is (`testedBurnTime`, `overburnPenalty`).
+	//     The in and out tangents (which are equal) on this point are set to provide a smooth
+	//     transition in failure chance from `ratedBurnTime` to `testedBurnTime`, and then to
+	//     complete failure at (2.5 x `testedBurnTime`, 100).
+	@TESTFLIGHT,*
 	{
 		cycle
 		{
-			key = 0.00 1.00
+			// Failure rate at start of burn.
+			key = 0.00 10.00
+			key = 5.00 1.00 -0.8 0
 
-			btPlus = #$../cycleBurnTime$
-			bt25 = #$../cycleBurnTime$
-			@bt25 *= 2.5
-			timeDelta = #$bt25$
-			@timeDelta -= #$btPlus$
-			slope = 292.8
-			@slope /= #$timeDelta$
+			// 5 seconds of overburn for free.
+			rbtCushioned = #$../ratedBurnTime$
+			@rbtCushioned += 5
+			key = #$rbtCushioned$ 1 0 0
 
-			key = #$btPlus$ 1 0 0
-			key = #$bt25$ 100 $slope$ 0
+			// Complete failure at 2.5x burn time.
+			failTime = #$../ratedBurnTime$
+			@failTime *= 2.5
+			rbtToFailInterval = #$failTime$
+			@rbtToFailInterval -= #$rbtCushioned$
+			failInSlope = 292.8 // Magic number.
+			@failInSlope /= #$rbtToFailInterval$
 
-			!btPlus = DEL
-			!bt25 = DEL
-			!timeDelta = DEL
-			!slope = DEL
+			key = #$failTime$ 100 $failInSlope$ 0
+
+			// Cleanup.
+			!rbtCushioned = DEL
+			!failTime = DEL
+			!rbtToFailInterval = DEL
+			!failInSlope = DEL
 		}
 	}
-	
+	@TESTFLIGHT:HAS[#ratedContinuousBurnTime]
+	{
+		continuousCycle
+		{
+			// Failure rate at start of burn.
+			key = 0.00 10.00
+			key = 5.00 1.00 -0.8 0
+
+			// 5 seconds of overburn for free.
+			rcbtCushioned = #$../ratedContinuousBurnTime$
+			@rcbtCushioned += 5
+			key = #$rcbtCushioned$ 1 0 0
+
+			// Complete failure at 2.5x burn time.
+			failTime = #$../ratedContinuousBurnTime$
+			@failTime *= 2.5
+			rcbtToFailInterval = #$failTime$
+			@rcbtToFailInterval -= #$rcbtCushioned$
+			failInSlope = 292.8 // Magic number.
+			@failInSlope /= #$rcbtToFailInterval$
+
+			key = #$failTime$ 100 $failInSlope$ 0
+
+			// Cleanup.
+			!rcbtCushioned = DEL
+			!failTime = DEL
+			!rcbtToFailInterval = DEL
+			!failInSlope = DEL
+		}
+	}
+	@TESTFLIGHT:HAS[#testedBurnTime]
+	{
+		@cycle
+		{
+			// Remove the original full failure point.
+			!key,3 = DEL
+
+			// Curve has value `overburnPenalty` at tested burn time, transition smoothly.
+			// No 5s cushion here.
+			ratedToTestedInterval = #$../testedBurnTime$
+			@ratedToTestedInterval -= #$key,2[0, ]$  // This key contains the cushioned rated burn time.
+			// Compute the slope at the tested burn time. The curve is made to be differentiable
+			// at this point, but the exact slope depends on the overburn penalty.
+			tbtTransitionSlope = 3.135 // Magic number, for an overburn penalty of 2.
+			@tbtTransitionSlope /= #$ratedToTestedInterval$
+			tbtTransitionSlopeMult = #$../overburnPenalty$
+			@tbtTransitionSlopeMult -= 1.0 // When overburn penalty is 1 the slope should be 0.
+			@tbtTransitionSlope *= #$tbtTransitionSlopeMult$
+			key = #$../testedBurnTime$ $../overburnPenalty$ $tbtTransitionSlope$ $tbtTransitionSlope$
+
+			// Fail at 2.5x tested burn time.
+			failTime = #$../testedBurnTime$
+			@failTime *= 2.5
+			tbtToFailInterval = #$failTime$
+			@tbtToFailInterval -= #$../testedBurnTime$
+			// Compute the in-tangent slope.
+			failInSlope = 1.989  // Magic number.
+			@failInSlope /= #$tbtToFailInterval$
+			// The end point of this segment of the curve is always 100, but the start point
+			// depends on the overburn penalty. Adjust accordingly.
+			failInSlopeMult = 100
+			@failInSlopeMult -= #$../overburnPenalty$
+			@failInSlope *= #$failInSlopeMult$
+			key = #$failTime$ 100 $failInSlope$ 0
+
+			// Cleanup.
+			!ratedToTestedInterval = DEL
+			!tbtTransitionSlope = DEL
+			!tbtTransitionSlopeMult = DEL
+			!failTime = DEL
+			!tbtToFailInterval = DEL
+			!failInSlope = DEL
+			!failInSlopeMult = DEL
+		}
+	}
+
+	// Create placeholder continuous curves for engines that don't have them. This would normally be
+	// done by TF (see https://github.com/KSP-RO/TestFlight/blob/c2a4fc999e827a6a8b98d9b2746d1bc9256d18c7/TestFlightReliability_EngineCycle.cs#L153-L172)
+	// but we need to do it ourselves here because we need to paste them in an `MM_PATCH_LOOP` later
+	// and there's no easy way to do so unconditionally.
+	@TESTFLIGHT:HAS[~ratedContinuousBurnTime]
+	{
+		ratedContinuousBurnTime = #$ratedBurnTime$
+		continuousCycle { key = 0 1 }
+	}
+
 	// If we are not setting an explicit data rate,
 	// then we normalize it based on the burn time.
 	@TESTFLIGHT:HAS[~explicitDataRate[?rue]]
@@ -377,6 +417,7 @@
 		configVersion = 2
 	}
 }
+
 
 // Iterate over each TESTFLIGHT node, appending new config data into each module.
 // Constant data gets patched in at the end.


### PR DESCRIPTION
Now, there are three cases:

1. Only `ratedBurnTime` is specified. This is the pre-TF v2.1 behavior (only a `cycle` curve, 100 at 2.5x `ratedBurnTime`).
2. `ratedBurnTime` and `ratedContinuousBurnTime` are specified. This is for 'space taxi' engines whose full burn time is split across multiple small burns. In this case, create a `cycle` curve as with (a) but also a `continuousCycle` curve with the same rules (100 at 2.5x `ratedContinuousBurnTime`).
3. `ratedBurnTime` and `testedBurnTime` are specified. This is for engines that have been tested for a longer duration on the test stand than what they have been 'rated' for. In this case, Create only a `cycle` curve, but use more keys. After the (`ratedBurnTime` + 5, 1) point, the next point is (`testedBurnTime`, `overburnPenalty`). The in and out tangents (which are equal) on this point are set to provide a smooth transition in failure chance from `ratedBurnTime` to `testedBurnTime`, and then to complete failure at (2.5x `testedBurnTime`, 100).

Example of `cycle` curve generated for case (3) (this is the RL-10A-1):

![image](https://user-images.githubusercontent.com/35266431/124360087-d01d8c80-dbf5-11eb-8e42-e92c15f29cee.png)

