### PR TITLE
Increase Tiny Tim reliability

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/TinyTim_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TinyTim_Config.cfg
@@ -169,12 +169,13 @@
 	TESTFLIGHT
 	{
 		name = 30Klbf
-		ratedBurnTime = 1
-		ignitionReliabilityStart = 0.93 // starts higher than expected
-		ignitionReliabilityEnd = 0.95
+		ratedBurnTime = 5	//account for thrust tail-off
+		ignitionReliabilityStart = 0.98 // starts higher than expected
+		ignitionReliabilityEnd = 0.9999 // literal steel tube of explosives, thousands built and used in pacific theatre
+		ignitionDynPresFailMultiplier = 50	//started life as anti-ship rocket
 		// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.
-		cycleReliabilityStart = 0.99 // starts higher than expected
-		cycleReliabilityEnd = 0.996
+		cycleReliabilityStart = 0.999
+		cycleReliabilityEnd = 0.9997
 		reliabilityDataRateMultiplier = 1.5
 		isSolid = True
 		techTransfer = 50Klbf:80
@@ -186,12 +187,13 @@
 	TESTFLIGHT
 	{
 		name = 50Klbf
-		ratedBurnTime = 1
-		ignitionReliabilityStart = 0.93 // starts higher than expected
-		ignitionReliabilityEnd = 0.97
+		ratedBurnTime = 3	//account for thrust tail-off
+		ignitionReliabilityStart = 0.98 // starts higher than expected
+		ignitionReliabilityEnd = 0.9999 // literal steel tube of explosives, thousands built and used in pacific theatre
+		ignitionDynPresFailMultiplier = 50	//started life as anti-ship rocket
 		// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.
-		cycleReliabilityStart = 0.99 // starts higher than expected
-		cycleReliabilityEnd = 0.997
+		cycleReliabilityStart = 0.999 // starts higher than expected
+		cycleReliabilityEnd = 0.9997
 		reliabilityDataRateMultiplier = 1.5
 		isSolid = True
 		techTransfer = 30Klbf:80


### PR DESCRIPTION
Increase Tiny Tim reliability to more sensible levels. It's literally a steel pipe full of guncotton, and they were used by the hundreds without managing to blow up their parent aircraft.