### PR TITLE
Fix RS-25D mass mult

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -212,7 +212,7 @@
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
 			minThrust = 1400.4
 			maxThrust = 2319.9
-			massMult - 1.065
+			massMult = 1.065
 			PROPELLANT
 			{
 				name = LqdHydrogen


### PR DESCRIPTION
RS-25D mass mult was using a - instead of an =, and so wasn't actually setting the mass.