### PR TITLE
Add J57-P-8, RD-9B; adjust size and CoM offset of jets

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -13,8 +13,9 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.2, 1.6, 1.2
+		scale = 1.2, 2.24, 1.2
 	}
+	%CoMOffset = 0, 2.2, 0
 }
 @PART[aje_j85]:FOR[RealismOverhaul]
 {
@@ -31,8 +32,9 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.2, 1.32, 1.2
+		scale = 1.2, 3.95, 1.2
 	}
+	%CoMOffset = 0, 2.8, 0
 }
 @PART[turboFanEngine]:FOR[RealismOverhaul] // j58
 {
@@ -50,8 +52,9 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.6, 1.8, 1.6
+		scale = 1.6, 3.75, 1.6
 	}
+	%CoMOffset = 0, 2.68, 0
 }
 @PART[aje_j79]:FOR[RealismOverhaul]
 {
@@ -61,8 +64,9 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.28, 1.6, 1.28
+		scale = 1.28, 3.52, 1.28
 	}
+	%CoMOffset = 0, 2.5, 0
 }
 @PART[aje_al31]:FOR[RealismOverhaul]
 {
@@ -70,8 +74,9 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.6, 2.2, 1.6
+		scale = 1.6, 2.5, 1.6
 	}
+	%CoMOffset = 0, 2.8, 0
 }
 @PART[aje_atar]:FOR[RealismOverhaul]
 {
@@ -81,7 +86,7 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.2, 1.32, 1.2
+		scale = 1.2, 3.1, 1.2
 	}
 }
 @PART[aje_avon]:FOR[RealismOverhaul]
@@ -92,8 +97,9 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.152, 1.25, 1.152
+		scale = 1.152, 1.72, 1.152
 	}
+	%CoMOffset = 0, 1.8, 0
 }
 @PART[turboJet]:FOR[RealismOverhaul] // F100
 {
@@ -101,7 +107,7 @@
 	MODEL
 	{
 		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.6, 2.2, 1.6
+		scale = 1.6, 2.8, 1.6
 	}
 }
 
@@ -111,13 +117,12 @@
 	%RSSROConfig = True
 	@name = RO-J48
 
-	!MODEL,* {}
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
 
-	MODEL
+	@MODEL
 	{
-		model = VenStockRevamp/PartBin/NewParts/JetEngines/HighBypassJet
-		position = 0, -1.383335, 0
-		scale = 0.6217, 0.6217, 0.6217
+		@position = 0, -1.383335, 0
+		@scale = 0.6217, 0.6217, 0.6217
 	}
 
 	MODEL
@@ -150,7 +155,7 @@
 	
 	@title = J48-P-6
 	@manufacturer = Pratt & Whitney
-	@description = Also known as the Rolls-Royce Tay. Essentially an enlarged Nene, the Tay was abandoned by Rolls-Royce in favor of the Avon. However, Pratt & Whitney was able to aqcuire the design, and produced it as the J48. It was used in the F9F-5 Panther, F-94C Starfire, and several early 50s prototypes. Available 1949. 5.0 OPR, no afterburner. SFC 1.14 lb/lbf-hr static. Temperature limit Mach 1.
+	@description = Also known as the Rolls-Royce Tay. Essentially an enlarged Nene, the Tay was abandoned by Rolls-Royce in favor of the Avon. However, Pratt & Whitney was able to aqcuire the design, and produced it as the J48. It was used in the F9F-5 Panther, F-94C Starfire, and several early 50s prototypes. Available 1949. 5.0 OPR, water injection, no afterburner. SFC 1.14 lb/lbf-hr static. Temperature limit Mach 1.
 
 	@MODULE[ModuleEngines*]
 	{
@@ -287,17 +292,9 @@
 	%RSSROConfig = True
 	@name = RO-J57P8
 
-
-	!MODEL:HAS[#model[*EngineCore-Medium]] {}
-	MODEL
-	{
-		model = RealismOverhaul/Models/EngineCore-Medium
-		scale = 1.2, 1.32, 1.2
-	}
-
 	@title = J57-P-8 Turbojet
 	@manufacturer = Pratt & Whitney
-	@description = Early 50s turbojet. The J57 was a workhorse, designed in the early 1950s and powering the B-52, most of the Century Series fighters, and even the U-2. This represents an early model, the -8, which powered the F4D Skyray/F5D Skylancer. 71.1kN wet, 45.3kN dry. SFC 0.80/2.1 lb/lbf-hr static. Temperature limit Mach 1.25.
+	@description = Early 50s turbojet. The J57 was a workhorse, designed in the early 1950s and powering the B-52, most of the Century Series fighters, and even the U-2. This represents an early model, the -8, which powered the F4D Skyray/F5D Skylancer. 71.1kN wet, 45.3kN dry. SFC 0.90/2.1 lb/lbf-hr static. Temperature limit Mach 1.5.
 
 	@MODULE[ModuleEngines*]
 	{
@@ -319,12 +316,12 @@
 		%TAB = 3140		//Afterburner temp?
 		%exhaustMixer = False
 		%thrustUpperLimit = 100
-		%maxT3 = 650	//Turbine max temperature. A little lower than J57-P-21
+		%maxT3 = 670	//Turbine max temperature. A little lower than J57-P-21
 		
 		// Engine fitting params
 		%dryThrust = 45.3
 		%wetThrust = 71.1
-		%drySFC = 0.80	//assume a little worse than later J57s
+		%drySFC = 0.90	//assume a little worse than later J57s
 		%throttleResponseMultiplier = 0.18
 		
 		%engineSpoolIdle = 0.05
@@ -345,23 +342,12 @@
 	@name = RO-RD9B
 	%rescaleFactor = 0.71
 
-	//@MODEL
-	//{
-	//	model = VenStockRevamp/PartBin/NewParts/JetEngines/HighBypassJet
-	//	position = 0, -1.03750125, 0
-	//	@scale = 0.6662, 0.6662, 0.6662
-	//}
-	//MODEL
-	//{
-	//	model = RealismOverhaul/Models/EngineCore-Medium
-	//	scale = 0.85, 0.94, 0.85
-	//}
-
 	@mass = 0.659
+	%CoMOffset = 0, 2.00, 0
 
 	@title = RD-9B Turbojet
 	@manufacturer = Tumansky
-	@description = Early 50s turbojet. Developed as a scaled down Mikulin AM-3, the RD-9 was designed for fighter aircraft, and powered the Yak-25, 26, 27, 28, and MiG-19. This represents an early model, the -9B, which powered early MiG-19s. 31.9kN wet, 25.1kN dry. SFC 0.96/1.6 lb/lbf-hr static. Temperature limit Mach 1.25.
+	@description = Early 50s turbojet. Developed as a scaled down Mikulin AM-3, the RD-9 was designed for fighter aircraft, and powered the Yak-25, 26, 27, 28, and MiG-19. This represents an early model, the -9B, which powered early MiG-19s. 31.9kN wet, 25.1kN dry. SFC 0.96/1.6 lb/lbf-hr static. Temperature limit Mach 1.5.
 
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -281,6 +281,126 @@
 	}
 }
 
+//Clone J57 to be J57-P-8
++PART[aje_j57]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-J57P8
+
+
+	!MODEL:HAS[#model[*EngineCore-Medium]] {}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.2, 1.32, 1.2
+	}
+
+	@title = J57-P-8 Turbojet
+	@manufacturer = Pratt & Whitney
+	@description = Early 50s turbojet. The J57 was a workhorse, designed in the early 1950s and powering the B-52, most of the Century Series fighters, and even the U-2. This represents an early model, the -8, which powered the F4D Skyray/F5D Skylancer. 71.1kN wet, 45.3kN dry. SFC 0.80/2.1 lb/lbf-hr static. Temperature limit Mach 1.25.
+
+	@MODULE[ModuleEngines*]
+	{
+		//just assume same as J27-P-21 other than thrust
+		@name = ModuleEnginesAJEJet
+		%maxThrust = 71.1
+		%Area = 0.24	//Compressor Area
+		%BPR = 0		//Bypass Ratio
+		%CPR = 13		//Compressor Pressure Ratio
+		%FPR = 0		//Fan Ratio
+		//%TPR = 0.95		//Turbine Pressure Ratio
+		%Mdes = 0.9		//Mach Design Point
+		%Tdes = 250		//Temp Design Point
+		%eta_c = 0.95	//Efficiency at burner inlet
+		%eta_t = 0.98	//Efficiency at burner exit
+		%eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
+		%FHV = 35000000	//Fuel heat of burning (joules?)
+		%TIT = 1330		//Combustion peak temp
+		%TAB = 3140		//Afterburner temp?
+		%exhaustMixer = False
+		%thrustUpperLimit = 100
+		%maxT3 = 650	//Turbine max temperature. A little lower than J57-P-21
+		
+		// Engine fitting params
+		%dryThrust = 45.3
+		%wetThrust = 71.1
+		%drySFC = 0.80	//assume a little worse than later J57s
+		%throttleResponseMultiplier = 0.18
+		
+		%engineSpoolIdle = 0.05
+		%engineSpoolTime = 2.0
+		%EngineType = Turbine
+		
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+}
+
+//Clone J57 to be RD-9B
++PART[RO-J57P8]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-RD9B
+	%rescaleFactor = 0.71
+
+	//@MODEL
+	//{
+	//	model = VenStockRevamp/PartBin/NewParts/JetEngines/HighBypassJet
+	//	position = 0, -1.03750125, 0
+	//	@scale = 0.6662, 0.6662, 0.6662
+	//}
+	//MODEL
+	//{
+	//	model = RealismOverhaul/Models/EngineCore-Medium
+	//	scale = 0.85, 0.94, 0.85
+	//}
+
+	@mass = 0.659
+
+	@title = RD-9B Turbojet
+	@manufacturer = Tumansky
+	@description = Early 50s turbojet. Developed as a scaled down Mikulin AM-3, the RD-9 was designed for fighter aircraft, and powered the Yak-25, 26, 27, 28, and MiG-19. This represents an early model, the -9B, which powered early MiG-19s. 31.9kN wet, 25.1kN dry. SFC 0.96/1.6 lb/lbf-hr static. Temperature limit Mach 1.25.
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%maxThrust = 31.9
+		%Area = 0.20	//Compressor Area
+		%BPR = 0		//Bypass Ratio
+		%CPR = 7.14		//Compressor Pressure Ratio
+		%FPR = 0		//Fan Ratio
+		//%TPR = 0.95		//Turbine Pressure Ratio
+		%Mdes = 0.9		//Mach Design Point
+		%Tdes = 250		//Temp Design Point
+		%eta_c = 0.95	//Efficiency at burner inlet
+		%eta_t = 0.98	//Efficiency at burner exit
+		%eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
+		%FHV = 35000000	//Fuel heat of burning (joules?)
+		%TIT = 1330		//Combustion peak temp
+		%TAB = 3140		//Afterburner temp?
+		%exhaustMixer = False
+		%thrustUpperLimit = 75
+		%maxT3 = 625	//Turbine max temperature
+		
+		// Engine fitting params
+		%dryThrust = 25.5
+		%wetThrust = 31.9
+		%drySFC = 0.96
+		%throttleResponseMultiplier = 0.25
+		
+		%engineSpoolIdle = 0.05
+		%engineSpoolTime = 2.0
+		%EngineType = Turbine
+		
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+}
+
 // Set RSSROConfig, set AvGas
 @PART[*]:HAS[@MODULE[ModuleEnginesAJEPropeller]]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -32,7 +32,7 @@
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 	
 	@mass = 0.57
-	%CoMOffset = 0, 0.25, 0
+	%CoMOffset = 0, 0.4, 0	//compressor is heaviest part
 	
 	@title = Derwent V
 	@manufacturer = Rolls-Royce
@@ -116,7 +116,7 @@
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 	
 	@mass = 0.872
-	%CoMOffset = 0, 0.25, 0
+	%CoMOffset = 0, 0.6, 0	//compressor is heaviest part
 	
 	@title = VK-1
 	@manufacturer = Klimov
@@ -188,7 +188,7 @@
 	@node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
 	
 	@mass = 1.158
-	%CoMOffset = 0, 0.25, 0
+	%CoMOffset = 0, 1.3, 0
 	
 	@maxTemp = 593
 	%skinMaxTemp = 773


### PR DESCRIPTION
Add the J57P8 and RD-9B so the 1951 node actually has some supersonic capable engines.
Adjust size and CoM offset of jets.