### PR TITLE
Add tagging system for ModuleCargoPart

### DIFF
--- a/GameData/RealismOverhaul/RO_Cargo.cfg
+++ b/GameData/RealismOverhaul/RO_Cargo.cfg
@@ -1,6 +1,6 @@
 // Unless the part has ROCargoConfig tag, removes the partmodule
 // that is responsible for the part being usable in the stock inventory system.
-@PART:HAS[~ROCargoConfig,@MODULE[ModuleCargoPart]]:LAST[RealismOverhaul]
+@PART:HAS[~ROCargoConfig[?rue],@MODULE[ModuleCargoPart]]:LAST[RealismOverhaul]
 {
     !MODULE[ModuleCargoPart],* {}
 }

--- a/GameData/RealismOverhaul/RO_Cargo.cfg
+++ b/GameData/RealismOverhaul/RO_Cargo.cfg
@@ -1,0 +1,11 @@
+// Unless the part has ROCargoConfig tag, removes the partmodule
+// that is responsible for the part being usable in the stock inventory system.
+@PART:HAS[~ROCargoConfig,@MODULE[ModuleCargoPart]]:LAST[RealismOverhaul]
+{
+    !MODULE[ModuleCargoPart],* {}
+}
+
+@PART:HAS[#ROCargoConfig]:LAST[RealismOverhaul]
+{
+    !ROCargoConfig = DEL
+}


### PR DESCRIPTION
Every part that doesn't have ROCargoConfig tag will be stripped of it's ModuleCargoPart PM.