### PR TITLE
Fix RD-107 and RD-108

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -97,7 +97,7 @@
 //	RD-107-8D728
 //	Molniya-M 8K78M, Soyuz 11A511
 //
-//	Dry Mass: 1180 Kg
+//	Dry Mass: 1100 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 995.37 kN
 //	ISP: 256.87 SL / 314.07 Vac
@@ -109,13 +109,14 @@
 //	Nozzle Ratio: 18.86
 //	Ignitions: 1
 //	=================================================================================
-//	RD-107-11D511 (RD-117)
+//	LPRE seems to have swapped the data for the RD-107 and RD-108
+//	RD-107-11D512 (RD-117)
 //	Soyuz-U 11A511U
 //
-//	Dry Mass: 1237 Kg
+//	Dry Mass: 1155 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 977.72 kN
-//	ISP: 252.89 SL / 315.91 Vac
+//	Thrust (Vac): 999.3 kN
+//	ISP: 256.87 SL / 314.58 Vac
 //	Burn Time: 140
 //	Chamber Pressure: 5.86 MPa
 //	Propellant: LOX / RP-1
@@ -124,13 +125,15 @@
 //	Nozzle Ratio: 18.86
 //	Ignitions: 1
 //	=================================================================================
-//	RD-107-11D511P (RD-117P)
+//	Soyuz boosters never actually got Syntin, which is why the performance given is almost identical to the standard 11D512
+//	Since this is already here, guesstimate some Syntin numbers for it
+//	RD-107-11D512P (RD-117P)
 //	Soyuz-U2 11A511U2
 //
-//	Dry Mass: 1190 Kg
+//	Dry Mass: 1155 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 996.4 kN
-//	ISP: 257 SL / 314 Vac
+//	Thrust (Vac): 1033.3 kN
+//	ISP: 261 SL / 317.6 Vac
 //	Burn Time: 140
 //	Chamber Pressure: ??? MPa
 //	Propellant: LOX / Syntin
@@ -142,7 +145,7 @@
 //	RD-107A-14D22
 //	Soyuz-FG
 //
-//	Dry Mass: 1121 Kg
+//	Dry Mass: 1090 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1019.89 kN
 //	ISP: 263.09 SL / 319.99 Vac
@@ -525,7 +528,7 @@
 			specLevel = operational
 			maxThrust = 995.37
 			minThrust = 995.37
-			massMult = 0.9912
+			massMult = 0.9244
 
 			ullage = True
 			pressureFed = False
@@ -573,12 +576,12 @@
 		}
 		CONFIG
 		{
-			name = RD-107-11D511
-			description = Used on Soyuz-U 11A511U (also known as RD-117)
+			name = RD-107-11D511	//This should be 11D512
+			description = Used on Soyuz-U 11A511U and Soyuz-U2 11A511U2 (also known as RD-117)
 			specLevel = operational
-			maxThrust = 977.72
-			minThrust = 977.72
-			massMult = 1.0396
+			maxThrust = 999.3
+			minThrust = 999.3
+			massMult = 0.9706
 
 			ullage = True
 			pressureFed = False
@@ -620,17 +623,18 @@
 
 			atmosphereCurve
 			{
-				key = 0 315.91
-				key = 1 252.89
+				key = 0 314.58
+				key = 1 256.87
 			}
 		}
 		CONFIG
 		{
-			name = RD-107-11D511P
-			description = Used on Soyuz-U2 11A511U2 (also known as RD-117)
-			specLevel = operational
-			maxThrust = 996.4
-			minThrust = 996.4
+			name = RD-107-11D511P	//Should be 11D512P
+			description = RD-117 converted to run on Syntin. In reality, only the core used Syntin to save costs
+			specLevel = speculative
+			maxThrust = 1033.3
+			minThrust = 1033.3
+			massMult = 0.9706
 
 			ullage = True
 			pressureFed = False
@@ -672,18 +676,18 @@
 
 			atmosphereCurve
 			{
-				key = 0 314
-				key = 1 257
+				key = 0 317.6
+				key = 1 261
 			}
 		}
 		CONFIG
 		{
 			name = RD-107A-14D22
-			description = Used on Soyuz-FG
+			description = Used on Soyuz-FG and Soyuz-2. Switching to a modern injector based on the RD-111 greatly improves engine performance.
 			specLevel = operational
 			maxThrust = 1019.89
 			minThrust = 1019.89
-			massMult = 0.9427
+			massMult = 0.9160
 
 			ullage = True
 			pressureFed = False

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -97,7 +97,7 @@
 //	RD-108-8D727
 //	Molniya-M 8K78M, Soyuz 11A511
 //
-//	Dry Mass: 1228 Kg
+//	Dry Mass: 1145 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 973.8 kN
 //	ISP: 252.79 SL / 315.81 Vac
@@ -109,13 +109,14 @@
 //	Nozzle Ratio: 18.86
 //	Ignitions: 1
 //	=================================================================================
-//	RD-108-11D512 (RD-118)
+//	LPRE seems to have swapped the data for the RD-107 and RD-108
+//	RD-108-11D511 (RD-118)
 //	Soyuz-U 11A511U
 //
-//	Dry Mass: 1403 Kg
+//	Dry Mass: 1250 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 999.3 kN
-//	ISP: 256.87 SL / 314.58 Vac
+//	Thrust (Vac): 977.72 kN
+//	ISP: 252.89 SL / 315.91 Vac	
 //	Burn Time: 340
 //	Chamber Pressure: 5.86 MPa
 //	Propellant: LOX / RP-1
@@ -124,10 +125,10 @@
 //	Nozzle Ratio: 18.86
 //	Ignitions: 1
 //	=================================================================================
-//	RD-108-11D512P (RD-118P)
+//	RD-108-11D511P (RD-118P)
 //	Soyuz-U2 11A511U2
 //
-//	Dry Mass: 1403 Kg
+//	Dry Mass: 1250 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1011 kN
 //	ISP: 257 SL / 319 Vac
@@ -142,7 +143,7 @@
 //	RD-108A-14D21
 //	Soyuz-FG
 //
-//	Dry Mass: 1068 Kg
+//	Dry Mass: 1075 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 990.47 kN
 //	ISP: 257.48 SL / 320.39 Vac
@@ -533,7 +534,7 @@
 			specLevel = operational
 			maxThrust = 973.8
 			minThrust = 973.8
-			massMult = 0.9612
+			massMult = 0.8959
 
 			ullage = True
 			pressureFed = False
@@ -584,9 +585,9 @@
 			name = RD-108-11D512
 			description = Used on Soyuz-U 11A511U (also known as RD-118)
 			specLevel = operational
-			maxThrust = 999.3
-			minThrust = 999.3
-			massMult = 1.0985
+			maxThrust = 977.72
+			minThrust = 977.72
+			massMult = 0.9781
 
 			ullage = True
 			pressureFed = False
@@ -628,18 +629,18 @@
 
 			atmosphereCurve
 			{
-				key = 0 314.58
-				key = 1 256.87
+				key = 0 315.91
+				key = 1 252.89
 			}
 		}
 		CONFIG
 		{
-			name = RD-108-11D512P
+			name = RD-108-11D512P	//Should be 11D511P
 			description = Used on Soyuz-U2 11A511U2 (also known as RD-118P)
 			specLevel = operational
 			maxThrust = 1011
 			minThrust = 1011
-			massMult = 1.0985
+			massMult = 0.9781
 
 			ullage = True
 			pressureFed = False
@@ -682,17 +683,17 @@
 			atmosphereCurve
 			{
 				key = 0 319
-				key = 1 263.5
+				key = 1 257
 			}
 		}
 		CONFIG
 		{
 			name = RD-108A-14D21
-			description = Used on Soyuz-FG
+			description = Used on Soyuz-FG and Soyuz-2. Switching to a modern injector based on the RD-111 greatly improves engine performance.
 			specLevel = operational
 			maxThrust = 990.47
 			minThrust = 990.47
-			massMult = 0.836
+			massMult = 0.8412
 
 			ullage = True
 			pressureFed = False


### PR DESCRIPTION
Fix various issues in the RD-107 and RD-108 configs, including incorrect masses, and the 11D511/11D512 configs being swapped.

* Adjust engine mass based on data from LPRE.de. This seems to be the best (and only) source for most engine versions, directly citing Energomash manuals

* Fix the 11D511/11D512 configs. The data for these seems to have been swapped, assigning the even-numbered RD-107 model to the RD-108, and the odd-numbered RD-108 model to the RD-107. These have been swapped back. However, the engine config names are still wrong, because changing them would be (slightly) save-breaking

* Correct the 11D512P config. Syntin was never used on the R-7 boosters for cost reasons, and the config we're using has basically identical performance to the standard 11D512 because it is the same engine, just with numbers from different sources. Instead, it has been replaced by a speculative Syntin-based config, with new performance numbers extrapolated.

* The names of the 11D511/11D512 configs are also left incorrect, because changing them would be (slightly) save-breaking