### PR TITLE
Basic configs for KSP 1.11+ kerbals

### DIFF
--- a/GameData/RealismOverhaul/EVA.cfg
+++ b/GameData/RealismOverhaul/EVA.cfg
@@ -5,6 +5,13 @@
 	@MODULE[KerbalEVA]
 	{
 		@linPower /= 5
+		@propellantResourceName = Nitrogen
+	}
+
+	// Set the carry limit to mass of Jetpack + Parachute + 75 kg (value of jetpack + parachute gotten by testing the mass in-game)
+	@MODULE[ModuleInventoryPart]
+	{
+		@massLimit = 0.180
 	}
 }
 

--- a/GameData/RealismOverhaul/EVA.cfg
+++ b/GameData/RealismOverhaul/EVA.cfg
@@ -8,6 +8,11 @@
 		@propellantResourceName = Nitrogen
 	}
 
+	@RESOURCE[EVA?Propellant]
+	{
+		@name = Nitrogen
+	}
+
 	// Set the carry limit to mass of Jetpack + Parachute + 75 kg (value of jetpack + parachute gotten by testing the mass in-game)
 	@MODULE[ModuleInventoryPart]
 	{

--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -1,6 +1,8 @@
 @PHYSICSGLOBALS:FOR[RealismOverhaul]
 {
 
+	%kerbalCrewMass = 0.1
+	
 	// AeroFX
 	@aeroFXDensityScalar1 = 0.00004
 	@aeroFXDensityExponent1 = 0.7

--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -1,10 +1,6 @@
 @PHYSICSGLOBALS:FOR[RealismOverhaul]
 {
 
-	%kerbalCrewMass = 0.1
-	%perSeatReduction = 0
-	%perCommandSeatReduction = 0
-	
 	// AeroFX
 	@aeroFXDensityScalar1 = 0.00004
 	@aeroFXDensityExponent1 = 0.7
@@ -80,4 +76,12 @@
 	// GENERAL
 	@stack_PriUsesSurf = True
 	
+}
+
+// Add crew mass to KSP 1.11+ installs
+@PHYSICSGLOBALS:FOR[RealismOverhaul]:NEEDS[Squad/Parts/Cargo/ScienceKit]
+{
+	%kerbalCrewMass = 0.1
+	%perSeatReduction = 0
+	%perCommandSeatReduction = 0
 }

--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -2,6 +2,8 @@
 {
 
 	%kerbalCrewMass = 0.1
+	%perSeatReduction = 0
+	%perCommandSeatReduction = 0
 	
 	// AeroFX
 	@aeroFXDensityScalar1 = 0.00004

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
@@ -1,14 +1,15 @@
 // Balance the EVA Jet Pack to the numbers for the AMU
+//Mass of the AMU, the jetpack developed for and flown on Gemini, but never used.
+//Mass of other space suits: AMU - 76 kg, MMU - 148 kg, SAFER - 38 kg
 @PART[evaJetpack]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = true
-    @mass = 0.076   //Mass of the AMU, the jetpack developed for and flown on Gemini, but never used.
-                    //Mass of other space suits: AMU - 76 kg, MMU - 148 kg, SAFER - 38 kg
+	%RSSROConfig = true
+	@mass = 0.076
 }
 
 // Parachute based on ACES
 @PART[evaChute]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = true
-    @mass = 0.029 //Mass of the ACES Parachute and Survival Systems
+	%RSSROConfig = true
+	@mass = 0.029 //Mass of the ACES Parachute and Survival Systems
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
@@ -1,14 +1,14 @@
 // Balance the EVA Jet Pack to the numbers for the AMU
 @PART[evaJetpack]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = true
-	@mass = 0.076 	//Mass of the AMU, the jetpack developed for and flown on Gemini, but never used.
-					//Mass of other space suits: AMU - 76 kg, MMU - 148 kg, SAFER - 38 kg
+    %RSSROConfig = true
+    @mass = 0.076   //Mass of the AMU, the jetpack developed for and flown on Gemini, but never used.
+                    //Mass of other space suits: AMU - 76 kg, MMU - 148 kg, SAFER - 38 kg
 }
 
 // Parachute based on ACES
 @PART[evaChute]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = true
-	@mass = 0.029 //Mass of the ACES Parachute and Survival Systems
+    %RSSROConfig = true
+    @mass = 0.029 //Mass of the ACES Parachute and Survival Systems
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
@@ -1,0 +1,14 @@
+// Balance the EVA Jet Pack to the numbers for the AMU
+@PART[evaJetpack]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@mass = 0.076 	//Mass of the AMU, the jetpack developed for and flown on Gemini, but never used.
+					//Mass of other space suits: AMU - 76 kg, MMU - 148 kg, SAFER - 38 kg
+}
+
+// Parachute based on ACES
+@PART[evaChute]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@mass = 0.029 //Mass of the ACES Parachute and Survival Systems
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Cargo.cfg
@@ -5,6 +5,20 @@
 {
 	%RSSROConfig = true
 	@mass = 0.076
+
+	@RESOURCE[EVA?Propellant]
+	{
+		@name = Nitrogen
+	}
+}
+
+// Patch the 1.11+ "eva fuel cylinders" inventory item with Nitrogen
+@PART[evaCylinder]:FOR[RealismOverhaul]
+{
+  @RESOURCE[EVA?Propellant]
+	{
+		@name = Nitrogen
+	}
 }
 
 // Parachute based on ACES


### PR DESCRIPTION
None of the changes should apply to KSP 1.10 installs, since either the parts that are patched do not exist, or the patch is only applied when a KSP 1.11+ part is present (:NEEDS[Squad/Parts/Cargo/ScienceKit])