### PR TITLE
Fix AltairIII fuel amount

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
@@ -42,14 +42,14 @@
 	{
 		name = ModuleFuelTanks
 		type = PBAN
-		volume = 254.8664
+		volume = 154.8664
 		basemass = -1
 		
 		TANK
 		{
 			name = PBAN
-			amount = 254.8664
-			maxAmount = 254.8664
+			amount = 154.8664
+			maxAmount = 154.8664
 		}
 	}
 	


### PR DESCRIPTION
Top of file says 274.4kg; "254.8664" PBAN is way too much for that. The limited precision of the RF UI got me ~154.86 for the right mass, so I'm assuming it was a just a 1->2 typo

Now getting a burn time of ~30s, close enough to stated 31.5