### PR TITLE
Merge & Deprecate XLR43

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -476,7 +476,7 @@
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
 		cycleReliabilityEnd = 0.965217
-		techTransfer = XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
+		techTransfer = XLR43-NA-1,XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR43-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR43-NA-5]/ratedBurnTime$ } }
 }
@@ -496,7 +496,7 @@
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
-		techTransfer = XLR43-NA-3,LR43-NA-5:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-5:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-3]/ratedBurnTime$ } }
 }
@@ -533,7 +533,7 @@
 		ignitionReliabilityEnd = 0.991342
 		cycleReliabilityStart = 0.956710
 		cycleReliabilityEnd = 0.991342
-		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-5,LR105-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-5]/ratedBurnTime$ } }
 }
@@ -563,7 +563,7 @@
 		ignitionReliabilityEnd = 0.987879
 		cycleReliabilityStart = 0.939394
 		cycleReliabilityEnd = 0.987879
-		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-6] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-6]/ratedBurnTime$ } }
 }
@@ -581,7 +581,7 @@
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
-		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.1]/ratedBurnTime$ } }
 }
@@ -599,7 +599,7 @@
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
-		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6,LR105-NA-7.1:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6,LR105-NA-7.1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.2]/ratedBurnTime$ } }
 }
@@ -618,7 +618,7 @@
 		ignitionReliabilityEnd = 0.998947
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
-		techTransfer = XLR43-NA-3,LR43-NA-5,LR105-NA-5,LR105-NA-6,LR105-NA-7.1,LR105-NA-7.2,RS-27,RS-27A:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-5,LR105-NA-5,LR105-NA-6,LR105-NA-7.1,LR105-NA-7.2,RS-27,RS-27A:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-56-OSA] { %ratedBurnTime = #$/TESTFLIGHT[RS-56-OSA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -398,7 +398,7 @@
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
-		techTransfer = XLR43-NA-3:40	//Direct derivative of LR43
+		techTransfer = XLR43-NA-1,XLR43-NA-3:40	//Direct derivative of LR43
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[S-3] { %ratedBurnTime = #$/TESTFLIGHT[S-3]/ratedBurnTime$ } }
 }
@@ -418,7 +418,7 @@
 		ignitionReliabilityEnd = 0.976471
 		cycleReliabilityStart = 0.882353
 		cycleReliabilityEnd = 0.976471
-		techTransfer = XLR43-NA-3,S-3:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,S-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[S-3D] { %ratedBurnTime = #$/TESTFLIGHT[S-3D]/ratedBurnTime$ } }
 }
@@ -457,7 +457,7 @@
 		ignitionReliabilityEnd = 0.957955
 		cycleReliabilityStart = 0.789773
 		cycleReliabilityEnd = 0.957955
-		techTransfer = XLR43-NA-3,S-3,S-3D:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,S-3,S-3D:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-9] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-9]/ratedBurnTime$ } }
 }
@@ -484,7 +484,7 @@
 		ignitionReliabilityEnd = 0.987273
 		cycleReliabilityStart = 0.936364
 		cycleReliabilityEnd = 0.987273
-		techTransfer = XLR43-NA-3,S-3,S-3D,LR79-NA-9:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,S-3,S-3D,LR79-NA-9:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-11] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-11]/ratedBurnTime$ } }
 }
@@ -531,7 +531,7 @@
 		ignitionReliabilityEnd = 0.992929
 		cycleReliabilityStart = 0.964646
 		cycleReliabilityEnd = 0.992929
-		techTransfer = XLR43-NA-3,S-3,S-3D,LR79-NA-9,LR79-NA-11:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,S-3,S-3D,LR79-NA-9,LR79-NA-11:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-13] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-13]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -4,6 +4,21 @@
 //	Manufacturer: Rocketdyne
 //
 //	=================================================================================
+//	XLR43-NA-3
+//	Navaho Phase IV
+//
+//	Dry Mass: 489 Kg	//Without gimbal. Use half of XLR71 mass (567 kg) to estimate gimbal mass
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 617.4 kN
+//	ISP: 230 SL / 265 Vac
+//	Burn Time: 65
+//	Chamber Pressure: ??? MPa
+//	Propellant: LOX / Ethanol90
+//	Prop Ratio: 1.375
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
 //	LR43-NA-3
 //	MA-1, or MA-0 without the sustainer
 //
@@ -160,13 +175,50 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = False
-		configuration = LR43-NA-3
+		configuration = XLR43-NA-3
 		origMass = 0.72
 		literalZeroIgnitions = True
 		CONFIG
 		{
+			name = XLR43-NA-3
+			description = Uprated XLR43 for later Navaho applications. First US engine to use tubular wall, aka spaghetti, thrust chamber which greatly reduced weight. Also first to use a gas generator, removing the need for HTP to power the turbopump.
+			minThrust = 617.4
+			maxThrust = 617.4
+			massMult = 0.79
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = Ethanol90
+				ratio = 0.4945
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.5055
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 265
+				key = 1 230
+			}
+		}
+		CONFIG
+		{
 			name = LR43-NA-3
-			description = MA-0 and prototype MA-1 Atlas Booster engine. An XLR43 modified to burn kerosene. Used on Convair X12 and Atlas A
+			description = MA-0 and prototype MA-1 Atlas Booster engine, converted to burn kerosene. Used on Convair X12 and Atlas A
 			minThrust = 756.8
 			maxThrust = 756.8
 			heatProduction = 100
@@ -487,6 +539,25 @@
 }
 //Unfortunatly most sources do not differeciate Atlas booster from Atlas Sustainer (listing both as "first stage")
 //Since the sources that do differenciate between booster and sustainer show all 1st stage engines have a similar failure rate, the LR89s and LR105s use the same dataset
+//Navaho G-26 Booster: 11 flights, 6 failures (3 engine failures, incl one double failure)
+//22 engines flown, 4 failed
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR43-NA-3]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = XLR43-NA-3
+		testedBurnTime = 200		//switched to spaghetti tube design, can probably safely make longer burns
+		ratedBurnTime = 65
+		safeOverburn = true
+		ignitionReliabilityStart = 0.666667		//Very troublesome to start, < 3 attempts required for most launches
+		ignitionReliabilityEnd = 0.933333
+		cycleReliabilityStart = 0.818182
+		cycleReliabilityEnd = 0.963636
+		techTransfer = XLR41-NA-1,XLR43-NA-1,A-6,A-7,A-6H:50
+		}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR43-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[XLR43-NA-3]/ratedBurnTime$ } }
+}
+
 //XSM-65A: 8 flights, 5 failures (No sustainer)
 //XSM-65B: 9 flights, 3 failures
 //Atlas-B: 1 flight, 0 failures
@@ -503,7 +574,7 @@
 		ignitionReliabilityEnd = 0.965217
 		cycleReliabilityStart = 0.826087
 		cycleReliabilityEnd = 0.965217
-		techTransfer = XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
+		techTransfer = XLR43-NA-1,XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR43-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR43-NA-3]/ratedBurnTime$ } }
 }
@@ -522,7 +593,7 @@
 		ignitionReliabilityEnd = 0.966667
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
-		techTransfer = XLR43-NA-3,LR43-NA-3:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-3]/ratedBurnTime$ } }
 }
@@ -561,7 +632,7 @@
 		ignitionReliabilityEnd = 0.991342
 		cycleReliabilityStart = 0.956710
 		cycleReliabilityEnd = 0.991342
-		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-3,LR89-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-5]/ratedBurnTime$ } }
 }
@@ -593,7 +664,7 @@
 		ignitionReliabilityEnd = 0.987879
 		cycleReliabilityStart = 0.939394
 		cycleReliabilityEnd = 0.987879
-		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-6] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-6]/ratedBurnTime$ } }
 }
@@ -613,7 +684,7 @@
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
-		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-7.1]/ratedBurnTime$ } }
 }
@@ -633,7 +704,7 @@
 		ignitionReliabilityEnd = 0.996296
 		cycleReliabilityStart = 0.981481
 		cycleReliabilityEnd = 0.996296
-		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6,LR89-NA-7.1:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6,LR89-NA-7.1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-7.2]/ratedBurnTime$ } }
 }
@@ -654,7 +725,7 @@
 		ignitionReliabilityEnd = 0.998947
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
-		techTransfer = XLR43-NA-3,LR43-NA-3,LR89-NA-7.1,LR89-NA-7.2,RS-27,RS-27A:50
+		techTransfer = XLR43-NA-1,XLR43-NA-3,LR43-NA-3,LR89-NA-7.1,LR89-NA-7.2,RS-27,RS-27A:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-56-OBA] { %ratedBurnTime = #$/TESTFLIGHT[RS-56-OBA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -4,6 +4,21 @@
 //	Manufacturer: North American Aviation
 //
 //	=================================================================================
+//	XLR43-NA-1 aka NAA75-65
+//	Navaho
+//
+//	Dry Mass: 670 Kg
+//	Thrust (SL): 333.6 kN
+//	Thrust (Vac): 383 kN
+//	ISP: 216 SL / 248 Vac
+//	Burn Time: 65
+//	Chamber Pressure: 2.06 MPa
+//	Propellant: LOX / Ethanol75
+//	Prop Ratio: 1.354
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
 //	A-6
 //	Redstone
 //
@@ -108,6 +123,54 @@
 		configuration = A-6
 		origMass = 0.74
 		literalZeroIgnitions = True
+
+		CONFIG
+		{
+			name = XLR43-NA-1
+			description = Also known as NAA75-65, XLR43-NA-1 is the USAF service designation. Used for early Navaho applications.
+			maxEngineTemp = 3000
+			chamberNominalTemp = 2923
+			minThrust = 383
+			maxThrust = 383
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = Ethanol75
+				ratio = 0.5003
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4997
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.0175
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 248	
+				key = 1 216
+			}
+		}
 
 		CONFIG
 		{
@@ -257,6 +320,23 @@
 //	TestFlight compatibility.
 //	==================================================
 
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[XLR43-NA-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = XLR43-NA-1
+		testedBurnTime = 121		//same as NAA75-110. No longer, double walled design had heat issues
+		ratedBurnTime = 65
+		safeOverburn = true
+		ignitionReliabilityStart = 0.70	//Broadly the same performance of Redstone, slightly worse because it was first large single chamber engine
+		ignitionReliabilityEnd = 0.95 // a bit worse than production-variant A-6
+		cycleReliabilityStart = 0.75
+		cycleReliabilityEnd = 0.93
+		techTransfer = XLR41-NA-1:50			// A-4/V-2 derivative.
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR43-NA-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR43-NA-1]/ratedBurnTime$ } }
+}
+
 //Redstone R&D: 52 flights, 6 failures
 //Jupiter-A: 23 flights, 3 failures
 // 75 engines, 9 failed
@@ -270,7 +350,7 @@
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.77 // a bit higher than XLR43-NA-1
 		cycleReliabilityEnd = 0.94
-		techTransfer = XLR41-NA-1:30&XLR43-NA-1:50			// A-4/V-2 derivative. Modified XLR43-NA-1
+		techTransfer = XLR41-NA-1,XLR43-NA-1:50			// A-4/V-2 derivative. Modified XLR43-NA-1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[A-6] { %ratedBurnTime = #$/TESTFLIGHT[A-6]/ratedBurnTime$ } }
 }
@@ -288,7 +368,7 @@
 		ignitionReliabilityEnd = 0.977778
 		cycleReliabilityStart = 0.8
 		cycleReliabilityEnd = 0.977778
-		techTransfer = XLR41-NA-1:25&XLR43-NA-1,A-6,A-6H:50
+		techTransfer = XLR41-NA-1,XLR43-NA-1,A-6,A-6H:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[A-7] { %ratedBurnTime = #$/TESTFLIGHT[A-7]/ratedBurnTime$ } }
 }
@@ -307,7 +387,7 @@
 		ignitionReliabilityEnd = 0.968
 		cycleReliabilityStart = 0.77
 		cycleReliabilityEnd = 0.939
-		techTransfer = XLR41-NA-1:25&A-6,XLR43-NA-1:50
+		techTransfer = XLR41-NA-1,XLR43-NA-1,A-6:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[A-6H] { %ratedBurnTime = #$/TESTFLIGHT[A-6H]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -744,7 +744,7 @@
 		ignitionReliabilityEnd = 0.983077
 		cycleReliabilityStart = 0.915385
 		cycleReliabilityEnd = 0.983077
-		techTransfer = RD-200:25
+		techTransfer = RD-200:50
 		
 		reliabilityMidH = 0.6
 		reliabilityDataRateMultiplier = 0.4
@@ -766,7 +766,7 @@
 		ignitionReliabilityEnd = 0.981818
 		cycleReliabilityStart = 0.909091
 		cycleReliabilityEnd = 0.981818
-		techTransfer = RD-200:25&RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D74:50
 		
 		reliabilityMidH = 0.55
 		reliabilityDataRateMultiplier = 0.4
@@ -788,7 +788,7 @@
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
 		cycleReliabilityEnd = 0.980000
-		techTransfer = RD-200:25&RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -810,7 +810,7 @@
 		ignitionReliabilityEnd = 0.987692
 		cycleReliabilityStart = 0.938462
 		cycleReliabilityEnd = 0.987692
-		techTransfer = RD-200:25&RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -831,7 +831,7 @@
 		ignitionReliabilityEnd = 0.996970
 		cycleReliabilityStart = 0.984848
 		cycleReliabilityEnd = 0.996970
-		techTransfer = RD-200:25&RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -853,7 +853,7 @@
 		ignitionReliabilityEnd = 0.999882
 		cycleReliabilityStart = 0.999410
 		cycleReliabilityEnd = 0.999882
-		techTransfer = RD-200:25&RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -879,7 +879,7 @@
 		ignitionReliabilityEnd = 0.999857
 		cycleReliabilityStart = 0.999286
 		cycleReliabilityEnd = 0.999857
-		techTransfer = RD-200:25&RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -900,7 +900,7 @@
 		ignitionReliabilityEnd = 0.999845
 		cycleReliabilityStart = 0.999227
 		cycleReliabilityEnd = 0.999845
-		techTransfer = RD-200:25&RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -921,7 +921,7 @@
 		ignitionReliabilityEnd = 0.999446
 		cycleReliabilityStart = 0.997230
 		cycleReliabilityEnd = 0.999446
-		techTransfer = RD-200:25&RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -944,7 +944,7 @@
 		ignitionReliabilityEnd = 0.999546
 		cycleReliabilityStart = 0.997732
 		cycleReliabilityEnd = 0.999546
-		techTransfer = RD-200:25&RD-107-11D511P,RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-200,RD-107-11D511P,RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -740,7 +740,7 @@
 }
 
 //Unfortunatly most sources do not differeciate R-7 booster from R-7 Sustainer (listing both as "first stage")
-//Since the sources that do differenciate between booster and sustainer show all similar failure rate1, the RD107s and RD108s use the same dataset
+//Since the sources that do differenciate between booster and sustainer show all similar failure rate, the RD107s and RD108s use the same dataset
 //R-7 (R&D): 26 flights, 11 failures
 //130 engines, 11 failed
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-108-8D75]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]		
@@ -755,8 +755,7 @@
 		ignitionReliabilityEnd = 0.983077
 		cycleReliabilityStart = 0.915385
 		cycleReliabilityEnd = 0.983077
-		techTransfer = RD-200:25
-		
+		techTransfer = RD-200:50
 		reliabilityMidH = 0.6
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75]/ratedBurnTime$ } }
@@ -776,7 +775,7 @@
 		ignitionReliabilityEnd = 0.981818
 		cycleReliabilityStart = 0.909091
 		cycleReliabilityEnd = 0.981818
-		techTransfer = RD-200:25&RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D75:50
 		
 		reliabilityMidH = 0.55
 	}
@@ -797,7 +796,7 @@
 		ignitionReliabilityEnd = 0.980000
 		cycleReliabilityStart = 0.900000
 		cycleReliabilityEnd = 0.980000
-		techTransfer = RD-200:25&RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D77] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D77]/ratedBurnTime$ } }
 }
@@ -817,7 +816,7 @@
 		ignitionReliabilityEnd = 0.987692
 		cycleReliabilityStart = 0.938462
 		cycleReliabilityEnd = 0.987692
-		techTransfer = RD-200:25&RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75-1958] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75-1958]/ratedBurnTime$ } }
 }
@@ -836,7 +835,7 @@
 		ignitionReliabilityEnd = 0.996970
 		cycleReliabilityStart = 0.984848
 		cycleReliabilityEnd = 0.996970
-		techTransfer = RD-200:25&RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75-1959] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75-1959]/ratedBurnTime$ } }
 }
@@ -856,7 +855,7 @@
 		ignitionReliabilityEnd = 0.999882
 		cycleReliabilityStart = 0.999410
 		cycleReliabilityEnd = 0.999882
-		techTransfer = RD-200:25&RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75K] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75K]/ratedBurnTime$ } }
 }
@@ -880,7 +879,7 @@
 		ignitionReliabilityEnd = 0.999857
 		cycleReliabilityStart = 0.999286
 		cycleReliabilityEnd = 0.999857
-		techTransfer = RD-200:25&RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D727] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D727]/ratedBurnTime$ } }
 }
@@ -899,7 +898,7 @@
 		ignitionReliabilityEnd = 0.999845
 		cycleReliabilityStart = 0.999227
 		cycleReliabilityEnd = 0.999845
-		techTransfer = RD-200:25&RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-11D512] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-11D512]/ratedBurnTime$ } }
 }
@@ -918,7 +917,7 @@
 		ignitionReliabilityEnd = 0.999446
 		cycleReliabilityStart = 0.997230
 		cycleReliabilityEnd = 0.999446
-		techTransfer = RD-200:25&RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-11D512P] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-11D512P]/ratedBurnTime$ } }
 }
@@ -939,7 +938,7 @@
 		ignitionReliabilityEnd = 0.999546
 		cycleReliabilityStart = 0.997732
 		cycleReliabilityEnd = 0.999546
-		techTransfer = RD-200:25&RD-108-11D512P,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-200,RD-108-11D512P,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108A-14D21] { %ratedBurnTime = #$/TESTFLIGHT[RD-108A-14D21]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
@@ -182,7 +182,7 @@
 @PART[ROE-XLR11]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-XLR25]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-XLR41]:FOR[RealismOverhaul] { %RSSROConfig = true }
-@PART[ROE-XLR43]:FOR[RealismOverhaul] { %RSSROConfig = true }
+//@PART[ROE-XLR43]:FOR[RealismOverhaul] { %RSSROConfig = true } // deprecated
 @PART[ROE-XLR99]:FOR[RealismOverhaul] { %RSSROConfig = true }
 
 @PART[ROE-Agena_EquipmentRack]:FOR[RealismOverhaul] { %RSSROConfig = true }


### PR DESCRIPTION
Based on new information, deprecate the XLR43. The XLR43-NA-1 will be moved into the NAA-75-110 config, and the XLR43-NA-3 will be moved to the LR89 config.