### PR TITLE
Fix :FOR[RealPlume] in RealismOverhaul

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/ROKestrel.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/ROKestrel.cfg
@@ -2,7 +2,7 @@
 //  Kestrel plume configuration.
 //  ==================================================
 
-@PART[RO-Kestrel]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-Kestrel]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/VR1vulcan.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/VR1vulcan.cfg
@@ -2,7 +2,7 @@
 //  RS-68 plume configuration.
 //  ==================================================
 
-@PART[VR1vulcan]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[VR1vulcan]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/dest5Engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/dest5Engine.cfg
@@ -2,7 +2,7 @@
 //  Generic 2 kN thruster plume configuration.
 //  ==================================================
 
-@PART[dest5Engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[dest5Engine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/engineexper05.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/engineexper05.cfg
@@ -2,7 +2,7 @@
 //  RL60 plume configuration.
 //  ==================================================
 
-@PART[engineexper05]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[engineexper05]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/enginelmodc.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/enginelmodc.cfg
@@ -2,7 +2,7 @@
 //  LMDE plume configuration.
 //  ==================================================
 
-@PART[enginelmodc]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[enginelmodc]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/galaxvr2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/galaxvr2.cfg
@@ -2,7 +2,7 @@
 //  Aestus plume configuration.
 //  ==================================================
 
-@PART[galaxvr2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[galaxvr2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEngineconstelacion.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEngineconstelacion.cfg
@@ -2,7 +2,7 @@
 //  J-2X plume configuration.
 //  ==================================================
 
-@PART[liquidEngineconstelacion]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[liquidEngineconstelacion]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEnginemogulmp1500.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEnginemogulmp1500.cfg
@@ -2,7 +2,7 @@
 //  RD-170 plume configuration.
 //  ==================================================
 
-@PART[liquidEnginemogulmp1500]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[liquidEnginemogulmp1500]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEngineorbit2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEngineorbit2.cfg
@@ -2,7 +2,7 @@
 //  LR91 plume configuration.
 //  ==================================================
 
-@PART[liquidEngineorbit2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[liquidEngineorbit2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEngineprodulVR2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/liquidEngineprodulVR2.cfg
@@ -2,7 +2,7 @@
 //  LR87 plume configuration.
 //  ==================================================
 
-@PART[liquidEngineprodulVR2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[liquidEngineprodulVR2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/microEngineSE1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/microEngineSE1.cfg
@@ -2,7 +2,7 @@
 //  LMAE plume configuration.
 //  ==================================================
 
-@PART[microEngineSE1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[microEngineSE1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AIES/microEngineex1sat.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AIES/microEngineex1sat.cfg
@@ -2,7 +2,7 @@
 //  Generic 0.5 kN thruster plume configuration.
 //  ==================================================
 
-@PART[microEngineex1sat]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[microEngineex1sat]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/AtomicAge/AtomicAge.cfg.bak
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AtomicAge/AtomicAge.cfg.bak
@@ -1,4 +1,4 @@
-@PART[nuclearEngineLightbulb]:FOR[RealPlume]:NEEDS[SmokeScreen]	//United Technologies UAGC-156 Nuclear Lightbulb
+@PART[nuclearEngineLightbulb]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//United Technologies UAGC-156 Nuclear Lightbulb
 {
 
 
@@ -241,7 +241,7 @@ speed
 
 }
 
-@PART[nuclearEngineLANTR]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Pratt & Whitney TRITON LANTR
+@PART[nuclearEngineLANTR]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Pratt & Whitney TRITON LANTR
 {
 
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/AtomicAge/nuclearEngineLANTR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AtomicAge/nuclearEngineLANTR.cfg
@@ -1,4 +1,4 @@
-@PART[nuclearEngineLANTR]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Pratt & Whitney TRITON LANTR
+@PART[nuclearEngineLANTR]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Pratt & Whitney TRITON LANTR
 {
 
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/AtomicAge/nuclearEngineLightbulb.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/AtomicAge/nuclearEngineLightbulb.cfg
@@ -1,4 +1,4 @@
-@PART[nuclearEngineLightbulb]:FOR[RealPlume]:NEEDS[SmokeScreen]	//United Technologies UAGC-156 Nuclear Lightbulb
+@PART[nuclearEngineLightbulb]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//United Technologies UAGC-156 Nuclear Lightbulb
 {
 
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/BahaRd180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/BahaRd180.cfg
@@ -2,7 +2,7 @@
 //	RD-180 plume configuration.
 //	==================================================
 
-	@PART[BahaRd180]:FOR[RealPlume]:NEEDS[SmokeScreen]
+	@PART[BahaRd180]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 	{
 		PLUME
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/atlasSrb.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/atlasSrb.cfg
@@ -2,7 +2,7 @@
 //	AJ-60A plume configuration.
 //	==================================================
 
-	@PART[atlasvSrb]:FOR[RealPlume]:NEEDS[SmokeScreen]
+	@PART[atlasvSrb]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 	{
 		PLUME
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/bahars68b.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/bahars68b.cfg
@@ -2,7 +2,7 @@
 //  RS-68 engine plume configuration.
 //  ==================================================
 
-@PART[bahars68b]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[bahars68b]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/constellationBNTR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/constellationBNTR.cfg
@@ -2,7 +2,7 @@
 //  Bimodal NTR engine plume configuration.
 //  ==================================================
 
-@PART[constellationBNTR]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[constellationBNTR]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BlacklegIndustries/satbusengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BlacklegIndustries/satbusengine.cfg
@@ -2,7 +2,7 @@
 //  R-4D-11 HiPAT plume configuration.
 //  ==================================================
 
-@PART[satbusengine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[satbusengine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/ARES.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/ARES.cfg
@@ -1,4 +1,4 @@
-@PART[AresV_2stage]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[AresV_2stage]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -25,7 +25,7 @@
 	}
 }
 
-@PART[AresV_J2-X_engine|Ares1_J2-X]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[AresV_J2-X_engine|Ares1_J2-X]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -52,7 +52,7 @@
 	}
 }
 
-@PART[Ares1_SRB]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Ares1_SRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -79,7 +79,7 @@
 	}
 }
 
-@PART[Ares_SRB_Nose_Cone|Ares_SRB_Avionic]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Ares_SRB_Nose_Cone|Ares_SRB_Avionic]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/FGB-DOS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/FGB-DOS.cfg
@@ -1,4 +1,4 @@
-@PART[Mir_Kristall|Mir_Kvant_2|Mir_Priroda|Mir_Spektr|TKS_tug|Mir_Core_Module]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[Mir_Kristall|Mir_Kvant_2|Mir_Priroda|Mir_Spektr|TKS_tug|Mir_Core_Module]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK33.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK33.cfg
@@ -1,4 +1,4 @@
-@PART[NK33_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-33
+@PART[NK33_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-33
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK43.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK43.cfg
@@ -1,4 +1,4 @@
-@PART[NK43_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-43
+@PART[NK43_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-43
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9.cfg
@@ -1,4 +1,4 @@
-@PART[RO-BobCat-NK9]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-9, using halved NK-43
+@PART[RO-BobCat-NK9]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-9, using halved NK-43
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9V.cfg
@@ -1,4 +1,4 @@
-@PART[RO-BobCat-NK9V]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-9V, using halved NK-43
+@PART[RO-BobCat-NK9V]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-9V, using halved NK-43
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OME.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OME.cfg
@@ -2,7 +2,7 @@
 //	AJ10-190 plume configuration.
 //	==================================================
 
-	@PART[Orion_InstrumentServise_Module]:FOR[RealPlume]:NEEDS[SmokeScreen]
+	@PART[Orion_InstrumentServise_Module]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 	{
 		PLUME
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OrionLES.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OrionLES.cfg
@@ -2,7 +2,7 @@
 //	Orion LAS plume configuration.
 //	==================================================
 
-	@PART[Orion_LES]:FOR[RealPlume]:NEEDS[SmokeScreen]
+	@PART[Orion_LES]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 	{
 		PLUME
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0110.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0110.cfg
@@ -1,4 +1,4 @@
-@PART[RO-BobCat-RD0110]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0124
+@PART[RO-BobCat-RD0110]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-0124
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0120.cfg
@@ -1,4 +1,4 @@
-@PART[RD0120_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0120
+@PART[RD0120_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-0120
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0124.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0124.cfg
@@ -1,4 +1,4 @@
-@PART[RD0124_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0124
+@PART[RD0124_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-0124
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0146.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0146.cfg
@@ -1,4 +1,4 @@
-@PART[RD0146_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0146
+@PART[RD0146_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-0146
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD171.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD171.cfg
@@ -1,4 +1,4 @@
-@PART[RD171_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-171
+@PART[RD171_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-171
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD180.cfg
@@ -1,4 +1,4 @@
-@PART[RD180_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-180
+@PART[RD180_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-180
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD191.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD191.cfg
@@ -1,4 +1,4 @@
-@PART[RD191_StockVersion]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-191
+@PART[RD191_StockVersion]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-191
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270.cfg
@@ -1,4 +1,4 @@
-@PART[RO-BobCat-RD270]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-270
+@PART[RO-BobCat-RD270]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-270
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270M.cfg
@@ -1,4 +1,4 @@
-@PART[RO-BobCat-RD270M]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-270M
+@PART[RO-BobCat-RD270M]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RD-270M
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD701.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD701.cfg
@@ -2,7 +2,7 @@
 //  RD-701 engine plume configuration.
 //  ==================================================
 
-@PART[RO-BobCat-RD701]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-BobCat-RD701]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD704.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD704.cfg
@@ -2,7 +2,7 @@
 //  RD-704 engine plume setup.
 //  ==================================================
 
-@PART[RO-BobCat-RD704]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-BobCat-RD704]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/CHAKAKWsrbGlobeIz.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/CHAKAKWsrbGlobeIz.cfg
@@ -2,7 +2,7 @@
 //  GEM 60 plume configuration.
 //  ==================================================
 
-@PART[CHAKAKWsrbGlobeIz]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[CHAKAKWsrbGlobeIz]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/CHAKAOME2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/CHAKAOME2.cfg
@@ -2,7 +2,7 @@
 //  AJ10-190 plume configuration.
 //  ==================================================
 
-@PART[CHAKAOME2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[CHAKAOME2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/MonkeyCargoBoosterSLSADJ.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/MonkeyCargoBoosterSLSADJ.cfg
@@ -2,7 +2,7 @@
 //  SLS core stage plume configuration.
 //  ==================================================
 
-@PART[MonkeyCargoBoosterSLSADJ]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[MonkeyCargoBoosterSLSADJ]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/TKS_RD-02225_EngineLANDERS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/TKS_RD-02225_EngineLANDERS.cfg
@@ -2,7 +2,7 @@
 //  Kestrel-1B plume setup.
 //  ==================================================
 
-@PART[XKosmos_TKS_RD-0225_EngineLANDERS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XKosmos_TKS_RD-0225_EngineLANDERS]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XAltair2descent2stageX.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XAltair2descent2stageX.cfg
@@ -2,7 +2,7 @@
 //  Altair Descent Module plume configuration.
 //  ==================================================
 
-@PART[XAltair2descent2stageX]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XAltair2descent2stageX]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XKWsrbGlobeX5X.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XKWsrbGlobeX5X.cfg
@@ -2,7 +2,7 @@
 //  Advanced Booster plume configuration.
 //  ==================================================
 
-@PART[XKWsrbGlobeX5X]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XKWsrbGlobeX5X]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XKosmos_Angara_RD-275KX.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XKosmos_Angara_RD-275KX.cfg
@@ -2,7 +2,7 @@
 //  RD-253/275 plume configuration.
 //  ==================================================
 
-@PART[XKosmos_Angara_RD-275KX]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XKosmos_Angara_RD-275KX]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XOrionLES.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XOrionLES.cfg
@@ -2,7 +2,7 @@
 //  Orion LAS plume configuration.
 //  ==================================================
 
-@PART[XOrionLES]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XOrionLES]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XROVERENGINE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XROVERENGINE.cfg
@@ -2,7 +2,7 @@
 //  J-2X plume configuration.
 //  ==================================================
 
-@PART[XROVERENGINE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XROVERENGINE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XSLSSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XSLSSRB.cfg
@@ -2,7 +2,7 @@
 //  4 Segment RSRM plume configuration.
 //  ==================================================
 
-@PART[XSLSSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XSLSSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/XXxAres1J2-XHIGH.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/XXxAres1J2-XHIGH.cfg
@@ -2,7 +2,7 @@
 //  RL-10 plume configuration.
 //  ==================================================
 
-@PART[XXxAres1J2-XHIGH]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[XXxAres1J2-XHIGH]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/altairPod.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/altairPod.cfg
@@ -2,7 +2,7 @@
 //  Altair Ascent Module plume configuration.
 //  ==================================================
 
-@PART[altairPod]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[altairPod]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/nervaII_kerbscalexx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/nervaII_kerbscalexx.cfg
@@ -2,7 +2,7 @@
 //  BNTR engine plume configuration.
 //  ==================================================
 
-@PART[nervaII_kerbscalexx]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[nervaII_kerbscalexx]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/nosExplorerRadialEngine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/nosExplorerRadialEngine.cfg
@@ -2,7 +2,7 @@
 //  Pegasus radial engine pod plume configuration.
 //  ==================================================
 
-@PART[nosExplorerRadialEngine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[nosExplorerRadialEngine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xKWsrbGlobeX10Lx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xKWsrbGlobeX10Lx.cfg
@@ -2,7 +2,7 @@
 //  5 Segment RSRM plume configuration.
 //  =================================================
 
-@PART[xKWsrbGlobeX10Lx]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xKWsrbGlobeX10Lx]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xKosmos_SepRetrox.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xKosmos_SepRetrox.cfg
@@ -2,7 +2,7 @@
 //  SEP-100 SRM plume setup.
 //  ==================================================
 
-@PART[xKosmos_SepRetrox]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xKosmos_SepRetrox]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xKosmos_SepRetroxMLS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xKosmos_SepRetroxMLS.cfg
@@ -2,7 +2,7 @@
 //  SEP-50 SRM plume setup.
 //  ==================================================
 
-@PART[xKosmos_SepRetroxMLS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xKosmos_SepRetroxMLS]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xLazTekSuperDracosx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xLazTekSuperDracosx.cfg
@@ -2,7 +2,7 @@
 //  SuperDraco engine pod plume configuration.
 //  ==================================================
 
-@PART[xLazTekSuperDracosx]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xLazTekSuperDracosx]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xbahars68bx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xbahars68bx.cfg
@@ -2,7 +2,7 @@
 //  RS-68 plume configuration.
 //  ==================================================
 
-@PART[xbahars68bx]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xbahars68bx]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xmonkeyreptarvacx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xmonkeyreptarvacx.cfg
@@ -2,7 +2,7 @@
 //  Merlin engine (vacuum version) plume configuration.
 //  ==================================================
 
-@PART[xmonkeyreptarvacx]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xmonkeyreptarvacx]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CMES/xmonkeyreptarx.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CMES/xmonkeyreptarx.cfg
@@ -2,7 +2,7 @@
 //  Merlin engine (surface version) plume configuration.
 //  ==================================================
 
-@PART[xmonkeyreptarx]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[xmonkeyreptarx]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CSS/CSS.cfg.bak
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CSS/CSS.cfg.bak
@@ -1,4 +1,4 @@
-@PART[CSS_SSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[CSS_SSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{
@@ -212,7 +212,7 @@
 		%type = ModuleEnginesRF
     }
 }
-@PART[km_ssme_rs25]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[km_ssme_rs25]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/CSS/CSS_SSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CSS/CSS_SSRB.cfg
@@ -1,4 +1,4 @@
-@PART[CSS_SSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[CSS_SSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/CSS/SSP.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CSS/SSP.cfg
@@ -1,4 +1,4 @@
-@PART[SRB2D]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[SRB2D]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -25,7 +25,7 @@
 	}
 }
 
-@PART[STS?SRB?Nose?Cone]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[STS?SRB?Nose?Cone]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/CSS/km_ssme_rs25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CSS/km_ssme_rs25.cfg
@@ -1,4 +1,4 @@
-@PART[km_ssme_rs25]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[km_ssme_rs25]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KFS/RO_KFS_CZ3B_Plumes.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KFS/RO_KFS_CZ3B_Plumes.cfg
@@ -1,4 +1,4 @@
-@PART[long_march_3B_Engine_YF-21C]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_Engine_YF-21C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -17,7 +17,7 @@
     }
 }
 
-@PART[long_march_3B_Engine_YF25]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_Engine_YF25]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -36,7 +36,7 @@
     }
 }
 
-@PART[long_march_3B_Engine_YF22E]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_Engine_YF22E]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -55,7 +55,7 @@
     }
 }
 
-@PART[long_march_3B_Engine_YF23C1_float]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_Engine_YF23C1_float]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -74,7 +74,7 @@
     }
 }
 
-@PART[long_march_3B_Engine_YF75]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_Engine_YF75]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -94,7 +94,7 @@
     }
 }
 
-@PART[long_march_3B_2nd_stage_fueltank]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_2nd_stage_fueltank]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{
@@ -125,7 +125,7 @@
     }
 }
 
-@PART[long_march_3B_boost_stage_fueltank]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_boost_stage_fueltank]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{
@@ -156,7 +156,7 @@
     }
 }
 
-@PART[long_march_3B_Equipment]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[long_march_3B_Equipment]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KSLO/LVT1C.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KSLO/LVT1C.cfg
@@ -1,4 +1,4 @@
-@PART[LVT1C]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[LVT1C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineMaverick1D.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineMaverick1D.cfg
@@ -1,4 +1,4 @@
-@PART[KW1mengineMaverick1D]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL10 CONFIRMED WORKING
+@PART[KW1mengineMaverick1D]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // RL10 CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineVestaVR1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineVestaVR1.cfg
@@ -1,4 +1,4 @@
-@PART[KW1mengineVestaVR1]:FOR[RealPlume]:NEEDS[SmokeScreen] //AJ10-118K copied from FASAGeminiLFECentarTwin CONFIRMED WORKING
+@PART[KW1mengineVestaVR1]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //AJ10-118K copied from FASAGeminiLFECentarTwin CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineWildCatV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineWildCatV.cfg
@@ -1,4 +1,4 @@
-@PART[KW1mengineWildCatV]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL10 //COPIED FROM SQUAD engineLargeSkipper CONFIRMED WORKING
+@PART[KW1mengineWildCatV]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // RL10 //COPIED FROM SQUAD engineLargeSkipper CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineGriffonG8D.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineGriffonG8D.cfg
@@ -1,4 +1,4 @@
-@PART[KW2mengineGriffonG8D]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD107-108, taken from RD-170 novapunch.cfg 
+@PART[KW2mengineGriffonG8D]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//RD107-108, taken from RD-170 novapunch.cfg 
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineMaverickV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineMaverickV.cfg
@@ -1,4 +1,4 @@
-@PART[KW2mengineMaverickV]:FOR[RealPlume]:NEEDS[SmokeScreen] //RS-27, used H1-RS27 config CONFIRMED WORKING
+@PART[KW2mengineMaverickV]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //RS-27, used H1-RS27 config CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineVestaVR9D.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineVestaVR9D.cfg
@@ -1,4 +1,4 @@
-@PART[KW2mengineVestaVR9D]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Dual LE-7A H-2B Launcher
+@PART[KW2mengineVestaVR9D]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Dual LE-7A H-2B Launcher
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineTitanT1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineTitanT1.cfg
@@ -1,4 +1,4 @@
-@PART[KW3mengineTitanT1]:FOR[RealPlume]:NEEDS[SmokeScreen] //Vulcain 2 [5.0m] taken from RS-68 AEIS CONFIRMED WORKING
+@PART[KW3mengineTitanT1]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //Vulcain 2 [5.0m] taken from RS-68 AEIS CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineWildcatXR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineWildcatXR.cfg
@@ -1,4 +1,4 @@
-@PART[KW3mengineWildcatXR]:FOR[RealPlume]:NEEDS[SmokeScreen] // HM-7(B)
+@PART[KW3mengineWildcatXR]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // HM-7(B)
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineGriffonC.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineGriffonC.cfg
@@ -1,4 +1,4 @@
-@PART[KW5mengineGriffonC]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne F-1 [5.5m] from Squad.cfg CONFIRMED WORKING
+@PART[KW5mengineGriffonC]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Rocketdyne F-1 [5.5m] from Squad.cfg CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineTitanV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineTitanV.cfg
@@ -1,4 +1,4 @@
-@PART[KW5mengineTitanV]:FOR[RealPlume]:NEEDS[SmokeScreen] // J2, uses J-2 FX for now. CONFIRMED WORKING
+@PART[KW5mengineTitanV]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // J2, uses J-2 FX for now. CONFIRMED WORKING
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWSepMotors.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWSepMotors.cfg
@@ -1,4 +1,4 @@
-@PART[KW2mSRBNoseCone]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KW2mSRBNoseCone]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -17,7 +17,7 @@
         speed = 1
     }
 }
-@PART[KWsrbGlobeV]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeV]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -36,7 +36,7 @@
         speed = 1.5
     }
 }
-@PART[KWsrbUllage]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbUllage]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -55,7 +55,7 @@
         speed = 1.5
     }
 }
-@PART[KWsrbUllageLarge]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbUllageLarge]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeVI.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeVI.cfg
@@ -1,4 +1,4 @@
-@PART[KWsrbGlobeVI]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeVI]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX.cfg
@@ -1,4 +1,4 @@
-@PART[KWsrbGlobeX]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeX]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10L.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10L.cfg
@@ -1,4 +1,4 @@
-@PART[KWsrbGlobeX10L]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeX10L]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10S.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10S.cfg
@@ -1,4 +1,4 @@
-@PART[KWsrbGlobeX10S]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeX10S]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX2.cfg
@@ -1,4 +1,4 @@
-@PART[KWsrbGlobeX2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeX2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX5.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX5.cfg
@@ -1,4 +1,4 @@
-@PART[KWsrbGlobeX5]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[KWsrbGlobeX5]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-1.cfg
@@ -1,4 +1,4 @@
-@PART[ntr-sc-125-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[ntr-sc-125-1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-2.cfg
@@ -1,4 +1,4 @@
-@PART[ntr-sc-125-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[ntr-sc-125-2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-25-1_BNTR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-25-1_BNTR.cfg
@@ -1,4 +1,4 @@
-@PART[ntr-sc-25-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[ntr-sc-25-1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Ariane6_Plumes.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Ariane6_Plumes.cfg
@@ -1,4 +1,4 @@
-@PART[upperStage]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[upperStage]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -27,7 +27,7 @@
 	}
 }
 
-@PART[vulcain2]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[vulcain2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -56,7 +56,7 @@
 	}
 }
 
-@PART[p120Booster]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[p120Booster]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -85,7 +85,7 @@
 	}
 }
 
-@PART[nosecone]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[nosecone]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -114,7 +114,7 @@
 	}
 }
 
-@PART[pphstage1]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[pphstage1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -143,7 +143,7 @@
 	}
 }
 
-@PART[pphstage2]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[pphstage2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Delta3_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Delta3_Plume.cfg
@@ -1,4 +1,4 @@
-@PART[delta3rs27a]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[delta3rs27a]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -37,7 +37,7 @@
 	}
 }
 
-@PART[gem46]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[gem46]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Vega_Plume
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Vega_Plume
@@ -1,5 +1,5 @@
 
-@PART[stage1]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[stage1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!fx_exhaustFlame_yellow = DELETE
 	!fx_exhaustLight_yellow = DELETE
@@ -42,7 +42,7 @@
 	}
 }
 
-@PART[stage2]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[stage2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -71,7 +71,7 @@
 	}
 }
 
-@PART[stage3]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[stage3]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{
@@ -100,7 +100,7 @@
 	}
 }
 
-@PART[separatorAdapter]:FOR[RealPlume]:NEEDS[SmokeScreen] // 
+@PART[separatorAdapter]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // 
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -126,7 +126,7 @@
 	}
 }
 
-@PART[VegaC_separatorAdapter]:FOR[RealPlume]:NEEDS[SmokeScreen] // 
+@PART[VegaC_separatorAdapter]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // 
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -152,7 +152,7 @@
     }
 }
 
-@PART[RO_Vega_P120C]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[RO_Vega_P120C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!fx_exhaustFlame_yellow = DELETE
 	!fx_exhaustLight_yellow = DELETE
@@ -195,7 +195,7 @@
 	}
 }
 
-@PART[VegaC_stage2b]:FOR[RealPlume]:NEEDS[SmokeScreen]	//
+@PART[VegaC_stage2b]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_0_625m_AdvBlite3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_0_625m_AdvBlite3.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_0_625m_AdvBlite3]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50XLT derived from FASAGerminiSRB175
+@PART[NP_SRB_0_625m_AdvBlite3]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50XLT derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_0_625m_AdvBlitePAM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_0_625m_AdvBlitePAM.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_0_625m_AdvBlitePAM]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63D derived from FASAGerminiSRB175
+@PART[NP_SRB_0_625m_AdvBlitePAM]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63D derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlite2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlite2.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_1_25m_AdvBlite2]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50T derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlite2]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50T derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlite3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlite3.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_1_25m_AdvBlite3]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50ST derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlite3]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50ST derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlite4.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlite4.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_1_25m_AdvBlite4]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50S XL derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlite4]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50S XL derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlitePAM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_1_25m_AdvBlitePAM.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_1_25m_AdvBlitePAM]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63F derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlitePAM]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63F derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB2.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_2_5m_AdvSRB2]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (2)
+@PART[NP_SRB_2_5m_AdvSRB2]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (2)
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB3.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_2_5m_AdvSRB3]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (3)
+@PART[NP_SRB_2_5m_AdvSRB3]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (3)
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB4.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB4.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_2_5m_AdvSRB4]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (4)
+@PART[NP_SRB_2_5m_AdvSRB4]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (4)
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB5.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_SRB_2_5m_AdvSRB5.cfg
@@ -1,4 +1,4 @@
-@PART[NP_SRB_2_5m_AdvSRB5]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (5)
+@PART[NP_SRB_2_5m_AdvSRB5]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (5)
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_lfb_25m_Adv.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_lfb_25m_Adv.cfg
@@ -1,4 +1,4 @@
-@PART[NP_lfb_25m_Adv]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Dynetics Pyrios Booster (2xF1B)
+@PART[NP_lfb_25m_Adv]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Dynetics Pyrios Booster (2xF1B)
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_lfb_25m_conical.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_lfb_25m_conical.cfg
@@ -1,4 +1,4 @@
-@PART[NP_lfb_25m_conical]:FOR[RealPlume]:NEEDS[SmokeScreen] // Strap-on Liquid Booster (RD-107), modified from RD-58 in Squad.cfg
+@PART[NP_lfb_25m_conical]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Strap-on Liquid Booster (RD-107), modified from RD-58 in Squad.cfg
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_smokeTrail_light = DELETE

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_srb_miniBooster.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_srb_miniBooster.cfg
@@ -1,4 +1,4 @@
-@PART[NP_srb_miniBooster]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 38 derived from FASAGerminiSRB175
+@PART[NP_srb_miniBooster]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 38 derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_srb_radialbooster.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NP_srb_radialbooster.cfg
@@ -1,4 +1,4 @@
-@PART[NP_srb_radialbooster]:FOR[RealPlume]:NEEDS[SmokeScreen] // Zenit Energia Liquid Booster, scaled up from RD-107 above.
+@PART[NP_srb_radialbooster]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Zenit Energia Liquid Booster, scaled up from RD-107 above.
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_smokeTrail_light = DELETE

--- a/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NovaPunch.cfg.bak
+++ b/GameData/RealismOverhaul/RealPlume_Configs/NovaPunch/NovaPunch.cfg.bak
@@ -1,4 +1,4 @@
-@PART[NP_lfb_25m_Adv]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Dynetics Pyrios Booster (2xF1B)
+@PART[NP_lfb_25m_Adv]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Dynetics Pyrios Booster (2xF1B)
 {
 	!EFFECTS
 	{
@@ -203,7 +203,7 @@
 	}
 }
 
-@PART[NP_lfb_25m_conical]:FOR[RealPlume]:NEEDS[SmokeScreen] // Strap-on Liquid Booster (RD-107), modified from RD-58 in Squad.cfg
+@PART[NP_lfb_25m_conical]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Strap-on Liquid Booster (RD-107), modified from RD-58 in Squad.cfg
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_smokeTrail_light = DELETE
@@ -409,7 +409,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_srb_radialbooster]:FOR[RealPlume]:NEEDS[SmokeScreen] // Zenit Energia Liquid Booster, scaled up from RD-107 above.
+@PART[NP_srb_radialbooster]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Zenit Energia Liquid Booster, scaled up from RD-107 above.
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_smokeTrail_light = DELETE
@@ -615,7 +615,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_2_5m_AdvSRB2]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (2)
+@PART[NP_SRB_2_5m_AdvSRB2]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (2)
 {
 	!EFFECTS {}
 
@@ -853,7 +853,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_2_5m_AdvSRB3]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (3)
+@PART[NP_SRB_2_5m_AdvSRB3]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (3)
 {
 	!EFFECTS {}
 
@@ -1089,7 +1089,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_2_5m_AdvSRB4]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (4)
+@PART[NP_SRB_2_5m_AdvSRB4]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (4)
 {
 	!EFFECTS {}
 
@@ -1325,7 +1325,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_2_5m_AdvSRB5]:FOR[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (5)
+@PART[NP_SRB_2_5m_AdvSRB5]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // Advanced Segmented Solid Booster (5)
 {
 	!EFFECTS
 	{
@@ -1560,7 +1560,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_1_25m_AdvBlite2]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50T derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlite2]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50T derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 
@@ -1796,7 +1796,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_1_25m_AdvBlite3]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50ST derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlite3]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50ST derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 
@@ -2032,7 +2032,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_1_25m_AdvBlite4]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50S XL derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlite4]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50S XL derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 
@@ -2268,7 +2268,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_1_25m_AdvBlitePAM]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63F derived from FASAGerminiSRB175
+@PART[NP_SRB_1_25m_AdvBlitePAM]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63F derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 
@@ -2504,7 +2504,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_0_625m_AdvBlite3]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50XLT derived from FASAGerminiSRB175
+@PART[NP_SRB_0_625m_AdvBlite3]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 50XLT derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 
@@ -2740,7 +2740,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_SRB_0_625m_AdvBlitePAM]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63D derived from FASAGerminiSRB175
+@PART[NP_SRB_0_625m_AdvBlitePAM]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK STAR 63D derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 
@@ -2976,7 +2976,7 @@
 		@gimbalTransformName = thrustTransform
 	}
 }
-@PART[NP_srb_miniBooster]:FOR[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 38 derived from FASAGerminiSRB175
+@PART[NP_srb_miniBooster]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // ATK Orion 38 derived from FASAGerminiSRB175
 {
 	!EFFECTS {}
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/OLDD/RO_OLDD_Saturn_V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/OLDD/RO_OLDD_Saturn_V.cfg
@@ -2,7 +2,7 @@
 //  S-IVB ullage SRM.
 //  ==================================================
 
-@PART[S-IVB_ullageSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[S-IVB_ullageSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -36,7 +36,7 @@
 //  S-II retro SRM.
 //  ==================================================
 
-@PART[S-IIsepSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[S-IIsepSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -70,7 +70,7 @@
 //  S-II ullage SRM.
 //  ==================================================
 
-@PART[S-II_ullageSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[S-II_ullageSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -104,7 +104,7 @@
 //  S-IC retro SRM.
 //  ==================================================
 
-@PART[S-1CsepSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[S-1CsepSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -138,7 +138,7 @@
 //  Rocketdyne J-2 engine.
 //  ==================================================
 
-@PART[J2engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[J2engine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -173,7 +173,7 @@
 //  Rocketdyne F-1 engine.
 //  ==================================================
 
-@PART[F1engine]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[F1engine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA.cfg.bak
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA.cfg.bak
@@ -1,4 +1,4 @@
-@PART[RO_RLA_AJ260_HL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO_RLA_AJ260_HL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS {}
 
@@ -149,7 +149,7 @@
 				// ***************
 
 
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½
 				angle = 45.0 1.0
 				angle = 50.0 1.0
 				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -249,7 +249,7 @@
 		%type = ModuleEnginesRF
     }
 }
-@PART[RO_RLA_AJ260_FL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO_RLA_AJ260_FL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS {}
 
@@ -400,7 +400,7 @@
 				// ***************
 
 
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½
 				angle = 45.0 1.0
 				angle = 50.0 1.0
 				distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -501,7 +501,7 @@
     }
 }
 
-@PART[RLA_s_highengine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-253/RD-275
+@PART[RLA_s_highengine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//RD-253/RD-275
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE
@@ -649,7 +649,7 @@
 		}
 	}
 }
-@PART[RLA_s_lowengine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-210/RD-213
+@PART[RLA_s_lowengine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//RD-210/RD-213
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_highengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_highengine.cfg
@@ -1,4 +1,4 @@
-@PART[RLA_s_highengine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-253/RD-275
+@PART[RLA_s_highengine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//RD-253/RD-275
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_lowengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_lowengine.cfg
@@ -1,4 +1,4 @@
-@PART[RLA_s_lowengine]:FOR[RealPlume]:NEEDS[SmokeScreen]	//RD-210/RD-213
+@PART[RLA_s_lowengine]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//RD-210/RD-213
 {
 	!fx_exhaustFlame_blue = DELETE
 	!fx_exhaustFlames_white_tiny = DELETE

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_FL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_FL.cfg
@@ -1,4 +1,4 @@
-@PART[RO_RLA_AJ260_FL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO_RLA_AJ260_FL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS {}
 
@@ -149,7 +149,7 @@
 				// ***************
 
 
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½
 				angle = 45.0 1.0
 				angle = 50.0 1.0
 				distance = 0.0 1.0 // Display if the distance to camera is higher than 110

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_HL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_HL.cfg
@@ -1,4 +1,4 @@
-@PART[RO_RLA_AJ260_HL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO_RLA_AJ260_HL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS {}
 
@@ -149,7 +149,7 @@
 				// ***************
 
 
-				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45°
+				angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½
 				angle = 45.0 1.0
 				angle = 50.0 1.0
 				distance = 0.0 1.0 // Display if the distance to camera is higher than 110

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/A7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/A7.cfg
@@ -2,7 +2,7 @@
 //  NAA-75-110 A-Series engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-A-7]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-A-7]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_104.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_104.cfg
@@ -2,7 +2,7 @@
 //  AJ10-104 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-AJ10-104]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-104]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_137.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_137.cfg
@@ -2,7 +2,7 @@
 //  AJ10-137 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-AJ10-137]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-137]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_190.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_190.cfg
@@ -2,7 +2,7 @@
 //  AJ10-190 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-AJ10-190]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-190]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_37.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/AJ10_37.cfg
@@ -2,7 +2,7 @@
 //  AJ10-37 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-AJ10-37]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-AJ10-37]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/J2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/J2.cfg
@@ -2,7 +2,7 @@
 //  J-2 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-J2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-J2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/KTDU35.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/KTDU35.cfg
@@ -2,7 +2,7 @@
 //  KTDU-35 propulsion system plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-KTDU-35]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-KTDU-35]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMAE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMAE.cfg
@@ -2,7 +2,7 @@
 //  APS (LMAE) engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-LMAE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-LMAE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMDE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/LMDE.cfg
@@ -2,7 +2,7 @@
 //  DPS (LMDE) engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-LMDE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-LMDE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK33engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK33engine.cfg
@@ -2,7 +2,7 @@
 //  NK-33 series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-NK-33]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-33]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK43engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK43engine.cfg
@@ -2,7 +2,7 @@
 //  NK-43 series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-NK-43]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-43]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9.cfg
@@ -2,7 +2,7 @@
 //  NK-9 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-NK-9]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-9]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/NK9V.cfg
@@ -2,7 +2,7 @@
 //  NK-9V engine series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-NK-9V]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-NK-9V]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD-856.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD-856.cfg
@@ -2,7 +2,7 @@
 //  RD-856 vernier engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-856]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-856]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0105.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0105.cfg
@@ -2,7 +2,7 @@
 //  RD-0105 engine series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0105]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0105]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0110.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0110.cfg
@@ -2,7 +2,7 @@
 //  RD-0110 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0110]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0110]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124Aengine.cfg
@@ -2,7 +2,7 @@
 //  RD-0124A plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0124A]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0124A]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0124engine.cfg
@@ -2,7 +2,7 @@
 //  RD-0124 series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0124]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0124]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0146engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0146engine.cfg
@@ -2,7 +2,7 @@
 //  RD-0146 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0146]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0146]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0210.cfg
@@ -2,7 +2,7 @@
 //  RD-0210/0211 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0210]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0210]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD0212.cfg
@@ -2,7 +2,7 @@
 //  RD-0212 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0212]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0212]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD107.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD107.cfg
@@ -2,7 +2,7 @@
 //  RD-107 series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-107]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-107]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD108.cfg
@@ -2,7 +2,7 @@
 //  RD-108 series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-108]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-108]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD120.cfg
@@ -2,7 +2,7 @@
 //  RD-120 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-120]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-120]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD275.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD275.cfg
@@ -2,7 +2,7 @@
 //  RD-253/275 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-253]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-253]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD58.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD58.cfg
@@ -2,7 +2,7 @@
 //  RD-58 series plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-58]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-58]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD8.cfg
@@ -2,7 +2,7 @@
 //  RD-8 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-8]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-8]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD805.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/RD805.cfg
@@ -2,7 +2,7 @@
 //  RD-805 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-805]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-805]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_Vacuum.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_Vacuum.cfg
@@ -2,7 +2,7 @@
 //  Raptor engine (vacuum variant) plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-Raptor-VAC]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-Raptor-VAC]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/Raptor_engine.cfg
@@ -2,7 +2,7 @@
 //  Raptor engine (surface variant) plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-Raptor-ASL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-Raptor-ASL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S2.253.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S2.253.cfg
@@ -2,7 +2,7 @@
 //  S2.253 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-S2.253]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-S2.253]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_92fversion.cfg
@@ -2,7 +2,7 @@
 //  S5.92 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-S5-92]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-S5-92]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/S5_98M.cfg
@@ -2,7 +2,7 @@
 //  S5.98M engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-S5-98]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-S5-98]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SSME_Engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SSME_Engine.cfg
@@ -2,7 +2,7 @@
 //  RS-25 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-SSME]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-SSME]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/STEERING_MOTOR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/STEERING_MOTOR.cfg
@@ -2,7 +2,7 @@
 //  RD-0110R vernier engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0110R]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0110R]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SuperDrago.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/SuperDrago.cfg
@@ -2,7 +2,7 @@
 //  SuperDraco engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-SuperDraco]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-SuperDraco]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd0120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd0120.cfg
@@ -2,7 +2,7 @@
 //  RD-0120 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-0120]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-0120]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd100.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd100.cfg
@@ -2,7 +2,7 @@
 //  RD-103 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-100]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-100]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd170engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd170engine.cfg
@@ -2,7 +2,7 @@
 //  RD-170 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-170]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-170]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd180engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd180engine.cfg
@@ -2,7 +2,7 @@
 //  RD-180 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-180]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-180]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd191engine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealEngines/rd191engine.cfg
@@ -2,7 +2,7 @@
 //  RD-191 engine plume setup.
 //  ==================================================
 
-@PART[RO-RealEngines-RD-191]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-RealEngines-RD-191]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBathenaOAM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBathenaOAM.cfg
@@ -2,7 +2,7 @@
 //  OAM plume configuration.
 //  ==================================================
 
-@PART[RSBathenaOAM]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBathenaOAM]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSII8.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSII8.cfg
@@ -2,7 +2,7 @@
 //  S-II-8 retro motor plume configuration.
 //  ==================================================
 
-@PART[RSBdecouplerSaturnSII8]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdecouplerSaturnSII8]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSIVB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSIVB.cfg
@@ -2,7 +2,7 @@
 //  S-II retro motor plume configuration.
 //  ==================================================
 
-@PART[RSBdecouplerSaturnSIVB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdecouplerSaturnSIVB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSIVB2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdecouplerSaturnSIVB2.cfg
@@ -2,7 +2,7 @@
 //  S-IB retro motor plume configuration.
 //  ==================================================
 
-@PART[RSBdecouplerSaturnSIVB2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdecouplerSaturnSIVB2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta2srm.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta2srm.cfg
@@ -2,7 +2,7 @@
 //  GEM-40 plume configuration.
 //  ==================================================
 
-@PART[RSBdelta2srm]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdelta2srm]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srm.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srm.cfg
@@ -2,7 +2,7 @@
 //  GEM-46 plume configuration.
 //  ==================================================
 
-@PART[RSBdelta3srm]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdelta3srm]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srmG.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdelta3srmG.cfg
@@ -2,7 +2,7 @@
 //  GEM-46 plume configuration.
 //  ==================================================
 
-@PART[RSBdelta3srmG]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdelta3srmG]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdeltaIVsrm.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBdeltaIVsrm.cfg
@@ -2,7 +2,7 @@
 //  GEM-60 plume configuration.
 //  ==================================================
 
-@PART[RSBdeltaIVsrm]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBdeltaIVsrm]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAJ10-118K.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAJ10-118K.cfg
@@ -2,7 +2,7 @@
 //  AJ10-118F/K engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineAJ10-118K]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineAJ10-118K]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAresSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAresSRB.cfg
@@ -2,7 +2,7 @@
 //  Five segment RSRM plume configuration.
 //  ==================================================
 
-@PART[RSBengineAresSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineAresSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineArianeVSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineArianeVSRB.cfg
@@ -2,7 +2,7 @@
 //  EAP-241A plume configuration.
 //  ==================================================
 
-@PART[RSBengineArianeVSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineArianeVSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAtlasSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineAtlasSRB.cfg
@@ -2,7 +2,7 @@
 //  AJ-60A plume configuration.
 //  ==================================================
 
-@PART[RSBengineAtlasSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineAtlasSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor120.cfg
@@ -2,7 +2,7 @@
 //  Castor 120 plume configuration.
 //  ==================================================
 
-@PART[RSBengineCastor120]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineCastor120]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor30.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineCastor30.cfg
@@ -2,7 +2,7 @@
 //  Castor 30 plume configuration.
 //  ==================================================
 
-@PART[RSBengineCastor30]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineCastor30]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1.cfg
@@ -2,7 +2,7 @@
 //  F-1 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineF1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineF1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1A.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1A.cfg
@@ -2,7 +2,7 @@
 //  F-1A engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineF1A]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineF1A]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1B.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineF1B.cfg
@@ -2,7 +2,7 @@
 //  F-1B engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineF1B]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineF1B]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineH1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineH1.cfg
@@ -2,7 +2,7 @@
 //  H-1 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineH1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineH1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineHM7B.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineHM7B.cfg
@@ -2,7 +2,7 @@
 //  HM-7B engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineHM7B]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineHM7B]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineJ2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineJ2.cfg
@@ -2,7 +2,7 @@
 //  J-2 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineJ2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineJ2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineJ2T.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineJ2T.cfg
@@ -2,7 +2,7 @@
 //  J-2T engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineJ2T]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineJ2T]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineJ2X.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineJ2X.cfg
@@ -2,7 +2,7 @@
 //  J-2X engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineJ2X]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineJ2X]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineLR101.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineLR101.cfg
@@ -2,7 +2,7 @@
 //  LR101 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineLR101]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineLR101]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVps1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVps1.cfg
@@ -2,7 +2,7 @@
 //  PS1 plume configuration.
 //  ==================================================
 
-@PART[RSBenginePSLVps1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBenginePSLVps1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVps3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVps3.cfg
@@ -2,7 +2,7 @@
 //  PS3 plume configuration.
 //  ==================================================
 
-@PART[RSBenginePSLVps3]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBenginePSLVps3]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb10m.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb10m.cfg
@@ -2,7 +2,7 @@
 //  PSOM-S9 plume configuration.
 //  ==================================================
 
-@PART[RSBenginePSLVsrb10m]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBenginePSLVsrb10m]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb13m.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBenginePSLVsrb13m.cfg
@@ -2,7 +2,7 @@
 //  PSOM-S12 plume configuration.
 //  ==================================================
 
-@PART[RSBenginePSLVsrb13m]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBenginePSLVsrb13m]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRD180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRD180.cfg
@@ -2,7 +2,7 @@
 //  RD-180 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineRD180]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRD180]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10A3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10A3.cfg
@@ -2,7 +2,7 @@
 //  RL10 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineRL10A3]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRL10A3]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10A42.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10A42.cfg
@@ -2,7 +2,7 @@
 //  RL10 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineRL10A42]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRL10A42]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10B2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRL10B2.cfg
@@ -2,7 +2,7 @@
 //  RL10 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineRL10B2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRL10B2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRS25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRS25.cfg
@@ -2,7 +2,7 @@
 //  RS-25 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineRS25]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRS25]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRS27A.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRS27A.cfg
@@ -2,7 +2,7 @@
 //  RS-27 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineRS27A]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRS27A]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRS68.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineRS68.cfg
@@ -2,7 +2,7 @@
 //  RS-68 plume configuration.
 //  ==================================================
 
-@PART[RSBengineRS68]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineRS68]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineSTSSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineSTSSRB.cfg
@@ -2,7 +2,7 @@
 //  Four segment RSRM plume configuration.
 //  ==================================================
 
-@PART[RSBengineSTSSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineSTSSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineVikas.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineVikas.cfg
@@ -2,7 +2,7 @@
 //  Vikas engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineVikas]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineVikas]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineVulcain2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineVulcain2.cfg
@@ -2,7 +2,7 @@
 //  Vulcain 2 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineVulcain2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineVulcain2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineXLR81.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBengineXLR81.cfg
@@ -2,7 +2,7 @@
 //  XLR81 engine plume configuration.
 //  ==================================================
 
-@PART[RSBengineXLR81]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBengineXLR81]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBnoseconeArianeVSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBnoseconeArianeVSRB.cfg
@@ -2,7 +2,7 @@
 //  EAP-241A separation motor plume configuration.
 //  ==================================================
 
-@PART[RSBnoseconeArianeVSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBnoseconeArianeVSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBnoseconeSTSSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBnoseconeSTSSRB.cfg
@@ -2,7 +2,7 @@
 //  RSRM nose cone plume configuration.
 //  ==================================================
 
-@PART[RSBnoseconeSTSSRB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBnoseconeSTSSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBretroPSLV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBretroPSLV.cfg
@@ -2,7 +2,7 @@
 //  PSLV separation motor plume configuration.
 //  ==================================================
 
-@PART[RSBretroPSLV]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBretroPSLV]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankAtlasVcore.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankAtlasVcore.cfg
@@ -2,7 +2,7 @@
 //  STAR 5F retro motor plume configuration.
 //  ==================================================
 
-@PART[RSBtankAtlasVcore]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBtankAtlasVcore]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankPSLVps4.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankPSLVps4.cfg
@@ -2,7 +2,7 @@
 //  PS4 plume configuration.
 //  ==================================================
 
-@PART[RSBtankPSLVps4]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBtankPSLVps4]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankSaturnSIC.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBtankSaturnSIC.cfg
@@ -2,7 +2,7 @@
 //  S-IC retro motor plume configuration.
 //  ==================================================
 
-@PART[RSBtankSaturnSIC]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBtankSaturnSIC]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBullagePSLV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBullagePSLV.cfg
@@ -2,7 +2,7 @@
 //  PSLV ullage motor plume configuration.
 //  ==================================================
 
-@PART[RSBullagePSLV]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBullagePSLV]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBullageSaturnSII.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBullageSaturnSII.cfg
@@ -2,7 +2,7 @@
 //  S-II ullage motor plume configuration.
 //  ==================================================
 
-@PART[RSBullageSaturnSII]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBullageSaturnSII]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBullageSaturnSIVB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RealScaleBoosters/RSBullageSaturnSIVB.cfg
@@ -2,7 +2,7 @@
 //  S-IVB ullage motor plume configuration.
 //  ==================================================
 
-@PART[RSBullageSaturnSIVB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RSBullageSaturnSIVB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/E1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/E1.cfg
@@ -1,4 +1,4 @@
-@PART[SHIP_E1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SHIP_E1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3-SL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3-SL.cfg
@@ -1,4 +1,4 @@
-@PART[SHIP_HG_3_SL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SHIP_HG_3_SL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 
 	@MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/HG-3.cfg
@@ -1,4 +1,4 @@
-@PART[SHIP_HG_3_VAC]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SHIP_HG_3_VAC]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 
 	@MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR79.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR79.cfg
@@ -1,4 +1,4 @@
-@PART[SHIP_LR_71]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SHIP_LR_71]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR87.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR87.cfg
@@ -1,4 +1,4 @@
-@PART[SHIP_LR_87_3579|SHIP_LR_87_11|SHIP_LR_87_LH2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SHIP_LR_87_3579|SHIP_LR_87_11|SHIP_LR_87_LH2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR91.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR91.cfg
@@ -1,4 +1,4 @@
-@PART[SHIP_LR_91]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SHIP_LR_91]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-ASCE.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_LanderCore_LC2-ASCE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_LanderCore_LC2-ASCE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-DESE.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_LanderCore_LC2-DESE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_LanderCore_LC2-DESE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-ASCE.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_LanderCore_LC3-ASCE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_LanderCore_LC3-ASCE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-DESE.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_LanderCore_LC3-DESE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_LanderCore_LC3-DESE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-ASCE.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_LanderCore_LC5-ASCE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_LanderCore_LC5-ASCE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-DESE.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_LanderCore_LC5-DESE]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_LanderCore_LC5-DESE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-E1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-E1.cfg
@@ -1,4 +1,4 @@
-@PART[RO-SSTU-E1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-SSTU-E1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-M1-SL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-M1-SL.cfg
@@ -1,4 +1,4 @@
-@PART[RO-SSTU-M1-SL]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-SSTU-M1-SL]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-RL10C.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-RL10C.cfg
@@ -1,4 +1,4 @@
-@PART[RO-SSTU-RL10C]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-SSTU-RL10C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-B-SM]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-B-SM]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-C-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-C-SM.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-C-SM]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-C-SM]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     @MODULE[ModuleEngines*]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-M1-RO.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-M1-RO.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-M1-RO]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-M1-RO]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-RD-171.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-RD-171.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-RD-171]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-RD-171]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-RD-180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-RD-180.cfg
@@ -2,7 +2,7 @@
 //  RD-180 engine plume setup.
 //  ==================================================
 
-@PART[SSTU-SC-ENG-RD-180]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-RD-180]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-RD-181.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-RD-181.cfg
@@ -2,7 +2,7 @@
 //  RD-181 Plume Code.
 // ==============================
 
-@PART[SSTU-SC-ENG-RD-181]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-RD-181]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	PLUME
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_A_SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_A_SM.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_A_SM]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_ShipCore_A_SM]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_HUS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_HUS.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-B-HUS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-B-HUS]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -25,7 +25,7 @@
     }
 }
 
-@PART[SSTU-SC-B-HUS]:FOR[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-B-HUS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
 {
 	@EFFECTS
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_ICPS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_ICPS.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-B-ICPS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-B-ICPS]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -26,7 +26,7 @@
     }
 }
 
-@PART[SSTU-SC-B-ICPS]:FOR[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-B-ICPS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
 {
 	@EFFECTS
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB2.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_B_SRB2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_ShipCore_B_SRB2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB3.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_B_SRB3]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_ShipCore_B_SRB3]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB4.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB4.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_B_SRB4]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_ShipCore_B_SRB4]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB5.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB5.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU_ShipCore_B_SRB5]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU_ShipCore_B_SRB5]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	!EFFECTS
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_HUS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_HUS.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-C-HUS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-C-HUS]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -26,7 +26,7 @@
     }
 }
 
-@PART[SSTU-SC-C-HUS]:FOR[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-C-HUS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
 {
 	@EFFECTS
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_ICPS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_ICPS.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-C-ICPS]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-C-ICPS]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -28,7 +28,7 @@
     }
 }
 
-@PART[SSTU-SC-C-ICPS]:FOR[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-C-ICPS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
 {
 	@EFFECTS
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-F1]:NEEDS[RealPlume]:FOR[RealPlume]
+@PART[SSTU-SC-ENG-F1]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
 
 		@MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1B.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1B.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-F1B]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-F1B]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-J-2]:NEEDS[RealPlume]:FOR[RealPlume]
+@PART[SSTU-SC-ENG-J-2]:NEEDS[RealPlume]:BEFORE[RealPlume]
 {
     
     PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10A-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10A-3.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-RL10A-3]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-RL10A-3]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10B-2_Vinci_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10B-2_Vinci_Plume.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-RL10B-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-RL10B-2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -26,7 +26,7 @@
         speed = 1.2
     }
 }
-@PART[SSTU-SC-ENG-Vinci]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-Vinci]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RS-25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RS-25.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-RS-25]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-RS-25]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/NK21V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/NK21V.cfg
@@ -1,4 +1,4 @@
-@PART[SXTNK21BlockV]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SXTNK21BlockV]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTCastor30.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTCastor30.cfg
@@ -2,7 +2,7 @@
 //  STAR 17 plume setup.
 //  ==================================================
 
-@PART[SXTCastor30]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SXTCastor30]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVA.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVA.cfg
@@ -2,7 +2,7 @@
 //  Bimodal NTR plume setup.
 //  ==================================================
 
-@PART[SXTNERVA]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SXTNERVA]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVAB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVAB.cfg
@@ -1,4 +1,4 @@
-@PART[SXTNERVAB]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[SXTNERVAB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTWaxwing.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTWaxwing.cfg
@@ -1,4 +1,4 @@
-@PART[SXTWaxWing]:FOR[RealPlume]:NEEDS[SmokeScreen] // From FASA Sgt 11x, scaled up
+@PART[SXTWaxWing]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // From FASA Sgt 11x, scaled up
 {
 
 	@MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Squad/2kNThruster.cfg
@@ -2,7 +2,7 @@
 //  Generic 2 kN thruster plume setup.
 //  ==================================================
 
-@PART[RO-2kN-Thruster]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[RO-2kN-Thruster]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME:NEEDS[!VenStockRevamp/Squad]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineKE-1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineKE-1.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineKE-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[LiquidEngineKE-1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-I2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-I2.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineRE-I2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[LiquidEngineRE-I2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 
 	@MODULE[ModuleEngines*]

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-J10.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-J10.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineRE-J10]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[LiquidEngineRE-J10]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRK-7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRK-7.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineRK-7|LiquidEngineRK-7B]:FOR[RealPlume]
+@PART[LiquidEngineRK-7|LiquidEngineRK-7B]:BEFORE[RealPlume]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRV-1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRV-1.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineRV-1]:FOR[RealPlume]
+@PART[LiquidEngineRV-1]:BEFORE[RealPlume]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-T91.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-T91.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineLV-T91]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[LiquidEngineLV-T91]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-TX87.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-TX87.cfg
@@ -1,4 +1,4 @@
-@PART[LiquidEngineLV-TX87]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[LiquidEngineLV-TX87]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_MerlinPack_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_MerlinPack_Plume.cfg
@@ -1,5 +1,5 @@
 // Uses generic kerolox lower and upper plumes
-@PART[merlin1D]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[merlin1D]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -25,7 +25,7 @@
     }
 }
 
-@PART[merlin1D_vac]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[merlin1D_vac]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_Vinci_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_Vinci_Plume.cfg
@@ -1,4 +1,4 @@
-@PART[engineVinci]:FOR[RealPlume]:NEEDS[SmokeScreen] // RL10B-2
+@PART[engineVinci]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // RL10B-2
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/n1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/n1.cfg
@@ -1,4 +1,4 @@
-@PART[LLV_Engine_A]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-33 x30
+@PART[LLV_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-33 x30
 {
     PLUME
     {
@@ -26,7 +26,7 @@
     }
 }
 
-@PART[LLV_Engine_B,LLV_Engine_C,LLV_Engine_D]:FOR[RealPlume]:NEEDS[SmokeScreen] //NK-43 x8 and others
+@PART[LLV_Engine_B,LLV_Engine_C,LLV_Engine_D]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-43 x8 and others
 {
     PLUME
     {
@@ -54,7 +54,7 @@
     }
 }
 
-@PART[Libra_Engine_B]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Libra_Engine_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/nerva_1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/nerva_1.cfg
@@ -1,4 +1,4 @@
-@PART[Castor_Nerva]:FOR[RealPlume]:NEEDS[SmokeScreen]	//Aerojet NERVA I Nuclear Engine
+@PART[Castor_Nerva]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//Aerojet NERVA I Nuclear Engine
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/proton.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/proton.cfg
@@ -1,5 +1,5 @@
 //Proton first stage
-@PART[ALV_Engine_A]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[ALV_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -27,7 +27,7 @@
 }
 
 //RD-0210/0211
-@PART[ALV_Motor_A]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[ALV_Motor_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -55,7 +55,7 @@
 }
 
 //RD-0212/0213
-@PART[ALV_Motor_B]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[ALV_Motor_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/r7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/r7.cfg
@@ -1,5 +1,5 @@
 //RD-107/108
-@PART[TLV_Engine_A]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -26,7 +26,7 @@
 	}
 }
 
-@PART[TLV_Engine_RD108]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Engine_RD108]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -53,7 +53,7 @@
 	}
 }
 
-@PART[TLV_Vernier]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Vernier]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -81,7 +81,7 @@
 }
 
 //RD-0110/0124
-@PART[TLV_Engine_B]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Engine_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -109,7 +109,7 @@
 }
 
 //RD-0105/0109
-@PART[Alto_Engine_A]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Alto_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {
@@ -136,7 +136,7 @@
 	}
 }
 
-@PART[Alto_Engine_B]:FOR[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Alto_Engine_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/soyuz_lok_lk.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/soyuz_lok_lk.cfg
@@ -1,4 +1,4 @@
-@PART[Libra_Engine_A]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[Libra_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -25,7 +25,7 @@
     }
 }
 
-@PART[Tantares_Engine_A,Tantares_Engine_B,Tantares_Engine_C,Vostok_Engine_A,IronVostok_Engine_A]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[Tantares_Engine_A,Tantares_Engine_B,Tantares_Engine_C,Vostok_Engine_A,IronVostok_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {
@@ -52,7 +52,7 @@
     }
 }
 
-@PART[Vega_Engine_A,Vega_Engine_B,Vega_Engine_C]:FOR[RealPlume]:NEEDS[SmokeScreen]
+@PART[Vega_Engine_A,Vega_Engine_B,Vega_Engine_C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
     PLUME
     {


### PR DESCRIPTION
Hi KSP-RO team,

RO has a few hundred `:FOR[RealPlume]` clauses in it at the moment. Module Manager interprets this to mean that RealPlume is installed; other mods' patches with `:NEEDS[RealPlume]` would be activated even if RealPlume is absent. RO depends on RealPlume, so there should be no impact as long as the user's install is valid, but it's still better to avoid this:

https://github.com/sarbian/ModuleManager/wiki/Patch-Ordering#the-beforemodname-formodname-and-aftermodname-directives

> It is not recommended to use the :FOR directive to refer to other mods than the one you are writing.

In case these clauses were being used to control the patch orering, they are now changed to `:BEFORE[RealPlume]`, which should be (mostly) equivalent except for not telling MM that RO is RealPlume.

Cheers!