### PR TITLE
Add RD-0120T, fix RD-0120, 701, 704

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0120T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120T_Config.cfg
@@ -1,0 +1,173 @@
+//	==================================================
+//	RD-0120T
+//
+//	Manufacturer: KB Khimavtomatika
+//
+//	=================================================================================
+//	RD-0120T Mode 1
+//	Tripropellant mode
+//
+//	Dry Mass: 3800 Kg	//assume a bit heavier for kero TP
+//	Thrust (SL): 1394.1 kN
+//	Thrust (Vac): 1809.8 kN
+//	ISP: 322.5 SL / 418.7 Vac
+//	Burn Time: 600
+//	Chamber Pressure: 19.38 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 8.9% LH2, 11.1% Kerosene, 80.0% LOX
+//	Throttle: 100% to 38%
+//	Nozzle Ratio: 85.7
+//	Ignitions: 1
+//	=================================================================================
+//	RD-0120TP Mode 2
+//	Bipropellant mode
+//
+//	Dry Mass: 3800 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 735.3 kN
+//	ISP: ??? SL / 454 Vac
+//	Burn Time: 600
+//	Chamber Pressure: 8.14 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.95
+//	Throttle: 100% to 90%	guess, based on overall pressure ratio
+//	Nozzle Ratio: 85.7
+//	Ignitions: 1
+//	=================================================================================
+
+//	Sources:
+
+//	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//	http://www.lpre.de/kbkha/RD-0120/index.htm
+//	http://www.astronautix.com/r/rd-0120.html
+//	https://ur.booksc.eu/book/66908213/dc76fb
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[RD0120T]]:FOR[RealismOverhaulEngines]
+{
+	%title = RD-0120T
+	%manufacturer = KB Khimavtomatika
+	%description = 1990s medium TWR, atmospheric and vacuum use. The RD-0120T is a fuel-rich staged combustion tripropellant engine developed from the the RD-0120, for use on SSTOs and other high performance vehicles. Tested in collaboration with Aerojet, but never flew.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 11
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleHybridEngine
+		type = ModuleEngines
+		origMass = 3.8
+		configuration = RD0120T-Mode-1
+		modded = false
+
+		CONFIG
+		{
+			name = RD0120T-Mode-1
+			minThrust = 687.7
+			maxThrust = 1809.8
+			heatProduction = 100
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.0647
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.6003
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.3350
+				DrawGauge = False
+			}
+			atmosphereCurve
+			{
+				key = 0 418.7
+				key = 1 322.5
+			}
+			
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+
+		CONFIG
+		{
+			name = RD0120T-Mode-2
+			minThrust = 661.8
+			maxThrust = 735.3
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.729
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.271
+				DrawGauge = False
+			}
+			atmosphereCurve
+			{
+				key = 0 454
+				key = 1 350
+			}
+			
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+	}
+}
+
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0120T-Mode-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-0120T-Mode-1
+		testedBurnTime = 3000		//Rated for 5 flights
+		ratedBurnTime = 600
+		overburnPenalty = 1.25
+		safeOverburn = true
+		ignitionReliabilityStart = 0.95
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.995
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0120T-Mode-1] { %ratedBurnTime = #$/TESTFLIGHT[RD-0120T-Mode-1]/ratedBurnTime$ } }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
@@ -7,10 +7,10 @@
 //	RD-0120
 //	Energia
 //
-//	Dry Mass: 3450 Kg
+//	Dry Mass: 3449 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1961 kN
-//	ISP: 336 SL / 454.5 Vac
+//	ISP: 353.2 SL / 454.5 Vac
 //	Burn Time: 600
 //	Chamber Pressure: 21.87 MPa
 //	Propellant: LOX / LH2
@@ -22,7 +22,7 @@
 //	RD-0120M
 //	Energia-M
 //
-//	Dry Mass: 3450 Kg
+//	Dry Mass: 3449 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1961.7 kN
 //	ISP: 359.1 SL / 454.6 Vac
@@ -34,10 +34,28 @@
 //	Nozzle Ratio: 85.7
 //	Ignitions: 1
 //	=================================================================================
+//	RD-0122
+//	Energia-MT (Energia II), Angara
+//
+//	Dry Mass: 3449 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 2313 kN
+//	ISP: 359.1 SL / 460.7 Vac
+//	Burn Time: 600
+//	Chamber Pressure: 22.06 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.95
+//	Throttle: ???
+//	Nozzle Ratio: 85.7
+//	Ignitions: 1
+//	=================================================================================
 
 //	Sources:
 
 //	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//	http://www.lpre.de/kbkha/RD-0120/index.htm
+//	http://www.astronautix.com/r/rd-0120.html
+//	https://ur.booksc.eu/book/66908213/dc76fb
 
 //	Used by:
 
@@ -69,13 +87,14 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		origMass = 3.45
+		origMass = 3.449
 		configuration = RD-0120
 		modded = false
 
 		CONFIG
 		{
 			name = RD-0120
+			description = Used on core stage of Energia. AKA 11D122
 			minThrust = 882.45
 			maxThrust = 1961
 			heatProduction = 100
@@ -93,7 +112,7 @@
 			atmosphereCurve
 			{
 				key = 0 454.5
-				key = 1 336
+				key = 1 353.2
 			}
 			
 			ullage = True
@@ -108,6 +127,7 @@
 		CONFIG
 		{
 			name = RD-0120M
+			description = Designed for Energia-M, a quarter sized Energia derivative, after the collapse of the Soviet Union ended the Buran program. Tested, but never flew. AKA 11D122A
 			minThrust = 745.44
 			maxThrust = 1961.7
 			heatProduction = 100
@@ -125,6 +145,39 @@
 			atmosphereCurve
 			{
 				key = 0 455.6
+				key = 1 359.1
+			}
+			
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+
+		CONFIG
+		{
+			name = RD-0122
+			description = Upgraded RD-0120 for later Energia versions. Proposed to power Angara after the cancellation of Energia
+			minThrust = 878.9
+			maxThrust = 2313
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.729
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.271
+			}
+			atmosphereCurve
+			{
+				key = 0 460.7
 				key = 1 359.1
 			}
 			
@@ -172,6 +225,29 @@
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.9
 		cycleReliabilityEnd = 0.98
+		
+		techTransfer = RD-0120:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0120M] { %ratedBurnTime = #$/TESTFLIGHT[RD-0120M]/ratedBurnTime$ } }
+}
+
+//no data, never flew
+//Use SSME data
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0122]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-0122
+		testedBurnTime = 1670		//Rated to 1670 seconds
+		ratedBurnTime = 600
+		overburnPenalty = 1.25
+		safeOverburn = true
+		ignitionReliabilityStart = 0.989362
+		ignitionReliabilityEnd = 0.997872
+		cycleReliabilityStart = 0.989362
+		cycleReliabilityEnd = 0.997872
+		
+		techTransfer = RD-0120,RD-0120M:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0122] { %ratedBurnTime = #$/TESTFLIGHT[RD-0122]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD701.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD701.cfg
@@ -108,21 +108,21 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.126
+				ratio = 0.0897
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.06
+				ratio = 0.4941
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.814
+				ratio = 0.4162
 				DrawGauge = False
 			}
 
@@ -140,6 +140,7 @@
 			maxThrust = 1588
 			heatProduction = 100
 			massMult = 1.0
+			throttleResponseRate = 100
 
 			ullage = True
 			pressureFed = False
@@ -154,15 +155,13 @@
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.7252
-				DrawGauge = True
+				ratio = 0.729
+				DrawGauge = true
 			}
-
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.2748
-				DrawGauge = False
+				ratio = 0.271
 			}
 
 			atmosphereCurve

--- a/GameData/RealismOverhaul/Engine_Configs/RD704.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD704.cfg
@@ -109,21 +109,21 @@
 			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.126
+				ratio = 0.0897
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.06
+				ratio = 0.4941
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.814
+				ratio = 0.4162
 				DrawGauge = False
 			}
 
@@ -141,6 +141,7 @@
 			maxThrust = 785
 			heatProduction = 100
 			massMult = 1.0
+			throttleResponseRate = 100
 
 			ullage = True
 			pressureFed = False
@@ -155,15 +156,13 @@
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.7252
-				DrawGauge = True
+				ratio = 0.729
+				DrawGauge = true
 			}
-
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.2748
-				DrawGauge = False
+				ratio = 0.271
 			}
 
 			atmosphereCurve


### PR DESCRIPTION
- Add the RD-0120T, a tri-propellant modification of the RD-0120 and predecessor to RD-701/704
- Correct the sea level ISP of the RD-0120
- Correct the O/F/F ratios of the RD-701/704, and remove spoolup for instant mode switching