### PR TITLE
Tune composite/advanced composite tank mass

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -435,9 +435,9 @@ TANK_DEFINITION
 	title = Carbon Composite Tank
 	description = The unparalleled low density and high strength of carbon composites have long been the siren call of tank design. Ever since the X-33 and Venture Star program of the 1990s was aborted only a few years years before the leaking problems that had killed Venture Star were solved, space companies have been trying to justify the very high cost of composite materials. Although costs continue to drop, the intensive manufacturing process is still very expensive, requiring the wrapping and weaving of hundreds of layers of carbon fiber with resins that are then baked off in massive autoclaves. Currently, the only rocket to use composite materials is the smallsat Electron orbital launcher developed by Rocket Lab.
 	highlyPressurized = False
-	basemass = 0.000010 * volume
+	basemass = 0.0000095 * volume
 	baseCost = 0.008 * volume
-	balloonTemps = true
+	//balloonTemps = true
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -446,7 +446,7 @@ TANK_DEFINITION
 {
 	@TANK[*]:HAS[~mass[*]]
 	{
-		mass = 0.000010
+		mass = 0.0000095
 	}
 }
 
@@ -455,9 +455,9 @@ TANK_DEFINITION
 {
 	name = Tank-Int-Magic
 	title = Advanced Carbon Composite Tank
-	description = Ceramic-metal alloys and insulating complex composite structures are still speculative, but if they ever come to fruitition, they'd probably be something like this.
+	description = Advanced carbon composite tankage, more resistant to cryogenic temperatures, and built using cutting edge construction techniques to maximize strength. Although small technology demonstrators have been made, no launch vehicle has utilized this style of advanced composite tankage.
 	highlyPressurized = False
-	basemass = 0.0000094021 * volume
+	basemass = 0.0000065 * volume
 	baseCost = 0.01 * volume
 	addResources = true
 	addLead = true
@@ -467,7 +467,7 @@ TANK_DEFINITION
 {
 	@TANK[*]:HAS[~mass[*]]
 	{
-		mass = 0.0000095
+		mass = 0.0000065
 	}
 }
 
@@ -1630,8 +1630,8 @@ TANK_DEFINITION
 		maxAmount = 0.0
 	}
 }
-// Balloon insulation fixes
-@TANK_DEFINITION:HAS[~balloonTemps[true]] // not FIRST anymore.
+// LH2 tank mass fixes
+@TANK_DEFINITION:HAS[~balloonTemps[true]]
 {
 	@TANK[LqdHydrogen]
 	{


### PR DESCRIPTION
Based on 
https://hydrogen-central.com/hypoint-zero-emission-hydrogen-flight-range-ultralight-liquid-hydrogen-fuel-tanks/ 

improve the mass ratio of advanced composite tanks to ~10 when loaded with LH2. (The example tank achieved a mass ratio of nearly 13.5, but it's just a tank. Adding mass of stage structure and other systems, and assuming improvements continue, a mass ratio of 10 seems fairly reasonable for near future tankage. The example tank, when completed as a dewar, has a much less impressive mass ratio, but still very good for a dewar. SM-V material?)

Also make composite tanks slightly better based on RL electron performance info.