### PR TITLE
BDB Keyhole Parachute Fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -241,7 +241,7 @@
         	mustGoDown = false
         	cutSpeed = 0.5
         	spareChutes = 1
-		    reverseOrientation = true
+            reverseOrientation = true
 	        invertCanopy = true
 
        PARACHUTE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -241,7 +241,8 @@
         	mustGoDown = false
         	cutSpeed = 0.5
         	spareChutes = 1
-		invertCanopy = true
+			reverseOrientation = true
+			invertCanopy = true
 
        PARACHUTE
        {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -241,7 +241,7 @@
         	mustGoDown = false
         	cutSpeed = 0.5
         	spareChutes = 1
-            reverseOrientation = true
+        	reverseOrientation = true
 	        invertCanopy = true
 
        PARACHUTE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -242,7 +242,7 @@
         	cutSpeed = 0.5
         	spareChutes = 1
 		    reverseOrientation = true
-		    invertCanopy = true
+	        invertCanopy = true
 
        PARACHUTE
        {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -241,8 +241,8 @@
         	mustGoDown = false
         	cutSpeed = 0.5
         	spareChutes = 1
-			reverseOrientation = true
-			invertCanopy = true
+		    reverseOrientation = true
+		    invertCanopy = true
 
        PARACHUTE
        {


### PR DESCRIPTION
This adds the "reverseOrientation" parameter to BDB's Keyhole parachute RealChute module in order to prevent it from visually deploying inverted as it previously had been doing. 