### PR TITLE
RD-0212's vernier is 1 engine, not 4

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -7,11 +7,11 @@
 //	RD-0212
 //	Proton
 //
-//	Dry Mass: 910 Kg
+//	Dry Mass: 550 Kg + 90kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 584.77 kN
-//	ISP: ??? SL / 327 Vac
-//	Burn Time: 250
+//	Thrust (Vac): 584.77 kN + 30kN
+//	ISP: ??? SL / 327 Vac + 293 Vac = 322.6
+//	Burn Time: 250 (270 for verniers?)
 //	Chamber Pressure: 14.71 MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.54
@@ -35,8 +35,9 @@
 
 //	Notes:
 
-//	* The RD-0212 propulsion module is a combination of the RD-0213 main engine and four RD-0214 vernier engines.
-//	* The inert mass value includes the mass of the vernier engines (90 Kg each).
+//	* The RD-0212 propulsion module is a combination of the RD-0213 main engine and the 4-chambered RD-0214
+//	* vernier engine.
+//	* Mass and thrust is the sum of the two; Isp is the weighted average of the two.
 //	==================================================
 
 @PART[*]:HAS[#engineType[RD0212]]:FOR[RealismOverhaulEngines]
@@ -56,6 +57,8 @@
 
 	@MODULE[ModuleGimbal],*
 	{
+		// A poor approximation of what should be 4 single-axis gimballing
+		// verniers
 		%gimbalRange = 45.0
 		%useGimbalResponseSpeed = True
 		%gimbalResponseSpeed = 16
@@ -66,13 +69,13 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = RD-0212
-		origMass = 0.91
+		origMass = 0.64
 
 		CONFIG
 		{
 			name = RD-0212
-			minThrust = 584.77
-			maxThrust = 584.77
+			minThrust = 614.77
+			maxThrust = 614.77
 			gimbalRange = 45.0
 			ullage = True
 			pressureFed = False
@@ -100,7 +103,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 327
+				key = 0 322.6
 				key = 1 164
 			}
 		}
@@ -148,3 +151,4 @@
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0212] { %ratedBurnTime = #$/TESTFLIGHT[RD-0212]/ratedBurnTime$ } }
 }
+


### PR DESCRIPTION
Based on a re-interpretation of the sources (ie. russianspaceweb.com)
RD-0212 didn't have 4 90kg vernier engines, it had 1 90kg vernier
engine with 4 nozzles.

Also take vernier's thrust and Isp into account.

Source also suggests a small throttle range; left out because it
would have negligible impact even if accurate.