### PR TITLE
Move data to RF

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1080,7 +1080,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 180.65
-		loss_rate = 0.00000000023
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1101,7 +1100,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 184.65
-		loss_rate = 0.00000000025
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1113,7 +1111,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 169.45
-		loss_rate = 0.00000000035
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1125,7 +1122,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 128.4
-		loss_rate = 0.000000001
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1137,7 +1133,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 85.04
-		loss_rate = 0.0000000055
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1149,7 +1144,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 85.04
-		loss_rate = 0.0000000055
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1161,7 +1155,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 85.04
-		loss_rate = 0.0000000055
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1173,7 +1166,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 85.04
-		loss_rate = 0.0000000055
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1185,7 +1177,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 200.15
-		loss_rate = 0.00000000017
 		//note = (lacks insulation)
 	}
 	TANK
@@ -1333,6 +1324,36 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 	}
+	TANK
+	{
+		name = LqdNitrogen
+		//mass = 0.000014
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		wallThickness = 0.0025
+		wallConduction = 16
+		temperature = 77.36
+		insulationThickness = 0.01
+		insulationConduction = 0.02
+		//note = (lacks insulation)
+	}
+	TANK
+	{
+		name = LqdHelium
+		//mass = 0.000002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		temperature = 4.21
+		wallThickness = 0.0025
+		wallConduction = 205
+		insulationThickness = 0.0381
+		insulationConduction = 0.014
+		//note = (basic insulation)
+	}
 }
 
 // HP resources
@@ -1452,6 +1473,22 @@ TANK_DEFINITION
 	{
 		@temperature = 119.62
 	}
+	@TANK[LqdNitrogen]
+	{
+		@temperature = 103.75
+	}
+	@TANK[LqdHelium]
+	{
+		@temperature = 5.11
+	}
+	@TANK[Ethane]
+	{
+		@temperature = 241.1
+	}
+	@TANK[Ethylene]
+	{
+		@temperature = 221.3
+	}
 }
 
 // SM resources
@@ -1559,6 +1596,14 @@ TANK_DEFINITION
 	@TANK[LqdFluorine] {
 		isDewar = True
 		boiloffProduct = Fluorine
+	}
+	@TANK[LqdNitrogen] {
+		isDewar = True
+		boiloffProduct = Nitrogen
+	}
+	@TANK[LqdHelium] {
+		isDewar = True
+		boiloffProduct = Helium
 	}
 	@TANK[FLOX30] {
 		isDewar = True

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -39,24 +39,6 @@ RESOURCE_DEFINITION
   ksparpicon = RealFuels/Resources/ARPIcons/Aniline
 }
 
-//add vsp to water, ethanol, so it can boil
-@RESOURCE_DEFINITION[Ethanol75]:FOR[RealismOverhaul]
-{
-  @vsp = 1193640
-}
-@RESOURCE_DEFINITION[Ethanol90]:FOR[RealismOverhaul]
-{
-  @vsp = 952612
-}
-@RESOURCE_DEFINITION[Ethanol]:FOR[RealismOverhaul]
-{
-  @vsp = 839187
-}
-@RESOURCE_DEFINITION[Water]:FOR[RealismOverhaul]
-{
-  %vsp = 2257000
-}
-
 //Add Beryllium
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Move thermal data to RF, where it probably belongs, and add tank definitions for liquid Nitrogen and liquid Helium.

Thermal data is moved here: https://github.com/NathanKell/ModularFuelSystem/pull/286