### PR TITLE
Bump up RD-215-8D513 reliability

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
@@ -370,10 +370,10 @@
 		testedBurnTime = 400
 		ratedBurnTime = 146
 		safeOverburn = true
-		ignitionReliabilityStart = 0.9
-		ignitionReliabilityEnd = 0.96
-		cycleReliabilityStart = 0.88
-		cycleReliabilityEnd = 0.93
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.98
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.98
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}


### PR DESCRIPTION
Because giving a 10% failure chance to an engine with a perfect record
is excessive, even if the sample is small (28/28); especially considering
how reliable the successor configs proved. The RD-217 fared worse, but
also seems to have been "more different" than RD-215->RD-215M.

Picked 95% arbitrarily; if we suppose the next launch had failed, we'd
get 28/29=96.5%

This works out to a 10% failure rate for a dual-rd215 launch, so still
on the high side. (and worse if we count ignition failures)