### PR TITLE
MIGHT BREAK SSPX CRAFT - Fixed typos in existing configs, added new configs for new sspx parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_375m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_375m_Parts.cfg
@@ -1,0 +1,272 @@
+//	=================================================================
+//	3.75m Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//
+//	sspx-attach-1875-1  	PMA-AR Radial Attachment Module
+//	sspx-core-1875-1		PMA-2 'Quay' Station Core
+//	sspx-cupola-1875-1		PMA-C 'Panoptes' Observation Module
+//  sspx-habitation-1875-1	PMA-5 'Dawn' Habitation Module
+//	sspx-habitation-1875-2	PMA-5B 'Evening' Habitation Module
+//	sspx-hub-1875-1			PMA-MULT Multi-Point Station Connector
+//	sspx-science-1875-1		PMA-4 'Nature' Science Lab
+//	sspx-tube-1875-1		PMA-T1 Pressurized Crew Tube
+//	sspx-tube-1875-2		PMA-T2 Pressurized Crew Tube
+//	sspx-tube-1875-3		PMA-T3 Pressurized Crew Tube
+//	sspx-tube-1875-angled-1	PMA-1A Angled Pressurized Crew Tube
+//	sspx-utility-1875-1		PMA-3 'Spectra' Utility Module
+//		
+//	=================================================================
+
+@PART[sspx-attach-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+
+	@title = 3.75m Pressurized Radial Attachment Point
+	@manufacturer = Generic
+	@tags = sspx, station, radial, attach
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.5
+}
+
+@PART[sspx-core-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Station Core
+	@manufacturer = Generic
+	@tags = sspx, station, core, control
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	
+	@mass = 4.5
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel] {}
+	
+	@MODULE[ModuleProbeControlPoint] {}
+	@MODULE[ModuleCommand] {}
+	@MODULE[ModuleDataTransmitter] {}
+	
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 1
+	}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 4750
+		basemass = -1
+	}
+}
+
+@PART[sspx-cupola-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Cupola
+	@manufacturer = Generic
+	@tags = sspx, station, cupola
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 3.75
+
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+}
+
+@PART[sspx-habitation-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Habitation Module (Large)
+	@manufacturer = Generic
+	@tags = sspx, station, hab, habitation, living
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 8.786
+
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE 
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 7000
+		basemass = -1
+	}
+}
+
+@PART[sspx-habitation-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+
+	@title = 3.75m Habitation Module (Small)
+	@manufacturer = Generic
+	@tags = sspx, station, hab, habitation, living
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 7.144
+
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 5000
+		basemass = -1
+	}
+}
+
+@PART[sspx-hub-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Station Hub
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 5.7
+}
+
+@PART[sspx-science-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Station Science Lab
+	@manufacturer = Generic
+	@tags = sspx, station, lab, science
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 10.143
+
+	!RESOURCE,* {}
+}
+
+@PART[sspx-tube-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Pressurized Crew Tube (Long)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 4
+}
+
+@PART[sspx-tube-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Pressurized Crew Tube (Medium)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2
+}
+
+@PART[sspx-tube-1875-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Pressurized Crew Tube (Short)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.95
+}
+
+@PART[sspx-tube-1875-angled-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Pressurized Crew Tube (Angled)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 3
+}
+
+@PART[sspx-utility-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Utility Module
+	@manufacturer = Generic
+	@tags = sspx, station, cupola
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 5.243
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+	// This is the first part of the storage, but Cargo Containers are still preferred
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 22500
+        basemass = -1
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_83m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_83m_Parts.cfg
@@ -1,0 +1,301 @@
+//	=================================================================
+//	8.3m Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//
+//	sspx-core-5-1               SDV-3 'Minerva' Deep Space Control Module
+//  sspx-dome-5-1               SDV-G1 'Tholos' Geodesic Dome
+//  sspx-dome-cupola-5-1        SDV-G4 'Astrolabe' Observation Dome
+//  sspx-dome-habitation-5-1    SDV-G3 'Domus' Habitation Dome
+//  sspx-habitation-5-1         SDV-2 'Atlas' Deep Space Habitation Module
+//  sspx-habitation-5-2         SDV-2B 'Titan' Compact Deep Space Habitation Module
+//  sspx-lab-5-1                SDV-6 'Delphi' Science Module
+//  sspx-lab-pallet-1           SD-2x2 Structural Panel
+//  sspx-lab-pallet-2           SD-1x1 Structural Panel
+//  sspx-logistics-5-1          SDV-1 'Leto' Deep Space Logistics Module
+//  sspx-logistics-5-2          SDV-1X 'Atriedes' Deep Space Logistics Module
+//		
+//	=================================================================
+
+@PART[sspx-core-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+    %rescaleFactor = 1.66
+
+    @title = 8.3m Station Core
+    @manufacturer = Generic
+    @tags = sspx, station, core, control
+
+    @maxTemp = 773.15
+    @skinMaxTemp = 773.15
+    @crashTolerance = 10
+
+    @mass = 22.691
+
+    !RESOURCE,* {}
+	!MODULE[ModuleReactionWheel] {}
+	
+	@MODULE[ModuleProbeControlPoint] {}
+	@MODULE[ModuleCommand] {}
+	@MODULE[ModuleDataTransmitter] {}
+	
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 2
+	}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 12000
+        basemass = -1
+    }
+}
+
+@PART[sspx-dome-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+    %rescaleFactor = 1.66
+
+    @title = 8.3m Geodesic Dome
+    @manufacturer = Generic
+    @tags = sspx, station, dome
+
+    @maxTemp = 773.15
+    @skinMaxTemp = 773.15
+    @crashTolerance = 10
+
+    @mass = 15
+
+    !RESOURCE,* {}
+
+    // This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 5000
+        basemass = -1
+    }
+}
+
+@PART[sspx-dome-cupola-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+    %rescaleFactor = 1.66
+
+    @title = 8.3m Geodesic Observation Dome
+    @manufacturer = Generic
+    @tags = sspx, station, dome
+
+    @maxTemp = 773.15
+    @skinMaxTemp = 773.15
+    @crashTolerance = 10
+
+    @mass = 30
+
+    !RESOURCE,* {}
+
+    // This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 5000
+        basemass = -1
+    }
+}
+
+@PART[sspx-dome-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+    %rescaleFactor = 1.66
+
+    @title = 8.3m Geodesic Habitation Dome
+    @manufacturer = Generic
+    @tags = sspx, station, dome
+
+    @maxTemp = 773.15
+    @skinMaxTemp = 773.15
+    @crashTolerance = 10
+
+    @mass = 50
+
+    !RESOURCE,* {}
+    !MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+
+    // This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 15000
+        basemass = -1
+    }
+}
+
+@PART[sspx-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Habitation Module (Large)
+	@manufacturer = Generic
+	@tags = sspx, station, hab, habitation, living
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 28
+
+    !RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+    !MODULE[ModuleB9PartSwitch],3 {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 15000
+        basemass = -1
+    }
+}
+
+@PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Habitation Module (Small)
+	@manufacturer = Generic
+	@tags = sspx, station, hab, habitation, living
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 22.691
+	
+    !RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 10000
+        basemass = -1
+    }
+}
+
+@PART[sspx-lab-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Station Science Lab
+	@manufacturer = Generic
+	@tags = sspx, station, lab, science
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 25
+
+    !RESOURCE,* {}
+}
+
+@PART[sspx-lab-pallet-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 2x2 Structural Pallet
+	@manufacturer = Generic
+	@tags = sspx, station, tructural
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.6
+}
+
+@PART[sspx-lab-pallet-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 1x1 Structural Pallet
+	@manufacturer = Generic
+	@tags = sspx, station, tructural
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.15
+}
+
+@PART[sspx-logistics*]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	
+	%rescaleFactor = 1.66
+	@attachRules = 1,1,1,1,0
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.0
+	
+	@MODULE[ModuleB9DisableTransform]
+	{
+		%transform = OreDecal
+	}
+
+	!MODULE[ModuleB9PartSwitch] {}
+	!MODULE[ModuleFuelTanks] {}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5670
+		basemass = 1
+		utilizationTweakable = true
+		maxUtilization = 75
+		utilization = 75
+		type = SM-IV
+		typeAvailable = SM-IV
+	}
+}
+
+// 5m Logistics container (Long) - 5m x 4.8m
+// 8.3 x 7.968
+@PART[sspx-logistics-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	@title = 8.3m Logistics Module (Long)
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume *= 80 //453600
+	}
+}
+
+// 5m Logistics container (Short) - 5m x 2.7m
+// 8.3 x 4.482
+@PART[sspx-logistics-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	@title = 8.3m Logistics Module (Short)
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume *= 40 //226800
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Adapters_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Adapters_Utility.cfg
@@ -1,11 +1,17 @@
 //	=================================================================
 //	Adapters - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
-//	sspx-adapter-0625-125-1	PTD-C Flat Adapter
-//	sspx-adapter-125-25-1	PPD-PTD Flat Adapter
-//	sspx-adapter-125-25-2	PPD-PTD Adapter
-//	sspx-adapter-25-375-1	PXL-2A Conical Adapter
-//	sspx-adapter-25-375-2	PXL-2A Flat Adapter
+//	sspx-adapter-0625-125-1		PTD-C Flat Adapter
+//	sspx-adapter-125-25-1		PPD-PTD Flat Adapter
+//	sspx-adapter-125-25-2		PPD-PTD Adapter
+//	sspx-adapter-1875-125-1		PMA-PAS Flat Adapter
+//	sspx-adapter-1875-125-2		PMA-PAS Adapter
+//	sspx-adapter-1875-0625-1	PMA Narrow Adapter
+//	sspx-adapter-25-1875-1		PPD-PAS Adapter
+//	sspx-adapter-25-375-1		PXL-2A Conical Adapter
+//	sspx-adapter-25-375-2		PXL-2A Flat Adapter
+//	sspx-adapter-375-5-1		SDV-4 Adapter
+//	sspx-adapter-375-5-2		SDV-6 Flat Adapter
 //
 //	=================================================================
 
@@ -57,6 +63,68 @@
 	@mass = 0.7204
 }
 
+@PART[sspx-adapter-1875-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux] {
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = Station Flat Adapter [3.75m to 2.5m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, flat
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.25
+}
+
+@PART[sspx-adapter-1875-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux] {
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = Station Conical Adapter [3.75m to 2.5m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.7
+}
+
+@PART[sspx-adapter-1875-0625-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = Station Conical Adapter [3.75m to 1.25m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, Conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.2
+}
+
+@PART[sspx-adapter-25-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = Station Conical Adapter [4.15m to 3.1125m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.92
+}
+
 @PART[sspx-adapter-25-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
@@ -87,6 +155,38 @@
 	@crashTolerance = 10
 
 	@mass = 0.9456
+}
+
+@PART[sspx-adapter-375-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = Station Conical Adapter [8.3m to 6.225m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.5
+}
+
+@PART[sspx-adapter-375-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = Station Flat Adapter [8.3m to 6.225m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, flat
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2
 }
 
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Base.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Base.cfg
@@ -2,11 +2,16 @@
 //	Adjusting Bases - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-adjusting-base-125-1			BZ-1 Adjustable Base Frame
+//	sspx-adjusting-base-1875-1			BZ-1B Adjustable Base Frame
 //	sspx-adjusting-base-25-1			BZ-2 Adjustable Base Frame
 //	sspx-adjusting-base-375-1			BZ-3 Adjustable Base Frame
+//	sspx-adjusting-base-5-1				BZ-4 Adjustable Base Frame
 //	sspx-adjusting-base-cradle-125-1	BR-1 Adjustable Base Cradle
+//	sspx-adjusting-base-cradle-1875-1	BR-1B Adjustable Base Cradle
 //	sspx-adjusting-base-cradle-25-1		BR-2 Adjustable Base Cradle
 //	sspx-adjusting-base-cradle-375-1	BR-3 Adjustable Base Cradle
+//	sspx-adjusting-base-crade-5-1		BR-4 Adjustable Base Cradle
+//	sspx-adjusting-stairs-1				B-ST41R Extensible Stairway
 //
 //	=================================================================
 
@@ -24,6 +29,22 @@
 	@crashTolerance = 10
 
 	@mass = 1
+}
+
+@PART[sspx-adjusting-base-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Adjustable Base Frame
+	@manufacturer = Generic
+	@tags = leg, station, frame
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.25
 }
 
 @PART[sspx-adjusting-base-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -58,6 +79,22 @@
 	@mass = 2.041
 }
 
+@PART[sspx-adjusting-base-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Adjustable Base Frame
+	@manufacturer = Generic
+	@tags = leg, station, frame
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.75
+}
+
 @PART[sspx-adjusting-base-cradle-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
@@ -72,6 +109,22 @@
 	@crashTolerance = 10
 
 	@mass = 1.5
+}
+
+@PART[sspx-adjusting-base-cradle-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2
+	
+	@title = 3.75m Adjustable Base Cradle
+	@manufacturer = Generic
+	@tags = leg, station, frame, cradle
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.8
 }
 
 @PART[sspx-adjusting-base-cradle-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -104,4 +157,36 @@
 	@crashTolerance = 10
 
 	@mass = 3.062
+}
+
+@PART[sspx-adjusting-base-cradle-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Adjustable Base Cradle
+	@manufacturer = Generic
+	@tags = leg, station, frame, cradle
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 4.083
+}
+
+@PART[sspx-adjusting-stairs-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = Adjustable Stairs
+	@manufacturer = Generic
+	@tags = leg, station, stairs, stairway
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.2
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Containers.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Containers.cfg
@@ -20,7 +20,7 @@
 //	of my tests, it came out to be easy to calculate the masses and volumes
 //	from the original configs. This is important for the radial tanks that
 //	have the different shapes that we cannot easily recreate as Procedural Parts.
-//	Volume	= Original / 0.76394 (rounded to nearest 10's)
+//	Volume	= Original / 0.76394 (rounded to nearest 10s)
 //	Mass 	= Handled by RealFuels
 //	=================================================================
 
@@ -57,7 +57,6 @@
 	}
 }
 
-
 // 2.5m Cargo container (Long) - 2.5 x 4m
 // 4.15 x 6.64
 @PART[sspx-cargo-container-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -91,7 +90,7 @@
 	}
 }
 
-// 3.755m Cargo container (Long) - 3.75 x 4m
+// 3.75m Cargo container (Long) - 3.75 x 4m
 // 6.225 x 6.64
 @PART[sspx-cargo-container-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
@@ -195,7 +194,7 @@
 }
 
 // Small Radial Cargo Container (Small)
-@PART[sspx-cargo-container-radial-small-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-cargo-container-radial-small-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	@title = Radial Cargo Container (Small)
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
@@ -3,17 +3,21 @@
 //  All parts should be scaled by 1.6667 for human sizes
 //
 //  1.25m *******
-//  sspx-inflatable-centrifuge-125-1 => RO-sspx-iss-demo	ISS Centrifuge Demo
-//  sspx-inflatable-centrifuge-125-1    Nautilus-X Centrifuge
-//  sspx-inflatable-centrifuge-125-2    REMOVE
-//	sspx-inflatable-hab-125-1			1.25m Inflatable Hab (Long)
-//	sspx-inflatable-hab-125-2			1.25m Inflatable Hab (Medium)
-//	sspx-inflatable-hab-125-3			BA330
+//  sspx-inflatable-hab-125-1           PAF-2 'Eclair' Inflatable Habitation Module
+//  sspx-inflatable-hab-125-2           PAF-1A 'Volleyball' Inflatable Habitation Module
 //
 //  2.5m ********
-//  sspx-inflatable-centrifuge-25-1     2.5m Inflatable Centrifuge
-//  sspx-inflatable-hab-25-1            2.5m Inflatable Hab (Long)
-//  sspx-inflatable-hab-25-2            2.5m Inflatable Hab (Short)
+//  sspx-inflatable-centrifuge-25-1     PPF-C 'Coriolis' Inflatable Centrifuge Module
+//  sspx-inflatable-hab-25-1            PPF-A 'Dirigible' Inflatable Habitation Module
+//  sspx-inflatable-hab-25-2            PPF-B 'Blimp' Inflatable Habitation Module
+//
+//  3.75m *******
+//  sspx-expandable-centrifuge-375-1    PXL-E 'Mercury' Extensible Centrifuge
+//  sspx-expandable-centrifuge-375-2    PXL-F 'Pilgrim' Extensible Centrifuge
+//
+//  5m **********
+//  sspx-expandable-centrifuge-5-1      SDV-X 'Cronus' Extensible Centrifuge
+//
 //	===========================================================================
 
 @PART[sspx-inflatable*]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -25,68 +29,184 @@
 	@crashTolerance = 10
 }
 
-@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	@title = 20m Diameter Centrifuge (Mars Gravity)
-	%rescaleFactor = 2.44
-	//@mass = 
-}
-
-@PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-expandable*]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	@tags = sspx, station, expandable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
 }
 
 @PART[sspx-inflatable-hab-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 2.44
+
+    @title = 3.05m Inflatable Habitat Module (Long)
+    @mass = 6
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1500
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 2.44
+
+    @title = 3.05m Inflatable Habitat Module (Short)
+    @mass = 3
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 750
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-centrifuge-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.66
+
+    @title = 4.15m Inflatable Centrifuge Module
+    @mass = 25
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1500
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.66
+
+    @title = 4.15m Inflatable Habitat Module (Long)
+    @mass = 30
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 5000
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.66
+
+    @title = 4.15m Inflatable Habitat Module (Short)
+    @mass = 15
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 2500
+        basemass = -1
+    }
 }
 
-@PART[sspx-inflatable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-expandable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+    %RSSROConfig = True
+	%rescaleFactor = 1.66
+    @title = 6.225m Extensible Habitat Module (Large)
+    @mass = 70
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 7500
+        basemass = -1
+    }
+}
+
+@PART[sspx-expandable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.66
+    @title = 6.225m Extensible Habitat Module (Small)
+    @mass = 50
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 5000
+        basemass = -1
+    }
 }
 
-@PART[sspx-inflatable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-expandable-centrifuge-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.66
+    @title = 8.3m Extensible Habitat Module
+    @mass = 90
+
+    !RESOURCE,* {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 10000
+        basemass = -1
+    }
 }
+
+
+//	===========================================================================
+//	
+//  REAL-WORLD COUNTERPARTS
+//  sspx-inflatable-centrifuge-125-1    Nautilus-X Centrifuge
+//  sspx-inflatable-centrifuge-125-2    ISS Centrifuge Demo
+//  sspx-inflatable-hab-125-3           Bigelow BA330
+//
+//	===========================================================================
 
 // ISS Centrifuge Demo
-+PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	@name = RO-sspx-iss-demo
-}
-
-@PART[RO-sspx-iss-demo]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 2.44
@@ -114,7 +234,7 @@
 	}
 }
 
-@PART[RO-sspx-iss-demo]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,TacLifeSupport]
+@PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,TacLifeSupport]
 {
     @description ^= :$: Supports a crew of 4 for 1 day of active operations.:
 
@@ -372,17 +492,6 @@
 @PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-
-	//@MODEL,0
-	//{
-	//	@position = 0, -1.984, 0
-	//	@scale = 1.292, -1, 1.292
-	//}
-	//@MODEL,1
-	//{
-	//	@scale = 1.292, 2.252, 1.292
-	//}
-
 	%rescaleFactor = 2.44
 
 	@maxTemp = 773.15
@@ -393,7 +502,7 @@
 
 	@mass = 14.795
 
-	@title = BA330 Inflatable Habitat
+	@title = Bigelow BA330 Inflatable Habitat
 	@manufacturer = Bigelow
 	@description = The Bigelow BA330 inflatable habitat. As the name suggests, it has 330 cubic meters of pressurized volume. Room for 6, and 30 days of supplies. Add a few tonnes of water for radiation shielding purposes to simulate the Deep Space configuration (otherwise it's only suitable for low Earth orbit).
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Special.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Special.cfg
@@ -1,10 +1,49 @@
 //	=================================================================
 //	Special Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
+//	sspx-cupola-telescope-125-1		PAS-T 'Oculus' Remote Telescope
+//	sspx-cupola-greenhouse-125-1	PAS-G 'G4RD3N' Hydroponics Cupola
 //	sspx-greenhouse-25-1			PPD-F412M Hydroponics Module
 //	sspx-greenhouse-375-1			PXL-R4NCH-3R Hydroponics Module
+//	sspx-aquaculture-375-1			PXL-F15H Aquaculture Module
+//	sspx-greenhouse-5-1				SDV-4 'Demeter' Cultivation Module
+//	sspx-dome-greenhouse-5-1		SDV-G2 'Villa' Cultimation Dome
 //
 //	=================================================================
+
+@PART[sspx-cupola-telescope-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2.44
+	
+	@title = 3.05m Remote Telescope
+	@manufacturer = Generic
+	@tags = sspx, station, hydroponics, cupola
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.5
+}
+
+@PART[sspx-cupola-greenhouse-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 2.44
+	
+	@title = 3.05m Hydroponics Cupola
+	@manufacturer = Generic
+	@tags = sspx, station, hydroponics, cupola
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.5
+
+	!MODULE[ModuleExperienceManagement] {}
+}
 
 @PART[sspx-greenhouse-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
@@ -19,7 +58,9 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 99
+	@mass = 25
+
+	!MODULE[ModuleExperienceManagement] {}
 }
 
 @PART[sspx-greenhouse-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -35,5 +76,61 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 99
+	@mass = 30
+
+	!MODULE[ModuleExperienceManagement] {}
+}
+
+@PART[sspx-aquaculture-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 6.225m Aquaculture Module
+	@manufacturer = Generic
+	@tags = station, aquaculture
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 50
+
+	!MODULE[ModuleExperienceManagement] {}
+}
+
+@PART[sspx-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Hydroponics Module
+	@manufacturer = Generic
+	@tags = station, hydroponics, greenhouse
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 75
+
+	!MODULE[ModuleExperienceManagement] {}
+}
+
+@PART[sspx-dome-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.66
+	
+	@title = 8.3m Geodesic Hydroponics Dome
+	@manufacturer = Generic
+	@tags = station, hydroponics, greenhouse, dome
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 80
+
+	!MODULE[ModuleExperienceManagement] {}
 }


### PR DESCRIPTION
Fixed various typos in the existing configs and finished up some unfinished configs. Also added new configs for all the new parts that were recently added to SSPX, including the new 1.875m station parts, the new 5m station parts, and the new 5m geodesic ground domes. Scaled the 5m parts by 1.66 to result in 8.3m, and scaled the 1.875m parts by 2 to result in 3.75m. This was done to keep them between the original 1.25m and 2.5m parts, which were scaled by different factors (2.44 vs 1.66). With the addition of the 1.875m parts, I personally think all parts from SSPX should now be scaled by 1.66. I understand why the original 1.25m parts were scaled up to 3.05m initially, but with the new parts added at 1.875m, those could now cover 3.1125m parts if scaled by 1.66. If everything was scaled by 1.66, this would result in 2.075m, 3.1125m, 4.15m, 6.225m, and 8.3m parts, and all the adapters would then properly work between sizes. I had not done that yet, as that would definitely break any crafts that currently use the 3.05m scaled parts. Let me know your thoughts on making the scaling consistent!