### PR TITLE
Update BDB SAF Configs, Rescale Able Parts, and other fixes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_AtlasV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_AtlasV.cfg
@@ -1,4 +1,4 @@
-@PART[bluedog_AtlasV_CCBLowerTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_CCBLowerTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -25,7 +25,7 @@
 	}	
 }
 
-@PART[bluedog_AtlasV_CCBUpperTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_CCBUpperTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -52,7 +52,7 @@
 	}	
 }
 
-@PART[bluedog_AtlasV_FairingBase5xx]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_FairingBase5xx]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -63,7 +63,7 @@
 	@mass = 0.2
 }
 
-@PART[bluedog_AtlasV_FairingBase5xx_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_FairingBase5xx_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -74,7 +74,7 @@
 	@mass = 0.2
 }
 
-@PART[bluedog_AtlasV_RD180]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_RD180]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -97,7 +97,7 @@
 	%clusterMultiplier = 2
 }
 
-@PART[bluedog_AtlasV_Star5F]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_Star5F]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -126,7 +126,7 @@
 	}
 }
 
-@PART[bluedog_AtlasV_AJ60]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_AJ60]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
@@ -1,6 +1,6 @@
 // AGENA
 
-@PART[bluedog_Agena_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Avionics]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -43,7 +43,7 @@
 
 // REDSTONE
 
-@PART[bluedog_Redstone_Guidance]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_Guidance]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -85,7 +85,7 @@
 	}
 }
 
-@PART[bluedog_Sparta_Guidance]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sparta_Guidance]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -130,7 +130,7 @@
 
 // JUNO
 
-@PART[bluedog_Juno1_Guidance]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno1_Guidance]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -199,7 +199,7 @@
 
 // JUPITER
 
-@PART[bluedog_Jupiter_Guidance]:NEEDS[RealismOverhaul]
+@PART[bluedog_Jupiter_Guidance]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -269,7 +269,7 @@
 
 // DELTA
 
-@PART[bluedog_Delta_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_Avionics]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -313,7 +313,7 @@
 
 // VANGUARD
 
-@PART[bluedog_Vanguard_S2_Guidance]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S2_Guidance]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -356,7 +356,7 @@
 
 // ABLE
 
-@PART[bluedog_ThorAble_Guidance]:NEEDS[RealismOverhaul]
+@PART[bluedog_ThorAble_Guidance]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -399,7 +399,7 @@
 
 // CENTAUR
 
-@PART[bluedog_CentaurD_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_Avionics]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -440,7 +440,7 @@
 	}
 }
 
-@PART[bluedog_CentaurT_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurT_Avionics]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -486,7 +486,7 @@
 
 // TITAN
 
-@PART[bluedog_Titan3_AvionicsTruss]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_AvionicsTruss]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
@@ -67,7 +67,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 	!MODULE[ModuleFuelTanks] {}
 
 	MODULE
@@ -109,7 +109,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 	!MODULE[ModuleFuelTanks] {}
 
 	MODULE
@@ -154,7 +154,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 	!MODULE[ModuleFuelTanks] {}
 
 	@MODULE[ModuleRCSFX]
@@ -223,7 +223,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 	!MODULE[ModuleFuelTanks] {}
 
 	@MODULE[ModuleRCSFX]
@@ -359,7 +359,7 @@
 @PART[bluedog_ThorAble_Guidance]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 	
 
 	@title = Able Avionics
@@ -399,7 +399,7 @@
 
 // CENTAUR
 
-@PART[bluedog_Centaur_Avionics]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_Avionics]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -460,7 +460,7 @@
 	
 	!MODULE[ModuleReactionWheel] {}
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	@MODULE[ModuleSAS]
 	{
@@ -506,7 +506,7 @@
 	
 	!MODULE[ModuleReactionWheel] {}
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	@MODULE[ModuleSAS]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
@@ -460,7 +460,7 @@
 	
 	!MODULE[ModuleReactionWheel] {}
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	@MODULE[ModuleSAS]
 	{
@@ -506,7 +506,7 @@
 	
 	!MODULE[ModuleReactionWheel] {}
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	@MODULE[ModuleSAS]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Avionics.cfg
@@ -67,7 +67,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 	!MODULE[ModuleFuelTanks] {}
 
 	MODULE
@@ -109,7 +109,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 	!MODULE[ModuleFuelTanks] {}
 
 	MODULE
@@ -154,7 +154,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 	!MODULE[ModuleFuelTanks] {}
 
 	@MODULE[ModuleRCSFX]
@@ -223,7 +223,7 @@
 		%SASServiceLevel = 1
 	}
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 	!MODULE[ModuleFuelTanks] {}
 
 	@MODULE[ModuleRCSFX]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ProbeExpansion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_ProbeExpansion.cfg
@@ -1,7 +1,7 @@
 
 // BIOSAT 
 
-@PART[bluedog_Biosat_Adapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Biosat_Adapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -69,7 +69,7 @@
 	}
 }
 
-@PART[bluedog_Biosat_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Biosat_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -81,7 +81,7 @@
 		
 }
 
-@PART[bluedog_Biosat_Magnetometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_Biosat_Magnetometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -96,7 +96,7 @@
 
 // PIONEER ABLE
 
-@PART[bluedog_PioneerAble_Adapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_PioneerAble_Adapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -107,7 +107,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_PioneerAble_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_PioneerAble_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -118,7 +118,7 @@
 	@mass = 0.002
 }
 
-@PART[bluedog_PioneerAble_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_PioneerAble_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -177,7 +177,7 @@
 	}
 }
 
-@PART[bluedog_PioneerAble_Engine]:NEEDS[RealismOverhaul]
+@PART[bluedog_PioneerAble_Engine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -237,7 +237,7 @@
 	}
 }
 
-@PART[bluedog_PioneerAble_SolarPaddle]:NEEDS[RealismOverhaul]
+@PART[bluedog_PioneerAble_SolarPaddle]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -255,7 +255,7 @@
 
 // PIONEER 6
 
-@PART[bluedog_Pioneer6_Bus]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_Bus]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -278,7 +278,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer6_IonSensor]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_IonSensor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -288,7 +288,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Pioneer6_Magnetometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_Magnetometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -298,7 +298,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Pioneer6_MainAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_MainAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -308,7 +308,7 @@
 	@mass = 0.03
 }
 
-@PART[bluedog_Pioneer6_MidcourseEngine]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_MidcourseEngine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -369,7 +369,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer6_RCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_RCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -403,7 +403,7 @@
     }
 }
 
-@PART[bluedog_Pioneer6_ServiceModule]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_ServiceModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -447,7 +447,7 @@
 	
 }
 
-@PART[bluedog_Pioneer6_StanfordAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer6_StanfordAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -457,7 +457,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_TTS1]:NEEDS[RealismOverhaul]
+@PART[bluedog_TTS1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -489,7 +489,7 @@
 
 // OGO
 
-@PART[bluedog_OGO_ExperimentBoom_3]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_ExperimentBoom_3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -499,7 +499,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_OGO_Adapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_Adapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -511,7 +511,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_Bus]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_Bus]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -560,7 +560,7 @@
 	}
 }
 
-@PART[bluedog_OGO_ExperimentBoom_1]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_ExperimentBoom_1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -570,7 +570,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_ExperimentBoom_2]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_ExperimentBoom_2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -580,7 +580,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_HighGainAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_HighGainAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -590,7 +590,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_LongBoom_Ball]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_LongBoom_Ball]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -600,7 +600,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_LongBoom_Hoop]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_LongBoom_Hoop]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -610,7 +610,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_OPEP]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_OPEP]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -620,7 +620,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OGO_RCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_RCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -655,7 +655,7 @@
     }
 }
 
-@PART[bluedog_OGO_SolarPanel_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_SolarPanel_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -671,7 +671,7 @@
 
 }
 
-@PART[bluedog_OGO_SolarPanel_Basic]:NEEDS[RealismOverhaul]
+@PART[bluedog_OGO_SolarPanel_Basic]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -690,7 +690,7 @@
 
 // NIMBUS
 
-@PART[bluedog_Nimbus_BeaconAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_BeaconAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -701,7 +701,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Nimbus_Decoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Decoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -712,7 +712,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_EarlyCommandAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_EarlyCommandAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -765,7 +765,7 @@
     }
 }
 
-@PART[bluedog_Nimbus_EarlyControlCore]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_EarlyControlCore]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -814,7 +814,7 @@
 	}
 }
 
-@PART[bluedog_Nimbus_Instrument_ERB]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_ERB]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -825,7 +825,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_Instrument_ESMR]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_ESMR]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -835,7 +835,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Nimbus_Instrument_SAMS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_SAMS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -846,7 +846,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_Instrument_SIS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_SIS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -856,7 +856,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_Instrument_SMMR]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_SMMR]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -866,7 +866,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_Instrument_THIR]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_THIR]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -876,7 +876,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_Instrument_TOMS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Instrument_TOMS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -887,7 +887,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_InstrumentTorus]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_InstrumentTorus]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -923,7 +923,7 @@
 	}
 }
 
-@PART[bluedog_Nimbus_LateCommandAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_LateCommandAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -934,7 +934,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_LateControlCore]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_LateControlCore]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1019,7 +1019,7 @@
     }
 }
 
-@PART[bluedog_Nimbus_PayloadDeck]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_PayloadDeck]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1030,7 +1030,7 @@
 	@mass = 0.06
 }
 
-@PART[bluedog_Nimbus_SBandAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_SBandAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1041,7 +1041,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Nimbus_SolarPanel]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_SolarPanel]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1052,7 +1052,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Nimbus_Truss]:NEEDS[RealismOverhaul]
+@PART[bluedog_Nimbus_Truss]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1066,7 +1066,7 @@
 
 // TELSTAR
 
-@PART[bluedog_Telstar_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Telstar_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1076,7 +1076,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_Telstar_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_Telstar_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1127,7 +1127,7 @@
 
 // OSO
 
-@PART[bluedog_OSO_Arm]:NEEDS[RealismOverhaul]
+@PART[bluedog_OSO_Arm]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1161,7 +1161,7 @@
     }
 }
 
-@PART[bluedog_OSO_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_OSO_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1210,7 +1210,7 @@
 	}
 }
 
-@PART[bluedog_OSO_Experiment]:NEEDS[RealismOverhaul]
+@PART[bluedog_OSO_Experiment]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1220,7 +1220,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_OSO_Photometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_OSO_Photometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1230,7 +1230,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_OSO_Sail]:NEEDS[RealismOverhaul]
+@PART[bluedog_OSO_Sail]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1273,7 +1273,7 @@
 
 // HELIOS
 
-@PART[bluedog_Helios_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_Helios_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1317,7 +1317,7 @@
 	}
 }
 
-@PART[bluedog_Helios_Dish]:NEEDS[RealismOverhaul]
+@PART[bluedog_Helios_Dish]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1328,7 +1328,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Helios_Magnetometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_Helios_Magnetometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1339,7 +1339,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Helios_RPWSAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Helios_RPWSAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1350,7 +1350,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Helios_SunShade]:NEEDS[RealismOverhaul]
+@PART[bluedog_Helios_SunShade]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1364,7 +1364,7 @@
 
 // ALOUETTE
 
-@PART[bluedog_Alouette_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Alouette_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1375,7 +1375,7 @@
 	@mass = 0.002
 }
 
-@PART[bluedog_Alouette_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_Alouette_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1428,7 +1428,7 @@
 
 // EARLY COMSATS
 
-@PART[bluedog_Courier_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_Courier_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1477,7 +1477,7 @@
 
 }
 
-@PART[bluedog_Relay_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Relay_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1487,7 +1487,7 @@
 	@mass = 0.002
 }
 
-@PART[bluedog_Relay_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_Relay_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1536,7 +1536,7 @@
 
 }
 
-@PART[bluedog_TRYP_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_TRYP_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1582,7 +1582,7 @@
 
 // TIROS
 
-@PART[bluedog_TIROS]:NEEDS[RealismOverhaul]
+@PART[bluedog_TIROS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1658,7 +1658,7 @@
 
 // AIMP
 
-@PART[bluedog_SmallSquarePanel_Static]:NEEDS[RealismOverhaul]
+@PART[bluedog_SmallSquarePanel_Static]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1674,7 +1674,7 @@
 
 }
 
-@PART[bluedog_SmallSquarePanel_Rotating]:NEEDS[RealismOverhaul]
+@PART[bluedog_SmallSquarePanel_Rotating]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1693,7 +1693,7 @@
 
 // IDCSP
 
-@PART[bluedog_IDCSP_Probe]:NEEDS[RealismOverhaul]
+@PART[bluedog_IDCSP_Probe]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1768,7 +1768,7 @@
 
 // RANGER LANDER
 
-@PART[bluedog_Ranger_BareCore]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_BareCore]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1811,7 +1811,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Lander_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Lander_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1821,7 +1821,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_Ranger_Lander_Leg]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Lander_Leg]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1832,7 +1832,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Ranger_Lander_Propulsion]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Lander_Propulsion]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1902,7 +1902,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Lander_Solar_Fixed]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Lander_Solar_Fixed]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1916,7 +1916,7 @@
     	}
 }
 
-@PART[bluedog_Ranger_Lander_Solar_Tracking]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Lander_Solar_Tracking]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1930,7 +1930,7 @@
     	}
 }
 
-@PART[bluedog_Ranger_Lander_Truss]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Lander_Truss]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1939,7 +1939,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Ranger_PayloadDeck]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_PayloadDeck]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1951,7 +1951,7 @@
 
 // OFO
 
-@PART[bluedog_OFO_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_OFO_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1960,7 +1960,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_OFO_Experiment]:NEEDS[RealismOverhaul]
+@PART[bluedog_OFO_Experiment]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Probes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_Probes.cfg
@@ -1,6 +1,6 @@
 // EXPLORER 1
 
-@PART[bluedog_Juno1_Explorer1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno1_Explorer1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -29,7 +29,7 @@
 
 // VANGUARD
 
-@PART[bluedog_Vanguard_Satellite1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_Satellite1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -132,7 +132,7 @@
 	}
 }
 
-@PART[bluedog_Vanguard_Satellite2]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_Satellite2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -158,7 +158,7 @@
 	}
 }
 
-@PART[bluedog_Vanguard_Satellite3]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_Satellite3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -186,7 +186,7 @@
 
 // REDSTONE
 
-@PART[bluedog_WRESAT]:NEEDS[RealismOverhaul]
+@PART[bluedog_WRESAT]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -210,7 +210,7 @@
 
 // JUNO
 
-@PART[bluedog_HoopAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_HoopAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -223,7 +223,7 @@
 }
 
 
-@PART[bluedog_Explorer_7]:NEEDS[RealismOverhaul]
+@PART[bluedog_Explorer_7]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -248,7 +248,7 @@
 
 }
 
-@PART[bluedog_Explorer_8]:NEEDS[RealismOverhaul]
+@PART[bluedog_Explorer_8]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -267,7 +267,7 @@
 	}
 }
 
-@PART[bluedog_Explorer_11]:NEEDS[RealismOverhaul]
+@PART[bluedog_Explorer_11]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -292,7 +292,7 @@
 
 }
 
-@PART[bluedog_Explorer_S45]:NEEDS[RealismOverhaul]
+@PART[bluedog_Explorer_S45]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -317,7 +317,7 @@
 
 }
 
-@PART[bluedog_Explorer_S46]:NEEDS[RealismOverhaul]
+@PART[bluedog_Explorer_S46]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -342,7 +342,7 @@
 
 }
 
-@PART[bluedog_Pioneer_1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer_1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -361,7 +361,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer_4]:NEEDS[RealismOverhaul]
+@PART[bluedog_Pioneer_4]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -382,7 +382,7 @@
 
 // RANGER
 
-@PART[bluedog_Ranger_Block2_RoughLander]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block2_RoughLander]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -406,7 +406,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Bus]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Bus]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -475,7 +475,7 @@
     }
 }
 
-@PART[bluedog_MarinerB_Bus]:NEEDS[RealismOverhaul]
+@PART[bluedog_MarinerB_Bus]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -551,7 +551,7 @@
     }
 }
 
-@PART[bluedog_Mariner2_CosmicDustDetector]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mariner2_CosmicDustDetector]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -561,7 +561,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Mariner2_IonTrap]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mariner2_IonTrap]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -571,7 +571,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Mariner2_Radiometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mariner2_Radiometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -581,7 +581,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Mariner2_Solar_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mariner2_Solar_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -607,7 +607,7 @@
 	}
 }
 
-@PART[bluedog_Mariner2_Solar_Basic]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mariner2_Solar_Basic]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -627,7 +627,7 @@
     	}
 }
 
-@PART[bluedog_Mariner2_Truss]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mariner2_Truss]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -637,7 +637,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_MarinerB_Solar]:NEEDS[RealismOverhaul]
+@PART[bluedog_MarinerB_Solar]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -651,7 +651,7 @@
     	}
 }
 
-@PART[bluedog_MarinerB_Truss]:NEEDS[RealismOverhaul]
+@PART[bluedog_MarinerB_Truss]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -661,7 +661,7 @@
 	@mass = 0.025
 }
 
-@PART[bluedog_Ranger_Battery]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Battery]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -679,7 +679,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -690,7 +690,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Device2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -700,7 +700,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Experiment]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Experiment]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -710,7 +710,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block1_LymanAlphaTelescope]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -720,7 +720,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Ranger_Block1_Truss]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block1_Truss]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -730,7 +730,7 @@
 	@mass = 0.025
 }
 
-@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -740,7 +740,7 @@
 	@mass = 0.015
 }
 
-@PART[bluedog_Ranger_Block2_OmniAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block2_OmniAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -755,7 +755,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Block2_RadarAltimeter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block2_RadarAltimeter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -765,7 +765,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Ranger_Block2_RetroDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block2_RetroDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -776,7 +776,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_Ranger_Block2_TVCamera]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block2_TVCamera]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -786,7 +786,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Ranger_Block3_TVSystem]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Block3_TVSystem]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -796,7 +796,7 @@
 	@mass = 0.04
 }
 
-@PART[bluedog_Ranger_Decoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Decoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -807,7 +807,7 @@
 	@mass = 0.015
 }
 
-@PART[bluedog_Ranger_Dish]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Dish]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -817,7 +817,7 @@
 	@mass = 0.035
 }
 
-@PART[bluedog_Ranger_OmniAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_OmniAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -832,7 +832,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Solar]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ranger_Solar]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -850,7 +850,7 @@
 
 // LUNAR ORBITER
 
-@PART[bluedog_LunarOrbiter_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -883,7 +883,7 @@
 	}
 }
 
-@PART[bluedog_LunarOrbiter_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -900,7 +900,7 @@
 	}
 }
 
-@PART[bluedog_LunarOrbiter_Camera]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Camera]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -912,7 +912,7 @@
 	%skinMaxTemp = 873
 }
 
-@PART[bluedog_LunarOrbiter_Dish]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Dish]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -929,7 +929,7 @@
 	}
 }
 
-@PART[bluedog_LunarOrbiter_Propulsion]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Propulsion]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1032,7 +1032,7 @@
 
 }
 
-@PART[bluedog_LunarOrbiter_Solar_SideMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Solar_SideMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1046,7 +1046,7 @@
     	}
 }
 
-@PART[bluedog_LunarOrbiter_Solar_UnderFold]:NEEDS[RealismOverhaul]
+@PART[bluedog_LunarOrbiter_Solar_UnderFold]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1062,7 +1062,7 @@
 
 // EXPLORER 33
 
-@PART[bluedog_AIMP_Core]:NEEDS[RealismOverhaul]
+@PART[bluedog_AIMP_Core]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1111,7 +1111,7 @@
 	}
 }
 
-@PART[bluedog_AIMP_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_AIMP_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1122,7 +1122,7 @@
 	@mass = 0.001
 }
 
-@PART[bluedog_AIMP_Magnetometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_AIMP_Magnetometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1133,7 +1133,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_AIMP_SolarPaddle]:NEEDS[RealismOverhaul]
+@PART[bluedog_AIMP_SolarPaddle]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1165,7 +1165,7 @@
     	}
 }
 
-@PART[bluedog_AIMP_SolidDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_AIMP_SolidDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1177,7 +1177,7 @@
 	@mass = 0.0005
 }
 
-@PART[bluedog_IMP_Magnetometer]:NEEDS[RealismOverhaul]
+@PART[bluedog_IMP_Magnetometer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1189,7 +1189,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_SmallSquarePanel_Rotating]:NEEDS[RealismOverhaul]
+@PART[bluedog_SmallSquarePanel_Rotating]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1203,7 +1203,7 @@
     	}
 }
 
-@PART[bluedog_SmallSquarePanel_Static]:NEEDS[RealismOverhaul]
+@PART[bluedog_SmallSquarePanel_Static]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
@@ -1,4 +1,132 @@
+//ABLE
+
+@PART[bluedog_Ablestar_Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Ablestar Fairing
+	@description = Fairing for the Ablestar series upper stage vehicle. 
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_FairingBase_0p625m_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Able/Able II Fairing
+	@description = Fairing for the Able series of upper stage vehicles. 
+
+	%ROSAFRescale = 1.6 
+}
+
+//ATLAS
+
+@PART[bluedog_Agena_SLV3B_Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Atlas SLV-3B 1.875m Fairing Base SAF.
+	@description = A special 1.875m fairing base designed to fully shroud an Agena upper stage on top of the Atlas SLV-3B rocket. Place on top of the SLV-3B 1.875m Adapter Fairing Base. An optional attach node can be enabled in the editor to use it as a standalone fairing base.
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_AtlasV_400Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Atlas V 400 series fairing.
+	@description = Fairing for the Atlas V 400 series launch vehicle. 
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_AtlasV_500Fairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Atlas V 500 series fairing. 
+	@description = Fairing for the Atlas V 500 series launch vehicle. 
+	
+	%ROSAFRescale = 1.6 
+}
+
+// CARRACK
+
+@PART[bluedog_Carrack_StraightAdapter_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Carrack 1.5m Straight Fairing Adapter SAF
+	@description = 1.5m straight fairing base adapter for the Carrack rocket. Includes optional hardware for use as an interstage decoupler and/or a fairing base.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
+// CENTAUR
+
+@PART[bluedog_Centaur_MPF_FairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Atlas II-Centaur-MPF 2.08m Fairing Base SAF
+	@description = Fairing for the Centaur upper stage used with the Atlas II vehicle. 
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
 // DELTA
+
+@PART[bluedog_Delta_Miniskirt_1p875m_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Delta-P/K 1.875m Fairing Adapter
+	@description = This 1.875m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has an integrated adjustable solid fairing.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Delta2_metalFairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Delta-P/K 1.5m Fairing Adapter
+	@description = This 1.5m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has built in adjustable fairings for Delta 1000 and Delta II.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Delta2_1875_adapter_fairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
+
+	@title = Delta-P/K 1.875m Titan Fairing Adapter SAF
+	@description = This 1.875m fairing base was designed to allow the 1.5m Delta P/K Fairing Adapter to use the standard Titan fairing. Simply place on top of the 1.5m Delta fairing skirt. Also features an optional top attach node to enable its use as a standalone fairing base.
+	@mass = 0.2
+
+	%ROSAFRescale = 1.6 
+}
 
 @PART[bluedog_Delta2_metalFairing_SAF]:NEEDS[RealismOverhaul]
 {
@@ -10,36 +138,33 @@
 	@description = This 2.4m fairing base ring allows you to "hang" a 1.5m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has a built in adjustable metallic fairing.
 	@mass = 0.2
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
+	%ROSAFRescale = 1.6 
+}
 
-		@segmentLength = 1.5218096 //086
+@PART[bluedog_DCSS_2p5mFairing_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
 
-        	@shieldingCenter = 0, 3.312, 0
-        	@shieldingBaseRadius = 4.28 //
+	@title = Delta III 2.5m Fairing Base
+	@description = Fairing for the Delta III launch vehicle. 
+	@mass = 0.2
 
-        	@editorOpenOffset = 12, 0, 0
+	%ROSAFRescale = 1.6 
+}
 
+@PART[bluedog_DeltaIV_DCSS_fairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	
 
-        	@WALL_BASE
-        	{
-            	@CoM = 0.6,0.8036864,0
-            	@rootOffset = 0,-0.64424,0
-        	}
+	@title = Delta IV DCSS 3.125m Fairing Base SAF
+	@description = Fairing for the Delta IV launch vehicle. 
+	@mass = 0.2
 
-        	@WALL
-        	{
-            	@CoM = 0.732, 3.42256, 0
-            	@rootOffset = 0, 4.28048, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.732, 4.54988, 0
-            	@rootOffset = 0, 4.28048, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 // TITAN
@@ -51,40 +176,20 @@
 
 	@title = Titan III-C 3m Fairing Base adapter SAF
 	@description = 3m fairing base for the Titan III rocket. Used on late Titan C, Titan 23C, 34D as well as 23G. *This version has an integrated adjustable solid fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.524 //086
-
-        	@shieldingCenter = 0, 2.3, 0
-        	@shieldingBaseRadius = 2.4 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.736,0.1,0
-            	@rootOffset = 0,0.1,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.736, 1.9288, 0
-            	@rootOffset = 0, 1.9288, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.736, 1.9288, 0
-            	@rootOffset = 0, 1.9288, 0
-        	}
-     	}
+	%ROSAFRescale = 1.6 
 }
 
+@PART[bluedog_FairingBase_3p125m_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = LDC Titan 3.125m Fairing Base SAF
+	@description = This low profile 3.125m fairing base integrates the cavernous fairing from the Titan IV rocket. Ideal for use on the LDC Titan.
+
+	%ROSAFRescale = 1.6 
+}
 
 @PART[bluedog_Titan3_CommercialDPAF_SAF]:NEEDS[RealismOverhaul]
 {
@@ -94,31 +199,8 @@
 
 	@title = Commercial Titan III 4m Dual Payload Adapter SAF
 	@description = 4m dual payload adapter for the Commercial Titan III. This innovative device has an integrated fairing on top and has room to carry a another payload underneath. First attach your lower payload to the stock version of the 4m Titan fairing base and then place this on top. The adapter needs to be manually decoupled in the part action window after the upper payload has deployed.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 5.792 //086
-
-        	@shieldingCenter = 0, 3.424, 0
-        	@shieldingBaseRadius = 2.856 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@WALL
-        	{
-            	@CoM = 1, 4.668768, 0
-            	@rootOffset = 0, 4.668768, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1, 3.359488, 0
-            	@rootOffset = 0, 3.359488, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Titan3_CommercialPLF_SAF]:NEEDS[RealismOverhaul]
@@ -129,31 +211,8 @@
 
 	@title = Commercial Titan III 4m Fairing Base Adapter SAF
 	@description = 3m to 4m fairing base adapter for the Commercial Titan III. *This version has an integrated adjustable solid fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 5.792 //086
-
-        	@shieldingCenter = 0, 2.38, 0
-        	@shieldingBaseRadius = 3.52 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@WALL
-        	{
-            	@CoM = 1, 4.0632, 0
-            	@rootOffset = 0, 4.0632, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1, 2.75392, 0
-            	@rootOffset = 0, 2.75392, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Titan3E_PLF_SAF]:NEEDS[RealismOverhaul]
@@ -163,86 +222,78 @@
 
 	@title = Titan III-E 4.16m Fairing Base adapter SAF
 	@description = 3m to 4.16m fairing base adapter for the Titan III-E rocket. Includes room inside for mounting upper stages up to 3m. *This version has an integrated adjustable solid fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 4.2128 //086
-
-        	@shieldingCenter = 0, 6.259712, 0
-        	@shieldingBaseRadius = 7.776 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 1.04,5.583536,0
-            	@rootOffset = 0,5.583536,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 1.04, 10.751248, 0
-            	@rootOffset = 0, 10.751248, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1.04, 10.6744, 0
-            	@rootOffset = 0, 10.6744, 0
-        	}
-     	}
+	%ROSAFRescale = 1.6 
 }
 
+
+@PART[bluedog_Agena_Titan33B_adapterFairingBase]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Titan 33/34B 1.875m to 0.9375m Adapter Fairing Base.
+	@description = 1.875m fairing base that integrates a 1.875m to 0.9375m structural adapter. Designed to completely enclose the Agena upper stage and sensitive payloads for the Titan 33B and 34B rockets. Was also adapted for the unique Atlas 23F Seasat launch vehicle. Can be enabled as a decoupler but it is recommended to place the Atlas SLV-3B 0.9375m Interstage on top when using with an Agena.
+
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Titan4_PLF_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Titan IV 3.125m Fairing Base adapter SAF
+	@description = Fairing for the Titan IV launch vehicle. 
+
+	%ROSAFRescale = 1.6 
+}
+
+
 // AGENA
+
+@PART[bluedog_Strawman_Bus_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Strawman Satellite Bus Fairing SAF
+	@description = The Strawman Bus is intended to push Agena-based satellites' life and capabilities to their full potential. Not only does this bus expand the Agena's profile from 0.9375m to 1.25m, it also introduces redundant systems, intregated batteries, a built-in fairing, and a new state-of-the-art solid-state data recording system. While intended to be a platform for signals intelligence reconnaissance collection, this bus can be used for any number of applications with the Agena upper stage and beyond. This version supports simple adjustable fairings.
+	
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Agena_SOT_SupportSkirt_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Agena SOT Structural Support Skirt SAF
+	@description = This 1.875m fairing base ring mounts to the interstage node of an Agena engine mount, allowing 1.875m interstages to be used. This version version comes with adjustable hard fairings.
+	
+	%ROSAFRescale = 1.6 
+}
+
+@PART[bluedog_Agena_POPPY_fairingBase_SAF]:NEEDS[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+
+	@title = Agena 1.25m POPPY Fairing Base
+	@description = This flared 1.25m fairing base was originally made for a secretive surveillance satellite. One of the larger options available for the Agena upper stage, it has plenty of other uses though.
+	
+	%ROSAFRescale = 1.6 
+}
 
 @PART[bluedog_Agena_SAC]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Standard Agena Clamshell Fairing SAF
+	@title = Standard Agena/Delta-E Clamshell Fairing SAF
 	@description = A 1.568m fairing base used as the standard shroud for the Agena upper stage. Used for payloads such as Nimbus. Later adapted as the standard fairing for the Delta-E upper stage. This version has a built in adjustable hard fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 0.9939504 //086
-
-        	@shieldingCenter = 0, 2.7496208, 0
-        	@shieldingBaseRadius = 2.864 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.784,1.08,0
-            	@rootOffset = 0,0.048,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.784, 2.656, 0
-            	@rootOffset = 0, 2.211712, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.784, 2.656, 0
-            	@rootOffset = 0, 2.211712, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 4.30288, 0
-            	@rootOffset = 0, 4.30288, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_AgenaB_FairingBase_Ranger_SAF]:NEEDS[RealismOverhaul]
@@ -252,31 +303,8 @@
 
 	@title = JPL 1.5m flared fairing base SAF
 	@description = Flared fairing built by JPL for the Agena upper stage to house the Ranger probes. This version has a built in adjustable hard fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.6 //086
-
-        	@shieldingCenter = 0, 2.7496208, 0
-        	@shieldingBaseRadius = 2.864 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@WALL
-        	{
-            	@CoM = 0.784, 1.92, 0
-            	@rootOffset = 0, 0.176, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.784, 2.656, 0
-            	@rootOffset = 0, 0.176, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_AgenaD_FairingBase_LunarOrbiterSAF]:NEEDS[RealismOverhaul]
@@ -286,38 +314,8 @@
 
 	@title = Lunar Orbiter 1.5m Flared Fairing Base SAF
 	@description = Flared fairing built by JPL for the Agena upper stage to house the Lunar Orbiter probes. This version has a built in adjustable hard fairing.
-	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.5476288 //086
-
-        	@shieldingCenter = 0, 2.08, 0
-        	@shieldingBaseRadius = 2.16 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.784,1.08,0
-            	@rootOffset = 0,0.0876016,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.784, 2.6272, 0
-            	@rootOffset = 0, 2.2525936, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.784, 1.92, 0
-            	@rootOffset = 0, 2.2525936, 0
-        	}
-     	}
+	%ROSAFRescale = 1.6 
 }
 
 
@@ -332,28 +330,7 @@
 	@description = A special fairing base for the Juno II rocket. The fairing might not be very spacious but will safely enclose a Sergeant cluster and a small payload.
 	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 0.9939504 //086
-
-        	@shieldingCenter = 0, 2.73632, 0
-        	@shieldingBaseRadius = 2.752 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-        	@CONE
-        	{
-            	@CoM = 0.75, 4.168, 0
-            	@rootOffset = 0, 3.00096, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 5.9032, 0
-            	@rootOffset = 0, 5.314352, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Juno4_FairingBase_0p9375]:NEEDS[RealismOverhaul]
@@ -364,41 +341,7 @@
 	@title = Juno IV Fairing SAF
 	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.4852816 //086
-
-        	@shieldingCenter = 0, 2.41712, 0
-        	@shieldingBaseRadius = 2.496 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 0.75,1.232,0
-            	@rootOffset = 0,0.07888,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 0.75, 3.13456, 0
-            	@rootOffset = 0, 2.39216, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 0.75, 3.64016, 0
-            	@rootOffset = 0, 2.39216, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 5.504, 0
-            	@rootOffset = 0, 4.869952, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }
 
 @PART[bluedog_Juno4_FairingBase_1p25m]:NEEDS[RealismOverhaul]
@@ -409,39 +352,5 @@
 	@title = Juno IV Fairing 2 SAF
 	@mass = 0.4
 
-	@MODULE[ModuleSimpleAdjustableFairing]
-    	{
-		scale = 1.6
-
-		@segmentLength = 1.980384 //086
-
-        	@shieldingCenter = 0, 3.28, 0
-        	@shieldingBaseRadius = 3.36 //
-
-        	@editorOpenOffset = 12, 0, 0
-
-
-        	@WALL_BASE
-        	{
-            	@CoM = 1 ,1.6, 0
-            	@rootOffset = 0,0.0505936,0
-        	}
-
-        	@WALL
-        	{
-            	@CoM = 1, 4.128, 0
-            	@rootOffset = 0, 3.1403056, 0
-        	}
-
-        	@CONE
-        	{
-            	@CoM = 1, 4.8, 0
-            	@rootOffset = 0, 3.1403056, 0
-        	}
-        	@CAP
-        	{
-            	@CoM = 0, 7.2, 0
-            	@rootOffset = 0, 6.4653616, 0
-        	}
-    	}
+	%ROSAFRescale = 1.6 
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
@@ -5,7 +5,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Ablestar Fairing
+	@title = Ablestar Fairing SAF
 	@description = Fairing for the Ablestar series upper stage vehicle. 
 
 	%ROSAFRescale = 1.6 
@@ -16,7 +16,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Able/Able II Fairing
+	@title = Able/Able II Fairing SAF
 	@description = Fairing for the Able series of upper stage vehicles. 
 
 	%ROSAFRescale = 1.6 
@@ -29,7 +29,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Atlas SLV-3B 1.875m Fairing Base SAF.
+	@title = Atlas SLV-3B 1.875m Fairing Base SAF
 	@description = A special 1.875m fairing base designed to fully shroud an Agena upper stage on top of the Atlas SLV-3B rocket. Place on top of the SLV-3B 1.875m Adapter Fairing Base. An optional attach node can be enabled in the editor to use it as a standalone fairing base.
 
 	%ROSAFRescale = 1.6 
@@ -40,7 +40,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Atlas V 400 series fairing.
+	@title = Atlas V 400 series fairing SAF
 	@description = Fairing for the Atlas V 400 series launch vehicle. 
 
 	%ROSAFRescale = 1.6 
@@ -51,7 +51,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Atlas V 500 series fairing. 
+	@title = Atlas V 500 series fairing SAF
 	@description = Fairing for the Atlas V 500 series launch vehicle. 
 	
 	%ROSAFRescale = 1.6 
@@ -64,7 +64,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
 	@title = Carrack 1.5m Straight Fairing Adapter SAF
 	@description = 1.5m straight fairing base adapter for the Carrack rocket. Includes optional hardware for use as an interstage decoupler and/or a fairing base.
 	@mass = 0.2
@@ -79,7 +78,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
 	@title = Atlas II-Centaur-MPF 2.08m Fairing Base SAF
 	@description = Fairing for the Centaur upper stage used with the Atlas II vehicle. 
 	@mass = 0.2
@@ -94,8 +92,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
-	@title = Delta-P/K 1.875m Fairing Adapter
+	@title = Delta-P/K 1.875m Fairing Adapter SAF
 	@description = This 1.875m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has an integrated adjustable solid fairing.
 	@mass = 0.2
 
@@ -107,8 +104,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
-	@title = Delta-P/K 1.5m Fairing Adapter
+	@title = Delta-P/K 1.5m Fairing Adapter SAF
 	@description = This 1.5m fairing base ring allows you to "hang" a 0.9375m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has built in adjustable fairings for Delta 1000 and Delta II.
 	@mass = 0.2
 
@@ -120,7 +116,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
 	@title = Delta-P/K 1.875m Titan Fairing Adapter SAF
 	@description = This 1.875m fairing base was designed to allow the 1.5m Delta P/K Fairing Adapter to use the standard Titan fairing. Simply place on top of the 1.5m Delta fairing skirt. Also features an optional top attach node to enable its use as a standalone fairing base.
 	@mass = 0.2
@@ -133,8 +128,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
-	@title = Delta-P/K 2.4m Fairing Adapter
+	@title = Delta-P/K 2.4m Fairing Adapter SAF
 	@description = This 2.4m fairing base ring allows you to "hang" a 1.5m rocket stage within a large interstage, so it doesn't have to sustain the full launch loads. Use with the Delta P and Delta K upper stages. Attach below the Delta K avionics core. This version has a built in adjustable metallic fairing.
 	@mass = 0.2
 
@@ -146,8 +140,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
-	@title = Delta III 2.5m Fairing Base
+	@title = Delta III 2.5m Fairing Base SAF
 	@description = Fairing for the Delta III launch vehicle. 
 	@mass = 0.2
 
@@ -159,7 +152,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
 	@title = Delta IV DCSS 3.125m Fairing Base SAF
 	@description = Fairing for the Delta IV launch vehicle. 
 	@mass = 0.2
@@ -196,7 +188,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
 	@title = Commercial Titan III 4m Dual Payload Adapter SAF
 	@description = 4m dual payload adapter for the Commercial Titan III. This innovative device has an integrated fairing on top and has room to carry a another payload underneath. First attach your lower payload to the stock version of the 4m Titan fairing base and then place this on top. The adapter needs to be manually decoupled in the part action window after the upper payload has deployed.
 
@@ -208,7 +199,6 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	
-
 	@title = Commercial Titan III 4m Fairing Base Adapter SAF
 	@description = 3m to 4m fairing base adapter for the Commercial Titan III. *This version has an integrated adjustable solid fairing.
 
@@ -226,13 +216,12 @@
 	%ROSAFRescale = 1.6 
 }
 
-
 @PART[bluedog_Agena_Titan33B_adapterFairingBase]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Titan 33/34B 1.875m to 0.9375m Adapter Fairing Base.
+	@title = Titan 33/34B 1.875m to 0.9375m Adapter Fairing Base SAF
 	@description = 1.875m fairing base that integrates a 1.875m to 0.9375m structural adapter. Designed to completely enclose the Agena upper stage and sensitive payloads for the Titan 33B and 34B rockets. Was also adapted for the unique Atlas 23F Seasat launch vehicle. Can be enabled as a decoupler but it is recommended to place the Atlas SLV-3B 0.9375m Interstage on top when using with an Agena.
 
 	%ROSAFRescale = 1.6 
@@ -248,7 +237,6 @@
 
 	%ROSAFRescale = 1.6 
 }
-
 
 // AGENA
 
@@ -279,7 +267,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Agena 1.25m POPPY Fairing Base
+	@title = Agena 1.25m POPPY Fairing Base SAF
 	@description = This flared 1.25m fairing base was originally made for a secretive surveillance satellite. One of the larger options available for the Agena upper stage, it has plenty of other uses though.
 	
 	%ROSAFRescale = 1.6 
@@ -318,7 +306,6 @@
 	%ROSAFRescale = 1.6 
 }
 
-
 // JUPITER
 
 @PART[bluedog_Juno2FairingBase]:FOR[RealismOverhaul]
@@ -326,7 +313,7 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 
-	@title = Juno II Fairing Cone
+	@title = Juno II Fairing Cone SAF
 	@description = A special fairing base for the Juno II rocket. The fairing might not be very spacious but will safely enclose a Sergeant cluster and a small payload.
 	@mass = 0.4
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_SAF.cfg
@@ -1,6 +1,6 @@
 //ABLE
 
-@PART[bluedog_Ablestar_Fairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ablestar_Fairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -11,7 +11,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_FairingBase_0p625m_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_FairingBase_0p625m_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -24,7 +24,7 @@
 
 //ATLAS
 
-@PART[bluedog_Agena_SLV3B_Fairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SLV3B_Fairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -35,7 +35,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_AtlasV_400Fairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_400Fairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -46,7 +46,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_AtlasV_500Fairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_500Fairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -59,7 +59,7 @@
 
 // CARRACK
 
-@PART[bluedog_Carrack_StraightAdapter_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Carrack_StraightAdapter_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -74,7 +74,7 @@
 
 // CENTAUR
 
-@PART[bluedog_Centaur_MPF_FairingBase_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_MPF_FairingBase_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -89,7 +89,7 @@
 
 // DELTA
 
-@PART[bluedog_Delta_Miniskirt_1p875m_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_Miniskirt_1p875m_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -102,7 +102,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Delta2_metalFairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta2_metalFairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -115,7 +115,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Delta2_1875_adapter_fairingBase_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta2_1875_adapter_fairingBase_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -128,7 +128,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Delta2_metalFairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta2_metalFairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -141,7 +141,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_DCSS_2p5mFairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_DCSS_2p5mFairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -154,7 +154,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_DeltaIV_DCSS_fairingBase_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaIV_DCSS_fairingBase_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -169,7 +169,7 @@
 
 // TITAN
 
-@PART[bluedog_Titan3C_StandardFairing_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3C_StandardFairing_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -180,7 +180,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_FairingBase_3p125m_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_FairingBase_3p125m_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -191,7 +191,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Titan3_CommercialDPAF_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_CommercialDPAF_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -203,7 +203,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Titan3_CommercialPLF_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_CommercialPLF_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -215,7 +215,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Titan3E_PLF_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3E_PLF_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -227,7 +227,7 @@
 }
 
 
-@PART[bluedog_Agena_Titan33B_adapterFairingBase]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Titan33B_adapterFairingBase]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -238,7 +238,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Titan4_PLF_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan4_PLF_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -252,7 +252,7 @@
 
 // AGENA
 
-@PART[bluedog_Strawman_Bus_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Strawman_Bus_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -263,7 +263,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Agena_SOT_SupportSkirt_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SOT_SupportSkirt_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -274,7 +274,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Agena_POPPY_fairingBase_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_POPPY_fairingBase_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -285,7 +285,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Agena_SAC]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SAC]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -296,7 +296,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_AgenaB_FairingBase_Ranger_SAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AgenaB_FairingBase_Ranger_SAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -307,7 +307,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_AgenaD_FairingBase_LunarOrbiterSAF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AgenaD_FairingBase_LunarOrbiterSAF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -321,7 +321,7 @@
 
 // JUPITER
 
-@PART[bluedog_Juno2FairingBase]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno2FairingBase]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -333,7 +333,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Juno4_FairingBase_0p9375]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_FairingBase_0p9375]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -344,7 +344,7 @@
 	%ROSAFRescale = 1.6 
 }
 
-@PART[bluedog_Juno4_FairingBase_1p25m]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_FairingBase_1p25m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_agena.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_agena.cfg
@@ -1,5 +1,5 @@
 
-@PART[bluedog_Agena_Decoupler_LunarOrbiter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Decoupler_LunarOrbiter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -11,7 +11,7 @@
 		
 }
 
-@PART[bluedog_GATV_MaterialsBay]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_MaterialsBay]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -21,7 +21,7 @@
 		
 }
 
-@PART[bluedog_Agena_MultiPayloadAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_MultiPayloadAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -32,7 +32,7 @@
 		
 }
 
-@PART[bluedog_Agena_RetroThrustModule]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_RetroThrustModule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -76,7 +76,7 @@
     	}
 }
 
-@PART[bluedog_AgenaD_FairingBase_LunarOrbiter]:NEEDS[RealismOverhaul]
+@PART[bluedog_AgenaD_FairingBase_LunarOrbiter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -86,7 +86,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_ATDA_Battery]:NEEDS[RealismOverhaul]
+@PART[bluedog_ATDA_Battery]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -95,7 +95,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_ATDA_VHFAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_ATDA_VHFAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -104,7 +104,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_ATDA_RCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_ATDA_RCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -153,7 +153,7 @@
     }
 }
 
-@PART[bluedog_GATV_AcquisitionLight]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_AcquisitionLight]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -162,7 +162,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_GATV_DockingPort]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_DockingPort]:FOR[RealismOverhaul]
 {
     	%RSSROConfig = True
     	@mass = 0.05           
@@ -189,7 +189,7 @@
     	}
 }
 
-@PART[bluedog_GATV_LBandAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_LBandAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -199,7 +199,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_GATV_MMDetector]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_MMDetector]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -208,7 +208,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_GATV_NoseCone]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_NoseCone]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -218,7 +218,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_GATV_NuclearPackage]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_NuclearPackage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -228,7 +228,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_GATV_RunningLight]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_RunningLight]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -237,7 +237,7 @@
 	@mass = 0.005
 }
 
-@PART[bluedog_GATV_SpiralAntenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_SpiralAntenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -247,7 +247,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_GATV_SPS]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_SPS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -344,7 +344,7 @@
     	}
 }
 
-@PART[bluedog_GATV_SPS_LFO]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_SPS_LFO]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -417,7 +417,7 @@
 	}	
 }
 
-@PART[bluedog_GATV_SPS_RCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_GATV_SPS_RCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -479,7 +479,7 @@
     	}
 }
 
-@PART[bluedog_Agena_SOT_1p875m]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SOT_1p875m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -507,7 +507,7 @@
 		
 }
 
-@PART[bluedog_Agena_SOT_2p5m]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SOT_2p5m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -535,7 +535,7 @@
 		
 }
 
-@PART[bluedog_Agena_SOT_GuidanceArray]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SOT_GuidanceArray]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -545,7 +545,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Agena_SOT_SupportSkirt]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_SOT_SupportSkirt]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -196,7 +196,7 @@
         	%charMin = 1
     	}
 
-    	@MODULE[ModuleAblator]:FOR[DeadlyReentry]
+    	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
     	{
         	@name = ModuleHeatShield
         	%depletedMaxTemp = 1200

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_keyhole.cfg
@@ -1,6 +1,6 @@
 // CAMERAS
 
-@PART[bluedog_Keyhole_Camera_KH1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_Camera_KH1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -10,7 +10,7 @@
 	@mass = 0.08
 }
 
-@PART[bluedog_Keyhole_Camera_KH4]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_Camera_KH4]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -21,7 +21,7 @@
 	@mass = 0.2
 }
 
-@PART[bluedog_Keyhole_Camera_KH4B]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_Camera_KH4B]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -32,7 +32,7 @@
 	@mass = 0.25
 }
 
-@PART[bluedog_Keyhole_Camera_KH7]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_Camera_KH7]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -43,7 +43,7 @@
 	@mass = 0.6
 }
 
-@PART[bluedog_Keyhole_Camera_KH8]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_Camera_KH8]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -57,7 +57,7 @@
 
 // MISC
 
-@PART[bluedog_Titan3B_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3B_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -68,7 +68,7 @@
 }
 
 
-@PART[bluedog_Keyhole_DualAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_DualAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -79,7 +79,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Keyhole_RVAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_RVAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -90,7 +90,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Keyhole_OCV_KH7]:NEEDS[RealismOverhaul]
+@PART[bluedog_Keyhole_OCV_KH7]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -173,7 +173,7 @@
 
 // RETURN CAPSULES
 
-@PART[bluedog_Corona_Heatshield]:NEEDS[RealismOverhaul]
+@PART[bluedog_Corona_Heatshield]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -196,7 +196,7 @@
         	%charMin = 1
     	}
 
-    	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+    	@MODULE[ModuleAblator]:FOR[DeadlyReentry]
     	{
         	@name = ModuleHeatShield
         	%depletedMaxTemp = 1200
@@ -218,7 +218,7 @@
 
 }
 
-@PART[bluedog_Corona_Parachute]:NEEDS[RealismOverhaul]
+@PART[bluedog_Corona_Parachute]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -306,7 +306,7 @@
     }
 }
 
-@PART[bluedog_Corona_Pod]:NEEDS[RealismOverhaul]
+@PART[bluedog_Corona_Pod]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -347,7 +347,7 @@
 	}
 }
 
-@PART[bluedog_Corona_Retro]:NEEDS[RealismOverhaul]
+@PART[bluedog_Corona_Retro]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_mercury.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_mercury.cfg
@@ -1,6 +1,6 @@
 // NEW
 
-@PART[bluedog_Mercury_Parachute]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Parachute]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -11,7 +11,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Mercury_ParachuteRCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_ParachuteRCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -41,7 +41,7 @@
     	}
 }
 
-@PART[bluedog_Mercury_AntennaNose]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_AntennaNose]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -128,7 +128,7 @@
     	}
 }
 
-@PART[bluedog_Mercury_PosigradeRocket]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_PosigradeRocket]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -153,7 +153,7 @@
 
 }
 
-@PART[bluedog_Mercury_Retropack]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Retropack]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -164,7 +164,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Mercury_RetroRocket]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_RetroRocket]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -212,7 +212,7 @@
 	}
 }
 
-@PART[bluedog_Mercury_Heatshield]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Heatshield]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -234,7 +234,7 @@
         	%charMax = 1
         	%charMin = 1
     	}
-    	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
+    	@MODULE[ModuleAblator]:FOR[DeadlyReentry]
     	{
         	@name = ModuleHeatShield
         	%depletedMaxTemp = 1200
@@ -254,7 +254,7 @@
 
 }
 
-@PART[bluedog_Mercury_Decoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Decoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -265,7 +265,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Mercury_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -276,7 +276,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Mercury_LES]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_LES]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -300,7 +300,7 @@
 
 }
 
-@PART[bluedog_Mercury_Airbrake]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Airbrake]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -311,7 +311,7 @@
 	@mass = 0.3
 }
 
-@PART[bluedog_Mercury_Capsule]:NEEDS[RealismOverhaul]
+@PART[bluedog_Mercury_Capsule]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_mercury.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_mercury.cfg
@@ -234,7 +234,7 @@
         	%charMax = 1
         	%charMin = 1
     	}
-    	@MODULE[ModuleAblator]:FOR[DeadlyReentry]
+    	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
     	{
         	@name = ModuleHeatShield
         	%depletedMaxTemp = 1200

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
@@ -622,7 +622,7 @@
 	!RESOURCE,*{}
 }
 
-@PART[bluedog_Atlas_SustainerAdapterTank]:FOR[RealismOverhaul]:FOR[Bluedog_DB]
+@PART[bluedog_Atlas_SustainerAdapterTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.6
@@ -644,7 +644,7 @@
 	}
 }
 
-@PART[bluedog_CELV_SustainerTank]:FOR[RealismOverhaul]:FOR[Bluedog_DB]
+@PART[bluedog_CELV_SustainerTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.6
@@ -1067,7 +1067,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan_SRB_Parachute]:FOR[RealismOverhaul,RealChute]
+@PART[bluedog_Titan_SRB_Parachute]:FOR[RealismOverhaul]:NEEDS[RealChute]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
@@ -71,7 +71,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -231,7 +231,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -290,7 +290,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -383,7 +383,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -755,7 +755,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -840,7 +840,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1085,8 +1085,8 @@
 
 
     maximum_drag = 0.32
-    !sound_parachute_open
-    !sound_parachute_single
+    !sound_parachute_open = DELETE
+    !sound_parachute_single = DELETE
 
     !MODULE[ModuleParachute]{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
@@ -71,7 +71,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -231,7 +231,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -290,7 +290,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -383,7 +383,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -739,7 +739,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Centaur_EngineMountA]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_EngineMount]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -755,7 +755,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -840,7 +840,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1085,8 +1085,8 @@
 
 
     maximum_drag = 0.32
-    !sound_parachute_open = DELETE
-    !sound_parachute_single = DELETE
+    !sound_parachute_open
+    !sound_parachute_single
 
     !MODULE[ModuleParachute]{}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
@@ -1,6 +1,6 @@
 // JUNO
 
-@PART[bluedog_Juno1_Nose]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno1_Nose]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -11,7 +11,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Sergeant_3x_Decoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sergeant_3x_Decoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -22,7 +22,7 @@
 	@mass = 0.003
 }
 
-@PART[bluedog_Sergeant_11x_Decoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sergeant_11x_Decoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -33,7 +33,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Sparta_0p625mAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sparta_0p625mAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -44,7 +44,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Sparta_0p625mInterstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sparta_0p625mInterstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -55,7 +55,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Redstone_AirVane]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_AirVane]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -106,7 +106,7 @@
     }
 }
 
-@PART[bluedog_Redstone_Fin_Basic]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_Fin_Basic]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -116,7 +116,7 @@
 	@mass = 0.08
 }
 
-@PART[bluedog_Redstone_Fin_CtrlSurf]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_Fin_CtrlSurf]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -128,7 +128,7 @@
 
 // JUPITER
 
-@PART[bluedog_Juno4_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -138,7 +138,7 @@
 	@mass = 0.2
 }
 
-@PART[bluedog_Juno4_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -148,7 +148,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Jupiter_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_Jupiter_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -161,7 +161,7 @@
 
 // AGENA
 
-@PART[bluedog_Agena_ResupplyContainer]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_ResupplyContainer]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -172,7 +172,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Agena_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -183,7 +183,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Agena_UllageMotor]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_UllageMotor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -194,7 +194,7 @@
 	@mass = 0.02
 }
 
-@PART[bluedog_Agena_StraightInterstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_StraightInterstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -205,7 +205,7 @@
 	@mass = 0.2
 }
 
-@PART[bluedog_Agena_AInterstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_AInterstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -216,7 +216,7 @@
 	@mass = 0.22
 }
 
-@PART[bluedog_Agena_EngineShroud]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_EngineShroud]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -275,7 +275,7 @@
 	}
 }
 
-@PART[bluedog_Agena_EquipmentRack]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_EquipmentRack]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -336,7 +336,7 @@
 
 // DELTA
 
-@PART[bluedog_DeltaP_FairingTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaP_FairingTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -347,7 +347,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_DeltaK_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -358,7 +358,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_DCSS_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_DCSS_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -369,7 +369,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_DCSS_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DCSS_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -424,7 +424,7 @@
     }
 }
 
-@PART[bluedog_Delta_Miniskirt_1p5m]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_Miniskirt_1p5m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -435,7 +435,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Delta_Miniskirt_1p875m]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_Miniskirt_1p875m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -449,7 +449,7 @@
 
 // THOR
 
-@PART[bluedog_Thor_AbleAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_AbleAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -460,7 +460,7 @@
 	@mass = 0.07
 }
 
-@PART[bluedog_Thor_1p25mAdapter_Short]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_1p25mAdapter_Short]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -471,7 +471,7 @@
 	@mass = 0.07
 }
 
-@PART[bluedog_Thor_0p9375mAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_0p9375mAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -482,7 +482,7 @@
 	@mass = 0.07
 }
 
-@PART[bluedog_Thor_0p9375mInterstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_0p9375mInterstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -493,7 +493,7 @@
 	@mass = 0.07
 }
 
-@PART[bluedog_Thor_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -504,7 +504,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Thor_CZFin]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_CZFin]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -514,7 +514,7 @@
 	@mass = 0.04
 }
 
-@PART[bluedog_Delta_Fin]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta_Fin]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -525,7 +525,7 @@
 }
 
 
-@PART[bluedog_ThorDelta_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_ThorDelta_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -536,7 +536,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Castor_RadialDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Castor_RadialDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -549,7 +549,7 @@
 
 // VANGUARD
 
-@PART[bluedog_Vanguard_S1_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S1_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -560,7 +560,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_Vanguard_S2_RetroRocket]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S2_RetroRocket]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -573,7 +573,7 @@
 
 // ATLAS
 
-@PART[bluedog_Atlas_Decoupler1875m]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_Decoupler1875m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -584,7 +584,7 @@
 	@mass = 0.06
 }
 
-@PART[bluedog_CELV_BoosterSkirt]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_BoosterSkirt]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -595,7 +595,7 @@
 	@mass = 2
 }
 
-@PART[bluedog_CELV_Fin]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_Fin]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -622,7 +622,7 @@
 	!RESOURCE,*{}
 }
 
-@PART[bluedog_Atlas_SustainerAdapterTank]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_Atlas_SustainerAdapterTank]:FOR[RealismOverhaul]:FOR[Bluedog_DB]
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.6
@@ -644,7 +644,7 @@
 	}
 }
 
-@PART[bluedog_CELV_SustainerTank]:FOR[RealismOverhaul]:NEEDS[Bluedog_DB]
+@PART[bluedog_CELV_SustainerTank]:FOR[RealismOverhaul]:FOR[Bluedog_DB]
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.6
@@ -668,7 +668,7 @@
 
 // LDC
 
-@PART[bluedog_LDC_S2_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S2_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -680,7 +680,7 @@
 		
 }
 
-@PART[bluedog_LDC_S2_Interstage]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S2_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -692,7 +692,7 @@
 		
 }
 
-@PART[bluedog_LDC_S2_Interstage2]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S2_Interstage2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1
@@ -706,7 +706,7 @@
 
 // CENTAUR
 
-@PART[bluedog_Centaur_FairingBase]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_FairingBase]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -717,7 +717,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Centaur_FairingBase_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_FairingBase_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -728,7 +728,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_centaur1875mAdapterFairing]:NEEDS[RealismOverhaul]
+@PART[bluedog_centaur1875mAdapterFairing]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -739,7 +739,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_CentaurD_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -824,7 +824,7 @@
     }
 }
 
-@PART[bluedog_CentaurV_EngineMount]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurV_EngineMount]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -875,7 +875,7 @@
     }
 }
 
-@PART[bluedog_AtlasV_Interstage4xx]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_Interstage4xx]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -886,7 +886,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_AtlasV_FairingBase4xx]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_FairingBase4xx]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -897,7 +897,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_AtlasV_FairingBase4xx_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AtlasV_FairingBase4xx_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -910,7 +910,7 @@
 
 // TITAN I
 
-@PART[bluedog_SOLTAN_NoseCone]:NEEDS[RealismOverhaul]
+@PART[bluedog_SOLTAN_NoseCone]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -921,7 +921,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan1_S1_EngineShroud]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_S1_EngineShroud]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -932,7 +932,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan1_StructuralAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_StructuralAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -943,7 +943,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan1_SeparationBottle]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_SeparationBottle]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -955,7 +955,7 @@
 
 // TITAN II
 
-@PART[bluedog_Titan2_S2_NoseCone]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_NoseCone]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -966,7 +966,7 @@
 	@mass = 0.4	
 }
 
-@PART[bluedog_Titan2_S2_EngineDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_EngineDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -977,7 +977,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan2_S2_GeminiDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_GeminiDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -988,7 +988,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan2_S2_1p5mAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_1p5mAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -999,7 +999,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan2_S2_1p25mAdapter]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_1p25mAdapter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1010,7 +1010,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan2_S2_RetroMotor]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_RetroMotor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1021,7 +1021,7 @@
 	@mass = 0.05	
 }
 
-@PART[bluedog_Titan2_S2_VernierMotor]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_VernierMotor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1034,7 +1034,7 @@
 
 // TITAN III
 
-@PART[bluedog_1875_NoseSep]:NEEDS[RealismOverhaul]
+@PART[bluedog_1875_NoseSep]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1045,7 +1045,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_1875_RadialDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_1875_RadialDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1056,7 +1056,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_1875_RadialSep]:NEEDS[RealismOverhaul]
+@PART[bluedog_1875_RadialSep]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1067,7 +1067,7 @@
 	@mass = 0.2	
 }
 
-@PART[bluedog_Titan_SRB_Parachute]:NEEDS[RealismOverhaul,RealChute]
+@PART[bluedog_Titan_SRB_Parachute]:FOR[RealismOverhaul,RealChute]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6
@@ -1161,7 +1161,7 @@
     }
 }
 
-@PART[bluedog_Titan_Transtage_Antenna]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage_Antenna]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1172,7 +1172,7 @@
 	@mass = 0.05	
 }
 
-@PART[bluedog_Titan3_S1_EngineShroud]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_S1_EngineShroud]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_misc.cfg
@@ -347,7 +347,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_DeltaK_Interstage]:FOR[RealismOverhaul]
+@PART[bluedog_Delta_Interstage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_payload_separators.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_payload_separators.cfg
@@ -1,6 +1,6 @@
 // 
 
-@PART[bluedog_PSM_0p625m_HighProfile]:NEEDS[RealismOverhaul]
+@PART[bluedog_PSM_0p625m_HighProfile]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -12,7 +12,7 @@
 		
 }
 
-@PART[bluedog_PSM_0p625m_LowProfile]:NEEDS[RealismOverhaul]
+@PART[bluedog_PSM_0p625m_LowProfile]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -24,7 +24,7 @@
 		
 }
 
-@PART[bluedog_PSM_0p625m_MediumProfile]:NEEDS[RealismOverhaul]
+@PART[bluedog_PSM_0p625m_MediumProfile]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -36,7 +36,7 @@
 		
 }
 
-@PART[bluedog_PSM_0p3125m_HighProfile]:NEEDS[RealismOverhaul]
+@PART[bluedog_PSM_0p3125m_HighProfile]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -48,7 +48,7 @@
 		
 }
 
-@PART[bluedog_PSM_0p3125m_LowProfile]:NEEDS[RealismOverhaul]
+@PART[bluedog_PSM_0p3125m_LowProfile]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -60,7 +60,7 @@
 		
 }
 
-@PART[bluedog_PSM_0p3125m_MediumProfile]:NEEDS[RealismOverhaul]
+@PART[bluedog_PSM_0p3125m_MediumProfile]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -72,7 +72,7 @@
 		
 }
 
-@PART[bluedog_SpinDecoupler_p3125m]:NEEDS[RealismOverhaul]
+@PART[bluedog_SpinDecoupler_p3125m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -86,7 +86,7 @@
 
 // AGENA
 
-@PART[bluedog_AgenaB_FairingBase_Ranger]:NEEDS[RealismOverhaul]
+@PART[bluedog_AgenaB_FairingBase_Ranger]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -97,7 +97,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_AgenaB_FairingBase_Ranger_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_AgenaB_FairingBase_Ranger_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -110,7 +110,7 @@
 
 // VANGUARD
 
-@PART[bluedog_FairingBase_0p625m]:NEEDS[RealismOverhaul]
+@PART[bluedog_FairingBase_0p625m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -121,7 +121,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_FairingBase_0p625m_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_FairingBase_0p625m_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -132,7 +132,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Vanguard_S2_LongProbeDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S2_LongProbeDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -143,7 +143,7 @@
 	@mass = 0.01
 }
 
-@PART[bluedog_Vanguard_S2_ShortProbeDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S2_ShortProbeDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -155,7 +155,7 @@
 }
 
 
-@PART[bluedog_625mDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_625mDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -166,7 +166,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_625mFairing]:NEEDS[RealismOverhaul]
+@PART[bluedog_625mFairing]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -177,7 +177,7 @@
 	@mass = 0.05
 }
 
-@PART[bluedog_625mFairing_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_625mFairing_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -191,7 +191,7 @@
 
 // THOR
 
-@PART[bluedog_FairingBase_0p9375m]:NEEDS[RealismOverhaul]
+@PART[bluedog_FairingBase_0p9375m]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -202,7 +202,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_FairingBase_0p9375m_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_FairingBase_0p9375m_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -213,7 +213,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_9375mDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_9375mDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -224,7 +224,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_125mDecoupler]:NEEDS[RealismOverhaul]
+@PART[bluedog_125mDecoupler]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -237,7 +237,7 @@
 
 // TITAN
 
-@PART[bluedog_Titan3_CommercialPLF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_CommercialPLF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -248,7 +248,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Titan3_CommercialPLF_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_CommercialPLF_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -259,7 +259,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Titan3E_PLF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3E_PLF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -270,7 +270,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Titan3E_PLF_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3E_PLF_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -281,7 +281,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Titan4_PLF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan4_PLF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -292,7 +292,7 @@
 	@mass = 0.1
 }
 
-@PART[bluedog_Titan4_PLF_PF]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan4_PLF_PF]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_rcs.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_rcs.cfg
@@ -1,6 +1,6 @@
 // REDSTONE
 
-@PART[bluedog_Sparta_ControlJets]:NEEDS[RealismOverhaul]
+@PART[bluedog_Sparta_ControlJets]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -38,7 +38,7 @@
 
 // CENTAUR
 
-@PART[bluedog_Centaur_SmallRCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_SmallRCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -73,7 +73,7 @@
     }
 }
 
-@PART[bluedog_Centaur_LargeRCS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_LargeRCS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -110,7 +110,7 @@
 
 // ATLAS II
 
-@PART[bluedog_Atlas2_RollControlSystem]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas2_RollControlSystem]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -164,7 +164,7 @@
 
 // TITAN
 
-@PART[bluedog_Titan23G_ACS]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan23G_ACS]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -217,7 +217,7 @@
 
 // TRANSTAGE
 
-@PART[bluedog_Titan_Transtage_RCS_A]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage_RCS_A]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -253,7 +253,7 @@
     }
 }
 
-@PART[bluedog_Titan_Transtage_RCS_B]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage_RCS_B]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -289,7 +289,7 @@
     }
 }
 
-@PART[bluedog_Titan_Transtage_RCS_C]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage_RCS_C]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -325,7 +325,7 @@
     }
 }
 
-@PART[bluedog_Titan_Transtage_RCS_D]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage_RCS_D]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -361,7 +361,7 @@
     }
 }
 
-@PART[bluedog_Titan_Transtage_RCS_E]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan_Transtage_RCS_E]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
@@ -16,7 +16,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -44,7 +44,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -72,7 +72,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -102,7 +102,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -130,7 +130,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	@MODULE[ModuleCommand]
 	{
@@ -212,7 +212,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -231,7 +231,7 @@
 @PART[bluedog_ThorAble_Tank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 	// %useRcsConfig = RCSBlock
 
 	@title = Able Tank (Thor-Able) 
@@ -244,7 +244,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -299,7 +299,7 @@
 @PART[bluedog_Vanguard_S2_Tank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 	
 
 	@title = Able Tank (Vanguard)
@@ -312,7 +312,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -383,7 +383,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	@MODULE[ModuleCommand]
 	{
@@ -462,7 +462,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	@MODULE[ModuleCommand]
 	{
@@ -525,7 +525,7 @@
 @PART[bluedog_DeltaB_Tank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%rescaleFactor = 1.3
+	%rescaleFactor = 1.6
 
 	!MODULE[ModuleReactionWheel] {}
 	!MODULE[ModuleSAS] {}
@@ -541,7 +541,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -611,7 +611,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -642,7 +642,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -670,7 +670,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -698,7 +698,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -726,7 +726,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -754,7 +754,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -782,7 +782,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -813,7 +813,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -841,7 +841,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -872,7 +872,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -900,7 +900,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -928,7 +928,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -956,7 +956,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -988,7 +988,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1017,7 +1017,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1046,7 +1046,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1074,7 +1074,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1103,7 +1103,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1132,7 +1132,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1184,7 +1184,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1212,7 +1212,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1280,7 +1280,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1352,7 +1352,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1381,7 +1381,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1409,7 +1409,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1437,7 +1437,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1465,7 +1465,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1494,7 +1494,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1522,7 +1522,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1550,7 +1550,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1579,7 +1579,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1607,7 +1607,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1635,7 +1635,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1663,7 +1663,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1691,7 +1691,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1721,7 +1721,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1749,7 +1749,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1777,7 +1777,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1805,7 +1805,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1833,7 +1833,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1863,7 +1863,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1890,7 +1890,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1901,7 +1901,7 @@
 	}		
 }
 
-@PART[bluedog_Centaur_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_FuelTank]:NEEDS[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1917,7 +1917,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1944,7 +1944,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1971,7 +1971,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -1998,7 +1998,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2025,7 +2025,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2055,7 +2055,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2082,7 +2082,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2110,7 +2110,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2137,7 +2137,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2166,7 +2166,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2193,7 +2193,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2220,7 +2220,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2250,7 +2250,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2279,7 +2279,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{
@@ -2306,7 +2306,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE,* {}
+	!RESOURCE, * {}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
@@ -383,7 +383,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	@MODULE[ModuleCommand]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
@@ -16,7 +16,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -44,7 +44,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -72,7 +72,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -102,7 +102,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -130,7 +130,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	@MODULE[ModuleCommand]
 	{
@@ -212,7 +212,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -244,7 +244,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -312,7 +312,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -462,7 +462,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	@MODULE[ModuleCommand]
 	{
@@ -541,7 +541,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -611,7 +611,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -642,7 +642,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -670,7 +670,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -698,7 +698,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -726,7 +726,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -754,7 +754,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -782,7 +782,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -813,7 +813,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -841,7 +841,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -872,7 +872,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -900,7 +900,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -928,7 +928,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -956,7 +956,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -988,7 +988,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1017,7 +1017,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1046,7 +1046,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1074,7 +1074,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1103,7 +1103,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1132,7 +1132,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1184,7 +1184,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1212,7 +1212,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1280,7 +1280,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1352,7 +1352,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1381,7 +1381,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1409,7 +1409,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1437,7 +1437,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1465,7 +1465,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1494,7 +1494,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1522,7 +1522,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1550,7 +1550,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1579,7 +1579,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1607,7 +1607,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1635,7 +1635,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1663,7 +1663,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1691,7 +1691,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1721,7 +1721,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1749,7 +1749,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1777,7 +1777,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1805,7 +1805,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1833,7 +1833,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1863,7 +1863,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1890,7 +1890,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1917,7 +1917,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1944,7 +1944,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1971,7 +1971,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -1998,7 +1998,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2025,7 +2025,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2055,7 +2055,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2082,7 +2082,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2110,7 +2110,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2137,7 +2137,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2166,7 +2166,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2193,7 +2193,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2220,7 +2220,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2250,7 +2250,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2279,7 +2279,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{
@@ -2306,7 +2306,7 @@
 	%thermalMassModifier = 1.0
 	%skinMassPerArea = 4
 
-	!RESOURCE, * {}
+	!RESOURCE,* {}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
@@ -1,6 +1,6 @@
 // REDSTONE
 
-@PART[bluedog_Redstone_FuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_FuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -28,7 +28,7 @@
 		
 }
 
-@PART[bluedog_Redstone_MediumFuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_MediumFuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -56,7 +56,7 @@
 		
 }
 
-@PART[bluedog_Redstone_ShortFuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Redstone_ShortFuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -86,7 +86,7 @@
 
 // JUPITER
 
-@PART[bluedog_Juno4_FuelTank_1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_FuelTank_1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -114,7 +114,7 @@
 		
 }
 
-@PART[bluedog_Juno4_FuelTank_2]:NEEDS[RealismOverhaul]
+@PART[bluedog_Juno4_FuelTank_2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -196,7 +196,7 @@
 }
 
 
-@PART[bluedog_Jupiter_FuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Jupiter_FuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -228,7 +228,7 @@
 
 // ABLE
 
-@PART[bluedog_ThorAble_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_ThorAble_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -296,7 +296,7 @@
     }
 }
 
-@PART[bluedog_Vanguard_S2_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S2_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -364,7 +364,7 @@
     }
 }
 
-@PART[bluedog_Ablestar_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Ablestar_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -443,7 +443,7 @@
     }
 }
 
-@PART[bluedog_DeltaE_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaE_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -522,7 +522,7 @@
     }
 }
 
-@PART[bluedog_DeltaB_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaB_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -595,7 +595,7 @@
 
 // VANGUARD
 
-@PART[bluedog_Vanguard_S1_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Vanguard_S1_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.3
@@ -626,7 +626,7 @@
 
 // THOR
 
-@PART[bluedog_Thor_1p25mAdapter_Long]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_1p25mAdapter_Long]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -654,7 +654,7 @@
 		
 }
 
-@PART[bluedog_Thor_1p25mAdapter_Medium]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_1p25mAdapter_Medium]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -682,7 +682,7 @@
 		
 }
 
-@PART[bluedog_Thor_LowerTank_1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_LowerTank_1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -710,7 +710,7 @@
 		
 }
 
-@PART[bluedog_Thor_MediumExtensionTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_MediumExtensionTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -738,7 +738,7 @@
 		
 }
 
-@PART[bluedog_Thor_ShortExtensionTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_ShortExtensionTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -766,7 +766,7 @@
 		
 }
 
-@PART[bluedog_Thor_UpperTank_1]:NEEDS[RealismOverhaul]
+@PART[bluedog_Thor_UpperTank_1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -797,7 +797,7 @@
 
 // AGENA
 
-@PART[bluedog_Agena_Tank_Long]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Tank_Long]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -825,7 +825,7 @@
 		
 }
 
-@PART[bluedog_Agena_Tank_Short]:NEEDS[RealismOverhaul]
+@PART[bluedog_Agena_Tank_Short]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -856,7 +856,7 @@
 
 // LDC
 
-@PART[bluedog_LDC_S1_Tank1]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S1_Tank1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -884,7 +884,7 @@
 		
 }
 
-@PART[bluedog_LDC_S1_Tank2]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S1_Tank2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -912,7 +912,7 @@
 		
 }
 
-@PART[bluedog_LDC_S2_Tank1]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S2_Tank1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -940,7 +940,7 @@
 		
 }
 
-@PART[bluedog_LDC_S2_Tank2]:NEEDS[RealismOverhaul]
+@PART[bluedog_LDC_S2_Tank2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -972,7 +972,7 @@
 // DELTA
 
 
-@PART[bluedog_Delta2_LowerTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta2_LowerTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1001,7 +1001,7 @@
 }
 
 
-@PART[bluedog_Delta2_UpperTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta2_UpperTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1030,7 +1030,7 @@
 }
 
 
-@PART[bluedog_Delta3_AdapterTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Delta3_AdapterTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1058,7 +1058,7 @@
 		
 }
 
-@PART[bluedog_DeltaK_FairingTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_FairingTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1087,7 +1087,7 @@
 }
 
 
-@PART[bluedog_DeltaK_LongTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_LongTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1116,7 +1116,7 @@
 }
 
 
-@PART[bluedog_DeltaK_LowerTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_LowerTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1168,7 +1168,7 @@
 
 }
 
-@PART[bluedog_DeltaK_ShortTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_ShortTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1196,7 +1196,7 @@
 		
 }
 
-@PART[bluedog_DeltaK_Stage]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaK_Stage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1264,7 +1264,7 @@
     }
 }
 
-@PART[bluedog_DeltaP_Stage]:NEEDS[RealismOverhaul]
+@PART[bluedog_DeltaP_Stage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1336,7 +1336,7 @@
 // ATLAS
 
 
-@PART[bluedog_CELV_AdapterTank_1p875m_Short]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_AdapterTank_1p875m_Short]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1364,7 +1364,7 @@
 		
 }
 
-@PART[bluedog_CELV_AdapterTank_1p875m_Long]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_AdapterTank_1p875m_Long]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1393,7 +1393,7 @@
 		
 }
 
-@PART[bluedog_CELV_AdapterTank_2p5m_Long]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_AdapterTank_2p5m_Long]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1421,7 +1421,7 @@
 		
 }
 
-@PART[bluedog_CELV_AdapterTank_2p5m_Short]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_AdapterTank_2p5m_Short]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1449,7 +1449,7 @@
 		
 }
 
-@PART[bluedog_CELV_LongTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_LongTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1477,7 +1477,7 @@
 		
 }
 
-@PART[bluedog_CELV_MainTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_MainTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1506,7 +1506,7 @@
 		
 }
 
-@PART[bluedog_CELV_MediumTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_MediumTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1534,7 +1534,7 @@
 		
 }
 
-@PART[bluedog_CELV_ShortTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CELV_ShortTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1562,7 +1562,7 @@
 		
 }
 
-@PART[bluedog_SLV3X_LowerTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_SLV3X_LowerTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1591,7 +1591,7 @@
 		
 }
 
-@PART[bluedog_SLV3X_MainTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_SLV3X_MainTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1619,7 +1619,7 @@
 		
 }
 
-@PART[bluedog_SLV3X_MediumTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_SLV3X_MediumTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1647,7 +1647,7 @@
 		
 }
 
-@PART[bluedog_SLV3X_ShortTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_SLV3X_ShortTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1675,7 +1675,7 @@
 		
 }
 
-@PART[bluedog_SLV3X_UpperTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_SLV3X_UpperTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1704,7 +1704,7 @@
 }
 
 
-@PART[bluedog_Atlas_AdapterFuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_AdapterFuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1733,7 +1733,7 @@
 		
 }
 
-@PART[bluedog_Atlas_LongFuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_LongFuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1761,7 +1761,7 @@
 		
 }
 
-@PART[bluedog_Atlas_MediumFuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_MediumFuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1789,7 +1789,7 @@
 		
 }
 
-@PART[bluedog_Atlas_ShortAdapterTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_ShortAdapterTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1817,7 +1817,7 @@
 		
 }
 
-@PART[bluedog_Atlas_ShortFuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Atlas_ShortFuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1847,7 +1847,7 @@
 
 // CENTAUR
 
-@PART[bluedog_Centaur_D3Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur_D3Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1874,7 +1874,7 @@
 	}		
 }
 
-@PART[bluedog_Centaur4_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Centaur4_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1901,7 +1901,7 @@
 	}		
 }
 
-@PART[bluedog_CentaurD_FuelTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurD_FuelTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1928,7 +1928,7 @@
 	}		
 }
 
-@PART[bluedog_CentaurT_AdapterTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurT_AdapterTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1955,7 +1955,7 @@
 	}		
 }
 
-@PART[bluedog_CentaurT_ShortTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurT_ShortTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -1982,7 +1982,7 @@
 	}		
 }
 
-@PART[bluedog_CentaurT_WideTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurT_WideTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2009,7 +2009,7 @@
 	}		
 }
 
-@PART[bluedog_CentaurV_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_CentaurV_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2038,7 +2038,7 @@
 
 // TITAN I
 
-@PART[bluedog_Titan1_S1_LowerTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_S1_LowerTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2066,7 +2066,7 @@
 	}		
 }
 
-@PART[bluedog_Titan1_S1_UpperTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_S1_UpperTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2093,7 +2093,7 @@
 	}		
 }
 
-@PART[bluedog_Titan1_S2_ShortTank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_S2_ShortTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2121,7 +2121,7 @@
 	}		
 }
 
-@PART[bluedog_Titan1_S2_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan1_S2_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2150,7 +2150,7 @@
 
 // TITAN II
 
-@PART[bluedog_Titan2_S1_Lower_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S1_Lower_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2177,7 +2177,7 @@
 	}		
 }
 
-@PART[bluedog_Titan2_S1_Upper_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S1_Upper_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2204,7 +2204,7 @@
 	}		
 }
 
-@PART[bluedog_Titan2_S2_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan2_S2_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2233,7 +2233,7 @@
 
 // TITAN III
 
-@PART[bluedog_Titan3_S1_Stretched_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan3_S1_Stretched_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2263,7 +2263,7 @@
 
 // TITAN IV
 
-@PART[bluedog_Titan4_S1_Lower_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan4_S1_Lower_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
@@ -2290,7 +2290,7 @@
 	}		
 }
 
-@PART[bluedog_Titan4_S2_Tank]:NEEDS[RealismOverhaul]
+@PART[bluedog_Titan4_S2_Tank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/RO_BDB_tanks.cfg
@@ -1030,7 +1030,7 @@
 }
 
 
-@PART[bluedog_Delta3_AdapterTank]:FOR[RealismOverhaul]
+@PART[bluedog_DeltaIII_AdapterTank]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6


### PR DESCRIPTION
This request aims to update some of the old RO configs for Bluedog Design Bureau. The changes are:

1. Updating the part name of the Centaur D configs so the rescaling and properties for RO are applied.

2. Changing the rescale factor of the Able parts from 1.3 to 1.6 so they match and can be used with the other launch vehicles.

3. Adding RO configs to all SAF fairings, including the ROSAFRescale factor made by @StonesmileGit 

I will add the :FOR[RealismOverhaul] to the parts I have patched in a future commit. 
There are no parts that were patched before that are not patched now, the ones that are being patched now just were renamed. 

(Sorry I did not read the responses to the other request until I had already done this.) :(
