### PR TITLE
Un-hide restockplus RSRM

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RO_RestockPlus_Engine_Part_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RO_RestockPlus_Engine_Part_Config.cfg
@@ -239,6 +239,7 @@
     %rescaleFactor = 2.1025
 
     %engineType = RSRM
+    !TechHidden = delete
 
     !MODULE[ModuleGimbal],*{}
     %MODULE[ModuleGimbal] { %gimbalTransformName = thrustTransform }


### PR DESCRIPTION
It shows up in the VAB, so hiding it in R&D is just confusing