### PR TITLE
Updated Space Shuttle System Configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/Engines.cfg
@@ -39,8 +39,8 @@
 	%rescaleFactor = 1.5625
 	
 	@mass = 0.125
-	@maxTemp = 573.15
-    %skinMaxTemp = 673.15
+	@maxTemp = 873.15
+    %skinMaxTemp = 1173.15
 	
 	%engineType = AJ10_190
 	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/Fuselage.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/Fuselage.cfg
@@ -34,7 +34,7 @@
 	
 	@mass = 11.556
 	
-	@maxTemp = 1400
+	@maxTemp = 2200
 	%skinMaxTemp = 2700
 	
 	@MODULE[ModuleCommand]
@@ -71,7 +71,12 @@
 			name = MON3
 			ratio = 0.4922
 		}
-		
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 12.9
+			ignoreForIsp = True
+		}
 		@atmosphereCurve
 		{
 			@key, 0 = 0 320
@@ -115,6 +120,12 @@
 		}
 		TANK
 		{
+			name = Helium
+			amount = 12086
+			maxAmount = 12086
+		}
+		TANK
+		{
 			name = ElectricCharge
 			amount = 3024
 			maxAmount = 3024
@@ -149,11 +160,16 @@
 	
 	%rescaleFactor = 1.5625
 	
-	@maxTemp = 1400
+	@maxTemp = 2200
 	%skinMaxTemp = 2400
 	
 	@mass = 18.806
-	%CoMOffset = 0,0,1.5
+	%CoMOffset = 0,-0.5,1.5	//0,0,1.5
+	
+	@MODULE[ModuleLiftingSurface]{
+		%deflectionLiftCoeff = 20.0	
+		%dragAtMaxAoA = 0.1
+	}
 	
 	//https://www.bernd-leitenberger.de/space-shuttle.shtml
 	// 3 LqdHydrogen tanks with 42 kg (593.2 L) each, and 3 LqdOxygen tanks with 354 kg (310.2 L) each.
@@ -217,7 +233,7 @@
 	@mass = 10.7
 	
 	%skinMaxTemp = 2700
-	%maxTemp = 1173
+	%maxTemp = 2200
 	
 	%rescaleFactor = 1.5625
 	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/OMSPod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/OMSPod.cfg
@@ -15,6 +15,7 @@
 	
 	%rescaleFactor = 1.5625
 	
+	%maxTemp = 1700
 	%skinMaxTemp = 1900
 	
 	@mass = 2.79
@@ -40,6 +41,12 @@
 			amount = 3035.5
 			maxAmount = 3035.5
 		}
+		TANK
+		{
+			name = Helium
+			amount = 77757.0
+			maxAmount = 77757.0
+		}
 	}
 	
 	@MODULE[ModuleRCS*],*
@@ -55,7 +62,12 @@
 			name = MON3
 			ratio = 0.4922
 		}
-		
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 12.9
+			ignoreForIsp = True
+		}
 		@atmosphereCurve
 		{
 			@key, 0 = 0 320

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/RSRM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/RSRM.cfg
@@ -88,6 +88,11 @@
 	%RSSROConfig = true
 	
 	%rescaleFactor = 1.5625
+	
+	@MODULE[ModuleDecouple*]
+	{
+		@ejectionForce = 10000
+	}
 }
 
 // Source : https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950018020.pdf

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/WingSurfaces.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/WingSurfaces.cfg
@@ -4,7 +4,7 @@
 	
 	@mass = 5.3
 	
-	@maxTemp = 1600
+	@maxTemp = 2200
 	%skinMaxTemp = 2700
 	
 	%rescaleFactor = 1.5625
@@ -19,13 +19,14 @@
 	}
 	
 	!MODULE[ModuleLiftingSurface]{}
+	//new MAC value taken from https://archive.org/details/nasa_techdoc_19810067693
 	%MODULE[FARWingAerodynamicModel]
 	{
-		%MAC = 8.62
+		%MAC = 12.06	//8.62
 		%MidChordSweep = 33.6
-		%b_2 = 8.95
+		%b_2 = 8.95	
 		%TaperRatio = 0.185
-		%rootMidChordOffsetFromOrig = 0, 0, 0
+		%rootMidChordOffsetFromOrig = 0, 0.5, 0
 		%massOverride = 0
 	}
 }
@@ -33,7 +34,7 @@
 {
 	@MODULE[FARWingAerodynamicModel]
 	{
-		%rootMidChordOffsetFromOrig[0] = 6.91
+		%rootMidChordOffsetFromOrig = 6.91, 0.5, 0
 	}
 }
 @PART[EVELON_L_SHUTTLE|EVELON_R_SHUTTLE|ShuttleElevonL|ShuttleElevonR]:FOR[RealismOverhaul]
@@ -42,8 +43,8 @@
 	
 	@mass = 0.3
 	
-	%maxTemp = 1600
-	%skinMaxTemp = 2500
+	%maxTemp = 2200
+	%skinMaxTemp = 2700
 	
 	%rescaleFactor = 1.5625
 	
@@ -80,7 +81,8 @@
 	
 	@mass += 0.1
 	
-	%skinMaxTemp = 2200
+	%maxTemp = 2200
+	%skinMaxTemp = 2700
 	
 	%rescaleFactor = 1.5625
 	
@@ -140,6 +142,9 @@
 	
 	%rescaleFactor = 1.5625
 	
+	%maxTemp = 2200
+	%skinMaxTemp = 2700
+	
 	@maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -172,8 +177,8 @@
 	
 	%rescaleFactor = 1.5625
 	
-	%skinMaxTemp = 1873.15
-	%maxTemp = 1500
+	%maxTemp = 2200
+	%skinMaxTemp = 2700
 	
 	@maximum_drag = 0
     @minimum_drag = 0


### PR DESCRIPTION
-Adjusted max temperatures of various parts and OMS engines.
-Added helium tanks since new OMS configs use it
-Added Helium consumption to RCS
-Increased SRB decoupler force
-Adjusted cargo bay CG offset to bring CG where it used to be after the FAR wing mass overrides were removed
-Fixed right wing FAR offset (resulted in roll moment)
-Fixed MAC of FAR wing configs (was too short)
- Adjusted value of cargo bay lifting coefficient (part of an attempt to increase L/D and crossrange)