### PR TITLE
Add restart timer to RD-119, S5.92, update descriptions

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -328,7 +328,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-7
-			description = Model 8081, Agena B
+			description = Model 8081, Agena B. Cannot restart between 15 minutes and 3 hours after shutdown.
 			maxThrust = 70.7
 			minThrust = 70.7
 			heatProduction = 100
@@ -363,7 +363,7 @@
 		CONFIG
 		{
 			name			= XLR81-BA-11
-			description		= Model 8096, Agena D
+			description		= Model 8096, Agena D. Cannot restart between 15 minutes and 3 hours after shutdown.
 			maxThrust		= 71.17
 			minThrust		= 71.17
 			heatProduction	= 100
@@ -402,7 +402,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-13
-			description = Model 8247, Gemini ATV
+			description = Model 8247, Gemini ATV. Cannot restart between 15 minutes and 3 hours after shutdown.
 			maxThrust = 71.2
 			minThrust = 71.2
 			heatProduction = 100
@@ -439,7 +439,7 @@
 		CONFIG
 		{
 			name			= Model8096-39
-			description		= Improved propellant, using high density acid (HDA)
+			description		= Improved propellant, using high density acid (HDA). Cannot restart between 15 minutes and 3 hours after shutdown.
 			maxThrust		= 75.62 //17 klbf
 			minThrust		= 75.62
 			heatProduction	= 100
@@ -478,7 +478,7 @@
 		CONFIG
 		{
 			name			= Model8096A // (5)
-			description		= Higher expansion ratio nozzle prototype
+			description		= Higher expansion ratio nozzle prototype. Cannot restart between 15 minutes and 3 hours after shutdown.
 			maxThrust		= 78.3
 			minThrust		= 78.3
 			heatProduction	= 100

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -115,7 +115,7 @@
 		CONFIG
 		{
 			name = J-2-200K
-			description = This was the earliest variant of the J-2 that flew on the first 3 Saturn IB flights AS-201 to AS-203.
+			description = This was the earliest variant of the J-2 that flew on the first 3 Saturn IB flights AS-201 to AS-203. One hour minimum, six hours maximum between restarts.
 			minThrust = 685.026
 			maxThrust = 889.644
 			heatProduction = 100
@@ -149,7 +149,7 @@
 		CONFIG
 		{
 			name = J-2-225K
-			description = The uprated 225k variant was flown starting with SA-501 Saturn V.
+			description = The uprated 225k variant was flown starting with SA-501 Saturn V. Six hours maximum between restarts.
 			minThrust = 770.654
 			maxThrust = 1000.850
 			heatProduction = 100
@@ -183,7 +183,7 @@
 		CONFIG
 		{
 			name = J-2-230K
-			description = The final version of the J-2 that flew on the Saturn, the 230k variant flew starting with Apollo 8, SA-208 and all subsequent flights.
+			description = The final version of the J-2 that flew on the Saturn, the 230k variant flew starting with Apollo 8, SA-208 and all subsequent flights. One hour minimum, six hours maximum between restarts.
 			minThrust = 787.780
 			maxThrust = 1023.091
 			heatProduction = 100
@@ -217,7 +217,7 @@
 		CONFIG
 		{
 			name = J-2S
-			description = The J-2S (J-2 Simplified) was a improvement on the J-2 Engine. It was completely tested and logged more than 30,000 seconds of static fire before the program was terminated.
+			description = The J-2S (J-2 Simplified) was a improvement on the J-2 Engine. It was completely tested and logged more than 30,000 seconds of static fire before the program was terminated. One hour minimum, six hours maximum between restarts.
 			minThrust = 196.463	// 6:1 throttling thanks to redesigned pumps and injectors
 			maxThrust = 1178.778
 			massMult = 1.036835 // All sources state the J-2S was heavier than J-2

--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -111,7 +111,7 @@
 	CONFIG
 		{
 			name = RD-119-8D710
-			description = Upper stage for Kosmos-2 (11K63)
+			description = Upper stage for Kosmos-2 (11K63). Warning: only rated for 90 minutes before restart.
 			minThrust = 105.5
 			maxThrust = 105.5
 			massMult = 0.8	//168 kg
@@ -176,6 +176,15 @@
 		testedBurnTime = 400
 		ratedBurnTime = 260
 		safeOverburn = true
+		//Had a sort of "pumped idle" where the gas generator would run at a low power to keep fuel ullaged and engine warm during coast
+		//No idea how long it was intended to run, but probably not long, Kosmos-2 was used mostly for LEO/MEO
+		//Lets go with one orbit (~90 minutes)
+		restartWindowPenalty
+		{
+			key = 0 1 0 0
+			key = 5400 1 0 0		//drop off after 90 minutes
+			key = 7200 0 0 0
+		}
 		ignitionReliabilityStart = 0.994207
 		ignitionReliabilityEnd = 0.999085
 		cycleReliabilityStart = 0.947866

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -87,6 +87,7 @@
 		CONFIG
 		{
 			name = S5.92
+			description = 6 minutes minimum, 300 days maximum between restarts.
 			minThrust = 13.73
 			maxThrust = 19.61
 			gimbalRange = 5.0
@@ -125,6 +126,7 @@
 		CONFIG
 		{
 			name = S5.92-l.n.
+			description = Extended nozzle for higher performance. 6 minutes minimum, 300 days maximum between restarts.
 			minThrust = 13.96
 			maxThrust = 20.01
 			gimbalRange = 5.0
@@ -181,6 +183,13 @@
 	{
 		name = S5-92
 		ratedBurnTime = 2000
+		restartWindowPenalty
+		{
+			key = 0 0 0 0
+			key = 360 1 0 0		//6 minutes between restarts
+			key = 2.592e+07 1 0 0	//300 day limit
+			key = 3.000e+07 0 0 0		//drops to zero
+		}
 		ignitionReliabilityStart = 0.996545
 		ignitionReliabilityEnd = 0.999455
 		ignitionDynPresFailMultiplier = 0.1
@@ -196,6 +205,13 @@
 	{
 		name = S5-92-l.n.
 		ratedBurnTime = 2000
+		restartWindowPenalty
+		{
+			key = 0 0 0 0
+			key = 360 1 0 0		//6 minutes between restarts
+			key = 2.592e+07 1 0 0	//300 day limit
+			key = 3.000e+07 0 0 0		//drops to zero
+		}
 		ignitionReliabilityStart = 0.996545
 		ignitionReliabilityEnd = 0.999455
 		ignitionDynPresFailMultiplier = 0.1

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -61,6 +61,7 @@
 		CONFIG
 		{
 			name = S5.98M
+			description = 6 minutes minimum, 300 days maximum between restarts.
 			minThrust = 19.61
 			maxThrust = 19.61
 			heatProduction = 100
@@ -113,6 +114,13 @@
 	{
 		name = S5-98M
 		ratedBurnTime = 3200
+		restartWindowPenalty	//assuming same as S5.92
+		{
+			key = 0 0 0 0
+			key = 360 1 0 0		//6 minutes between restarts
+			key = 2.592e+07 1 0 0	//300 day limit
+			key = 3.000e+07 0 0 0		//drops to zero
+		}
 		ignitionReliabilityStart = 0.992435
 		ignitionReliabilityEnd = 0.999109
 		ignitionDynPresFailMultiplier = 0.1


### PR DESCRIPTION
Add restart timer to RD-119 to prevent it from staying in pumped idle forever. Due to lack of data, we're going with 90 minutes. Also add a restart timer to the S5.92 and S5.98M, and add the restart window to the descriptions of the engines.