### PR TITLE
Fix typo in :FOR[RealismOveraul]

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RestockDragCubeHandling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RestockDragCubeHandling.cfg
@@ -1,51 +1,51 @@
 // Remove DRAG_CUBE definitions where ReStock creates them, or apply the drag cube rescaler
 
-@PART[basicFin|R8winglet|winglet|winglet3]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[basicFin|R8winglet|winglet|winglet3]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[batteryBankMini|batteryBank|batteryBankLarge]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[batteryBankMini|batteryBank|batteryBankLarge]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[sasModule|advSasModule|asasmodule1-2]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[sasModule|advSasModule|asasmodule1-2]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[HeatShield0|HeatShield1|HeatShield2|HeatShield3]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[HeatShield0|HeatShield1|HeatShield2|HeatShield3]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[probeStackSmall|probeStackLarge]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[probeStackSmall|probeStackLarge]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[SSME|liquidEngine3_v2|liquidEngine|liquidEngine2|Size3AdvancedEngine]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[SSME|liquidEngine3_v2|liquidEngine|liquidEngine2|Size3AdvancedEngine]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[solidBooster_v2|solidBooster_sm_v2|liquidEngine1-2|engineLargeSkipper]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[solidBooster_v2|solidBooster_sm_v2|liquidEngine1-2|engineLargeSkipper]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[liquidEngine2-2_v2|liquidEngineMainsail_v2|engineLargeSkipper_v2|liquidEngineMini_v2]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[liquidEngine2-2_v2|liquidEngineMainsail_v2|engineLargeSkipper_v2|liquidEngineMini_v2]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[largeAdapter]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[largeAdapter]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     !DRAG_CUBE {}
 }
 
-@PART[externalTankToroid]:HAS[#rescaleFactor,@DRAG_CUBE]:FOR[RealismOveraul]:NEEDS[ReStock]
+@PART[externalTankToroid]:HAS[#rescaleFactor,@DRAG_CUBE]:FOR[RealismOverhaul]:NEEDS[ReStock]
 {
     %rescaleCube = true
     @DRAG_CUBE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RestockPlusDragCubeHandling.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RestockPlusDragCubeHandling.cfg
@@ -1,30 +1,30 @@
-@PART[restock-adapter-skeletal-25-375-1]:FOR[RealismOveraul]:NEEDS[ReStockPlus]
+@PART[restock-adapter-skeletal-25-375-1]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
 {
     !DRAG_CUBE {}
 }
 
-@PART[restock-decoupler-1875-1|restock-decoupler-1875-truss-1|restock-separator-1875-1]:FOR[RealismOveraul]:NEEDS[ReStockPlus]
+@PART[restock-decoupler-1875-1|restock-decoupler-1875-truss-1|restock-separator-1875-1]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
 {
     !DRAG_CUBE {}
 }
 
-@PART[restock-decoupler-5-1|restock-separator-5-1]:FOR[RealismOveraul]:NEEDS[ReStockPlus]
+@PART[restock-decoupler-5-1|restock-separator-5-1]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
 {
     !DRAG_CUBE {}
 }
 
-@PART[restock-engine-125-pug|restock-engine-boar|restock-engine-375-corgi|restock-engine-125-valiant]:FOR[RealismOveraul]:NEEDS[ReStockPlus]
+@PART[restock-engine-125-pug|restock-engine-boar|restock-engine-375-corgi|restock-engine-125-valiant]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
 {
     !DRAG_CUBE {}
 }
 
-@PART[restock-structural-tube-1875-1|restock-structural-tube-25-1|restock-structural-tube-375-1|restock-structural-tube-5-1]:FOR[RealismOveraul]:NEEDS[ReStockPlus]
+@PART[restock-structural-tube-1875-1|restock-structural-tube-25-1|restock-structural-tube-375-1|restock-structural-tube-5-1]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
 {
     !DRAG_CUBE {}
 }
 
 // Restock+ hollow (so we should rescale)
-@PART[restock-drone-core-375-1|restock-adapter-hollow-25-375-1]:HAS[#rescaleFactor,@DRAG_CUBE]:FOR[RealismOveraul]:NEEDS[ReStockPlus]
+@PART[restock-drone-core-375-1|restock-adapter-hollow-25-375-1]:HAS[#rescaleFactor,@DRAG_CUBE]:FOR[RealismOverhaul]:NEEDS[ReStockPlus]
 {
     %rescaleCube = true
     @DRAG_CUBE


### PR DESCRIPTION
Hi KSP-RO team,

While doing some more dev for KSP-CKAN/CKAN#3525, I noticed that the name of the mod is misspelled in some of the `:FOR[]` clauses.
This PR fixes them.

Cheers!