### PR TITLE
Fix one more cfg syntax error

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/RO_RealChute.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/RO_RealChute.cfg
@@ -113,12 +113,13 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ProceduralChute]|@MODULE[RealChuteModule]]:FOR[zzzRealismOverhaul]
+@PART[*]:HAS[@MODULE[ProceduralChute]]:FOR[zzzRealismOverhaul]
 {
 	!MODULE[TweakScale] {}
 }
 @PART[*]:HAS[@MODULE[RealChuteModule]]:FOR[zzzRealismOverhaul]
 {
+	!MODULE[TweakScale] {}
 	@MODULE[RealChuteModule]
 	{
 		@PARACHUTE:HAS[#material[Kevlar]]


### PR DESCRIPTION
Hi KSP-RO team,

This is a follow-up to #2612. I missed one; I think the parser was in a less complete state when I ran it over RO's files.

Quoth @al2me6's superb MM syntax documentation:

![image](https://user-images.githubusercontent.com/1559108/160731819-0c470fe9-1865-46e9-984e-b074f74805cb.png)

`:HAS` supports logical AND (`,` / `&`) but not logical OR (`|`).

RO has one example of trying to use `|` in a `:HAS`; the impact of this would be that the TweakScale module would not be deleted in some cases related to chutes where it is expected to be.

This is now fixed by splitting it into two separate node statements, one per part of the OR. Then I noticed that the next line edits `:HAS[@MODULE[RealChuteModule]]` already, so I merged one of the new nodes with that block.
