### PR TITLE
Increase RSRM dry mass and add tech transfer between configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -7,7 +7,8 @@
 //	RSRM
 //	Shuttle
 //
-//	Dry Mass: 65770 Kg
+//	Dry Mass for the entire booster, Part Configs can edit the weight
+//	Dry Mass: 87518 Kg (4), (7) P 156
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 14819 kN
 //	ISP: 243 SL / 268 Vac
@@ -26,12 +27,13 @@
 
 //	Sources:
 
-//	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024183.pdf
-//	http://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
-//	http://www.braeunig.us/space/specs/shuttle.htm
-//	http://www.b14643.de/Spacerockets_2/United_States_1/Space_Shuttle/Description/Frame.htm
-//	http://www.b14643.de/Spacerockets_2/United_States_1/Space_Shuttle/Propulsion/engines.htm
-//	https://www.northropgrumman.com/Capabilities/PropulsionSystems/Documents/NGIS_MotorCatalog.pdf
+//	(1)	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024183.pdf
+//	(2)	http://www.orbitalatk.com/flight-systems/propulsion-systems/GEM-strapon-booster-system/docs/orbital_atk_motor_catalog_%282012%29.pdf
+//	(3)	http://www.braeunig.us/space/specs/shuttle.htm
+//	(4)	http://www.b14643.de/Spacerockets_2/United_States_1/Space_Shuttle/Description/Frame.htm
+//	(5)	http://www.b14643.de/Spacerockets_2/United_States_1/Space_Shuttle/Propulsion/engines.htm
+//	(6)	https://www.northropgrumman.com/Capabilities/PropulsionSystems/Documents/NGIS_MotorCatalog.pdf
+//	(7)	http://www.alternatewars.com/BBOW/Space/JSC-26098_Design_Mass_Properties_II.pdf
 
 //	Used by:
 //		Real Scale Boosters
@@ -88,7 +90,8 @@
 		type = ModuleEngines
 		configuration = RSRM-1981
 		modded = False
-		origMass = 65.77
+		// Dry Mass of the entire Booster, change in part configs to account for split of parts like nose cones
+		origMass = 87.518 // (4), (7) P 156
 
 		CONFIG
 		{
@@ -240,156 +243,12 @@
 				key = 0       0
 			}
 		}
-		
-		CONFIG
+
+		// Everything is the same on the RSRM-1986 config; it exists to have another Reliability config
+		+CONFIG[RSRM-1981]
 		{
-			name = RSRM-1986
-			description = Redesigned RSRM, after Challenger disaster
-			minThrust = 14819
-			maxThrust = 14819
-			heatProduction = 100
-			curveResource = PBAN
-			gimbalRange = 5.0
-			ullage = False
-			pressureFed = False
-			ignitions = 1
-
-			PROPELLANT
-			{
-				name = PBAN
-				ratio = 1.0
-				DrawGauge = True
-			}
-
-			atmosphereCurve
-			{
-				key = 0 268
-				key = 1 243
-			}
-
-			thrustCurve
-			{
-				key = 0.98942 0.945
-				key = 0.97888 0.942
-				key = 0.96834 0.942
-				key = 0.95773 0.948
-				key = 0.947   0.959
-				key = 0.93618 0.967
-				key = 0.92524 0.978
-				key = 0.91426 0.981
-				key = 0.90323 0.986
-				key = 0.89216 0.989
-				key = 0.8811  0.989
-				key = 0.87    0.992
-				key = 0.8589  0.992
-				key = 0.84777 0.994
-				key = 0.83665 0.994
-				key = 0.82552 0.994
-				key = 0.81439 0.994
-				key = 0.80323 0.997
-				key = 0.79207 0.997
-				key = 0.78088 1
-				key = 0.7697  1
-				key = 0.75851 1
-				key = 0.74744 0.989
-				key = 0.73665 0.964
-				key = 0.7261  0.942
-				key = 0.71568 0.932
-				key = 0.70544 0.915
-				key = 0.69526 0.91
-				key = 0.68518 0.901
-				key = 0.67521 0.89
-				key = 0.66537 0.88
-				key = 0.65562 0.871
-				key = 0.64599 0.86
-				key = 0.63649 0.849
-				key = 0.62711 0.838
-				key = 0.61782 0.83
-				key = 0.60862 0.822
-				key = 0.59952 0.814
-				key = 0.59047 0.808
-				key = 0.58152 0.8
-				key = 0.57269 0.789
-				key = 0.56392 0.784
-				key = 0.55527 0.773
-				key = 0.54672 0.765
-				key = 0.53823 0.759
-				key = 0.52976 0.756
-				key = 0.52136 0.751
-				key = 0.51302 0.745
-				key = 0.5048  0.734
-				key = 0.49671 0.723
-				key = 0.48868 0.718
-				key = 0.4807  0.713
-				key = 0.47273 0.713
-				key = 0.46476 0.713
-				key = 0.45675 0.715
-				key = 0.44869 0.721
-				key = 0.44056 0.726
-				key = 0.43241 0.729
-				key = 0.42422 0.732
-				key = 0.416   0.734
-				key = 0.40772 0.74
-				key = 0.39941 0.743
-				key = 0.39107 0.745
-				key = 0.3827  0.748
-				key = 0.3743  0.751
-				key = 0.36586 0.754
-				key = 0.3574  0.756
-				key = 0.34891 0.759
-				key = 0.34035 0.765
-				key = 0.33176 0.767
-				key = 0.32315 0.77
-				key = 0.31453 0.77
-				key = 0.30588 0.773
-				key = 0.29723 0.773
-				key = 0.28855 0.776
-				key = 0.27987 0.776
-				key = 0.2712  0.776
-				key = 0.26252 0.776
-				key = 0.25387 0.773
-				key = 0.24531 0.765
-				key = 0.23682 0.759
-				key = 0.22841 0.751
-				key = 0.2201  0.743
-				key = 0.21185 0.737
-				key = 0.20376 0.724
-				key = 0.19575 0.715
-				key = 0.18781 0.71
-				key = 0.18005 0.694
-				key = 0.17241 0.683
-				key = 0.16493 0.669
-				key = 0.1575  0.663
-				key = 0.15011 0.661
-				key = 0.14278 0.655
-				key = 0.13548 0.652
-				key = 0.12824 0.647
-				key = 0.12115 0.633
-				key = 0.11416 0.625
-				key = 0.10726 0.617
-				key = 0.10045 0.609
-				key = 0.0937  0.603
-				key = 0.08704 0.595
-				key = 0.08051 0.584
-				key = 0.07406 0.576
-				key = 0.06771 0.568
-				key = 0.06155 0.551
-				key = 0.05556 0.535
-				key = 0.0497  0.524
-				key = 0.04387 0.521
-				key = 0.03804 0.521
-				key = 0.03231 0.513
-				key = 0.0269  0.483
-				key = 0.02193 0.444
-				key = 0.01751 0.395
-				key = 0.0138  0.332
-				key = 0.01085 0.264
-				key = 0.00863 0.198
-				key = 0.00682 0.162
-				key = 0.00528 0.138
-				key = 0.00396 0.118
-				key = 0       0
-			}
+			@name = RSRM-1986
+			@description = Redesigned RSRM, after Challenger disaster
 		}
 	}
 }
@@ -422,6 +281,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995392
 		cycleReliabilityEnd = 0.999078
+		techTransfer = RSRM-1981:50
 
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/RSRM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SpaceShuttleSystem/RSRM.cfg
@@ -9,7 +9,6 @@
 	
 	%rescaleFactor = 1.5625
 	
-	@mass = 67.6
 	@maxTemp = 773.15
     %skinMaxTemp = 873.15
 	
@@ -21,22 +20,15 @@
 	}
 	
 	!RESOURCE[SolidFuel]{}
-	
-	MODULE
+}
+
+@PART[SSRBSH|ShuttleRocketBooster]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
 	{
-		name = ModuleFuelTanks
-		volume = 283126
-		type = PBAN
-		basemass = -1
-		TANK
-		{
-			name = PBAN
-			amount = 283126
-			maxAmount = 283126
-		}
+		// Remove mass of sep motors and Nosecone
+		@origMass -= 2.379
 	}
-	
-	!MODULE[ModuleAlternator] {}
 }
 
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/reDIRECT/RO_reDIRECT_SRB_STS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/reDIRECT/RO_reDIRECT_SRB_STS.cfg
@@ -38,6 +38,15 @@
     !RESOURCE,*{}
 }
 
+@PART[DIRECT_SRB_4]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		// Remove mass of Nosecone
+		@origMass -= 0.339
+	}
+}
+
 
 //  ==================================================
 //  5-Segment RSRM


### PR DESCRIPTION
* Increase Dry Mass from 65770 kg to 87518 kg according to [Design Mass Properties II](http://www.alternatewars.com/BBOW/Space/JSC-26098_Design_Mass_Properties_II.pdf), page 156
* Refactor the 1986 config to be copied from the 1981 config, since they are identical except for reliablility
* Add tech transfer from the 1981 config to the 1986 config