### PR TITLE
Add MLI PARTUPGRADES

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -14,6 +14,7 @@
 //	the new tooling mechanic and to create a proper mass ratio progression.
 //	===============================================================================
 
+//maxMLILayers will be defined by PARTUPGRADEs rather than by tank
 TANK_DEFINITION
 {
 	name = Tank-Sep-Steel
@@ -22,7 +23,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00007 * volume
 	baseCost = 0.002 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 83
@@ -43,7 +43,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00017 * volume
 	baseCost = 0.002 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -66,7 +65,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00003955 * volume
 	baseCost = 0.0022 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 87
@@ -87,7 +85,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00013364 * volume
 	baseCost = 0.0022 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -110,7 +107,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000027 * volume
 	baseCost = 0.0025 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -131,7 +127,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00010761 * volume
 	baseCost = 0.0025 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -154,7 +149,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00002 * volume
 	baseCost = 0.003 * volume
-	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -175,7 +169,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000804348 * volume
 	baseCost = 0.003 * volume
-	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -197,7 +190,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000155 * volume
 	baseCost = 0.0045 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -218,7 +210,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000445361 * volume
 	baseCost = 0.0045 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -240,7 +231,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000145 * volume
 	baseCost = 0.004 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -261,7 +251,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00003959 * volume
 	baseCost = 0.004 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -283,7 +272,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000018 * volume
 	baseCost = 0.0025 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -304,7 +292,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00005938 * volume
 	baseCost = 0.0025 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -326,7 +313,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000016 * volume
 	baseCost = 0.0042 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -347,7 +333,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000509053 * volume
 	baseCost = 0.0042 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -370,7 +355,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000121 * volume
 	baseCost = 0.005 * volume
-	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -391,7 +375,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000465053 * volume
 	baseCost = 0.005 * volume
-	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -413,7 +396,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000115 * volume
 	baseCost = 0.0065 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -434,7 +416,6 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.000038598 * volume
 	baseCost = 0.0065 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -456,7 +437,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000010 * volume
 	baseCost = 0.008 * volume
-	//maxMLILayers = 100	//Modern MLI
 	balloonTemps = true
 	addResources = true
 	addLead = true
@@ -479,7 +459,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000094021 * volume
 	baseCost = 0.01 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 96
@@ -500,7 +479,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000014 * volume
 	baseCost = 0.008 * volume
-	//maxMLILayers = 0	//Very hard to apply any kind of coatings to balloon tanks
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -523,7 +501,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000115 * volume
 	baseCost = 0.008 * volume
-	//maxMLILayers = 1	//Basic insulating coatings
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -546,7 +523,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000010 * volume
 	baseCost = 0.009 * volume
-	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -567,7 +543,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00007 * volume
 	baseCost = 0.008 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -603,7 +578,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000054 * volume
 	baseCost = 0.01 * volume
-	//maxMLILayers = 1
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -639,7 +613,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00004 * volume
 	baseCost = 0.012 * volume
-	//maxMLILayers = 20
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -675,7 +648,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000024 * volume
 	baseCost = 0.016 * volume
-	//maxMLILayers = 100
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -154,7 +154,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00002 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 20
+	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -175,7 +175,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000804348 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 20
+	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -197,7 +197,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000155 * volume
 	baseCost = 0.0045 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -218,7 +218,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000445361 * volume
 	baseCost = 0.0045 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -240,7 +240,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000145 * volume
 	baseCost = 0.004 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -261,7 +261,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00003959 * volume
 	baseCost = 0.004 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -283,7 +283,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000018 * volume
 	baseCost = 0.0025 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -304,7 +304,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00005938 * volume
 	baseCost = 0.0025 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -326,7 +326,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000016 * volume
 	baseCost = 0.0042 * volume
-	maxMLILayers = 20
+	maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -347,7 +347,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000509053 * volume
 	baseCost = 0.0042 * volume
-	maxMLILayers = 20
+	maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -370,7 +370,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000121 * volume
 	baseCost = 0.005 * volume
-	maxMLILayers = 20
+	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -391,7 +391,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000465053 * volume
 	baseCost = 0.005 * volume
-	maxMLILayers = 20
+	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -413,7 +413,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000115 * volume
 	baseCost = 0.0065 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -434,7 +434,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.000038598 * volume
 	baseCost = 0.0065 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -456,7 +456,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000010 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	balloonTemps = true
 	addResources = true
 	addLead = true
@@ -479,7 +479,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000094021 * volume
 	baseCost = 0.01 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 96
@@ -500,7 +500,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000014 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 50
+	maxMLILayers = 0	//Very hard to apply any kind of coatings to balloon tanks
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -523,7 +523,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000115 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 100
+	maxMLILayers = 1	//Basic insulating coatings
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -546,7 +546,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000010 * volume
 	baseCost = 0.009 * volume
-	maxMLILayers = 100
+	maxMLILayers = 100	//Modern MLI
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -567,7 +567,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00007 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 15
+	maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -603,7 +603,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000054 * volume
 	baseCost = 0.01 * volume
-	maxMLILayers = 15
+	maxMLILayers = 1
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -675,7 +675,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000024 * volume
 	baseCost = 0.016 * volume
-	maxMLILayers = 25
+	maxMLILayers = 100
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -687,7 +687,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000075 * volume
 	baseCost = 0.002 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 88
@@ -707,7 +706,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00012 * volume
 	baseCost = 0.002 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addSoundingPayload = true
 	maxUtilization = 88
@@ -727,7 +725,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00002 * volume
 	baseCost = 0.003 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -747,7 +744,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000064 * volume
 	baseCost = 0.003 * volume
-	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -769,7 +765,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000016 * volume
 	baseCost = 0.004 * volume
-	//maxMLILayers = 20
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -789,7 +784,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000014 * volume
 	baseCost = 0.008 * volume
-	//maxMLILayers = 50
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -810,7 +804,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00003 * volume
 	baseCost = 0.004 * volume
-	//maxMLILayers = 20
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -832,7 +825,6 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000015 * volume
 	baseCost = 0.005 * volume
-	//maxMLILayers = 50
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -852,7 +844,6 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00002 * volume
 	baseCost = 0.005 * volume
-	//maxMLILayers = 100
 	addResources = true
 	addResourcesHP = true
 	addLead = true

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -22,7 +22,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00007 * volume
 	baseCost = 0.002 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 83
@@ -43,7 +43,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00017 * volume
 	baseCost = 0.002 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -66,7 +66,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00003955 * volume
 	baseCost = 0.0022 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 87
@@ -87,7 +87,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00013364 * volume
 	baseCost = 0.0022 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -110,7 +110,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000027 * volume
 	baseCost = 0.0025 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -131,7 +131,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00010761 * volume
 	baseCost = 0.0025 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -154,7 +154,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00002 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
+	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -175,7 +175,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000804348 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
+	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -197,7 +197,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000155 * volume
 	baseCost = 0.0045 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -218,7 +218,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000445361 * volume
 	baseCost = 0.0045 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -240,7 +240,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000145 * volume
 	baseCost = 0.004 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -261,7 +261,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00003959 * volume
 	baseCost = 0.004 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -283,7 +283,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000018 * volume
 	baseCost = 0.0025 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -304,7 +304,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.00005938 * volume
 	baseCost = 0.0025 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -326,7 +326,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000016 * volume
 	baseCost = 0.0042 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -347,7 +347,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000509053 * volume
 	baseCost = 0.0042 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -370,7 +370,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000121 * volume
 	baseCost = 0.005 * volume
-	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
+	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -391,7 +391,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.0000465053 * volume
 	baseCost = 0.005 * volume
-	maxMLILayers = 20	//First deployment of proper MLI in 1967ish
+	//maxMLILayers = 20	//First deployment of proper MLI in 1967ish
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -413,7 +413,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000115 * volume
 	baseCost = 0.0065 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -434,7 +434,7 @@ TANK_DEFINITION
 	highlyPressurized = true
 	basemass = 0.000038598 * volume
 	baseCost = 0.0065 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -456,7 +456,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000010 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	balloonTemps = true
 	addResources = true
 	addLead = true
@@ -479,7 +479,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000094021 * volume
 	baseCost = 0.01 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	addLead = true
 	maxUtilization = 96
@@ -500,7 +500,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000014 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 0	//Very hard to apply any kind of coatings to balloon tanks
+	//maxMLILayers = 0	//Very hard to apply any kind of coatings to balloon tanks
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -523,7 +523,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.0000115 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 1	//Basic insulating coatings
+	//maxMLILayers = 1	//Basic insulating coatings
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -546,7 +546,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000010 * volume
 	baseCost = 0.009 * volume
-	maxMLILayers = 100	//Modern MLI
+	//maxMLILayers = 100	//Modern MLI
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -567,7 +567,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00007 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -603,7 +603,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000054 * volume
 	baseCost = 0.01 * volume
-	maxMLILayers = 1
+	//maxMLILayers = 1
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -639,7 +639,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00004 * volume
 	baseCost = 0.012 * volume
-	maxMLILayers = 20
+	//maxMLILayers = 20
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -675,7 +675,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000024 * volume
 	baseCost = 0.016 * volume
-	maxMLILayers = 100
+	//maxMLILayers = 100
 	addResources = true
 	addResourcesHP = true
 	addResourcesSM = true
@@ -715,7 +715,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000075 * volume
 	baseCost = 0.002 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 88
@@ -735,7 +735,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00012 * volume
 	baseCost = 0.002 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addSoundingPayload = true
 	maxUtilization = 88
@@ -755,7 +755,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.00002 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addLead = true
 	maxUtilization = 92
@@ -775,7 +775,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.000064 * volume
 	baseCost = 0.003 * volume
-	maxMLILayers = 0
+	//maxMLILayers = 0
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -797,7 +797,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000016 * volume
 	baseCost = 0.004 * volume
-	maxMLILayers = 20
+	//maxMLILayers = 20
 	addResources = true
 	addLead = true
 	maxUtilization = 95
@@ -817,7 +817,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000014 * volume
 	baseCost = 0.008 * volume
-	maxMLILayers = 50
+	//maxMLILayers = 50
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -838,7 +838,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00003 * volume
 	baseCost = 0.004 * volume
-	maxMLILayers = 20
+	//maxMLILayers = 20
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -860,7 +860,7 @@ TANK_DEFINITION
 	highlyPressurized = False
 	basemass = 0.000015 * volume
 	baseCost = 0.005 * volume
-	maxMLILayers = 50
+	//maxMLILayers = 50
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -880,7 +880,7 @@ TANK_DEFINITION
 	highlyPressurized = True
 	basemass = 0.00002 * volume
 	baseCost = 0.005 * volume
-	maxMLILayers = 100
+	//maxMLILayers = 100
 	addResources = true
 	addResourcesHP = true
 	addLead = true


### PR DESCRIPTION
Use the RF Part upgrades system to allow for MLI technology upgrades over time, rather than tying MLI to tank type.

RP-1 PR: https://github.com/KSP-RO/RP-0/pull/1632