### PR TITLE
Configs for BDB's Apollo Revamp

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ApolloRevamp.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ApolloRevamp.cfg
@@ -6,10 +6,13 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.553
 
-	@title = Apollo Block IV Command Module
+	//@CoPOffset = 0.0, 0.0, 0.0
+	@buoyancy = 1.1
+	@CoLOffset = 0.0, 0.0, 0.0
+	@title = Apollo Block III+ Command Module
 	%manufacturer = Rockwell International
-	@description = Apollo model developed for use with Space Station Freedom and Saturn Multibody. Built to use additional payload allowed by Saturn M02 compared to Saturn IC, Block IV is built on an enhanced-capacity service module (common with Aardvark Block II) and features a larger, more capable Mission Module, but retains the Block III command module with minor avionics updates. FICTIONAL (Eyes Turned Skyward)
-	@mass = 4.15
+	@description = Significant changes were made to better adapt Apollo to its new role as a crew shuttle for LEO, and the internal volume was modified to fit 5 crew for reentry. Be sure to bring extra living space by attaching the Mission Module to dock with after orbiting. By only using the Command Module, you will have resources for 5 crew for 72 hours. FICTIONAL (Eyes Turned Skyward)
+	@mass = 4.0	//-150 kg for 3 inflatable floats
 	@maxTemp = 973.15
 	@crashTolerance = 10
 	%stagingIcon = COMMAND_POD
@@ -82,7 +85,7 @@
 	{
 		name = ModuleFuelTanks
 		type = ServiceModule
-		volume = 600.0
+		volume = 550.0
 		basemass = -1
 		TANK
 		{
@@ -152,7 +155,7 @@
 
 @INTERNAL[bdbKP0110internal2]:FOR[RealismOverhaul]
 {
-	@offset = 0.0, 0.0, 0.195
+	@offset = 0.0, 0.0, 0.25
 	%scaleAll = 1.5, 1.5, 1.5
 	//@MODULE[InternalSeat],*
 	//{
@@ -169,9 +172,11 @@
 	%rescaleFactor = 1.553
 	
 
-	@title = Apollo Block IV Heatshield
+	//@CoPOffset = 0.0, 0.0, 0.0
+	//@CoLOffset = 0.0, 0.0, 0.0
+	@title = Apollo Block III+ Heatshield
 	%manufacturer = Rockwell International
-	@description = LEO Heatshield for the Apollo Block IV Capsule. A lighter heat shield for use with LEO operations.
+	@description = LEO Heatshield for the Apollo Block III+ Capsule. A lighter heat shield for use with LEO operations.
 	@mass = 0.15
 	@maxTemp = 2600
 	@crashTolerance = 20
@@ -542,9 +547,14 @@
 	%skinMaxTemp = 773.15
 	%stagingIcon = DECOUPLER_VERT
 	
+	@MODULE[ModuleBdbDecouplerAnimation]
+	{
+		@waitForAnimation = 0.1
+	}
+	
 	@MODULE[ModuleDecouple]
 	{
-		@ejectionForce = 15
+		@ejectionForce = 150
 	}
 	
 	!MODULE[ModuleToggleCrossfeed] {}
@@ -557,9 +567,9 @@
 	%rescaleFactor = 1.553
 	
 	
-	@title = Apollo Block IV Service Module
+	@title = Apollo Block III+/IV Service Module
 	%manufacturer = Rockwell International
-	@description = Built to use additional payload allowed by Saturn M02 compared to Saturn IC, Apollo Block IV is built on an enhanced-capacity service module, common with Aardvark Block II (Note - AARDV Block II SM holds 3500 kg of propellant, while Apollo Block IV SM holds 2000 kg of propellant). FICTIONAL (Eyes Turned Skyward)
+	@description = Significant changes were made to better adapt Apollo to its new role as a crew shuttle for LEO and the Block III Service Module was decreased in size and weight. Built to use additional payload allowed by Saturn M02 compared to Saturn IC, Apollo Block IV is built on an enhanced-capacity service module, common with Aardvark Block II (Note - AARDV Block II SM holds 3500 kg of propellant, while Apollo Block IV SM holds 2000 kg of propellant). FICTIONAL (Eyes Turned Skyward)
 	@mass = 3.1
 	%maxTemp = 673.15
 	%skinMaxTemp = 773.15
@@ -780,7 +790,7 @@
 	@title = Apollo 3-Way RCS Block
 	%manufacturer = Rocketdyne
 	@description = This attitude and translation thruster pack was developed for the Apollo program. This one comes in a three-way mounting, for all your three-way needs.
-	@mass = 0.014
+	@mass = 0.01
 	%maxTemp = 673.15
 	%skinMaxTemp = 773.15
 	%stagingIcon = RCS_MODULE
@@ -874,7 +884,7 @@
 	@title = Apollo Linear RCS Thruster
 	%manufacturer = Rocketdyne
 	@description = This attitude and translation thruster pack was developed for the Apollo program. This one comes in a single mount, for use on the top of the AARDV and other places.
-	@mass = 0.014
+	@mass = 0.003
 	%maxTemp = 673.15
 	%skinMaxTemp = 773.15
 	%stagingIcon = RCS_MODULE
@@ -1281,7 +1291,7 @@
 	%skinMaxTemp = 773.15
 }
 
-@PART[bluedog_LM_Ascent_Engine]:AFTER[RealismOverhaulEngines]
+@PART[bluedog_LM_Ascent_Engine]:AFTER[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.553
@@ -1294,7 +1304,7 @@
 	%engineType = LMAE
 }
 
-@PART[bluedog_LM_Descent_Engine]:AFTER[RealismOverhaulEngines]
+@PART[bluedog_LM_Descent_Engine]:AFTER[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.553
@@ -1307,7 +1317,7 @@
 	%engineType = LMDE
 }
 
-@PART[bluedog_Apollo_Block2_SPS]:AFTER[RealismOverhaulEngines]
+@PART[bluedog_Apollo_Block2_SPS]:AFTER[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.553

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ApolloRevamp.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ApolloRevamp.cfg
@@ -1,0 +1,1348 @@
+// https://www.alternatehistory.com/wiki/doku.php?id=timelines:eyes_turned_skyward_spacecraft_and_launch_vehicle_technical_data
+// **************************************************************************************
+
+@PART[bluedog_Apollo_CrewPod_5crew]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+
+	@title = Apollo Block IV Command Module
+	%manufacturer = Rockwell International
+	@description = Apollo model developed for use with Space Station Freedom and Saturn Multibody. Built to use additional payload allowed by Saturn M02 compared to Saturn IC, Block IV is built on an enhanced-capacity service module (common with Aardvark Block II) and features a larger, more capable Mission Module, but retains the Block III command module with minor avionics updates. FICTIONAL (Eyes Turned Skyward)
+	@mass = 4.15
+	@maxTemp = 973.15
+	@crashTolerance = 10
+	%stagingIcon = COMMAND_POD
+	
+	//@CoMOffset = 0.0, -0.5, 0.0
+	
+	%skinMaxTemp = 3600
+	%emissiveConstant = 0.6
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+	
+	!EFFECTS {}
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel] {}
+	!MODULE[ModuleConductionMultiplier] {}
+	!MODULE[ModuleB9PartSwitch] {}
+	!MODULE[ModuleLiftingSurface] {}
+	
+	@MODULE[ModuleCommand]
+	{
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 1.6
+		}
+		@minimumCrew = 0
+	}
+	
+	MODULE
+	{
+		name = AdjustableCoMShifter
+		DescentModeCoM = 0, 0, -0.17
+	}
+
+	MODULE
+	{
+		name = ModuleSAS
+		SASServiceLevel = 3
+	}
+	
+	MODULE
+	{
+		name:NEEDS[!DeadlyReentry] = ModuleAblator
+		name:NEEDS[DeadlyReentry] = ModuleHeatShield
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 0.75
+		lossExp = -25000
+		lossConst = 15
+		pyrolysisLossFactor = 1458330
+		ablationTempThresh = 1250
+		reentryConductivity = 0.001
+		depletedMaxTemp:NEEDS[DeadlyReentry] = 1200
+		infoTemp = 3000
+	}
+	RESOURCE
+	{
+		name = Ablator
+		maxAmount = 10
+		amount = 10
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		maxAmount = 7.5
+		amount = 0
+	}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 600.0
+		basemass = -1
+		TANK
+		{
+			name = ElectricCharge
+			amount = 12096
+			maxAmount = 12096
+		}
+		TANK
+		{
+			name = MMH
+			amount = 46
+			maxAmount = 46
+		}
+		TANK
+		{
+			name = NTO
+			amount = 55
+			maxAmount = 55
+		}
+		TANK
+		{
+			name = Helium
+			amount = 1010
+			maxAmount = 1010
+		}
+	}
+	
+	@MODULE[ModuleRCSFX]
+	{
+		@thrusterPower = 0.415
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4557
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.5443
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 10.0
+			ignoreForIsp = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 274
+			@key,1 = 1 137
+			key = 4 0.001
+		}
+	}
+}
+
+@PART[bluedog_Apollo_CrewPod_5crew]:BEFORE[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 3.0		//Guess based on Block II
+		RFBand = S		//Default to S-band
+	}
+}
+
+@INTERNAL[bdbKP0110internal2]:FOR[RealismOverhaul]
+{
+	@offset = 0.0, 0.0, 0.195
+	%scaleAll = 1.5, 1.5, 1.5
+	//@MODULE[InternalSeat],*
+	//{
+	//	%kerbalScale = 1.553, 1.553, 1.553
+	//	%kerbalOffset = 0.0, 0.0, 0.0
+	//	%kerbalEyeOffset = 0.0, 0.0, 0.0
+	//	@allowCrewHelmet = false
+	//}
+}
+
+@PART[bluedog_Apollo_Heatshield]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+
+	@title = Apollo Block IV Heatshield
+	%manufacturer = Rockwell International
+	@description = LEO Heatshield for the Apollo Block IV Capsule. A lighter heat shield for use with LEO operations.
+	@mass = 0.15
+	@maxTemp = 2600
+	@crashTolerance = 20
+	
+	%skinMaxTemp = 3600
+	%maxTemp = 2600
+	%emissiveConstant = 0.4
+	%thermalMassModifier = 1.0
+	%skinMassPerArea = 4
+	
+	!MODULE[ModuleAblator] {}
+	!MODULE[ModuleTestSubject] {}
+	//!MODULE[ModuleLiftingSurface] {}
+	
+	!RESOURCE,* {}
+	
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 0.75
+		lossExp = -7000
+		lossConst = 0.085
+		pyrolysisLossFactor = 70000
+		ablationTempThresh = 500
+		reentryConductivity = 0.01
+		charMax = 1
+		charMin = 1
+	}
+	
+	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+	{
+		@name = ModuleHeatShield
+		depletedMaxTemp = 1200
+	}
+	
+	RESOURCE
+	{
+		name = Ablator
+		amount = 380.0
+		maxAmount = 380.0
+	}
+	
+	RESOURCE
+	{
+		name = CharredAblator
+		amount = 0
+		maxAmount = 285.0
+	}
+	
+	//DRAG_CUBE
+	//{
+	//	cube = Default, 1.8,0.456,0.059, 1.8,0.4557,0.059, 12.56,0.9197,0.0057, 12.56,0.9031,0.0239, 1.8,0.4582,0.059, 1.8,0.4559,0.059, -2.605E-08,-0.2616,9.442E-07, 5.8,0.5232,5.8
+	//}
+}
+
+@PART[bluedog_Apollo_ParachuteCover]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo CM Forward Heat Shield
+	%manufacturer = Rockwell International
+	@description = The forward heat shield for the Apollo Command Module.
+	@mass = 0.104
+	@maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 20
+	}
+}
+
+@PART[bluedog_Apollo_ProbeDockingPort]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Docking Mechanism Probe
+	%manufacturer = Rockwell International
+	@description = Structural adapter for Apollo parachutes and docking port. Place on top of the capsule, add parachutes in 3x symmetry. The Active Docking Mechanism goes on top. Includes a decoupler for the docking mechanism, to clear the way for the parachutes.
+	@mass = 0.036
+	%maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 10
+	}
+}
+
+@PART[bluedog_Apollo_ConeDockingPort]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Drogue Docking Port
+	%manufacturer = Rockwell International
+	@description = This is the drogue (accepting) part of the Apollo Docking System. It will only work with the Apollo Command Module Probe.
+	@mass = 0.2
+	%maxTemp = 973.15
+	%skinMaxTemp = 1073.15
+	
+	@MODULE[ModuleDockingNode]
+	{
+        %gendered = True
+        %genderFemale = True
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}
+
+@PART[bluedog_Apollo_DrogueChute]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Drogue Parachute
+	%manufacturer = Rockwell International
+	@description = The drogue parachute pack is meant to slow down the Apollo spacecraft at a high altitude in preparation for the deployment of the main parachute pack. Attach this to the front node before placing the Forward Heat Shield.
+	@mass = 0.25
+	%maxTemp = 973.15
+	%skinMaxTemp = 1073.15
+	
+	!MODULE[ModuleBdbCutDrogue] {}
+	!MODULE[ModuleDragModifier] {}
+	!MODULE[ModuleDragModifier] {}
+	!MODULE[ModuleParachute]{}
+	
+	MODULE:NEEDS[RealChute]
+	{
+		name = RealChuteModule
+		caseMass = 0.0206
+		timer = 0
+		mustGoDown = True
+		spareChutes = 0
+		cutSpeed = 0.5
+		secondaryChute = False
+
+		PARACHUTE
+		{
+			parachuteName = canopy
+			capName = Cap
+			preDeploymentAnimation = partialDeploy
+			deploymentAnimation = fullDeploy
+			material = Nylon
+			minIsPressure = False
+			minPressure = 0.01
+			preDeployedDiameter = 5.2
+			preDeploymentSpeed = 1.6
+			minDeployment = 7625
+			deployedDiameter = 10.0
+			deploymentSpeed = 10.0
+			deploymentAlt = 7315
+			cutAlt = 3350
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleDragModifier
+		dragCubeName = SEMIDEPLOYED
+		dragModifier = 0.78125
+	}
+	MODULE
+	{
+		name = ModuleDragModifier
+		dragCubeName = DEPLOYED
+		dragModifier = 1.25
+	}
+	
+	EFFECTS
+	{
+		rcpredeploy
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_parachute_open
+				volume = 1
+			}
+		}
+
+		rcdeploy
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_parachute_single
+				volume = 1
+			}
+		}
+
+		rccut
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealChute/Sounds/sound_parachute_cut
+				volume = 1
+			}
+		}
+
+		rcrepack
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealChute/Sounds/sound_parachute_repack
+				volume = 1
+			}
+		}
+	}
+}
+
+@PART[bluedog_Apollo_DrogueChute]:AFTER[zzzRealismOverhaul]
+{
+	// RO forces all RealChuteModules to minDeploy 5000, deploy 1000,
+	// which would make the drogue cut before it even deploys. Get back
+	// our historical numbers
+	@MODULE[RealChuteModule]
+	{
+		@PARACHUTE
+		{
+			@minDeployment = 7525
+			@deploymentAlt = 7315
+		}
+	}	 
+}
+
+@PART[bluedog_Apollo_MainChute]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Main Parachute
+	%manufacturer = Rockwell International
+	@description = The main parachute pack of the Apollo Command Module. Attach this to the central top node before placing the Forward Heat Shield.
+	@mass = 0.175
+	%maxTemp = 973.15
+	%skinMaxTemp = 1073.15
+	
+	!MODULE[ModuleBdbCutDrogue] {}
+	!MODULE[ModuleDragModifier] {}
+	!MODULE[ModuleDragModifier] {}
+	!MODULE[ModuleParachute]{}
+	
+	MODULE:NEEDS[RealChute]
+	{
+		name = RealChuteModule
+		caseMass = 0.1106
+		mustGoDown = True
+		spareChutes = 0
+		cutSpeed = 0.5
+
+		PARACHUTE
+		{
+			parachuteName = canopy
+			capName = Cap
+			preDeploymentAnimation = partialDeploy
+			deploymentAnimation = fullDeploy
+			material = Nylon
+			minIsPressure = False
+			minPressure = 0.01
+			preDeployedDiameter = 19.1
+			preDeploymentSpeed = 6.0
+			minDeployment = 3350
+			deployedDiameter = 38.1
+			deploymentSpeed = 10.0
+			deploymentAlt = 3000
+			cutAlt = 0
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleDragModifier
+		dragCubeName = SEMIDEPLOYED
+		dragModifier = 0.9375
+	}
+	MODULE
+	{
+		name = ModuleDragModifier
+		dragCubeName = DEPLOYED
+		dragModifier = 3.125
+	}
+	
+	EFFECTS
+	{
+		rcpredeploy
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_parachute_open
+				volume = 1
+			}
+		}
+
+		rcdeploy
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_parachute_single
+				volume = 1
+			}
+		}
+
+		rccut
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealChute/Sounds/sound_parachute_cut
+				volume = 1
+			}
+		}
+
+		rcrepack
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = RealChute/Sounds/sound_parachute_repack
+				volume = 1
+			}
+		}
+	}
+}
+
+@PART[bluedog_Apollo_MainChute]:AFTER[zzzRealismOverhaul]
+{
+	// RO forces all RealChuteModules to minDeploy 5000, deploy 1000,
+	// Get back our historical numbers
+	@MODULE[RealChuteModule]
+	{
+		@PARACHUTE
+		{
+			@minDeployment = 3350
+			@deploymentAlt = 3000
+		}
+	}	 
+}
+
+@PART[bluedog_Apollo_Decoupler]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = Apollo Command/Service Module Decoupler
+	%manufacturer = Rockwell International
+	@description = This is used to decouple the Command Module from the Service Module prior to reentry. This one has been seperated from the Service Module, to allow you to attatch whatever you want to your Apollo capsule.
+	@mass = 0.9504
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	%stagingIcon = DECOUPLER_VERT
+	
+	@MODULE[ModuleDecouple]
+	{
+		@ejectionForce = 15
+	}
+	
+	!MODULE[ModuleToggleCrossfeed] {}
+	!MODULE[ModuleTestSubject] {}
+}
+
+@PART[bluedog_Apollo_Block3_SM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = Apollo Block IV Service Module
+	%manufacturer = Rockwell International
+	@description = Built to use additional payload allowed by Saturn M02 compared to Saturn IC, Apollo Block IV is built on an enhanced-capacity service module, common with Aardvark Block II (Note - AARDV Block II SM holds 3500 kg of propellant, while Apollo Block IV SM holds 2000 kg of propellant). FICTIONAL (Eyes Turned Skyward)
+	@mass = 3.1
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	!RESOURCE,* {}
+	
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 6200.0
+		basemass = -1
+		TANK
+		{
+			name = Aerozine50
+			amount = 855.0
+			maxAmount = 855.0
+		}
+		TANK
+		{
+			name = NTO
+			amount = 850.0
+			maxAmount = 855.0
+		}
+		TANK
+		{
+			name = Helium
+			amount = 24000
+			maxAmount = 24000
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 540000
+			maxAmount = 540000
+		}
+	}
+}
+
+@PART[bluedog_Apollo_Block4_MissionModule]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Block IV Mission Module
+	%manufacturer = Rockwell International
+	@description = Following the introduction of more capable lifters for crewed LEO missions, the venerable Apollo Block III+ mission module was replaced with a larger can. Includes a larger attachment node on top for using larger androgynous docking ports. Place it upside down in place of the lunar module, with docking ports on each end. Extract with the CSM after circularization. FICTIONAL (Eyes Turned Skyward)
+	@mass = 4.014	//4500kg - 286 - 200 of docking ports
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 3000
+		basemass = -1
+	}
+}
+
+@PART[bluedog_Apollo_Block5_highGain]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Block V High Gain Antenna
+	%manufacturer = Rockwell International
+	@description = A collapsible relay antenna consisting of a high gain dish, for transmitting the many exciting things you've discovered. Intended to be placed on the mounting bracket of the Apollo Service Engine Block V. FICTIONAL (Eyes Turned Skyward)
+	@mass = 0.025
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+}
+
+@PART[bluedog_Apollo_Block5_highGain]:BEFORE[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		antennaDiameter = 1.5	//Guess, no documentation
+		RFBand = S	//Default to S-band
+	}
+}
+
+@PART[bluedog_Apollo_Block5_SolarPanel]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Block V Solar Array
+	%manufacturer = Boeing-Grumman
+	@description = Extendable sun-tracking Level 3 solar panel used for the Block V Apollo CSM. 8.05m^2. FICTIONAL (Eyes Turned Skyward)
+	@mass = 0.04669 // Level 3 moving @ 0.0008t/m^2 + 0.005t/m^2
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 1.87565	// Level 3 @ 0.18kW/m^2
+	}
+	
+	!SolarConfig,* { }
+	
+	%useSolarConfig = true
+	%solarUseMass = true
+	SolarConfig
+	{
+		area = 8.05
+		level = 5
+		type = tracking
+	}
+}
+
+@PART[bluedog_Apollo_CADS_active]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = CADS Docking Port (Active)
+	%manufacturer = RKK Energiya
+	@description = Common Androgynous Docking Port. Developed to eliminate the limitations of the gendered Apollo docking system, as well as provide a larger passageway for delivering cargo. Equipped with a deployable capture ring to dampen impact. Permanent station ports can use the passive version, which is simpler and lighter.
+	@mass = 0.311	//active CBM Type II
+	%maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	
+	@MODULE[ModuleDockingNode]
+	{
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}
+
+@PART[bluedog_Apollo_CADS_passive]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = CADS Docking Port (Passive)
+	%manufacturer = RKK Energiya
+	@description = Common Androgynous Docking System, passive version intended to mate with active counterparts. Useful for permanent fixtures that won't have to form the active docking partner, such as berthing ports on station modules.
+	@mass = 0.2	//passive CBM
+	%maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	
+	@MODULE[ModuleDockingNode]
+	{
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}
+
+@PART[bluedog_Apollo_DockingSpotlight]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Docking Floodlight
+	%manufacturer = Rockwell International
+	@description = Essentially a pen light glued to a flap, this light (traditionally mounted to the decoupler ring on the Apollo CSM) swings out to provide illumination for docking/berthing operations.
+	@mass = 0.002
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_EVAFloodlight]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Docking Floodlight
+	%manufacturer = Rockwell International
+	@description = Essentially a pen light on the end of a straw, this light (traditionally mounted to the decoupler ring on the Apollo CSM) swings out to provide illumination to aid kerbonauts on EVAs.
+	@mass = 0.005
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_EngineMount]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo SM Engine Mount
+	%manufacturer = Rockwell International
+	@description = Mounting plate for attaching a single engine to Apollo Service Module. Includes a node just below the top rim for attaching the Saturn SLA as well as a mounting point for the high gain antenna system.
+	@mass = 0.15
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_RCS_3Way]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	//%useRcsConfig = RCSBlock
+	%rescaleFactor = 1.553
+	
+	@title = Apollo 3-Way RCS Block
+	%manufacturer = Rocketdyne
+	@description = This attitude and translation thruster pack was developed for the Apollo program. This one comes in a three-way mounting, for all your three-way needs.
+	@mass = 0.014
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	%stagingIcon = RCS_MODULE
+	
+	!EFFECTS {}
+	
+	@MODULE[ModuleRCS*]
+	{
+		%stagingEnabled = True
+		%resourceFlowMode = STACK_PRIORITY_SEARCH
+		%thrusterPower = 0.445
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4973
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5027
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 10.0
+			ignoreForIsp = True
+		}
+		!atmosphereCurve,* {}
+		atmosphereCurve
+		{
+			key,0 = 0 278
+			key,1 = 1 168
+		}
+	}
+}
+
+@PART[bluedog_Apollo_RCS_Quad]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	//%useRcsConfig = RCSBlock
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Service Module RCS Block
+	%manufacturer = Rocketdyne
+	@description = The attitude control thruster blocks of the Apollo Service Module (SM). Four of these allow full three-axis attitude control and translation of the Apollo CSM.
+	@mass = 0.014
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	%stagingIcon = RCS_MODULE
+	
+	!EFFECTS {}
+	
+	@MODULE[ModuleRCS*]
+	{
+		%stagingEnabled = True
+		%resourceFlowMode = STACK_PRIORITY_SEARCH
+		%thrusterPower = 0.445
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4973
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5027
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 10.0
+			ignoreForIsp = True
+		}
+		!atmosphereCurve,* {}
+		atmosphereCurve
+		{
+			key,0 = 0 278
+			key,1 = 1 168
+		}
+	}
+}
+
+@PART[bluedog_Apollo_RCS_Sideways]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	//%useRcsConfig = RCSBlock
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Linear RCS Thruster
+	%manufacturer = Rocketdyne
+	@description = This attitude and translation thruster pack was developed for the Apollo program. This one comes in a single mount, for use on the top of the AARDV and other places.
+	@mass = 0.014
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	%stagingIcon = RCS_MODULE
+	
+	!EFFECTS {}
+	
+	@MODULE[ModuleRCS*]
+	{
+		%stagingEnabled = True
+		%resourceFlowMode = STACK_PRIORITY_SEARCH
+		%thrusterPower = 0.445
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4973
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5027
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 10.0
+			ignoreForIsp = True
+		}
+		!atmosphereCurve,* {}
+		atmosphereCurve
+		{
+			key,0 = 0 278
+			key,1 = 1 168
+		}
+	}
+}
+
+@PART[bluedog_Apollo_ScimitarAntenna]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Scimitar Antenna
+	%manufacturer = Rockwell International
+	@description = This interesting device is known as a scimitar antenna. It is a curved antenna inside of an aerodynamic casing allowing it used while travelling though the atmosphere or as backup to a high gain antenna. And we think it looks cool. Place in 2x symmetry on the Apollo block II Service Module.
+	@mass = 0.002
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_AARDV_Cargo_Block1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = AARDV Block II Cargo Module
+	%manufacturer = Rockwell International
+	@description = As the lifetime of stations increased from months to years, it became impossible to rely solely on supplies brought up using the limited space inside Apollo capsules. This is the cargo volume for the AARDV Block I automated resupply ship, the standardized cargo vessel. FICTIONAL (Eyes Turned Skyward)
+	@mass = 4.0	//4500kg - 286 - 200 of docking ports
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleInventoryPart] {}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 24000
+		basemass = -1
+	}
+	
+	MODULE:NEEDS[KIS]
+	{
+		name = ModuleKISInventory
+		maxVolume = 6000
+		externalAccess = true
+		internalAccess = true
+		slotsX = 6
+		slotsY = 4
+		slotSize = 50
+		itemIconResolution = 128
+		selfIconResolution = 128
+		openSndPath = KIS/Sounds/containerOpen
+		closeSndPath = KIS/Sounds/containerClose
+		defaultMoveSndPath = KIS/Sounds/itemMove
+	}
+
+	MODULE:NEEDS[KIS]
+	{
+		name = ModuleKISItem
+		volumeOverride = 8000
+		editorItemsCategory = false
+	}
+}
+
+@PART[bluedog_Apollo_AARDV_Core]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel] {}
+	
+	@title = AARDV Block II Avionics
+	%manufacturer = Rockwell International
+	@description = Control core for AARDV Block II spacecraft. Goes between the cargo module and service module, and provides control and guidance for resupply vehicles and tugs.
+	@mass = 0.4
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_AARDV_Core]:BEFORE[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter],* {}
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 1.5
+		RFBand = UHF
+	}
+}
+
+@PART[bluedog_Apollo_AARDV_Nose]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = AARDV Nose Adapter
+	%manufacturer = Rockwell International
+	@description = Small cone to adapt the AARDV-CRM's top node to the Apollo Docking Mechanism.
+	@mass = 0.025
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_AARDV_Plate]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	@title = Apollo Structural Adapter
+	%manufacturer = Rockwell International
+	@description =  A nearly flat plate, for adapting the top of the AARDV cargo module to the docking nose.
+	@mass = 0.04
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	
+}
+
+@PART[bluedog_Apollo_Block2_SM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = BDB Apollo Service Module
+	%manufacturer = North American Aviation
+	@description = The Apollo Service Module contains the main propellant tanks, the fuel cells, life support and everything else that it is needed for a flight to the Moon. Connect this directly to the Command Module.
+	@mass = 7.22 // for some reason, this part's mass is terribly broken and is growing as a function: 0.4x+0.699848, thus this should result in ~3.588
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	!RESOURCE,* {}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[configSwitch]] {}
+	!MODULE[ModuleResourceConverter]
+	
+	MODULE	//	Copied from the ROCapsules Config by Luci on 1/3/21
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 17858
+		basemass = -1
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 0
+			maxAmount = 43200
+		}
+
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 367
+			maxAmount = 367
+			isDewar = True
+		}
+
+		TANK
+		{
+			name = LqdOxygen
+			amount = 254
+			maxAmount = 254
+			isDewar = True
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 100
+			maxAmount = 100
+		}
+
+		TANK
+		{
+			name = Aerozine50
+			amount = 7942
+			maxAmount = 7942
+		}
+		TANK
+		{
+			name = MMH
+			amount = 270.5
+			maxAmount = 270.5
+		}
+
+		TANK
+		{
+			name = NTO
+			amount = 8051
+			maxAmount = 8051
+		}
+		
+		TANK
+		{
+			name = Helium
+			amount = 165810
+			maxAmount = 165810
+		}
+	}
+}
+
+@PART[bluedog_LM_Ascent_Cockpit]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = Lunar Module Ascent Stage
+	@description = Ascent Stage for the Apollo Lunar Module
+	%manufacturer = Grumman
+	@mass = 1.984 //1.786
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	!RESOURCE,* {}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[configSwitch]] {}
+	
+	
+	MODULE	//	Quantities copied from the ROCapsules Config by Luci on 1/3/21
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 2463.7
+		basemass = -1
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 59675
+			maxAmount = 59675
+		}
+		
+		TANK
+		{
+			name = Aerozine50
+			amount = 1124.6
+			maxAmount = 1124.6
+		}
+		
+		TANK
+		{
+			name = NTO
+			amount = 1139.9
+			maxAmount = 1139.9
+		}
+		
+		TANK
+		{
+			name = Helium
+			amount = 27828.3
+			maxAmount = 27828.3
+		}
+		
+		// Life Support Tanks
+		
+		TANK
+		{
+			name = Food
+			amount = 23.4
+			maxAmount = 35.1
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 40
+			maxAmount = 40
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 1563.4
+			maxAmount = 1563.4
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 4.1
+			maxAmount = 6.2
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 3.2
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 29.3
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1023
+		}
+	}
+}
+
+@PART[bluedog_LM_Descent_Tanks]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = Lunar Module Descent Stage
+	@description = Descent Stage for the Apollo Lunar Module
+	%manufacturer = Grumman
+	@mass = 1.5
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	!RESOURCE,* {}
+	
+	
+	MODULE	//	Quantities copied from the ROCapsules Config by Luci on 1/3/21
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 8163
+		basemass = -1
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 161280
+			maxAmount = 201600
+		}
+
+		TANK
+		{
+			name = Aerozine50
+			amount = 3544
+			maxAmount = 3791
+		}
+
+		TANK
+		{
+			name = NTO
+			amount = 3520
+			maxAmount = 3765
+		}
+		
+		TANK
+		{
+			name = Helium
+			amount = 75231.6
+			maxAmount = 80471.4
+		}
+	}
+}
+
+@PART[bluedog_LM_Descent_Leg]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = Lunar Module Leg
+	@description = Landing Legs for the Apollo Lunar Module
+	%manufacturer = Grumman
+	@mass = 0.0815
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+}
+
+@PART[bluedog_LM_Ascent_Engine]:AFTER[RealismOverhaulEngines]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	!RESOURCE,* {}
+
+	@title = Ascent Propulsion System (LMAE)
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	%engineType = LMAE
+}
+
+@PART[bluedog_LM_Descent_Engine]:AFTER[RealismOverhaulEngines]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	!RESOURCE,* {}
+
+	@title = Descent Propulsion System (LMDE)
+	%maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	%engineType = LMDE
+}
+
+@PART[bluedog_Apollo_Block2_SPS]:AFTER[RealismOverhaulEngines]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+
+	!RESOURCE,* {}
+
+	@title = AJ-10-137(Service Propulsion System)
+	%maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	%engineType = AJ10_137
+}
+
+@PART[bluedog_Saturn_S4B_SLA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+	
+	
+	@title = S-IVB Spacecraft Launch Adapter
+	%manufacturer = Douglas
+	@description = This adapter opens in four 'petals' to separate the Apollo Service Engine's hidden attach node from a Saturn stack. Staging the decoupler opens the petals and releases the CSM. Manually decouple the LEM once the transposition and docking manuever is complete.
+	@mass = 2.0
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+}
+
+@PART[bluedog_Saturn_Engine_J2A2]:AFTER[RealismOverhaulEngines]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.553
+
+	!RESOURCE,* {}
+
+	@title = J-2A
+	%maxTemp = 1973.15
+	%skinMaxTemp = 3600
+	%engineType = J2
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/Bluedog_DB/BDB_ApolloRevamp_WF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/Bluedog_DB/BDB_ApolloRevamp_WF.cfg
@@ -1,0 +1,194 @@
+//@PART[bluedog_Apollo_CrewPod_5crew]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+//{
+//    !EFFECTS {}
+//	
+//	ROWaterfall
+//    {
+//        template = rowaterfall-rcs-cold-gas-1
+//        audio = rcs-jet-1
+//        transform = rcsTransform
+//        position = 0,-0.05,0
+//        rotation = 0, 0, 180
+//        scale = 0.7, 1.5, 0.7
+//    }
+//}
+
+//@PART[bluedog_Apollo_RCS_3Way|bluedog_Apollo_RCS_Quad|bluedog_Apollo_RCS_Sideways]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+//{
+//    !EFFECTS {}
+//	
+//	ROWaterfall
+//    {
+//        template = rowaterfall-rcs-hypergolic-1
+//        audio = rcs-jet-1
+//        transform = rcsTransform
+//        position = 0,-0.005,0
+//        rotation = 5, 0, 180
+//        scale = 1.6, 1.6, 1.6
+//    }
+//}
+
+@PART[bluedog_Apollo_RCS_Quad,bluedog_Apollo_RCS_Sideways,bluedog_Apollo_RCS_3Way]:NEEDS[Waterfall]
+{
+	// Removes the stock effect block, and replace it with one that has no particles
+	!EFFECTS {}
+	EFFECTS
+	{
+		rcs
+		{
+			AUDIO_MULTI
+			{
+				channel = Ship
+				transformName = rcsTransform
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.1 0.0
+				volume = 0.5 0.025
+				volume = 1.0 0.2
+				pitch = 0.0 0.75
+				pitch = 1.0 1.5
+				loop = true
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = Apollo_RCSQuad
+		// This links the effects to a given ModuleEngines
+
+		// List out all controllers we want available
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+			thrusterTransformName = rcsTransform
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = BDB_RCS_big_1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = rcsFX
+			position = 0,-0.002,0
+			rotation = 5, 0, 180
+			scale = 1.7, 2, 1.7
+		}
+	}
+
+}
+
+
+@PART[bluedog_Apollo_CrewPod|bluedog_Apollo_CrewPod_5crew]:NEEDS[Waterfall]
+{
+	// Removes the stock effect block, and replace it with one that has no particles
+	!EFFECTS {}
+	EFFECTS
+	{
+		rcs
+		{
+			AUDIO_MULTI
+			{
+				channel = Ship
+				transformName = rcsTransform
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.1 0.0
+				volume = 0.5 0.025
+				volume = 1.0 0.2
+				pitch = 0.0 0.75
+				pitch = 1.0 1.5
+				loop = true
+			}
+		}
+	}
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = Apollo
+		// This links the effects to a given ModuleEngines
+
+		// List out all controllers we want available
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+			thrusterTransformName = rcsTransform
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = BDB_RCS_small_1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = rcsTransform
+			position = 0,-0.02,0
+			rotation = 0, 0, 180
+			scale = 0.5, 0.8, 0.5
+		}
+	}
+
+}
+
+@PART[bluedog_Saturn_Engine_J2A2]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hydrolox-upper-1
+        audio = pump-fed-medium-1
+        position = 0,0,0.07
+        rotation = 0, 0, 0
+        scale = 2.2, 2.2, 2.5
+        glow = ro-hydrolox-blue
+    }
+}
+
+@PART[bluedog_LM_Ascent_Engine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-aerozine50-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0.01
+        rotation = 0, 0, 0
+        scale = 0.67, 0.67, 0.67
+        glow = ro-hypergolic-az50
+    }
+}
+
+@PART[bluedog_LM_Descent_Engine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-aerozine50-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0.08
+        rotation = 0, 0, 0
+        scale = 1.2, 1.2, 1.2
+        glow = ro-hypergolic-az50      
+    }
+}
+
+@PART[bluedog_Saturn_Engine_J2A2|bluedog_LM_Ascent_Engine|bluedog_LM_Descent_Engine]:AFTER[zROWaterfall_99_Finalize]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = running_engine
+        }
+    }
+}


### PR DESCRIPTION
This repo should have all the real Apollo parts, alongside a goof bit of ETS stuff (AARDV, Block III+ etc.) for BDB's new Apollo Revamp: https://github.com/CobaltWolf/Bluedog-Design-Bureau/tree/apollo-saturn-revamp

