### PR TITLE
Add SolarConfig support for multiple identical solar modules

### DIFF
--- a/GameData/RealismOverhaul/RO_SolarConfig.cfg
+++ b/GameData/RealismOverhaul/RO_SolarConfig.cfg
@@ -102,7 +102,7 @@
 	{
 		@kgm2 *= #$massMult$
 	}
-	
+
 	@SolarConfig:HAS[#type[hinged]]
 	{
 		@kgm2 *= #$massMultHinged$
@@ -119,7 +119,7 @@
 
 @PART[*]:HAS[@MODULE[ModuleDeployableSolarPanel],@SolarConfig]:FOR[RealismOverhaul_SolarPanels]
 {
-	@MODULE[ModuleDeployableSolarPanel]
+	@MODULE[ModuleDeployableSolarPanel]:HAS[~realismOverhaulSolarIgnore]
 	{
 		@chargeRate = #$../SolarConfig/kwm2$
 		@chargeRate *= #$../SolarConfig/area$
@@ -145,6 +145,10 @@
 	!SolarConfig {}
 	!solarUseMass = DEL
 	!useSolarConfig = DEL
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		!realismOverhaulSolarIgnore = DEL
+	}
 }
 
 @PART:HAS[@MODULE[ModuleDeployableSolarPanel],!MODULE[ModuleROSolarPanel]]:FOR[RealismOverhaul]
@@ -154,7 +158,7 @@
 		%useKopernicusSolarPanels = false
 	}
 	@description ^=:$: Solar Panels degrade, affecting the power output over time.  Check this effect in the PAW.
-	
+
 	MODULE
 	{
 		name = ModuleROSolarPanel

--- a/GameData/RealismOverhaul/RO_SolarConfig.cfg
+++ b/GameData/RealismOverhaul/RO_SolarConfig.cfg
@@ -145,7 +145,7 @@
 	!SolarConfig {}
 	!solarUseMass = DEL
 	!useSolarConfig = DEL
-	@MODULE[ModuleDeployableSolarPanel]
+	@MODULE[ModuleDeployableSolarPanel],*
 	{
 		!realismOverhaulSolarIgnore = DEL
 	}


### PR DESCRIPTION
Also adds support to tag a module with `realismOverhaulSolarIgnore` to make the patch tool ignore the module