### PR TITLE
Correct X-405, Stentor sea-level thrust

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
@@ -64,8 +64,8 @@
 		{
 			name = Stentor
 			description = Booster for the Blue Steel missile
-			minThrust = 110
-			maxThrust = 110
+			minThrust = 121	// 110 kN (~25klbf) at sea level
+			maxThrust = 121
 			heatProduction = 100
 			massMult = 1.0
 

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -8,8 +8,8 @@
 //	Vangaurd
 //
 //	Dry Mass: 192 Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 135.5 kN
+//	Thrust (SL): 123.6 kN		// 27,785 lbf
+//	Thrust (Vac): 135.28 kN		// 30,410 lbf
 //	ISP: 254 SL / 278 Vac
 //	Burn Time: 145
 //	Chamber Pressure: ??? MPa
@@ -118,8 +118,8 @@
 		CONFIG
 		{
 			name = X-405
-			minThrust = 123.6
-			maxThrust = 123.6 // 27800lbf at sea level
+			minThrust = 135.28
+			maxThrust = 135.28 // 27800lbf at sea level
 			heatProduction = 78
 			massMult = 1.0
 			ullage = True


### PR DESCRIPTION
Fixes #2579.
X-405 values should be in-line with outlined performance (27,800 lbf SL, 254/278 Isp). Stentor lists 110 kN thrust SL but sets vac as 110, this corrects for that, regardless of the accuracy of 110 kN SL for the stentor.