### PR TITLE
Classify NOS gas as an HP resource

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1005,16 +1005,6 @@ TANK_DEFINITION
 	}
 	TANK
 	{
-		name = NitrousOxide
-		//mass = 0.00003
-		utilization = 100
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		//note = (pressurized)
-	}
-	TANK
-	{
 		name = Aniline
 		//mass = 0.00002
 		utilization = 1
@@ -1459,6 +1449,16 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = NitrousOxide
+		//mass = 0.00003
+		utilization = 100
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		//note = (pressurized)
 	}
 }
 


### PR DESCRIPTION
Move Nitrous Oxide from the normal resources section to the HP resources section. As a gas, it should be considered HP