### PR TITLE
BDB Updates

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
@@ -359,7 +359,7 @@
 @PART[bluedog_ThorAble_Guidance]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 	
 
 	@title = Able Avionics
@@ -399,7 +399,7 @@
 
 // CENTAUR
 
-@PART[bluedog_Centaur_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_Avionics]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
@@ -1,4 +1,132 @@
+//ABLE
+
+@PART[bluedog_Ablestar_Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Ablestar Fairing
+	@description = Fairing for the Ablestar series upper stage vehicle. 
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_FairingBase_0p625m_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Able/Able II Fairing
+	@description = Fairing for the Able series of upper stage vehicles. 
+
+	%ROSAFRescale = 1.6 
+}
+
+//ATLAS
+
+@PART[bluedog_Agena_SLV3B_Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Atlas SLV-3B 1.875m Fairing Base SAF.
+	@description = A special 1.875m fairing base designed to fully shroud an Agena upper stage on top of the Atlas SLV-3B rocket. Place on top of the SLV-3B 1.875m Adapter Fairing Base. An optional attach node can be enabled in the editor to use it as a standalone fairing base.
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_AtlasV_400Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Atlas V 400 series fairing.
+	@description = Fairing for the Atlas V 400 series launch vehicle. 
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_AtlasV_500Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Atlas V 500 series fairing. 
+	@description = Fairing for the Atlas V 500 series launch vehicle. 
+	
+	%ROSAFRescale = 1.6 
+}
+
+// CARRACK
+
+@PART[bluedog_Carrack_StraightAdapter_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Carrack 1.5m Straight Fairing Adapter SAF
+	@description = 1.5m straight fairing base adapter for the Carrack rocket. Includes optional hardware for use as an interstage decoupler and/or a fairing base.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
+// CENTAUR
+
+@PART[bluedog_Centaur_MPF_FairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Atlas II-Centaur-MPF 2.08m Fairing Base SAF
+	@description = Fairing for the Centaur upper stage used with the Atlas II vehicle. 
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
 // DELTA
+
+@PART[bluedog_Delta_Miniskirt_1p875m_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Delta-P/K 1.875m Fairing Adapter
+	@description = This 1.875m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has an integrated adjustable solid fairing.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Delta2_metalFairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Delta-P/K 1.5m Fairing Adapter
+	@description = This 1.5m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has built in adjustable fairings for Delta 1000 and Delta II.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Delta2_1875_adapter_fairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Delta-P/K 1.875m Titan Fairing Adapter SAF
+	@description = This 1.875m fairing base was designed to allow the 1.5m Delta P/K Fairing Adapter to use the standard Titan fairing. Simply place on top of the 1.5m Delta fairing skirt. Also features an optional top attach node to enable its use as a standalone fairing base.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
 
 @PART[bluedog_Delta2_metalFairing_SAF]:NEEDS[RealismOverhaul]
 {
@@ -10,36 +138,33 @@
 	@description = This 2.4m fairing base ring allows you to "hang" a 1.5m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has a built in adjustable metallic fairing.
 	@mass = 0.2
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
+	%ROSAFRescale = 1.6 
+}
 
-		@segmentLength = 1.5218096 //086
+@PART[bluedog_DCSS_2p5mFairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
 
-        	@shieldingCenter = 0, 3.312, 0
-        	@shieldingBaseRadius = 4.28 //
+	@title = Delta III 2.5m Fairing Base
+	@description = Fairing for the Delta III launch vehicle. 
+	@mass = 0.2
 
-        	@editorOpenOffset = 12, 0, 0
+	%ROSAFRescale = 1.6 
+}
 
+@PART[bluedog_DeltaIV_DCSS_fairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
 
-        	@WALL_BASE
-        	{
-            	@CoM = 0.6,0.8036864,0
-            	@rootOffset = 0,-0.64424,0
-        	}
+	@title = Delta IV DCSS 3.125m Fairing Base SAF
+	@description = Fairing for the Delta IV launch vehicle. 
+	@mass = 0.2
 
-        	@WALL
-        	{
-            	@CoM = 0.732, 3.42256, 0
-            	@rootOffset = 0, 4.28048, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.732, 4.54988, 0
-            	@rootOffset = 0, 4.28048, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 // TITAN
@@ -51,40 +176,20 @@
 
 	@title = Titan III-C 3m Fairing Base adapter SAF
 	@description = 3m fairing base for the Titan III rocket. Used on late Titan C, Titan 23C, 34D as well as 23G. *This version has an integrated adjustable solid fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.524 //086
-
-        	@shieldingCenter = 0, 2.3, 0
-        	@shieldingBaseRadius = 2.4 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.736,0.1,0
-            	@rootOffset = 0,0.1,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.736, 1.9288, 0
-            	@rootOffset = 0, 1.9288, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.736, 1.9288, 0
-            	@rootOffset = 0, 1.9288, 0
-        	}
-     	}
+	%ROSAFRescale = 1.6 
 }
 
+@PART[bluedog_FairingBase_3p125m_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = LDC Titan 3.125m Fairing Base SAF
+	@description = This low profile 3.125m fairing base integrates the cavernous fairing from the Titan IV rocket. Ideal for use on the LDC Titan.
+
+	%ROSAFRescale = 1.6 
+}
 
 @PART[bluedog_Titan3_CommercialDPAF_SAF]:NEEDS[RealismOverhaul]
 {
@@ -94,31 +199,8 @@
 
 	@title = Commercial Titan III 4m Dual Payload Adapter SAF
 	@description = 4m dual payload adapter for the Commercial Titan III. This innovative device has an integrated fairing on top and has room to carry a another payload underneath. First attach your lower payload to the stock version of the 4m Titan fairing base and then place this on top. The adapter needs to be manually decoupled in the part action window after the upper payload has deployed.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 5.792 //086
-
-        	@shieldingCenter = 0, 3.424, 0
-        	@shieldingBaseRadius = 2.856 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@WALL
-        	{
-            	@CoM = 1, 4.668768, 0
-            	@rootOffset = 0, 4.668768, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1, 3.359488, 0
-            	@rootOffset = 0, 3.359488, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Titan3_CommercialPLF_SAF]:NEEDS[RealismOverhaul]
@@ -129,31 +211,8 @@
 
 	@title = Commercial Titan III 4m Fairing Base Adapter SAF
 	@description = 3m to 4m fairing base adapter for the Commercial Titan III. *This version has an integrated adjustable solid fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 5.792 //086
-
-        	@shieldingCenter = 0, 2.38, 0
-        	@shieldingBaseRadius = 3.52 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@WALL
-        	{
-            	@CoM = 1, 4.0632, 0
-            	@rootOffset = 0, 4.0632, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1, 2.75392, 0
-            	@rootOffset = 0, 2.75392, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Titan3E_PLF_SAF]:NEEDS[RealismOverhaul]
@@ -163,86 +222,78 @@
 
 	@title = Titan III-E 4.16m Fairing Base adapter SAF
 	@description = 3m to 4.16m fairing base adapter for the Titan III-E rocket. Includes room inside for mounting upper stages up to 3m. *This version has an integrated adjustable solid fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 4.2128 //086
-
-        	@shieldingCenter = 0, 6.259712, 0
-        	@shieldingBaseRadius = 7.776 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 1.04,5.583536,0
-            	@rootOffset = 0,5.583536,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 1.04, 10.751248, 0
-            	@rootOffset = 0, 10.751248, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1.04, 10.6744, 0
-            	@rootOffset = 0, 10.6744, 0
-        	}
-     	}
+	%ROSAFRescale = 1.6 
 }
 
+
+@PART[bluedog_Agena_Titan33B_adapterFairingBase]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Titan 33/34B 1.875m to 0.9375m Adapter Fairing Base.
+	@description = 1.875m fairing base that integrates a 1.875m to 0.9375m structural adapter. Designed to completely enclose the Agena upper stage and sensitive payloads for the Titan 33B and 34B rockets. Was also adapted for the unique Atlas 23F Seasat launch vehicle. Can be enabled as a decoupler but it is recommended to place the Atlas SLV-3B 0.9375m Interstage on top when using with an Agena.
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Titan4_PLF_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Titan IV 3.125m Fairing Base adapter SAF
+	@description = Fairing for the Titan IV launch vehicle. 
+
+	%ROSAFRescale = 1.6 
+}
+
+
 // AGENA
+
+@PART[bluedog_Strawman_Bus_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Strawman Satellite Bus Fairing SAF
+	@description = The Strawman Bus is intended to push Agena-based satellites' life and capabilities to their full potential. Not only does this bus expand the Agena's profile from 0.9375m to 1.25m, it also introduces redundant systems, intregated batteries, a built-in fairing, and a new state-of-the-art solid-state data recording system. While intended to be a platform for signals intelligence reconnaissance collection, this bus can be used for any number of applications with the Agena upper stage and beyond. This version supports simple adjustable fairings.
+	
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Agena_SOT_SupportSkirt_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Agena SOT Structural Support Skirt SAF
+	@description = This 1.875m fairing base ring mounts to the interstage node of an Agena engine mount, allowing 1.875m interstages to be used. This version version comes with adjustable hard fairings.
+	
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Agena_POPPY_fairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Agena 1.25m POPPY Fairing Base
+	@description = This flared 1.25m fairing base was originally made for a secretive surveillance satellite. One of the larger options available for the Agena upper stage, it has plenty of other uses though.
+	
+	%ROSAFRescale = 1.6 
+}
 
 @PART[bluedog_Agena_SAC]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Standard Agena Clamshell Fairing SAF
+	@title = Standard Agena/Delta-E Clamshell Fairing SAF
 	@description = A 1.568m fairing base used as the standard shroud for the Agena upper stage. Used for payloads such as Nimbus. Later adapted as the standard fairing for the Delta-E upper stage. This version has a built in adjustable hard fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 0.9939504 //086
-
-        	@shieldingCenter = 0, 2.7496208, 0
-        	@shieldingBaseRadius = 2.864 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.784,1.08,0
-            	@rootOffset = 0,0.048,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.784, 2.656, 0
-            	@rootOffset = 0, 2.211712, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.784, 2.656, 0
-            	@rootOffset = 0, 2.211712, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 4.30288, 0
-            	@rootOffset = 0, 4.30288, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_AgenaB_FairingBase_Ranger_SAF]:NEEDS[RealismOverhaul]
@@ -252,31 +303,8 @@
 
 	@title = JPL 1.5m flared fairing base SAF
 	@description = Flared fairing built by JPL for the Agena upper stage to house the Ranger probes. This version has a built in adjustable hard fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.6 //086
-
-        	@shieldingCenter = 0, 2.7496208, 0
-        	@shieldingBaseRadius = 2.864 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@WALL
-        	{
-            	@CoM = 0.784, 1.92, 0
-            	@rootOffset = 0, 0.176, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.784, 2.656, 0
-            	@rootOffset = 0, 0.176, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_AgenaD_FairingBase_LunarOrbiterSAF]:NEEDS[RealismOverhaul]
@@ -286,38 +314,8 @@
 
 	@title = Lunar Orbiter 1.5m Flared Fairing Base SAF
 	@description = Flared fairing built by JPL for the Agena upper stage to house the Lunar Orbiter probes. This version has a built in adjustable hard fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.5476288 //086
-
-        	@shieldingCenter = 0, 2.08, 0
-        	@shieldingBaseRadius = 2.16 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.784,1.08,0
-            	@rootOffset = 0,0.0876016,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.784, 2.6272, 0
-            	@rootOffset = 0, 2.2525936, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.784, 1.92, 0
-            	@rootOffset = 0, 2.2525936, 0
-        	}
-     	}
+	%ROSAFRescale = 1.6 
 }
 
 
@@ -332,28 +330,7 @@
 	@description = A special fairing base for the Juno II rocket. The fairing might not be very spacious but will safely enclose a Sergeant cluster and a small payload.
 	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 0.9939504 //086
-
-        	@shieldingCenter = 0, 2.73632, 0
-        	@shieldingBaseRadius = 2.752 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@CONE
-        	{
-            	@CoM = 0.75, 4.168, 0
-            	@rootOffset = 0, 3.00096, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 5.9032, 0
-            	@rootOffset = 0, 5.314352, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Juno4_FairingBase_0p9375]:NEEDS[RealismOverhaul]
@@ -364,41 +341,7 @@
 	@title = Juno IV Fairing SAF
 	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.4852816 //086
-
-        	@shieldingCenter = 0, 2.41712, 0
-        	@shieldingBaseRadius = 2.496 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.75,1.232,0
-            	@rootOffset = 0,0.07888,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.75, 3.13456, 0
-            	@rootOffset = 0, 2.39216, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.75, 3.64016, 0
-            	@rootOffset = 0, 2.39216, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 5.504, 0
-            	@rootOffset = 0, 4.869952, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Juno4_FairingBase_1p25m]:NEEDS[RealismOverhaul]
@@ -409,39 +352,5 @@
 	@title = Juno IV Fairing 2 SAF
 	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.980384 //086
-
-        	@shieldingCenter = 0, 3.28, 0
-        	@shieldingBaseRadius = 3.36 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 1 ,1.6, 0
-            	@rootOffset = 0,0.0505936,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 1, 4.128, 0
-            	@rootOffset = 0, 3.1403056, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1, 4.8, 0
-            	@rootOffset = 0, 3.1403056, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 7.2, 0
-            	@rootOffset = 0, 6.4653616, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
@@ -739,7 +739,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Centaur_EngineMountA]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_EngineMount]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
@@ -231,7 +231,7 @@
 @PART[bluedog_ThorAble_Tank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 	// %useRcsConfig = RCSBlock
 
 	@title = Able Tank (Thor-Able) 
@@ -299,7 +299,7 @@
 @PART[bluedog_Vanguard_S2_Tank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 	
 
 	@title = Able Tank (Vanguard)
@@ -525,7 +525,7 @@
 @PART[bluedog_DeltaB_Tank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 
 	!MODULE[ModuleReactionWheel] {}
 	!MODULE[ModuleSAS] {}
@@ -1901,7 +1901,7 @@
 	}		
 }
 
-@PART[bluedog_Centaur_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_FuelTank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6


### PR DESCRIPTION
This request aims to update some of the old RO configs for Bluedog Design Bureau. The changes are:

1. Updating the part name of the Centaur D configs so the rescaling and properties for RO are applied. 

2. Changing the rescale factor of the Able parts from 1.3 to 1.6 so they match and can be used with the other launch vehicles. 

3. Adding RO configs to all SAF fairings, including the ROSAFRescale factor made by @StonesmileGit. 

I have tested everything with my install and it seems to work fine. Nevertheless, I'm new to all of this so there's a high possibility that I have missed something. Apologies in advance if that's the case. 