### PR TITLE
Update 1.12 Squad RCS blocks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -296,8 +296,7 @@
 		@type = RealismOverhaulStackHollow
 	}
 }
-
-@PART[RCSBlock]:FOR[RealismOverhaul]
+@PART[RCSBlock_v2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@PhysicsSignificance = 0
@@ -332,7 +331,7 @@
 	}
 }
 
-+PART[RCSBlock]:AFTER[RealismOverhaul]
++PART[RCSBlock_v2]:AFTER[RealismOverhaul]
 {
 	@name = SquadRCSBlockHalf
 	%rescaleFactor = 1.326
@@ -350,7 +349,7 @@
 	}
 }
 
-+PART[RCSBlock]:AFTER[RealismOverhaul]
++PART[RCSBlock_v2]:AFTER[RealismOverhaul]
 {
 	@name = RCSBlockQuarter
 	%rescaleFactor = 0.9375
@@ -368,7 +367,7 @@
 	}
 }
 
-+PART[RCSBlock]:AFTER[RealismOverhaul]
++PART[RCSBlock_v2]:AFTER[RealismOverhaul]
 {
 	@name = SquadRCSBlockTenth
 	%rescaleFactor = 0.5925


### PR DESCRIPTION
Changed to 1.12's new stock RCS blocks (RCSBlock_v2) which were previously working in the RO dev branch.