### PR TITLE
Update Cryo Engines Support

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
@@ -1,4 +1,18 @@
 //=============
+//	Common patch
+//=============
+
+@PART[cryoengine-deinonychus-1|cryoengine-eagle-1|cryoengine-stromboli-1|cryoengine-tharsis-1|cryoengine-pavonis-1|cryoengine-etna-1|cryoengine-ulysses-1|cryoengine-fuji-1|cryoengine-hecate-1|cryoengine-vesuvius-1|cryoengine-tyrannosaur-1|cryoengine-iguanodon-1|cryoengine-hawk-1|cryoengine-allosaur-1|cryoengine-erebus-1]:FOR[RealismOverhaul]
+{
+	%crashTolerance = 10
+	%maxTemp = 673.15
+	%skinMaxTemp = 773.15
+	%fuelCrossFeed = true
+	%breakingForce = 10000
+	%breakingTorque = 10000
+}
+
+//=============
 //	Vulcain 2
 //=============
 
@@ -7,12 +21,6 @@
 {
 	%RSSROConfig = True
 	%rescaleFactor = 2
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-	
 	%engineType = Vulcain
 }
 
@@ -36,14 +44,7 @@
 @PART[cryoengine-hecate-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-
 	%rescaleFactor = 2
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = RL10
 }
 
@@ -74,13 +75,7 @@
 {
 	%RSSROConfig = True
 	// No rescale needed, model nozzle exit diameter matches LE-9 spec
-
 	%mass = 1.72
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = LE7
 }
 
@@ -92,12 +87,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.667
-
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = J2X
 }
 
@@ -109,12 +98,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.3333 // Actually 1.461, but this way we keep the shroud at 5 meters for use on Delta IV's CBC
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-	
 	%engineType = RS68
 	
 	@MODULE[ModuleEngines*]
@@ -144,12 +127,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.458
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = RD0120
 }
 
@@ -161,12 +138,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.317
-
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = RL60
 }
 
@@ -178,12 +149,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.317
-
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = RL60
 	%engineTypeMult = 2
 }
@@ -196,12 +161,6 @@
 {
 	%RSSROConfig = True
 	// No rescale needed, model inner nozzle exit diameter matches RL10A-5 spec
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = RL10
 }
 
@@ -227,12 +186,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.557
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = Raptor
 }
 
@@ -254,12 +207,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.7
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = Raptor
 }
 
@@ -283,12 +230,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.603
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = Raptor
 	%clusterMultiplier = 9
 	%engineTypeMult = 9
@@ -312,12 +253,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.272
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = BE4
 }
 
@@ -328,12 +263,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.41
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = LMAE
 }
 
@@ -355,12 +284,6 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor = 1.717
-	
-	%maxTemp = 1700
-	%crashTolerance = 12
-	%breakingForce = 250
-	%breakingTorque = 250
-
 	%engineType = STBE1
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CryoEngines/RO_CryoEngines_Engines.cfg
@@ -218,3 +218,159 @@
 		!CONFIG[*]:HAS[~name[RL10A-5]] {}
 	}
 }
+
+//=============
+//	Raptor SL
+//=============
+
+@PART[cryoengine-deinonychus-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.557
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = Raptor
+}
+
+@PART[cryoengine-deinonychus-1]:FOR[RealismOverhaulEnginesPost]
+{
+	@title = Raptor (Surface Variant)
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		!CONFIG[Raptor?Vacuum] {}
+	}
+}
+
+//=============
+//	Raptor Vac
+//=============
+
+@PART[cryoengine-eagle-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.7
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = Raptor
+}
+
+@PART[cryoengine-eagle-1]:FOR[RealismOverhaulEnginesPost]
+{
+	@title = Raptor (Vacuum Variant)
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@configuration = Raptor Vacuum
+		!CONFIG[Raptor] {}
+		!CONFIG[Raptor?Non-Throttleable] {}
+	}
+}
+
+//=============
+//	Raptor SL (9x)
+//=============
+
+@PART[cryoengine-tyrannosaur-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.603
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = Raptor
+	%clusterMultiplier = 9
+	%engineTypeMult = 9
+}
+
+@PART[cryoengine-tyrannosaur-1]:FOR[RealismOverhaulEnginesPost]
+{
+	@title = Raptor (Surface Variant)
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		!CONFIG[Raptor?Vacuum] {}
+	}
+}
+
+//=============
+//	BE-4
+//=============
+
+@PART[cryoengine-iguanodon-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.272
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = BE4
+}
+
+//=============
+//	RS-18
+//=============
+@PART[cryoengine-hawk-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.41
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = LMAE
+}
+
+@PART[cryoengine-hawk-1]:FOR[RealismOverhaulEnginesPost]
+{
+	@title = RS-18
+    @description = LMAE converted to run on Methalox for use on future manned Lunar and Martian landers. Developed and test fired, but cancelled in 2020 in favor of commercially developed landers.
+	@MODULE[ModuleEngineConfigs]
+	{
+		!CONFIG[LMAE] {}
+	}
+}
+
+//=============
+//	STBE
+//=============
+
+@PART[cryoengine-allosaur-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.717
+	
+	%maxTemp = 1700
+	%crashTolerance = 12
+	%breakingForce = 250
+	%breakingTorque = 250
+
+	%engineType = STBE1
+}
+
+@PART[cryoengine-allosaur-1]:FOR[RealismOverhaulEnginesPost]
+{
+	@title = STBE-3
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		!CONFIG[STBE-1A] {}
+		!CONFIG[STBE-1B] {}
+	}
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
@@ -1,6 +1,17 @@
 //=============
 //	Waterfall
 //=============
+@PART[cryoengine-deinonychus-1|cryoengine-eagle-1|cryoengine-stromboli-1|cryoengine-tharsis-1|cryoengine-pavonis-1|cryoengine-etna-1|cryoengine-ulysses-1|cryoengine-fuji-1|cryoengine-hecate-1|cryoengine-vesuvius-1|cryoengine-tyrannosaur-1|cryoengine-iguanodon-1|cryoengine-hawk-1|cryoengine-allosaur-1]:BEFORE[ROWaterfall]
+{
+	@MODULE[ModuleWaterfallFX]
+	{
+        @TEMPLATE
+	    {
+	        @scale[*] *= #$/rescaleFactor$
+		} 
+	}
+}
+
 @PART[cryoengine-deinonychus-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
 	//kill the stock smoke plumes
@@ -9,15 +20,6 @@
 		@fx-deinonychus
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -32,15 +34,6 @@
 			!PREFAB_PARTICLE {}
 		}
 	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
-		}
-	}
 }
 
 @PART[cryoengine-stromboli-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
@@ -51,15 +44,6 @@
 		@fx-stromboli
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -74,15 +58,6 @@
 			!PREFAB_PARTICLE {}
 		}
 	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
-		}
-	}
 }
 
 @PART[cryoengine-pavonis-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
@@ -93,15 +68,6 @@
 		@fx-pavonis
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -137,15 +103,6 @@
 		@fx-etna
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -207,15 +164,6 @@
 			!PREFAB_PARTICLE {}
 		}
 	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
-		}
-	}
 }
 
 @PART[cryoengine-fuji-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
@@ -226,15 +174,6 @@
 		@fx-fuji
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -249,15 +188,6 @@
 			!PREFAB_PARTICLE {}
 		}
 	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
-		}
-	}
 }
 
 @PART[cryoengine-vesuvius-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
@@ -268,15 +198,6 @@
 		@fx-vesuvius
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -291,15 +212,6 @@
 			!PREFAB_PARTICLE {}
 		}
 	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
-		}
-	}
 }
 @PART[cryoengine-iguanodon-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
@@ -309,15 +221,6 @@
 		@fx-iguanodon
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }
@@ -332,15 +235,6 @@
 			!PREFAB_PARTICLE {}
 		}
 	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
-		}
-	}
 }
 
 @PART[cryoengine-allosaur-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
@@ -351,15 +245,6 @@
 		@fx-allosaur
 		{
 			!PREFAB_PARTICLE {}
-		}
-	}
-
-	//just rescale the plumes
-	@MODULE[ModuleWaterfallFX]
-	{
-		@TEMPLATE
-		{
-			@scale[*] *= #$/rescaleFactor$
 		}
 	}
 }

--- a/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
@@ -85,7 +85,7 @@
 
 	//Use SSME plume, similar to ROEngines' one
 	!MODULE[ModuleWaterfallFX] {}
-	ROWaterfall
+    ROWaterfall
     {
         template = rowaterfall-hydrolox-ssme
         audio = pump-fed-medium-1

--- a/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
@@ -85,14 +85,14 @@
 
 	//Use SSME plume, similar to ROEngines' one
 	!MODULE[ModuleWaterfallFX] {}
-    ROWaterfall
-    {
-        template = rowaterfall-hydrolox-ssme
-        audio = pump-fed-medium-1
-        position = 0,0,-0.05
-        rotation = 0, 0, 0
-        scale = 1.487, 1.487, 1.487
-    }
+        ROWaterfall
+        {
+            template = rowaterfall-hydrolox-ssme
+            audio = pump-fed-medium-1
+            position = 0,0,-0.05
+            rotation = 0, 0, 0
+            scale = 1.487, 1.487, 1.487
+        }
 }
 
 @PART[cryoengine-etna-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]

--- a/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
@@ -5,9 +5,9 @@
 {
 	@MODULE[ModuleWaterfallFX]
 	{
-        @TEMPLATE
-	    {
-	        @scale[*] *= #$/rescaleFactor$
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
 		} 
 	}
 }
@@ -26,7 +26,6 @@
 
 @PART[cryoengine-eagle-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-eagle
@@ -38,7 +37,6 @@
 
 @PART[cryoengine-stromboli-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-stromboli
@@ -50,7 +48,6 @@
 
 @PART[cryoengine-tharsis-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-tharsis
@@ -62,7 +59,6 @@
 
 @PART[cryoengine-pavonis-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-pavonis
@@ -74,7 +70,6 @@
 
 @PART[cryoengine-erebus-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-erebus
@@ -97,7 +92,6 @@
 
 @PART[cryoengine-etna-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-etna
@@ -156,10 +150,9 @@
 
 @PART[cryoengine-ulysses-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
-		@fx-usysses
+		@fx-ulysses
 		{
 			!PREFAB_PARTICLE {}
 		}
@@ -168,7 +161,6 @@
 
 @PART[cryoengine-fuji-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-fuji
@@ -180,7 +172,6 @@
 
 @PART[cryoengine-hecate-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-hecate
@@ -192,7 +183,6 @@
 
 @PART[cryoengine-vesuvius-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-vesuvius
@@ -204,7 +194,6 @@
 
 @PART[cryoengine-tyrannosaur-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-tyrannosaur
@@ -215,7 +204,6 @@
 }
 @PART[cryoengine-iguanodon-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-iguanodon
@@ -227,7 +215,6 @@
 
 @PART[cryoengine-hawk-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-hawk
@@ -239,7 +226,6 @@
 
 @PART[cryoengine-allosaur-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-	//kill the stock smoke plumes
 	@EFFECTS
 	{
 		@fx-allosaur

--- a/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/CryoEngines/CryoEnginesWF.cfg
@@ -1,0 +1,365 @@
+//=============
+//	Waterfall
+//=============
+@PART[cryoengine-deinonychus-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-deinonychus
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-eagle-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-eagle
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-stromboli-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-stromboli
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-tharsis-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-tharsis
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-pavonis-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-pavonis
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-erebus-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-erebus
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//Use SSME plume, similar to ROEngines' one
+	!MODULE[ModuleWaterfallFX] {}
+	ROWaterfall
+    {
+        template = rowaterfall-hydrolox-ssme
+        audio = pump-fed-medium-1
+        position = 0,0,-0.05
+        rotation = 0, 0, 0
+        scale = 1.487, 1.487, 1.487
+    }
+}
+
+@PART[cryoengine-etna-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-etna
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+//Adding gas generator effect (copied from the mod's RealPlume config)
+@PART[cryoengine-etna-1]:AFTER[zRealPlume]:NEEDS[zRealPlume,SmokeScreen,!Waterfall]
+{
+    %EFFECTS
+    {
+        %CryoEngines375LowerRed
+        {
+            MODEL_MULTI_SHURIKEN_PERSIST
+            {
+                name = turbo
+                modelName = CryoEngines/FX/fx-etna-turbo-1
+                transformName = fxTransformTurbo
+                localPosition = 0,0.25,0
+                localRotation = 90,0,0
+                emission
+                {
+                power = #$@CryoEnginesPlume/PowerKeys/startup$       0
+                power = #$@CryoEnginesPlume/PowerKeys/flameout$     0.0
+                power = #$@CryoEnginesPlume/PowerKeys/ignition$     0.6
+                power = #$@CryoEnginesPlume/PowerKeys/deepThrottle$ 0.9
+                power = #$@CryoEnginesPlume/PowerKeys/maxThrottle$  2.5
+                }
+                speed
+                {
+                power = #$@CryoEnginesPlume/PowerKeys/startup$      0.5
+                power = #$@CryoEnginesPlume/PowerKeys/flameout$     0.5
+                power = #$@CryoEnginesPlume/PowerKeys/ignition$     0.6
+                power = #$@CryoEnginesPlume/PowerKeys/deepThrottle$ 0.9
+                power = #$@CryoEnginesPlume/PowerKeys/maxThrottle$  1.2
+
+                density = #$@CryoEnginesPlume/atmosphereKeys/key4$ 1
+                density = #$@CryoEnginesPlume/atmosphereKeys/key5$ 0.7
+                }
+                logGrow
+                {
+                density = #$@CryoEnginesPlume/atmosphereKeys/key0$ 0
+                density = #$@CryoEnginesPlume/atmosphereKeys/key1$ 1.5
+                density = #$@CryoEnginesPlume/atmosphereKeys/key2$ 5
+                density = #$@CryoEnginesPlume/atmosphereKeys/key3$ 10
+                density = #$@CryoEnginesPlume/atmosphereKeys/key4$ 10
+                density = #$@CryoEnginesPlume/atmosphereKeys/key5$ 15
+                }
+            }
+        }
+    }
+}
+
+
+@PART[cryoengine-ulysses-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-usysses
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-fuji-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-fuji
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-hecate-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-hecate
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-vesuvius-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-vesuvius
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-tyrannosaur-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-tyrannosaur
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+@PART[cryoengine-iguanodon-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-iguanodon
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-hawk-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-hawk
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}
+
+@PART[cryoengine-allosaur-1]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	//kill the stock smoke plumes
+	@EFFECTS
+	{
+		@fx-allosaur
+		{
+			!PREFAB_PARTICLE {}
+		}
+	}
+
+	//just rescale the plumes
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+}


### PR DESCRIPTION
A small update that brings beautiful models of the Raptors (finally lol)
New: 
- Raptor SL;
- Raptor SL (9x);
- Raptor Vacuum;
- RS-18 (methalox LMAE);
- BE-4;
- STBE-3;
- Waterfall support;
Doesn't have support (yet) for:
- BE-4U (Vulture);
- ESA Prometheus (Compsognatus);
- Avio M-10 (Buzzard);
- Landspace TQ11/12 (Harrier);
These ones require engine configs in RO.
