### PR TITLE
Adjust tank masses when LH2 is loaded

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1594,6 +1594,18 @@ TANK_DEFINITION
 		maxAmount = 0.0
 	}
 }
+// Balloon insulation fixes
+@TANK_DEFINITION:HAS[~balloonTemps[true]] // not FIRST anymore.
+{
+	@TANK[LqdHydrogen]
+	{
+		// LH2 is much lighter than most liquids, and therefore allows reduced tank structural mass
+		// Balloon tanks do not benefit from this since their structure is mostly provided by internal pressure
+		// And they need thicker walls anyway to prevent LH2 leakage/wall crumpling
+		// This only adjusts the additional tankage mass, not the base part mass, so tanks aren't 80% lighter
+		@mass *= 0.2
+	}
+}
 
 // Balloon insulation fixes
 @TANK_DEFINITION:HAS[#balloonTemps[true]] // not FIRST anymore.
@@ -1609,7 +1621,7 @@ TANK_DEFINITION
 	@TANK[LqdHydrogen]
 	{
 		// Centaur A crumpled with Atlas-level walls. Later Centaurs had heavier walls.
-		@mass += 0.000004
+		@mass *= 5
 		%wallThickness = 0.0012
 		%wallConduction = 205
 		%insulationThickness = 0.038181


### PR DESCRIPTION
Decrease the tankage mass of all tanks except balloon when LH2 is loaded. This is to simulate the fact that LH2 is extremely light, and requires much less structural mass to support. Balloon tanks still get a mass increase to avoid crumpling.

The 80% mass reduction seems to accurately simulate CBC and SII/SIV, without making smaller stages like DCSS significantly underweight.

This does make later integral tankage loaded with pure LH2 lighter than balloon tanks, which might not be realistic.