### PR TITLE
Sspx update

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
@@ -32,7 +32,7 @@
 	@mass = 0.5
 }
 
-@PART[sspx-core-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-core-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -158,7 +158,7 @@
 	@mass = 1.06 //scaled from 3.05m as a square 
 }
 
-@PART[sspx-habitation-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -185,7 +185,7 @@
         basemass = -1
     }
 	
-		@MODULE[ModuleFuelTanks]
+	@MODULE[ModuleFuelTanks]
 	{
 
 		TANK
@@ -261,7 +261,7 @@
 	@mass = 0.6
 }
 
-@PART[sspx-utility-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-utility-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -288,7 +288,7 @@
         basemass = -1
     }
 	
-		@MODULE[ModuleFuelTanks]
+	@MODULE[ModuleFuelTanks]
 	{
 
 		TANK

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
@@ -1,11 +1,13 @@
 //	=================================================================
-//	3.05m (MOL Size) Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//	2.25m Modules (Rassvet, Pirs, Prichal, various chambers and adapters, MOL) - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-attach-125-1			Pressurized BZ-15 Radial Attachment Point
 //	sspx-core-125-1				PTD-8R 'Pier' Station Core
 //	sspx-cupola-125-1			PTD-C 'Porthole' Observation Window
-//	sspx-extendable-tube-125-1	B-EX-1 Extensible Crew Tube
-//	sspx-habitation-125-1		PTD-5 'Sunrise' Habitation Module
+//	sspx-cupola-greenhouse-125-1
+//	sspx-cupola-telescope-125-1
+//	sspx-extendable-tube-125-1		B-EX-1 Extensible Crew Tube
+//	sspx-habitation-125-1			PTD-5 'Sunrise' Habitation Module
 //	sspx-hub-125-1				PTD-MULT Multi-Point Station Connector
 //	sspx-tube-125-1				PTD-1 Pressurized Crew Tube
 //	sspx-tube-125-2				PTD-2 Pressurized Crew Tube
@@ -17,9 +19,9 @@
 @PART[sspx-attach-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Pressurized Radial Attachement Point
+	@title = 2.25m Pressurized Radial Attachement Point
 	@manufacturer = Generic
 	@tags = sspx, station, radial, attach
 	
@@ -27,15 +29,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.2
+	@mass = 0.5
 }
 
 @PART[sspx-core-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Station Core
+	@title = 2.25m Station Core
 	@manufacturer = Generic
 	@tags = sspx, station, core, control
 	
@@ -43,7 +45,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 4.199
+	@mass = 2.285 //scaled from 3.05m as a square 
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleReactionWheel] {}
@@ -63,7 +65,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 2800
+        volume = 1120 //scaled from 3.05m as a cube
         basemass = -1
     }
 }
@@ -71,9 +73,9 @@
 @PART[sspx-cupola-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Cupola
+	@title = 2.25m Cupola
 	@manufacturer = Generic
 	@tags = sspx, station, cupola
 	
@@ -81,18 +83,60 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.983
+	@mass = 1.093 // ISS Cupola has m=1880kg and d=2.95m. This one is 1.31 smaller, so wall area and mass are 1.31^2 smaller
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleScienceExperiment] {}
 }
 
+@PART[sspx-cupola-greenhouse-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 2.25m Greenhouse Dome
+	@manufacturer = Generic
+	@tags = sspx, station, cupola, dome
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+			
+	@mass = 1.093 // same as cupola
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+	@MODULE[ModuleCommand] {}
+}
+
+@PART[sspx-cupola-telescope-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 2.25m Telescope Dome
+	@manufacturer = Generic
+	@tags = sspx, station, cupola, dome
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+			
+	@mass = 1.093 // same as cupola
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+	@MODULE[ModuleCommand] {}
+}
+
 @PART[sspx-extendable-tube-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Extendable Crew Tube
+	@title = 2.25m Extendable Crew Tube
 	@manufacturer = Generic
 	@tags = sspx, station, tube, extendable
 	
@@ -100,15 +144,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.95
+	@mass = 1.06 //scaled from 3.05m as a square 
 }
 
 @PART[sspx-habitation-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Habitation Module
+	@title = 2.25m Habitation Module
 	@manufacturer = Generic
 	@tags = sspx, station, tube, extendable
 	
@@ -116,7 +160,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 7.144
+	@mass = 3.670 // As for Poisk module
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -126,7 +170,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 5000
+        volume = 2000 //scaled from 3.05m as a cube
         basemass = -1
     }
 }
@@ -134,9 +178,9 @@
 @PART[sspx-hub-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Station Hub
+	@title = 2.25m Station Hub
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -144,15 +188,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 3.728
+	@mass = 3.2 // Prichal dry mass 3.5kg (as its sphere diameter is about 3.5m too), minus 6*0.05kg=0.3kg of docking ports
 }
 
 @PART[sspx-tube-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Pressurized Crew Tube (Long)
+	@title = 2.25m Pressurized Crew Tube (Long)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -160,15 +204,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 3.562
+	@mass = 1.938 // scaled from 3.05m as a square 
 }
 
 @PART[sspx-tube-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Pressurized Crew Tube (Medium)
+	@title = 2.25m Pressurized Crew Tube (Medium)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -176,15 +220,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.79
+	@mass = 0.974 //scaled from 3.05m as a square 
 }
 
 @PART[sspx-tube-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Pressurized Crew Tube (Short)
+	@title = 2.25m Pressurized Crew Tube (Short)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -192,15 +236,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 0.877
+	@mass = 0.6
 }
 
 @PART[sspx-utility-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Utility Module
+	@title = 2.25m Utility Module
 	@manufacturer = Generic
 	@tags = sspx, station, cupola
 	
@@ -208,7 +252,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 2.89
+	@mass = 1.6 //scaled from 3.05m as a square 
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleScienceExperiment] {}
@@ -218,7 +262,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 15000
+        volume = 8000 //scaled from 3.05m as a cube. This is about half a volume of the module
         basemass = -1
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
@@ -68,6 +68,17 @@
         volume = 1120 //scaled from 3.05m as a cube
         basemass = -1
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10800
+			maxAmount = 10800
+		}
+	}
 }
 
 @PART[sspx-cupola-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -173,6 +184,17 @@
         volume = 2000 //scaled from 3.05m as a cube
         basemass = -1
     }
+	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10800
+			maxAmount = 10800
+		}
+	}
 }
 
 @PART[sspx-hub-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -262,7 +284,18 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 8000 //scaled from 3.05m as a cube. This is about half a volume of the module
+        volume = 6000
         basemass = -1
     }
+	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 21600
+			maxAmount = 21600
+		}
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
@@ -33,7 +33,7 @@
 	@mass = 1.831 //scaled from 4.15m as a square
 }
 
-@PART[sspx-core-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-core-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -80,10 +80,22 @@
         volume = 4000
         basemass = -1
     }
+		
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 21600
+			maxAmount = 21600
+		}
+	}
+	
 }
 
 
-@PART[sspx-habitation-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -122,7 +134,7 @@
 	}
 }
 
-@PART[sspx-habitation-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -161,7 +173,7 @@
 	}
 }
 
-@PART[sspx-utility-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-utility-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -201,7 +213,7 @@
 	}
 }
 
-@PART[sspx-science-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-science-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
@@ -1,0 +1,302 @@
+//	=================================================================
+//	3.38m Modules (4.0m max width, Soviet Stations, Mir, ISS Russian Segment)  - STOCKALIKE STATION PARTS EXPANSION REDUX
+//
+//	sspx-attach-1875-1
+//	sspx-core-1875-1
+//	sspx-habitation-1875-1
+//	sspx-habitation-1875-2
+//	sspx-utility-1875-1
+//	sspx-science-1875-1
+//	sspx-hub-1875-1
+//	sspx-cupola-1875-1
+//	sspx-tube-1875-1
+//	sspx-tube-1875-2
+//	sspx-tube-1875-3
+//	sspx-tube-1875-angled-1
+//
+//
+//	=================================================================
+
+@PART[sspx-attach-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Pressurized Radial Attachement Point
+	@manufacturer = Generic
+	@tags = sspx, station, radial, attach
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.831 //scaled from 4.15m as a square
+}
+
+@PART[sspx-core-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Station Core
+	@manufacturer = Generic
+	@tags = sspx, station, core, control
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 7.0 // Similar to Kvant module. 11t minus 4t of payload (http://www.russianspaceweb.com/mir_kvant.html)
+	
+	!RESOURCE,* {}
+	
+	//Kvant had reaction wheels
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 1.0
+		@YawTorque = 1.0
+		@RollTorque = 1.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.6
+		}
+	}
+	
+	@MODULE[ModuleProbeControlPoint] {}
+	@MODULE[ModuleCommand] {}
+	@MODULE[ModuleDataTransmitter] {}
+	
+	{
+		name = ModuleCommand
+		minimumCrew = 1
+	}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4000
+        basemass = -1
+    }
+}
+
+
+@PART[sspx-habitation-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Habitation Module (Long)
+	@manufacturer = Generic
+	@tags = sspx, station, tube, extendable
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 6.909 // twice the short version
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4000 // twice the short version
+        basemass = -1 
+    }
+}
+
+@PART[sspx-habitation-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Habitation Module (Short)
+	@manufacturer = Generic
+	@tags = sspx, station, tube, extendable
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 3.454 //scaled from stock 2.5m 1890kg Hitchhiker as a square
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 2000
+        basemass = -1 
+    }
+}
+
+@PART[sspx-utility-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Utility Module
+	@manufacturer = Generic
+	@tags = sspx, station, tube, extendable
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 7.4 	// Mir's Spektr was 20t, 7t of payload, had about 3t of panels (roughly 100m^2 on photos), so its about 10t for the hull
+			// If medium crew tube (1.6t) is placed above it and ~1t of other structures added, it would leave 7.4t for the part.
+			// This is close to 6.909 used for long hab module above.
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 7000 // 7 tons of payload, let it have water density.
+        basemass = -1 
+    }
+}
+
+@PART[sspx-science-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Science Module
+	@manufacturer = Generic
+	@tags = sspx, station, tube, extendable
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 8.4 	// Mir's Priroda was 20t, 7t of payload, so its about 13t for the hull
+			// If medium crew tube (1.6t) is placed above it and ~1t of other structures added, it would leave 10.4t for the part.
+			// This is probably too much, so lets have  8.4
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4000 // 7 tons of payload, but some was outside, so let it have the same as long hab module.
+        basemass = -1 
+    }
+}
+
+@PART[sspx-hub-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Station Hub
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 4.519 //scaled from 4.15m as a square
+}
+
+@PART[sspx-cupola-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Observation Module
+	@manufacturer = Generic
+	@tags = sspx, station, cupola
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 5.289 //scaled from 4.15m as a square
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleReactionWheel]
+	
+	@MODULE[ModuleCommand] {}
+}
+
+@PART[sspx-tube-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Pressurized Crew Tube (Long)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.916 //scaled from 4.15m as a square
+}
+
+@PART[sspx-tube-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Pressurized Crew Tube (Medium)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.6 
+}
+
+@PART[sspx-tube-1875-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Pressurized Crew Tube (Short)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.9
+}
+
+@PART[sspx-tube-1875-angled-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 3.38m Pressurized Crew Tube (Angled)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.25 // In the middle between short and medium
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
@@ -109,6 +109,17 @@
         volume = 4000 // twice the short version
         basemass = -1 
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 54000
+			maxAmount = 54000
+		}
+	}
 }
 
 @PART[sspx-habitation-1875-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -137,6 +148,17 @@
         volume = 2000
         basemass = -1 
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 32400
+			maxAmount = 32400
+		}
+	}
 }
 
 @PART[sspx-utility-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -152,9 +174,8 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 7.4 	// Mir's Spektr was 20t, 7t of payload, had about 3t of panels (roughly 100m^2 on photos), so its about 10t for the hull
-			// If medium crew tube (1.6t) is placed above it and ~1t of other structures added, it would leave 7.4t for the part.
-			// This is close to 6.909 used for long hab module above.
+	@mass = 5.0 	// The part is basically FGB (TKS spacecraft without VA). TKS mass in orbit was 17.5t,
+			// its payload was 12.6t (VA, fuel and cargo)
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -164,9 +185,20 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 7000 // 7 tons of payload, let it have water density.
+        volume = 9000 // About 9t of payload, let it have water density.
         basemass = -1 
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 64800
+			maxAmount = 64800
+		}
+	}
 }
 
 @PART[sspx-science-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -182,9 +214,8 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 8.4 	// Mir's Priroda was 20t, 7t of payload, so its about 13t for the hull
-			// If medium crew tube (1.6t) is placed above it and ~1t of other structures added, it would leave 10.4t for the part.
-			// This is probably too much, so lets have  8.4
+	@mass = 8.4 	// Mir's Priroda was 20t, 7t of payload, so its about 13t for the hull with fuel (let it be 2t)
+			// If medium crew tube (1.6t) is placed above it and ~1t of other structures added, it would leave 8.4t for the part.
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -197,6 +228,17 @@
         volume = 4000 // 7 tons of payload, but some was outside, so let it have the same as long hab module.
         basemass = -1 
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 21600
+			maxAmount = 21600
+		}
+	}
 }
 
 @PART[sspx-hub-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
@@ -65,6 +65,17 @@
         volume = 7000 // scaled from 4.15m as a cube
         basemass = -1
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 21600
+			maxAmount = 21600
+		}
+	}
 }
 
 @PART[sspx-extendable-tube-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -109,6 +120,17 @@
         volume = 4000
         basemass = -1
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 64800
+			maxAmount = 64800
+		}
+	}
 }
 
 @PART[sspx-hub-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -141,6 +163,14 @@
 	@crashTolerance = 10
 
 	@mass = 14
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4000
+        basemass = -1
+    }
 }
 
 @PART[sspx-observation-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
@@ -30,7 +30,7 @@
 	@mass = 3.827 // scaled from 4.15m as a square
 }
 
-@PART[sspx-core-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-core-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -94,7 +94,7 @@
 	@mass = 2.61 // scaled from 4.15m as a square
 }
 
-@PART[sspx-habitation-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -149,7 +149,7 @@
 	@mass = 8.0 // scaled from 4.15m as a square
 }
 
-@PART[sspx-greenhouse-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-greenhouse-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
@@ -1,11 +1,12 @@
 //	=================================================================
-//	4.15m (Salyut Size) Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//	4.5m Modules (ISS American segment, Gateway, Axiom) - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-attach-25-1			Pressurized Radial Attachment Point
 //	sspx-core-25-1				Station Core
 //	sspx-extendable-tube-25-1	Extensible Crew Tube
 //	sspx-habitation-25-1		Habitation Module
 //	sspx-hub-25-1				Multi-Point Station Connector
+//	sspx-greenhouse-25-1
 //	sspx-observation-25-1		Observation Window
 //	sspx-tube-25-1				Pressurized Crew Tube
 //	sspx-tube-25-2				Pressurized Crew Tube
@@ -16,9 +17,9 @@
 @PART[sspx-attach-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Pressurized Radial Attachement Point
+	@title = 4.5m Pressurized Radial Attachement Point
 	@manufacturer = Generic
 	@tags = sspx, station, radial, attach
 	
@@ -26,15 +27,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 3.255
+	@mass = 3.827 // scaled from 4.15m as a square
 }
 
 @PART[sspx-core-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Station Core
+	@title = 4.5m Station Core
 	@manufacturer = Generic
 	@tags = sspx, station, core, control
 	
@@ -42,7 +43,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 4.675
+	@mass = 5.5 // scaled from 4.15m as a square
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleReactionWheel] {}
@@ -61,7 +62,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 6000
+        volume = 7000 // scaled from 4.15m as a cube
         basemass = -1
     }
 }
@@ -69,9 +70,9 @@
 @PART[sspx-extendable-tube-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Extendable Crew Tube
+	@title = 4.5m Extendable Crew Tube
 	@manufacturer = Generic
 	@tags = sspx, station, tube, extendable
 	
@@ -79,15 +80,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 2.22
+	@mass = 2.61 // scaled from 4.15m as a square
 }
 
 @PART[sspx-habitation-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Habitation Module
+	@title = 4.5m Habitation Module
 	@manufacturer = Generic
 	@tags = sspx, station, tube, extendable
 	
@@ -95,7 +96,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 9.838
+	@mass = 11.4 // Unity mass is 11.9, minus 0.5t for additional structures
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -105,7 +106,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 7500
+        volume = 4000
         basemass = -1
     }
 }
@@ -113,9 +114,9 @@
 @PART[sspx-hub-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Station Hub
+	@title = 4.5m Station Hub
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -123,15 +124,31 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 6.812
+	@mass = 8.0 // scaled from 4.15m as a square
+}
+
+@PART[sspx-greenhouse-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 4.5m Greenhouse Module
+	@manufacturer = Generic
+	@tags = station, hydroponics, greenhouse
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 14
 }
 
 @PART[sspx-observation-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Cupola
+	@title = 4.5m Cupola
 	@manufacturer = Generic
 	@tags = sspx, station, cupola
 	
@@ -139,7 +156,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 7.974
+	@mass = 9.376 // scaled from 4.15m as a square/ Real cupola weights 1.8, but its not of this scale
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleScienceExperiment] {}
@@ -150,9 +167,9 @@
 @PART[sspx-tube-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Pressurized Crew Tube (Long)
+	@title = 4.5m Pressurized Crew Tube (Long)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -160,15 +177,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 4.396
+	@mass = 5.169 // scaled from 4.15m as a square
 }
 
 @PART[sspx-tube-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Pressurized Crew Tube (Medium)
+	@title = 4.5m Pressurized Crew Tube (Medium)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -176,15 +193,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 2.198
+	@mass = 2.6 // scaled from 4.15m as a square
 }
 
 @PART[sspx-tube-25-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Pressurized Crew Tube (Short)
+	@title = 4.5m Pressurized Crew Tube (Short)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -192,5 +209,5 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.082
+	@mass = 1.4 // scaled from 4.15m as a square
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
@@ -88,7 +88,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
 	
-	@title = 4.5m Habitation Module
+	@title = 4.5m Habitation Module Long
 	@manufacturer = Generic
 	@tags = sspx, station, tube, extendable
 	
@@ -96,7 +96,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 11.4 // Unity mass is 11.9, minus 0.5t for additional structures
+	@mass = 11.4 // 
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -148,7 +148,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
 	
-	@title = 4.5m Cupola
+	@title = 4.5m Cupola (Large)
 	@manufacturer = Generic
 	@tags = sspx, station, cupola
 	
@@ -156,7 +156,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 9.376 // scaled from 4.15m as a square/ Real cupola weights 1.8, but its not of this scale
+	@mass = 9.376 // scaled from 4.15m as a square
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleScienceExperiment] {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
@@ -32,7 +32,7 @@
 	@mass = 6.847 // scaled from 6.225 as a square
 }
 
-@PART[sspx-core-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-core-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -112,7 +112,7 @@
 	@MODULE[ModuleCommand] {}
 }
 
-@PART[sspx-habitation-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -151,7 +151,7 @@
 	}
 }
 
-@PART[sspx-habitation-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -189,7 +189,7 @@
 	}
 }
 
-@PART[sspx-habitation-375-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-375-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -228,7 +228,7 @@
 	}
 }
 
-@PART[sspx-greenhouse-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-greenhouse-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -242,9 +242,18 @@
 	@crashTolerance = 10
 
 	@mass = 17
+
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 10000
+        basemass = -1 
+    }
 }
 
-@PART[sspx-aquaculture-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-aquaculture-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -268,7 +277,7 @@
     }
 }
 
-@PART[sspx-lab-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-lab-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
@@ -1,5 +1,5 @@
 //	=================================================================
-//	6.225m Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//	6.75m Modules (Skylab) - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-attach-375-1			Pressurized Radial Attachment Point
 //	sspx-core-375-1				Station Core
@@ -7,6 +7,8 @@
 //	sspx-habitation-375-1		Habitation Module
 //	sspx-habitation-375-2		Habitation Module
 //	sspx-habitation-375-3		Habitation Module
+//	sspx-greenhouse-375-1
+//	sspx-aquaculture-375-1
 //	sspx-lab-375-1				Science Lab
 //	sspx-tube-375-1				Pressurized Crew Tube
 //	sspx-tube-375-2				Pressurized Crew Tube
@@ -17,9 +19,9 @@
 @PART[sspx-attach-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Pressurized Radial Attachement Point
+	@title = 6.75m Pressurized Radial Attachement Point
 	@manufacturer = Generic
 	@tags = sspx, station, radial, attach
 	
@@ -27,15 +29,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 5.823
+	@mass = 6.847 // scaled from 6.225 as a square
 }
 
 @PART[sspx-core-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Station Core
+	@title = 6.75m Station Core
 	@manufacturer = Generic
 	@tags = sspx, station, core, control
 	
@@ -43,10 +45,20 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 10.691
+	@mass = 12.570 // scaled from 6.225m as a square
 	
 	!RESOURCE,* {}
-	!MODULE[ModuleReactionWheel] {}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 2.5
+		@YawTorque = 2.5
+		@RollTorque = 2.5
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.5
+		}
+	}
 	
 	@MODULE[ModuleProbeControlPoint] {}
 	@MODULE[ModuleCommand] {}
@@ -63,7 +75,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 9000
+        volume = 11000 // scaled from 6.225m as a cube
         basemass = -1
     }
 }
@@ -71,9 +83,9 @@
 @PART[sspx-cupola-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Cupola
+	@title = 6.75m Cupola
 	@manufacturer = Generic
 	@tags = sspx, station, cupola
 	
@@ -81,7 +93,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 8.798
+	@mass = 10.345 // scaled from 6.225m as a square
 	
 	!RESOURCE,* {}
 	!MODULE[ModuleScienceExperiment] {}
@@ -92,9 +104,9 @@
 @PART[sspx-habitation-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Habitation Module (Large)
+	@title = 6.75m Habitation Module (Large)
 	@manufacturer = Generic
 	@tags = sspx, station, hab, habitation, living
 	
@@ -102,7 +114,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 16.371
+	@mass = 19.249 // scaled from 6.225m as a square
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -112,7 +124,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 10000
+        volume = 12500 // scaled from 6.225m as a cube
         basemass = -1
     }
 }
@@ -120,9 +132,9 @@
 @PART[sspx-habitation-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Habitation Module (Small)
+	@title = 6.75m Habitation Module (Small)
 	@manufacturer = Generic
 	@tags = sspx, station, hab, habitation, living
 	
@@ -130,7 +142,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 10.52
+	@mass = 12.369 // scaled from 6.225m as a square
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
@@ -140,7 +152,7 @@
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 7500
+        volume = 9500 // scaled from 6.225m as a cube
         basemass = -1
     }
 }
@@ -148,9 +160,9 @@
 @PART[sspx-habitation-375-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Habitation Module (Shielded)
+	@title = 6.75m Habitation Module (Shielded)
 	@manufacturer = Generic
 	@tags = sspx, station, hab, habitation, living
 	
@@ -158,27 +170,60 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 6.006
+	@mass = 7.061 // scaled from 6.225m as a square
 	
 	!MODULE[ModuleScienceExperiment] {}
 	!MODULE[ModuleExperienceManagement] {}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[tankSwitch]] {}
 	
 	// This is not the primary storage for resources in the station, but should be used in an emergency
 	MODULE
     {
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 5300
+        volume = 100000 // Part has 16 almost cylindrical tanks around the wall each 1.35m diameter and 4.5m height. This is 16*6.441 m^3
         basemass = -1
     }
+}
+
+@PART[sspx-greenhouse-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 6.75m Greenhouse Module
+	@manufacturer = Generic
+	@tags = station, hydroponics, greenhouse
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 17
+}
+
+@PART[sspx-aquaculture-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 6.75m Aquaculture Module
+	@manufacturer = Generic
+	@tags = station, aquaculture, greenhouse
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 21
 }
 
 @PART[sspx-lab-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Station Science Lab
+	@title = 6.75m Station Science Lab
 	@manufacturer = Generic
 	@tags = sspx, station, lab, science
 	
@@ -186,15 +231,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 14.35
+	@mass = 16.873  // scaled from 6.225m as a square
 }
 
 @PART[sspx-tube-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Pressurized Crew Tube (Long)
+	@title = 6.75m Pressurized Crew Tube (Long)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -202,15 +247,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 19.78
+	@mass = 23.257  // scaled from 6.225m as a square
 }
 
 @PART[sspx-tube-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Pressurized Crew Tube (Medium)
+	@title = 6.75m Pressurized Crew Tube (Medium)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -218,15 +263,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 9.891
+	@mass = 12.000 // scaled from 6.225m as a square
 }
 
 @PART[sspx-tube-375-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Pressurized Crew Tube (Short)
+	@title = 6.75m Pressurized Crew Tube (Short)
 	@manufacturer = Generic
 	@tags = sspx, station, hub
 	
@@ -234,5 +279,5 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 4.946
+	@mass = 6.200 // scaled from 6.225m as a square 
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
@@ -78,6 +78,17 @@
         volume = 11000 // scaled from 6.225m as a cube
         basemass = -1
     }
+	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 43200
+			maxAmount = 43200
+		}
+	}
 }
 
 @PART[sspx-cupola-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -127,6 +138,17 @@
         volume = 12500 // scaled from 6.225m as a cube
         basemass = -1
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 129600
+			maxAmount = 129600
+		}
+	}
 }
 
 @PART[sspx-habitation-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -155,6 +177,16 @@
         volume = 9500 // scaled from 6.225m as a cube
         basemass = -1
     }
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 64800
+			maxAmount = 64800
+		}
+	}
 }
 
 @PART[sspx-habitation-375-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -176,7 +208,6 @@
 	!MODULE[ModuleExperienceManagement] {}
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[tankSwitch]] {}
 	
-	// This is not the primary storage for resources in the station, but should be used in an emergency
 	MODULE
     {
         name = ModuleFuelTanks
@@ -184,6 +215,17 @@
         volume = 100000 // Part has 16 almost cylindrical tanks around the wall each 1.35m diameter and 4.5m height. This is 16*6.441 m^3
         basemass = -1
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 129600
+			maxAmount = 129600
+		}
+	}
 }
 
 @PART[sspx-greenhouse-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -216,6 +258,14 @@
 	@crashTolerance = 10
 
 	@mass = 21
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 10000
+        basemass = -1
+    }
 }
 
 @PART[sspx-lab-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -232,6 +282,27 @@
 	@crashTolerance = 10
 
 	@mass = 16.873  // scaled from 6.225m as a square
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 4000
+        basemass = -1
+    }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 64800
+			maxAmount = 64800
+		}
+	}
+
 }
 
 @PART[sspx-tube-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -62,6 +62,17 @@
         volume = 27000  // scaled from 6.225m as a cube
         basemass = -1
     }
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 108000
+			maxAmount = 108000
+		}
+	}
 }
 
 
@@ -155,7 +166,17 @@
         volume = 3000
         basemass = -1
    }
+	
+	@MODULE[ModuleFuelTanks]
+	{
 
+		TANK
+		{
+			name = ElectricCharge
+			amount = 108000
+			maxAmount = 108000
+		}
+	}
 }
 
 @PART[sspx-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -186,6 +207,17 @@
         volume = 200000
         basemass = -1
     }
+		
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 108000
+			maxAmount = 108000
+		}
+	}
 }
 
 @PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]:
@@ -213,6 +245,17 @@
         volume = 7500
         basemass = -1
     }
+		
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 108000
+			maxAmount = 108000
+		}
+	}
 }
 
 @PART[sspx-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -220,7 +220,7 @@
 	}
 }
 
-@PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]:
+@PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -16,7 +16,7 @@
 //	=================================================================
 
 
-@PART[sspx-core-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-core-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -121,7 +121,7 @@
 	@MODULE[ModuleCommand] {}
 }
 
-@PART[sspx-dome-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-dome-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -139,9 +139,17 @@
 	!RESOURCE,* {}
 	!MODULE[ModuleScienceExperiment] {}
 	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 3000
+        basemass = -1
+	}
+	
 }
 
-@PART[sspx-dome-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-dome-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -165,7 +173,7 @@
         type = ServiceModule
         volume = 3000
         basemass = -1
-   }
+	}
 	
 	@MODULE[ModuleFuelTanks]
 	{
@@ -179,7 +187,7 @@
 	}
 }
 
-@PART[sspx-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -220,7 +228,7 @@
 	}
 }
 
-@PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -258,7 +266,7 @@
 	}
 }
 
-@PART[sspx-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -272,6 +280,14 @@
 	@crashTolerance = 10
 
 	@mass = 40
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 3000
+        basemass = -1
+	}
 }
 
 @PART[sspx-lab-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -290,7 +306,7 @@
 	@mass = 30
 }
 
-@PART[sspx-logistics-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-logistics-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
@@ -316,7 +332,7 @@
     	}
 }
 
-@PART[sspx-logistics-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-logistics-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {	
 	%RSSROConfig = True
 	%rescaleFactor = 1.8

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -1,0 +1,300 @@
+//	=================================================================
+//	9m Modules (Skylab II, Starship) - STOCKALIKE STATION PARTS EXPANSION REDUX
+//
+//	sspx-core-5-1
+//	sspx-dome-5-1
+//	sspx-dome-cupola-5-1
+//	sspx-dome-greenhouse-5-1
+//	sspx-dome-habitation-5-1
+//	sspx-habitation-5-1
+//	sspx-habitation-5-2
+//	sspx-greenhouse-5-1
+//	sspx-lab-5-1
+//	sspx-logistics-5-1
+//	sspx-logistics-5-2
+//	
+//	=================================================================
+
+
+@PART[sspx-core-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Station Core
+	@manufacturer = Generic
+	@tags = sspx, station, core, control
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 22.912  // scaled from 6.225m as a square
+	
+	!RESOURCE,* {}
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 2.5
+		@YawTorque = 2.5
+		@RollTorque = 2.5
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.5
+		}
+	}
+	
+	@MODULE[ModuleProbeControlPoint] {}
+	@MODULE[ModuleCommand] {}
+	@MODULE[ModuleDataTransmitter] {}
+	
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 1
+	}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 27000  // scaled from 6.225m as a cube
+        basemass = -1
+    }
+}
+
+
+@PART[sspx-dome-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Dome
+	@manufacturer = Generic
+	@tags = sspx, station, cupola, dome, base
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+			// Lets assume dome is made of Aluminium oxynitride (ALON), which is all-new bulletproof material.
+			//ISS Cupola uses 5cm bulletproof glass, ALON would need about half (41mm ALON stops .50 BMG which penetrates 94mm glass laminate)
+			//So it would be 2.5cm windows. ALON density is 3.69, Hemisphere area for d=9m is 127m^2. so its 3.175m^3 of ALON, or 11.715t
+			//Lets add 3t for other structures
+	@mass = 14.715// 
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+	@MODULE[ModuleCommand] {}
+}
+
+@PART[sspx-dome-cupola-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Observation Dome
+	@manufacturer = Generic
+	@tags = sspx, station, cupola, dome, base
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+			
+	@mass = 16.715// 14.715 dome + 2t center cupola
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+	@MODULE[ModuleCommand] {}
+}
+
+@PART[sspx-dome-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Greenhouse Dome
+	@manufacturer = Generic
+	@tags = sspx, station, cupola, dome, base
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+			
+	@mass = 18.715// 14.715 dome + 4t greenhouse
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+}
+
+@PART[sspx-dome-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Habitation Dome
+	@manufacturer = Generic
+	@tags = sspx, station, cupola, dome, base
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+			
+	@mass = 19.715// 14.715 dome + 5t habitation module
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 3000
+        basemass = -1
+   }
+
+}
+
+@PART[sspx-habitation-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Habitation Module (Large)
+	@manufacturer = Generic
+	@tags = sspx, station, hab, habitation, living
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 16.371
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[tankSwitch]] {}
+	
+	// This is not the primary storage for resources in the station, but should be used in an emergency
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 200000
+        basemass = -1
+    }
+}
+
+@PART[sspx-habitation-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]:
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Habitation Module (Small)
+	@manufacturer = Generic
+	@tags = sspx, station, hab, habitation, living
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 10.52
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 7500
+        basemass = -1
+    }
+}
+
+@PART[sspx-greenhouse-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9mm Greenhouse
+	@manufacturer = Generic
+	@tags = sspx, station, lab, science
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 40
+}
+
+@PART[sspx-lab-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Station Science Lab
+	@manufacturer = Generic
+	@tags = sspx, station, lab, science
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 30
+}
+
+@PART[sspx-logistics-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Logistics Module (Long)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 19.78
+	
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch]] {}	
+
+	MODULE
+	{
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 500000
+        basemass = -1
+    	}
+}
+
+@PART[sspx-logistics-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{	
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 9m Logistics Module (Short)
+	@manufacturer = Generic
+	@tags = sspx, station, hub
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 9.891
+	
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch]] {}
+
+	MODULE
+	{
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 250000
+        basemass = -1
+    	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -319,7 +319,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 19.78
+	@mass = 44.0
 	
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch]] {}	
 
@@ -327,7 +327,7 @@
 	{
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 500000
+        volume = 340000 // Service tank, d=9.5m, l=8.3m, v=440kL; Minus cylindrical crew passage d=4.5m v=100kL, 340 kL hollow cylinder, m=44t dry
         basemass = -1
     	}
 }
@@ -345,7 +345,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 9.891
+	@mass = 23.0
 	
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch]] {}
 
@@ -353,7 +353,7 @@
 	{
         name = ModuleFuelTanks
         type = ServiceModule
-        volume = 250000
+        volume = 170000
         basemass = -1
     	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -220,7 +220,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.8
 	
-	@title = 9mm Greenhouse
+	@title = 9m Greenhouse
 	@manufacturer = Generic
 	@tags = sspx, station, lab, science
 	

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Adapters_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Adapters_Utility.cfg
@@ -2,83 +2,25 @@
 //	Adapters - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-adapter-0625-125-1	PTD-C Flat Adapter
+//	sspx-adapter-1875-0625-1
+//	sspx-adapter-1875-125-1
+//	sspx-adapter-1875-125-2
 //	sspx-adapter-125-25-1	PPD-PTD Flat Adapter
 //	sspx-adapter-125-25-2	PPD-PTD Adapter
+//	sspx-adapter-25-1875-1
 //	sspx-adapter-25-375-1	PXL-2A Conical Adapter
 //	sspx-adapter-25-375-2	PXL-2A Flat Adapter
+//	sspx-adapter-375-5-1
+//	sspx-adapter-375-5-2
 //
 //	=================================================================
 
 @PART[sspx-adapter-0625-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = Station Flat Adapter [3.05m to 1.525m]
-	@manufacturer = Generic
-	@tags = sspx, adapter, station, mol, flat
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 0.156
-}
-
-@PART[sspx-adapter-125-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = Station Flat Adapter [4.15m to 2.075m]
-	@manufacturer = Generic
-	@tags = sspx, adapter, station, salyut, flat
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 0.262
-}
-
-@PART[sspx-adapter-125-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = Station Conical Adapter [4.15m to 2.075m]
-	@manufacturer = Generic
-	@tags = sspx, adapter, station, salyut, conical
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 0.7204
-}
-
-@PART[sspx-adapter-25-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = Station Conical Adapter [6.225m to 4.15m]
-	@manufacturer = Generic
-	@tags = sspx, adapter, station, conical
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 1.778
-}
-
-@PART[sspx-adapter-25-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = Station Flat Adapter [6.225m to 4.15m]
+	@title = Station Flat Adapter [2.25m to 1.125m]
 	@manufacturer = Generic
 	@tags = sspx, adapter, station, flat
 	
@@ -86,7 +28,168 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 0.9456
+	@mass = 0.085
+}
+
+@PART[sspx-adapter-1875-0625-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Flat Adapter [3.38m to 1.125m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.100
+}
+
+@PART[sspx-adapter-1875-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Flat Adapter [3.38m to 2.25m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, Flat
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.200
+}
+
+@PART[sspx-adapter-1875-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Conical Adapter [3.38m to 2.25m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.600
+}
+
+@PART[sspx-adapter-125-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Flat Adapter [4.5m to 2.25m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, flat
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.308
+}
+
+@PART[sspx-adapter-125-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Conical Adapter [4.5m to 2.25m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.847
+}
+
+@PART[sspx-adapter-25-1875-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Conical Adapter [4.5m to 3.38m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.000
+}
+
+
+@PART[sspx-adapter-25-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Conical Adapter [6.75m to 4.5m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.090
+}
+
+@PART[sspx-adapter-25-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Flat Adapter [6.75m to 4.5m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, flat
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.111
+}
+
+@PART[sspx-adapter-375-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Conical Adapter [6.75m to 9m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, conical
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 4.253
+}
+
+@PART[sspx-adapter-375-5-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = Station Flat Adapter [6.75m to 9m]
+	@manufacturer = Generic
+	@tags = sspx, adapter, station, flat
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.041
 }
 
 
@@ -102,9 +205,9 @@
 @PART[sspx-airlock-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Service Airlock
+	@title = 2.25m Service Airlock
 	@manufacturer = Generic
 	@tags = sspx, airlock, service, station
 	
@@ -112,23 +215,23 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.14
+	@mass = 0.62
 }
 
 @PART[sspx-airlock-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.73
 	
-	@title = 4.15m Service Airlock w/ Extendable NASA Docking System
+	@title = 4.5m Service Airlock w/ Extendable NASA Docking System
 	@manufacturer = Generic
-	@tags = sspx, airlock, service, station
+	@tags = sspx, airlock, service, station, nds
 	
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 3.46
+	@mass = 4.068
 	
 	@MODULE[ModuleDockingNode]
 	{
@@ -146,21 +249,21 @@
 @PART[sspx-docking-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.5316
+	%rescaleFactor = 1.73
 	
-	@title = Extendable Common Berthing Mechanism
+	@title = Extendable NASA Docking System
 	@manufacturer = Generic
-	@tags = sspx, station, dock, cbm
+	@tags = sspx, station, dock, nds
 	
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 0.35
+	@mass = 0.200
 	
 	@MODULE[ModuleDockingNode]
 	{
-		@nodeType = CBM
+		@nodeType = NASADock
 	}
 }
 
@@ -176,9 +279,9 @@
 @PART[sspx-cargo-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Storage Module
+	@title = 2.25m Storage Module
 	@manufacturer = Generic
 	@tags = sspx, station, storage
 	
@@ -186,15 +289,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 1.79
+	@mass = 0.974
 }
 
 @PART[sspx-cargo-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Storage Module
+	@title = 4.5m Storage Module
 	@manufacturer = Generic
 	@tags = sspx, station, storage
 	
@@ -202,15 +305,15 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 4.396
+	@mass = 5.168
 }
 
 @PART[sspx-cargo-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Storage Module (Short)
+	@title = 4.5m Storage Module (Short)
 	@manufacturer = Generic
 	@tags = sspx, station, storage
 	
@@ -218,5 +321,5 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 2.164
+	@mass = 2.544
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Base.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Base.cfg
@@ -7,47 +7,16 @@
 //	sspx-adjusting-base-cradle-125-1	BR-1 Adjustable Base Cradle
 //	sspx-adjusting-base-cradle-25-1		BR-2 Adjustable Base Cradle
 //	sspx-adjusting-base-cradle-375-1	BR-3 Adjustable Base Cradle
+//	sspx-adjusting-stairs-1
 //
 //	=================================================================
 
 @PART[sspx-adjusting-base-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Adjustable Base Frame
-	@manufacturer = Generic
-	@tags = leg, station, mol, frame
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 1
-}
-
-@PART[sspx-adjusting-base-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = 4.15m Adjustable Base Frame
-	@manufacturer = Generic
-	@tags = leg, station, salyut, dos, frame
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 1.361
-}
-
-@PART[sspx-adjusting-base-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = 6.225m Adjustable Base Frame
+	@title = 2.25m Adjustable Base Frame
 	@manufacturer = Generic
 	@tags = leg, station, frame
 	
@@ -55,47 +24,47 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 2.041
+	@mass = 0.6
+}
+
+@PART[sspx-adjusting-base-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 4.5m Adjustable Base Frame
+	@manufacturer = Generic
+	@tags = leg, station, frame
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 1.6
+}
+
+@PART[sspx-adjusting-base-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 6.75m Adjustable Base Frame
+	@manufacturer = Generic
+	@tags = leg, station, frame
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.4
 }
 
 @PART[sspx-adjusting-base-cradle-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+	%rescaleFactor = 1.8
 	
-	@title = 3.05m Adjustable Base Cradle
-	@manufacturer = Generic
-	@tags = leg, station, mol, frame, cradle
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 1.5
-}
-
-@PART[sspx-adjusting-base-cradle-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = 4.15m Adjustable Base Cradle
-	@manufacturer = Generic
-	@tags = leg, station, salyut, dos, frame, cradle
-	
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 10
-
-	@mass = 2.041
-}
-
-@PART[sspx-adjusting-base-cradle-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-	
-	@title = 6.225m Adjustable Base Cradle
+	@title = 2.25m Adjustable Base Cradle
 	@manufacturer = Generic
 	@tags = leg, station, frame, cradle
 	
@@ -103,5 +72,55 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 3.062
+	@mass = 0.8
 }
+
+@PART[sspx-adjusting-base-cradle-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 4.5m Adjustable Base Cradle
+	@manufacturer = Generic
+	@tags = leg, station, frame, cradle
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 2.4
+}
+
+@PART[sspx-adjusting-base-cradle-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.8
+	
+	@title = 6.75m Adjustable Base Cradle
+	@manufacturer = Generic
+	@tags = leg, station, frame, cradle
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 3.6
+}
+
+@PART[sspx-adjusting-stairs-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.5
+	
+	@title = Extensible Stairs
+	@manufacturer = Generic
+	@tags = leg, station, frame, cradle
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 0.225
+}
+
+

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Containers.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Containers.cfg
@@ -83,10 +83,10 @@
 }
 
 // 2.5m Cargo container (Small) - 2.5 x 1m
-// 4.15 x 1.8
+// 4.5 x 1.8
 @PART[sspx-cargo-container-25-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
-	@title = 4.15m Storage Module (Short)
+	@title = 4.5m Storage Module (Short)
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume *= 4 // 22680*(1.8/1.66)^3

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Containers.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Containers.cfg
@@ -23,12 +23,14 @@
 //	Volume	= Original / 0.76394 (rounded to nearest 10's)
 //	Mass 	= Handled by RealFuels
 //	=================================================================
+//	All parts are now rescaled from factor 1.67 to 1.8, base volume increased as (1.8/1.67)^3, 
+
 
 @PART[sspx-cargo-container*]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	@attachRules = 1,1,1,1,0
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
@@ -47,7 +49,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 5670
+		volume = 7229
 		basemass = 1
 		utilizationTweakable = true
 		maxUtilization = 75
@@ -59,68 +61,68 @@
 
 
 // 2.5m Cargo container (Long) - 2.5 x 4m
-// 4.15 x 6.64
+// 4.5 x 7.2
 @PART[sspx-cargo-container-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {	
-	@title = 4.15m Storage Module (Long)
+	@title = 4.5m Storage Module (Long)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 16 // 90720
+		@volume *= 16 // 90720*(1.8/1.66)^3
 	}
 }
 
 // 2.5m Cargo container (Medium) - 2.5 x 2m
-// 4.15 x 3.32
+// 4.5 x 3.6
 @PART[sspx-cargo-container-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
-	@title = 4.15m Storage Module (Medium)
+	@title = 4.5m Storage Module (Medium)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 8 // 45360
+		@volume *= 8 // 45360*(1.8/1.66)^3
 	}
 }
 
 // 2.5m Cargo container (Small) - 2.5 x 1m
-// 4.15 x 1.66
+// 4.15 x 1.8
 @PART[sspx-cargo-container-25-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	@title = 4.15m Storage Module (Short)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 4 // 22680
+		@volume *= 4 // 22680*(1.8/1.66)^3
 	}
 }
 
-// 3.755m Cargo container (Long) - 3.75 x 4m
-// 6.225 x 6.64
+// 3.75m Cargo container (Long) - 3.75 x 4m
+// 6.75 x 7.2
 @PART[sspx-cargo-container-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
-	@title = 6.225m Storage Module (Long)
+	@title = 6.75m Storage Module (Long)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 36 // 204120
+		@volume *= 36 // 204120*(1.8/1.66)^3
 	}
 }
 
 // 3.75m Cargo container (Medium) - 3.75 x 2m
-// 6.225 x 3.32
+// 6.75 x 3.6
 @PART[sspx-cargo-container-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	@title = 6.225m Storage Module (Medium)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 18 // 102060
+		@volume *= 18 // 102060*(1.8/1.66)^3
 	}
 }
 
 // 3.75m Cargo container (Small) - 3.75 x 1m
-// 6.225 x 1.66
+// 6.75 x 1.8
 @PART[sspx-cargo-container-375-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
-	@title = 6.225m Storage Module (Short)
+	@title = 6.75m Storage Module (Short)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 9 // 51030
+		@volume *= 9 // 51030*(1.8/1.66)^3
 	}
 }
 
@@ -130,7 +132,7 @@
 	@title = Large Radial Cargo Container (Long)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 88 // 502990
+		@volume *= 88 // 502990*(1.8/1.66)^3
 	}
 }
 
@@ -140,7 +142,7 @@
 	@title = Large Radial Cargo Container (Short)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 44 // 249480
+		@volume *= 44 // 249480*(1.8/1.66)^3
 	}
 }
 
@@ -150,7 +152,7 @@
 	@title = Twin Radial Cargo Container (Long)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 8 // 45360
+		@volume *= 8 // 45360*(1.8/1.66)^3
 	}
 }
 
@@ -160,7 +162,7 @@
 	@title = Twin Radial Cargo Container (Medium)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 4 // 22680
+		@volume *= 4 // 22680*(1.8/1.66)^3
 	}
 }
 
@@ -170,7 +172,7 @@
 	@title = Twin Radial Cargo Container (Short)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 2 // 11340
+		@volume *= 2 // 11340*(1.8/1.66)^3
 	}
 }
 
@@ -180,7 +182,7 @@
 	@title = Radial Cargo Container (Long)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 4 // 22680
+		@volume *= 4 // 22680*(1.8/1.66)^3
 	}
 }
 
@@ -190,7 +192,7 @@
 	@title = Radial Cargo Container (Medium)
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 2 // 11340
+		@volume *= 2 // 11340*(1.8/1.66)^3
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
@@ -24,7 +24,7 @@
 //	===========================================================================
 
 
-@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 2.25m Inflatable Centrifuge (16m Diameter)
 
@@ -60,7 +60,7 @@
 	
 }
 
-@PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 2.25m Inflatable Centrifuge (13m Diameter)
 
@@ -96,7 +96,7 @@
     }
 }
 
-@PART[sspx-inflatable-hab-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-hab-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 2.25m Inflatable Habitat (Long)
 
@@ -119,7 +119,7 @@
 	
 }
 
-@PART[sspx-inflatable-hab-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-hab-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 2.25m Inflatable Habitat (Medium)
 
@@ -141,7 +141,7 @@
     }
 }
 
-@PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 2.25m Inflatable Habitat (Short)
 
@@ -163,7 +163,7 @@
     }
 }
 
-@PART[sspx-inflatable-centrifuge-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-centrifuge-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 4.5m Inflatable Centrifuge (25m Diameter)
 
@@ -198,7 +198,7 @@
     }
 }
 
-@PART[sspx-inflatable-hab-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-hab-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 4.5m Inflatable Habitat (Long)
 
@@ -220,7 +220,7 @@
     }
 }
 
-@PART[sspx-inflatable-hab-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-inflatable-hab-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 4.5m Inflatable Habitat (Short)
 
@@ -242,7 +242,7 @@
     }
 }
 
-@PART[sspx-expandable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-expandable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 6.75m Expandable Centrifuge (43m Diameter)
 
@@ -277,7 +277,7 @@
     }
 }
 
-@PART[sspx-expandable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-expandable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 6.75m Expandable Centrifuge (36m Diameter)
 
@@ -312,7 +312,7 @@
     }
 }
 
-@PART[sspx-expandable-centrifuge-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-expandable-centrifuge-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,RealFuels]
 {
 	@title = 9m Extendable Centrifuge (43m Diameter)
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
@@ -1,532 +1,179 @@
 //	===========================================================================
 //	Extendable Parts - STOCKALIKE STATION PARTS EXPANSION REDUX
-//  All parts should be scaled by 1.6667 for human sizes
+//  All parts are scaled by 1.8 for human sizes
 //
-//  1.25m *******
-//  sspx-inflatable-centrifuge-125-1 => RO-sspx-iss-demo	ISS Centrifuge Demo
-//  sspx-inflatable-centrifuge-125-1    Nautilus-X Centrifuge
-//  sspx-inflatable-centrifuge-125-2    REMOVE
-//	sspx-inflatable-hab-125-1			1.25m Inflatable Hab (Long)
-//	sspx-inflatable-hab-125-2			1.25m Inflatable Hab (Medium)
-//	sspx-inflatable-hab-125-3			BA330
+//  	1.25m	-> 2.25m				
+//	sspx-inflatable-centrifuge-125-2	
+//	sspx-inflatable-centrifuge-125-1    	
+//	sspx-inflatable-hab-125-1		
+//	sspx-inflatable-hab-125-2		
+//	sspx-inflatable-hab-125-3		
 //
-//  2.5m ********
-//  sspx-inflatable-centrifuge-25-1     2.5m Inflatable Centrifuge
-//  sspx-inflatable-hab-25-1            2.5m Inflatable Hab (Long)
-//  sspx-inflatable-hab-25-2            2.5m Inflatable Hab (Short)
+// 	 2.5m	-> 4.5m
+// 	 sspx-inflatable-centrifuge-25-1     
+//  	sspx-inflatable-hab-25-1            
+//  	sspx-inflatable-hab-25-2     
+//	
+//	3.75m 	-> 6.75m
+//	sspx-expandable-centrifuge-375-1
+//	sspx-expandable-centrifuge-375-2
+//	
+//	5m	-> 9m
+//      sspx-expandable-centrifuge-5-1
+//
 //	===========================================================================
 
-@PART[sspx-inflatable*]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+
+@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 2.25m Inflatable Centrifuge (16m Diameter)
+
 	%RSSROConfig = True
+
 	@tags = sspx, station, inflatable
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
-}
-
-@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	@title = 20m Diameter Centrifuge (Mars Gravity)
-	%rescaleFactor = 2.44
-	//@mass = 
+	%rescaleFactor = 1.8
+	@mass = 16
 }
 
 @PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 2.25m Inflatable Centrifuge (13m Diameter)
+
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 6
 }
 
 @PART[sspx-inflatable-hab-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 2.25m Inflatable Habitat (Long)
+
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 4.0
 }
 
 @PART[sspx-inflatable-hab-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 2.25m Inflatable Habitat (Medium)
+
 	%RSSROConfig = True
-	%rescaleFactor = 2.44
+
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 2.0
+}
+
+@PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	@title = 2.25m Inflatable Habitat (Short)
+
+	%RSSROConfig = True
+
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 1.4 // BEAM
 }
 
 @PART[sspx-inflatable-centrifuge-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 4.5m Inflatable Centrifuge (25m Diameter)
+
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 25.0
 }
 
 @PART[sspx-inflatable-hab-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 4.5m Inflatable Habitat (Long)
+
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 31.6 
 }
 
 @PART[sspx-inflatable-hab-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
+	@title = 4.5m Inflatable Habitat (Short)
+
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
-}
 
-@PART[sspx-inflatable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-}
-
-@PART[sspx-inflatable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 1.66
-}
-
-// ISS Centrifuge Demo
-+PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	@name = RO-sspx-iss-demo
-}
-
-@PART[RO-sspx-iss-demo]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 2.44
-
+	@tags = sspx, station, inflatable
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
-	@crashTolerance = 6
-	@breakingForce = 250
-	@breakingTorque = 250
-
-	@mass = 6.0 // 5.75
-
-	@title = ISS Centrifuge Demo
-	@description = A downsized version of the centrifuge from the Nautilus-X design study, proposed to be installed at the ISS to demonstrate the feasibility of the concept. Only large enough to serve as sleeping quarters for 4 people under partial gravity. Not enough space to stand up, too small a radius to provide full gravity. Relatively high spin rate quite possibly makes the whole experience very nauseating. Could nonetheless still be a substantial health benefit for the crew on a long mission.
-
-	MODULE
-	{
-		name = ModuleGenerator
-		isAlwaysActive = true
-		OUTPUT_RESOURCE
-		{
-			name = ElectricCharge
-			rate = -0.200
-		}
-	}
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 15.8 
 }
 
-@PART[RO-sspx-iss-demo]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,TacLifeSupport]
+@PART[sspx-expandable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
-    @description ^= :$: Supports a crew of 4 for 1 day of active operations.:
+	@title = 6.75m Expandable Centrifuge (43m Diameter)
 
-    @mass -= 0.03
-
-	!MODULE[ModuleFuelTanks] {}
-
-    MODULE
-	{
-		name = ModuleFuelTanks
-        volume = 500
-
-        TANK
-        {
-            name = Food
-            amount = 23.4
-            maxAmount = 23.4
-        }
-
-        TANK
-        {
-            name = Water
-            amount = 15.5
-            maxAmount = 15.5
-        }
-
-        TANK
-        {
-            name = Oxygen
-            amount = 2368
-            maxAmount = 2368
-        }
-
-        TANK
-        {
-            name = CarbonDioxide
-            amount = 0
-            maxAmount = 2046
-        }
-
-        TANK
-        {
-            name = Waste
-            amount = 0
-            maxAmount = 2.14
-        }
-
-        TANK
-        {
-            name = WasteWater
-            amount = 0
-            maxAmount = 19.7
-        }
-
-        TANK
-        {
-            name = LithiumHydroxide
-            amount = 3
-            maxAmount = 3
-        }
-    }
-
-    !MODULE[TacGenericConverter],*{}
-
-    MODULE
-    {
-        name = TacGenericConverter
-        converterName = CO2 Scrubber
-        StartActionName = Start CO2 Scrubber
-        StopActionName = Stop CO2 Scrubber
-        conversionRate = 4.0
-        tag = Life Support
-        GeneratesHeat = False
-        UseSpecialistBonus = False
-
-        INPUT_RESOURCE
-        {
-            ResourceName = CarbonDioxide
-            Ratio = 0.006216
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = ElectricCharge
-            Ratio = 0.01
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = LithiumHydroxide
-            Ratio = 0.0000085683
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = WasteWater
-            Ratio = 0.0000046828
-            DumpExcess = True
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = Waste
-            Ratio = 0.0000257297
-            DumpExcess = False
-        }
-    }
-}
-
-// Nautilus-X Centrifuge
-@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
-	%RSSROConfig = True
-	%rescaleFactor = 2.44
-
-	@maxTemp = 773.15
-	@skinMaxTemp = 773.15
-	@crashTolerance = 6
-	@breakingForce = 250
-	@breakingTorque = 250
-
-	@mass = 21.596
-
-	@title = Nautilus-X Centrifuge
-	@description = The full-sized version of the centrifuge from the Nautilus-X proposal. With a habitable volume close to that of the entire ISS put together, it's large enough to provide comfortable habitation to six astronauts. Although the diameter remains too small to allow for full Earth-like gravity under tolerable rotation rates, Martian gravity levels are easily achievable.
-
-	@MODULE[ModuleDeployableCentrifuge]
-	{
-		@Radius = 7.5
-	}
-
-	MODULE
-	{
-		name = ModuleGenerator
-		isAlwaysActive = true
-		OUTPUT_RESOURCE
-		{
-			name = ElectricCharge
-			rate = -0.350
-		}
-	}
-}
-
-@PART[sspx-inflatable-centrifuge-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,TacLifeSupport]
-{
-    @description ^= :$: Supports a crew of 6 for 1 day of active operations.:
-
-    @mass -= 0.05
-
-	!MODULE[ModuleFuelTanks] {}
-
-    MODULE
-	{
-		name = ModuleFuelTanks
-        volume = 750
-
-        TANK
-        {
-            name = Food
-            amount = 35.1
-            maxAmount = 35.1
-        }
-
-        TANK
-        {
-            name = Water
-            amount = 23.25
-            maxAmount = 23.25
-        }
-
-        TANK
-        {
-            name = Oxygen
-            amount = 3552
-            maxAmount = 3552
-        }
-
-        TANK
-        {
-            name = CarbonDioxide
-            amount = 0
-            maxAmount = 3552
-        }
-
-        TANK
-        {
-            name = Waste
-            amount = 0
-            maxAmount = 3.21
-        }
-
-        TANK
-        {
-            name = WasteWater
-            amount = 0
-            maxAmount = 29.55
-        }
-
-        TANK
-        {
-            name = LithiumHydroxide
-            amount = 4.5
-            maxAmount = 4.5
-        }
-    }
-
-    !MODULE[TacGenericConverter],*{}
-
-    MODULE
-    {
-        name = TacGenericConverter
-        converterName = CO2 Scrubber
-        StartActionName = Start CO2 Scrubber
-        StopActionName = Stop CO2 Scrubber
-        conversionRate = 6.0
-        tag = Life Support
-        GeneratesHeat = False
-        UseSpecialistBonus = False
-
-        INPUT_RESOURCE
-        {
-            ResourceName = CarbonDioxide
-            Ratio = 0.006216
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = ElectricCharge
-            Ratio = 0.01
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = LithiumHydroxide
-            Ratio = 0.0000085683
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = WasteWater
-            Ratio = 0.0000046828
-            DumpExcess = True
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = Waste
-            Ratio = 0.0000257297
-            DumpExcess = False
-        }
-    }
-}
-
-// BA330
-@PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
-{
 	%RSSROConfig = True
 
-	//@MODEL,0
-	//{
-	//	@position = 0, -1.984, 0
-	//	@scale = 1.292, -1, 1.292
-	//}
-	//@MODEL,1
-	//{
-	//	@scale = 1.292, 2.252, 1.292
-	//}
-
-	%rescaleFactor = 2.44
-
+	@tags = sspx, station, inflatable
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
-	@crashTolerance = 6
-	@breakingForce = 250
-	@breakingTorque = 250
-
-	@mass = 14.795
-
-	@title = BA330 Inflatable Habitat
-	@manufacturer = Bigelow
-	@description = The Bigelow BA330 inflatable habitat. As the name suggests, it has 330 cubic meters of pressurized volume. Room for 6, and 30 days of supplies. Add a few tonnes of water for radiation shielding purposes to simulate the Deep Space configuration (otherwise it's only suitable for low Earth orbit).
-
-	@MODULE[ModuleDeployableHabitat]
-	{
-		@DeployedCrewCapacity = 6
-		@Deployed = False
-	}
-
-	MODULE
-	{
-		name = ModuleCommand
-		minimumCrew = 0
-		RESOURCE
-		{
-			name = ElectricCharge
-			rate = 0.125
-		}
-	}
-
-	!MODULE[ModuleConnectedLivingSpace] {}
-	
-	MODULE:NEEDS[ConnectedLivingSpace]
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 51.03 
 }
 
-@PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux,TacLifeSupport]
+@PART[sspx-expandable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
-    @description ^= :$: Supports a crew of 6 for 60 days of active operations.:
+	@title = 6.75m Expandable Centrifuge (36m Diameter)
 
-	!MODULE[ModuleFuelTanks] {}
+	%RSSROConfig = True
 
-    MODULE
-	{
-		name = ModuleFuelTanks
-        volume = 750
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 36.45 
+}
 
-        TANK
-        {
-            name = Food
-            amount = 35.1
-            maxAmount = 35.1
-        }
+@PART[sspx-expandable-centrifuge-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	@title = 9m Extendable Centrifuge (43m Diameter)
 
-        TANK
-        {
-            name = Water
-            amount = 23.25
-            maxAmount = 23.25
-        }
+	%RSSROConfig = True
 
-        TANK
-        {
-            name = Oxygen
-            amount = 3552
-            maxAmount = 3552
-        }
-
-        TANK
-        {
-            name = CarbonDioxide
-            amount = 0
-            maxAmount = 3552
-        }
-
-        TANK
-        {
-            name = Waste
-            amount = 0
-            maxAmount = 3.21
-        }
-
-        TANK
-        {
-            name = WasteWater
-            amount = 0
-            maxAmount = 29.55
-        }
-
-        TANK
-        {
-            name = LithiumHydroxide
-            amount = 4.5
-            maxAmount = 4.5
-        }
-    }
-
-    !MODULE[TacGenericConverter],*{}
-
-    MODULE
-    {
-        name = TacGenericConverter
-        converterName = CO2 Scrubber
-        StartActionName = Start CO2 Scrubber
-        StopActionName = Stop CO2 Scrubber
-        conversionRate = 6.0
-        tag = Life Support
-        GeneratesHeat = False
-        UseSpecialistBonus = False
-
-        INPUT_RESOURCE
-        {
-            ResourceName = CarbonDioxide
-            Ratio = 0.006216
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = ElectricCharge
-            Ratio = 0.01
-        }
-
-        INPUT_RESOURCE
-        {
-            ResourceName = LithiumHydroxide
-            Ratio = 0.0000085683
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = WasteWater
-            Ratio = 0.0000046828
-            DumpExcess = True
-        }
-
-        OUTPUT_RESOURCE
-        {
-            ResourceName = Waste
-            Ratio = 0.0000257297
-            DumpExcess = False
-        }
-    }
+	@tags = sspx, station, inflatable
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+	%rescaleFactor = 1.8
+	@mass = 71. 
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
@@ -323,7 +323,7 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
-	@mass = 71. 0
+	@mass = 71.0
 	
 	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
 	@MODULE[ModuleReactionWheel]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Extendable.cfg
@@ -36,6 +36,28 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 16
+	
+	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 1.0
+		@YawTorque = 1.0
+		@RollTorque = 1.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.6
+		}
+	}
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 10000
+        basemass = -1
+    }
+	
 }
 
 @PART[sspx-inflatable-centrifuge-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -50,6 +72,28 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 6
+	
+	
+	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 1.0
+		@YawTorque = 1.0
+		@RollTorque = 1.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.6
+		}
+	}
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 5000
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-125-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -64,6 +108,15 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 4.0
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 7000
+        basemass = -1
+    }
+	
 }
 
 @PART[sspx-inflatable-hab-125-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -78,6 +131,14 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 2.0
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 3000
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-125-3]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -92,6 +153,14 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 1.4 // BEAM
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 3000
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-centrifuge-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -106,6 +175,27 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 25.0
+	
+	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 2.0
+		@YawTorque = 2.0
+		@RollTorque = 2.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.2
+		}
+	}
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 30000
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -120,6 +210,14 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 31.6 
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 60000
+        basemass = -1
+    }
 }
 
 @PART[sspx-inflatable-hab-25-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -134,6 +232,14 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 15.8 
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 30000
+        basemass = -1
+    }
 }
 
 @PART[sspx-expandable-centrifuge-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -148,6 +254,27 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 51.03 
+	
+	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 4.0
+		@YawTorque = 4.0
+		@RollTorque = 4.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 2.4
+		}
+	}
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 900000
+        basemass = -1
+    }
 }
 
 @PART[sspx-expandable-centrifuge-375-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -162,6 +289,27 @@
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
 	@mass = 36.45 
+	
+	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 3.0
+		@YawTorque = 3.0
+		@RollTorque = 3.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.8
+		}
+	}
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 300000
+        basemass = -1
+    }
 }
 
 @PART[sspx-expandable-centrifuge-5-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
@@ -175,5 +323,26 @@
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 	%rescaleFactor = 1.8
-	@mass = 71. 
+	@mass = 71. 0
+	
+	// Adding a reaction wheel to imitate an ability to regulate counterweight spin
+	@MODULE[ModuleReactionWheel]
+	{
+		@PitchTorque = 5.0
+		@YawTorque = 5.0
+		@RollTorque = 5.0
+	
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 3.0
+		}
+	}
+	
+	MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1000000
+        basemass = -1
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Special.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Special.cfg
@@ -21,7 +21,7 @@
 	@mass = 0.972
 }
 
-@PART[sspx-lab-pallet-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-lab-pallet-2]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.8

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Special.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Special.cfg
@@ -1,39 +1,39 @@
 //	=================================================================
 //	Special Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
-//	sspx-greenhouse-25-1			PPD-F412M Hydroponics Module
-//	sspx-greenhouse-375-1			PXL-R4NCH-3R Hydroponics Module
 //
 //	=================================================================
 
-@PART[sspx-greenhouse-25-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+
+@PART[sspx-lab-pallet-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 4.15m Hydroponics Module
+	@title = External Stowage Platform (3.6m x 3.6m)
 	@manufacturer = Generic
-	@tags = station, hydroponics, greenhouse
+	@tags = station, aquaculture, greenhouse
 	
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 99
+	@mass = 0.972
 }
 
-@PART[sspx-greenhouse-375-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+@PART[sspx-lab-pallet-1]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.66
+	%rescaleFactor = 1.8
 	
-	@title = 6.225m Hydroponics Module
+	@title = External Stowage Platform (1.8m x 1.8m)
 	@manufacturer = Generic
-	@tags = station, hydroponics, greenhouse
+	@tags = station, aquaculture, greenhouse
 	
 	@maxTemp = 773.15
 	@skinMaxTemp = 773.15
 	@crashTolerance = 10
 
-	@mass = 99
+	@mass = 0.243
 }
+

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Stock_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_Stock_Parts.cfg
@@ -1,0 +1,56 @@
+// Here several stock parts are resized to fit other RO SSPX diameters
+
+@PART[crewCabin]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%rescaleFactor = 1.8
+	
+	@title = 4.5m Habitation Module Short
+	@manufacturer = Generic
+	@tags = sspx, station, tube
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 11.0 // As Unity module
+	
+	!MODULE[ModuleScienceExperiment] {}
+	!MODULE[ModuleExperienceManagement] {}
+	
+
+}
+
+@PART[cupola]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%rescaleFactor = 1.8
+	
+	@title = 4.5m Cupola (Small)
+	@manufacturer = Generic
+	@tags = sspx, station, cupola
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 4.19 //  Real cupola weights 1.8t and it is 2.95m. Mass of this one is scaled as a square.
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleScienceExperiment] {}
+	
+	@MODULE[ModuleCommand] {}
+}
+
+@PART[Large_Crewed_Lab]:FOR[RealismOverhaul]:NEEDS[StationPartsExpansionRedux]
+{
+	%rescaleFactor = 1.8
+	
+	@title = 4.5m Station Science Lab
+	@manufacturer = Generic
+	@tags = sspx, station, lab, science
+	
+	@maxTemp = 773.15
+	@skinMaxTemp = 773.15
+	@crashTolerance = 10
+
+	@mass = 14.0  // As Destiny module
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/SSPX_NOTES.txt
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/SSPX_NOTES.txt
@@ -1,17 +1,12 @@
-1.25m parts ==> 3.05m (MOL) x 2.44
-2.5m parts	==> 4.15m (Salyut) x 1.66
-3.75m parts	==> 6.225m x 1.66
+Original parts diameter		Scale	    RO diameter			Real Analogue
+1.25m	(1.58m max width)	x 1.8	==> 2.25m (2.8m max width)	(Rassvet 2.35m, Pirs 2.55, various chambers and adapters, MOL 3m) 
+1.875m 	(2.22m max width)	x 1.8	==> 3.38m (4.0m max width) 	(Salyut, Mir Modules 4.15, Almaz 4.2, Zvezda 4.35)
+2.5m				x 1.8	==> 4.5m 			(Harmony 4.4, Columbus 4.48, Unity, Leonardo 4.57, Gateway Modules 4.4m)
+3.75m				x 1.8	==> 6.75m			(Skylab 6.7m)
+5m				x 1.8	==> 9.0m			(Skylab II 8.5m, Starship 9m)
 
 
-
-
-
-
-
-
-
-
-
+// RP-1 placement is WIP
 
 // SPACE STATION PROTOTYPES =========================================
 spaceStationPrototypes (1967)
@@ -91,3 +86,17 @@ improvedOrbitalConstruction (2004)
 Habitats
 
 sspx-inflatable-centrifuge-125-1 $4B 2011
+
+
+//INFLATABLE MODULES =================================
+
+Game Name	File Name				Original Inflated Diameter	Scale	RO Diameter	Real Analogue
+Doughnut 	sspx-inflatable-centrifuge-125-2	7.3m OD				x1.8	13.3m OD	ISS Centrifuge Demo ~9-12m OD
+Bagel 		sspx-inflatable-centrifuge-125-1	8.7m OD				x1.8	15.7m OD	Nautilus-X Centrifuge ~20m OD
+Coriolis	sspx-inflatable-centrifuge-25-1		15.0m OD			x1.8	25.0m OD	
+Pilgrim		sspx-inflatable-centrifuge-375-1	24.0m OD			x1.8	43.2m OD	Pilgrim Observer (Not to scale)
+Mercury		sspx-inflatable-centrifuge-375-2	20.0m OD			x1.8	36.0m OD	The Martian Hermes Centrifuge ~35m OD
+Cronus		sspx-inflatable-centrifuge-5-2		24.0m OD			x1.8	43.2m OD	Kronos 1 by Maciej Rebisz (Not to scale)
+
+
+


### PR DESCRIPTION
**Might break existing crafts or change their proportions!**
- New, unified scaling system. Every part is scaled to 1.8 from stock. SPPX-remodeled stock parts (Hitchhiker, Lab, Cupola) are affected too.
- Masses and tank volumes are rescales accordingly
- Latest SSPX parts, 1.875m (3.38m in RO) and 5m (9m in RO) are now supported
- Extendable habitats are now supported.
- Also, see Kerbalism and RP-1 changes