### PR TITLE
Add speclevel tagging to engines, fix techTransfer

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/000Template_Config.cfg
@@ -56,6 +56,8 @@
 	%manufacturer = ???
 	%description = ???
 
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel	//LiquidFuel or SolidBooster
@@ -102,6 +104,7 @@
 		{
 			name = Config_Name_1	//No spaces in config names
 			description = ???
+			specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 			minThrust = 1
 			maxThrust = 1
 			ratedBurnTime = 120
@@ -143,6 +146,7 @@
 		{
 			name = Config_Name_2
 			description = ???
+			specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
 			minThrust = 35.2
 			maxThrust = 35.2
 			ratedBurnTime = 120

--- a/GameData/RealismOverhaul/Engine_Configs/18KS7800_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/18KS7800_Config.cfg
@@ -34,7 +34,9 @@
 	%title = Aerojet 1.8KS7800
 	%manufacturer = Aerojet
 	%description = Small, solid fueled booster, taken from the AIM-7 Sparrow missile. It was used as the third stage on the Aerobee 300 and Aerobee 300A sounding rockets.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -72,6 +74,7 @@
 		CONFIG
 		{
 			name = 1_8KS7800
+			specLevel = operational
 			minThrust = 34.09116
 			maxThrust = 34.09116
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/25KS18000_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/25KS18000_Config.cfg
@@ -34,7 +34,9 @@
 	%title = Aerojet 2.5KS18000
 	%manufacturer = Aerojet
 	%description = Small, but powerful solid fueled booster used as the first stage for the Aerobee line of Sounding Rockets.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -72,6 +74,7 @@
 		CONFIG
 		{
 			name = 2_5KS18000
+			specLevel = operational
 			minThrust = 88.06796
 			maxThrust = 88.06796
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
@@ -52,6 +52,8 @@
 	%manufacturer = Thiel
 	%description = Thiel Lox/Alcohol rocket engine. Used on V-2 missile. Work began June 1936. Interim design, but went into production. Used 18 x 1.5 tonne thrust chambers, feeding common mixing chamber. Tested from 1939, mass production 1943-1945.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -79,6 +81,7 @@
 		CONFIG
 		{
 			name = A-4
+			specLevel = operational
 			maxThrust = 284.68
 			minThrust = 284.68
 			maxEngineTemp = 3000
@@ -128,7 +131,7 @@
 			minThrust = 288.68
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
-			//speculative = fictional
+			specLevel = speculative
 
 			atmosphereCurve
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_137_Config.cfg
@@ -48,6 +48,8 @@
 	%manufacturer = Aerojet
 	%description = The Aerojet AJ10-137 was used as the Service Propulsion System (SPS) on the Apollo Service Module. It was designed to operate for up to 750 seconds and could restart 50 times.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -74,6 +76,7 @@
 		CONFIG
 		{
 			name = AJ10-137
+			specLevel = operational
 			minThrust = 97.416
 			maxThrust = 97.416
 			heatProduction = 38

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_190_Config.cfg
@@ -61,6 +61,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = Low thrust pressure-fed hypergolic engine. It was used on the Space Shuttle for orbital insertion, maneuvering and deorbiting. Currently used by the Orion MPCV.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -89,6 +91,7 @@
 		CONFIG
 		{
 			name = AJ10-190-OMS
+			specLevel = operational
 			minThrust = 26.7
 			maxThrust = 26.7
 			heatProduction = 28
@@ -133,13 +136,13 @@
 		CONFIG
 		{
 			name = AJ10-190-Orion
+			specLevel = operational	//technically hasn't flown yet, but design frozen and will soon
 			minThrust = 33.4
 			maxThrust = 33.4
 			massMult = 1.0
 			ullage = False
 			pressureFed = True
 			ignitions = 500
-			techRequired = specializedCommandModules
 
 			IGNITOR_RESOURCE
 			{
@@ -201,7 +204,7 @@
 		ignitionReliabilityEnd = 0.999814
 		cycleReliabilityStart = 0.996468
 		cycleReliabilityEnd = 0.999442
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138:50
+		techTransfer = AJ10-138,AJ10-137,AJ10-118K,AJ10-118F,AJ10-118,AJ10-142,AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-190-OMS] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-190-OMS]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-190-OMS] { %ratedContinuousBurnTime = #$/TESTFLIGHT[AJ10-190-OMS]/ratedContinuousBurnTime$ } }
@@ -226,7 +229,7 @@
 		ignitionReliabilityEnd = 0.999814
 		cycleReliabilityStart = 0.996468
 		cycleReliabilityEnd = 0.999442
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
+		techTransfer = AJ10-190-OMS,AJ10-138,AJ10-137,AJ10-118K,AJ10-118F,AJ10-118,AJ10-142,AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-190-Orion] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-190-Orion]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-190-Orion] { %ratedContinuousBurnTime = #$/TESTFLIGHT[AJ10-190-Orion]/ratedContinuousBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Adv_Config.cfg
@@ -88,6 +88,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents advanced era AJ10s with a nozzle extension and restart capability. Used on Transtage as AJ10-138; similar models but back with the -118 designation were used on the Delta F and Delta K upper stages.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -117,6 +119,7 @@
 		{
 			name = AJ10-138
 			description = Upper Stage engine used on the Titan Transtage
+			specLevel = operational
 			maxThrust = 35.585
 			minThrust = 35.585
 			heatProduction = 100
@@ -161,6 +164,7 @@
 		{
 			name = AJ10-118F
 			description = Delta-F Upper Stage Engine
+			specLevel = operational
 			minThrust = 42.3
 			maxThrust = 42.3
 			heatProduction = 100
@@ -210,6 +214,7 @@
 		{
 			name = AJ10-118K
 			description = Upper stage engine for the Delta-K
+			specLevel = operational
 			minThrust = 43.7
 			maxThrust = 43.7
 			heatProduction = 100
@@ -257,6 +262,7 @@
 		{
 			name = AJ10-133-LH
 			description = AJ10 variant burning liquid hydrogen and oxygen, proposed for use on the GE D-2 Apollo vehicle.
+			specLevel = prototype
 			minThrust = 26.67
 			maxThrust = 26.67
 			heatProduction = 100
@@ -322,7 +328,7 @@
 		ignitionReliabilityEnd = 0.997718
 		cycleReliabilityStart = 0.972634
 		cycleReliabilityEnd = 0.995679
-		techTransfer = AJ10-104,AJ10-118E:15	// New dual design lead to many early growing pains issues
+		techTransfer = AJ10-118E,AJ10-104:15	// New dual design lead to many early growing pains issues
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-138] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-138]/ratedBurnTime$ } }
 }
@@ -347,7 +353,7 @@
 		ignitionReliabilityEnd = 0.999414
 		cycleReliabilityStart = 0.994444
 		cycleReliabilityEnd = 0.999123
-		techTransfer = AJ10-138,AJ10-118E:50
+		techTransfer = AJ10-118E,AJ10-138:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118F] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118F]/ratedBurnTime$ } }
 }
@@ -365,7 +371,7 @@
 		ignitionReliabilityEnd = 0.999414
 		cycleReliabilityStart = 0.994444
 		cycleReliabilityEnd = 0.999123
-		techTransfer = AJ10-138,AJ10-118E,AJ10-118F:50
+		techTransfer = AJ10-118F,AJ10-118E,AJ10-138:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118K] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118K]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -115,6 +115,8 @@
 	%manufacturer = Aerojet
 	%description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This is the original Vanguard second stage / Able / Delta configuration, without restart capability.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -143,6 +145,7 @@
 		{
 			name = AJ10-37
 			description = Developed for the upper stage of the Vanguard launch vehicle.
+			specLevel = operational
 			minThrust = 33.8
 			maxThrust = 33.8
 			heatProduction = 100
@@ -182,6 +185,7 @@
 		{
 			name = AJ10-42 // The only advantage is this is slightly more reliable (and a tad lighter)
 			description = More reliable version of the AJ10-37 used on the Able Upper Stage.
+			specLevel = operational
 			minThrust = 33.0
 			maxThrust = 33.0
 			heatProduction = 100
@@ -221,6 +225,7 @@
 		{
 			name = AJ10-101A
 			description = Used on the improved version of the Able upper stage for Thor-Able and Atlas-Able.
+			specLevel = operational
 			minThrust = 33.4
 			maxThrust = 33.4
 			heatProduction = 100
@@ -260,6 +265,7 @@
 		{
 			name = AJ10-142
 			description = Used as the upper stage engine on the very late Thor-Able and very early Thor-Delta launch vehicles.
+			specLevel = operational
 			minThrust = 34.25
 			maxThrust = 34.25
 			heatProduction = 100
@@ -299,6 +305,7 @@
 		{
 			name = AJ10-118
 			description = Second stage engine for the Thor-Delta A.
+			specLevel = operational
 			minThrust = 33.1
 			maxThrust = 33.1
 			heatProduction = 100
@@ -337,6 +344,7 @@
 		CONFIG // Delta B-D
 		{
 			name = AJ10-118D
+			specLevel = operational
 			minThrust = 33.7
 			maxThrust = 33.7
 			heatProduction = 100
@@ -390,7 +398,7 @@
 			cycleReliabilityStart = 0.750000	//cap at .75 for gameplay reasons
 			cycleReliabilityEnd = 0.916667
 
-			techTransfer = WAC-Corporal,XASR-1,AJ10-27:10
+			techTransfer = AJ10-27,XASR-1:10
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-37] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-37]/ratedBurnTime$ } }
 }
@@ -438,7 +446,7 @@
 			cycleReliabilityStart = 0.936667
 			cycleReliabilityEnd = 0.990000
 
-			techTransfer = AJ10-37,AJ10-42:50
+			techTransfer = AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-142] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-142]/ratedBurnTime$ } }
 }
@@ -456,7 +464,7 @@
 			cycleReliabilityStart = 0.936667
 			cycleReliabilityEnd = 0.990000
 
-			techTransfer = AJ10-37,AJ10-42:50
+			techTransfer = AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-101A] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-101A]/ratedBurnTime$ } }
 }
@@ -475,7 +483,7 @@
 			cycleReliabilityStart = 0.950741
 			cycleReliabilityEnd = 0.992222
 
-			techTransfer = AJ10-37,AJ10-42,AJ10-142:50
+			techTransfer = AJ10-142,AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118]/ratedBurnTime$ } }
 }
@@ -500,7 +508,7 @@
 			cycleReliabilityStart = 0.964815
 			cycleReliabilityEnd = 0.994444
 
-			techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118:50
+			techTransfer = AJ10-118,AJ10-142,AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118D] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118D]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Mid_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = Aerojet
 	%description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents mid-period AJ10s with a nozzle extension and restart capability. Used on Thor-Ablestar and Delta E through Delta N.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -81,6 +83,7 @@
 		{
 			name = AJ10-104	// Main engine used on Ablestar
 			description = The AJ10-104 was used on the Thor-Able-Star and it was the first upper stage engine with the ability to restart.
+			specLevel = operational
 			minThrust = 35.1
 			maxThrust = 35.1
 			heatProduction = 100
@@ -121,6 +124,7 @@
 			name = AJ10-118E	// Delta E-N
 			// should be made more reliable than 104D
 			description = Upgrade to the AJ10-118 used on the Delta E-N upper stages.
+			specLevel = operational
 			minThrust = 35.2
 			maxThrust = 35.2
 			heatProduction = 100
@@ -183,7 +187,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.869608
 		cycleReliabilityEnd = 0.979412
-		techTransfer = AJ10-37,AJ10-42,AJ10-142:50
+		techTransfer = AJ10-142,AJ10-42,AJ10-37:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-104] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-104]/ratedBurnTime$ } }
 }
@@ -218,7 +222,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.980208
 		cycleReliabilityEnd = 0.996875
-		techTransfer =	AJ10-37,AJ10-104,AJ10-42,AJ10-142:50
+		techTransfer = AJ10-118D,AJ10-118,AJ10-142,AJ10-42,AJ10-37:50
 		reliabilityDataRateMultiplier = 2
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-118E] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-118E]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Transtar_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Transtar_Config.cfg
@@ -86,6 +86,8 @@
 	%manufacturer = Aerojet
 	%description = Pump-fed upgrade for the AJ10. Developed in the 1980s as a high performance upper stage and tug. Based heavily on shuttle OMS, using the same nozzle and combustion chamber, with turbomachinery installed in place of pressure-fed system. The program was cancelled following the Challenger disaster, but Transtar 1 flew as the Titan Launch Dispenser on Titan IV.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -113,6 +115,7 @@
 		{
 			name = AJ10-151-OMS
 			description = Planned upgrade for space shuttle OMS, cancelled after Challenger disaster
+			specLevel = prototype
 			minThrust = 26.7
 			maxThrust = 26.7
 			heatProduction = 28
@@ -151,6 +154,7 @@
 		{
 			name = AJ10-153
 			description = Engine for Transtar I, a high performance upper stage. Later renamed to Titan Launch Dispenser and used to deploy NRO SIGINT satellites, and may have powered other classified NRO payloads.
+			specLevel = operational
 			minThrust = 16.7
 			maxThrust = 16.7
 			heatProduction = 28
@@ -189,6 +193,7 @@
 		{
 			name = AJ10-154
 			description = Hydrolox engine, for high performance reusable space shuttle upper stages
+			specLevel = concept
 			minThrust = 13.3
 			maxThrust = 13.3
 			heatProduction = 28
@@ -225,6 +230,7 @@
 		{
 			name = AJ10-156
 			description = Engine for Transtar III, reusable upgrade of Transtar I
+			specLevel = concept
 			minThrust = 16.7
 			maxThrust = 16.7
 			heatProduction = 28
@@ -277,7 +283,7 @@
 		ignitionReliabilityEnd = 0.999814
 		cycleReliabilityStart = 0.996468
 		cycleReliabilityEnd = 0.999442
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
+		techTransfer = AJ10-190-OMS:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-151-OMS] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-151-OMS]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-151-OMS] { %ratedContinuousBurnTime = #$/TESTFLIGHT[AJ10-151-OMS]/ratedContinuousBurnTime$ } }
@@ -295,7 +301,7 @@
 		ignitionReliabilityEnd = 0.999414
 		cycleReliabilityStart = 0.994444
 		cycleReliabilityEnd = 0.999123
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
+		techTransfer = AJ10-151-OMS,AJ10-190-OMS:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-153] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-153]/ratedBurnTime$ } }
 }
@@ -310,7 +316,7 @@
 		ignitionReliabilityEnd = 0.999414
 		cycleReliabilityStart = 0.994444
 		cycleReliabilityEnd = 0.999123
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-133-LH,AJ10-137,AJ10-138,AJ10-190-OMS:50
+		techTransfer = AJ10-153,AJ10-151-OMS,AJ10-190-OMS,AJ10-133-LH:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-154] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-154]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-154] { %ratedContinuousBurnTime = #$/TESTFLIGHT[AJ10-154]/ratedContinuousBurnTime$ } }
@@ -326,7 +332,7 @@
 		ignitionReliabilityEnd = 0.999414
 		cycleReliabilityStart = 0.994444
 		cycleReliabilityEnd = 0.999123
-		techTransfer = AJ10-37,AJ10-42,AJ10-142,AJ10-118,AJ10-118F,AJ10-118K,AJ10-137,AJ10-138,AJ10-190-OMS:50
+		techTransfer = AJ10-153,AJ10-151-OMS,AJ10-154,AJ10-190-OMS:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-156] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-156]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-156] { %ratedContinuousBurnTime = #$/TESTFLIGHT[AJ10-156]/ratedContinuousBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/AJ260FL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ260FL_Config.cfg
@@ -30,6 +30,8 @@
 	%manufacturer = Aerojet
 	%description = The AJ-260 was the largest rocket motor to ever be tested. This is the Full Length version of the engine that has a gross mass of more than 1600 tons and provides a thrust of 35,391 kN for more than 2 minutes. This version was te be used as an alternative to the Saturn IB and as booster motors for Apollo Applications launch vehicles.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -72,6 +74,7 @@
 		CONFIG
 		{
 			name = AJ260-FL
+			specLevel = prototype
 			minThrust = 35391
 			maxThrust = 35391
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/AJ260SL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ260SL_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Aerojet
 	%description = The AJ-260 was the largest rocket motor to ever be tested. This is the Short Length version that was a 21.6 x 6.6 meter behemoth that, when fully loaded, weighed more than 842 tons. It was capable of providing over 15,000 kN of thrust for 120 seconds. Ultimately the program was cancelled but not before three test firings where the engines performed exactly to specifications.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -81,6 +83,7 @@
 		CONFIG
 		{
 			name = AJ260-SL1
+			specLevel = prototype
 			minThrust = 17741
 			maxThrust = 17741
 			heatProduction = 100
@@ -118,6 +121,7 @@
 		{
 			name = AJ260-SL3
 			description = This was the test version that used the nozzle for the Full Length design.
+			specLevel = prototype
 			minThrust = 26708
 			maxThrust = 26708
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ60A_Config.cfg
@@ -44,6 +44,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = AJ-60A is a solid rocket booster produced by Aerojet Rocketdyne. They are currently used as strap-on boosters on United Launch Alliance's Atlas V rocket.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -91,6 +93,7 @@
 		CONFIG
 		{
 			name = AJ-60A
+			specLevel = operational
 			minThrust = 1688.4
 			maxThrust = 1688.4
 			heatProduction = 100
@@ -330,6 +333,7 @@
 		CONFIG
 		{
 			name = AJ-60A_TVC
+			specLevel = operational
 			minThrust = 1688.4
 			maxThrust = 1688.4
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Aerojet
 	%description = The Advanced Material Bi-propellant Rocket engine is a high performance, higher thrust, radiation cooled, storable bi-propellant space engine of the same physical envelope as the High Performance Apogee Thruster. Diameter: [0.37 m].
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,6 +63,7 @@
 		CONFIG
 		{
 			name = AMBR-623N
+			specLevel = operational
 			minThrust = 0.445
 			maxThrust = 0.623
 			heatProduction = 10
@@ -104,6 +107,7 @@
 		CONFIG
 		{
 			name = AMBR-623N-MON3
+			specLevel = operational
 			minThrust = 0.445
 			maxThrust = 0.623
 			heatProduction = 10
@@ -147,6 +151,7 @@
 		CONFIG
 		{
 			name = AMBR-Dual-Mode-623N
+			specLevel = operational
 			minThrust = 0.445
 			maxThrust = 0.623
 			heatProduction = 10
@@ -190,6 +195,7 @@
 		CONFIG
 		{
 			name = AMBR-Dual-Mode-623N-MON3
+			specLevel = operational
 			minThrust = 0.445
 			maxThrust = 0.623
 			heatProduction = 10
@@ -233,6 +239,7 @@
 		CONFIG
 		{
 			name = AMBR-890N
+			specLevel = operational
 			minThrust = 0.620
 			maxThrust = 0.890
 			heatProduction = 10
@@ -276,6 +283,7 @@
 		CONFIG
 		{
 			name = AMBR-890N-MON3
+			specLevel = operational
 			minThrust = 0.620
 			maxThrust = 0.890
 			heatProduction = 10
@@ -319,6 +327,7 @@
 		CONFIG
 		{
 			name = AMBR-Dual-Mode-890N
+			specLevel = operational
 			minThrust = 0.620
 			maxThrust = 0.890
 			heatProduction = 10
@@ -362,6 +371,7 @@
 		CONFIG
 		{
 			name = AMBR-Dual-Mode-890N-MON3
+			specLevel = operational
 			minThrust = 0.620
 			maxThrust = 0.890
 			heatProduction = 10

--- a/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = The AR-1 is a 2,200-kilonewton-class (500,000 lbf) thrust RP-1/LOX advanced oxidizer-rich staged combustion cycle engine. Two of those were proposed to replace the Russian made RD-180 on the Atlas V rocket. Development of this engine was halted, because Aerojet Rocketdyne wasn't willing to do it within its own budget.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = AR-1
+			specLevel = prototype
 			minThrust = 1244
 			maxThrust = 2487
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/ASRB_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ASRB_Config.cfg
@@ -19,6 +19,8 @@
 	%manufacturer = Orbital ATK
 	%description = A composite solid rocket motor designed as a drop - in replacement for the 5 Segment RSRM used on the Space Launch System (SLS) launch vehicle. It's lower inert mass along with the higher surface thrust will enable the SLS to lift more than 130 metric tonnes into low Earth orbit.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -48,6 +50,7 @@
 		CONFIG
 		{
 			name = ASRB
+			specLevel = concept
 			minThrust = 0
 			maxThrust = 20337
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aerobee_Config.cfg
@@ -72,6 +72,8 @@
 	%manufacturer = Aerojet
 	%description = Small sustainer for WAC Corporal and Aerobee sounding rockets. Pressure-fed. Used after a small solid booster.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -96,6 +98,7 @@
 		{
 			name = WAC-Corporal
 			description = A RATO booster modified to be used on the WAC-Corporal for the US Army
+			specLevel = operational
 			maxThrust = 7.733 // 1500lbf (6.672kN) at _sea level_, vac calculated
 			minThrust = 7.733
 			heatProduction = 40
@@ -139,6 +142,7 @@
 			// More info: http://rasaero.com/dloads/The%20Aerobee%20Sounding%20Rockets.pdf
 			name = XASR-1
 			description = Developed for the Aerobee X-8, an improved WAC-Corporal for upper atmosphere research to replace the limited stocks of captured V-2s
+			specLevel = operational
 			maxThrust = 13.7628
 			minThrust = 13.7628
 			heatProduction = 40
@@ -178,6 +182,7 @@
 		{
 			name = AJ10-27
 			description = Developed as an upgrade to the XASR-1. Continued to be used until the 1980s for meteorlogical studies.
+			specLevel = operational
 			maxThrust = 21.28
 			minThrust = 21.28
 			heatProduction = 40
@@ -255,7 +260,7 @@
 			cycleReliabilityStart = 0.95
 			cycleReliabilityEnd = 0.96
 
-			techTransfer = WAC-Corporal,XASR-1:50
+			techTransfer = XASR-1,WAC-Corporal:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AJ10-27] { %ratedBurnTime = #$/TESTFLIGHT[AJ10-27]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
@@ -79,6 +79,8 @@
 	%manufacturer = EADS Astrium
 	%description = A hypergolic upper stage engine. The baseline Aestus engine is pressure fed and it used on the Ariane 5 G, GS and ES series, while the Aestus II (also known as RS-72) variant is pump-fed and develops a higher overall performance.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -105,6 +107,7 @@
 		CONFIG
 		{
 			name = Aestus
+			specLevel = operational
 			minThrust = 27.8
 			maxThrust = 27.8
 			heatProduction = 36
@@ -151,6 +154,7 @@
 		CONFIG
 		{
 			name = AestusMod
+			specLevel = concept
 			minThrust = 35
 			maxThrust = 35
 			heatProduction = 36
@@ -198,6 +202,7 @@
 		{
 			name = Aestus-II
 			description = Developed privately in collaboration with Rocketdyne. Turbopump system from XLR-32 added, allowing much higher performance. A.K.A RS-72
+			specLevel = prototype
 			minThrust = 55.4
 			maxThrust = 55.4
 			heatProduction = 56
@@ -268,6 +273,7 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.967742
 		cycleReliabilityEnd = 0.993548
+		techTransfer = Aestus:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[AestusMod] { %ratedBurnTime = #$/TESTFLIGHT[AestusMod]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/AgenaSPS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AgenaSPS_Config.cfg
@@ -44,6 +44,8 @@
 	@manufacturer = Bell Aerosystems Company
 	@description = A Secondary Propulsion System developed for use in the Gemini program on the Agena Target Vehicle, allowing for fine control and orbital manuevers without igniting the main engine. It was also later made available to commercial customers as an optional upgrade for Agena. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
 
+	%specLevel = operational
+
 	!MODULE[ModuleAlternator] {}
 	!RESOURCE,* {}
 
@@ -57,6 +59,7 @@
 		CONFIG
 		{
 			name = AgenaSPS
+			specLevel = operational
 			maxThrust = 0.9608 //200 + 16 lbf (1)
 			minThrust = 0.0712 //16 lbf (1)
 			heatProduction = 20
@@ -85,6 +88,7 @@
 		{
 			name = TRW-SPS
 			description = Upgrade for the Agena SPS developed by TRW, using an electric pump system to allow it to draw directly from the Agena fuel tanks.
+			specLevel = operational
 			maxThrust = 0.471 //90 + 16 lbf (2)
 			minThrust = 0.0712 //16 lbf (1)
 			heatProduction = 20
@@ -123,6 +127,7 @@
 		{
 			name = TRW-SPS-HDA
 			description = Upgrade for the Agena SPS developed by TRW, using an electric pump system to allow it to draw directly from the Agena fuel tanks. HDA version
+			specLevel = operational
 			maxThrust = 0.516 //100 + 16 lbf (2)
 			minThrust = 0.0712 //16 lbf (1)
 			heatProduction = 20

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -203,6 +203,8 @@
 	@manufacturer = Bell Aerosystems Company
 	@description = Gas-generator nitric acid/UDMH vacuum engine used on Agena. The XLR81 family was derived from the Bell Hustler Rocket Engine, which was developed for use on an air-to-surface missile. Early engines were nearly identical to the Hustler engine, while later variants offered new capabilities and improved performance. Engine restart was introduced on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D used propellant sumps to eliminate the need for ullage thrust. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -230,6 +232,7 @@
 		{
 			name = Model117
 			description = B-58 Hustler rocket pod
+			specLevel = prototype
 			maxThrust = 67
 			minThrust = 67
 			heatProduction = 100
@@ -263,6 +266,7 @@
 		{
 			name = XLR81-BA-3
 			description = Model 8001, Agena Prototype
+			specLevel = operational
 			maxThrust = 67
 			minThrust = 67
 			heatProduction = 100
@@ -296,6 +300,7 @@
 		{
 			name = XLR81-BA-5
 			description = Model 8048, Agena A
+			specLevel = operational
 			maxThrust = 68.9
 			minThrust = 68.9
 			heatProduction = 100
@@ -329,6 +334,7 @@
 		{
 			name = XLR81-BA-7
 			description = Model 8081, Agena B. Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel = operational
 			maxThrust = 70.7
 			minThrust = 70.7
 			heatProduction = 100
@@ -364,6 +370,7 @@
 		{
 			name			= XLR81-BA-11
 			description		= Model 8096, Agena D. Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel		= operational
 			maxThrust		= 71.17
 			minThrust		= 71.17
 			heatProduction	= 100
@@ -403,6 +410,7 @@
 		{
 			name = XLR81-BA-13
 			description = Model 8247, Gemini ATV. Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel = operational
 			maxThrust = 71.2
 			minThrust = 71.2
 			heatProduction = 100
@@ -440,6 +448,7 @@
 		{
 			name			= Model8096-39
 			description		= Improved propellant, using high density acid (HDA). Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel		= operational
 			maxThrust		= 75.62 //17 klbf
 			minThrust		= 75.62
 			heatProduction	= 100
@@ -479,6 +488,7 @@
 		{
 			name			= Model8096A // (5)
 			description		= Higher expansion ratio nozzle prototype. Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel		= prototype
 			maxThrust		= 78.3
 			minThrust		= 78.3
 			heatProduction	= 100
@@ -518,6 +528,7 @@
 		{
 			name			= Model8096L // (6)
 			description		= Reusable Agena for STS
+			specLevel		= concept
 			maxThrust		= 71.1 //16 klbf
 			minThrust		= 71.1
 			heatProduction	= 100
@@ -557,6 +568,7 @@
 		{
 			name			= Model8096C // (6)
 			description		= Growth Agena option, sacrificing thrust for improved effeciency
+			specLevel		= concept
 			maxThrust		= 53.4 //12 klbf
 			minThrust		= 53.4
 			heatProduction	= 100
@@ -596,6 +608,7 @@
 		{
 			name			= Agena-2000	//(7)
 			description		= Agena upgrade for proposed Atlas V upper stage. Tested, but cancelled when studies showed it would be more economical to use single engine centaur instead.
+			specLevel		= prototype
 			maxThrust		= 67.5 //15170 lbf
 			minThrust		= 67.5
 			heatProduction	= 100
@@ -635,6 +648,7 @@
 		{
 			name			= XLR81-LF2-SPS // (5)
 			description		= Liquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
+			specLevel		= prototype
 			maxThrust		= 53.7 //12 klbf
 			minThrust		= 17.7 //3.98 klbf
 			heatProduction	= 100
@@ -732,7 +746,7 @@
 		
 		cycleReliabilityStart = 0.883333
 		cycleReliabilityEnd = 0.981579
-		techTransfer = Model117,XLR81-BA-3:50
+		techTransfer = XLR81-BA-3,Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-5] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-5]/ratedBurnTime$ } }
@@ -767,7 +781,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.948010
 		cycleReliabilityEnd = 0.991791
-		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5:50
+		techTransfer = XLR81-BA-5,XLR81-BA-3,Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-7] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-7]/ratedBurnTime$ } }
@@ -813,7 +827,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7:50
+		techTransfer = XLR81-BA-7,XLR81-BA-5,XLR81-BA-3,Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-11] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-11]/ratedBurnTime$ } }
@@ -841,7 +855,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11:50
+		techTransfer = XLR81-BA-11,XLR81-BA-7,XLR81-BA-5,XLR81-BA-3,Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-BA-13] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-BA-13]/ratedBurnTime$ } }
@@ -869,7 +883,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
+		techTransfer = XLR81-BA-13,XLR81-BA-11,XLR81-BA-7,XLR81-BA-5,XLR81-BA-3,Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096-39] { %ratedBurnTime = #$/TESTFLIGHT[Model8096-39]/ratedBurnTime$ } }
@@ -897,7 +911,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model117,XLR81-BA-3,XLR81-BA-11,XLR81-BA-13,Model8096-39:50
+		techTransfer = Model8096-39,XLR81-BA-13,XLR81-BA-11,XLR81-BA-7,XLR81-BA-5,XLR81-BA-3,Model117:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096A] { %ratedBurnTime = #$/TESTFLIGHT[Model8096A]/ratedBurnTime$ } }
@@ -918,7 +932,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model8096-39,Model8096-39A:50
+		techTransfer = Model8096-39A,Model8096-39,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096L] { %ratedBurnTime = #$/TESTFLIGHT[Model8096L]/ratedBurnTime$ } }
@@ -940,7 +954,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model8096-39,Model8096-39A:50
+		techTransfer = Model8096-39A,Model8096-39,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Model8096C] { %ratedBurnTime = #$/TESTFLIGHT[Model8096C]/ratedBurnTime$ } }
@@ -961,7 +975,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986067
 		cycleReliabilityEnd = 0.997800
-		techTransfer = Model8096-39,Model8096A,Model8096L:50
+		techTransfer = Model8096C,Model8096-39A,Model8096-39,XLR81-BA-13:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Agena-2000] { %ratedBurnTime = #$/TESTFLIGHT[Agena-2000]/ratedBurnTime$ } }
@@ -984,7 +998,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.958763
 		cycleReliabilityEnd = 0.995
-		techTransfer = Model117,XLR81-BA-3,XLR81-BA-5,XLR81-BA-7,XLR81-BA-11,XLR81-BA-13:50
+		techTransfer = XLR81-BA-13,XLR81-BA-11,XLR81-BA-7,XLR81-BA-5,XLR81-BA-3,Model117:20
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR81-LF2-SPS] { %ratedBurnTime = #$/TESTFLIGHT[XLR81-LF2-SPS]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Alcyone_Config.cfg
@@ -26,6 +26,8 @@
 	@manufacturer = Hercules
 	@description = A very small solid kick motor. This was developed for use as the 5th stage on the Scout launch vehicles. It was only ever launched once on a Scout E-1 used for Explorer 52. Maximum thrust 27.5kN, burn time 9 seconds.
 
+	%specLevel = operational
+
 	!MODULE[ModuleGimbal] {}
 	!MODULE[ModuleFuelTanks],* {}
 	!MODULE[ModuleAlternator],*{}
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = Alcyone
+			specLevel = operational
 			minThrust = 27.491
 			maxThrust = 27.491
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = First stage solid rocket motor used on the early X-1 and X-2 Scout launch vehicles.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -79,6 +81,7 @@
 		CONFIG
 		{
 			name = Algol-I
+			specLevel = operational
 			minThrust = 493.6442
 			maxThrust = 493.6442
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = The final development version of the first stage solid rocket motor used on the Scout launch vehicles.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = Algol-III
+			specLevel = operational
 			minThrust = 530.25896
 			maxThrust = 530.25896
 			heatProduction = 100
@@ -125,7 +128,7 @@
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground-lit SRMs
 		cycleReliabilityStart = 0.973611
 		cycleReliabilityEnd = 0.997727
-		techTransfer = Algol-I,Algol-II:50
+		techTransfer = Algol-II,Algol-I:50
 		reliabilityDataRateMultiplier = 2
 		
 		isSolid = True

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_II_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = First stage solid rocket motor developed from Algol I and used on the Scout launch vehicles.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -80,6 +82,7 @@
 		CONFIG
 		{
 			name = Algol-II
+			specLevel = operational
 			minThrust = 449.02112
 			maxThrust = 449.02112
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
@@ -25,7 +25,9 @@
 	@title = Altair III FW-4S
 	@manufacturer = United Technology Center
 	@description = A small solid kick motor. Developed from the Altair, this final version was used on later Scout B launch vehicles. Used to circularize at apogee or perform final payload kick. Maximum thrust 25.6kN, burn time 31 seconds.
-	
+
+	%specLevel = operational
+
 	!MODULE[ModuleGimbal] {}
 	!MODULE[ModuleFuelTanks],* {}
 	!MODULE[ModuleAlternator],*{}
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = Altair-III
+			specLevel = operational
 			minThrust = 31
 			maxThrust = 31
 			heatProduction = 100
@@ -132,7 +135,7 @@
 		ignitionReliabilityEnd = 0.995333
 		cycleReliabilityStart = 0.970045
 		cycleReliabilityEnd = 0.995270
-		techTransfer = Altair,Altair-II:50
+		techTransfer = Altair-II,Altair:50
 		reliabilityDataRateMultiplier = 2
 		
 		isSolid = True

--- a/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairII_Config.cfg
@@ -23,7 +23,9 @@
 	@title = Altair II X-258
 	@manufacturer = Allegany Ballistics Laboratory
 	@description = A small solid kick motor. Developed from the Altair, this successor was used on Scout and Delta. Used to circularize at apogee or perform final payload kick. Average thrust 28.48 kN, burn time 22 seconds.
-	
+
+	%specLevel = operational
+
 	!MODULE[ModuleGimbal] {}
 	!MODULE[ModuleFuelTanks],* {}
 	!MODULE[ModuleAlternator],*{}
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = Altair-II
+			specLevel = operational
 			minThrust = 35
 			maxThrust = 35
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
@@ -41,7 +41,9 @@
 	%title = Altair X-248
 	@manufacturer = Allegany Ballistics Laboratory
 	@description = A small solid kick motor. Developed as alternative Vanguard third stage, reused on many later LVs with Able/Delta upper stage (or simply "Thor Burner") to circularize at apogee or perform final payload kick. Burn time 39 seconds.
-	
+
+	%specLevel = operational
+
 	!MODULE[ModuleAlternator]{}
 	!RESOURCE,*{}
 	!MODULE[ModuleGimbal],* {}
@@ -82,6 +84,7 @@
 		CONFIG
 		{
 			name = Altair
+			specLevel = operational
 			minThrust = 16.35
 			maxThrust = 16.35
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
@@ -36,7 +36,9 @@
 	%title = Antares I X-254
 	%manufacturer = Allegany Ballistics Laboratory
 	%description = The Antares solid rocket motor was used as the third stage for the Scout launch vehicle.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Antares-I
+			specLevel = operational
 			minThrust = 62.27508
 			maxThrust = 62.27508
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
@@ -35,7 +35,9 @@
 	%title = Antares IIA X-259
 	%manufacturer = Allegany Ballistics Laboratory
 	%description = The Antares II solid rocket motor was used as the third stage for the majority of the Scout launch vehicle launches.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Antares-II
+			specLevel = operational
 			minThrust = 93.074555
 			maxThrust = 93.074555
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Astris_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Astris_Config.cfg
@@ -56,6 +56,8 @@
 	%manufacturer = EADS Astrium
 	%description = German pressure-fed vacuum engine burning Aerozine50 and NTO. Used on the stage of the same name on the Europa I and II launch vehicles.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -84,6 +86,7 @@
 			// source: https://books.google.com/books?id=s1C9Oo2I4VYC&pg=PA773&lpg=PA773&dq=europa+third+stage+gimbal&source=bl&ots=eO39M9csLZ&sig=oJvSI-Q3gzyob4cikpy06eWkAdA&hl=en&sa=X&ved=0CCgQ6AEwAWoVChMIt4jqtYSJxgIViiGsCh36xwB9#v=onepage&q=europa%20third%20stage%20gimbal&f=false
 			name = AstrisI
 			description = Used on Europa I. Extremely unreliable
+			specLevel = operational
 			maxThrust = 22.56
 			minThrust = 22.56
 			PROPELLANT
@@ -121,6 +124,7 @@
 			//			 http://www.astronautix.com/a/astrisengine.html
 			name = AstrisII
 			description = Upgrade developed for Europa II. Cancelled after first launch following continued failures and lack of funding
+			specLevel = operational
 			maxThrust = 23.3
 			minThrust = 23.3
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/BE-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-3_Config.cfg
@@ -33,6 +33,8 @@
 	%manufacturer = Blue Origin
 	%description = The BE-3 (Blue Engine 3) is a LH2/LOX rocket engine developed by Blue Origin. The BE-3 uses a combustion tap-off cycle engine design which takes a small amount of combustion gases from the main combustion chamber in order to power the engine turbopumps.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -58,6 +60,7 @@
 		CONFIG
 		{
 			name = BE3
+			specLevel = operational
 			maxThrust = 490
 			minThrust = 89
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/BE-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-4_Config.cfg
@@ -44,6 +44,8 @@
 	%manufacturer = Blue Origin
 	%description = The BE-4 is an oxidizer-rich staged combustion Methalox engine. Though initially developed for use on a Blue Origin launch vehicle, in 2014 United Launch Alliance announced that their new Vulcan launch vehicle, the successor to both the Atlas V and Delta IV launch vehicles, will be powered by a pair of BE-4 engines.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -70,6 +72,7 @@
 		CONFIG
 		{
 			name = BE-4
+			specLevel = prototype
 			minThrust = 794.25
 			maxThrust = 2647.5
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BNTR_Config.cfg
@@ -55,6 +55,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = Low thrust pump-fed expander nuclear engine. Evolved from the original NERVA design the Bimodal NTR, instead of wasting precious propellant mass for cooling the engine reactor, uses a Brayton cycle electricity generator unit to convert the waste thermal energy into useful electrical power. It also supports liquid oxygen injection (TRITON - trimodal operation) for increased thrust but with the cost of a lower overall efficiency.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -84,6 +86,7 @@
 		CONFIG
 		{
 			name = BNTR
+			specLevel = concept
 			minThrust = 66.72
 			maxThrust = 66.72
 			massMult = 1.0
@@ -124,6 +127,7 @@
 		CONFIG
 		{
 			name = TRITON
+			specLevel = concept
 			minThrust = 182.37
 			maxThrust = 182.37
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/Baby_Sergeant.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Baby_Sergeant.cfg
@@ -54,6 +54,8 @@
 	%manufacturer = Thiokol
 	%description = A small solid kick motor used on the Jupiter-C sounding rocket (and later the Juno I and II launch vehicles) as upper stages in clusters of 11, 3 and, finally, one attached to the payload. The standard version uses the T17-E2 grain mixture while the higher performance one uses the JPL-532A. Very low overall performance and reliability.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -76,6 +78,7 @@
 		{
 			name = T17-E2
 			description = Derived from the Sergeant ballistic missile, for use as an upper stage to the Juno-C to test high velocity re-entry.
+			specLevel = operational
 			minThrust = 8
 			maxThrust = 8
 			heatProduction = 27
@@ -104,6 +107,7 @@
 		{
 			name = JPL-532A
 			description = Improved fuel mix created by JPL
+			specLevel = operational
 			minThrust = 8
 			maxThrust = 8
 			heatProduction = 29

--- a/GameData/RealismOverhaul/Engine_Configs/COBRAHigh_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/COBRAHigh_Config.cfg
@@ -40,6 +40,8 @@
 	@manufacturer = Pratt & Whitney-Aerojet Propulsion Associates 
 	@description = "Co-optimized Booster for Reusable Applications". Propulsion system proposed by	Pratt & Whitney-Aerojet Propulsion Associates to cover a wide range of thrust. This LH2/LOX reusable rocket engine was designed in 2003 to produce 4,500 kN thrust. Proposed as a long-life, moderate-to high-thrust, reusable booster engine that incorporated a safe, low-cost, low-risk, LH2/LOX single burner, using a fuel-rich, staged combustion cycle. Diameter: [3.5 m].
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = COBRAH
+			specLevel = concept
 			minThrust = 2669				 //60%
 			maxThrust = 4448
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/COBRA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/COBRA_Config.cfg
@@ -40,6 +40,8 @@
 	%manufacturer = Aerojet
 	%description = Co-Optimized Booster for Reusable Applications. Early 2000s atmospheric staged combustion hydrolox engine. Developed as the main engine for a Space Shuttle replacement as a part of the Space Launch Initiative program. Extremely high performance, cancelled during protorype phase.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -65,6 +67,7 @@
 		CONFIG
 		{
 			name = COBRA
+			specLevel = concept
 			maxThrust = 2669
 			minThrust = 1335
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/Cajun_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Cajun_Config.cfg
@@ -46,7 +46,9 @@
 	%title = Cajun SRM
 	%manufacturer = Thiokol Chemical Corporation
 	%description = Second stage solid rocket motor used on the Nike-Cajun sounding rocket.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -82,6 +84,7 @@
 		CONFIG
 		{
 			name = Cajun
+			specLevel = operational
 			minThrust = 36
 			maxThrust = 36
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_120_Config.cfg
@@ -6,7 +6,9 @@
 	@title = Castor 120
 	@manufacturer = Thiokol (ATK)
 	@description = The Castor 120 is a medium solid booster used on the Minotaur and Athena launch vehicles. Its design was based on the TU-903, which serves as the first stage of the Peacekeeper ICBM. The standard thrust curve can be modified to produce a regressive burn that reduces maximum acceleration or a saddle-shaped profile that limits aerodynamic forces. Burn time 79 seconds.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -50,6 +52,7 @@
 		CONFIG
 		{
 			name = Castor-120
+			specLevel = operational
 			minThrust = 1875
 			maxThrust = 1875
 			heatProduction = 100
@@ -281,6 +284,8 @@
 		CONFIG
 		{
 			name = Castor-120/Saddle
+			specLevel = operational
+			minThrust = 1950
 			maxThrust = 1950
 			heatProduction = 100
 			PROPELLANT
@@ -511,8 +516,9 @@
 		CONFIG
 		{
 			name = Castor-120/Regressive
+			specLevel = operational
 			minThrust = 2125
-	  maxThrust = 2125
+			maxThrust = 2125
 			heatProduction = 100
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
@@ -49,6 +49,8 @@
 	%manufacturer = Thiokol
 	%description = The Castor 1 was first used for a successful suborbital launch of a Scout X-1 rocket on September 2, 1960. Castor 1 stages were also used as strap-on boosters for launch vehicles using Thor first stages, including the Delta-D.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -88,6 +90,7 @@
 		CONFIG
 		{
 			name = XM-20
+			specLevel = operational
 			minThrust = 304.3
 			maxThrust = 304.3
 			heatProduction = 100
@@ -137,6 +140,7 @@
 		CONFIG
 		{
 			name = Castor-1-SL
+			specLevel = operational
 			minThrust = 324.6
 			maxThrust = 324.6
 			heatProduction = 100
@@ -188,6 +192,7 @@
 		CONFIG
 		{
 			name = Castor-1-Vac
+			specLevel = operational
 			minThrust = 349.3
 			maxThrust = 349.3
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -32,6 +32,8 @@
 	%manufacturer = Thiokol
 	%description = A derivative of the Castor 1 motor, the Castor 2 featured higher specific impulse and propellant load and lower dry mass fraction as well as a longer burn time. It was used as strap-on booster starting with Delta E and was also used in all but the early Scouts. Burn time 39s.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -69,6 +71,7 @@
 		CONFIG
 		{
 			name = Castor-2-SL
+			specLevel = operational
 			minThrust = 293.865
 			maxThrust = 293.865
 			heatProduction = 100
@@ -125,6 +128,7 @@
 		CONFIG
 		{
 			name = Castor-2-Vac
+			specLevel = operational
 			minThrust = 318.1
 			maxThrust = 318.1
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30A_Config.cfg
@@ -5,7 +5,9 @@
 	%title = Castor 30A
 	%manufacturer = Northrop Grumman
 	%description = The CASTOR 30 is a low cost, robust, state-of-the-art upper stage motor. This commercially-developed motor is 144 inches long and nominally designed as an upper stage that can function as a second or third stage depending on the vehicle configuration.
-	
+
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -48,6 +50,7 @@
 		CONFIG
 		{
 			name = Castor-30A
+			specLevel = prototype
 			minThrust = 330.7653 //taken from atk catalog
 			maxThrust = 330.7653
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30B_Config.cfg
@@ -5,7 +5,9 @@
 	%title = Castor 30B
 	%manufacturer = Northrop Grumman
 	%description = The CASTOR 30B is a low cost, robust, state-of-the-art upper stage motor. This production motor incorporates a few modifications from the CASTOR 30, primarily a change in propellant and a longer nozzle. It is 169.9 inches long and nominally designed as an upper stage that can function as a second or third stage depending on the vehicle configuration.
-	
+
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -48,6 +50,7 @@
 		CONFIG
 		{
 			name = Castor-30B
+			specLevel = prototype
 			minThrust = 396.2921 //taken from atk catalog
 			maxThrust = 396.2921
 			heatProduction = 100
@@ -209,7 +212,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.996885
 		cycleReliabilityEnd = 0.999508
-		techTransfer = Castor-120,Castor-120/Regressive,Castor-120/Saddle,Castor-30A:50
+		techTransfer = Castor-30A,Castor-120,Castor-120/Regressive,Castor-120/Saddle:50
 		
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_30XL_Config.cfg
@@ -5,7 +5,9 @@
 	@title = Castor 30XL
 	@manufacturer = Northrop Grumman
 	@description = The CASTOR 30XL is more than a stretched version of the CASTOR 30. The motor is 235.8 inches long and nominally designed as an upper stage that can function as a second or third stage depending on the vehicle configuration. The nozzle is 8 feet long with a submerged design with a high-performance expansion ratio (55.9:1) and a dual density exit cone well suited for high altitude operation. It features an electro-mechanical TVA system with actuators, thermal battery and electronic controller.
-	
+
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -48,6 +50,7 @@
 		CONFIG
 		{
 			name = Castor-30XL
+			specLevel = prototype
 			minThrust = 533.3418 //taken from atk catalog
 			maxThrust = 533.3418
 			heatProduction = 100
@@ -209,7 +212,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.996885
 		cycleReliabilityEnd = 0.999508
-		techTransfer = Castor-120,Castor-120/Regressive,Castor-120/Saddle,Castor-30A,Castor-30B:50
+		techTransfer = Castor-30B,Castor-30A,Castor-120,Castor-120/Regressive,Castor-120/Saddle:50
 		
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4AXL_Config.cfg
@@ -7,7 +7,9 @@
 	%manufacturer = Thiokol
 	// via astronautix
 	@description = Strap-on booster, improvement of Castor 4A, first tested May 1992. Its 30% performance increase would improve performance of Atlas IIAS, H-II, and other vehicles. First flight 2001.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -46,6 +48,7 @@
 		CONFIG
 		{
 			name = Castor-4AXL
+			specLevel = operational
 			minThrust = 765
 			maxThrust = 765
 			heatProduction = 100
@@ -135,7 +138,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.996885
 		cycleReliabilityEnd = 0.999508
-		techTransfer = Castor-1-SL,Castor-1-Vac,Castor-2-SL,Castor-2-Vac,Castor-4,Castor-4A:50
+		techTransfer = Castor-4A,Castor-4,Castor-2-SL,Castor-2-Vac,Castor-1-SL,Castor-1-Vac:50
 		
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4A_Config.cfg
@@ -5,7 +5,9 @@
 	@title = Castor 4A
 	%manufacturer = Thiokol
 	@description = The Castor 4A was introduced on the first generation of Delta II launchers, the 6000-series, and offered improved thrust and specific impulse by replacing PBAA with higher energy HTPB. This, combined with a stretched first stage (the Extra-Extended Long Tank Thor) and a return to the more efficient 6-3 SRM ignition sequence, improved Delta's performance by 11% over the 3000-series. The Castor 4A was flown on the Delta II from 1989 until 1993, when it was replaced by the GEM 40. The boosters were also used on the Atlas IIAS from 1993 until 2004. Burn time 53 seconds.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -44,6 +46,7 @@
 		CONFIG
 		{
 			name = Castor-4A
+			specLevel = operational
 			minThrust = 538
 			maxThrust = 538
 			heatProduction = 100
@@ -130,7 +133,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.996885
 		cycleReliabilityEnd = 0.999508
-		techTransfer = Castor-1-SL,Castor-1-Vac,Castor-2-SL,Castor-2-Vac,Castor-4:50
+		techTransfer = Castor-4,Castor-2-SL,Castor-2-Vac,Castor-1-SL,Castor-1-Vac:50
 		
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_4_Config.cfg
@@ -7,6 +7,8 @@
 	%manufacturer = Thiokol
 	@description = The Castor 4 was developed as the second stage of the Athena H missile and first flew in 1971. It was later adapted to replace Delta's Castor 2 boosters, increasing GTO capacity from 1593 lb (723 kg) to nearly 2000 lb (900 kg). The resulting Delta 3000-series launched in 1975 and was the first to adopt a staggered booster staging sequence. Previous Delta vehicles burned their motors in a 6-3 sequence and then jettisoned all SRMs at once. The heavier and longer-burning Castor 4 required that the ground-lit motors be jettisoned immediately after depletion to reduce dead weight. Early launches used a less efficient 5-4 sequence to reduce acceleration but returned to a 6-3 sequence after Delta was strengthened in the early 80s.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -45,6 +47,7 @@
 		CONFIG
 		{
 			name = Castor-4
+			specLevel = operational
 			minThrust = 460
 			maxThrust = 460
 			heatProduction = 100
@@ -289,7 +292,7 @@
 		ignitionReliabilityEnd = 1.0	//Not a probable failure mode for ground lit SRMs
 		cycleReliabilityStart = 0.993860
 		cycleReliabilityEnd = 0.999584
-		techTransfer = Castor-1-SL,Castor-1-Vac,Castor-2-SL,Castor-2-Vac:50
+		techTransfer = Castor-2-SL,Castor-2-Vac,Castor-1-SL,Castor-1-Vac:50
 		
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/DFMMHPE.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/DFMMHPE.cfg
@@ -52,6 +52,8 @@
 	@description = Aerojet Dual Fuel Mixed-Mode High Pressure Engine for SSTO Vehicles. It burned RP-1 and LOX in sea level mode, and then at high altitude would deploy a nozzle extension and switch to burning LH2 and LOX for higher performance.
 	@tags ^= :$: booster Aerojet throttle tripropellant upper SSTO
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		@EngineType = LiquidFuel
@@ -73,6 +75,7 @@
 		CONFIG
 		{
 			name = DFMMHPE-Mode-1
+			specLevel = concept
 			minThrust = 2194
 			maxThrust = 2926
 			heatProduction = 100
@@ -118,6 +121,7 @@
 		CONFIG
 		{
 			name = DFMMHPE-Mode-2
+			specLevel = concept
 			minThrust = 1719
 			maxThrust = 2292
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
@@ -22,6 +22,8 @@
 	%manufacturer = Aerospatiale
 	%description = Small, French Solid Rocket motor that was used as the third stage on the Diamant B and BP4 launch vehicle.
 
+	%specLevel = operational
+
 	!MODULE[ModuleAlternator],*{}
 	!RESOURCE,*{}
 
@@ -57,6 +59,7 @@
 		CONFIG
 		{
 			name = Dropt
+			specLevel = operational
 			minThrust = 50
 			maxThrust = 50
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
@@ -54,6 +54,8 @@
 	%manufacturer = Rocketdyne
 	%description = Pump-fed kerolox open cycle (gas generator) booster engine developed from LR79/89. Backup proposal for the first stage engine on the Titan 1 ICBM, and proposed first stage engine on the Saturn 1 but ultimately never flown (4 E-1s replaced with 8 H-1s).
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -80,6 +82,7 @@
 		CONFIG
 		{
 			name = E-1
+			specLevel = prototype
 			minThrust = 1884.59 // 380klbf sea level
 			maxThrust = 1884.59
 			heatProduction = 100
@@ -125,6 +128,7 @@
 		{
 			name = E-1-Upgrade
 			description = Speculative upgrade configuration for the E-1 intended for use with the Dyna Soar project. This version is without boostback hardware.
+			specLevel = speculative
 			minThrust = 2358.25 // 468klbf sea level
 			maxThrust = 2358.25
 			heatProduction = 100
@@ -170,11 +174,11 @@
 		{
 			name = E-1-Upgrade2
 			description = Speculative upgrade configuration using late 1960s technology.
+			specLevel = speculative
 			minThrust = 2662.6 //525klbf sea level
 			maxThrust = 2662.6
 			heatProduction = 100
 			massMult = 1.2
-			//speculative = fictional
 
 			ullage = True
 			pressureFed = False
@@ -216,11 +220,11 @@
 		{
 			name = E-1A_KS
 			description = E-1A as found in 'Kolyma's Shadow'.
+			specLevel = altHist
 			minThrust = 2250
 			maxThrust = 2250
 			heatProduction = 100
 			massMult = 1.0
-			//speculative = fictional
 
 			ullage = True
 			pressureFed = False
@@ -318,7 +322,7 @@
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.97
 		cycleReliabilityEnd = 0.998
-		techTransfer = E-1,E-1-Upgrade,E-1A_KS:50
+		techTransfer = E-1-Upgrade,E-1A_KS,E-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[E-1-Upgrade2] { %ratedBurnTime = #$/TESTFLIGHT[E-1-Upgrade2]/ratedBurnTime$ } }
 }
@@ -337,7 +341,7 @@
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.99
 		cycleReliabilityEnd = 0.998
-		techTransfer = E-1,E-1-Upgrade,E-1-Upgrade2:50
+		techTransfer = E-1-Upgrade2,E-1-Upgrade,E-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[E-1A_KS] { %ratedBurnTime = #$/TESTFLIGHT[E-1A_KS]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/EAP241_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EAP241_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = Avio/Regulus/SABCA
 	%description = A steel casing solid rocket motor used in pairs by the Ariane 5 launch vehicle for the initial phases of the flight.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -99,6 +101,7 @@
 		CONFIG
 		{
 			name = MPS-241
+			specLevel = operational
 			minThrust = 7040
 			maxThrust = 7040
 			heatProduction = 20
@@ -338,6 +341,7 @@
 		CONFIG
 		{
 			name = MPS-241A
+			specLevel = operational
 			minThrust = 7040
 			maxThrust = 7040
 			heatProduction = 20

--- a/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
@@ -21,6 +21,8 @@
 	%manufacturer = Rocketdyne
 	%description = The massive Rocketdyne F-1 engine. One of the largest, most powerful rocket engines ever built. Ensure you enable roll capability or disable gimbal as required for your application. Represents the throttlable F-1A engine as found in 'Eyes Turned Skyward'.
 
+	%specLevel = altHist
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -49,11 +51,11 @@
 		CONFIG
 		{
 			name = F-1A_ETS
+			specLevel = altHist
 			minThrust = 5513.8
 			maxThrust = 9189.6
 			massMult = 0.97673
 			heatProduction = 100
-			//speculative = fictional
 			
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1B_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = The F-1B engine was designed to power the proposed Pyrios advanced boosters for the Space Launch System. A highly modified version of the original F-1, the F-1B uses modern manufacturing techniques including 3D printing and features a simpler gas generator exhaust arrangment in order to reduce manufacturing costs and increase thrust at a slight cost of efficiency.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = F-1B
+			specLevel = concept
 			minThrust = 6390 // http://www.thespacereview.com/article/2410/1 2015-11-17, throttleable 8 MN - 5.8 MN sea level
 			maxThrust = 8815
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
@@ -65,6 +65,8 @@
 	%manufacturer = Rocketdyne
 	@description = The massive Rocketdyne F-1 engine. One of the largest, most powerful rocket engines ever built. Ensure you enable roll capability or disable gimbal as required for your application.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -92,6 +94,7 @@
 		{
 			name = F-1-1.5M
 			description = Early production version
+			specLevel = operational
 			minThrust = 7775.49
 			maxThrust = 7775.49
 			heatProduction = 100
@@ -130,6 +133,7 @@
 		{
 			name = F-1-1.52M
 			description = Later model, with redesigned injectors
+			specLevel = operational
 			minThrust = 7895.01
 			maxThrust = 7895.01
 			heatProduction = 100
@@ -168,6 +172,7 @@
 		{
 			name = F-1A
 			description = Uprated and simplified F-1 developed for post-Apollo launch vehicles. Tested extensively, but cancelled following the cancellation of Apollo
+			specLevel = prototype
 			minThrust = 7855.6
 			maxThrust = 9189.6
 			massMult = 0.97673
@@ -263,7 +268,7 @@
 		ignitionReliabilityEnd = 0.998
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.998
-		techTransfer = F-1-1.5M,F-1-1.52M:50
+		techTransfer = F-1-1.52M,F-1-1.5M:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[F-1A] { %ratedBurnTime = #$/TESTFLIGHT[F-1A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/G1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/G1_Config.cfg
@@ -51,6 +51,8 @@
 	%manufacturer = Rocketdyne
 	%description = Developed for the NOMAD high energy upper stage, intended to replace Agena. The Hydrazine/Fluorine fuel mix was high energy and very dense, and testing showed impressive performance. However, concerns over the toxicity of Fluorine lead to the project being cancelled despite extensive work being completed on NOMAD.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -77,6 +79,7 @@
 		CONFIG
 		{
 			name = G-1
+			specLevel = prototype
 			minThrust = 53.38
 			maxThrust = 53.38
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GCRC_Config.cfg
@@ -67,6 +67,8 @@
 	@manufacturer = Grand Central Rocket Company
 	@description = A small solid kick motor, used as the third stage on all but the last Vanguard launch. Burn time 33 seconds.
 
+	%specLevel = operational
+
 	!MODULE[ModuleEngineConfigs],*{}
 	!MODULE[ModuleGimbal] {}
 	!MODULE[ModuleFuelTanks],* {}
@@ -106,6 +108,7 @@
 		CONFIG
 		{
 			name = GCRC
+			specLevel = operational
 			minThrust = 17.3 // With thrust curve gives avg of 12.45
 			maxThrust = 17.3
 			techRequired = solids1957

--- a/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM40_Config.cfg
@@ -6,7 +6,9 @@
 	%title = GEM 40
 	%manufacturer = Hercules
 	%description = The Graphite-Epoxy Motor (GEM) replaced the steel case used on earlier Castor-series boosters with a lighter composite case. The 40-inch (1-meter) diameter GEM 40 was used on the Delta II 7000-series in sets of three, four, or nine. When nine boosters were used, six were ignited at liftoff and the remaining three were ignited after burnout and jettison of the first six. Burn time: 58 seconds.
-	
+
+	%specLevel = operational
+
 	!RESOURCE,*{}
 	!MODULE[ModuleFuelTanks],*{}
 	!MODULE[ModuleGimbal] {}
@@ -42,6 +44,7 @@
 		CONFIG
 		{
 			name = GEM-40/Ground
+			specLevel = operational
 			minThrust = 644
 			maxThrust = 644
 			heatProduction = 100
@@ -126,6 +129,7 @@
 		CONFIG
 		{
 			name = GEM-40/Air
+			specLevel = operational
 			minThrust = 666
 			maxThrust = 666
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM46_Config.cfg
@@ -7,7 +7,9 @@
 	%title = GEM 46
 	%manufacturer = ATK
 	%description = The 46-inch (1.2-meter) diameter GEM 46 was used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with thrust vector control (TVC) while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC. Burn time 75 seconds.
-	
+
+	%specLevel = operational
+
 	!MODULE[ModuleAlternator],*{}
 	!RESOURCE,*{}
 	!MODULE[ModuleFuelTanks],*{}
@@ -43,6 +45,7 @@
 		CONFIG
 		{
 			name = GEM-46/TVC-Ground
+			specLevel = operational
 			minThrust = 875
 			maxThrust = 875 //Checked
 			heatProduction = 100
@@ -276,6 +279,7 @@
 		CONFIG
 		{
 			name = GEM-46/Fixed-Ground
+			specLevel = operational
 			gimbalRange = 0
 			minThrust = 885
 			maxThrust = 885 //Checked
@@ -508,6 +512,7 @@
 		CONFIG
 		{
 			name = GEM-46/Fixed-Air
+			specLevel = operational
 			minThrust = 915
 			maxThrust = 915 //Checked
 			massMult = 1.1020 //2.204
@@ -751,7 +756,7 @@
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/TVC-Ground,GEM-46/Fixed-Air:100
+		techTransfer = GEM-40/Air,GEM-40/Ground:50&GEM-46/TVC-Ground,GEM-46/Fixed-Air:100
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-46?Fixed-Ground] { %ratedBurnTime = #$/TESTFLIGHT[GEM-46?Fixed-Ground]/ratedBurnTime$ } }
@@ -766,7 +771,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/Fixed-Ground,GEM-46/Fixed-Air:100
+		techTransfer = GEM-40/Air,GEM-40/Ground:50&GEM-46/Fixed-Ground,GEM-46/Fixed-Air:100
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-46?TVC-Ground] { %ratedBurnTime = #$/TESTFLIGHT[GEM-46?TVC-Ground]/ratedBurnTime$ } }
@@ -781,7 +786,7 @@
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground:50 & GEM-46/TVC-Ground,GEM-46/Fixed-Ground:100
+		techTransfer = GEM-40/Air,GEM-40/Ground:50&GEM-46/TVC-Ground,GEM-46/Fixed-Ground:100
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-46?Fixed-Air] { %ratedBurnTime = #$/TESTFLIGHT[GEM-46?Fixed-Air]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM60_Config.cfg
@@ -24,6 +24,8 @@
 	%manufacturer = Orbital ATK
 	%description = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time 90 seconds.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -71,6 +73,7 @@
 		CONFIG
 		{
 			name = GEM-60/TVC
+			specLevel = operational
 			minThrust = 1235.947
 			maxThrust = 1235.947
 			heatProduction = 100
@@ -193,6 +196,7 @@
 		CONFIG
 		{
 			name = GEM-60/Fixed
+			specLevel = operational
 			minThrust = 1248.91
 			maxThrust = 1248.91
 			gimbalRange = 0
@@ -325,7 +329,7 @@
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground:50 & GEM-60/TVC:100
+		techTransfer = GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-40/Air,GEM-40/Ground:50&GEM-60/TVC:100
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-60?Fixed] { %ratedBurnTime = #$/TESTFLIGHT[GEM-60?Fixed]/ratedBurnTime$ } }
@@ -340,7 +344,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground:50 & GEM-60/Fixed:100
+		techTransfer = GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-40/Air,GEM-40/Ground:50&GEM-60/Fixed:100
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-60?TVC] { %ratedBurnTime = #$/TESTFLIGHT[GEM-60?TVC]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63XL_Config.cfg
@@ -6,7 +6,9 @@
 	@title = GEM 63XL
 	%manufacturer = Orbital ATK
 	@description = In addition to the GEM 63 for Atlas V, Orbital ATK will develop a larger variant, the GEM 63XL, for Vulcan. The boosters will be approximately 1.5 m longer than the GEM 63 and Vulcan will be able to use up to four boosters with a four-meter fairing or six boosters with a five-meter fairing.
-	
+
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -44,6 +46,7 @@
 		CONFIG
 		{
 			name = GEM-63XL
+			specLevel = prototype
 			minThrust = 2026
 			maxThrust = 2026
 			heatProduction = 100
@@ -170,7 +173,7 @@
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-60/TVC,GEM-60/Fixed,GEM-63:50
+		techTransfer = GEM-63,GEM-60/TVC,GEM-60/Fixed,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-40/Air,GEM-40/Ground:50
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-63XL] { %ratedBurnTime = #$/TESTFLIGHT[GEM-63XL]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/GEM63_Config.cfg
@@ -6,7 +6,9 @@
 	@title = GEM 63
 	%manufacturer = Orbital ATK
 	@description = In 2015, ULA announced that Orbital ATK had been contracted to develop the GEM 63 as a drop-in replacement for the AJ-60A, and would replace Aerojet Rocketdyne as their Atlas V SRM supplier by the end of 2018. The GEM 63 will be larger than the GEM 60 SRMs used on the Delta IV and will not be equipped with thrust vectoring. As with the AJ-60A, launches using the four-meter fairing will be able to be equipped with up to three boosters while up to five boosters can be used with the five-meter fairing. 
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -45,6 +47,7 @@
 		CONFIG
 		{
 			name = GEM-63
+			specLevel = operational
 			minThrust = 1658
 			maxThrust = 1658
 			heatProduction = 100
@@ -171,7 +174,7 @@
 		ignitionReliabilityEnd = 1.0	//not likely for ground-lit motor
 		cycleReliabilityStart = 0.998132
 		cycleReliabilityEnd = 0.999626
-		techTransfer = GEM-40/Air,GEM-40/Ground,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-60/TVC,GEM-60/Fixed,GEM-63XL:50
+		techTransfer = GEM-60/TVC,GEM-60/Fixed,GEM-46/TVC-Ground,GEM-46/Fixed-Air,GEM-46/Fixed-Ground,GEM-40/Air,GEM-40/Ground:50
 		isSolid = True
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[GEM-63] { %ratedBurnTime = #$/TESTFLIGHT[GEM-63]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Bristol Siddeley
 	%description = A two chamber version of Gamma, used for the second stage of the Black Arrow satellite launch vehicle. As the only Gamma not required to operate at sea level, the nozzles were extended to allow better expansion.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = Gamma-2
+			specLevel = operational
 			minThrust = 68.236
 			maxThrust = 68.236
 			heatProduction = 100
@@ -113,7 +116,7 @@
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.883889
 		cycleReliabilityEnd = 0.981667
-		techTransfer = Gamma-201, Gamma-301, Gamma-8:50
+		techTransfer = Gamma-8,Gamma-301,Gamma-201:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-2] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
@@ -52,6 +52,8 @@
 	%manufacturer = Saunders-Roe
 	%description = This was an 4 chamber development of Gamma, used for the first stage of the Black Knight sounding rocket. Gamma thrust chambers were mounted in pairs radially, each pair on a one-axis tangential gimbal. Collective movement gave roll control, differential movement pitch.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = Gamma-201
+			specLevel = operational
 			minThrust = 71.17
 			maxThrust = 71.17
 			heatProduction = 100
@@ -111,6 +114,7 @@
 		CONFIG
 		{
 			name = Gamma-301
+			specLevel = operational
 			minThrust = 76.95
 			maxThrust = 96.97
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Bristol Siddeley
 	%description = This was an 8 chamber development of Gamma, used for the first stage of the Black Arrow satellite launch vehicle. Gamma thrust chambers were mounted in pairs radially, each pair on a one-axis tangential gimbal. Collective movement gave roll control, differential movement pitch.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = Gamma-8
+			specLevel = operational
 			minThrust = 256.395
 			maxThrust = 256.395
 			heatProduction = 100
@@ -111,7 +114,7 @@
 		ignitionReliabilityEnd = 0.995000
 		cycleReliabilityStart = 0.883889
 		cycleReliabilityEnd = 0.981667
-		techTransfer = Gamma-201, Gamma-301, Gamma-2:50
+		techTransfer = Gamma-2,Gamma-301,Gamma-201:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-8] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-8]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -128,6 +128,8 @@
 	%manufacturer = Rocketdyne
 	%description = The H-1 is an upgrade to the original LR79 engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1/RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters and the core burns rather longer.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -154,6 +156,7 @@
 		{
 			name = H-1-165K
 			description = Earliest prototype version of the H-1 Engine that flew on the Saturn I, Block I. It is rated at 165k lbf sea level thrust.
+			specLevel = operational
 			minThrust = 823.25
 			maxThrust = 823.25
 			heatProduction = 100
@@ -200,6 +203,7 @@
 		{
 			name = H-1-188K
 			description = Improved version of the H-1 Engine for the Saturn I, Block II. It is rated at 188k lbf sea level thrust.
+			specLevel = operational
 			minThrust = 938.02
 			maxThrust = 938.02
 			heatProduction = 100
@@ -246,6 +250,7 @@
 		{
 			name = H-1-200K
 			description = H-1 Engine that flew on the first 5 Saturn IB launches. It is rated at 200k lbf sea level thrust.
+			specLevel = operational
 			minThrust = 997.889
 			maxThrust = 997.889
 			heatProduction = 100
@@ -292,6 +297,7 @@
 		{
 			name = H-1-205K
 			description = Final version of the H-1 Engine for the Saturn IB that flew on the 4 flights of Skylab and ASTP. It is rated at 205k lbf sea level thrust.
+			specLevel = operational
 			minThrust = 1054.22
 			maxThrust = 1054.22
 			heatProduction = 100
@@ -338,12 +344,13 @@
 		{
 			name = RS-27
 			description = Remanufactured H-1 for use with Delta
+			specLevel = operational
 			maxThrust = 1023
 			minThrust = 1023
 			heatProduction = 100
 			massMult = 1.0395
 
-            %gimbalRange = 8.5
+			%gimbalRange = 8.5
 			ullage = True
 			pressureFed = False
 			ignitions = 1
@@ -385,6 +392,7 @@
 		{
 			name = RS-27A
 			description = RS-27 with a higher expansion nozzle for Delta II
+			specLevel = operational
 			maxThrust = 1054
 			minThrust = 1054
 			heatProduction = 100
@@ -451,7 +459,7 @@
 		ignitionReliabilityEnd = 0.995455
 		cycleReliabilityStart = 0.971212
 		cycleReliabilityEnd = 0.995455
-		techTransfer = S-3, S-3D:25	//Based on S-3
+		techTransfer = S-3D,S-3:25	//Based on S-3
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-165K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-165K]/ratedBurnTime$ } }
 }
@@ -469,7 +477,7 @@
 		ignitionReliabilityEnd = 0.996939
 		cycleReliabilityStart = 0.980612
 		cycleReliabilityEnd = 0.996939
-		techTransfer = H-1-165K:50
+		techTransfer = S-3D,S-3:25&H-1-165K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-188K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-188K]/ratedBurnTime$ } }
 }
@@ -487,7 +495,7 @@
 		ignitionReliabilityEnd = 0.996341
 		cycleReliabilityStart = 0.976829
 		cycleReliabilityEnd = 0.996341
-		techTransfer = H-1-165K,H-1-188K:50
+		techTransfer = S-3D,S-3:25&H-1-188K,H-1-165K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-200K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-200K]/ratedBurnTime$ } }
 }
@@ -505,7 +513,7 @@
 		ignitionReliabilityEnd = 0.996341
 		cycleReliabilityStart = 0.976829
 		cycleReliabilityEnd = 0.996341
-		techTransfer = H-1-165K,H-1-188K,H-1-205K:50
+		techTransfer = S-3D,S-3:25&H-1-200K,H-1-188K,H-1-165K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-205K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-205K]/ratedBurnTime$ } }
 }
@@ -537,7 +545,7 @@
 		ignitionReliabilityEnd = 0.996535
 		cycleReliabilityStart = 0.978053
 		cycleReliabilityEnd = 0.996535
-		techTransfer = H-1-188K,H-1-200K,H-1-205K:50
+		techTransfer = S-3D,S-3:25&H-1-205K,H-1-200K,H-1-188K,H-1-165K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-27] { %ratedBurnTime = #$/TESTFLIGHT[RS-27]/ratedBurnTime$ } }
 }
@@ -564,7 +572,7 @@
 		ignitionReliabilityEnd = 0.998944
 		cycleReliabilityStart = 0.993310
 		cycleReliabilityEnd = 0.998944
-		techTransfer = H-1-188K,H-1-200K,H-1-205K,RS-27:50
+		techTransfer = S-3D,S-3:25&RS-27,H-1-205K,H-1-200K,H-1-188K,H-1-165K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-27A] { %ratedBurnTime = #$/TESTFLIGHT[RS-27A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -20,7 +20,9 @@
 	@title = HG-3 Series
 	%manufacturer = Rocketdyne
 	@description = Rocketdyne HG-3 engine, which served as a stepping stone between the J-2 and RS-25. Ensure you enable roll capability or disable gimbal as required for your application.
-	
+
+	%specLevel = concept
+
 	@MODULE[ModuleGimbal]
 	{
 		%gimbalRange = 7.5
@@ -42,6 +44,7 @@
 		CONFIG
 		{
 			name = HG-3
+			specLevel = concept
 			minThrust = 938.469
 			maxThrust = 1400.70
 			heatProduction = 100
@@ -74,6 +77,7 @@
 		CONFIG
 		{
 			name = HG-3-SL
+			specLevel = speculative
 			minThrust = 925.987
 			maxThrust = 1382.07
 			massMult = 0.973574409
@@ -108,6 +112,7 @@
 		{
 			name = HG-3A
 			description = Speculative upgrade, using lessons learned from experience with HG-3 in service and development of RS-25 to improve reliability.
+			specLevel = speculative
 			minThrust = 938.469
 			maxThrust = 1400.70
 			heatProduction = 100
@@ -142,6 +147,7 @@
 		{
 			name = HG-3A-SL
 			description = Sea-level variant of HG-3A upgrade
+			specLevel = speculative
 			minThrust = 925.987
 			maxThrust = 1382.07
 			massMult = 0.973574409
@@ -177,6 +183,7 @@
 		{
 			name = HG-3B
 			description = Further refinement of the HG-3 engine, taking into account developements with the RL-10 and RS-25. Run time and reliability are extended compared to original models, although turbopump throughput is decreased to reduce strain on engine components.
+			specLevel = speculative
 			minThrust = 938.469
 			maxThrust = 1400.70
 			heatProduction = 100
@@ -211,6 +218,7 @@
 		{
 			name = HG-3B-SL
 			description = Sea-level variant of HG-3B upgrade. Increased specific impulse compared to other sea-level variants prior to B version development results in slightly higher thrust for the same level of turbopump throughput as the HG-3B vacuum engine.
+			specLevel = speculative
 			minThrust = 926.174
 			maxThrust = 1382.35
 			massMult = 0.973574409
@@ -246,6 +254,7 @@
 		{
 			name = HG-3B-2
 			description = Modified version of HG-3B, running the turbopumps harder to generate the same level of mass flow as in previous models. This results in improved thrust compared to the normal B model, at the cost of slightly less reliability in comparison.
+			specLevel = speculative
 			minThrust = 950.035
 			maxThrust = 1422.44
 			heatProduction = 100
@@ -280,6 +289,7 @@
 		{
 			name = HG-3B-SL-2
 			description = Sea-level version of HG-3B-2 upgrade and modification. The improved specific impulse now means that this version produces more vacuum thrust than previous vacuum versions of the engine.
+			specLevel = speculative
 			minThrust = 940.553
 			maxThrust = 1403.81
 			heatProduction = 100
@@ -419,7 +429,7 @@
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.90
 		cycleReliabilityEnd = 0.988
-		techTransfer = HG-3A,HG-3A-SL,HG-3B,HG-3B-SL:50
+		techTransfer = HG-3B,HG-3B-SL,HG-3A,HG-3A-SL:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3B-2] { %ratedBurnTime = #$/TESTFLIGHT[HG-3B-2]/ratedBurnTime$ } }
 }
@@ -435,7 +445,7 @@
 		ignitionReliabilityEnd = 0.97
 		cycleReliabilityStart = 0.90
 		cycleReliabilityEnd = 0.988
-		techTransfer = HG-3A,HG-3A-SL,HG-3B,HG-3B-SL:50
+		techTransfer = HG-3B,HG-3B-SL,HG-3A,HG-3A-SL:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[HG-3B-SL-2] { %ratedBurnTime = #$/TESTFLIGHT[HG-3B-SL-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
@@ -90,6 +90,8 @@
 	%manufacturer = Snecma S.A.
 	%description = Hydrolox gas generator upper stage engine. Direct descendant of the HM4 testbed engine. Used on the upper stages of the Ariane launch vehicle family.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -118,6 +120,7 @@
 		{
 			name = HM-7
 			description = Developed for Ariane 1
+			specLevel = operational
 			maxThrust = 62.4
 			minThrust = 62.4
 			massMult = 0.909
@@ -157,6 +160,7 @@
 		{
 			name = HM-7B
 			description = Improved version of the HM-7 used for Ariane 3 and 4.
+			specLevel = operational
 			maxThrust = 64.2
 			minThrust = 64.2
 			massMult = 1.0
@@ -196,6 +200,7 @@
 		{
 			name = HM-7B+
 			description = Upgraded for higher performance on Ariane 4.
+			specLevel = operational
 			maxThrust = 64.6
 			minThrust = 64.6
 			massMult = 1.0
@@ -235,6 +240,7 @@
 		{
 			name = HM-7B++
 			description = Upgraded for higher performance for later Ariane 4s and Ariane 5
+			specLevel = operational
 			maxThrust = 64.8
 			minThrust = 64.8
 			massMult = 1.0
@@ -336,7 +342,7 @@
 		ignitionReliabilityEnd = 0.997973
 		cycleReliabilityStart = 0.970045
 		cycleReliabilityEnd = 0.995270
-		techTransfer = HM-7,HM-7B:50
+		techTransfer = HM-7B,HM-7:50
 		ignitionDynPresFailMultiplier = 0.1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[HM-7B+] { %ratedBurnTime = #$/TESTFLIGHT[HM-7B+]/ratedBurnTime$ } }
@@ -355,7 +361,7 @@
 		ignitionReliabilityEnd = 0.998000
 		cycleReliabilityStart = 0.987162
 		cycleReliabilityEnd = 0.997973
-		techTransfer = HM-7,HM-7B,HM-7B+:50
+		techTransfer = HM-7B+,HM-7B,HM-7:50
 		ignitionDynPresFailMultiplier = 0.1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[HM-7B++] { %ratedBurnTime = #$/TESTFLIGHT[HM-7B++]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -52,6 +52,8 @@
 	@manufacturer = Rocketdyne
 	@description = Aerospike. Using proven technology from the J-2 and introducing an aerospike nozzle to the developing J-2S machinery.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = J-2T-200K
+			specLevel = prototype
 			maxThrust = 889.3
 			minThrust = 177.8
 			PROPELLANT
@@ -107,6 +110,7 @@
 		CONFIG
 		{
 			name = J-2T-250K
+			specLevel = prototype
 			maxThrust = 1111.6
 			minThrust = 222.32
 			PROPELLANT
@@ -148,7 +152,7 @@
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665
 		cycleReliabilityEnd = 0.9999
-		techTransfer = J-2-200K,J-2-225K,J-2-230K:30
+		techTransfer = J-2-230K,J-2-225K,J-2-200K:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2T-200K] { %ratedBurnTime = #$/TESTFLIGHT[J-2T-200K]/ratedBurnTime$ } }
 }
@@ -165,7 +169,7 @@
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9665
 		cycleReliabilityEnd = 0.9999
-		techTransfer = J-2-200K,J-2-225K,J-2-230K,J-2T-200K:30
+		techTransfer = J-2T-200K,J-2-230K,J-2-225K,J-2-200K:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2T-250K] { %ratedBurnTime = #$/TESTFLIGHT[J-2T-250K]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2X_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = 2000s medium TWR, vacuum engine. The J-2X was intended to be used on the upper stages of Ares I and Ares V. Development continued after the cancellation of Ares, and early designs of SLS incorporated the engine, but selection of the RL10-powered Exploration Upper Stage resulted in the project being mothballed.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,6 +63,7 @@
 		CONFIG
 		{
 			name = J-2X
+			specLevel = prototype
 			maxThrust = 1308
 			minThrust = 1072
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -89,6 +89,8 @@
 	%manufacturer = Rocketdyne
 	@description = The Rocketdyne J-2 rocket engine was the first large hydrolox engine. It was used on the S-II stage on the Saturn V and also on the S-IVB stage on the Saturn IB and the Saturn V.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -116,6 +118,7 @@
 		{
 			name = J-2-200K
 			description = This was the earliest variant of the J-2 that flew on the first 3 Saturn IB flights AS-201 to AS-203. One hour minimum, six hours maximum between restarts.
+			specLevel = operational
 			minThrust = 685.026
 			maxThrust = 889.644
 			heatProduction = 100
@@ -150,6 +153,7 @@
 		{
 			name = J-2-225K
 			description = The uprated 225k variant was flown starting with SA-501 Saturn V. Six hours maximum between restarts.
+			specLevel = operational
 			minThrust = 770.654
 			maxThrust = 1000.850
 			heatProduction = 100
@@ -184,6 +188,7 @@
 		{
 			name = J-2-230K
 			description = The final version of the J-2 that flew on the Saturn, the 230k variant flew starting with Apollo 8, SA-208 and all subsequent flights. One hour minimum, six hours maximum between restarts.
+			specLevel = operational
 			minThrust = 787.780
 			maxThrust = 1023.091
 			heatProduction = 100
@@ -218,6 +223,7 @@
 		{
 			name = J-2S
 			description = The J-2S (J-2 Simplified) was a improvement on the J-2 Engine. It was completely tested and logged more than 30,000 seconds of static fire before the program was terminated. One hour minimum, six hours maximum between restarts.
+			specLevel = prototype
 			minThrust = 196.463	// 6:1 throttling thanks to redesigned pumps and injectors
 			maxThrust = 1178.778
 			massMult = 1.036835 // All sources state the J-2S was heavier than J-2
@@ -338,7 +344,7 @@
 		ignitionReliabilityEnd = 0.998077
 		cycleReliabilityStart = 0.986029
 		cycleReliabilityEnd = 0.997794
-		techTransfer = J-2-200K,J-2-225K:50
+		techTransfer = J-2-225K,J-2-200K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2-230K] { %ratedBurnTime = #$/TESTFLIGHT[J-2-230K]/ratedBurnTime$ } }
 }
@@ -362,7 +368,7 @@
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.9995
-		techTransfer = J-2-200K,J-2-225K,J-2-230K:50
+		techTransfer = J-2-230K,J-2-225K,J-2-200K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[J-2S] { %ratedBurnTime = #$/TESTFLIGHT[J-2S]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = JPL
 	%description = When work began on successors to the early Juno launch vehicles, there was an obvious demand for higher performance engines. In order to satisfy this demand, JPL worked on a second stage engine for the Juno IV launch vehicle that would provide 45,000 pounds of thrust in vacuum. The engines were tested, but they were ultimately decided against using them in favor of the X-405 of the Vanguard launch vehicle.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = Juno45k
+			specLevel = concept
 			minThrust = 200.17
 			maxThrust = 200.17
 			heatProduction = 100
@@ -116,7 +119,6 @@
 			ignitionReliabilityEnd = 0.98
 			cycleReliabilityStart = 0.84
 			cycleReliabilityEnd = 0.985
-			techTransfer =	AJ10-37,AJ10-104,AJ10-42,AJ10-142,AJ10-118E:10&Juno6k:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Juno45k] { %ratedBurnTime = #$/TESTFLIGHT[Juno45k]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = JPL
 	%description = Early exploration into pressure-fed hypergolic upper stage engines. This was designed by JPL to be the third stage on the Juno IV launch vehicle. After cancellation of the Juno IV, it was then selected to power the Vega upper stage for the Atlas-Vega launcher. Eventually the Vega program was canceled in 1959. The "6K" upper stage engine was tested often, but never flew and was ultimately cancelled.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = Juno6k
+			specLevel = prototype
 			minThrust = 26.68932
 			maxThrust = 26.68932
 			heatProduction = 100
@@ -117,7 +120,7 @@
 			ignitionReliabilityEnd = 0.98
 			cycleReliabilityStart = 0.78
 			cycleReliabilityEnd = 0.98
-			techTransfer =	AJ10-37,AJ10-104,AJ10-42,AJ10-142:50&Juno45k:30
+			techTransfer =	AJ10-142,AJ10-42,AJ10-37:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Juno6k] { %ratedBurnTime = #$/TESTFLIGHT[Juno6k]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/KDU414_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KDU414_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = Isayev Design Bureau (Khimmash)
 	%description = A small manuevering engine used on the Soviet 1MV and 2MV spacecraft busses, and KAUR-2 comsat bus. Used on early Venera, Mars, Zond and Molnyia satellites.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = KDU-414
+			specLevel = operational
 			description = a.k.a. 11D414, S5.19
 			minThrust = 1.96
 			maxThrust = 1.96

--- a/GameData/RealismOverhaul/Engine_Configs/KIWIA24_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KIWIA24_Config.cfg
@@ -36,6 +36,8 @@
 	@title = Kiwi A3 Atomic Rocket Motor
 	@manufacturer = Aerojet & Westinghouse
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -47,6 +49,7 @@
 			CONFIG
 		{
 			name = KIWIA24-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			minThrust = 4.2				

--- a/GameData/RealismOverhaul/Engine_Configs/KIWIB48_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KIWIB48_Config.cfg
@@ -25,6 +25,8 @@
 	@title = Kiwi B4E Atomic Rocket Motor
 	@manufacturer = Aerojet & Westinghouse
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -36,6 +38,7 @@
 		CONFIG
 		{
 			name = KIWIB48-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			minThrust = 22

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU35.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU35.cfg
@@ -59,7 +59,9 @@
 	%title = KTDU-35
 	%manufacturer = Isayev Design Bureau
 	%description = The KTDU-35 is a gas generator hypergolic propulsion system, capable of multiple ignitions and used on the first generation Soyuz and Progress spacecrafts (the 7K series). It consists of the single nozzle S5.60 main engine and the dual nozzle S5.35 backup engine. In the case of a failure of the main engine, the backup one assumes it's position.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -82,6 +84,7 @@
 		CONFIG
 		{
 			name = S5_60
+			specLevel = operational
 			minThrust = 4.09
 			maxThrust = 4.09
 			heatProduction = 1
@@ -134,6 +137,7 @@
 		CONFIG
 		{
 			name = S5_35
+			specLevel = operational
 			minThrust = 4.03
 			maxThrust = 4.03
 			heatProduction = 1

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU417_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU417_Config.cfg
@@ -59,6 +59,8 @@
 	%manufacturer = Isayev Design Bureau (Khimmash)
 	%description = The landing engine for Luna 15-24. The main gas generator engine was used for orbital manuevering and descent, and then switched over to a secondary pressurefed engine for terminal descent. Use an action group to toggle between the main and secondary engines quickly to make landing easier.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -87,6 +89,7 @@
 		CONFIG
 		{
 			name = 11D417
+			specLevel = operational
 			minThrust = 7.35
 			maxThrust = 18.89
 			heatProduction = 100
@@ -140,6 +143,7 @@
 		CONFIG
 		{
 			name = 11D417B
+			specLevel = operational
 			minThrust = 2.06
 			maxThrust = 3.43
 			heatProduction = 1

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU425A.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU425A.cfg
@@ -56,6 +56,8 @@
 	%manufacturer = Isayev Design Bureau (Khimmash)
 	%description = A Soviet gas generator hypergolic vacuum engine. Designed for use in the propulsion systems of the Mars and Venera 3MV, 4MV and 5MV spacecraft buses.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -83,6 +85,7 @@
 		CONFIG
 		{
 			name = KTDU-425
+			specLevel = operational
 			minThrust = 7.05
 			maxThrust = 18.85
 			heatProduction = 35
@@ -122,6 +125,7 @@
 		CONFIG
 		{
 			name = KTDU-425A
+			specLevel = operational
 			minThrust = 9.86
 			maxThrust = 18.89
 			heatProduction = 35

--- a/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
@@ -67,7 +67,9 @@
 	%title = KVD-1/CE-7.5
 	%manufacturer = KB Khimavtomatiki (Kosberg) / ISRO
 	%description = Staged combustion hydrolox upper stage engine intended for use on the N-1M and considered for use on Proton and Angara, eventually licensed to India for its GSLV MkI and MkII.	Later versions were developed by India for domestic use on the as the CE-7.5.  The main engine bell is fixed in place, and two verniers are used to provide combined pitch-yaw-roll control; this leads to lower control authority than on stages where the main engine can gimbal.	 This engine runs with a somewhat higher than average O/F ratio, resulting in a denser than average hydrolox stage.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -96,6 +98,7 @@
 		{
 			name = RD-56
 			description = Developed for use as an N-1 upper stage. Cancelled with the N-1, but considered for use on Proton and Angara
+			specLevel = prototype
 			minThrust = 69.6
 			maxThrust = 69.6
 			heatProduction = 100
@@ -129,6 +132,7 @@
 		{
 			name = KVD-1
 			description = AKA RD-56M. Upgraded model of the RD-56. Never saw use in the USSR, but was sold to India, and later license built in India. Poor overall reliability
+			specLevel = operational
 			minThrust = 73.6
 			maxThrust = 73.6
 			heatProduction = 100
@@ -163,6 +167,7 @@
 		{
 			name = CE-7.5
 			description = Natively developed Indian upgrade of the KVD-1 following embargos and poor performance. Used for GSLV Mk.II.
+			specLevel = operational
 			minThrust = 69.55
 			maxThrust = 69.55
 			heatProduction = 100
@@ -249,7 +254,7 @@
 		ignitionReliabilityEnd = 0.989286
 		cycleReliabilityStart = 0.864286
 		cycleReliabilityEnd = 0.978571
-		techTransfer = RD-56,CE-7.5:50
+		techTransfer = CE-7.5,RD-56:50
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Kestrel1B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Kestrel1B_Config.cfg
@@ -42,6 +42,8 @@
 	%manufacturer = SpaceX
 	%description = A Methalox derivative of the original pressure - fed Kestrel engine that was used on the upper stage of the Falcon 1 launch vehicle. Features a multi - ignition capability and a limited throttling range.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		@EngineType = LiquidFuel
@@ -68,6 +70,7 @@
 		CONFIG
 		{
 			name = Kestrel-1B
+			specLevel = concept
 			minThrust = 23.1
 			maxThrust = 30.7
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/Kestrel_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Kestrel_Config.cfg
@@ -50,6 +50,8 @@
 	@manufacturer = SpaceX
 	@description = Pressure-fed kerosene/LOX engine that was used in the second stage of the Falcon 1 launcher.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = Kestrel
+			specLevel = operational
 			minThrust = 30.5
 			maxThrust = 30.5
 			heatProduction = 90
@@ -121,6 +124,7 @@
 		CONFIG
 		{
 			name = Kestrel-2
+			specLevel = prototype
 			minThrust = 30.7
 			maxThrust = 30.7
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/LE7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LE7_Config.cfg
@@ -69,7 +69,9 @@
 	%title = LE-7 Series
 	%manufacturer = Mitsubishi Heavy Industries
 	%description = 1990s medium TWR, atmospheric and vacuum use. Fuel-rich staged combustion engines used on the core stage of H-II series launchers. The original LE-7 was replaced by the LE-7A, which sacrificed some performance in favor of reduced cost and better reliability.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -96,6 +98,7 @@
 		{
 			name = LE-7
 			description = Developed as a first stage engine for the Japanese H-II.
+			specLevel = operational
 			maxThrust = 1096.1
 			minThrust = 1096.1
 			PROPELLANT
@@ -127,6 +130,7 @@
 		{
 			name = LE-7A
 			description = Simplified design for the H-IIA. Lower cost and better reliability, at the cost of lower performance. Intended to have a nozzle extension, but it had to be removed due to unexpected combustion instability issues.
+			specLevel = operational
 			maxThrust = 996.4
 			minThrust = 717.4
 			PROPELLANT
@@ -158,7 +162,8 @@
 		CONFIG
 		{
 			name = LE-7A-2 //long nozzle
-			description = A Redesigned nozzle extension allowed for the LE-7A to achieve its intended performance, at the cost of slightly more weight.
+			description = A redesigned nozzle extension allowed for the LE-7A to achieve its intended performance, at the cost of slightly more weight.
+			specLevel = operational
 			maxThrust = 1098
 			minThrust = 790
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/LEROS4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LEROS4_Config.cfg
@@ -35,6 +35,8 @@
 	@manufacturer = Moog ISP
 	@description = The LEROS 4 High Thrust Apogee Engine is a ESA funded 1100 N spacecraft main engine undergoing development by Moog. The engine will uniquely support the agencies future interplanetary exploration missions by reducing the mass of spacecraft propellant required for orbit insertion manoeuvres and so allow increased scientific payload to be accommodated on these missions.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -55,6 +57,7 @@
 		CONFIG
 		{
 			name = LEROS-4
+			specLevel = operational
 			minThrust = 0.9
 			maxThrust = 1.3
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/LEROS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LEROS_Config.cfg
@@ -67,6 +67,8 @@
 	@manufacturer = Moog ISP
 	@description = LEROS is a family of chemical rocket engines manufactured by Moog-ISP. LEROS engines have been used as primary apogee engines for telecommunications satellites such as the Lockheed Martin A2100 as well as deep space missions such as Juno.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -88,6 +90,7 @@
 		{
 			name = LEROS-1b
 			description = Used for deep space trajectory correction and planetary orbit insertion.
+			specLevel = operational
 			minThrust = 0.534
 			maxThrust = 0.644
 			heatProduction = 90
@@ -128,6 +131,7 @@
 		CONFIG
 		{
 			name = LEROS-1c
+			specLevel = operational
 			minThrust = 0.376
 			maxThrust = 0.458
 			heatProduction = 90
@@ -169,6 +173,7 @@
 		CONFIG
 		{
 			name = LEROS-2b
+			specLevel = operational
 			minThrust = 0.313
 			maxThrust = 0.4
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMAE_Config.cfg
@@ -56,6 +56,8 @@
 	%manufacturer = Bell / Rocketdyne
 	%description = Pressure-fed engine used for the ascent module of the Apollo lunar lander.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = LMAE
+			specLevel = operational
 			minThrust = 15.57
 			maxThrust = 15.57
 			heatProduction = 20
@@ -123,6 +126,7 @@
 		{
 			name = RS-18
 			description = LMAE converted to run on Methalox for use on future manned Lunar and Martian landers. Developed and test fired, but cancelled in 2020 in favor of commercially developed landers.
+			specLevel = prototype
 			minThrust = 24.5
 			maxThrust = 24.5
 			heatProduction = 20

--- a/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LMDE_Config.cfg
@@ -82,6 +82,8 @@
 	%manufacturer = TRW
 	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boiloff, but are far less efficient than hydrolox or even kerolox. The version used on J-class missions had slightly higher specific impulse (this, along with other changes, gave enough payload capacity for the rover, for example). A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -109,6 +111,7 @@
 		{
 			name = LMDE-H
 			description = Lunar Module Descent Engine used up to Apollo 15
+			specLevel = operational
 			minThrust = 4.67
 			maxThrust = 43.8
 			heatProduction = 35
@@ -155,6 +158,7 @@
 		{
 			name = LMDE-J
 			description = LMDE upgraded for J-class missions. Improved performance and more fuel allowed the LEM to carry rovers and extra scientific equipment to the surface.
+			specLevel = operational
 			minThrust = 4.67
 			maxThrust = 45.04
 			heatProduction = 36
@@ -201,6 +205,7 @@
 		{
 			name = TR-201
 			description = Simplifed LMDE used on Delta-P as an upper stage engine.
+			specLevel = operational
 			minThrust = 43.5
 			maxThrust = 43.5
 			heatProduction = 48
@@ -336,7 +341,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.964247
 		cycleReliabilityEnd = 0.994355
-		techTransfer = LMDE-H,LMDE-J:50
+		techTransfer = LMDE-J,LMDE-H:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[TR-201] { %ratedBurnTime = #$/TESTFLIGHT[TR-201]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = Rocketdyne
 	%description = Pump or pressure-fed kerolox vernier engine. Used for attitude control and final velocity adjustment in the MA-x system (2x LR89 + LR105 + 2x LR101) on Atlas, and MB-x system (LR79 or RS-27 + 2xLR101) on Thor-Able / Thor-Agena / Thor-Delta / Delta.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -84,6 +86,7 @@
 		{
 			name = LR101-NA-3
 			description = First production version. Used on Thor and Atlas as vernier engines
+			specLevel = operational
 			minThrust = 5.1144
 			maxThrust = 5.1144
 			heatProduction = 10
@@ -123,6 +126,7 @@
 		{
 			name = LR101-NA-11
 			description = Developed for later, larger Thor variants, with improved performance
+			specLevel = operational
 			minThrust = 5.369
 			maxThrust = 5.369
 			heatProduction = 10
@@ -161,6 +165,7 @@
 		{
 			name = LR101-NA-15
 			description = Downrated for later Atlas variants when studies showed much lower thrust could be used to maintain control
+			specLevel = operational
 			minThrust = 2.976
 			maxThrust = 2.976
 			heatProduction = 10
@@ -238,7 +243,7 @@
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.998
-		techTransfer =	LR101-NA-3,LR101-NA-11:50
+		techTransfer =	LR101-NA-11,LR101-NA-3:50
 		reliabilityDataRateMultiplier = 2
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR101-NA-15] { %ratedBurnTime = #$/TESTFLIGHT[LR101-NA-15]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -139,6 +139,8 @@
 	%manufacturer = Rocketdyne
 	%description = Kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s) are lit on the ground, but after a bit over 2 minutes' flight the boosters are dropped and the Atlas core continues to orbit under the power of the sustainer engine (and the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for increased performance. As a sustainer engine, the LR105 has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -168,6 +170,7 @@
 		{
 			name = LR43-NA-5
 			description = Prototype MA-1 Atlas sustainer sustainer. An XLR43 modified with vaccum optimzed nozzle and burning kerosene. Used on Atlas B (Atlas A had no sustainer)
+			specLevel = operational
 			minThrust = 240.2
 			maxThrust = 240.2
 			heatProduction = 100
@@ -210,6 +213,7 @@
 		{
 			name = LR105-NA-3
 			description = MA-1 Atlas sustainer engine. Significantly upgraded and simplified, used on Atlas B/C
+			specLevel = operational
 			minThrust = 352.2
 			maxThrust = 352.2
 			heatProduction = 100
@@ -251,6 +255,7 @@
 		{
 			name = LR105-NA-5
 			description = MA-3 Atlas Sustainer engine. Developed for the USAF for Atlas D
+			specLevel = operational
 			minThrust = 366.1
 			maxThrust = 366.1
 			heatProduction = 100
@@ -291,6 +296,7 @@
 		{
 			name = LR105-NA-6
 			description = MA-3 Atlas sustainer engine. Slightly upgraded for Atlas E/F
+			specLevel = operational
 			minThrust = 373.2
 			maxThrust = 373.2
 			heatProduction = 100
@@ -331,6 +337,7 @@
 		{
 			name = LR105-NA-7.1
 			description = MA-5.1 sustainer engine for Atlas-Agena launches
+			specLevel = operational
 			minThrust = 385.2
 			maxThrust = 385.2
 			heatProduction = 100
@@ -371,6 +378,7 @@
 		{
 			name = LR105-NA-7.2
 			description = MA-5.2 sustainer engine for Atlas-Centaur launches
+			specLevel = operational
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
@@ -411,6 +419,7 @@
 		{
 			name = RS-56-OSA
 			description = Atlas MA-5A sustainer engine. Upgraded with RS-27 components to reduce cost and improve performance. Used on Atlas II
+			specLevel = operational
 			minThrust = 386.4
 			maxThrust = 386.4
 			heatProduction = 100
@@ -476,7 +485,7 @@
 		ignitionReliabilityEnd = 0.962766
 		cycleReliabilityStart = 0.764184
 		cycleReliabilityEnd = 0.962766
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3:50	//LR43 was an XLR43-NA-3 modified to burn kerosene. Derived from XLR43-NA-1/NAA-75 TP
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&XLR43-NA-3:50	//LR43 was an XLR43-NA-3 modified to burn kerosene. Derived from XLR43-NA-1/NAA-75 TP
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR43-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR43-NA-5]/ratedBurnTime$ } }
 }
@@ -496,7 +505,7 @@
 		ignitionReliabilityEnd = 0.960526
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.960526
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-5:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-3]/ratedBurnTime$ } }
 }
@@ -533,7 +542,7 @@
 		ignitionReliabilityEnd = 0.991189
 		cycleReliabilityStart = 0.944198
 		cycleReliabilityEnd = 0.991189
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-5,LR105-NA-3:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-5]/ratedBurnTime$ } }
 }
@@ -563,7 +572,7 @@
 		ignitionReliabilityEnd = 0.987581
 		cycleReliabilityStart = 0.921346
 		cycleReliabilityEnd = 0.987581
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-5,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-6] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-6]/ratedBurnTime$ } }
 }
@@ -581,7 +590,7 @@
 		ignitionReliabilityEnd = 0.993636
 		cycleReliabilityStart = 0.963661
 		cycleReliabilityEnd = 0.993636
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-6,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.1]/ratedBurnTime$ } }
 }
@@ -599,7 +608,7 @@
 		ignitionReliabilityEnd = 0.993636
 		cycleReliabilityStart = 0.963661
 		cycleReliabilityEnd = 0.993636
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-5,LR105-NA-3,LR105-NA-5,LR105-NA-6,LR105-NA-7.1:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-7.1,LR105-NA-6,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.2]/ratedBurnTime$ } }
 }
@@ -618,7 +627,7 @@
 		ignitionReliabilityEnd = 0.999211
 		cycleReliabilityStart = 0.995000
 		cycleReliabilityEnd = 0.999211
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-5,LR105-NA-5,LR105-NA-6,LR105-NA-7.1,LR105-NA-7.2,RS-27,RS-27A:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&RS-27,RS-27A,LR105-NA-7.2,LR105-NA-7.1,LR105-NA-6,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-56-OSA] { %ratedBurnTime = #$/TESTFLIGHT[RS-56-OSA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
@@ -73,6 +73,8 @@
 	@manufacturer = Pratt & Whitney
 	@description = Staged combustion sustainer engine developed for the USAF ISINGLASS spaceplane. After the ISINGLASS project was cancelled, it was adapted by P&W for their SSME proposal. It utilized staged combustion, mixture control and extendable nozzles to allow for versitility and high performance.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -100,7 +102,7 @@
 		{
 			name = XLR129-P-1
 			description = Prototype for USAF ISINGLASS rocketplane
-			//prototype
+			specLevel = prototype
 			minThrust = 682		//Limit min thrust to 65% in SL mode to simulate flow separation
 			maxThrust = 1049.2
 			PROPELLANT
@@ -146,7 +148,7 @@
 		{
 			name = LR129-P-1
 			description = Production model for USAF ISINGLASS rocketplane
-			//concept
+			specLevel = concept
 			minThrust = 687		//Limit min thrust to 65% in SL mode to simulate flow separation
 			maxThrust = 1056.9
 			PROPELLANT
@@ -192,6 +194,7 @@
 		{
 			name = LR129-P-2
 			description = P&W proposal for Space Shuttle Main Engine
+			specLevel = concept
 			minThrust = 778.5
 			maxThrust = 1556.9
 			massMult = 1.39	//Guess, try to keep similar TWR
@@ -238,6 +241,7 @@
 		{
 			name = LR129-P-3
 			description = Speculative upgrade
+			specLevel = speculative
 			minThrust = 809.6
 			maxThrust = 1619.2
 			massMult = 1.39	//Guess
@@ -337,7 +341,7 @@
 		ignitionReliabilityEnd = 0.991176
 		cycleReliabilityStart = 0.897059
 		cycleReliabilityEnd = 0.979412
-		techTransfer = XLR129-P-1,LR129-P-1:50
+		techTransfer = LR129-P-1,XLR129-P-1:50
 	}
 	@MODULE[ModuleBimodalEngineConfigs] { @CONFIG[LR129-P-2] { %ratedBurnTime = #$/TESTFLIGHT[LR129-P-2]/ratedBurnTime$ } }
 }
@@ -351,7 +355,7 @@
 		ignitionReliabilityEnd = 0.9995
 		cycleReliabilityStart = 0.9415
 		cycleReliabilityEnd = 0.9995
-		techTransfer = XLR129-P-1,LR129-P-1,LR129-P-2:50
+		techTransfer = LR129-P-2,LR129-P-1,XLR129-P-1:50
 	}
 	@MODULE[ModuleBimodalEngineConfigs] { @CONFIG[LR129-P-3] { %ratedBurnTime = #$/TESTFLIGHT[LR129-P-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -113,6 +113,8 @@
 	%manufacturer = Rocketdyne
 	%description = Long-lasting US Kerolox gas-generator booster engine. The same components and broadly the same performance as the LR89, the LR79 (also known as S-3D in Jupiter / Juno II) powered Jupiter, Thor, and Thor-Delta (Delta) rockets.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -141,6 +143,7 @@
 		{
 			name = S-3
 			description = Main R&D engine for the early Thor DM-18 variant
+			specLevel = operational
 			// See calculation above. Previous reference from Ed Kyle was correct, but was SL thrust only
 			minThrust = 696.6
 			// OLD REFERENCE-NO LONGER USED: https://forum.nasaspaceflight.com/index.php?PHPSESSID=br6ak5uvm7sfiqsbqv53ej40g4&topic=40733.0
@@ -188,6 +191,7 @@
 		{
 			name = S-3D
 			description = Main engine for the Jupiter / Juno II launch vehicle
+			specLevel = operational
 			minThrust = 766.34
 			maxThrust = 766.34
 			heatProduction = 100
@@ -233,6 +237,7 @@
 		{
 			name = LR79-NA-9
 			description = Main engine for MB-3-I propulsion system
+			specLevel = operational
 			minThrust = 783
 			// SAME REFERENCE, BUT WHOEVER DID THE MATH DID IT WRONG
 			// 176,000 lbf * 0.00444822 = 782.88672 kN
@@ -284,6 +289,7 @@
 		{
 			name = LR79-NA-11
 			description = Main engine for MB-3-II propulsion system
+			specLevel = operational
 			minThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			maxThrust = 850	// 1961 NASA Launch Vehicle Handbook.  See RO/Github #804 for details
 			heatProduction = 100
@@ -332,6 +338,7 @@
 		{
 			name = LR79-NA-13
 			description = Main engine for MB-3-III propulsion system
+			specLevel = operational
 			minThrust = 873	// Source #6
 			maxThrust = 873	// Source #6
 			heatProduction = 100
@@ -398,7 +405,7 @@
 		ignitionReliabilityEnd = 0.962903
 		cycleReliabilityStart = 0.765054
 		cycleReliabilityEnd = 0.962903
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3:50	//Direct derivative of LR43
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&XLR43-NA-3:50	//Direct derivative of LR43
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[S-3] { %ratedBurnTime = #$/TESTFLIGHT[S-3]/ratedBurnTime$ } }
 }
@@ -418,7 +425,7 @@
 		ignitionReliabilityEnd = 0.969444
 		cycleReliabilityStart = 0.806481
 		cycleReliabilityEnd = 0.969444
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,S-3:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&S-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[S-3D] { %ratedBurnTime = #$/TESTFLIGHT[S-3D]/ratedBurnTime$ } }
 }
@@ -458,7 +465,7 @@
 		ignitionReliabilityEnd = 0.975
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.975
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,S-3,S-3D:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&S-3D,S-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-9] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-9]/ratedBurnTime$ } }
 }
@@ -485,7 +492,7 @@
 		ignitionReliabilityEnd = 0.986036
 		cycleReliabilityStart = 0.911562
 		cycleReliabilityEnd = 0.986036
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,S-3,S-3D,LR79-NA-9:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR79-NA-9,S-3D,S-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-11] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-11]/ratedBurnTime$ } }
 }
@@ -532,7 +539,7 @@
 		ignitionReliabilityEnd = 0.992211
 		cycleReliabilityStart = 0.950670
 		cycleReliabilityEnd = 0.992211
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,S-3,S-3D,LR79-NA-9,LR79-NA-11:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR79-NA-11,LR79-NA-9,S-3D,S-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR79-NA-13] { %ratedBurnTime = #$/TESTFLIGHT[LR79-NA-13]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
@@ -37,7 +37,9 @@
 	%title = LR83 Booster Engine
 	%manufacturer = Rocketdyne
 	%description = LOX/Kerosene rocket engine. Designed for booster applications. Gas generator, pump-fed. Three gimbaled engines would have been used in the Navaho booster.
-	
+
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = XLR83-NA-1
+			specLevel = prototype
 			minThrust = 1801.5
 			maxThrust = 1801.5
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2.cfg
@@ -13,6 +13,8 @@
 	%manufacturer = Aerojet
 	%description = Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. Aerojet also proposed this engine for Saturn upper stage duties, but NASA selected the J-2 over the LR87-LH2, however, and it was canceled in 1961.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -39,6 +41,7 @@
 		{
 			name = LR87-LH2-TitanC
 			description = Developed for Titan C
+			specLevel = prototype
 			minThrust = 667.0
 			maxThrust = 667.0
 			heatProduction = 175
@@ -64,6 +67,7 @@
 		{
 			name = LR87-LH2-Vacuum
 			description = Developed as Aerojets proposal for the Saturn V upper stage engines. It could be ready much earlier than its competition, but the J-2 was chosen due to its higher performance.
+			specLevel = concept
 			minThrust = 778.0
 			maxThrust = 778.0
 			heatProduction = 175
@@ -90,6 +94,7 @@
 		{
 			name = LR87-LH2-SustainerUpgrade
 			description = Speculative upgrade for Titan C
+			specLevel = speculative
 			minThrust = 801 // 180 klbf
 			maxThrust = 801
 			heatProduction = 175
@@ -117,6 +122,7 @@
 		{
 			name = LR87-LH2-VacuumUpgrade
 			description = Speculative upgrade for use on later Saturn V missions
+			specLevel = speculative
 			minThrust = 889.0
 			maxThrust = 889.0
 			heatProduction = 175

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_X2_Config.cfg
@@ -118,7 +118,9 @@
 	%title = LR87 Booster
 	%manufacturer = Aerojet
 	%description = Used in the first stage of the Titan rocket family, the LR87 is composed of two engines with separate turbomachinery integrated into one unit. The version used on Titan I burned kerosene and liquid oxygen, while Titan II through Titan IV burned storable propellants. A modified version burning liquid hydrogen was developed for the upper stages of Saturn V and Saturn IB, but the J-2 was selected instead.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -150,6 +152,7 @@
 			// [5]
 			name = LR87-AJ-3
 			description = First stage engine for the Titan I ICBM
+			specLevel = operational
 			minThrust = 765.95
 			maxThrust = 765.95
 			heatProduction = 100
@@ -186,6 +189,7 @@
 			// late model -5s.
 			name = LR87-AJ-5
 			description = First stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
+			specLevel = operational
 			minThrust = 1053.8
 			maxThrust = 1053.8
 			heatProduction = 100
@@ -218,6 +222,7 @@
 		{
 			// using Gemini mission reports here, with 7's vac Isp
 			name = LR87-AJ-7
+			specLevel = operational
 			description = First stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
 			minThrust = 1097.2
 			maxThrust = 1097.2
@@ -253,6 +258,7 @@
 			// Let's claim 450klbf, 298/262 for the 12 AR nozzle.
 			name = LR87-AJ-9
 			description = First stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
+			specLevel = operational
 			minThrust = 1172.1
 			maxThrust = 1172.1
 			heatProduction = 100
@@ -285,6 +291,7 @@
 		{
 			name = LR87-AJ-11
 			description = First stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Modified to light in midair, since the UA120x boosters used by Titan III could lift Titan without assistance. Ignited just before booster burnout.
+			specLevel = operational
 			minThrust = 1170
 			maxThrust = 1170
 			heatProduction = 100
@@ -317,6 +324,7 @@
 		{
 			name = LR87-AJ-11A
 			description = First stage engine for Titan IVA and IVB. Equipped with a nozzle extension to improve vacuum performance, since it was not needed at sea level.
+			specLevel = operational
 			minThrust = 1225.3
 			maxThrust = 1225.3
 			heatProduction = 100
@@ -349,6 +357,7 @@
 		{
 			name = LR87-AJ-9-Kero
 			description = Speculative config using equivalent technology to the -AJ-9 but burning Kerosene and LOX for purely civilian applications.
+			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
 			minThrust = 1016
 			maxThrust = 1016
@@ -383,6 +392,7 @@
 		{
 			name = LR87-AJ-9-Kero-15AR
 			description = Speculative config converted back to burning Kerosene and LOX to increase safety and performance, for a purely non-military design. Equipped with nozzle extensions to increase vacuum performance
+			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
 			minThrust = 1030
 			maxThrust = 1030
@@ -480,7 +490,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
-		techTransfer = XLR43-NA-3:25&LR87-AJ-3,LR87-AJ-5:50
+		techTransfer = XLR43-NA-3:25&LR87-AJ-5,LR87-AJ-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-7] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-7]/ratedBurnTime$ } }
 }
@@ -504,7 +514,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
-		techTransfer = XLR43-NA-3:25&LR87-AJ-3,LR87-AJ-5,LR87-AJ-7:50
+		techTransfer = XLR43-NA-3:25&LR87-AJ-7,LR87-AJ-5,LR87-AJ-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-9] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-9]/ratedBurnTime$ } }
 }
@@ -525,7 +535,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
-		techTransfer = XLR43-NA-3:25&LR87-AJ-5,LR87-AJ-7:20&LR87-AJ-3:50&LR87-AJ-9-Kero:100
+		techTransfer = XLR43-NA-3:25&LR87-AJ-7,LR87-AJ-5:20&LR87-AJ-3:50&LR87-AJ-9-Kero:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-9-Kero-15AR] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-9-Kero-15AR]/ratedBurnTime$ } }
 }
@@ -546,7 +556,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
-		techTransfer = XLR43-NA-3:25&LR87-AJ-5,LR87-AJ-7:20&LR87-AJ-3:50&LR87-AJ-9-Kero-15AR:100
+		techTransfer = XLR43-NA-3:25&LR87-AJ-7,LR87-AJ-5:20&LR87-AJ-3:50&LR87-AJ-9-Kero-15AR:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-9-Kero] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-9-Kero]/ratedBurnTime$ } }
 }
@@ -578,7 +588,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
-		techTransfer = XLR43-NA-3:25&LR87-AJ-3,LR87-AJ-5,LR87-AJ-7,LR87-AJ-9:50
+		techTransfer = XLR43-NA-3:25&LR87-AJ-9,LR87-AJ-5,LR87-AJ-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-11] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-11]/ratedBurnTime$ } }
 }
@@ -606,7 +616,7 @@
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
-		techTransfer = XLR43-NA-3:25&LR87-AJ-3,LR87-AJ-5,LR87-AJ-7,LR87-AJ-9,LR87-AJ-11:50
+		techTransfer = XLR43-NA-3:25&LR87-AJ-11,LR87-AJ-9,LR87-AJ-5,LR87-AJ-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR87-AJ-11A] { %ratedBurnTime = #$/TESTFLIGHT[LR87-AJ-11A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -153,6 +153,8 @@
 	%manufacturer = Rocketdyne
 	%description = Beginning its life as the high-test-ethanol/LOX powered XLR43-NA-3, this engine was the first in the US to use tubular-wall construction for its combustion chamber, and served as the basis for the early orbital engines of the US, with its lineage carrying on all the way to the 21st century. The LR43 was converted to run on kerosene for Atlas and was later renamed LR89, and the LR79 derivative powered Thor. Late model LR89s were upgraded with RS-27 components for higher efficiency, whereas the RS-27 itself was used on Delta by that point. LR89 configs are comparable to similar-era -79 configs, since they were the same engine underneath.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -182,6 +184,7 @@
 		{
 			name = XLR43-NA-3
 			description = Uprated XLR43 for later Navaho applications. First US engine to use tubular wall, aka spaghetti, thrust chamber which greatly reduced weight. Also first to use a gas generator, removing the need for HTP to power the turbopump.
+			specLevel = operational
 			minThrust = 617.4
 			maxThrust = 617.4
 			massMult = 0.79
@@ -219,6 +222,7 @@
 		{
 			name = LR43-NA-3
 			description = MA-0 and prototype MA-1 Atlas Booster engine, converted to burn kerosene. Used on Convair X12 and Atlas A
+			specLevel = operational
 			minThrust = 756.8
 			maxThrust = 756.8
 			heatProduction = 100
@@ -264,6 +268,7 @@
 		{
 			name = LR89-NA-3
 			description = MA-1 Atlas booster engine. Significantly upgraded and simplified, with both engines sharing turbopumps. Used on Atlas B/C
+			specLevel = operational
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
@@ -309,6 +314,7 @@
 		{
 			name = LR89-NA-5
 			description = MA-3 Atlas booster engine. Each engine had its own turbopump allow for engines to be quickly swapped. Developed for the USAF for Atlas D
+			specLevel = operational
 			minThrust = 831.4
 			maxThrust = 831.4
 			heatProduction = 100
@@ -354,6 +360,7 @@
 		{
 			name = LR89-NA-6
 			description = MA-3 Atlas booster engine. Slightly upgraded for Atlas E/F
+			specLevel = operational
 			minThrust = 846.6
 			maxThrust = 846.6
 			heatProduction = 100
@@ -399,6 +406,7 @@
 		{
 			name = LR89-NA-7.1
 			description = MA-5.1 booster engine. Both engines shared turbopumps due to NASA preferring that configuration. Used for Atlas-Agena launches
+			specLevel = operational
 			minThrust = 931.7
 			maxThrust = 931.7
 			heatProduction = 100
@@ -442,6 +450,7 @@
 		{
 			name = LR89-NA-7.2
 			description = MA-5.2 booster engine. Both engines shared turbopumps due to NASA preferring that configuration. Used for Atlas-Centaur launches
+			specLevel = operational
 			minThrust = 950.8
 			maxThrust = 950.8
 			heatProduction = 100
@@ -487,6 +496,7 @@
 		{
 			name = RS-56-OBA
 			description = Atlas MA-5A booster engine. Upgraded with RS-27 components to reduce cost and improve performance. Used on Atlas II
+			specLevel = operational
 			minThrust = 1067.5
 			maxThrust = 1067.5
 			%gimbalRange = 8.5 // [A]
@@ -553,7 +563,7 @@
 		ignitionReliabilityEnd = 0.958696
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.958696
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR43-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[XLR43-NA-3]/ratedBurnTime$ } }
 }
@@ -574,7 +584,7 @@
 		ignitionReliabilityEnd = 0.962766
 		cycleReliabilityStart = 0.764184
 		cycleReliabilityEnd = 0.962766
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&XLR43-NA-3:50	//LR43 was an XLR43 modified to burn kerosene.
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR43-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR43-NA-3]/ratedBurnTime$ } }
 }
@@ -593,7 +603,7 @@
 		ignitionReliabilityEnd = 0.960526
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.960526
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-3:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR43-NA-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-3] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-3]/ratedBurnTime$ } }
 }
@@ -632,7 +642,7 @@
 		ignitionReliabilityEnd = 0.991189
 		cycleReliabilityStart = 0.944198
 		cycleReliabilityEnd = 0.991189
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-3,LR89-NA-3:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR89-NA-3,LR43-NA-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-5] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-5]/ratedBurnTime$ } }
 }
@@ -664,7 +674,7 @@
 		ignitionReliabilityEnd = 0.987581
 		cycleReliabilityStart = 0.921346
 		cycleReliabilityEnd = 0.987581
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR89-NA-5,LR89-NA-3,LR43-NA-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-6] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-6]/ratedBurnTime$ } }
 }
@@ -684,7 +694,7 @@
 		ignitionReliabilityEnd = 0.993636
 		cycleReliabilityStart = 0.959697
 		cycleReliabilityEnd = 0.993636
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR89-NA-6,LR89-NA-5,LR89-NA-3,LR43-NA-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-7.1]/ratedBurnTime$ } }
 }
@@ -704,7 +714,7 @@
 		ignitionReliabilityEnd = 0.993636
 		cycleReliabilityStart = 0.959697
 		cycleReliabilityEnd = 0.993636
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-3,LR89-NA-3,LR89-NA-5,LR89-NA-6,LR89-NA-7.1:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR89-NA-7.1,LR89-NA-6,LR89-NA-5,LR89-NA-3,LR43-NA-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR89-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR89-NA-7.2]/ratedBurnTime$ } }
 }
@@ -725,7 +735,7 @@
 		ignitionReliabilityEnd = 0.999211
 		cycleReliabilityStart = 0.995000
 		cycleReliabilityEnd = 0.999211
-		techTransfer = XLR43-NA-1,A-6,A-6H,A-7:20&XLR43-NA-3,LR43-NA-3,LR89-NA-7.1,LR89-NA-7.2,RS-27,RS-27A:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&RS-27,RS-27A,LR89-NA-7.2,LR89-NA-7.1,LR89-NA-6,LR89-NA-5,LR89-NA-3,LR43-NA-3,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-56-OBA] { %ratedBurnTime = #$/TESTFLIGHT[RS-56-OBA]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -116,6 +116,8 @@
 	%manufacturer = Aerojet
 	%description = The LR91 powered the second stage of Titan launchers. Exhaust from the gas generator provided roll control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -144,6 +146,7 @@
 			// [5]
 			name = LR91-AJ-3
 			description = Second stage engine for the Titan I ICBM.
+			specLevel = operational
 			minThrust = 362.87
 			maxThrust = 362.87 // added the Verniers back to the thrust
 			heatProduction = 100
@@ -178,6 +181,7 @@
 			// [5]
 			name = LR91-AJ-5
 			description = Second stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
+			specLevel = operational
 			minThrust = 448.2
 			maxThrust = 448.2 // added the Verniers back to the thrust
 			heatProduction = 160
@@ -212,6 +216,7 @@
 			// Gemini 8 data
 			name = LR91-AJ-7
 			description = Second stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
+			specLevel = operational
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
 			heatProduction = 160
@@ -245,6 +250,7 @@
 		{
 			name = LR91-AJ-9
 			description = Second stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
+			specLevel = operational
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
 			heatProduction = 160
@@ -278,6 +284,7 @@
 		{
 			name = LR91-AJ-11
 			description = Second stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Slightly improved performance.
+			specLevel = operational
 			minThrust = 456.1
 			maxThrust = 456.1 // added the Verniers back to the thrust
 			heatProduction = 160
@@ -311,6 +318,7 @@
 		{
 			name = LR91-AJ-11A
 			description = Second stage engine for Titan IVA and IVB. Slightly improved performance
+			specLevel = operational
 			minThrust = 474.6
 			maxThrust = 474.6 // added the Verniers back to the thrust
 			heatProduction = 160
@@ -353,6 +361,7 @@
 		{
 			name = LR91-AJ-9-Kero
 			description = Speculative config using equivalent technology to the -AJ-9 but burning Kerosene and LOX for purely civilian applications.
+			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
 			minThrust = 398.7
 			maxThrust = 398.7 // added the Verniers back to the thrust
@@ -450,7 +459,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = LR91-AJ-5:50
+		techTransfer = LR91-AJ-5:50&LR91-AJ-3:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-7] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-7]/ratedBurnTime$ } }
 }
@@ -475,7 +484,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = LR91-AJ-5,LR91-AJ-7:50
+		techTransfer = LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-9] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-9]/ratedBurnTime$ } }
 }
@@ -496,7 +505,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = LR91-AJ-5,LR91-AJ-7:20&LR91-AJ-3:50
+		techTransfer = LR91-AJ-7,LR91-AJ-5:20&LR91-AJ-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-9-Kero] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-9-Kero]/ratedBurnTime$ } }
 }
@@ -529,7 +538,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = LR91-AJ-5,LR91-AJ-7,LR91-AJ-9:50
+		techTransfer = LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-11] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-11]/ratedBurnTime$ } }
 }
@@ -557,7 +566,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = LR91-AJ-5,LR91-AJ-7,LR91-AJ-9,LR91-AJ-11:50
+		techTransfer = LR91-AJ-11,LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR91-AJ-11A] { %ratedBurnTime = #$/TESTFLIGHT[LR91-AJ-11A]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/LRBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LRBE_Config.cfg
@@ -40,6 +40,8 @@
 	%manufacturer = Rocketdyne
 	%description = Developed from the RS-25 SSME, the Liquid Rocket Booster Engine (LRBE) was a design concept for a liquid fuelled space shuttle booster. Methane fuel was chosen, which increased density and thrust, while still allowing fuel-rich staged combustion operation.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -69,7 +71,7 @@
 		{
 			name = LRBE
 			//description = Phase I SSME+
-			//concept
+			specLevel = concept
 			minThrust = 1579
 			maxThrust = 2429
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M1_Config.cfg
@@ -103,6 +103,8 @@
 	%manufacturer = Aerojet
 	@description = The massive M-1 engine. The largest, most powerful, LH2/LOX engine ever designed. Individual components have been tested. Generally designed as an upper stage engine, first stages designs with expanding nozzles were being worked on.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -130,6 +132,7 @@
 		{
 			name = M-1-Spec
 			description = Initial version of the M-1, generating 1.2 mlbf of thrust
+			specLevel = prototype
 			minThrust = 5337.866
 			maxThrust = 5337.866
 			heatProduction = 100
@@ -162,6 +165,7 @@
 		{
 			name = M-1
 			description = Production version of the M-1, generating 1.5 mlbf of thrust
+			specLevel = prototype
 			minThrust = 6672.332
 			maxThrust = 6672.332
 			heatProduction = 100
@@ -194,6 +198,7 @@
 		{
 			name = M-1SL
 			description = 1990s proposal to convert the M-1 into a sea level sustainer engine for super-heavy launch vehicles
+			specLevel = concept
 			minThrust = 6928
 			maxThrust = 6928
 			heatProduction = 100
@@ -227,6 +232,7 @@
 		{
 			name = M-1U
 			description = M-1, uprated to 1.8 mlbf. All M-1 components were designed to handle 1200 psi chamber to allow this upgrade.
+			specLevel = concept
 			minThrust = 8006.799
 			maxThrust = 8006.799
 			heatProduction = 100
@@ -259,6 +265,7 @@
 		{
 			name = M-1U-SL
 			description = Sea level M-1, but running at 1200 psi chamber pressure.
+			specLevel = speculative
 			minThrust = 7708.87
 			maxThrust = 7708.87
 			heatProduction = 100
@@ -334,7 +341,7 @@
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
 		cycleReliabilityEnd = 0.9999
-		techTransfer = M-1-Spec,M-1:50
+		techTransfer = M-1,M-1-Spec:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1SL] { %ratedBurnTime = #$/TESTFLIGHT[M-1SL]/ratedBurnTime$ } }
 }
@@ -350,7 +357,7 @@
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
 		cycleReliabilityEnd = 0.9999
-		techTransfer = M-1-Spec,M-1,M-1SL:50
+		techTransfer = M-1SL,M-1,M-1-Spec:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1U] { %ratedBurnTime = #$/TESTFLIGHT[M-1U]/ratedBurnTime$ } }
 }
@@ -366,7 +373,7 @@
 		ignitionReliabilityEnd = 0.9999
 		cycleReliabilityStart = 0.9440
 		cycleReliabilityEnd = 0.9999
-		techTransfer = M-1-Spec,M-1,M-1SL:50
+		techTransfer = M-1U,M-1SL,M-1,M-1-Spec:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[M-1U-SL] { %ratedBurnTime = #$/TESTFLIGHT[M-1U-SL]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/M55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/M55_Config.cfg
@@ -36,6 +36,8 @@
 	@manufacturer = Thiokol
 	@description = First stage of the Minuteman ICBM, used in various proposed NASA launch vehicles as a solid booster. Burn time 75 seconds.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -72,6 +74,7 @@
 		CONFIG
 		{
 			name = M55
+			specLevel = operational
 			minThrust = 876
 			maxThrust = 876
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/MB35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB35_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Mitsubishi Heavy Industries
 	%description = 2000s Low TWR Expander bleed cycle vacuum engine. Mitsubishi and Boeing joint project for an engine for Delta IV cryogenic upper stages.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = MB-35
+			specLevel = concept
 			maxThrust = 155.7
 			minThrust = 155.7
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/MB45_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB45_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Mitsubishi Heavy Industries
 	%description = 2000s Low TWR Expander bleed cycle vacuum engine. Mitsubishi and Boeing joint project for an engine for Delta IV cryogenic upper stages.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = MB-XX-Demo
+			specLevel = prototype
 			maxThrust = 177.9
 			minThrust = 177.9
 			PROPELLANT
@@ -93,6 +96,7 @@
 		CONFIG
 		{
 			name = MB-45
+			specLevel = concept
 			maxThrust = 200.2
 			minThrust = 200.2
 			PROPELLANT
@@ -151,6 +155,7 @@
 		ignitionReliabilityEnd = 0.99995
 		cycleReliabilityStart = 0.985
 		cycleReliabilityEnd = 0.99995
+		techTransfer = MB-XX-Demo:50
 		
 		ignitionDynPresFailMultiplier = 0.05
 

--- a/GameData/RealismOverhaul/Engine_Configs/MB60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MB60_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Mitsubishi Heavy Industries
 	%description = 2000s Low TWR Expander bleed cycle vacuum engine. Mitsubishi and Boeing joint project for an engine for Delta IV cryogenic upper stages.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = MB-60
+			specLevel = concept
 			maxThrust = 266.9
 			minThrust = 266.9
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
@@ -36,6 +36,8 @@
 	@manufacturer = Aerojet Rocketdyne
 	@description = The Mars Landing Engine (MLE) is a derivative of the highly successful MR-80 engine used for the two Viking missions to Mars in 1976. Eight of these engines where used on the sky-crane which landed the Curiosity Rover on the martian surface.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -57,6 +59,7 @@
 		CONFIG
 		{
 			name = MR-80B
+			specLevel = operational
 			minThrust = 0.031
 			maxThrust = 3.603
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -188,6 +188,8 @@
 	%manufacturer = SpaceX
 	%description = The whole family of Merlin 1 rocket engines, made by SpaceX.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -215,6 +217,7 @@
 		{
 			name = Merlin1A
 			description = Used on Falcon 1 first stage
+			specLevel = operational
 			minThrust = 369.2
 			maxThrust = 369.2
 			heatProduction = 58
@@ -260,6 +263,7 @@
 		CONFIG
 		{
 			name = Merlin1B
+			specLevel = prototype
 			minThrust = 394.6
 			maxThrust = 394.6
 			heatProduction = 64
@@ -305,6 +309,7 @@
 		CONFIG
 		{
 			name = Merlin1BVac
+			specLevel = prototype
 			minThrust = 421.6
 			maxThrust = 421.6
 			heatProduction = 63
@@ -351,6 +356,7 @@
 		{
 			name = Merlin1C
 			description = Used on Falcon 9 Block 1 (v1.0)
+			specLevel = operational
 			minThrust = 482.63
 			maxThrust = 482.63
 			heatProduction = 96
@@ -397,6 +403,7 @@
 		{
 			name = Merlin1CVac
 			description = Used on Falcon 9 Block 1 (v1.0)
+			specLevel = operational
 			minThrust = 314.94
 			maxThrust = 524.9		// [9]
 			heatProduction = 76
@@ -443,6 +450,7 @@
 		{
 			name = Merlin1D
 			description = Used on Falcon 9 v1.1
+			specLevel = operational
 			minThrust = 290
 			maxThrust = 742.4
 			heatProduction = 196
@@ -489,6 +497,7 @@
 		{
 			name = Merlin1D+
 			description = Used on Falcon 9 v1.2 (Full Thrust)
+			specLevel = operational
 			minThrust = 330
 			maxThrust = 825			//[2]
 			heatProduction = 225
@@ -535,6 +544,7 @@
 		{
 			name = Merlin1D++		// Uprated again, slated to fly in mid/late 2016.
 			description = Used on Falcon 9 Block 5
+			specLevel = operational
 			minThrust = 330			// [5]
 			maxThrust = 914.12		// [3]
 			heatProduction = 248
@@ -581,6 +591,7 @@
 		{
 			name = Merlin1DVac
 			description = Used on Falcon 9 v1.1
+			specLevel = operational
 			minThrust = 360
 			maxThrust = 805
 			heatProduction = 233
@@ -626,6 +637,7 @@
 		{
 			name = Merlin1DVac+
 			description = Used on Falcon 9 v1.2 (Full Thrust and Block 5)
+			specLevel = operational
 			minThrust = 360
 			maxThrust = 934.12		 // [2]
 			heatProduction = 225
@@ -707,7 +719,7 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.90
 		cycleReliabilityEnd = 0.99
-		techTransfer = Merlin1A:50
+		techTransfer = Merlin1A:50&Merlin1BVac:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1B] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1B]/ratedBurnTime$ } }
 }
@@ -723,7 +735,7 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.90
 		cycleReliabilityEnd = 0.99
-		techTransfer = Merlin1A,Merlin1B:50
+		techTransfer = Merlin1A:50&Merlin1B:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1BVac] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1BVac]/ratedBurnTime$ } }
 }
@@ -743,7 +755,7 @@
 		ignitionReliabilityEnd = 0.992391
 		cycleReliabilityStart = 0.951812
 		cycleReliabilityEnd = 0.992391
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac:50
+		techTransfer = Merlin1BVac,Merlin1B,Merlin1A:50&Merlin1CVac:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1C] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1C]/ratedBurnTime$ } }
 }
@@ -764,7 +776,7 @@
 		ignitionReliabilityEnd = 0.975000
 		cycleReliabilityStart = 0.841667
 		cycleReliabilityEnd = 0.975000
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C:50
+		techTransfer = Merlin1BVac,Merlin1B,Merlin1A:50&Merlin1C:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1CVac] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1CVac]/ratedBurnTime$ } }
 }
@@ -786,7 +798,7 @@
 		ignitionReliabilityEnd = 0.997813
 		cycleReliabilityStart = 0.983701
 		cycleReliabilityEnd = 0.997426
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac:50
+		techTransfer = Merlin1CVac,Merlin1C,Merlin1BVac,Merlin1B,Merlin1A:50&Merlin1DVac:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1D] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1D]/ratedBurnTime$ } }
 }
@@ -809,7 +821,7 @@
 		ignitionReliabilityEnd = 0.999622
 		cycleReliabilityStart = 0.997077
 		cycleReliabilityEnd = 0.999538
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D:50
+		techTransfer = Merlin1D,Merlin1CVac,Merlin1C,Merlin1BVac,Merlin1B,Merlin1A:50&Merlin1DVac+:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1D+] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1D+]/ratedBurnTime$ } }
 }
@@ -835,7 +847,7 @@
 		ignitionReliabilityEnd = 0.999760
 		cycleReliabilityStart = 0.995415
 		cycleReliabilityEnd = 0.999276
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D,Merlin1D+:50
+		techTransfer = Merlin1D+,Merlin1D,Merlin1CVac,Merlin1C,Merlin1BVac,Merlin1B,Merlin1A:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1D++] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1D++]/ratedBurnTime$ } }
 }
@@ -859,7 +871,7 @@
 		ignitionReliabilityEnd = 0.994828
 		cycleReliabilityStart = 0.936667
 		cycleReliabilityEnd = 0.990000
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D,Merlin1D+,Merlin1D++:50
+		techTransfer = Merlin1CVac,Merlin1C,Merlin1BVac,Merlin1B,Merlin1A:50&Merlin1D:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1DVac] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1DVac]/ratedBurnTime$ } }
 }
@@ -886,7 +898,7 @@
 		ignitionReliabilityEnd = 0.999315
 		cycleReliabilityStart = 0.991364
 		cycleReliabilityEnd = 0.998636
-		techTransfer = Merlin1A,Merlin1B,Merlin1BVac,Merlin1C,Merlin1CVac,Merlin1D,Merlin1D+,Merlin1D++,Merlin1DVac:50
+		techTransfer = Merlin1DVac,Merlin1D,Merlin1CVac,Merlin1C,Merlin1BVac,Merlin1B,Merlin1A:50&Merlin1D+:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Merlin1DVac+] { %ratedBurnTime = #$/TESTFLIGHT[Merlin1DVac+]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockA_Config.cfg
@@ -5,7 +5,9 @@
 	@title = N1 Block A
 	%manufacturer = SNTK Kuznetsov
 	@description = N1 Block A is first stage of N1. Block A has 30x NK-15 or NK-33 engines.
-	
+
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -16,6 +18,7 @@
 		CONFIG
 		{
 			name = 30x_NK-15
+			specLevel = operational
 			maxThrust = 50308
 			minThrust = 10061// 6 engines
 			PROPELLANT
@@ -39,6 +42,7 @@
 		CONFIG
 		{
 			name = 30x_NK-33
+			specLevel = prototype
 			minThrust = 10092// 6 engines
 			maxThrust = 50460
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockB_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockB_Config.cfg
@@ -5,7 +5,9 @@
 	@title = N1 Block B
 	%manufacturer = SNTK Kuznetsov
 	@description = N1 Block B is second stage of N1. Block B has 8 NK-15V engines.
-	
+
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -16,6 +18,7 @@
 		CONFIG
 		{
 			name = 8x_NK-15V
+			specLevel = operational
 			maxThrust = 13184
 			minThrust = 13184
 			PROPELLANT
@@ -39,6 +42,7 @@
 		CONFIG
 		{
 			name = 8x_NK-43
+			specLevel = prototype
 			minThrust = 7020
 			maxThrust = 14040
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/N1_BlockV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/N1_BlockV_Config.cfg
@@ -5,7 +5,9 @@
 	@title = N1 Block V
 	%manufacturer = SNTK Kuznetsov
 	@description = N1 Block V is third stage of N1. Block V has 4 NK-21 engines.
-	
+
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -16,6 +18,7 @@
 		CONFIG
 		{
 			name = 4x_NK-21
+			specLevel = operational
 			maxThrust = 1608
 			minThrust = 1608
 			PROPELLANT
@@ -39,6 +42,7 @@
 		CONFIG
 		{
 			name = 4x_NK-39
+			specLevel = prototype
 			minThrust = 1628
 			maxThrust = 1628
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -100,6 +100,8 @@
 	%manufacturer = North American Aviation (NAA)
 	%description = The power plant of the PGM-11 Redstone Short Range Ballistic Missile (SRBM). Originally designed for Ethanol/LOX (A-6) it was later adapted to use Hydyne/LOx with approximately 6% higher performance (yet more toxic) for use in Jupiter-C / Juno I. When the Redstone was adapted from Jupiter-C for manned use under the Project Mercury (Mercury-Redstone Launch Vehicle - MRLV), the A-7 was used, with the original Ethalox mixture, accepting a slightly lower performance for the lack of toxicity. Thrust Vector Control (TVC) was provided by carbon thrust vanes and additional attitude control was provided by actuating fins placed in the guidance section.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -128,6 +130,7 @@
 		{
 			name = XLR43-NA-1
 			description = Also known as NAA75-65, XLR43-NA-1 is the USAF service designation. Used for early Navaho applications.
+			specLevel = operational
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
 			minThrust = 383
@@ -176,6 +179,7 @@
 		{
 			name = A-6
 			description = Main production variant for Redstone missile, very similar to USAF XLR43-NA-1 / NAA75-65, except with longer burn time.
+			specLevel = operational
 			minThrust = 383
 			maxThrust = 383
 			heatProduction = 41
@@ -223,6 +227,7 @@
 		{
 			name = A-7
 			description = Later production variant for Redstone missile, also used on Mercury-Redstone with stretched propellant tanks and extra HTP.
+			specLevel = operational
 			minThrust = 395.5
 			maxThrust = 395.5
 			heatProduction = 45
@@ -269,6 +274,7 @@
 		{
 			name = A-6H
 			description = A-6 engine converted to run Hydyne as fuel, used on Jupiter-C sounding rocket and Juno I launch vehicle.
+			specLevel = operational
 			minThrust = 409.36
 			maxThrust = 409.36
 			heatProduction = 45
@@ -368,7 +374,7 @@
 		ignitionReliabilityEnd = 0.974342
 		cycleReliabilityStart = 0.837500
 		cycleReliabilityEnd = 0.974342
-		techTransfer = XLR41-NA-1:25&XLR43-NA-1,A-6,A-6H:50
+		techTransfer = XLR41-NA-1:25&A-6,A-6H,XLR43-NA-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[A-7] { %ratedBurnTime = #$/TESTFLIGHT[A-7]/ratedBurnTime$ } }
 }
@@ -387,7 +393,7 @@
 		ignitionReliabilityEnd = 0.974342
 		cycleReliabilityStart = 0.837500
 		cycleReliabilityEnd = 0.974342
-		techTransfer = XLR41-NA-1:25&XLR43-NA-1,A-6,A-7:50
+		techTransfer = XLR41-NA-1:25&A-6,A-7,XLR43-NA-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[A-6H] { %ratedBurnTime = #$/TESTFLIGHT[A-6H]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NERVAII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVAII_Config.cfg
@@ -38,7 +38,9 @@
 	@title		  = NERVA II
 	@manufacturer = Aerojet
 	@description  = A later 70s atomic engine. Relatively low TWR but high ISP and power generation of 4200 MW. Derived from the Phoebus 2A ground demonstrator, tested in 1968.
-		
+
+	%specLevel = concept
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -50,6 +52,7 @@
 		CONFIG
 		{
 			name = NERVA-II
+			specLevel = concept
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/NERVANRX_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVANRX_Config.cfg
@@ -36,6 +36,8 @@
 	@title = NERVA NRX
 	@manufacturer = Aerojet & Westinghouse
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -47,6 +49,7 @@
 			CONFIG
 		{
 			name = NERVA_NRX-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			minThrust = 122

--- a/GameData/RealismOverhaul/Engine_Configs/NERVAXE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVAXE_Config.cfg
@@ -36,6 +36,8 @@
 	@title = Nerva XE-Prime
 	@manufacturer = Aerojet & Westinghouse
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -47,6 +49,7 @@
 			CONFIG
 		{
 			name = NERVA_XE-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			minThrust = 119

--- a/GameData/RealismOverhaul/Engine_Configs/NERVA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NERVA_Config.cfg
@@ -38,6 +38,8 @@
 	@manufacturer = Aerojet
 	@description = 1970s low TWR vacuum engine. the NERVA (Nuclear Engine for Rocket Vehicle Applications) is designed for orbital tugs and large rocket upper stages.
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -49,6 +51,7 @@
 		CONFIG
 		{
 			name = NERVA-I
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			minThrust = 222 //can't find a good source, just gonna go with this.

--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -74,6 +74,8 @@
 	%manufacturer = SNTK Kuznetsov
 	%description = The NK-15 and NK-33 were originally built in the 1960s/early 1970s for the Soviet N1 and then N1F rocket, respectively. Though the N1F was scrapped, the engines survived. Aerojet acquired several NK-33 engines in the 1990s and refurbished them as AJ26-62 engines for Orbital Science's Antares launch vehicle. Modifications made by Aerojet included increasing rated thrust and equipping the engines to support gimballing.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -100,6 +102,7 @@
 		{
 			name = NK-15
 			description = Developed as the first stage engine of the N-1 moon rocket. Gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 1681 // 378,000 Ibf 
 			minThrust = 841
 			heatProduction = 100
@@ -140,6 +143,7 @@
 		{
 			name = NK-15-Original-NoGimbal
 			description = Developed as the first stage engine of the N-1 moon rocket. No gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 1681
 			minThrust = 841
 			heatProduction = 100
@@ -180,6 +184,7 @@
 		{
 			name = NK-33
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. Gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 1766 //105% rated thrust
 			minThrust = 841
 			heatProduction = 100
@@ -220,6 +225,7 @@
 		{
 			name = NK-33-Original-NoGimbal
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. No gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 1766
 			minThrust = 841
 			heatProduction = 100
@@ -260,6 +266,7 @@
 		{
 			name = AJ26-62
 			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. Formerly used for the Antares-100 series
+			specLevel = operational
 			maxThrust = 1815
 			minThrust = 941.92
 			heatProduction = 100
@@ -326,7 +333,7 @@
 		ignitionReliabilityEnd = 0.985165
 		cycleReliabilityStart = 0.925824
 		cycleReliabilityEnd = 0.985165
-		techTransfer = NK-9,NK-9V,NK-15V,NK-15V-Original-NoGimbal:25
+		techTransfer = NK-15-Original-NoGimbal,NK-15V,NK-15V-Original-NoGimbal:100&NK-9,NK-9V:25
 		
 		reliabilityMidH = 0.65
 	}
@@ -344,7 +351,7 @@
 		ignitionReliabilityEnd = 0.985165
 		cycleReliabilityStart = 0.925824
 		cycleReliabilityEnd = 0.985165
-		techTransfer = NK-9,NK-9V,NK-15V,NK-15V-Original-NoGimbal:25
+		techTransfer = NK-15,NK-15V,NK-15V-Original-NoGimbal:100&NK-9,NK-9V:25
 		
 		reliabilityMidH = 0.65
 	}
@@ -369,7 +376,7 @@
 		ignitionReliabilityEnd = 0.980556
 		cycleReliabilityStart = 0.876852
 		cycleReliabilityEnd = 0.980556
-		techTransfer = NK-15,NK-15-Original-NoGimbal:50
+		techTransfer = NK-33-Original-NoGimbal,NK-43,NK-43-Original-NoGimbal:100&NK-15,NK-15-Original-NoGimbal:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-33] { %ratedBurnTime = #$/TESTFLIGHT[NK-33]/ratedBurnTime$ } }
 }
@@ -385,7 +392,7 @@
 		ignitionReliabilityEnd = 0.980556
 		cycleReliabilityStart = 0.876852
 		cycleReliabilityEnd = 0.980556
-		techTransfer = NK-15,NK-15-Original-NoGimbal:50
+		techTransfer = NK-33,NK-43,NK-43-Original-NoGimbal:100&NK-15,NK-15-Original-NoGimbal:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-33-Original-NoGimbal] { %ratedBurnTime = #$/TESTFLIGHT[NK-33-Original-NoGimbal]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -54,6 +54,8 @@
 	%manufacturer = SNTK Kuznetsov 
 	%description = Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -80,6 +82,7 @@
 		{
 			name = NK-15V
 			description = Developed as the second stage engine of the N-1 moon rocket. Gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 1755
 			minThrust = 877.5
 			heatProduction = 100
@@ -120,6 +123,7 @@
 		{
 			name = NK-15V-Original-NoGimbal
 			description = Developed as the second stage engine of the N-1 moon rocket. No gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 1755
 			minThrust = 877.5
 			heatProduction = 100
@@ -160,6 +164,7 @@
 		{
 			name = NK-43
 			description =  Developed as an upgrade to the NK-15V, and then abandoned with the cancellation of the N-1. Gimbal, differential throttle.
+			specLevel = prototype
 			minThrust = 877.5
 			maxThrust = 1755
 			heatProduction = 100
@@ -200,6 +205,7 @@
 		{
 			name = NK-43-Original-NoGimbal
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. No gimbal, differential throttle.
+			specLevel = prototype
 			maxThrust = 1755
 			minThrust = 877.5
 			heatProduction = 100
@@ -258,7 +264,7 @@
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.85
 		cycleReliabilityEnd = 0.96
-		techTransfer = NK-9,NK-9V,NK-15,NK-15-Original-NoGimbal:25
+		techTransfer = NK-15V-Original-NoGimbal,NK-15,NK-15-Original-NoGimbal:100&NK-9,NK-9V:25
 		
 		reliabilityMidH = 0.65
 	}
@@ -276,7 +282,7 @@
 		ignitionReliabilityEnd = 0.974
 		cycleReliabilityStart = 0.85
 		cycleReliabilityEnd = 0.96
-		techTransfer = NK-9,NK-9V,NK-15,NK-15-Original-NoGimbal:25
+		techTransfer = NK-15V,NK-15,NK-15-Original-NoGimbal:100&NK-9,NK-9V:25
 		
 		reliabilityMidH = 0.65
 	}
@@ -294,7 +300,7 @@
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.996
-		techTransfer = NK-15V,NK-15V-Original-NoGimbal,NK-43-Original-NoGimbal:50
+		techTransfer = NK-43-Original-NoGimbal,NK-33,NK-33-Original-NoGimbal:100&NK-15V,NK-15V-Original-NoGimbal:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-43] { %ratedBurnTime = #$/TESTFLIGHT[NK-43]/ratedBurnTime$ } }
 }
@@ -310,7 +316,7 @@
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.996
-		techTransfer = NK-15V,NK-15V-Original-NoGimbal,NK-43:50
+		techTransfer = NK-43,NK-33,NK-33-Original-NoGimbal:100&NK-15V,NK-15V-Original-NoGimbal:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-43-Original-NoGimbal] { %ratedBurnTime = #$/TESTFLIGHT[NK-43-Original-NoGimbal]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = SNTK Kuznetsov
 	%description = Staged combustion kerolox booster engine. Designed by Kuznetsov for the Korolev GR-1 project. Basis for the NK-15 used on the N1, and the NK-33 used today.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -66,6 +68,7 @@
 		{
 			name = NK-9
 			description = Developed for R-9 ICBM, and later used as the first stage engine for GR-1, the N-1 predecessor.
+			specLevel = prototype
 			maxThrust = 421 // sources differ. Nautix says 441kN for the engine, but 421kN for the GR-1's stage. lpre.de also says 421 kn, so go with this
 			minThrust = 421
 			heatProduction = 205
@@ -104,6 +107,7 @@
 		{
 			name = NK-9-1969
 			description = Speculative upgrade, assuming technologies from the NK-15 were integrated back into the NK-9
+			specLevel = speculative
 			maxThrust = 421
 			minThrust = 421
 			heatProduction = 205
@@ -143,6 +147,7 @@
 		{
 			name = NK-9-1972
 			description = Speculative upgrade, assuming technologies from the NK-33 were integrated back into the NK-9
+			specLevel = speculative
 			maxThrust = 436 // (for same TWR as NK-33 - (1766 / 1459) * 360)
 			minThrust = 436
 			heatProduction = 205
@@ -182,6 +187,7 @@
 		{
 			name = NK-9-2009
 			description = Speculative upgrade, assuming Aerojet purchased and upgraded NK-9s for their own use.
+			specLevel = speculative
 			maxThrust = 448 // (for same TWR as AJ26-62 - (1815 / (1222 * 1.1937)) * 360)
 			minThrust = 448
 			heatProduction = 205
@@ -261,7 +267,7 @@
 		ignitionReliabilityEnd = 0.985165
 		cycleReliabilityStart = 0.925824
 		cycleReliabilityEnd = 0.985165
-		techTransfer = NK-9-1972,NK-9V:50
+		techTransfer = NK-9,NK-9V:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9-1969] { %ratedBurnTime = #$/TESTFLIGHT[NK-9-1969]/ratedBurnTime$ } }
 }
@@ -279,7 +285,7 @@
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.92
 		cycleReliabilityEnd = 0.996
-		techTransfer = NK-9-2009,NK-9V:50
+		techTransfer = NK-9-1969,NK-9,NK-9V:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9-1972] { %ratedBurnTime = #$/TESTFLIGHT[NK-9-1972]/ratedBurnTime$ } }
 }
@@ -297,7 +303,7 @@
 		ignitionReliabilityEnd = 0.996
 		cycleReliabilityStart = 0.96
 		cycleReliabilityEnd = 0.996
-		techTransfer = NK-9V:50
+		techTransfer = NK-9-1972,NK-9-1969,NK-9,NK-9V:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-9-2009] { %ratedBurnTime = #$/TESTFLIGHT[NK-9-2009]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V.cfg
@@ -98,6 +98,8 @@
 	%manufacturer = SNTK Kuznetsov
 	%description = Staged combustion kerolox upper/vacuum engine. Designed by Kuznetsov for the Korolev GR-1 projet. Reused (as NK-19) on the N1, upgraded for the N1F with restart capability as NK-31.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -126,6 +128,7 @@
 		{
 			name = NK-9V
 			description = Original vacuum version of NK-9 for the GR-1 rocket.
+			specLevel = prototype
 			maxThrust = 451.1 // b14643
 			minThrust = 451.1
 			heatProduction = 205
@@ -165,6 +168,7 @@
 		{
 			name = NK-21
 			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
+			specLevel = operational
 			maxThrust = 400 // b14643
 			minThrust = 240 // assume 60% throttle.
 			heatProduction = 205
@@ -204,6 +208,7 @@
 		{
 			name = NK-19
 			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
+			specLevel = operational
 			maxThrust = 400
 			minThrust = 240
 			heatProduction = 205
@@ -243,6 +248,7 @@
 		{
 			name = NK-39
 			description = Improved for N1F Block V. No gimbal, differential throttle.
+			specLevel = prototype
 			maxThrust = 400
 			minThrust = 240 //FIXME guessing 60% min throttle
 			heatProduction = 205
@@ -282,6 +288,7 @@
 		{
 			name = NK-31
 			description = Improved for N1F Block G. Relightable. Gimbal, throttle.
+			specLevel = prototype
 			maxThrust = 402 // b14643
 			minThrust = 240 // assume some level of throttle, engine design was capable, and LH2 replacement engine for this stage had throttle.
 			heatProduction = 205
@@ -372,7 +379,7 @@
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.89
 		cycleReliabilityEnd = 0.975
-		techTransfer = NK-9,NK-9V,NK-19:50
+		techTransfer = NK-19,NK-9V,NK-9:50
 		
 		reliabilityMidH = 0.55
 	}
@@ -392,7 +399,7 @@
 		ignitionReliabilityEnd = 0.98
 		cycleReliabilityStart = 0.89
 		cycleReliabilityEnd = 0.975
-		techTransfer = NK-9,NK-9V,NK-21:50
+		techTransfer = NK-21,NK-19,NK-9V,NK-9:50
 		
 		reliabilityMidH = 0.55
 	}
@@ -412,7 +419,7 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
-		techTransfer = NK-9,NK-9V,NK-19,NK-21,NK-31:50
+		techTransfer = NK-31,NK-21,NK-19,NK-9V,NK-9:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-39] { %ratedBurnTime = #$/TESTFLIGHT[NK-39]/ratedBurnTime$ } }
 }
@@ -430,7 +437,7 @@
 		ignitionReliabilityEnd = 0.99
 		cycleReliabilityStart = 0.94
 		cycleReliabilityEnd = 0.985
-		techTransfer = NK-9V,NK-9,NK-19,NK-21,NK-39:50
+		techTransfer = NK-21,NK-19,NK-9V,NK-9:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[NK-31] { %ratedBurnTime = #$/TESTFLIGHT[NK-31]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Nike_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nike_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = ABL
 	%description = First stage solid rocket motor used on many sounding rockets including Nike-Deacon, Nike-Cajun, Nike-Apache, Nike-Aerobee170, Nike-Aerobee350, and more.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -88,6 +90,7 @@
 		CONFIG
 		{
 			name = Nike-M5E1
+			specLevel = operational
 			maxThrust = 224.46
 			minThrust = 224.46
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -56,6 +56,8 @@
 	%manufacturer = NPO Energomash
 	@description = Very early Soviet rocket engine, designed by Glushko in 1936 for use on the KR-212 cruise missile, and modified for the rocket aircraft RP-318. It was the first reliable, regenerativley cooled rocket.
 
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -66,6 +68,7 @@
 		CONFIG
 		{
 			name = ORM-65
+			specLevel = operational
 			minThrust = 0.510
 			maxThrust = 1.785
 			massMult = 1.0
@@ -103,6 +106,7 @@
 		{
 			name = RDA-1-150
 			description = Simplified ORM-65 for the RP-318 rocket planes
+			specLevel = operational
 			minThrust = 0.499
 			maxThrust = 1.460
 			massMult = 0.86
@@ -145,6 +149,7 @@
 		{
 			name = RDA-1-300
 			description = Uprated RDA-1-300, to allow the RP-318 to take off under its own power. Test site was overrun by the German army before it could be tested.
+			specLevel = prototype
 			minThrust = 0.499
 			maxThrust = 2.942
 			massMult = 0.86
@@ -228,7 +233,7 @@
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.99
-		techTransfer = ORM-65, RDA-1-150:50
+		techTransfer = RDA-1-150,ORM-65:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RDA-1-300] { %ratedBurnTime = #$/TESTFLIGHT[RDA-1-300]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/PEWEE100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/PEWEE100_Config.cfg
@@ -34,7 +34,9 @@
 {
 	@title = Peewee 100 Atomic Rocket Motor
 	@manufacturer = Aerojet
-		
+
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -46,10 +48,11 @@
 			CONFIG
 		{
 			name = PEWEE100-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 22				
-			maxThrust = 111	
+			minThrust = 22
+			maxThrust = 111
 			massMult = 1
 			heatProduction = 12
 			

--- a/GameData/RealismOverhaul/Engine_Configs/Phoebus1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Phoebus1_Config.cfg
@@ -36,6 +36,8 @@
 	@title = Phoebus 1B Atomic Rocket Motor
 	@manufacturer = Aerojet & Westinghouse
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -47,11 +49,12 @@
 			CONFIG
 		{
 			name = Phoebus1N50-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 99				
-			maxThrust = 299				
-			massMult = 1			
+			minThrust = 99
+			maxThrust = 299
+			massMult = 1
 			ignitions = 4
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.

--- a/GameData/RealismOverhaul/Engine_Configs/Phoebus2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Phoebus2_Config.cfg
@@ -36,6 +36,8 @@
 	@title = Phoebus 2A Atomic Rocket Motor
 	@manufacturer = Aerojet & Westinghouse
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -47,11 +49,12 @@
 			CONFIG
 		{
 			name = Phoebus2N100-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 228				
-			maxThrust = 913	
-			massMult = 1			
+			minThrust = 228
+			maxThrust = 913
+			massMult = 1
 			ignitions = 8
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.

--- a/GameData/RealismOverhaul/Engine_Configs/R40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R40_Config.cfg
@@ -57,6 +57,8 @@
 	%manufacturer = Kaiser Marquardt
 	%description = A pressure-fed vacuum hypergolic engine. Used for attitude control on the Space Shuttle (STS).
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = R-40A
+			specLevel = operational
 			minThrust = 3.87
 			maxThrust = 3.87
 			heatProduction = 100
@@ -124,6 +127,7 @@
 		CONFIG
 		{
 			name = R-40A-NTO
+			specLevel = operational
 			minThrust = 3.87
 			maxThrust = 3.87
 			heatProduction = 100
@@ -170,6 +174,7 @@
 		CONFIG
 		{
 			name = R-40B
+			specLevel = operational
 			minThrust = 4.0
 			maxThrust = 4.0
 			heatProduction = 100
@@ -216,6 +221,7 @@
 		CONFIG
 		{
 			name = R-40B-NTO
+			specLevel = operational
 			minThrust = 4.0
 			maxThrust = 4.0
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/R42_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R42_Config.cfg
@@ -58,6 +58,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = A pressure-fed vacuum hypergolic rocket engine, burning either MMH and NTO (R-42) or Hydrazine and NTO (R-42DM). Used as an apogee kick motor for geostationary satellites.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -79,6 +81,7 @@
 		CONFIG
 		{
 			name = R-42
+			specLevel = operational
 			minThrust = 0.89
 			maxThrust = 0.89
 			heatProduction = 100
@@ -124,6 +127,7 @@
 		CONFIG
 		{
 			name = R-42-NTO
+			specLevel = operational
 			minThrust = 0.89
 			maxThrust = 0.89
 			heatProduction = 100
@@ -170,6 +174,7 @@
 		CONFIG
 		{
 			name = R-42DM
+			specLevel = operational
 			minThrust = 0.89
 			maxThrust = 0.89
 			heatProduction = 100
@@ -216,6 +221,7 @@
 		CONFIG
 		{
 			name = R-42DM-NTO
+			specLevel = operational
 			minThrust = 0.89
 			maxThrust = 0.89
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R4D11_Config.cfg
@@ -76,6 +76,8 @@
 	%manufacturer = Aerojet (GenCorp)
 	%description = A 490 N bipropellant thruster as found in the propulsion system of the ESA ATV and the Orion MPCV Service Module. The R-4D HiPAT or High Performance Liquid Apogee Thruster performs orbit-raising manoeuvres for many of the world's communication satellite platforms, including the Astrium Eurostar 3000, Boeing Space Systems 702HP, MELCO DS-2000 & the Loral LS-1300. The R-4D has also played a critical role in NASA missions such as Cassini's orbit insertion of Saturn.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -98,6 +100,7 @@
 		{
 			name = R-4D-11
 			description = 164:1 nozzle ratio version used on the Cassini probe
+			specLevel = operational
 			minThrust = 0.490
 			maxThrust = 0.490
 			heatProduction = 10
@@ -143,6 +146,7 @@
 		{
 			name = HiPAT-445
 			description = 375:1 nozzle ratio version
+			specLevel = operational
 			minThrust = 0.445
 			maxThrust = 0.445
 			heatProduction = 90
@@ -187,6 +191,7 @@
 		{
 			name = HiPAT-445-Dual
 			description = 375:1 nozzle ratio version with improved efficiency
+			specLevel = operational
 			minThrust = 0.445
 			maxThrust = 0.445
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/RD-0410NTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD-0410NTR_Config.cfg
@@ -49,6 +49,8 @@
 	%title = RD-0410
 	%manufacturer = KBKHA
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = RD-0410MID-Hydrogen
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			minThrust = 0
@@ -106,7 +109,8 @@
 		}
 		CONFIG
 		{
-			name = RD-0410MID Methane
+			name = RD-0410MID-Methane
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
 			massMult = 1.02			//Stated in some places as dual mode also(heptane added in hydrogen mode) 

--- a/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0105_Config.cfg
@@ -57,6 +57,8 @@
 	%manufacturer = KB Khimavtomatiki (Kosberg)
 	%description = Kerolox gas generator vacuum engine which served in R-7 upper stages (Luna, Vostok). The RD-0105 was designed for Luna launches; it was the first upper stage for the R-7 series and was reused for uncrewed Vostok tests. An enhanced version, the RD-0109, was used for crewed Vostok launches.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -85,6 +87,7 @@
 		{
 			name = RD-0105
 			description = Modified RD-107 vernier for use as an independent upper stage for the R-7. Used on Luna and early Vostok rockets
+			specLevel = operational
 			minThrust = 49.4
 			maxThrust = 49.4
 			heatProduction = 100
@@ -129,6 +132,7 @@
 		{
 			name = RD-0109
 			description = RD-0105 upgraded with increase reliability and performance for manned flight. Used on Vostok
+			specLevel = operational
 			minThrust = 54.5
 			maxThrust = 54.5
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
@@ -44,6 +44,8 @@
 	%manufacturer = Voronezh Mechanical Plant (VMZ)
 	%description = The RD-0110R is a four-chamber, gas generator, surface kerolox vernier engine. It is used on the first stage of the Soyuz-2-1V launch vehicle family for two-axis attitude control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -74,6 +76,7 @@
 		CONFIG
 		{
 			name = RD-0110R
+			specLevel = operational
 			minThrust = 68.3
 			maxThrust = 68.3
 			gimbalRange = 42.0
@@ -139,7 +142,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.962000
 		cycleReliabilityEnd = 0.994000
-		techTransfer = RD-0107,RD-0110:50
+		techTransfer = RD-0110,RD-0107:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0110R] { %ratedBurnTime = #$/TESTFLIGHT[RD-0110R]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110Vernier_Config.cfg
@@ -45,6 +45,8 @@
 	%manufacturer = Voronezh Mechanical Plant (VMZ)
 	%description = The vernier engine for the RD-0110 power plant. Four of them are used on the Block I upper stage of the Soyuz U and FG launch vehicle variants for attitude control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = RD-0110-Vernier
+			specLevel = operational
 			minThrust = 6.0
 			maxThrust = 6.0
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
@@ -51,7 +51,9 @@
 	%title = RD-0110 Series
 	%manufacturer = KB Khimavtomatika
 	%description = An upper stage Kerosene/LOX engine designed for the Molniya launch vehicle. Also was used with the Voskhod and Soyuz launchers.
-	
+
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -62,6 +64,7 @@
 		{
 			name = RD-0107
 			description = Upper stage for the R-7 developed from the RD-0106 booster engine. Used on Vostok and early Molniya rockets.
+			specLevel = operational
 			maxThrust = 297.9
 			minThrust = 269.69 //90.5%
 			massMult = 1.0
@@ -99,6 +102,7 @@
 		{
 			name = RD-0110
 			description = Developed for the upgraded Molniya-M, and later used on Soyuz.
+			specLevel = operational
 			maxThrust = 298.2
 			minThrust = 269.69 //90.5%
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/RD0120T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120T_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = KB Khimavtomatika
 	%description = 1990s medium TWR, atmospheric and vacuum use. The RD-0120T is a fuel-rich staged combustion tripropellant engine developed from the RD-0120, for use on SSTOs and other high performance vehicles. Tested in collaboration with Aerojet, but never flew.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -86,6 +88,7 @@
 		CONFIG
 		{
 			name = RD0120T
+			specLevel = prototype
 			minThrust = 687.7
 			maxThrust = 1809.8
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0120_Config.cfg
@@ -68,6 +68,8 @@
 	%manufacturer = KB Khimavtomatika
 	%description = 1980s medium TWR, atmospheric and vacuum use. The RD-0120 is a fuel-rich staged combustion engine developed to power the core stage of the Energia launcher.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -95,6 +97,7 @@
 		{
 			name = RD-0120
 			description = Used on core stage of Energia. AKA 11D122
+			specLevel = operational
 			minThrust = 882.45
 			maxThrust = 1961
 			heatProduction = 100
@@ -128,6 +131,7 @@
 		{
 			name = RD-0120M
 			description = Designed for Energia-M, a quarter sized Energia derivative, after the collapse of the Soviet Union ended the Buran program. Tested, but never flew. AKA 11D122A
+			specLevel = prototype
 			minThrust = 745.44
 			maxThrust = 1961.7
 			heatProduction = 100
@@ -161,6 +165,7 @@
 		{
 			name = RD-0122
 			description = Upgraded RD-0120 for later Energia versions. Proposed to power Angara after the cancellation of Energia
+			specLevel = prototype
 			minThrust = 878.9
 			maxThrust = 2313
 			heatProduction = 100
@@ -225,7 +230,7 @@
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.995
-    
+
 		techTransfer = RD-0120:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0120M] { %ratedBurnTime = #$/TESTFLIGHT[RD-0120M]/ratedBurnTime$ } }
@@ -247,7 +252,7 @@
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
 		
-		techTransfer = RD-0120,RD-0120M:50
+		techTransfer = RD-0120M,RD-0120:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0122] { %ratedBurnTime = #$/TESTFLIGHT[RD-0122]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0124_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = KB Khimavtomatika
 	%description = An upper stage Kerosene/LOX engine designed for new versions of the Soyuz-2 launchers. To also be used with the Angara family of launchers.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,6 +63,7 @@
 		CONFIG
 		{
 			name = RD-0124
+			specLevel = operational
 			minThrust = 294.3
 			maxThrust = 294.3
 			heatProduction = 100
@@ -132,7 +135,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.986232
 		cycleReliabilityEnd = 0.997826
-		techTransfer = RD-0110:50
+		techTransfer = RD-0110:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0124] { %ratedBurnTime = #$/TESTFLIGHT[RD-0124]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0146_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = KB Khimavtomatika
 	%description = The first expander cycle engine to be developed in Russia. It was developed in collaboration with Pratt & Whitney, as a high performance upper stage for Proton. It was heavily inspired by the RL10, and some of its design elements were integrated into the RL10.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -79,6 +81,7 @@
 		{
 			name = RD-0146
 			description = High performance upper stage engine for Proton. Tested extensively by KB Khimavtomatika and P&W, but never flew.
+			specLevel = prototype
 			minThrust = 98.1
 			maxThrust = 98.1
 			heatProduction = 100
@@ -111,6 +114,7 @@
 		{
 			name = RD-0146D
 			description = Upgrade, intended for Angara.
+			specLevel = prototype
 			minThrust = 73.5
 			maxThrust = 73.5
 			heatProduction = 100
@@ -179,7 +183,7 @@
 		
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RD-0146
+		techTransfer = RD-0146:50&RL10A-4-1-2:30
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0146D] { %ratedBurnTime = #$/TESTFLIGHT[RD-0146D]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD0162_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0162_Config.cfg
@@ -51,6 +51,8 @@
 	%manufacturer = KB Khimavtomatiki
 	%description = Between 2002 and 2005, KBKhA teamed up with European industry to develop a reusable staged combustion methane engine with a thrust of 200 tons under the Volga project. In 2006, the company started work on a reusable engine designated RD-0162 for the Russian MRKS-1 reusable space booster.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = RD-0162
+			specLevel = prototype
 			minThrust = 995							 //45%
 			maxThrust = 2210
 			heatProduction = 100
@@ -113,6 +116,7 @@
 		{
 			name = RD-0162A
 			description = Variant uprated for 136% thrust.
+			specLevel = prototype
 			minThrust = 1355						 //45%
 			maxThrust = 3011
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = KB Khimavtomatiki
 	%description = Between 2002 and 2005, KBKhA teamed up with European industry to develop a reusable staged combustion methane engine with a thrust of 200 tons under the Volga project. In 2006, the company started work on a reusable engine designated RD-0162 for the Russian MRKS-1 reusable space booster. RD-0164 is higher thrust variant of that engine.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = RD-0164
+			specLevel = concept
 			minThrust = 1725		//45%
 			maxThrust = 3831
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = KB Khimavtomatiki
 	%description = Between 2002 and 2005, KBKhA teamed up with European industry to develop a reusable staged combustion methane engine with a thrust of 200 tons under the Volga project. In 2006, the company started work on a reusable engine designated RD-0162 for the Russian MRKS-1 reusable space booster. RD-0169 is an upper stage derivative of that engine. [2.45 m]
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,6 +63,7 @@
 		CONFIG
 		{
 			name = RD-0169
+			specLevel = concept
 			minThrust = 716
 			maxThrust = 716
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD0203_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0203_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = KB Khimavtomatiki (KBKhA)
 	%description = A staged combustion, hypergolic rocket engine. Used as a power plant on the first stage of the UR-200 rocket, with 3 RD-0203s and 1 RD-0204 forming a RD-0202 engine module. Features a two-axis gimbal mechanism for attitude control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -68,6 +70,7 @@
 		{
 			name = RD-0203
 			description = Used on the UR-200 first stage. AKA 8D44
+			specLevel = operational
 			minThrust = 558.9
 			maxThrust = 558.9
 			gimbalRange = 3.25

--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -59,6 +59,8 @@
 	%manufacturer = KB Khimavtomatiki (KBKhA)
 	%description = A staged combustion, hypergolic vacuum rocket engine. Used as a power plant on the second stage of the Proton launch vehicle family. Features a two-axis gimbal mechanism for attitude control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -86,6 +88,7 @@
 		{
 			name = RD-0208
 			description = Used on the UR-500 second stage. AKA 8D411
+			specLevel = operational
 			minThrust = 574.05
 			maxThrust = 574.05
 			gimbalRange = 3.25
@@ -125,6 +128,7 @@
 		{
 			name = RD-0210
 			description = Slight upgrade for use on the Proton second stage. AKA 8D411K
+			specLevel = operational
 			minThrust = 584.77
 			maxThrust = 584.77
 			gimbalRange = 3.25
@@ -220,7 +224,7 @@
 		ignitionDynPresFailMultiplier = 2	//proton stages pretty low and fast
 		cycleReliabilityStart = 0.992197
 		cycleReliabilityEnd = 0.998768
-		techTransfer = RD-0203,RD-0208:50
+		techTransfer = RD-0213,RD-0212,RD-0208,RD-0203:50
 
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -228,7 +228,7 @@
 		ignitionDynPresFailMultiplier = 2	//proton stages pretty low and fast
 		cycleReliabilityStart = 0.975142
 		cycleReliabilityEnd = 0.996075
-		techTransfer = RD-0203,RD-0205,RD-0208,RD-0210:50
+		techTransfer = RD-0213,RD-0210,RD-0205,RD-0203:50
 
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5

--- a/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
@@ -58,6 +58,8 @@
 	%manufacturer = KB Khimavtomatiki (KBKhA)
 	@description = A staged combustion engine found on the second stage of the UR-200 and third stage of the UR-500/Proton series launcher. It is fixed, and requires its accompanying vernier module for 3-axis control. It uses UDMH & NTO for propellant.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -81,6 +83,7 @@
 		{
 			name = RD-0206
 			description = UR-200 second stage main engine, used with RD-0207 verniers to form the RD-0205 engine module. AKA 8D47
+			specLevel = operational
 			minThrust = 575.5
 			maxThrust = 575.5
 			heatProduction = 100
@@ -106,6 +109,7 @@
 		{
 			name = RD-0213
 			description = UR-500/Proton second stage main engine, used with RD-0214 verniers to form the RD-0212 engine module. AKA 8D48
+			specLevel = operational
 			minThrust = 582.1
 			maxThrust = 582.1
 			heatProduction = 100
@@ -190,7 +194,7 @@
 		ignitionDynPresFailMultiplier = 2
 		cycleReliabilityStart = 0.975142
 		cycleReliabilityEnd = 0.996075
-		techTransfer = RD-0203,RD-0206,RD-0208,RD-0210:50
+		techTransfer = RD-0212,RD-0210,RD-0206,RD-0203:50
 
 		reliabilityMidH = 0.7
 		reliabilityDataRateMultiplier = 0.5

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -50,7 +50,9 @@
 	@title = RD-0207/0214
 	%manufacturer = KB Khimavtomatiki (KBKhA)
 	@description = A gas generator vernier engine cluster found on the second stage of the UR-200 and third stage of the UR-500/Proton series launcher.
-	
+
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -63,6 +65,7 @@
 		{
 			name = RD-0207
 			description = UR-200 second stage verniers, used with RD-0206 main engine to form the RD-0205 engine module. AKA 8D67
+			specLevel = operational
 			minThrust = 30.98
 			maxThrust = 30.98
 			heatProduction = 100
@@ -88,6 +91,7 @@
 		{
 			name = RD-0214
 			description = UR-500/Proton second stage verniers, used with RD-0213 main engine to form the RD-0212 engine module. AKA 8D811
+			specLevel = operational
 			minThrust = 30.98
 			maxThrust = 30.98
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD0216_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0216_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = KB Khimavtomatiki (KBKhA)
 	%description = A staged combustion, hypergolic rocket engine. Used as a power plant on the first stage of the UR-100 rocket, with 3 RD-0216s and 1 RD-0217 forming a 15D2 engine module. Features a two-axis gimbal mechanism for attitude control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -68,6 +70,7 @@
 		{
 			name = RD-0216
 			description = Used on the UR-100 first stage. AKA 15D2
+			specLevel = operational
 			minThrust = 219.2
 			maxThrust = 219.2
 			gimbalRange = 3.25

--- a/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
@@ -44,6 +44,8 @@
 	%description = The RD-0242M2 is a deep - throttle capable derivative of the RD-0242M1 upper stage engine engine. Modified to use Monomethyl Hydrazine (MMH) instead of Unsymmetrical Dimethylhydrazine (UDMH).
 	@tags ^= :$: throttle upper
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,11 +63,11 @@
 		type = ModuleEngines
 		configuration = RD-0242M2
 		origMass = 0.12
-		//fictional = speculative
 
 		CONFIG
 		{
 			name = RD-0242M2
+			specLevel = concept
 			minThrust = 30.0
 			maxThrust = 50.0
 			ullage = False

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -115,6 +115,8 @@
 	%manufacturer = NPO Energomash (OKB-456)
 	%description = The RD-100 engine series were the first large scale Ethalox Russian liquid propellant rocket engines ever developed and fired. The original RD-100 engine was a 1:1 copy of the German Model 39 engine (used on the A-4 ballistic missile), with later variants (RD-101 and RD-103/M) featuring ever increasing performance to satisfy the needs of the larger R-2 and R-5 IRBMs.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -142,6 +144,7 @@
 		CONFIG
 		{
 			name = RD-100
+			specLevel = operational
 			minThrust = 307.0
 			maxThrust = 307.0
 			heatProduction = 35
@@ -188,6 +191,7 @@
 		CONFIG
 		{
 			name = RD-101
+			specLevel = operational
 			minThrust = 404.0
 			maxThrust = 404.0
 			heatProduction = 45
@@ -234,6 +238,7 @@
 		CONFIG
 		{
 			name = RD-102
+			specLevel = prototype
 			minThrust = 428.0
 			maxThrust = 428.0
 			heatProduction = 45
@@ -280,6 +285,7 @@
 		CONFIG
 		{
 			name = RD-103
+			specLevel = operational
 			minThrust = 490.33
 			maxThrust = 490.33
 			heatProduction = 55
@@ -325,6 +331,7 @@
 		CONFIG
 		{
 			name = RD-103M
+			specLevel = operational
 			minThrust = 500.14
 			maxThrust = 500.14
 			heatProduction = 57

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -176,6 +176,8 @@
 	%manufacturer = NPO Energomash [Glushko]
 	%description = Booster engine for the R-7 Semyorka and its derivatives, including the Sputnik, Luna, Voskhod, Vostok, Soyuz, and Molniya launch vehicles. Differs from the core engine series (RD-108) with a higher chamber pressure, thrust, and smaller vernier layout. The R-7 family core was supplemented for (roughly) two minutes by four strap-on boosters powered by these engines.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -202,6 +204,7 @@
 		{
 			name = RD-107-8D74
 			description = Used on R-7 8K71
+			specLevel = operational
 			maxThrust = 1000.28
 			minThrust = 1000.28
 			massMult = 1.0
@@ -254,6 +257,7 @@
 		{
 			name = RD-107-8D74PS
 			description = Used on Sputnik 8K71PS
+			specLevel = operational
 			maxThrust = 972.3
 			minThrust = 972.3
 			massMult = 1.0
@@ -306,6 +310,7 @@
 		{
 			name = RD-107-8D76
 			description = Used on Sputnik 8A91
+			specLevel = operational
 			maxThrust = 972.8
 			minThrust = 972.8
 			massMult = 1.0
@@ -358,6 +363,7 @@
 		{
 			name = RD-107-8D74-1958
 			description = Used on Luna 8K72
+			specLevel = operational
 			maxThrust = 996.4
 			minThrust = 996.4
 			massMult = 1.0
@@ -410,6 +416,7 @@
 		{
 			name = RD-107-8D74-1959
 			description = Used on Vostok 8K72K
+			specLevel = operational
 			maxThrust = 996.4
 			minThrust = 996.4
 			massMult = 1.0
@@ -462,6 +469,7 @@
 		{
 			name = RD-107-8D74K
 			description = Used on Molniya 8K78 and Voskhod 11A57-1
+			specLevel = operational
 			maxThrust = 995.37
 			minThrust = 995.37
 			massMult = 0.9912
@@ -514,6 +522,7 @@
 		{
 			name = RD-107-8D728
 			description = Used on Molniya-M 8K78M and Soyuz 11A511
+			specLevel = operational
 			maxThrust = 995.37
 			minThrust = 995.37
 			massMult = 0.9912
@@ -566,6 +575,7 @@
 		{
 			name = RD-107-11D511
 			description = Used on Soyuz-U 11A511U (also known as RD-117)
+			specLevel = operational
 			maxThrust = 977.72
 			minThrust = 977.72
 			massMult = 1.0396
@@ -618,6 +628,7 @@
 		{
 			name = RD-107-11D511P
 			description = Used on Soyuz-U2 11A511U2 (also known as RD-117)
+			specLevel = operational
 			maxThrust = 996.4
 			minThrust = 996.4
 
@@ -669,6 +680,7 @@
 		{
 			name = RD-107A-14D22
 			description = Used on Soyuz-FG
+			specLevel = operational
 			maxThrust = 1019.89
 			minThrust = 1019.89
 			massMult = 0.9427

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -178,6 +178,8 @@
 	%manufacturer = NPO Energomash [Glushko]
 	%description = Core engine for the R-7 Semyorka and its derivatives, including the Sputnik, Luna, Voskhod, Vostok, Soyuz, and Molniya launch vehicles.	Differs from the booster engine series (RD-107) with a lower chamber pressure, thrust, and a wider vernier layout.	Powers the R-7 family core through a very long (roughly) five minute burn that starts on the pad alongside the boosters.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -210,6 +212,7 @@
 		{
 			name = RD-108-8D75
 			description = Used on R-7 8K71
+			specLevel = operational
 			maxThrust = 941.44
 			minThrust = 941.44
 			massMult = 1.0
@@ -262,6 +265,7 @@
 		{
 			name = RD-108-8D75PS
 			description = Used on Sputnik 8K71PS
+			specLevel = operational
 			maxThrust = 918.3
 			minThrust = 918.3
 			massMult = 0.9774
@@ -314,6 +318,7 @@
 		{
 			name = RD-108-8D77
 			description = Used on Sputnik 8A91
+			specLevel = operational
 			maxThrust = 803.2
 			minThrust = 803.2
 			massMult = 0.9774
@@ -366,6 +371,7 @@
 		{
 			name = RD-108-8D75-1958
 			description = Used on Luna 8K72
+			specLevel = operational
 			maxThrust = 945.4
 			minThrust = 945.4
 			massMult = 0.9774
@@ -418,6 +424,7 @@
 		{
 			name = RD-108-8D75-1959
 			description = Used on Vostok 8K72K
+			specLevel = operational
 			maxThrust = 941
 			minThrust = 941
 			massMult = 0.9774
@@ -470,6 +477,7 @@
 		{
 			name = RD-108-8D75K
 			description = Used on Molniya 8K78 and Voskhod 11A57-1
+			specLevel = operational
 			maxThrust = 941.47
 			minThrust = 941.47
 			massMult = 0.979
@@ -522,6 +530,7 @@
 		{
 			name = RD-108-8D727
 			description = Used on Molniya-M 8K78M and Soyuz 11A511
+			specLevel = operational
 			maxThrust = 973.8
 			minThrust = 973.8
 			massMult = 0.9612
@@ -574,6 +583,7 @@
 		{
 			name = RD-108-11D512
 			description = Used on Soyuz-U 11A511U (also known as RD-118)
+			specLevel = operational
 			maxThrust = 999.3
 			minThrust = 999.3
 			massMult = 1.0985
@@ -626,6 +636,7 @@
 		{
 			name = RD-108-11D512P
 			description = Used on Soyuz-U2 11A511U2 (also known as RD-118P)
+			specLevel = operational
 			maxThrust = 1011
 			minThrust = 1011
 			massMult = 1.0985
@@ -678,6 +689,7 @@
 		{
 			name = RD-108A-14D21
 			description = Used on Soyuz-FG
+			specLevel = operational
 			maxThrust = 990.47
 			minThrust = 990.47
 			massMult = 0.836

--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -54,6 +54,8 @@
 	%manufacturer = NPO Energomash
 	%description = A Soviet high performance semi-cryogenic upper stage engine. Originally developed as an upper stage for the R-7, it was never used due to Korolev's refusal to use toxic propellants. It was later adapted to to Kosmos-2 Launch Vehicle, which needed a high performance upper stage due to the low performance of its R-12 first stage.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -76,6 +78,7 @@
 		{
 			name = RD-109-8D711
 			description = Prototype for the R-7 (8K73) project
+			specLevel = prototype
 			minThrust = 101.6
 			maxThrust = 101.6
 			massMult = 1.0
@@ -112,6 +115,7 @@
 		{
 			name = RD-119-8D710
 			description = Upper stage for Kosmos-2 (11K63). Warning: only rated for 90 minutes before restart.
+			specLevel = operational
 			minThrust = 105.5
 			maxThrust = 105.5
 			massMult = 0.8	//168 kg
@@ -189,7 +193,7 @@
 		ignitionReliabilityEnd = 0.999085
 		cycleReliabilityStart = 0.947866
 		cycleReliabilityEnd = 0.991768
-		techTransfer = RD-0105,RD-109-8D711:50
+		techTransfer = RD-109-8D711,RD-0105:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-119-8D710] { %ratedBurnTime = #$/TESTFLIGHT[RD-119-8D710]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD111_config.cfg
@@ -35,6 +35,8 @@
 	%manufacturer = NPO Energomash
 	%description = 1st stage engine for the R-9 ICBM. Derived from the RD-107/108 engines of the R-7, the RD-111 was intended to provide a much quicker reaction time than the R-7. Although still using cryogenic liquid oxygen, it could be fuelled and launched in under 20 minutes. This, combined with its high performance, meant it was the last cryogenic ICBM to leave service.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -58,6 +60,7 @@
 		{
 			name = RD-111-8D716
 			description = 
+			specLevel = operational
 			minThrust = 1628
 			maxThrust = 1628
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
@@ -70,6 +70,8 @@
 	%manufacturer = PA Yuzhmash
 	%description = The RD-120 is a staged combustion vacuum kerolox engine, used as the main power plant on the Zenit launch vehicle family second stage.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -96,6 +98,7 @@
 		CONFIG
 		{
 			name = RD-120
+			specLevel = operational
 			minThrust = 583.49
 			maxThrust = 833.56
 			gimbalRange = 0
@@ -140,6 +143,7 @@
 		CONFIG
 		{
 			name = RD-120F
+			specLevel = operational
 			minThrust = 583.49
 			maxThrust = 912.02
 			gimbalRange = 0
@@ -184,6 +188,7 @@
 		CONFIG
 		{
 			name = RD-120K
+			specLevel = prototype
 			minThrust = 416.78
 			maxThrust = 853.18
 			gimbalRange = 6.0
@@ -293,7 +298,7 @@
 		ignitionReliabilityEnd = 0.998295
 		cycleReliabilityStart = 0.950741
 		cycleReliabilityEnd = 0.992222
-		techTransfer = RD-120,RD-120F:50
+		techTransfer = RD-120K,RD-120:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-120F] { %ratedBurnTime = #$/TESTFLIGHT[RD-120F]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD170_Config.cfg
@@ -82,6 +82,8 @@
 	%manufacturer = NPO Energomash
 	%description = 1980s to present, High TWR, atmospheric booster engine. The RD-170 is the most powerful liquid rocket engine ever flown. Originally developed for the Energia launcher's boosters, the engine consists of four combustion chambers fed by a single turbopump. A modified version, the RD-171, is used on the first stage of the Zenit launch vehicle.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -108,6 +110,7 @@
 		{
 			name = RD-170
 			description = Used on Energia liquid rocket boosters
+			specLevel = operational
 			minThrust = 3953
 			maxThrust = 7904
 			heatProduction = 100
@@ -146,6 +149,7 @@
 		{
 			name = RD-171
 			description = Used on Zenit, a rocket derived from Energia boosters
+			specLevel = operational
 			minThrust = 3953
 			maxThrust = 7904
 			heatProduction = 100
@@ -183,6 +187,7 @@
 		{
 			name = RD-172-173
 			description = Uprated RD-171 for the Vulkan ("Volcano"), baseline for the RD-180, RD-191 and it's derivatives.
+			specLevel = prototype
 			minThrust = 3953
 			maxThrust = 8316 //[2]
 			heatProduction = 100
@@ -221,6 +226,7 @@
 		{
 			name = RD-171M
 			description = Modernized model for use on Zenit
+			specLevel = operational
 			minThrust = 3953
 			maxThrust = 7904
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -40,6 +40,8 @@
 	%manufacturer = NPO Energomash
 	%description = The RD-180 is a two-chamber derivative of the four-chamber RD-170/171 and powers the first stage of the Atlas V.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -65,6 +67,7 @@
 		CONFIG
 		{
 			name = RD-180
+			specLevel = operational
 			minThrust = 1951.44
 			maxThrust = 4152
 			heatProduction = 100
@@ -127,7 +130,7 @@
 		ignitionReliabilityEnd = 0.996354
 		cycleReliabilityStart = 0.976910
 		cycleReliabilityEnd = 0.996354
-		techTransfer = RD-171M,RD-172-173,RD-171,RD-170:20
+		techTransfer = RD-172-173,RD-171,RD-170:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-180] { %ratedBurnTime = #$/TESTFLIGHT[RD-180]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
@@ -82,7 +82,9 @@
 	%title = RD-191
 	%manufacturer = NPO Energomash
 	%description = A further continuation of the RD-170/171 series, featuring a single combustion chamber and nozzle. The RD-191 powers the Angara family of launchers, while the RD-151 was used on the Naro-1 launch vehicle and the RD-181 will be used on the Antares 200-series.
-	
+
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -92,6 +94,7 @@
 		CONFIG
 		{
 			name = RD-191
+			specLevel = operational
 			minThrust = 565
 			maxThrust = 2085
 			heatProduction = 100
@@ -129,6 +132,7 @@
 		{
 			description = Downrated version for the Naro-1.
 			name = RD-151
+			specLevel = operational
 			minThrust = 565
 			maxThrust = 1918
 			heatProduction = 100
@@ -166,6 +170,7 @@
 		{
 			name = RD-181
 			description = Modified for the Antares to replace the NK-33.
+			specLevel = operational
 			minThrust = 980
 			maxThrust = 2085
 			heatProduction = 100
@@ -205,6 +210,7 @@
 		{
 			name = RD-193
 			description = No gimbal, planned to replace the NK-33 on Soyuz 2-1v.
+			specLevel = operational
 			minThrust = 834
 			maxThrust = 2085
 			heatProduction = 100
@@ -268,7 +274,7 @@
 		ignitionReliabilityEnd = 0.996354
 		cycleReliabilityStart = 0.976910
 		cycleReliabilityEnd = 0.996354
-		techTransfer = RD-171M,RD-172-173,RD-171,RD-170,RD-180:20
+		techTransfer = RD-172-173,RD-171,RD-170,RD-180:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-191] { %ratedBurnTime = #$/TESTFLIGHT[RD-191]/ratedBurnTime$ } }
 }
@@ -288,7 +294,7 @@
 		ignitionReliabilityEnd = 0.996354
 		cycleReliabilityStart = 0.976910
 		cycleReliabilityEnd = 0.996354
-		techTransfer = RD-191:50
+		techTransfer = RD-191:50&RD-172-173,RD-171,RD-170,RD-180:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-151] { %ratedBurnTime = #$/TESTFLIGHT[RD-151]/ratedBurnTime$ } }
 }
@@ -310,7 +316,7 @@
 		ignitionReliabilityEnd = 0.996354
 		cycleReliabilityStart = 0.976910
 		cycleReliabilityEnd = 0.996354
-		techTransfer = RD-191,RD-151:50
+		techTransfer = RD-191,RD-151:50&RD-172-173,RD-171,RD-170,RD-180:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-181] { %ratedBurnTime = #$/TESTFLIGHT[RD-181]/ratedBurnTime$ } }
 }
@@ -330,7 +336,7 @@
 		ignitionReliabilityEnd = 0.996354
 		cycleReliabilityStart = 0.976910
 		cycleReliabilityEnd = 0.996354
-		techTransfer = RD-191,RD-151,RD-181:50
+		techTransfer = RD-191,RD-151,RD-181:50&RD-172-173,RD-171,RD-170,RD-180:20
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-193] { %ratedBurnTime = #$/TESTFLIGHT[RD-193]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
@@ -32,6 +32,9 @@
 	%title = RD-1
 	%manufacturer = Glushko
 	%description = Four-chamber nitric acid and kerosene developed by Glushko duting WW2. Used in various rocket powered aircraft proposals, and tested extensivley in the Pe-2RD, a Pe-2 bomber with an RD-1 installed in the fuselage. Abandoned after WW2, as jet engines proved to be more reliable for high performance aircraft.
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -52,6 +55,7 @@
 		{
 			name = RD-1
 			description = 
+			specLevel = operational
 			minThrust = 12.6
 			maxThrust = 12.6
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Glushko
 	%description = First multi-chamber engine developed by Glushko. After Glushko's attempts to scale up existing engines for what would become the R-7 resulted in unresolvable combustion instability (RD-105/106), Glushko instead combined multiple chambers of his ED-140 engine into one to increase thrust. The result, the RD-200, proved successful, and although it never flew, its design formed the basis of the RD-107/108 and RD-214.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -67,6 +69,7 @@
 		{
 			name = RD-200
 			description = First multi-chamber engine designed by Glushko, basis of RD-107/108 and RD-214
+			specLevel = prototype
 			minThrust = 98.51
 			maxThrust = 98.51
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD211_Config.cfg
@@ -96,6 +96,8 @@
 	%manufacturer = NPO Energomash
 	%description = An early Soviet four combustion chamber rocket. Developed from the RD-100 for the R-12 IRBM in the mid 1950s, it provided a significant increase in power over earlier Soviet engines. It was later used for the Kosmos-2 launch vehicle.
 
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -125,6 +127,7 @@
 		{
 			name = RD-211-8D57
 			description = Prototype for the R-12 (8K63)
+			specLevel = prototype
 			minThrust = 642.3
 			maxThrust = 642.3
 			massMult = 1.0
@@ -173,6 +176,7 @@
 		{
 			name = RD-212-8D41
 			description = Prototype for Buran cruise missile
+			specLevel = prototype
 			minThrust = 437.0
 			maxThrust = 622.7
 			massMult = 1.01	//642 kg
@@ -220,6 +224,7 @@
 		{
 			name = RD-213-8D13
 			description = Prototype for Buran cruise missile
+			specLevel = prototype
 			minThrust = 549.0
 			maxThrust = 749.2
 			massMult = 0.984	//625 kg
@@ -267,6 +272,7 @@
 		{
 			name = RD-214-8D59
 			description = Engine for the R-12 (8K63)
+			specLevel = operational
 			minThrust = 730.2
 			maxThrust = 730.2
 			massMult = 1.03	//625 kg
@@ -314,6 +320,7 @@
 		{
 			name = RD-214U-8D59U
 			description = Engine for the R-12U (8K63S) and Kosmos-2 (11K63)
+			specLevel = operational
 			minThrust = 730.6
 			maxThrust = 730.6
 			massMult = 1.03	//625 kg
@@ -416,7 +423,7 @@
 		ignitionReliabilityEnd = 0.93
 		cycleReliabilityStart = 0.8
 		cycleReliabilityEnd = 0.9
-		techTransfer = RD-200:25&RD-211-8D57,RD-212-8D41:50
+		techTransfer = RD-200:25&RD-212-8D41,RD-211-8D57:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-213-8D13] { %ratedBurnTime = #$/TESTFLIGHT[RD-213-8D13]/ratedBurnTime$ } }
 }
@@ -434,7 +441,7 @@
 		ignitionReliabilityEnd = 0.987383
 		cycleReliabilityStart = 0.918571
 		cycleReliabilityEnd = 0.987383
-		techTransfer = RD-200:25&RD-211-8D57,RD-212-8D41,RD-213-8D13:50
+		techTransfer = RD-200:25&RD-213-8D13,RD-212-8D41,RD-211-8D57:50
 
 	}
 
@@ -456,7 +463,7 @@
 		ignitionReliabilityEnd = 0.988253
 		cycleReliabilityStart = 0.925602
 		cycleReliabilityEnd = 0.988253
-		techTransfer = RD-200:25&RD-211-8D57,RD-212-8D41,RD-213-8D13,RD-214-8D59:50
+		techTransfer = RD-200:25&RD-214-8D59,RD-213-8D13,RD-212-8D41,RD-211-8D57:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-214U-8D59U] { %ratedBurnTime = #$/TESTFLIGHT[RD-214U-8D59U]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
@@ -122,6 +122,8 @@
 	%manufacturer = NPO Energomash
 	%description = Soviet dual combustion chamber gas generator engine. Designed in the late 1950s to use storable propellants for ICBMs, since the current R-7 required cryogenic propellants that could not be stored for long periods, requiring lengthy fuelling before launch. It was used in clusters of up to three in many Soviet ICBMs, and later in the Kosmos and Tsiklon launch vehicles.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -149,6 +151,7 @@
 		{
 			name = RD-215-8D513
 			description = Used on R-14 8K65 as RD-216
+			specLevel = operational
 			minThrust = 869.9
 			maxThrust = 869.9
 			massMult = 1.0
@@ -185,6 +188,7 @@
 		{
 			name = RD-217-8D515
 			description = Used on R-16 8K64 as RD-218
+			specLevel = operational
 			minThrust = 869.9
 			maxThrust = 869.9
 			massMult = 0.967	//653 kg
@@ -220,6 +224,7 @@
 		{
 			name = RD-225-8D721
 			description = Used on R-26 8K66 as RD-224
+			specLevel = prototype
 			minThrust = 887.5
 			maxThrust = 887.5
 			massMult = 0.967	//653 kg
@@ -255,6 +260,7 @@
 		{
 			name = RD-215M-8D613
 			description = Used on Kosmos-3M 8K65M as RD-216M
+			specLevel = operational
 			minThrust = 872.3
 			maxThrust = 872.3
 			massMult = 0.97		//655 kg
@@ -290,6 +296,7 @@
 		{
 			name = RD-250-8D518
 			description = Used on R-36 and Tsiklon-2 8K65M as RD-251
+			specLevel = operational
 			minThrust = 881.3
 			maxThrust = 881.3
 			heatProduction = 100
@@ -325,6 +332,7 @@
 		{
 			name = RD-250PM
 			description = Used on Tsiklon-2M and Tsiklon-3 11K68 as RD-261
+			specLevel = operational
 			minThrust = 882.6
 			maxThrust = 882.6
 			heatProduction = 100
@@ -416,7 +424,7 @@
 		ignitionReliabilityEnd = 0.985
 		cycleReliabilityStart = 0.9
 		cycleReliabilityEnd = 0.985
-		techTransfer = RD-214-8D59:25&RD-215-8D513,RD-217-8D515:50
+		techTransfer = RD-214-8D59:25&RD-217-8D515,RD-215-8D513:50
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
@@ -437,7 +445,7 @@
 		ignitionReliabilityEnd = 0.998934
 		cycleReliabilityStart = 0.993247
 		cycleReliabilityEnd = 0.998934
-		techTransfer = RD-214-8D59:25&RD-215-8D513,RD-217-8D515,RD-225-8D721:50
+		techTransfer = RD-214-8D59:25&RD-225-8D721,RD-217-8D515,RD-215-8D513:50
 		
 		clusterMultiplier = #$../clusterMultiplier$
 
@@ -462,7 +470,7 @@
 		ignitionReliabilityEnd = 0.998180
 		cycleReliabilityStart = 0.988471
 		cycleReliabilityEnd = 0.998180
-		techTransfer = RD-214-8D59:25&RD-215-8D513,RD-217-8D515,RD-225-8D721,RD-215M-8D613:50
+		techTransfer = RD-214-8D59:25&RD-215M-8D613,RD-225-8D721,RD-217-8D515,RD-215-8D513:50
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}
@@ -483,7 +491,7 @@
 		ignitionReliabilityEnd = 0.999046
 		cycleReliabilityStart = 0.993960
 		cycleReliabilityEnd = 0.999046
-		techTransfer = RD-214-8D59:25&RD-215-8D513,RD-217-8D515,RD-225-8D721,RD-215M-8D613,RD-250-8D518:50
+		techTransfer = RD-214-8D59:25&RD-250-8D518,RD-215M-8D613,RD-225-8D721,RD-217-8D515,RD-215-8D513:50
 		
 		clusterMultiplier = #$../clusterMultiplier$
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
@@ -71,6 +71,8 @@
 	%manufacturer = NPO Energomash
 	%description = Soviet dual combustion chamber gas generator upper stage engine. Designed in the late 1950s to use storable propellants for ICBMs, since the current R-7 required cryogenic propellants that could not be stored for long periods, requiring lengthy fuelling before launch. Used on the R-16 and R-36 ICBMs, and Tsiklon-2 and Tsiklon-3 LVs.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -98,6 +100,7 @@
 		{
 			name = RD-219-8D713
 			description = Used on R-16 8K64
+			specLevel = operational
 			minThrust = 882.6
 			maxThrust = 882.6
 			massMult = 1.0
@@ -133,6 +136,7 @@
 		{
 			name = RD-252-8D724
 			description = Used on R-36 and Tsiklon-2 8K67
+			specLevel = operational
 			minThrust = 940.8
 			maxThrust = 940.8
 			heatProduction = 100
@@ -168,6 +172,7 @@
 		{
 			name = RD-262-11D26
 			description = Used on Tsiklon-2M and Tsiklon-3 11K68
+			specLevel = operational
 			minThrust = 941.4
 			maxThrust = 941.4
 			heatProduction = 100
@@ -258,7 +263,7 @@
 		ignitionReliabilityEnd = 0.998770
 		cycleReliabilityStart = 0.992213
 		cycleReliabilityEnd = 0.998770
-		techTransfer = RD-219-8D713,RD-252-8D724:50
+		techTransfer = RD-252-8D724,RD-219-8D713:50
 
 	}
 

--- a/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
@@ -115,6 +115,8 @@
 	%manufacturer = NPO Energomash
 	%description = A high thrust engine designed for use with storable propellants. In use with the Proton series of rockets.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -141,6 +143,7 @@
 		CONFIG
 		{
 			name = RD-253
+			specLevel = operational
 			minThrust = 1545
 			maxThrust = 1545
 			heatProduction = 100
@@ -174,6 +177,7 @@
 		CONFIG
 		{
 			name = RD-253-Mk2
+			specLevel = operational
 			minThrust = 1635
 			maxThrust = 1635
 			heatProduction = 100
@@ -208,6 +212,7 @@
 	CONFIG
 		{
 			name = RD-253-Mk3
+			specLevel = operational
 			minThrust = 1698
 			maxThrust = 1698
 			heatProduction = 100
@@ -241,6 +246,7 @@
 		CONFIG
 		{
 			name = RD-253-Mk4
+			specLevel = operational
 			minThrust = 1748
 			maxThrust = 1748
 			heatProduction = 100
@@ -275,6 +281,7 @@
 		{
 			name = RD-275
 			description = Mid-90s upgrade to improve performance of Proton
+			specLevel = operational
 			minThrust = 1746
 			maxThrust = 1746
 			heatProduction = 100
@@ -310,6 +317,7 @@
 		{
 			name = RD-275M
 			description = Modern upgrade to improve performance of Proton. AKA RD-276
+			specLevel = operational
 			minThrust = 1830
 			maxThrust = 1830
 			heatProduction = 100
@@ -419,7 +427,7 @@
 		ignitionReliabilityEnd = 0.999251
 		cycleReliabilityStart = 0.995253
 		cycleReliabilityEnd = 0.999251
-		techTransfer = RD-253,RD-253-Mk2:50
+		techTransfer = RD-253-Mk2,RD-253:50
 		
 		reliabilityMidH = 0.45
 		
@@ -441,7 +449,7 @@
 		ignitionReliabilityEnd = 0.999679
 		cycleReliabilityStart = 0.997970
 		cycleReliabilityEnd = 0.999679
-		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3:50
+		techTransfer = RD-253-Mk3,RD-253-Mk2,RD-253:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-253-Mk4] { %ratedBurnTime = #$/TESTFLIGHT[RD-253-Mk4]/ratedBurnTime$ } }
 }
@@ -464,7 +472,7 @@
 		ignitionReliabilityEnd = 0.999289
 		cycleReliabilityStart = 0.995498
 		cycleReliabilityEnd = 0.999289
-		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3,RD-253-Mk4:50
+		techTransfer = RD-253-Mk4,RD-253-Mk3,RD-253-Mk2,RD-253:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-275] { %ratedBurnTime = #$/TESTFLIGHT[RD-275]/ratedBurnTime$ } }
 }
@@ -488,7 +496,7 @@
 		ignitionReliabilityEnd = 0.999663
 		cycleReliabilityStart = 0.997865
 		cycleReliabilityEnd = 0.999663
-		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3,RD-253-Mk4,RD-275:50
+		techTransfer = RD-275,RD-253-Mk4,RD-253-Mk3,RD-253-Mk2,RD-253:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-275M] { %ratedBurnTime = #$/TESTFLIGHT[RD-275M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270M_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = NPO Energomash / V.P. Glushko
 	%description = Modification of the RD-270 to use highly toxic pentaborane as fuel. Although the M variant boasts higher thrust and isp, the fuel mixture is much, much more toxic than even UDMH.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = RD-270M
+			specLevel = concept
 			minThrust = 6443.1
 			maxThrust = 7159
 			heatProduction = 225
@@ -107,7 +110,7 @@
 		ignitionReliabilityEnd = 0.997966
 		cycleReliabilityStart = 0.989829
 		cycleReliabilityEnd = 0.997966
-		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3:50
+		techTransfer = RD-253-Mk3,RD-253-Mk2,RD-253:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-270M] { %ratedBurnTime = #$/TESTFLIGHT[RD-270M]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = NPO Energomash / V.P. Glushko
 	%description = Largest single-chamber engine ever built in the Soviet Union. Fueled by an NTO/UDMH mixture combined under some of the highest pressures ever encountered in an ignition chamber. Never flown but extensively tested.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = RD-270
+			specLevel = prototype
 			minThrust = 6041
 			maxThrust = 6713
 			heatProduction = 205
@@ -108,7 +111,7 @@
 		ignitionReliabilityEnd = 0.997966
 		cycleReliabilityStart = 0.989829
 		cycleReliabilityEnd = 0.997966
-		techTransfer = RD-253,RD-253-Mk2,RD-253-Mk3:50
+		techTransfer = RD-253-Mk3,RD-253-Mk2,RD-253:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-270] { %ratedBurnTime = #$/TESTFLIGHT[RD-270]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD301_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD301_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = NPO Energomash
 	%description = Exotic fuel rich staged combustion vacuum engine. Developed as a high-energy upper stage for Proton by Glushko, the RD-301 burned Liquid Flourine and Ammonia, which gave very high performance and density. Tested extensively, but never flew due to toxicity concerns.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -65,6 +67,7 @@
 		{
 			name = RD-301
 			description = A.K.A. 8D21
+			specLevel = prototype
 			minThrust = 97.67
 			maxThrust = 97.67
 			heatProduction = 205

--- a/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
@@ -54,6 +54,8 @@
 	%manufacturer = KB Saturn (Lyulka)
 	%description = 1970s Low TWR Vacuum engine. Staged combustion hydrolox upper stage engine intended for use on the N-1/N-1M. A later version designated RD-57M had am extendable nozzle and was intended for the Vulkan and Energia-M rockets. The engine was marketed by Aerojet in the 1990s under the designation D-57 for use on an SSTO demonstrator.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -79,6 +81,7 @@
 		CONFIG
 		{
 			name = RD-57
+			specLevel = prototype
 			minThrust = 78.46
 			maxThrust = 392.3
 			heatProduction = 100
@@ -111,6 +114,7 @@
 		CONFIG
 		{
 			name = RD-57M
+			specLevel = prototype
 			minThrust = 79.4 // some sources suggest min throttle is 303.0, this sounds unlikely. 
 			maxThrust = 397
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -146,6 +146,8 @@
 	%manufacturer = RKK Energiya
 	%description = World's first closed-cycle kerolox vacuum engine. The S1.5400 served as an R-7 upper stage and the RD-58 (an upgrade) as upper stage / OMS for many Soviet and Russian launchers and spacecraft (Proton, N1, Zenit, Buran...). The S1.5400 was designed for the Blok L stage which was the final stage for the Molniya configuration of the R-7, used to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (this was needed to perform apogee kick to place Molniya satellites in their final orbits). It was given the industry designation 11D33. An upgraded version, termed 11D33M, had slightly improved performance. The RD-58 is a derivative of the 11D33M engine with higher performance (industry designation 11D58); it has been used on many Russian launchers and is still in use today on Proton and Zenit. In comparison to hydrolox upper stages, kerolox ones do not suffer boiloff as badly and need far less volume (kerosene being far denser than liquid hydrogen), but have much lower specific impulse.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -174,6 +176,7 @@
 		{
 			name = S1_5400
 			description = Used on Molnyia (Blok L)
+			specLevel = operational
 			minThrust = 63.7
 			maxThrust = 63.7
 			heatProduction = 100
@@ -215,6 +218,7 @@
 		{
 			name = 11D33
 			description = Developed version of S1.5400 engine for the Blok ML and Blok MVL stage of the Molniya-M launch vehicle. Slightly better performance.
+			specLevel = operational
 			minThrust = 66.7
 			maxThrust = 66.7
 			heatProduction = 100
@@ -255,6 +259,7 @@
 		{
 			name = 11D33M
 			description = The S1.5400A engine, as used on Block 2BLM of the Molniya launch vehicle. Further performance improvements.
+			specLevel = operational
 			minThrust = 67.3
 			maxThrust = 67.3
 			heatProduction = 100
@@ -295,6 +300,7 @@
 		{
 			name = RD-58
 			description = Upgrade developed for use on the Blok D stage of the N-1, and later used on Proton. Significant upgrade over the S1.5400
+			specLevel = operational
 			maxThrust = 83.36
 			minThrust = 83.36
 			heatProduction = 100
@@ -335,6 +341,7 @@
 		{
 			name = RD-58M
 			description = Modification of the RD-58 for use on Proton Blok DM, after the N-1 was cancelled. 
+			specLevel = operational
 			maxThrust = 83.36
 			minThrust = 83.36
 			heatProduction = 100
@@ -375,6 +382,7 @@
 		{
 			name = RD-58S
 			description = Modification of the RD-58 burning Syntin instead of Kerosene. Used on Proton (Blok DM-2M)
+			specLevel = operational
 			maxThrust = 86.3
 			minThrust = 86.3
 			heatProduction = 100
@@ -415,6 +423,7 @@
 		{
 			name = RD-58M-CCN
 			description = Modification of the RD-58M with a Carbon Composite Nozzle extension for better vacuum performance. Used on Zenit Blok DM-SL.
+			specLevel = operational
 			maxThrust = 85
 			minThrust = 85
 			heatProduction = 100
@@ -454,6 +463,7 @@
 		{
 			name = 17D12
 			description = OMS engine for the Buran orbiter
+			specLevel = operational
 			maxThrust = 86.24
 			minThrust = 86.24
 			heatProduction = 100
@@ -560,7 +570,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.990206
 		cycleReliabilityEnd = 0.998454
-		techTransfer = S1_5400,11D33:50
+		techTransfer = 11D33,S1_5400:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[11D33M] { %ratedBurnTime = #$/TESTFLIGHT[11D33M]/ratedBurnTime$ } }
 }
@@ -581,7 +591,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.891146
 		cycleReliabilityEnd = 0.982813
-		techTransfer = 11D33M:25
+		techTransfer = 11D33M,11D33,S1_5400:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58] { %ratedBurnTime = #$/TESTFLIGHT[RD-58]/ratedBurnTime$ } }
 }
@@ -609,7 +619,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.988455
 		cycleReliabilityEnd = 0.998177
-		techTransfer = RD-58:50
+		techTransfer = RD-58:50&11D33M,11D33,S1_5400:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58M] { %ratedBurnTime = #$/TESTFLIGHT[RD-58M]/ratedBurnTime$ } }
 }
@@ -632,7 +642,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.976250
 		cycleReliabilityEnd = 0.996250
-		techTransfer = RD-58,RD-58M:50
+		techTransfer = RD-58M,RD-58:50&11D33M,11D33,S1_5400:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58S] { %ratedBurnTime = #$/TESTFLIGHT[RD-58S]/ratedBurnTime$ } }
 }
@@ -655,7 +665,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.945935
 		cycleReliabilityEnd = 0.991463
-		techTransfer = RD-58,RD-58M:50
+		techTransfer = RD-58M,RD-58:50&11D33M,11D33,S1_5400:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-58M-CCN] { %ratedBurnTime = #$/TESTFLIGHT[RD-58M-CCN]/ratedBurnTime$ } }
 }
@@ -672,7 +682,7 @@
 		ignitionDynPresFailMultiplier = 0.1
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.998
-		techTransfer = RD-58,RD-58M:50
+		techTransfer = RD-58S,RD-58M,RD-58:50&11D33M,11D33,S1_5400:25
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[17D12] { %ratedBurnTime = #$/TESTFLIGHT[17D12]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD701_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD701_Config.cfg
@@ -57,6 +57,8 @@
 	%description = A staged combustion tripropellant liquid fuel engine using Kerosene, liquid Hydrogen and liquid Oxygen. Originally developed for the MAKS space plane. In the booster phase of the ascent it uses a mixture of Kerosene with liquid Hydrogen and it switches to pure Hydrogen for the sustainer phase.
 	%tags ^= :$: booster energomash throttle tripropellant upper
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -90,7 +92,7 @@
 		CONFIG
 		{
 			name = RD-701
-			//prototype
+			specLevel = prototype
 			minThrust = 1588
 			maxThrust = 4004
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD704_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD704_Config.cfg
@@ -58,6 +58,8 @@
 	%description = A staged combustion tripropellant liquid fuel engine using Kerosene, liquid Hydrogen and liquid Oxygen. This is the single chamber version of the RD-701, originally developed for the MAKS space plane. In the booster phase of the ascent it uses a mixture of Kerosene with liquid Hydrogen and it switches to pure Hydrogen for the sustainer phase.
 	@tags ^= :$: booster energomash throttle tripropellant upper
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -91,7 +93,7 @@
 		CONFIG
 		{
 			name = RD-704
-			//prototype
+			specLevel = prototype
 			minThrust = 785
 			maxThrust = 2002
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD805_Config.cfg
@@ -42,6 +42,8 @@
 	%manufacturer = PA Yuzhmash
 	%description = A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use as a standalone upper stage engine.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -68,6 +70,7 @@
 		CONFIG
 		{
 			name = RD-805
+			specLevel = concept
 			minThrust = 19.6
 			maxThrust = 19.6
 			heatProduction = 69

--- a/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD855_Config.cfg
@@ -35,6 +35,8 @@
 	%manufacturer = KB Yuzhnoye
 	%description = A pump-fed hypergolic vernier thruster used on the first stage of the R-36 and Tsyklon rocket.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = RD-855
+			specLevel = operational
 			maxThrust = 83
 			minThrust = 83
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD856_Config.cfg
@@ -43,6 +43,8 @@
 	%manufacturer = KB Yuzhnoye
 	%description = A pump-fed hypergolic vernier thruster used on the second stage of the R-36 ICBM and the Tsyklon (Cyclone) launch vehicle series for attitude control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -73,6 +75,7 @@
 		CONFIG
 		{
 			name = RD-856
+			specLevel = operational
 			minThrust = 13.55
 			maxThrust = 13.55
 			heatProduction = 55

--- a/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD8_Config.cfg
@@ -47,6 +47,8 @@
 	%manufacturer = PA Yuzhmash
 	%description = The RD-8 is a four-chamber, staged combustion, vacuum kerolox vernier engine. It is used on the second stage of the Zenit launch vehicle family for two-axis attitude control.
 
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -78,6 +80,7 @@
 		{
 			name = RD-8
 			description = Vernier engine for the Zenit second stage.
+			specLevel = operational
 			minThrust = 78.44
 			maxThrust = 78.44
 			gimbalRange = 33.0

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -318,6 +318,8 @@
 	%manufacturer = Pratt & Whitney
 	%description = Hydrolox restartable expander-cycle vacuum engine used in multiple upper stages, including Centaur, the Saturn I S-IV, and the Delta Cryogenic Second Stage. It has low thrust, but very high specific impulse and low mass, making it ideal for high energy, beyond-low-Earth-orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all hydrolox engines, hydrogen boiloff is a serious issue without heat pumps or radiators.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -345,6 +347,7 @@
 		CONFIG
 		{
 			name = RL10A-1
+			specLevel = operational
 			minThrust = 65.6
 			maxThrust = 65.6
 			heatProduction = 100
@@ -378,6 +381,7 @@
 		CONFIG
 		{
 			name = RL10A-3-1
+			specLevel = operational
 			minThrust = 66.7
 			maxThrust = 66.7
 			heatProduction = 100
@@ -411,6 +415,7 @@
 		CONFIG
 		{
 			name = RL10A-3-3
+			specLevel = operational
 			minThrust = 70.05
 			maxThrust = 70.05
 			heatProduction = 100
@@ -444,6 +449,7 @@
 		CONFIG
 		{
 			name = RL10A-3-3-Lunex
+			specLevel = concept
 			minThrust = 11.5	//6:1 throttling goal
 			maxThrust = 69.4	//Some performance loss from extra baffling and hydrogen bleed assumed
 			heatProduction = 100
@@ -477,6 +483,7 @@
 		CONFIG
 		{
 			name = RL10A-3-3A
+			specLevel = operational
 			minThrust = 73.4
 			maxThrust = 73.4
 			heatProduction = 100
@@ -510,6 +517,7 @@
 		CONFIG
 		{
 			name = RL10A-4
+			specLevel = operational
 			minThrust = 91.2
 			maxThrust = 91.2
 			heatProduction = 100
@@ -543,6 +551,7 @@
 		CONFIG
 		{
 			name = RL10A-4N
+			specLevel = operational
 			minThrust = 92.5
 			maxThrust = 92.5
 			heatProduction = 100
@@ -576,6 +585,7 @@
 		CONFIG
 		{
 			name = RL10A-4-1-2
+			specLevel = operational
 			minThrust = 97.9
 			maxThrust = 97.9
 			heatProduction = 100
@@ -609,6 +619,7 @@
 		CONFIG
 		{
 			name = RL10A-4-1N
+			specLevel = operational
 			minThrust = 99.2
 			maxThrust = 99.2
 			heatProduction = 100
@@ -642,6 +653,7 @@
 		CONFIG
 		{
 			name = RL10A-4-2N
+			specLevel = operational
 			minThrust = 99.2
 			maxThrust = 99.2
 			heatProduction = 100
@@ -675,6 +687,7 @@
 		CONFIG
 		{
 			name = RL10A-5
+			specLevel = operational
 			minThrust = 19.4
 			maxThrust = 64.75
 			gimbalRange = 8.5 //average of 8 and 9 from 2 sources.
@@ -709,6 +722,7 @@
 		CONFIG
 		{
 			name = RL10B-2
+			specLevel = operational
 			minThrust = 110.1
 			maxThrust = 110.1
 			heatProduction = 100
@@ -742,6 +756,7 @@
 		CONFIG
 		{
 			name = RL10C-1
+			specLevel = operational
 			minThrust = 101.85
 			maxThrust = 101.85
 			heatProduction = 100
@@ -775,6 +790,7 @@
 		CONFIG
 		{
 			name = RL10C-1-1
+			specLevel = prototype
 			minThrust = 105.9
 			maxThrust = 105.9
 			heatProduction = 100
@@ -808,6 +824,7 @@
 		CONFIG
 		{
 			name = RL10C-2-1	//Mentioned as identical to the B-2, probably a cost-reduced drop-in replacement for DCSS
+			specLevel = operational
 			minThrust = 111.2
 			maxThrust = 111.2
 			heatProduction = 100
@@ -841,6 +858,7 @@
 		CONFIG
 		{
 			name = RL10C-3
+			specLevel = prototype
 			minThrust = 108.5
 			maxThrust = 108.5
 			heatProduction = 100
@@ -874,6 +892,7 @@
 		CONFIG
 		{
 			name = CECE-Base
+			specLevel = prototype
 			minThrust = 4.5 //15:1, target was 10-20:1 throttling
 			maxThrust = 67
 			heatProduction = 100
@@ -907,6 +926,7 @@
 		CONFIG
 		{
 			name = CECE-High
+			specLevel = prototype
 			minThrust = 110
 			maxThrust = 110
 			heatProduction = 100
@@ -940,6 +960,7 @@
 		CONFIG
 		{
 			name = CECE-Methane
+			specLevel = prototype
 			minThrust = 17 //4:1, target was 3-5:1
 			maxThrust = 67
 			heatProduction = 100
@@ -1045,7 +1066,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1:50
+		techTransfer = RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3]/ratedBurnTime$ } }
 }
@@ -1067,7 +1088,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3:50
+		techTransfer = RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3-Lunex] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3-Lunex]/ratedBurnTime$ } }
 }
@@ -1094,7 +1115,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3:50
+		techTransfer = RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3A] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3A]/ratedBurnTime$ } }
 }
@@ -1120,7 +1141,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4N:50	//share data between extension and no extension
+		techTransfer = RL10A-4N:100&RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50	//share data between extension and no extension
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4]/ratedBurnTime$ } }
 }
@@ -1141,7 +1162,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4:50	//share data between extension and no extension
+		techTransfer = RL10A-4:100&RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50	//share data between extension and no extension
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4N]/ratedBurnTime$ } }
 }
@@ -1178,7 +1199,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1N:50	//share data between extension and no extension
+		techTransfer = RL10A-4-1N,RL10A-4-2N:100&RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50	//share data between extension and no extension
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1]/ratedBurnTime$ } }
 }
@@ -1198,7 +1219,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2:50
+		techTransfer = RL10A-4-1-2,RL10A-4-2N:100&RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-1N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-1N]/ratedBurnTime$ } }
 }
@@ -1218,7 +1239,7 @@
 
 		ignitionDynPresFailMultiplier = 0.1
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N:50
+		techTransfer = RL10A-4-1-2,RL10A-4-1N:100&RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-4-2N] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-4-2N]/ratedBurnTime$ } }
 }
@@ -1240,7 +1261,7 @@
 		cycleReliabilityStart = 0.961111
 		cycleReliabilityEnd = 0.992222
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N:50
+		techTransfer = RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-5] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-5]/ratedBurnTime$ } }
 }
@@ -1274,7 +1295,7 @@
 
 		ignitionDynPresFailMultiplier = 0.05
 
-		techTransfer = RL10A-1,RL10A-3-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N:50
+		techTransfer = RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10B-2] { %ratedBurnTime = #$/TESTFLIGHT[RL10B-2]/ratedBurnTime$ } }
 }
@@ -1307,7 +1328,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2:50
+		techTransfer = RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1]/ratedBurnTime$ } }
 }
@@ -1329,7 +1350,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
+		techTransfer = RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-1-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-1-1]/ratedBurnTime$ } }
 }
@@ -1351,7 +1372,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1:50
+		techTransfer = RL10C-1-1,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-2-1] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-2-1]/ratedBurnTime$ } }
 }
@@ -1373,7 +1394,7 @@
 
 		ignitionDynPresFailMultiplier = 0.08
 
-		techTransfer = RL10A-1,RL10A-3-3,RL10A-3-3A,RL10A-4,RL10A-4N,RL10A-4-1-2,RL10A-4-1N,RL10A-4-2N,RL10B-2,RL10C-1,RL10C-1-1,RL10C-2-1:50
+		techTransfer = RL10C-2-1,RL10C-1-1,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10C-3] { %ratedBurnTime = #$/TESTFLIGHT[RL10C-3]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL60_Vinci_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = Pratt & Whitney
 	%description = Next generation cryogenic upper stage engine designed to replace the RL10, providing higher performance while maintaining the same installation envelope.  Also available in a lower 180kN thrust Vinci-180 model.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = RL60
+			specLevel = prototype
 			maxThrust = 289.1
 			minThrust = 289.1
 			heatProduction = 100
@@ -109,6 +112,7 @@
 		CONFIG
 		{
 			name = Vinci-180
+			specLevel = prototype
 			massMult = 1.100
 			maxThrust = 180
 			minThrust = 180

--- a/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Rocketdyne
 	%description = Rocketdyne's LH2/LOX full flow staged combustion engine proposal for next generation reusable launch vehicle boosters.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = RS-2100
+			specLevel = concept
 			maxThrust = 2399.5
 			minThrust = 1320
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/RS30_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS30_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Rocketdyne
 	%description = Reusable fuel rich staged combustion vacuum engine. Developed in the early 1970s to test technologies for the RS-25 Space Shuttle Main Engines.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -66,6 +68,7 @@
 		CONFIG
 		{
 			name = RS-30
+			specLevel = concept
 			maxThrust = 88.964
 			minThrust = 88.964
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -94,6 +94,8 @@
 	%manufacturer = Aerojet Rocketdyne
 	%description = 1990s Medium TWR atmospheric engine. Using technology developed for the Space Shuttle SSME, the RS-68 is a single-use engine, featuring a simplified design with less parts and an easier construction. The RS-68 powers the Delta IV launch vehicle family and is the most powerful LH2/LOX engine ever flown. Exhaust from the gas generator is used for roll control.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -120,6 +122,7 @@
 		CONFIG
 		{
 			name = RS-68
+			specLevel = operational
 			maxThrust = 3380.1 // 102% thrust
 			minThrust = 1822.6
 			heatProduction = 86
@@ -157,6 +160,7 @@
 		CONFIG
 		{
 			name = RS-68A
+			specLevel = operational
 			maxThrust = 3641.4 // 102% thrust
 			minThrust = 1820
 			heatProduction = 91
@@ -194,6 +198,7 @@
 		{
 			name = RS-68K
 			description = RS-68 upgrade with regeneratively cooled nozzle, allowing the engine to burn hotter.
+			specLevel = concept
 			maxThrust = 3719.9 // 102% Thrust
 			minThrust = 2006
 			heatProduction = 86
@@ -231,6 +236,7 @@
 		{
 			name = RS-800								//was proposed as RS-68 replacement for Delta IV, so assume the same size
 			descriptions = Proposed upgrade for Delta IV
+			specLevel = concept
 			maxThrust = 4192.2 // 102% thrust
 			minThrust = 2261
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Pratt & Whitney Rocketdyne
 	%description = Early 2000s atmospheric staged combustion kerolox engine. Developed as the booster engine for the liquid fly-back booster, a reusable space shuttle booster system. Extremely high performance, cancelled during protorype phase.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -65,6 +67,7 @@
 		CONFIG
 		{
 			name = RS-76
+			specLevel = prototype
 			maxThrust = 4378.81
 			minThrust = 2846.23
 			heatProduction = 86
@@ -107,6 +110,7 @@
 		{
 			name = RS-76A
 			description = Simplified and increased performance with upgrades based on the RD-180
+			specLevel = speculative
 			maxThrust = 4621.29
 			minThrust = 3003.84
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/RS83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS83_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = Pratt & Whitney Rocketdyne
 	%description = Early 2000s atmospheric staged combustion hydrolox engine. Developed as the main engine for a Space Shuttle replacement as a part of the Space Launch Initiative program. Extremely high performance, cancelled during protorype phase.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -67,6 +69,7 @@
 		CONFIG
 		{
 			name = RS-83
+			specLevel = concept
 			maxThrust = 3300
 			minThrust = 1650
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/RS84_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS84_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = Pratt & Whitney Rocketdyne
 	%description = Early 2000s atmospheric staged combustion kerolox engine. Developed as the booster engine for a Space Shuttle replacement as a part of the Space Launch Initiative program. Extremely high performance, cancelled during protorype phase.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -67,7 +69,7 @@
 		CONFIG
 		{
 			name = RS-84
-			//prototype (never fully assembled, but every part was tested individually)
+			specLevel = prototype
 			maxThrust = 5026.49
 			minThrust = 3267.22
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/RS88_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS88_Config.cfg
@@ -55,6 +55,8 @@
 	%manufacturer = Rocketdyne
 	%description = High thrust pressure-fed hypergolic engine. Initially designed and built as a part of the NASA Bantam System Technology program, aiming for a low cost, high power propulsion system. It was later modified by Lockheed Martin for use as a launch abort engine. A derivative of the RS-88 is used by the Boeing CST-100 "Starliner" spacecraft for launch aborts under the name "Launch Abort Engine - LAE".
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -77,6 +79,7 @@
 		CONFIG
 		{
 			name = RS-88
+			specLevel = operational
 			maxThrust = 220
 			minThrust = 220
 			ullage = True
@@ -113,6 +116,7 @@
 		CONFIG
 		{
 			name = LAE
+			specLevel = operational
 			minThrust = 258
 			maxThrust = 258
 			heatProduction = 0.88 //0.220

--- a/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
@@ -37,7 +37,9 @@
 	@title = RSRMV
 	%manufacturer = Orbital ATK
 	@description = The 5-segment Reusable Solid Rocket Motor (RSRMV) was first studied as an upgrade for the Space Shuttle, and entered full-scale development for Ares I. Development continued for SLS after the cancellation of Ares. Nose Cone 6.50662m tall.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -83,6 +85,7 @@
 		CONFIG
 		{
 			name = RSRMV
+			specLevel = operational
 			minThrust = 15800 //Checked, 3550 klbf
 			maxThrust = 15800
 			heatProduction = 100
@@ -325,7 +328,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995622
 		cycleReliabilityEnd = 0.999309
-		techTransfer = RSRM:50
+		techTransfer = RSRM-1986:50
 
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -63,6 +63,8 @@
 	%manufacturer = Thiokol
 	%description = A four segment Reusable Solid Rocket Motor, one of the most powerful rocket motors ever built and flown. Two of them were used by the Space Shuttle for liftoff and the initial part of the flight, providing more than 75% of the overall stack thrust. Manufactured by Thiokol and later by ATK.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -112,6 +114,7 @@
 		{
 			name = RSRM-1981
 			description = Original version of the RSRM, used on early shuttle launches
+			specLevel = operational
 			minThrust = 14819
 			maxThrust = 14819
 			heatProduction = 100
@@ -265,6 +268,7 @@
 		{
 			@name = RSRM-1986
 			@description = Redesigned RSRM, after Challenger disaster
+			@specLevel = operational
 		}
 
 		+CONFIG[RSRM-1981]
@@ -273,6 +277,7 @@
 			@description = The Filament-Wound Casing (FWC) boosters were developed to allow the shuttle to launch into polar orbits from Vandenberg. Two sets of flight hardware existed when the FWC boosters were cancelled after the Challenger disaster.
 			// (87518 - 12700) / 87518
 			@massMult = 0.8549 // (8) P15
+			@specLevel = prototype
 		}
 	}
 }
@@ -323,7 +328,7 @@
 		ignitionReliabilityEnd = 1.0
 		cycleReliabilityStart = 0.995622
 		cycleReliabilityEnd = 0.999309
-		techTransfer = RSRM-1981,RSRM-1986:50
+		techTransfer = RSRM-1986,RSRM-1981:50
 
 		isSolid = True
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -55,6 +55,8 @@
 	%manufacturer = Rolls-Royce
 	%description = Pump-fed gas generator hydrolox engine, developed as an upper stage for the Black Knight and Blue Streak. The use of furnace brazing, rather than hand brazing as used in many earlier designs, significantly reduced manufacturing costs. The design was tested, but cancelled in the late 60s due to funding concerns.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -82,6 +84,7 @@
 		CONFIG
 		{
 			name = RZ20-Mk1
+			specLevel = prototype
 			minThrust = 70 //16 klbf
 			maxThrust = 70
 			description = Prototype developed by Rolls-Royce
@@ -114,6 +117,7 @@
 		CONFIG
 		{
 			name = RZ20-Mk2
+			specLevel = concept
 			minThrust = 72.56
 			maxThrust = 72.56
 			description = Increased expansion ratio proposal
@@ -179,6 +183,7 @@
 		ignitionReliabilityEnd = 0.998128
 		cycleReliabilityStart = 0.976667
 		cycleReliabilityEnd = 0.996316
+		techTransfer = RZ20-Mk1:50
 		
 		ignitionDynPresFailMultiplier = 0.1
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -68,6 +68,8 @@
 	%manufacturer = Rolls-Royce
 	%description = British kerolox booster engine for the Blue Streak missile and first stage of the Europa launch vehicle. Derived from the Rocketdyne S-3, with minor modifications.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -92,6 +94,7 @@
 		{
 			name = RZ.1
 			description = License-Built version of the Rocketdyne S-3
+			specLevel = operational
 			minThrust = 696.6
 			maxThrust = 696.6
 			heatProduction = 100
@@ -137,6 +140,7 @@
 		{
 			name = RZ.2-Mk3
 			description = Production engine for the Blue Streak missile, based on the rocketdyne S-3D
+			specLevel = operational
 			minThrust = 763
 			maxThrust = 763
 			heatProduction = 100
@@ -182,6 +186,7 @@
 		{
 			name = RZ.2-Mk4
 			description = Uprated for Europa I and II
+			specLevel = operational
 			minThrust = 791.2
 			maxThrust = 791.2
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = JPL
 	%description = 225 N Hydrazine thruster, used on all Ranger and early Mariner spacecraft for midcourse corrections. Since reliable Hydrazine catalysts had not yet been developed, the engines were only capable of two starts.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -64,6 +66,7 @@
 		CONFIG
 		{
 			name = RangerRetro
+			specLevel = operational
 			maxThrust = 0.255
 			minThrust = 0.255
 			heatProduction = 40

--- a/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor.cfg
@@ -76,6 +76,8 @@
 	%manufacturer = SpaceX
 	%description = The Raptor is a CH4/LOX burning full-flow staged combustion engine designed for both the Starship & Super Heavy Launch Vehicle. The Super Heavy has 31 sea-level optimized engines to power the first stage, Starship has 3 sea-level engines and 3 vacuum engines.
 
+	%specLevel = prototype	//Still under development, no solid numbers at the moment?
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -103,6 +105,7 @@
 		CONFIG
 		{
 			name = Raptor //[6]
+			specLevel = prototype
 			maxThrust = 1650
 			minThrust = 660 // 40% throttle [3]
 			heatProduction = 100
@@ -149,6 +152,7 @@
 		CONFIG
 		{
 			name = Raptor Non-Throttleable // [7]
+			specLevel = prototype
 			maxThrust = 3000
 			minThrust = 3000
 			heatProduction = 100
@@ -195,6 +199,7 @@
 		CONFIG
 		{
 			name = Raptor Vacuum
+			specLevel = prototype
 			maxThrust = 2240.0 // ~ Guess
 			minThrust = 896.0 // 40% throttle [3]
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Rita_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rita_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = Aerospatiale
 	%description = French Solid Rocket Engine that was used on the Diamant BP4 Launch Vehicle replacing the Topaze Second Stage.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Rita
+			specLevel = operational
 			minThrust = 180
 			maxThrust = 180
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Aerospatiale
 	%description = Small, French Solid Rocket motor that was used as the third stage on the Diamant A launch vehicle.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = Rubis
+			specLevel = operational
 			minThrust = 53
 			maxThrust = 53
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -34,6 +34,8 @@
 	%manufacturer = RocketLab
 	%description = The Rutherford Engine is the worlds first electric turbo-pumped LOX/RP-1 engine. Rutherford adopts an entirely new propulsion cycle, making use of brushless DC motors and high performance Lithium Polymer batteries to drive its turbo-pumps. The engine is named after the famous New Zealand born physicist Ernest Rutherford.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,6 +63,7 @@
 		CONFIG
 		{
 			name = Rutherford-SL
+			specLevel = operational
 			minThrust = 17.05	//Guess
 			maxThrust = 24.91
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -34,6 +34,8 @@
 	%manufacturer = RocketLab
 	%description = The Rutherford Engine is the worlds first electric turbo-pumped LOX/RP-1 engine. Rutherford adopts an entirely new propulsion cycle, making use of brushless DC motors and high performance Lithium Polymer batteries to drive its turbo-pumps. The engine is named after the famous physicist Ernest Rutherford.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -61,6 +63,7 @@
 		CONFIG
 		{
 			name = RutherfordVac
+			specLevel = operational
 			minThrust = 17.5	//guess
 			maxThrust = 25.79
 			heatProduction = 90

--- a/GameData/RealismOverhaul/Engine_Configs/S155.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S155.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = Dushkin
 	@description = Throttleable rocket engine, designed to turn the MiG-21 into a super high performance rocket interceptor. It proved successful in tests, but the destruction of the only prototype due to an engine explosion, and the increasing performance of jet-powered aircraft, led to the project being abandoned.
 
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -51,6 +53,7 @@
 		CONFIG
 		{
 			name = S-155
+			specLevel = operational
 			minThrust = 19.5
 			maxThrust = 39
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -86,6 +86,8 @@
 	%manufacturer = OKB Isayev
 	%description = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile and sounding rocket, based on the German Wasserfall engine. Better known by its western designation, Scud, later versions were exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines],*
 	{
 		%EngineType = LiquidFuel
@@ -115,6 +117,7 @@
 		{
 			name = S2.253
 			description = Derived from the German Wasserfall engine, used on the R-11 (Scud-A)
+			specLevel = operational
 			minThrust = 93.3
 			maxThrust = 93.3
 			heatProduction = 35
@@ -166,6 +169,7 @@
 		{
 			name = S3.42T
 			description = Pump-fed upgrade, used on the R-11MU and some R-17 prototypes. Never entered service
+			specLevel = operational
 			minThrust = 127.5
 			maxThrust = 127.5
 			heatProduction = 35
@@ -210,6 +214,7 @@
 		{
 			name = S5.2
 			description = Upgrade, used on the Production R-17 and R-17M missile, A.K.A Scud-B and Scud-C. This was the most heavily exported variant, and copies were built by many countries.
+			specLevel = operational
 			minThrust = 146.3
 			maxThrust = 146.3
 			heatProduction = 35
@@ -254,6 +259,7 @@
 		{
 			name = Isayev-R17
 			description = Upgrade used for the R-17MU, A.K.A Scud-D. It saw very little use in the Soviet Union due to mediocore performance, so the remaining missiles were sold to North Korea, providing the basis for North Korean missile development.
+			specLevel = operational
 			minThrust = 165.5
 			maxThrust = 165.5
 			heatProduction = 35
@@ -353,7 +359,7 @@
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.960345
 		reliabilityDataRateMultiplier = 1
-		techTransfer = S2.253,S3.42T:50
+		techTransfer = S3.42T,S2.253:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[S5.2] { %ratedBurnTime = #$/TESTFLIGHT[S5.2]/ratedBurnTime$ } }
 }
@@ -370,7 +376,7 @@
 		cycleReliabilityStart = 0.750000
 		cycleReliabilityEnd = 0.960345
 		reliabilityDataRateMultiplier = 1
-		techTransfer = S2.253,S3.42T,S5.2:50
+		techTransfer = S5.2,S3.42T,S2.253:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Isayev-R17] { %ratedBurnTime = #$/TESTFLIGHT[Isayev-R17]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -60,6 +60,8 @@
 	%manufacturer = KB KhIMMASH
 	%description = A gas generator cycle hypergolic vacuum engine. Used on the Fregat upper stage series.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -88,6 +90,7 @@
 		{
 			name = S5.92
 			description = 6 minutes minimum, 300 days maximum between restarts.
+			specLevel = operational
 			minThrust = 13.73
 			maxThrust = 19.61
 			gimbalRange = 5.0
@@ -127,6 +130,7 @@
 		{
 			name = S5.92-l.n.
 			description = Extended nozzle for higher performance. 6 minutes minimum, 300 days maximum between restarts.
+			specLevel = operational
 			minThrust = 13.96
 			maxThrust = 20.01
 			gimbalRange = 5.0

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -40,6 +40,8 @@
 	%manufacturer = KB KhIMMASH
 	%description = A staged combustion cycle hypergolic vacuum engine. Used on the Briz upper stage series.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		{
 			name = S5.98M
 			description = 6 minutes minimum, 300 days maximum between restarts.
+			specLevel = operational
 			minThrust = 19.61
 			maxThrust = 19.61
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SIIUllageMotor.cfg
@@ -21,6 +21,8 @@
 	%manufacturer = Thiokol
 	%description = The ullage motor of the Saturn V S-II stage. Attaches to the upper part of the S-II interstage, in sets of 4 to 8.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -43,6 +45,7 @@
 		CONFIG
 		{
 			name = S-II-Ullage
+			specLevel = operational
 			minThrust = 102.3
 			maxThrust = 102.3
 			massMult = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/SNTPPFE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SNTPPFE_Config.cfg
@@ -54,6 +54,8 @@
 	@title = SNTP-PFE100 Atomic Rocket Motor
 	%manufacturer = Grumman & Aerojet
 
+	%specLevel = prototype
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -66,6 +68,7 @@
 		{
 			name = SNTPPFE100-Prototype
 			description = LV-03/DE-01 technology demonstrator
+			specLevel = prototype
 			minThrust = 41.2
 			maxThrust = 206
 			exhaustDamage = True
@@ -100,6 +103,7 @@
 		{
 			name = SNTPPFE100
 			description = Production engine predicted performance. Increased core temperature to 3000K and Carbon-Carbon turbopumps to handle higher flow rates and inlet temperatures
+			specLevel = concept
 			minThrust = 49
 			maxThrust = 245.2
 			exhaustDamage = True

--- a/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
@@ -32,7 +32,9 @@
 	%title = SRMU
 	%manufacturer = Hercules
 	%description = The Titan IVB Solid Rocket Motor Upgrade (SRMU, also know as the Upgraded Solid Rocket Motor or USRM), was developed with the goal of achieving a 25% increase in capacity over the Titan IVA with the UA1207 SRM. It achieved this through the use of a more energetic propellant and a 3-segment composite case that carried more fuel and weighed less than the UA1207's 7-segment steel case. Burn time 150 seconds.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = SRMU
+			specLevel = operational
 			minThrust = 8233.777
 			maxThrust = 8233.777
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/SSME150_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME150_Config.cfg
@@ -90,6 +90,8 @@
 	%manufacturer = Rocketdyne
 	%description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. This version uses a vacuum, 150:1 expansion ratio nozzle, improving vacuum performance, at the cost of weight and loss of sea level capabilities. Modifications have also been made to the turbopump assembly to allow 3 ignitions.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -118,7 +120,7 @@
 		{
 			name = RS-25-150
 			description = Phase I SSME
-			//concept
+			specLevel = concept
 			minThrust = 1425
 			maxThrust = 2127
 			PROPELLANT
@@ -151,7 +153,7 @@
 		{
 			name = RS-25A-150 //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
-			//speculative
+			specLevel = speculative
 			minThrust = 1425
 			maxThrust = 2212
 			PROPELLANT
@@ -184,7 +186,7 @@
 		{
 			name = RS-25C-150 //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
-			//speculative
+			specLevel = speculative
 			minThrust = 1425
 			maxThrust = 2318
 			massMult = 1.065
@@ -218,7 +220,7 @@
 		{
 			name = RS-25D-150 //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
-			//speculative
+			specLevel = speculative
 			minThrust = 1425
 			maxThrust = 2361
 			massMult = 1.065
@@ -286,7 +288,7 @@
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
-		techTransfer = RS-25,RS-25A,RS-25-150:50
+		techTransfer = RS-25A,RS-25-150,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25A-150] { %ratedBurnTime = #$/TESTFLIGHT[RS-25A-150]/ratedBurnTime$ } }
 }
@@ -306,7 +308,7 @@
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979167
 		cycleReliabilityEnd = 0.995833
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25-150,RS-25A-150:50
+		techTransfer = RS-25C,RS-25A-150,RS-25A,RS-25-150,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25C-150] { %ratedBurnTime = #$/TESTFLIGHT[RS-25C-150]/ratedBurnTime$ } }
 }
@@ -326,7 +328,7 @@
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25D-E,RS-25-150,RS-25A-150,RS-25C-150:50
+		techTransfer = RS-25D-E,RS-25C-150,RS-25C,RS-25A-150,RS-25A,RS-25-150,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25D-150] { %ratedBurnTime = #$/TESTFLIGHT[RS-25D-150]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SSME35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME35_Config.cfg
@@ -90,6 +90,8 @@
 	%manufacturer = Rocketdyne
 	%description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. This version uses a sea-level, 35:1 expansion ratio nozzle with a larger throat, reducing vacuum performance, for less weight and superior sea level performance, to act as a booster for various shuttle upgrades and replacements. Although the SSME was tested with a 35:1 nozzle at various points, it never flew with one.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -119,7 +121,7 @@
 		{
 			name = RS-25-35
 			description = Phase I SSME
-			//prototype
+			specLevel = prototype
 			minThrust = 1441
 			maxThrust = 2151
 			PROPELLANT
@@ -152,7 +154,7 @@
 		{
 			name = RS-25A-35 //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
-			//concept
+			specLevel = concept
 			minThrust = 1441
 			maxThrust = 2237
 			PROPELLANT
@@ -185,7 +187,7 @@
 		{
 			name = RS-25C-35 //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
-			//concept
+			specLevel = concept
 			minThrust = 1441
 			maxThrust = 2345
 			massMult = 1.065
@@ -219,7 +221,7 @@
 		{
 			name = RS-25D-35 //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
-			//concept
+			specLevel = concept
 			minThrust = 1441
 			maxThrust = 2388
 			massMult = 1.065
@@ -287,7 +289,7 @@
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
-		techTransfer = RS-25,RS-25A,RS-25-35:50
+		techTransfer = RS-25A,RS-25-35,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25A-35] { %ratedBurnTime = #$/TESTFLIGHT[RS-25A-35]/ratedBurnTime$ } }
 }
@@ -307,7 +309,7 @@
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979167
 		cycleReliabilityEnd = 0.995833
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25-35,RS-25A-35:50
+		techTransfer = RS-25C,RS-25A-35,RS-25A,RS-25-35,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25C-35] { %ratedBurnTime = #$/TESTFLIGHT[RS-25C-35]/ratedBurnTime$ } }
 }
@@ -327,7 +329,7 @@
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25D-E,RS-25-35,RS-25A-35,RS-25C-35:50
+		techTransfer = RS-25D-E,RS-25C-35,RS-25C,RS-25A-35,RS-25A,RS-25-35,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25D-35] { %ratedBurnTime = #$/TESTFLIGHT[RS-25D-35]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SSME50X_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME50X_config.cfg
@@ -62,6 +62,8 @@
 	%manufacturer = Rocketdyne
 	%description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. This version uses an extendable nozzle, allowing the SSME to switch from a 50:1 sea level nozzle to a 150:1 vacuum nozzle mid-flight. Intended for SSTO use, where the extending nozzle would allow for the required performance at sea level and vacuum.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -91,7 +93,7 @@
 		{
 			name = RS-25A-50X //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
-			//concept
+			specLevel = concept
 			minThrust = 1381
 			maxThrust = 2145
 			PROPELLANT
@@ -137,7 +139,7 @@
 		{
 			name = RS-25D-50X //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency.
-			//speculative
+			specLevel = speculative
 			minThrust = 1381
 			maxThrust = 2289
 			massMult = 1.065
@@ -198,7 +200,7 @@
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
-		techTransfer = RS-25,RS-25A:50
+		techTransfer = RS-25A,RS-25:50
 	}
 	@MODULE[ModuleBimodalEngineConfigs] { @CONFIG[RS-25A-50X] { %ratedBurnTime = #$/TESTFLIGHT[RS-25A-50X]/ratedBurnTime$ } }
 }
@@ -218,7 +220,7 @@
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25D-E,RS-25A-50X:50
+		techTransfer = RS-25D-E,RS-25A-50X,RS-25C,RS-25A,RS-25:50
 	}
 	@MODULE[ModuleBimodalEngineConfigs] { @CONFIG[RS-25D-50X] { %ratedBurnTime = #$/TESTFLIGHT[RS-25D-50X]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SSME50_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME50_Config.cfg
@@ -90,6 +90,8 @@
 	%manufacturer = Rocketdyne
 	%description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. This version uses a sea-level, 50:1 expansion ratio nozzle, reducing vacuum performance, for less weight and superior sea level performance, to act as a booster for various shuttle upgrades and replacements. Although the SSME was tested with a 50:1 nozzle at various points, it never flew with one.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -119,7 +121,7 @@
 		{
 			name = RS-25-50
 			description = Phase I SSME
-			//prototype
+			specLevel = prototype
 			minThrust = 1381
 			maxThrust = 2062
 			PROPELLANT
@@ -152,7 +154,7 @@
 		{
 			name = RS-25A-50 //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
-			//concept
+			specLevel = concept
 			minThrust = 1381
 			maxThrust = 2145
 			PROPELLANT
@@ -185,7 +187,7 @@
 		{
 			name = RS-25C-50 //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
-			//concept
+			specLevel = concept
 			minThrust = 1381
 			maxThrust = 2248
 			massMult = 1.065
@@ -219,7 +221,7 @@
 		{
 			name = RS-25D-50 //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
-			//concept
+			specLevel = concept
 			minThrust = 1381
 			maxThrust = 2289
 			massMult = 1.065
@@ -287,7 +289,7 @@
 		ignitionReliabilityEnd = 0.996825
 		cycleReliabilityStart = 0.994737
 		cycleReliabilityEnd = 0.998947
-		techTransfer = RS-25,RS-25A,RS-25-50:50
+		techTransfer = RS-25A,RS-25-50,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25A-50] { %ratedBurnTime = #$/TESTFLIGHT[RS-25A-50]/ratedBurnTime$ } }
 }
@@ -307,7 +309,7 @@
 		ignitionReliabilityEnd = 0.995918
 		cycleReliabilityStart = 0.979167
 		cycleReliabilityEnd = 0.995833
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25-50,RS-25A-50:50
+		techTransfer = RS-25C,RS-25A-50,RS-25A,RS-25-50,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25C-50] { %ratedBurnTime = #$/TESTFLIGHT[RS-25C-50]/ratedBurnTime$ } }
 }
@@ -327,7 +329,7 @@
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25D-E,RS-25-50,RS-25A-50,RS-25C-50:50
+		techTransfer = RS-25D-E,RS-25C-50,RS-25C,RS-25A-50,RS-25A,RS-25-50,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25D-50] { %ratedBurnTime = #$/TESTFLIGHT[RS-25D-50]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SSME650_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME650_Config.cfg
@@ -40,6 +40,8 @@
 	%manufacturer = Rocketdyne
 	%description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. This version has an enormous 650:1 vacuum nozzle, and has undergone extensive weight-reduction measures, for use on a martian space tug.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -67,7 +69,7 @@
 		CONFIG
 		{
 			name = RS-25-650
-			//concept
+			specLevel = concept
 			minThrust = 2093
 			maxThrust = 2093
 			PROPELLANT
@@ -114,7 +116,7 @@
 		ignitionReliabilityEnd = 0.997872
 		cycleReliabilityStart = 0.989362
 		cycleReliabilityEnd = 0.997872
-		techTransfer = RS-25,RS-25A,RS-25C,RS-25D-E:50
+		techTransfer = RS-25D-E,RS-25C,RS-25A,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25-650] { %ratedBurnTime = #$/TESTFLIGHT[RS-25-650]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -84,6 +84,8 @@
 	%manufacturer = Rocketdyne
 	%description = The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. Though complex and expensive, these engines provide very high performance and are extremely reliable. Three of these engines powered each Shuttle Orbiter and four will be used on the core stage of the SLS.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -113,7 +115,7 @@
 		{
 			name = RS-25
 			description = Phase I SSME
-			//operational
+			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2090
 			PROPELLANT
@@ -146,7 +148,7 @@
 		{
 			name = RS-25A //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
-			//operational
+			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2173.6
 			PROPELLANT
@@ -179,7 +181,7 @@
 		{
 			name = RS-25C //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
-			//operational
+			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2278.1
 			massMult = 1.065
@@ -213,7 +215,7 @@
 		{
 			name = RS-25D-E //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
-			//operational
+			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2319.9
 			massMult = 1.065
@@ -300,7 +302,7 @@
 		ignitionReliabilityEnd = 0.996939
 		cycleReliabilityStart = 0.954762
 		cycleReliabilityEnd = 0.992857
-		techTransfer = RS-25,RS-25A:50
+		techTransfer = RS-25A,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25C] { %ratedBurnTime = #$/TESTFLIGHT[RS-25C]/ratedBurnTime$ } }
 }
@@ -320,7 +322,7 @@
 		ignitionReliabilityEnd = 0.998404
 		cycleReliabilityStart = 0.989894
 		cycleReliabilityEnd = 0.998404
-		techTransfer = RS-25,RS-25A,RS-25C:50
+		techTransfer = RS-25C,RS-25A,RS-25:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RS-25D-E] { %ratedBurnTime = #$/TESTFLIGHT[RS-25D-E]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/STBE1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STBE1_Config.cfg
@@ -65,6 +65,8 @@
 	%manufacturer = Pratt & Whitney
 	%description = Space Transportation Booster Engine, a 1990s proposal forhighly reliable, low cost booster engine for both expendable and reusable launch vehicles. [2.49 m]
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -90,6 +92,7 @@
 		CONFIG
 		{
 			name = STBE-1A
+			specLevel = concept
 			minThrust = 1475				//45%
 			maxThrust = 3275
 			heatProduction = 100
@@ -126,6 +129,7 @@
 		CONFIG
 		{
 			name = STBE-1B
+			specLevel = concept
 			minThrust = 1475					//45%
 			maxThrust = 3273
 			heatProduction = 100
@@ -163,6 +167,7 @@
 		CONFIG
 		{
 			name = STBE-3
+			specLevel = concept
 			minThrust = 1428						//45%
 			maxThrust = 3172
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/STBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STBE_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Rocketdyne
 	%description = Late 1980s to Early 1990s Booster Engine Design Using JP-4 & Liquid Oxygen as its Propellant.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = STBE
+			specLevel = concept
 			minThrust = 8896.4
 			maxThrust = 8896.4
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/STME_Config.cfg
@@ -36,6 +36,8 @@
 	@manufacturer = Rocketdyne
 	@description = Rocketdyne LOx/LH2 rocket engine. Cancelled 1992. Space Transportation Main Engine. Rocketdyne was teamed with Aerojet and Pratt & Whitney on the STME, which was to have powered the next generation of large launch vehicles.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = STME
+			specLevel = concept
 			minThrust = 2023.9
 			maxThrust = 2891.3
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star13B_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	%description = Orbit insertion motor incorporated the lightweight case developed for the STAR 13 with the propellant and nozzle design of the earlier TE-M-516 apogee motor. The motor case was stretched 2.2 inches to provide for increased propellant loading. The motor was used to adjust orbit inclination of a satellite from a Delta launch.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-13B
+			specLevel = operational
 			minThrust = 9.61
 			maxThrust = 9.61
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star15G_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	%description = Single STAR 15G motor, used in a variety of applications. This has a straight nozzle.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-15G
+			specLevel = operational
 			minThrust = 12.5
 			maxThrust = 12.5
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17A_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	%description = Apogee kick motor. Modifications: 175 mm straight section added to the Star 17. The 17A has been used for circularized orbits for the Skynet 1, NATO 1, and IMP-H & J satellites. This motor provides the high case safety factor required for this program. The TE-M-521-7 model used for several Air Force missions provides a typical safety factor with a 1.3 pound weight savings.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-17A
+			specLevel = operational
 			minThrust = 17.4
 			maxThrust = 17.4
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star17_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Thiokol
 	%description = Small apogee kick motor for satellites, introduced in 1968 on Delta 57. Max thrust 12.34kN, burn time 18 seconds.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = STAR-17
+			specLevel = operational
 			minThrust = 12.343
 			maxThrust = 12.343
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star20_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	%description = The lightweight, external nozzle is a composite of graphite, plastic, and steel. The consumable pyrogen igniter is actuated by two 6-second-delay electrical initiators or two SBASI zero-time-delay initiators.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-20
+			specLevel = operational
 			minThrust = 28.9
 			maxThrust = 28.9
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star24C_Config.cfg
@@ -45,6 +45,8 @@
 	%manufacturer = Morton Thiokol
 	%description = The STAR 24C is an improved variant of the STAR 24 solid rocket motor, designed for the International Ultraviolet Explorer (IUE) mission. Features an increased propellant loading and higher chamber pressure compared to the baseline STAR 24 motor.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -84,6 +86,7 @@
 		CONFIG
 		{
 			name = STAR-24C
+			specLevel = operational
 			minThrust = 21.35
 			maxThrust = 21.35
 			heatProduction = 123

--- a/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star27_Config.cfg
@@ -51,6 +51,8 @@
 	%manufacturer = Thiokol
 	%description = Apogee motor was developed for the Canadian Communications Research Centre's Communications Technology Satellite, and an offloaded version was qualified and flown successfully. With various propellant loadings and explosive transfer assemblies, it was used for the Broadcast Satellite Experiment, the Geostationary Meteorological Satellite, the Navigation Technology Satellite No. 2, the Global Positioning System Satellites, the P78-1 Satellite, and the Geostationary Operational Environmental Satellite.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -90,6 +92,7 @@
 		CONFIG
 		{
 			name = Star-27
+			specLevel = operational
 			minThrust = 28.2
 			maxThrust = 28.2
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star30_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	%description = Total flown included in total for Star-30A.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-30BP
+			specLevel = operational
 			minThrust = 30.9
 			maxThrust = 30.9
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star31_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Thiokol
 	@description =	Antares III is the third-generation third stage for Vought Corporation's Scout launch vehicle. The design incorporates an 89-percent-solids HTPB propellant in a Kevlar(r) filament-wound case insulated with silica-filled EPDM rubber.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -78,6 +80,7 @@
 		CONFIG
 		{
 			name = Star-31
+			specLevel = operational
 			minThrust = 100.37408
 			maxThrust = 100.37408
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37E_Config.cfg
@@ -47,6 +47,8 @@
 	%manufacturer = Morton Thiokol
 	%description = The STAR 37E is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vacuum thrust. First used on the Delta 1000 launch vehicle family as a third stage kick motor.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -88,6 +90,7 @@
 		CONFIG
 		{
 			name = STAR-37E
+			specLevel = operational
 			minThrust = 68.8
 			maxThrust = 68.8
 			heatProduction = 95

--- a/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37FM_Config.cfg
@@ -43,6 +43,8 @@
 	%manufacturer = ATK
 	%description = The STAR 37FM is an improved version of the venerable STAR 37 solid rocket motor, featuring increased propellant loading, higher efficiency and vacuum thrust. First used on the FTLSATCOM satellites as an apogee motor.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -84,6 +86,7 @@
 		CONFIG
 		{
 			name = STAR-37FM
+			specLevel = operational
 			minThrust = 54.8
 			maxThrust = 54.8
 			gimbalRange = 0

--- a/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star37_Config.cfg
@@ -48,6 +48,8 @@
 	%manufacturer = Thiokol
 	%description = The STAR 37 is a vacuum solid rocket motor, originally developed for the Surveyor lunar lander program as a braking stage. Later variants were used exclusively as apogee kick stages.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -90,6 +92,7 @@
 		CONFIG
 		{
 			name = STAR-37
+			specLevel = operational
 			minThrust = 43.5
 			maxThrust = 43.5
 			heatProduction = 73

--- a/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star3_Config.cfg
@@ -35,7 +35,9 @@
 	%title = Star 3
 	%manufacturer = ATK
 	%description = The STAR 3 motor was developed and qualified in 2003 as the Transverse Impulse Rocket System (TIRS) for the Mars Exploration Rover (MER) program for the Jet Propulsion Laboratory (JPL) in Pasadena, CA. Three TIRS motors were carried on each of the MER landers. One of the TIRS motors was fired in January 2004 to provide the impulse necessary to reduce lateral velocity of the MER Spirit lander prior to landing on the Martian surface. The motor also has applicability for spin/despin and separation systems.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -74,6 +76,7 @@
 		CONFIG
 		{
 			name = Star-3
+			specLevel = operational
 			minThrust = 2
 			maxThrust = 2
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star48B_Config.cfg
@@ -66,6 +66,8 @@
 	%manufacturer = Thiokol
 	%description = Also known as the Payload Assistance Module (PAM) B, this kick motor was used for Delta and STS launches to add extra impulse to the payload. This is the short-nozzle version. Maximum thrust 76.11kN, burn time 85 seconds.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -110,6 +112,7 @@
 		CONFIG
 		{
 			name = Star-48B/Short
+			specLevel = operational
 			minThrust = 76.1
 			maxThrust = 76.1
 			heatProduction = 100
@@ -342,6 +345,7 @@
 		CONFIG
 		{
 			name = Star-48B/Long
+			specLevel = operational
 			minThrust = 78
 			maxThrust = 78
 			heatProduction = 100
@@ -573,6 +577,7 @@
 		CONFIG
 		{
 			name = Star-48BV
+			specLevel = operational
 			maxThrust = 78
 			heatProduction = 100
 			PROPELLANT
@@ -818,7 +823,7 @@
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.995
-		techTransfer = STAR-37,Star-37E:50 & Star-48B/Long,Star-48BV:100
+		techTransfer = STAR-37,Star-37E:50&Star-48B/Long,Star-48BV:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-48B?Short] { %ratedBurnTime = #$/TESTFLIGHT[Star-48B?Short]/ratedBurnTime$ } }
 }
@@ -833,7 +838,7 @@
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.995
-		techTransfer = STAR-37,Star-37E:50 & Star-48B/Short,Star-48BV:100
+		techTransfer = STAR-37,Star-37E:50&Star-48B/Short,Star-48BV:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-48B?Long] { %ratedBurnTime = #$/TESTFLIGHT[Star-48B?Long]/ratedBurnTime$ } }
 }
@@ -848,7 +853,7 @@
 		ignitionReliabilityEnd = 0.999
 		cycleReliabilityStart = 0.958
 		cycleReliabilityEnd = 0.995
-		techTransfer = STAR-37,Star-37E:50 & Star-48B/Short,Star-48/Long:100
+		techTransfer = STAR-37,Star-37E:50&Star-48B/Short,Star-48/Long:100
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Star-48BV] { %ratedBurnTime = #$/TESTFLIGHT[Star-48BV]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Star4G_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star4G_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = ATK
 	%description = This STAR motor was developed and tested in January 2000 under a NASA Goddard Space Flight Center program for a low-cost, high mass fraction orbit adjust motor for use in deploying constellations of very small satellites (nanosatellites). The first static test of the STAR 4G prototype motor was conducted 8 months after program start. The motor is designed to operate at high chamber pressure and incorporates a noneroding throat insert to maximize specific impulse.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -74,6 +76,7 @@
 		CONFIG
 		{
 			name = Star-4G
+			specLevel = operational
 			minThrust = 0.3
 			maxThrust = 0.3
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5C_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = ATK
 	%description = The STAR 5C rocket motor was initially designed, developed, qualified, and placed in production (1960-1963) under a contract with Martin Marietta. The STAR 5C is used to separate the second stage from the trans-stage on the Titan II missile and Titan launch vehicle. The current version was qualified for use in 1976, replacing the earlier main propellant grain with TP-H-3062.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -74,6 +76,7 @@
 		CONFIG
 		{
 			name = Star-5C
+			specLevel = operational
 			minThrust = 2.468
 			maxThrust = 2.468
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star5D_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	%description = The STAR 5D rocket motor was designed and qualified to serve as the rocket-assisted deceleration (RAD) motor on the Mars Pathfinder mission. Three of these motors were fired to slow the Pathfinder spacecraft to near-zero velocity before bouncing on the surface of Mars.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-5D
+			specLevel = operational
 			minThrust = 6.272
 			maxThrust = 6.272
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star63_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	@description = The STAR 63, as part of the PAM DII upper stage, has been flown from the Space Shuttle. The motor utilizes a head-end web and a carbon-phenolic nozzle. The case material is a Kevlar-epoxy composite, through future motors would be made using a graphiteepoxy composite. Testing of STAR 63 series motors began in 1978 with completion of the PAM DII motor qualification in 1985. The first STAR 63D flight was from the Shuttle in November 1985 to place a defense communication satellite in orbit.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -74,6 +76,7 @@
 		CONFIG
 		{
 			name = Star-63D
+			specLevel = operational
 			minThrust = 119
 			maxThrust = 119
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star6B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star6B_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = ATK
 	%description = The STAR 6B rocket motor was developed for spin-up and axial propulsion applications for re-entry vehicles. The design incorporates an aluminum case and a carbon-phenolic nozzle assembly. The STAR 6B was qualified in 1984 and first flew in 1985.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-6B
+			specLevel = operational
 			minThrust = 2.82
 			maxThrust = 2.82
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star8_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = Thiokol
 	@description = The STAR 8 was developed and qualified as the rocket assisted deceleration (RAD) motor for the Mars Exploration Rover (MER) program. The motor is based on the STAR 5D motor technology developed for JPL’s Mars Pathfinder program. The STAR 8 first flew in January 2004 when three motors were used to decelerate each of the Spirit and Opportunity rovers for landing at Gusev Crater and Meridiani Planum on Mars.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -75,6 +77,7 @@
 		CONFIG
 		{
 			name = Star-8
+			specLevel = operational
 			minThrust = 7.749
 			maxThrust = 7.749
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Star9_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star9_Config.cfg
@@ -36,6 +36,8 @@
 	%manufacturer = ATK
 	%description = The STAR 9 rocket motor was developed in 1993 on independent research and development (IR&D) funds to demonstrate a number of low-cost motor technologies. These included an integral aft polar boss/exit cone, two-dimensional carbon-carbon throat, and caseon-propellant manufacturing technique.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = Star-9
+			specLevel = operational
 			minThrust = 5.83
 			maxThrust = 5.83
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Armstrong Siddeley
 	%description = The Booster Chamber of the Stentor rocket. Stentor was developed as a two chamber booster-sustainer for the Blue Steel missile, with one chamber providing boost thrust, while another smaller chamber provided sustainer thrust. The smaller chamber was developed into the Gamma series of rocket engines. The larger chamber was proposed to be used for several projects, but was ultimatley never developed further.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel	//LiquidFuel or SolidBooster
@@ -64,6 +66,7 @@
 		{
 			name = Stentor
 			description = Booster for the Blue Steel missile
+			specLevel = operational
 			minThrust = 121	// 110 kN (~25klbf) at sea level
 			maxThrust = 121
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SuperDraco_Config.cfg
@@ -42,6 +42,8 @@
 	%manufacturer = SpaceX
 	%description = A powerful hypergolic engine. Used by the Dragon V2 Command Module for powered landings, trajectory corrections and as a Launch Abort System (LAS). Other applications include hypersonic deceleration and landing for crew and cargo modules.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -63,6 +65,7 @@
 		CONFIG
 		{
 			name = SuperDraco
+			specLevel = operational
 			minThrust = 17.0
 			maxThrust = 85.0
 			heatProduction = 54

--- a/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TD339_Config.cfg
@@ -42,6 +42,8 @@
 	%manufacturer = Thiokol
 	%description = The Vernier System as used on the Surveyor Probes. Uses storable hypergolic propellants, has infinite restarts and is not subject to ullage. Throttleable down to 30%. Historically 3 of them were used on the Surveyor probes which landed on the Moon.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -69,6 +71,7 @@
 		CONFIG
 		{
 			name = TD-339
+			specLevel = operational
 			minThrust = 0.133
 			maxThrust = 0.462
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
@@ -33,6 +33,8 @@
 	%manufacturer = Aerojet
 	%description = The Viking lander Terminal Descent Engine (TDE). The lander had three such engines, which were used during the final 45 seconds or so of the descent to the surface of Mars. Multiple small exhaust nozzles are used to diffuse the exhaust plume and eliminate a recirculation zone that could contaminate spacecraft instrumentation and avoid potential extensive erosion of the landing site.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -60,6 +62,7 @@
 		CONFIG
 		{
 			name = MR-80-TDE
+			specLevel = operational
 			minThrust = 0.276
 			maxThrust = 2.811
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/TR107_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TR107_Config.cfg
@@ -38,6 +38,8 @@
 	%manufacturer = Northrop Grumman
 	%description = Early 2000s atmospheric staged combustion kerolox engine. Developed as the booster engine for a Space Shuttle replacement as a part of the Space Launch Initiative program. High performance with reusability and throttling capabilities, cancelled during prototype phase.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -65,7 +67,7 @@
 		CONFIG
 		{
 			name = TR-107
-			//concept
+			specLevel = concept
 			maxThrust = 5323
 			minThrust = 3460
 			heatProduction = 86

--- a/GameData/RealismOverhaul/Engine_Configs/TinyTim_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TinyTim_Config.cfg
@@ -35,7 +35,9 @@
 	%title = Tiny Tim Booster
 	%manufacturer = CalTech
 	%description = Small solid fueled booster originally used to power anti-shipping missiles during WW2. Used as the kick stage on the WAC Corporal, the USA's first sounding rocket, and reused in modified form for the Aerobee line of sounding rockets.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -74,6 +76,7 @@
 		{
 			name = 30Klbf
 			description = 30 Klbf (133.4 kN) peak thrust version used by the military and some WAC launches.
+			specLevel = operational
 			minThrust = 146.6
 			maxThrust = 146.6
 			heatProduction = 100
@@ -120,6 +123,7 @@
 		{
 			name = 50Klbf
 			description = 50 Klbf (222.4 kN) peak thrust version used by later WAC launches.
+			specLevel = operational
 			minThrust = 244.4
 			maxThrust = 244.4
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Topaze_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Topaze_Config.cfg
@@ -39,6 +39,8 @@
 	%manufacturer = Aerospatiale
 	%description = Early, French solid rocket engine that was used as the second stage of the Diamant A and B launch vehicles.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -76,6 +78,7 @@
 		CONFIG
 		{
 			name = Topaze
+			specLevel = operational
 			minThrust = 156
 			maxThrust = 156
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1204_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = United Technologies
 	@description = 4 segment strap-on booster for proposed Saturn IB derivatives. Burn time 115s.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -83,6 +85,7 @@
 		CONFIG
 		{
 			name = UA1204
+			specLevel = prototype
 			minThrust = 4151.3
 			maxThrust = 4151.3
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1205_Config.cfg
@@ -38,7 +38,9 @@
 	%title = UA1205
 	%manufacturer = United Technologies
 	%description = 5 Segment strap-on booster for Titan IIIC, IIID, IIIE, proposed for Saturn IB derivatives. Burn time 115s.
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -82,6 +84,7 @@
 		CONFIG
 		{
 			name = UA1205
+			specLevel = operational
 			minThrust = 5338
 			maxThrust = 5338
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1206_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = United Technologies
 	@description = 5.5 segment strap-on booster for Titan 34D and Commercial Titan III. Burn time 115s.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -84,6 +86,7 @@
 		CONFIG
 		{
 			name = UA1206
+			specLevel = operational
 			minThrust = 6227
 			maxThrust = 6227
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1207_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = United Technologies
 	@description = The UA1207 was used on the Titan IVA, which was developed to launch payloads that had been designed to fly on the Shuttle from Vandenberg. It was a 7-segment modification of the 5-segment UA1205 used on the Titan 3. Burn time 130 seconds.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -84,6 +86,7 @@
 		CONFIG
 		{
 			name = UA1207
+			specLevel = operational
 			minThrust = 7450
 			maxThrust = 7450
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/UA1208_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = United Technologies
 	@description = Speculative 8 segment version of the UA107.
 
+	%specLevel = concept
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -84,6 +86,7 @@
 		CONFIG
 		{
 			name = UA1208
+			specLevel = concept
 			minThrust = 7450
 			maxThrust = 7450
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
@@ -73,6 +73,9 @@
 	%title = Véronique
 	%manufacturer = LRBA
 	%description = Wasserfall derivative engine, developed by German and French engineers after WW2 for the sounding rocket of the same name. It was the first French high altitude sounding rocket
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -93,6 +96,7 @@
 		{
 			name = Veronique
 			description = Early production model
+			specLevel = operational
 			minThrust = 49.3
 			maxThrust = 49.3
 			heatProduction = 100
@@ -145,6 +149,7 @@
 		{
 			name = VeroniqueAGI
 			description = Turpentine fuel for increased performance
+			specLevel = operational
 			minThrust = 49.3
 			maxThrust = 49.3
 			heatProduction = 100
@@ -197,6 +202,7 @@
 		{
 			name = Veronique61
 			description = Uprated version
+			specLevel = operational
 			minThrust = 73.8
 			maxThrust = 73.8
 			heatProduction = 100
@@ -298,7 +304,7 @@
 		ignitionReliabilityEnd = 0.984091
 		cycleReliabilityStart = 0.899242
 		cycleReliabilityEnd = 0.984091
-		techTransfer = Veronique,VeroniqueAGI:50
+		techTransfer = VeroniqueAGI,Veronique:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Veronique61] { %ratedBurnTime = #$/TESTFLIGHT[Veronique61]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
@@ -95,7 +95,9 @@
 	%title = LRBA Vexin/Valois engine
 	%manufacturer = LRBA
 	%description = Early French hypergolic engines that propelled the Diamant series of rockets, first flown in 1965. Early models had low efficiency due to the propellants being nitric acid and turpentine- later versions (called Valois, first flown in 1970) used UDMH and N2O4 and enjoyed the benefits of higher thrust and specific impulse. "Vesta" config doesn't gimbal!
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -124,6 +126,7 @@
 		{
 			name = Vesta
 			description = Used for the "Super-Veronique" Vesta sounding rocket. Has no gimbal
+			specLevel = operational
 			minThrust = 153.7
 			maxThrust = 153.7
 			heatProduction = 100
@@ -174,6 +177,7 @@
 		{
 			name = Vexin
 			description = First stage engine for the "precious stones" series of sounding rockets, culminating in the Diamant Launch Vehicle.
+			specLevel = operational
 			minThrust = 320.6
 			maxThrust = 320.6
 			heatProduction = 100
@@ -224,6 +228,7 @@
 		{
 			name = Vexin-A
 			description = Modified for vaccuum use and converted to UDMH/NTO as the second stage of the Europa Launch Vehicle.
+			specLevel = operational
 			minThrust = 262
 			maxThrust = 262
 			heatProduction = 100
@@ -268,6 +273,7 @@
 		{
 			name = Valois-A
 			description = Upgraded version of Vexin, used in the first stage of the Amethyste sounding rocket and Diamant-B launch vehicle.
+			specLevel = operational
 			minThrust = 406.8
 			maxThrust = 406.8
 			heatProduction = 100
@@ -314,6 +320,7 @@
 		{
 			name = Valois-B
 			description = Engine for the Diamant-BP first stage
+			specLevel = operational
 			minThrust = 373.5
 			maxThrust = 373.5
 			heatProduction = 100
@@ -369,7 +376,7 @@
 		ignitionReliabilityEnd = 0.9
 		cycleReliabilityStart = 0.833333
 		cycleReliabilityEnd = 0.966667
-		techTransfer = VeroniqueR,Veronique,VeroniqueAGI:40
+		techTransfer = Veronique61,VeroniqueAGI,Veronique:40
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Vesta] { %ratedBurnTime = #$/TESTFLIGHT[Vesta]/ratedBurnTime$ } }
 }
@@ -387,7 +394,7 @@
 		ignitionReliabilityEnd = 0.925000
 		cycleReliabilityStart = 0.75
 		cycleReliabilityEnd = 0.925000
-		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta:40
+		techTransfer = Vesta,Veronique61,VeroniqueAGI,Veronique:40
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Vexin] { %ratedBurnTime = #$/TESTFLIGHT[Vexin]/ratedBurnTime$ } }
 }
@@ -405,7 +412,7 @@
 		ignitionReliabilityEnd = 0.978571
 		cycleReliabilityStart = 0.75
 		cycleReliabilityEnd = 0.921429
-		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin:40
+		techTransfer = Vexin,Vesta,Veronique61,VeroniqueAGI,Veronique:40
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Vexin-A] { %ratedBurnTime = #$/TESTFLIGHT[Vexin-A]/ratedBurnTime$ } }
 }
@@ -422,7 +429,7 @@
 		ignitionReliabilityEnd = 0.983333
 		cycleReliabilityStart = 0.916667
 		cycleReliabilityEnd = 0.983333
-		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin,Vexin-A:40
+		techTransfer = Vexin-A,Vexin,Vesta,Veronique61,VeroniqueAGI,Veronique:40
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Valois-A] { %ratedBurnTime = #$/TESTFLIGHT[Valois-A]/ratedBurnTime$ } }
 }
@@ -437,7 +444,7 @@
 		ignitionReliabilityEnd = 0.983333
 		cycleReliabilityStart = 0.916667
 		cycleReliabilityEnd = 0.983333
-		techTransfer = VeroniqueR,Veronique,VeroniqueAGI,Vesta,Vexin,Vexin-A,Valois-A:40
+		techTransfer = Valois-A,Vexin-A,Vexin,Vesta,Veronique61,VeroniqueAGI,Veronique:40
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Valois-B] { %ratedBurnTime = #$/TESTFLIGHT[Valois-B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
@@ -24,6 +24,8 @@
     %manufacturer = Vikas Industry
     %description = High thrust hypergolic vacuum engine. Derived from the European Viking engine that were used on the early Ariane launch vehicles for booster or sustainer roles. ISRO adapted them as a vacuum engine for the second stage of the Polar Satellite Launch Vehicle (PSLV) and the Geosynchronous Satellite Launch Vehicle (GSLV) launch vehicle families.
 
+	%specLevel = operational
+
     @MODULE[ModuleEngines*]
     {
         %EngineType = LiquidFuel
@@ -43,6 +45,7 @@
         {
             name = Vikas-1
 			description = License built copy of the European Viking-5 engine.
+			specLevel = operational
             minThrust = 689
             maxThrust = 689
             heatProduction = 100
@@ -92,6 +95,7 @@
         {
             name = Vikas-1+
 			description = Uprated version of the Vikas-1.
+			specLevel = operational
             minThrust = 765.5
             maxThrust = 765.5
             heatProduction = 100
@@ -141,6 +145,7 @@
         {
             name = Vikas-2
 			description = License built copy of the Viking-4 vacuum engine.
+			specLevel = operational
             minThrust = 725
             maxThrust = 725
             heatProduction = 100
@@ -190,6 +195,7 @@
         {
             name = Vikas-2B
 			description = Uprated version of the Vikas-2.
+			specLevel = operational
             minThrust = 804.5
             maxThrust = 804.5
             heatProduction = 100
@@ -305,7 +311,7 @@
 		ignitionReliabilityEnd = 0.9965
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
-		techTransfer = Vikas-1:50
+		techTransfer = Vikas-2:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Vikas-2B] { %ratedBurnTime = #$/TESTFLIGHT[Vikas-2B]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -113,6 +113,8 @@
 	%manufacturer = Snecma S.A.
 	%description = Hypergolic booster engine developed for the European Ariane launch vehicle. Used as both a first stage engine, and second stage when equipped with an extended nozzle, and a booster version was also created for the Ariane 4 strap-on liquid boosters. Average performance compared to its contemporaries, but reliable.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -136,6 +138,7 @@
 		{
 			name = Viking-2
 			description = First stage engine for Ariane 1
+			specLevel = operational
 			minThrust = 690
 			maxThrust = 690
 			heatProduction = 100
@@ -185,6 +188,7 @@
 		{
 			name = Viking-4
 			description = Second stage engine for Ariane 1
+			specLevel = operational
 			minThrust = 721
 			maxThrust = 721
 			heatProduction = 100
@@ -234,6 +238,7 @@
 		{
 			name = Viking-2B
 			description = First stage engine for Ariane 2/3. Uses UH25 for extra performance.
+			specLevel = operational
 			minThrust = 720
 			maxThrust = 720
 			heatProduction = 100
@@ -283,6 +288,7 @@
 		{
 			name = Viking-4B
 			description = Second stage engine for Ariane 2/3/4. Uses UH25 for extra performance.
+			specLevel = operational
 			minThrust = 805
 			maxThrust = 805
 			heatProduction = 100
@@ -332,6 +338,7 @@
 		{
 			name = Viking-5C
 			description = First stage engine for Ariane 4
+			specLevel = operational
 			minThrust = 758
 			maxThrust = 758
 			heatProduction = 100
@@ -381,6 +388,7 @@
 		{
 			name = Viking-6
 			description = Booster engine for Ariane 4
+			specLevel = operational
 			minThrust = 758
 			maxThrust = 758
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Vulcain_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vulcain_Config.cfg
@@ -53,6 +53,8 @@
 	%manufacturer = Snecma
 	%description = 1990s high TWR, atmospheric and vacuum use. Vulcain is a gas-generator sustainer engine used on Ariane 5 and intended to be used on Ariane 6.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -79,6 +81,7 @@
 		CONFIG
 		{
 			name = Vulcain
+			specLevel = operational
 			maxThrust = 1145
 			minThrust = 1145
 			massMult = 0.70
@@ -111,6 +114,7 @@
 		{
 			name = Vulcain-2
 			description = Upgrade, utilizing flim cooling and new turbopumps for higher thrust.
+			specLevel = operational
 			maxThrust = 1350
 			minThrust = 1350
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Waxwing_Config.cfg
@@ -38,6 +38,8 @@
 	@manufacturer = Bristol Aerojet / RPE
 	@description = The Waxwing was a small solid kick motor for circularizing payloads in orbit, used as a third stage on the Black Arrow launch vehicle in 1970-71. 29.4kN average thrust.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -69,6 +71,7 @@
 		CONFIG
 		{
 			name = Waxwing
+			specLevel = operational
 			minThrust = 34.35
 			maxThrust = 34.35
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -91,6 +91,8 @@
 	%manufacturer = General Electric (GE)
 	%description = A very early kerolox gas generator booster engine used on the Vanguard launch vehicle.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -118,6 +120,7 @@
 		CONFIG
 		{
 			name = X-405
+			specLevel = operational
 			minThrust = 135.28
 			maxThrust = 135.28 // 27800lbf at sea level
 			heatProduction = 78
@@ -171,6 +174,7 @@
 		CONFIG
 		{
 			name = X-405H
+			specLevel = prototype
 			minThrust = 150.5
 			maxThrust = 150.5
 			heatProduction = 78
@@ -229,6 +233,7 @@
 		{
 			name = X-405H-3
 			description = Speculative upgrade configuration with increased expansion ratio
+			specLevel = speculative
 			minThrust = 161.86
 			maxThrust = 161.86
 			heatProduction = 78
@@ -283,6 +288,7 @@
 		{
 			name = X-405H-4
 			description = Speculative upgrade configuration with increased chamber pressure and upgrades with late 1960s technology.
+			specLevel = speculative
 			minThrust = 186.42
 			maxThrust = 186.42
 			heatProduction = 78

--- a/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
@@ -110,6 +110,8 @@
 	%manufacturer = Reaction Motors
 	%description = While it doesn't look a thing like it, this model represents the Reaction Motors XLR11, the first liquid fueled rocket engine designed for airplanes. Powered the X-1, early X-15s, and X-24B.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -139,6 +141,7 @@
 		{
 			name = XLR11-RM-3
 			description = Initial pressure-fed version used on X-1 #1 and #2
+			specLevel = operational
 			minThrust = 6.67
 			maxThrust = 26.68
 			massMult = 0.707
@@ -175,6 +178,7 @@
 		{
 			name = XLR11-RM-5
 			description = Pump-fed version used on X-1 #3 and later aircraft
+			specLevel = operational
 			minThrust = 6.67
 			maxThrust = 26.68
 			massMult = 1.0
@@ -210,6 +214,7 @@
 		{
 			name = XLR11-RM-13-8K
 			description = Uprated XLR11 used on early X-15 flights before the XLR99 was ready
+			specLevel = operational
 			minThrust = 9.61
 			maxThrust = 38.45 // 8.6 klbf thrust
 			massMult = 1.0
@@ -245,6 +250,7 @@
 		{
 			name = XLR11-RM-13-10K	//Uprated version used in X-24B
 			description = Uprated for use on X-24B flights
+			specLevel = operational
 			minThrust = 11.77
 			maxThrust = 47.08
 			massMult = 1.0
@@ -280,6 +286,7 @@
 		{
 			name = XLR35-RM-1
 			description = Modified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance. Includes gimbal assembly.
+			specLevel = operational
 			maxThrust = 27.56
 			massMult = 1.233
 			heatProduction = 100
@@ -385,7 +392,7 @@
 		ignitionDynPresFailMultiplier = 10.0 // still 70% chance at 50kPa
 		cycleReliabilityStart = 0.95
 		cycleReliabilityEnd = 0.998
-		techTransfer = XLR11-RM-3:20&XLR11-RM-5,XLR11-RM-13-8K:50
+		techTransfer = XLR11-RM-3:20&XLR11-RM-13-8K,XLR11-RM-5:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR11-RM-13-10K] { %ratedBurnTime = #$/TESTFLIGHT[XLR11-RM-13-10K]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR11-RM-13-10K] { %ratedContinuousBurnTime = #$/TESTFLIGHT[XLR11-RM-13-10K]/ratedContinuousBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR132_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR132_Config.cfg
@@ -36,6 +36,8 @@
 	@manufacturer = Rocketdyne
 	@description = Rocketdyne's pump-fed high performance upper stage engine for perigee/apogee stages, as well as transfer vehicles and lunar and Martian missions. It was tested extensively but has never flown.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = XLR132
+			specLevel = prototype
 			maxThrust = 16.7
 			minThrust = 16.7
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -37,6 +37,8 @@
 	%manufacturer = Curtiss-Wright
 	%description = The XLR25 was designed for the X-2, to test higher speeds and altitudes than the X-1. It was the first continously throttlable engine designed in the US. Although the engine was successful, the X-2 proved extremely unstable at high speeds and only a few flights were undertaken.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -58,6 +60,7 @@
 		CONFIG
 		{
 			name = XLR25-CW-1
+			specLevel = operational
 			minThrust = 12.02
 			maxThrust = 72.17
 			massMult = 1.0
@@ -109,7 +112,7 @@
 		cycleReliabilityStart = 0.931818
 		cycleReliabilityEnd = 0.986364
 		
-		techTransfer = XLR11-RM-5,XLR11-RM-13-8K:50	//Used a similar turbopump to the late-model XLR11, and was developed at around the same time
+		techTransfer = XLR11-RM-13-8K,XLR11-RM-5:50	//Used a similar turbopump to the late-model XLR11, and was developed at around the same time
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR25-CW-1] { %ratedBurnTime = #$/TESTFLIGHT[XLR25-CW-1]/ratedBurnTime$ } }
 	@MODULE[ModuleEngineConfigs] { @CONFIG[XLR25-CW-1] { %ratedContinuousBurnTime = #$/TESTFLIGHT[XLR25-CW-1]/ratedContinuousBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
@@ -44,6 +44,8 @@
 	%manufacturer = North American Aviation (NAA)
 	%description = Americanized version of the V-2 Model 39 (A-4). It was very similar to its predecessor, but was built using American SAE components rather than Metric components, and featured several minor upgrades.
 
+	%specLevel = prototype
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -71,6 +73,7 @@
 		CONFIG
 		{
 			name = XLR41-NA-1
+			specLevel = prototype
 			maxEngineTemp = 3000
 			chamberNominalTemp = 2923
 			minThrust = 333

--- a/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
@@ -41,6 +41,8 @@
 	%manufacturer = Reaction Motors
 	%description = LOX/Ammonia gas generator engine which powered the X-15 spaceplane. The first large, throttleable, restartable liquid fuel rocket engine.
 
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = LiquidFuel
@@ -62,6 +64,7 @@
 		CONFIG
 		{
 			name = XLR99
+			specLevel = operational
 			minThrust = 67.2
 			maxThrust = 224
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/XRS2200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XRS2200_Config.cfg
@@ -38,7 +38,9 @@
 	@title = XRS-2200
 	%manufacturer = Rocketdyne
 	@description = A linear aerospike engine developed for NASA's X-33 sub-scale SSTO technology demonstrator. Like the toroidal J-2T engines, the XRS-2200 used machinery derived from the J-2S.
-	
+
+	%specLevel = prototype
+
 	@MODULE[ModuleGimbal]
 	{
 		%gimbalRange = 15.0 // Throttles individual Thrust Zones to provide differences in thrust
@@ -56,6 +58,7 @@
 		CONFIG
 		{
 			name = XRS-2200
+			specLevel = prototype
 			minThrust = 584.6
 			maxThrust = 1169.3
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/YF-77.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/YF-77.cfg
@@ -35,6 +35,8 @@
 	%manufacturer = AALPT
 	%description = A Hydrolox engine used on the Long March 5 Rocket.
 
+	%specLevel = operational
+
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -45,6 +47,7 @@
 		CONFIG
 		{
 			name = YF-77
+			specLevel = operational
 			minThrust = 700
 			maxThrust = 700
 			heatProduction = 100


### PR DESCRIPTION
Add specLevel tagging to engine configs, and correct the ordering of techTransfer tags.