### PR TITLE
Support for new ROEngines parts

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -109,7 +109,7 @@
 //	Nozzle Ratio: 84
 //	Ignitions: 10
 //	=================================================================================
-//	RL10A-4-1
+//	RL10A-4-1 and RL10A-4-2 (represented as RL10A-4-1-2)
 //	Centaur D2A1/D3B-SEC
 //
 //	Dry Mass: 142 Kg		(guess, nozzle extension weighs ~25 kg)
@@ -575,11 +575,11 @@
 		}
 		CONFIG
 		{
-			name = RL10A-4-1
+			name = RL10A-4-1-2
 			minThrust = 97.9
 			maxThrust = 97.9
 			heatProduction = 100
-			description = Reworked turbopumps and improved performance for usage in a single & dual engine configuration on Atlas II & Atlas III & single engine configuration on Atlas V
+			description = This config represents the RL-10A-4-1 and RL-10A-4-2 variants. Reworked turbopumps and improved performance for usage in a single & dual engine configuration on Atlas II & Atlas III & single engine configuration on Atlas V.
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -1154,11 +1154,11 @@
 //49 engines, 0 failures
 //Assuming 2 ignitions per flight average
 //98 ignitions, 0 failed
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-1-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = RL10A-4-1
+		name = RL10A-4-1-2
 		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
 		ratedBurnTime = 850
 		safeOverburn = true
@@ -1169,7 +1169,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50	//share data between extension and no extension
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1N:50	//share data between extension and no extension
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1]/ratedBurnTime$ } }
 }
@@ -1189,7 +1189,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1N]/ratedBurnTime$ } }
 }
@@ -1209,7 +1209,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-2N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-2N]/ratedBurnTime$ } }
 }
@@ -1231,7 +1231,7 @@
 		cycleReliabilityStart = 0.977273
 		cycleReliabilityEnd = 0.995455
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-5] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-5]/ratedBurnTime$ } }
 }
@@ -1264,7 +1264,7 @@
 
 		ignitionDynPresFailMultiplier = 0.05
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10B-2] { %ratedBurnTime = #$/TESTFLIGHT[RL10B-2]/ratedBurnTime$ } }
 }
@@ -1295,7 +1295,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1]/ratedBurnTime$ } }
 }
@@ -1317,7 +1317,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1-1]/ratedBurnTime$ } }
 }
@@ -1339,7 +1339,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-2-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-2-1]/ratedBurnTime$ } }
 }
@@ -1361,7 +1361,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1,RL10C-1-1,RL10C-2-1:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1,RL10C-1-1,RL10C-2-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-3] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -65,7 +65,7 @@
 //	Ignitions: 10
 //	=================================================================================
 //	RL10A-3-3A
-//	Centaur D1AR
+//	Centaur D1AR, D1B, D2
 //
 //	Dry Mass: 141 Kg
 //	Thrust (SL): ??? kN
@@ -82,11 +82,26 @@
 //	RL10A-4
 //	Centaur D2A
 //
-//	Dry Mass: 168 Kg
+//	Dry Mass: 143 Kg		(guess, nozzle extension weighs ~25 kg)
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 91.2 kN
 //	ISP: ??? SL / 446.4 Vac
-//	Burn Time: 392
+//	Burn Time: 406
+//	Chamber Pressure: 3.98 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5
+//	Throttle: N/A
+//	Nozzle Ratio: 61
+//	Ignitions: 10
+//	=================================================================================
+//	RL10A-4N
+//	Centaur D2AN
+//
+//	Dry Mass: 168 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 92.5 kN
+//	ISP: ??? SL / 448.9 Vac
+//	Burn Time: 402
 //	Chamber Pressure: 3.98 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.5
@@ -94,10 +109,10 @@
 //	Nozzle Ratio: 84
 //	Ignitions: 10
 //	=================================================================================
-//	RL10A-4-1-2
-//	Centaur D2A1/D3A/D5
+//	RL10A-4-1
+//	Centaur D2A1/D3B-SEC
 //
-//	Dry Mass: 168 Kg
+//	Dry Mass: 142 Kg		(guess, nozzle extension weighs ~25 kg)
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 97.9 kN
 //	ISP: ??? SL / 446.4 Vac
@@ -106,17 +121,32 @@
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.5
 //	Throttle: N/A
+//	Nozzle Ratio: 61
+//	Ignitions: 10
+//	=================================================================================
+//	RL10A-4-1N
+//	Centaur D2A1N/D3A-SEC/D3B-DEC
+//
+//	Dry Mass: 167 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 99.2 kN
+//	ISP: ??? SL / 450.5 Vac
+//	Burn Time: 740
+//	Chamber Pressure: 4.20 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5
+//	Throttle: N/A
 //	Nozzle Ratio: 84
 //	Ignitions: 10
 //	=================================================================================
 //	RL10A-4-2N
-//	Centaur D5
+//	Centaur D5/III
 //
-//	Dry Mass: 170 Kg
+//	Dry Mass: 168 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 99.2 kN
 //	ISP: ??? SL / 451.0 Vac
-//	Burn Time: 850
+//	Burn Time: 894
 //	Chamber Pressure: 4.20 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.5
@@ -155,7 +185,7 @@
 //	Ignitions: 15
 //	=================================================================================
 //	RL10C-1
-//	Centaur D-5
+//	Centaur D5/III
 //
 //	Dry Mass: 191 Kg
 //	Thrust (SL): ??? kN
@@ -500,7 +530,7 @@
 				key = 0 446.4
 				key = 1 255
 			}
-			massMult = 1.006
+			massMult = 0.86
 
 			%ullage = True
 			%ignitions = 10
@@ -512,7 +542,40 @@
 		}
 		CONFIG
 		{
-			name = RL10A-4-1-2
+			name = RL10A-4N
+			minThrust = 92.5
+			maxThrust = 92.5
+			heatProduction = 100
+			description = Reworked turbopumps, improved performance, and extendable nozzle for usage in a single & dual engine configuration on Atlas II & Atlas III
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546 //5.5
+			}
+			atmosphereCurve
+			{
+				key = 0 448.9
+				key = 1 255
+			}
+			massMult = 1.01
+
+			%ullage = True
+			%ignitions = 10
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = RL10A-4-1
 			minThrust = 97.9
 			maxThrust = 97.9
 			heatProduction = 100
@@ -533,7 +596,40 @@
 				key = 0 446.4
 				key = 1 255
 			}
-			massMult = 1.0
+			massMult = 0.85
+
+			%ullage = True
+			%ignitions = 10
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = RL10A-4-1N
+			minThrust = 99.2
+			maxThrust = 99.2
+			heatProduction = 100
+			description = Reworked turbopumps, improved performance, and extendable nozzle for usage in a single & dual engine configuration on Atlas II & Atlas III
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546 //5.5
+			}
+			atmosphereCurve
+			{
+				key = 0 450.5
+				key = 1 255
+			}
+			massMult = 1.00
 
 			%ullage = True
 			%ignitions = 10
@@ -712,7 +808,7 @@
 		CONFIG
 		{
 			name = RL10C-2-1	//Mentioned as identical to the B-2, probably a cost-reduced drop-in replacement for DCSS
-			minThrust = 111.2 
+			minThrust = 111.2
 			maxThrust = 111.2
 			heatProduction = 100
 			description = RL10B-2 using RL10C-1 components to reduce cost.
@@ -879,7 +975,7 @@
 
 //Atlas-LV3C Centaur B: 1 flight, 0 failures
 //Atlas-LV3C Centaur-C: 2 flights, 1 failures
-//6 engines, 1 failed. 
+//6 engines, 1 failed.
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
@@ -981,8 +1077,8 @@
 	TESTFLIGHT
 	{
 		name = RL10A-3-3A
-		testedBurnTime = 1680		//RL10s tested to 28 minites (only limited by test stand propellant tanks)
-		ratedBurnTime = 620
+		testedBurnTime = 1680		//RL10s tested to 28 minutes (only limited by test stand propellant tanks)
+		ratedBurnTime = 550
 		safeOverburn = true
 		ignitionReliabilityStart = 0.990826
 		ignitionReliabilityEnd = 0.998165
@@ -1007,7 +1103,7 @@
 	{
 		name = RL10A-4
 		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedBurnTime = 392
+		ratedBurnTime = 406
 		safeOverburn = true
 		ignitionReliabilityStart = 0.995305
 		ignitionReliabilityEnd = 0.999061
@@ -1016,11 +1112,33 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4N:50	//share data between extension and no extension
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4]/ratedBurnTime$ } }
 }
 
+//Just a nozzle extension, use same data as A-4
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4N]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RL10A-4N
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 402
+		safeOverburn = true
+		ignitionReliabilityStart = 0.995305
+		ignitionReliabilityEnd = 0.999061
+		cycleReliabilityStart = 0.990654
+		cycleReliabilityEnd = 0.998131
+
+		ignitionDynPresFailMultiplier = 0.1
+
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50	//share data between extension and no extension
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4N]/ratedBurnTime$ } }
+}
+
+//Just use this data for A-4-1 and A-4-2, it's hard to tell which was used where
 //Atlas-3A: 2 flights, 0 failures
 //Atlas-3B-SEC: 3 flights, 0 failures
 //Atlas-3B-DEC: 1 flight, 0 failures
@@ -1036,11 +1154,11 @@
 //49 engines, 0 failures
 //Assuming 2 ignitions per flight average
 //98 ignitions, 0 failed
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-1-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
 {
 	TESTFLIGHT
 	{
-		name = RL10A-4-1-2
+		name = RL10A-4-1
 		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
 		ratedBurnTime = 850
 		safeOverburn = true
@@ -1051,9 +1169,29 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50	//share data between extension and no extension
 	}
-	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1-2] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1-2]/ratedBurnTime$ } }
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1]/ratedBurnTime$ } }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-1N]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RL10A-4-1N
+		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
+		ratedBurnTime = 740
+		safeOverburn = true
+		ignitionReliabilityStart = 0.989899
+		ignitionReliabilityEnd = 0.997980
+		cycleReliabilityStart = 0.980000
+		cycleReliabilityEnd = 0.996000
+
+		ignitionDynPresFailMultiplier = 0.1
+
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1N]/ratedBurnTime$ } }
 }
 
 @PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-4-2N]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
@@ -1062,7 +1200,7 @@
 	{
 		name = RL10A-4-2N
 		testedBurnTime = 3600		//first major turbopump revision, give 1 hour
-		ratedBurnTime = 850
+		ratedBurnTime = 894
 		safeOverburn = true
 		ignitionReliabilityStart = 0.989899
 		ignitionReliabilityEnd = 0.997980
@@ -1071,7 +1209,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-2N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-2N]/ratedBurnTime$ } }
 }
@@ -1093,7 +1231,7 @@
 		cycleReliabilityStart = 0.977273
 		cycleReliabilityEnd = 0.995455
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-5] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-5]/ratedBurnTime$ } }
 }
@@ -1126,7 +1264,7 @@
 
 		ignitionDynPresFailMultiplier = 0.05
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50
+		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10B-2] { %ratedBurnTime = #$/TESTFLIGHT[RL10B-2]/ratedBurnTime$ } }
 }
@@ -1157,7 +1295,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1]/ratedBurnTime$ } }
 }
@@ -1179,7 +1317,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2,RL10C-1:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1-1]/ratedBurnTime$ } }
 }
@@ -1201,7 +1339,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2,RL10C-1:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-2-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-2-1]/ratedBurnTime$ } }
 }
@@ -1214,7 +1352,7 @@
 	{
 		name = RL10C-3
 		testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-		ratedBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines 
+		ratedBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines
 		safeOverburn = true
 		ignitionReliabilityStart = 0.988506
 		ignitionReliabilityEnd = 0.997701
@@ -1223,7 +1361,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4-1-2,RL10A-4-2N,RL10B-2,RL10C-1,RL10C-1-1,RL10C-2-1:50
+		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1,RL10C-1-1,RL10C-2-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-3] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
@@ -5,6 +5,7 @@
 @PART[ROE-Aerobee]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-18KS7800]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-25KS18000]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-Agena]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Agena8048]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Agena8096]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Agena8096C]:FOR[RealismOverhaul] { %RSSROConfig = true }
@@ -69,6 +70,7 @@
 @PART[ROE-HG3]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-HiPAT]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-J2]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-J2T]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-J2X]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Juno45K]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Juno6K]:FOR[RealismOverhaul] { %RSSROConfig = true }
@@ -160,6 +162,10 @@
 @PART[ROE-SRMU]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Star5D]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Star8]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-Star37]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-Star37E]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-Star37FM]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-Star48B]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-Stentor]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-SuperDraco]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-SuperDracoDouble]:FOR[RealismOverhaul] { %RSSROConfig = true }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
@@ -136,8 +136,10 @@
 @PART[ROE-RD57]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RD58]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RD8]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-RL10Fixed]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RL10A3]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RL10A4]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-RL10A4N]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RL10A4-2N]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RL10A5]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-RL10B2]:FOR[RealismOverhaul] { %RSSROConfig = true }


### PR DESCRIPTION
Support for https://github.com/KSP-RO/ROEngines/pull/146, also adding the RL-10A-4N and RL-10A-4-1N extendable nozzle engine configs.