### PR TITLE
R-4D tweaks

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
@@ -115,14 +115,14 @@
 			PROPELLANT
 			{
 				name = MMH
-				ratio = 0.4990
+				ratio = 0.495
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = MON3
-				ratio = 0.5010
+				ratio = 0.505
 				DrawGauge = False
 			}
 
@@ -150,14 +150,14 @@
 			PROPELLANT
 			{
 				name = MMH
-				ratio = 0.4990
+				ratio = 0.495
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = MON3
-				ratio = 0.5010
+				ratio = 0.505
 				DrawGauge = False
 			}
 
@@ -194,15 +194,15 @@
 			
 			PROPELLANT
 			{
-				name = MMH
-				ratio = 0.4003
+				name = Hydrazine
+				ratio = 0.5863
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = MON3
-				ratio = 0.5997
+				ratio = 0.4137
 				DrawGauge = False
 			}
 


### PR DESCRIPTION
- Changed R-4D-15 Dual Mode fuel to Hydrazine instead of MMH. Corrected O/F ratio to 1 (according to Aerojet's In-Space Propulsion Data Sheet).
- Slightly tweaked propellant ratios on both R-4D-11 and R-4D-15 to get them closer to the specified 1.65 O/F ratio.