### PR TITLE
Add H-1-250K

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -68,6 +68,22 @@
 //	Ignitions: 1
 //  Gimbal: 10.5
 //	=================================================================================
+//	H-1 250K
+//	1975? Uprated S-IB concept
+//
+//	Dry Mass: 911 Kg
+//	Thrust (SL): 1112.1 kN
+//	Thrust (Vac): 1247.4 kN
+//	ISP: 263 SL / 295 Vac
+//	Burn Time: 155
+//	Chamber Pressure: ??? MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.23
+//	Throttle: N/A
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//  Gimbal: 10.5
+//	=================================================================================
 //	RS-27
 //	1974
 //
@@ -342,6 +358,53 @@
 
 		CONFIG
 		{
+			name = H-1-250K
+			description = Maximum possible thrust for H-1 design, proposed for a post-Apollo uprated Saturn IB. Although engines were tested at increased thrust levels, the end of Apollo and selection of Titan III over Saturn IB meant this was never developed further.
+			specLevel = concept
+			minThrust = 1247.4
+			maxThrust = 1247.4
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3842
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6158
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 295
+				key = 1 263
+			}
+		}
+
+		CONFIG
+		{
 			name = RS-27
 			description = Remanufactured H-1 for use with Delta
 			specLevel = operational
@@ -516,6 +579,24 @@
 		techTransfer = S-3D,S-3:25&H-1-200K,H-1-188K,H-1-165K:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-205K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-205K]/ratedBurnTime$ } }
+}
+
+//No data, same as 205K
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[H-1-250K]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = H-1-250K
+		testedBurnTime = 350
+		ratedBurnTime = 155
+		safeOverburn = true
+		ignitionReliabilityStart = 0.976829
+		ignitionReliabilityEnd = 0.996341
+		cycleReliabilityStart = 0.976829
+		cycleReliabilityEnd = 0.996341
+		techTransfer = S-3D,S-3:25&H-1-205K,H-1-200K,H-1-188K,H-1-165K:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[H-1-250K] { %ratedBurnTime = #$/TESTFLIGHT[H-1-250K]/ratedBurnTime$ } }
 }
 //Delta 2310: 3 flights, 0 failures
 //Delta 2313: 3 flights, 0 failures


### PR DESCRIPTION
Add H-1-250K from Saturn IB uprating study. Although the increase in thrust is significant, it is still below the TWR numbers achieved by late model LR87s and LR89s.