### PR TITLE
Plume patterns fix

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/BahaRd180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/BahaRd180.cfg
@@ -2,32 +2,29 @@
 //	RD-180 plume configuration.
 //	==================================================
 
-	@PART[BahaRd180]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[BahaRd180]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
 	{
-		PLUME
-		{
-			name		  = Kerolox-Lower
-			transformName = thrustTransform
-			localRotation = 0.000, 0.000, 0.000
-			localPosition = 0.000, 0.000, 0.500
-			fixedScale	  = 1.150
-			energy		  = 1.000
-			speed		  = 1.000
-		}
+		name		  = Kerolox-Lower
+		transformName = thrustTransform
+		localRotation = 0.000, 0.000, 0.000
+		localPosition = 0.000, 0.000, 0.500
+		fixedScale	  = 1.150
+		energy		  = 1.000
+		speed		  = 1.000
+	}
 
-		@MODULE[ModuleEngines*]
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Kerolox-Lower
+	}
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
 		{
-			%name			 = ModuleEnginesRF
 			%powerEffectName = Kerolox-Lower
 		}
-
-		@MODULE[ModuleEngineConfigs]
-		{
-			%type = ModuleEnginesRF
-
-			@CONFIG,*
-			{
-				%powerEffectName = Kerolox-Lower
-			}
-		}
 	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/atlasSrb.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BahamutoD/atlasSrb.cfg
@@ -2,33 +2,30 @@
 //	AJ-60A plume configuration.
 //	==================================================
 
-	@PART[atlasvSrb]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[atlasvSrb]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
 	{
-		PLUME
-		{
-			name		  = Solid-Lower
-			transformName = thrustTransform
-			localRotation = 0.000, 0.000,  0.000
-			flarePosition = 0.000, 0.000, -0.200
-			plumePosition = 0.000, 0.000, -0.100
-			fixedScale	  = 0.950
-			energy		  = 1.000
-			speed		  = 1.000
-		}
+		name		  = Solid-Lower
+		transformName = thrustTransform
+		localRotation = 0.000, 0.000,  0.000
+		flarePosition = 0.000, 0.000, -0.200
+		plumePosition = 0.000, 0.000, -0.100
+		fixedScale	  = 0.950
+		energy		  = 1.000
+		speed		  = 1.000
+	}
 
-		@MODULE[ModuleEngines*]
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Solid-Lower
+	}
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
 		{
-			%name			 = ModuleEnginesRF
 			%powerEffectName = Solid-Lower
 		}
-
-		@MODULE[ModuleEngineConfigs]
-		{
-			%type = ModuleEnginesRF
-
-			@CONFIG,*
-			{
-				%powerEffectName = Solid-Lower
-			}
-		}
 	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/BlacklegIndustries/satbusengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BlacklegIndustries/satbusengine.cfg
@@ -17,17 +17,14 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White
         }
-    }   
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/ARES.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/ARES.cfg
@@ -1,4 +1,4 @@
-@PART[AresV_2stage]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[AresV_2stage]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -11,21 +11,16 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-        %type = ModuleEnginesRF
+    @MODULE[ModuleEngineConfigs]
+    {
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Lower
         }
-	}
+    }
 }
 
-@PART[AresV_J2-X_engine|Ares1_J2-X]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[AresV_J2-X_engine|Ares1_J2-X]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -38,21 +33,16 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-        %type = ModuleEnginesRF
+    @MODULE[ModuleEngineConfigs]
+    {
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
         }
-	}
+    }
 }
 
-@PART[Ares1_SRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Ares1_SRB]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -65,21 +55,16 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-        %type = ModuleEnginesRF
+    @MODULE[ModuleEngineConfigs]
+    {
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower
         }
-	}
+    }
 }
 
-@PART[Ares_SRB_Nose_Cone|Ares_SRB_Avionic]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Ares_SRB_Nose_Cone|Ares_SRB_Avionic]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -92,10 +77,9 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
+    @MODULE[ModuleEngines*]
+    {
         !fxOffset = DELETE
         %powerEffectName = Solid-Sepmotor
-	}
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/FGB-DOS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/FGB-DOS.cfg
@@ -11,13 +11,8 @@
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*   //Add the effect to every engine config
         {
             %powerEffectName = Hypergolic-OMS-Red

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK33.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK33.cfg
@@ -12,13 +12,8 @@
         energy = 0.4
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK43.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK43.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9.cfg
@@ -12,13 +12,8 @@
         energy = 0.4
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/NK9V.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OME.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OME.cfg
@@ -15,11 +15,6 @@
 		speed		  = 1.700
 	}
 
-	@MODULE[ModuleEngines*]
-	{
-		%powerEffectName = Hypergolic-OMS-White
-	}
-
 	@MODULE[ModuleEngineConfigs]
 	{
 		@CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OME.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OME.cfg
@@ -2,32 +2,29 @@
 //	AJ10-190 plume configuration.
 //	==================================================
 
-	@PART[Orion_InstrumentServise_Module]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[Orion_InstrumentServise_Module]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
 	{
-		PLUME
-		{
-			name		  = Hypergolic-OMS-White
-			transformName = thrustTransform
-			localRotation = 0.000, 0.000,  0.000
-			localPosition = 0.000, 0.000, 0.0
-			fixedScale	  = 2.500
-			energy		  = 0.600
-			speed		  = 1.700
-		}
+		name		  = Hypergolic-OMS-White
+		transformName = thrustTransform
+		localRotation = 0.000, 0.000,  0.000
+		localPosition = 0.000, 0.000, 0.0
+		fixedScale	  = 2.500
+		energy		  = 0.600
+		speed		  = 1.700
+	}
 
-		@MODULE[ModuleEngines*]
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Hypergolic-OMS-White
+	}
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
 		{
-			%name			 = ModuleEnginesRF
 			%powerEffectName = Hypergolic-OMS-White
 		}
-
-		@MODULE[ModuleEngineConfigs]
-		{
-			%type = ModuleEnginesRF
-
-			@CONFIG,*
-			{
-				%powerEffectName = Hypergolic-OMS-White
-			}
-		}	
 	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OrionLES.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OrionLES.cfg
@@ -2,33 +2,30 @@
 //	Orion LAS plume configuration.
 //	==================================================
 
-	@PART[Orion_LES]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[Orion_LES]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+	PLUME
 	{
-		PLUME
-		{
-			name		  = Solid-Sepmotor
-			transformName = thrustTransform
-			localRotation = 0.000, 0.000, 0.000
-			flarePosition = 0.000, 0.030, 0.100
-			plumePosition = 0.000, 0.000, 0.000
-			fixedScale	  = 1.500
-			energy		  = 0.800
-			speed		  = 1.000
-		}
+		name		  = Solid-Sepmotor
+		transformName = thrustTransform
+		localRotation = 0.000, 0.000, 0.000
+		flarePosition = 0.000, 0.030, 0.100
+		plumePosition = 0.000, 0.000, 0.000
+		fixedScale	  = 1.500
+		energy		  = 0.800
+		speed		  = 1.000
+	}
 
-		@MODULE[ModuleEngines*]
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Solid-Sepmotor
+	}
+
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
 		{
-			%name			 = ModuleEnginesRF
 			%powerEffectName = Solid-Sepmotor
 		}
-
-		@MODULE[ModuleEngineConfigs]
-		{
-			%type = ModuleEnginesRF
-
-			@CONFIG,*
-			{
-				%powerEffectName = Solid-Sepmotor
-			}
-		}
 	}
+}

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OrionLES.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/OrionLES.cfg
@@ -16,11 +16,6 @@
 		speed		  = 1.000
 	}
 
-	@MODULE[ModuleEngines*]
-	{
-		%powerEffectName = Solid-Sepmotor
-	}
-
 	@MODULE[ModuleEngineConfigs]
 	{
 		@CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0110.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0110.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 1.4
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
@@ -26,7 +21,7 @@
     }
 }
 
-@PART[RD0110]:FOR[zzRealPlume] //just tweaking smoke
+@PART[RD0110]:BEFORE[zzzRealPlume] //just tweaking smoke
 {
   @EFFECTS
   {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0120.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0120.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 0.8
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0124.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0124.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 1.4
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
@@ -26,7 +21,7 @@
     }
 }
 
-@PART[RD0124]:FOR[zzRealPlume] //just tweaking smoke
+@PART[RD0124]:BEFORE[zzzRealPlume] //just tweaking smoke
 {
   @EFFECTS
   {

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0146.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD0146.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 0.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD171.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD171.cfg
@@ -12,13 +12,8 @@
         energy = 0.4
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD180.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD180.cfg
@@ -12,13 +12,8 @@
         energy = 0.4
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD191.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD191.cfg
@@ -12,13 +12,8 @@
         energy = 0.3
         speed = 1
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270.cfg
@@ -12,13 +12,8 @@
         energy = 2
         speed = 1
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270M.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/BobCat/RD270M.cfg
@@ -12,13 +12,8 @@
         energy = 2
         speed = 1
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/CSS/CSS_SSRB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CSS/CSS_SSRB.cfg
@@ -1,8 +1,6 @@
 @PART[CSS_SSRB]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 
 	EFFECTS
 	{
@@ -204,11 +202,6 @@
     	}
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		%powerEffectName = powerflame
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/CSS/SSP.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/CSS/SSP.cfg
@@ -1,4 +1,4 @@
-@PART[SRB2D]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[SRB2D]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -11,21 +11,16 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-        %type = ModuleEnginesRF
+    @MODULE[ModuleEngineConfigs]
+    {
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower
         }
-	}
+    }
 }
 
-@PART[STS?SRB?Nose?Cone]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[STS?SRB?Nose?Cone]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -38,10 +33,9 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
+    @MODULE[ModuleEngines*]
+    {
         !fxOffset = DELETE
         %powerEffectName = Solid-Sepmotor
-	}
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/KFS/RO_KFS_CZ3B_Plumes.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KFS/RO_KFS_CZ3B_Plumes.cfg
@@ -103,10 +103,6 @@
         energy = .65
         speed = 1
     }
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Lower
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*
@@ -130,10 +126,6 @@
         energy = .65
         speed = 1
     }  
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Lower
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*
@@ -156,10 +148,6 @@
         fixedScale = 0.35
         energy = .65
         speed = 1
-    }
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Lower
     }
     @MODULE[ModuleEngineConfigs]
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/KFS/RO_KFS_CZ3B_Plumes.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KFS/RO_KFS_CZ3B_Plumes.cfg
@@ -12,7 +12,6 @@
     }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesFX
         %powerEffectName = Hypergolic-Lower
     }
 }
@@ -31,7 +30,6 @@
     }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesFX
         %powerEffectName = Hypergolic-Lower
     }
 }
@@ -50,7 +48,6 @@
     }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesFX
         %powerEffectName = Hypergolic-Upper
     }
 }
@@ -69,7 +66,6 @@
     }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesFX
         %powerEffectName = Hypergolic-Vernier
     }
 }
@@ -89,35 +85,30 @@
     }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesFX
         %powerEffectName = Hydrolox-Upper
     }
 }
 
 @PART[long_march_3B_2nd_stage_fueltank]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	!EFFECTS
-	{
-	}
-    PLUME  
-    {  
+	!EFFECTS {}
+    PLUME
+    {
         name = Solid-Sepmotor
-        transformName = thrustTransform  
-        localRotation = 0,0,0  
+        transformName = thrustTransform
+        localRotation = 0,0,0
         flarePosition = 0,0,0
-        plumePosition = 0,0,0 
+        plumePosition = 0,0,0
         fixedScale = 0.35
         energy = .65
         speed = 1
-    }  
+    }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Solid-Lower
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower
@@ -127,28 +118,24 @@
 
 @PART[long_march_3B_boost_stage_fueltank]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	!EFFECTS
-	{
-	}
-    PLUME  
-    {  
+	!EFFECTS {}
+    PLUME
+    {
         name = Solid-Sepmotor
-        transformName = thrustTransform  
-        localRotation = 0,0,0  
+        transformName = thrustTransform
+        localRotation = 0,0,0
         flarePosition = 0,0,0
-        plumePosition = 0,0,0 
+        plumePosition = 0,0,0
         fixedScale = 0.35
         energy = .65
         speed = 1
     }  
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Solid-Lower
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower
@@ -158,28 +145,24 @@
 
 @PART[long_march_3B_Equipment]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	!EFFECTS
-	{
-	}
-    PLUME  
-    {  
+	!EFFECTS {}
+    PLUME
+    {
         name = Solid-Sepmotor
-        transformName = thrustTransform  
-        localRotation = 0,0,0  
+        transformName = thrustTransform
+        localRotation = 0,0,0
         flarePosition = 0,0,0
-        plumePosition = 0,0,0 
+        plumePosition = 0,0,0
         fixedScale = 0.35
         energy = .65
         speed = 1
-    }  
+    }
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Solid-Lower
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KSLO/LVT1C.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KSLO/LVT1C.cfg
@@ -1,16 +1,10 @@
 @PART[LVT1C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		%powerEffectName = Kerolox-Lower
-		!fxOffset = DELETE
-
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		%type = ModuleEnginesRF
-	}
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Kerolox-Lower
+        !fxOffset = DELETE
+    }
     PLUME
     {
         name = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineMaverick1D.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineMaverick1D.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineVestaVR1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineVestaVR1.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineWildCatV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW1mengineWildCatV.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineGriffonG8D.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineGriffonG8D.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineMaverickV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineMaverickV.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineSPS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineSPS.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Apollo-SM

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineVestaVR9D.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW2mengineVestaVR9D.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineGriffonXX.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineGriffonXX.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineTitanT1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineTitanT1.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineWildcatXR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW3mengineWildcatXR.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineGriffonC.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineGriffonC.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower-F1

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineTitanV.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KW5mengineTitanV.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWSepMotors.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWSepMotors.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Sepmotor
 	}
@@ -21,7 +20,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Sepmotor
 	}
@@ -40,7 +38,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Sepmotor
 	}
@@ -59,7 +56,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Sepmotor
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeI.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeI.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -23,7 +22,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -44,7 +42,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -64,7 +61,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -84,7 +80,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -104,7 +99,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -124,7 +118,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}
@@ -144,7 +137,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeVI.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeVI.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10L.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10L.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10S.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX10S.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX2.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX5.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KWRocketry/KWsrbGlobeX5.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
         %powerEffectName = Solid-Lower
 	}

--- a/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Ariane6_Plumes.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Ariane6_Plumes.cfg
@@ -1,8 +1,6 @@
 @PART[upperStage]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
     PLUME
     {
         name = Hydrolox-Upper
@@ -13,14 +11,9 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
-        	@CONFIG,*
+		@CONFIG,*
 		{
 			%powerEffectName = Hydrolox-Upper
 		}
@@ -29,9 +22,7 @@
 
 @PART[vulcain2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
     PLUME
     {
         name = Hydrolox-Lower
@@ -42,14 +33,9 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
-        	@CONFIG,*
+		@CONFIG,*
 		{
 			%powerEffectName = Hydrolox-Lower
 		}
@@ -58,9 +44,7 @@
 
 @PART[p120Booster]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
     PLUME
     {
         name = Solid-Lower
@@ -71,14 +55,9 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
-        	@CONFIG,*
+		@CONFIG,*
 		{
 			%powerEffectName = Solid-Lower
 		}
@@ -87,9 +66,7 @@
 
 @PART[nosecone]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
     PLUME
     {
         name = Solid-Sepmotor
@@ -100,13 +77,8 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Solid-Sepmotor
@@ -116,9 +88,7 @@
 
 @PART[pphstage1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 		name = Solid-Lower
@@ -129,13 +99,8 @@
 		energy = 1
 		speed = 1
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Lower
@@ -145,9 +110,7 @@
 
 @PART[pphstage2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 		name = Solid-Lower
@@ -158,13 +121,8 @@
 		energy = 1
 		speed = 1
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Delta3_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Delta3_Plume.cfg
@@ -1,8 +1,6 @@
 @PART[delta3rs27a]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
     PLUME
     {
         name = Kerolox-Lower
@@ -23,13 +21,8 @@
         energy = 0.2
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower
@@ -39,9 +32,7 @@
 
 @PART[gem46]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
     PLUME
     {
         name = Solid-Lower
@@ -52,13 +43,8 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Vega_Plume
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Liquidhype/RO_LqdH_Vega_Plume
@@ -1,23 +1,12 @@
 
 @PART[stage1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!fx_exhaustFlame_yellow = DELETE
-	!fx_exhaustLight_yellow = DELETE
-	!fx_exhaustSparks_yellow = DELETE
-	!fx_smokeTrail_light = DELETE	
-	
-	!fx_exhaustFlame_yellow = DELETE
-	!fx_exhaustLight_yellow = DELETE
-	!fx_exhaustSparks_yellow = DELETE
-	!fx_smokeTrail_light = DELETE
+	!fx_exhaustFlame_yellow,* = DELETE
+	!fx_exhaustLight_yellow,* = DELETE
+	!fx_exhaustSparks_yellow,* = DELETE
+	!fx_smokeTrail_light,* = DELETE
 
-	!fx_exhaustFlame_yellow = DELETE
-	!fx_exhaustLight_yellow = DELETE
-	!fx_exhaustSparks_yellow = DELETE
-	!fx_smokeTrail_light = DELETE
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 	        name = Solid-Lower
@@ -28,13 +17,8 @@
 	        energy = 1.5
 	        speed = 1.5
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Lower
@@ -44,9 +28,7 @@
 
 @PART[stage2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 	        name = Solid-Vacuum
@@ -57,13 +39,8 @@
 	        energy = 1
 	        speed = 1
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Vacuum
@@ -73,9 +50,7 @@
 
 @PART[stage3]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 		name = Solid-Vacuum
@@ -86,13 +61,8 @@
 		energy = 1
 		speed = 1
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Vacuum
@@ -102,13 +72,8 @@
 
 @PART[separatorAdapter]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // 
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Sepmotor
@@ -128,13 +93,8 @@
 
 @PART[VegaC_separatorAdapter]:BEFORE[RealPlume]:NEEDS[SmokeScreen] // 
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Solid-Sepmotor
@@ -154,23 +114,12 @@
 
 @PART[RO_Vega_P120C]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!fx_exhaustFlame_yellow = DELETE
-	!fx_exhaustLight_yellow = DELETE
-	!fx_exhaustSparks_yellow = DELETE
-	!fx_smokeTrail_light = DELETE	
-	
-	!fx_exhaustFlame_yellow = DELETE
-	!fx_exhaustLight_yellow = DELETE
-	!fx_exhaustSparks_yellow = DELETE
-	!fx_smokeTrail_light = DELETE
+	!fx_exhaustFlame_yellow,* = DELETE
+	!fx_exhaustLight_yellow,* = DELETE
+	!fx_exhaustSparks_yellow,* = DELETE
+	!fx_smokeTrail_light,* = DELETE
 
-	!fx_exhaustFlame_yellow = DELETE
-	!fx_exhaustLight_yellow = DELETE
-	!fx_exhaustSparks_yellow = DELETE
-	!fx_smokeTrail_light = DELETE
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 	        name = Solid-Lower
@@ -181,13 +130,8 @@
 	        energy = 1.5
 	        speed = 1.5
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Lower
@@ -197,9 +141,7 @@
 
 @PART[VegaC_stage2b]:BEFORE[RealPlume]:NEEDS[SmokeScreen]	//
 {
-	!EFFECTS
-	{
-	}
+	!EFFECTS {}
 	PLUME
 	{
 	        name = Solid-Vacuum
@@ -210,13 +152,8 @@
 	        energy = 1
 	        speed = 1
 	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Solid-Vacuum

--- a/GameData/RealismOverhaul/RealPlume_Configs/OLDD/RO_OLDD_Saturn_V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/OLDD/RO_OLDD_Saturn_V.cfg
@@ -15,11 +15,6 @@
         speed = 1.1
     }
 
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Sepmotor
-    }
-
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*
@@ -44,11 +39,6 @@
         fixedScale = 0.7
         energy = 0.75
         speed = 1.1
-    }
-
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Sepmotor
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -77,11 +67,6 @@
         speed = 1.1
     }
 
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Sepmotor
-    }
-
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*
@@ -106,11 +91,6 @@
         fixedScale = 1.15
         energy = 0.75
         speed = 1.1
-    }
-
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Sepmotor
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -142,7 +122,6 @@
     @MODULE[ModuleEngines*]
     {
         !runningEffectName = NULL
-        %powerEffectName = Hydrolox-Upper
     }
 
     @MODULE[ModuleEngineConfigs]
@@ -174,7 +153,6 @@
     @MODULE[ModuleEngines*]
     {
         !runningEffectName = NULL
-        %powerEffectName = Kerolox-Lower-F1
     }
 
     @MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/OLDD/RO_OLDD_Saturn_V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/OLDD/RO_OLDD_Saturn_V.cfg
@@ -17,14 +17,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         %powerEffectName = Solid-Sepmotor
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Solid-Sepmotor
@@ -51,14 +48,11 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         %powerEffectName = Solid-Sepmotor
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Solid-Sepmotor
@@ -85,19 +79,16 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         %powerEffectName = Solid-Sepmotor
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Solid-Sepmotor
         }
-    }	
+    }
 }
 
 //  ==================================================
@@ -119,19 +110,16 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         %powerEffectName = Solid-Sepmotor
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Solid-Sepmotor
         }
-    }	
+    }
 }
 
 //  ==================================================
@@ -153,20 +141,17 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         !runningEffectName = NULL
         %powerEffectName = Hydrolox-Upper
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
         }
-    }	
+    }
 }
 
 //  ==================================================
@@ -188,23 +173,20 @@
 
     @MODULE[ModuleEngines*]
     {
-        %name = ModuleEnginesRF
         !runningEffectName = NULL
         %powerEffectName = Kerolox-Lower-F1
     }
 
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower-F1
         }
-    }	
+    }
 }
 
-@PART[F1engine]:FOR[zzRealPlume]
+@PART[F1engine]:BEFORE[zzzRealPlume]
 {
     @EFFECTS
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_highengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_highengine.cfg
@@ -11,14 +11,9 @@
 	!sound_explosion_low = DELETE
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!directThrottleEffectName = DELETE
 		%runningEffectName = powerflame
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
 	EFFECTS
 	{
 		powerflame

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_lowengine.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RLA_s_lowengine.cfg
@@ -11,13 +11,8 @@
 	!sound_explosion_low = DELETE
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		%runningEffectName = powerflame
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
 	EFFECTS
 	{
 		powerflame

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_FL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_FL.cfg
@@ -244,9 +244,4 @@
 		%runningEffectName = powersmoke
 		%powerEffectName = powerflame
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_HL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RLA/RO_RLA_AJ260_HL.cfg
@@ -244,8 +244,4 @@
 		%runningEffectName = powersmoke
 		%powerEffectName = powerflame
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/E1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/E1.cfg
@@ -10,13 +10,8 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR79.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR79.cfg
@@ -10,13 +10,8 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR87.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR87.cfg
@@ -1,13 +1,7 @@
 @PART[SHIP_LR_87_3579|SHIP_LR_87_11|SHIP_LR_87_LH2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
-
 		@CONFIG,*
 		{
 			%runningEffectName = Hypergolic-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR91.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SHIP/LR91.cfg
@@ -46,7 +46,6 @@
 
     @MODULE[ModuleEngines*]:HAS[#engineID[mainEngine]]
     {
-		@name = ModuleEnginesRF
         %powerEffectName = Hypergolic-Upper
         !fxOffset = NULL
     }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-ASCE.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-ASCE.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU_LanderCore_LC2-ASCE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-DESE.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC2-DESE.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU_LanderCore_LC2-DESE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-ASCE.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-ASCE.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU_LanderCore_LC3-ASCE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-DESE.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC3-DESE.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU_LanderCore_LC3-DESE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-ASCE.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-ASCE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-ASCE.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU_LanderCore_LC5-ASCE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-DESE.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-DESE.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/LC5-DESE.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU_LanderCore_LC5-DESE]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-E1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-E1.cfg
@@ -10,13 +10,8 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-M1-SL.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-M1-SL.cfg
@@ -2,17 +2,11 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		!directThrottleEffectName = DELETE
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-RL10C.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/RO-SSTU-RL10C.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU-SC-B-SM]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-Apollo-SM
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-B-SM.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-Apollo-SM
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Apollo-SM

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-C-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-C-SM.cfg
@@ -2,12 +2,10 @@
 {
     @MODULE[ModuleEngines*]
     {
-        @name = ModuleEnginesRF
         %powerEffectName = Hypergolic-OMS-White
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-C-SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-C-SM.cfg
@@ -1,9 +1,5 @@
 @PART[SSTU-SC-C-SM]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Hypergolic-OMS-White
-    }
     @MODULE[ModuleEngineConfigs]
     {
         @CONFIG,*

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-AJ10-137.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-AJ10-137.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-AJ10-137]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-AJ10-137]:BEFORE[RealPlume]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-AJ10-190.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-AJ10-190.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-AJ10-190]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-AJ10-190]:BEFORE[RealPlume]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-H1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-H1.cfg
@@ -1,8 +1,8 @@
 @PART[SSTU-SC-ENG-H1]:NEEDS[RealPlume]:BEFORE[RealPlume]
  //H1
 {
-		PLUME
-		{
+	PLUME
+	{
 		name = Kerolox_LowerBlaze
 		transformName = H-1-ThrustTransform
 		emissionMult = 1.5
@@ -20,16 +20,11 @@
 		
 		flarePosition = 0,0,0.55
 		flareScale = 0.1
-		}
-
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
 	}
+
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
-        	@CONFIG,*
+		@CONFIG,*
 		{
 			%powerEffectName = Kerolox_LowerBlaze
 		}

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8048.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8048.cfg
@@ -2,19 +2,14 @@
 //	XLR81 Agena plume configuration.
 //	==================================================
 // Copied/adapted from VSR file
-@PART[SSTU-SC-ENG-LR81-8048]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-LR81-8048]:BEFORE[RealPlume]
 {
 	
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%powerEffectName = Hypergolic-OMS-White
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     PLUME
     {
         name = Hypergolic-OMS-White
@@ -26,7 +21,7 @@
         speed = 1.5
     }
 }
-@PART[SSTU-SC-ENG-LR81-8048]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-LR81-8048]:BEFORE[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8096.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-LR81-8096.cfg
@@ -2,19 +2,14 @@
 //	XLR81 Agena plume configuration.(large nozzle)
 //	==================================================
 // Copied/adapted from VSR file
-@PART[SSTU-SC-ENG-LR81-8096]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-LR81-8096]:BEFORE[RealPlume]
 {
 	
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%powerEffectName = Hypergolic-OMS-White
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     PLUME
     {
         name = Hypergolic-OMS-White
@@ -26,7 +21,7 @@
         speed = 1.5
     }
 }
-@PART[SSTU-SC-ENG-LR81-8096]:FOR[zzRealPlume]:NEEDS[SmokeScreen]
+@PART[SSTU-SC-ENG-LR81-8096]:BEFORE[zzRealPlume]:NEEDS[SmokeScreen]
 {
     @EFFECTS
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-M1-RO.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-M1-RO.cfg
@@ -2,17 +2,11 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		!directThrottleEffectName = DELETE
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -31,7 +25,7 @@
         speed = 1
     }
 }
-@PART[SSTU-SC-ENG-M1-RO]:FOR[zzRealPlume]
+@PART[SSTU-SC-ENG-M1-RO]:BEFORE[zzRealPlume]
 {
     @EFFECTS
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-SuperDraco.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-SuperDraco.cfg
@@ -17,18 +17,15 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		%name			   = ModuleEnginesRF
 		!runningEffectName = NULL
 		%powerEffectName   = Hypergolic-OMS-Red
 	}
 
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
-
 		@CONFIG,*
 		{
 			%powerEffectName = Hypergolic-OMS-Red
 		}
-	}	
+	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-SuperDraco.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU-SC-ENG-SuperDraco.cfg
@@ -2,7 +2,7 @@
 //	SuperDraco plume configuration.
 //	==================================================
 // Copied from laztek file
-@PART[SSTU-SC-ENG-SuperDraco]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-SuperDraco]:BEFORE[RealPlume]
 {
 	PLUME
 	{
@@ -18,7 +18,6 @@
 	@MODULE[ModuleEngines*]
 	{
 		!runningEffectName = NULL
-		%powerEffectName   = Hypergolic-OMS-Red
 	}
 
 	@MODULE[ModuleEngineConfigs]

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_A_SM.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_A_SM.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-OMS-White

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_HUS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_HUS.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -25,17 +23,17 @@
     }
 }
 
-@PART[SSTU-SC-B-HUS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-B-HUS]:BEFORE[zzzRealPlume]
 {
 	@EFFECTS
+	{
+		@Hydrolox-Upper
 		{
-			@Hydrolox-Upper
+			@MODEL_MULTI_SHURIKEN_PERSIST[flare]
 			{
-				@MODEL_MULTI_SHURIKEN_PERSIST[flare]
-				{
-					@localPosition = 0,0,2.3
-					@fixedScale = 1.9
-				}
+				@localPosition = 0,0,2.3
+				@fixedScale = 1.9
 			}
 		}
+	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_ICPS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_ICPS.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -26,17 +24,17 @@
     }
 }
 
-@PART[SSTU-SC-B-ICPS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-B-ICPS]:BEFORE[zzzRealPlume]
 {
 	@EFFECTS
+	{
+		@Hydrolox-Upper
 		{
-			@Hydrolox-Upper
+			@MODEL_MULTI_SHURIKEN_PERSIST[flare]
 			{
-				@MODEL_MULTI_SHURIKEN_PERSIST[flare]
-				{
-					@energy = 0.0 0.2
-					@energy = 1.0 0.2
-				}
+				@energy = 0.0 0.2
+				@energy = 1.0 0.2
 			}
 		}
+	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB2.cfg
@@ -23,12 +23,10 @@
     }
     @MODULE[ModuleEngines*]
     {
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB3.cfg
@@ -23,12 +23,10 @@
     }
     @MODULE[ModuleEngines*]
     {
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB4.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB4.cfg
@@ -23,12 +23,10 @@
     }
     @MODULE[ModuleEngines*]
     {
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB5.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_B_SRB5.cfg
@@ -26,12 +26,10 @@
     }
     @MODULE[ModuleEngines*]
     {
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
     }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Solid-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_HUS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_HUS.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -22,21 +20,21 @@
         fixedScale = 1.6
         energy = 1
         speed = 1.2
-	emissionMult = 0.5
+        emissionMult = 0.5
     }
 }
 
-@PART[SSTU-SC-C-HUS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-C-HUS]:BEFORE[zzRealPlume]
 {
 	@EFFECTS
+	{
+		@Hydrolox-Upper
 		{
-			@Hydrolox-Upper
+			@MODEL_MULTI_SHURIKEN_PERSIST[flare]
 			{
-				@MODEL_MULTI_SHURIKEN_PERSIST[flare]
-				{
-					@energy = 0.0 0.2
-					@energy = 1.0 0.2
-				}
+				@energy = 0.0 0.2
+				@energy = 1.0 0.2
 			}
 		}
+	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_ICPS.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_C_ICPS.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -28,17 +26,17 @@
     }
 }
 
-@PART[SSTU-SC-C-ICPS]:BEFORE[RealPlume]:NEEDS[zzRealPlume]
+@PART[SSTU-SC-C-ICPS]:BEFORE[zzRealPlume]
 {
 	@EFFECTS
+	{
+		@Hydrolox-Upper
 		{
-			@Hydrolox-Upper
+			@MODEL_MULTI_SHURIKEN_PERSIST[flare]
 			{
-				@MODEL_MULTI_SHURIKEN_PERSIST[flare]
-				{
-					@energy = 0.0 0.2
-					@energy = 1.0 0.2
-				}
+				@energy = 0.0 0.2
+				@energy = 1.0 0.2
 			}
 		}
+	}
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1.cfg
@@ -1,11 +1,9 @@
-@PART[SSTU-SC-ENG-F1]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-F1]:BEFORE[RealPlume]
 {
-
 		@MODULE[ModuleEngines*]
 		{
-				@name = ModuleEnginesFX
-				%powerEffectName = Kerolox_LowerBlaze
-				!runningEffectName = DELETE
+			%powerEffectName = Kerolox_LowerBlaze
+			!runningEffectName = DELETE
 		}
 		PLUME
 		{

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1B.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-F1B.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesFX
 		%powerEffectName = Kerolox-Lower-F1
     }
     PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-J-2]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-J-2]:BEFORE[RealPlume]
 {
     
     PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2X.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-J-2X.cfg
@@ -1,4 +1,4 @@
-@PART[SSTU-SC-ENG-J-2X]:NEEDS[RealPlume]:BEFORE[RealPlume]
+@PART[SSTU-SC-ENG-J-2X]:BEFORE[RealPlume]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10A-3.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10A-3.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10B-2_Vinci_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RL10B-2_Vinci_Plume.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -18,8 +16,8 @@
         name = Hydrolox-Upper
         transformName = RL10B-2-ThrustTransform
         localRotation = 0,0,0
-	plumePosition = 0,0,2.3
-        plumeScale = 1.9	
+        plumePosition = 0,0,2.3
+        plumeScale = 1.9
         flarePosition = 0,0,2.8
         flareScale = 1.9
         energy = 1
@@ -30,12 +28,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
@@ -54,4 +50,3 @@
         speed = 1.2
     }
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RS-25.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SSTU/SSTU_ShipCore_ENG-RS-25.cfg
@@ -2,7 +2,6 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesFX
 		%powerEffectName = Hydrolox-Lower
     }
     PLUME

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/NK21V.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/NK21V.cfg
@@ -2,14 +2,9 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%powerEffectName = Alcolox-Lower-A6
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     PLUME
     {
         name = Alcolox-Lower-A6

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVAB.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTNERVAB.cfg
@@ -10,13 +10,8 @@
         energy = 2
         speed = 1.7
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG[NERVA-II]
         {
             %powerEffectName = Hydrogen-NTR

--- a/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTWaxwing.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SXT/SXTWaxwing.cfg
@@ -3,14 +3,9 @@
 
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%powerEffectName = Solid-Vacuum
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     PLUME
     {
         name = Solid-Vacuum
@@ -19,7 +14,5 @@
         plumeScale = 0.8
         flarePosition = 0,0,0.25
         flareScale = 0.5
-
     }
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineKE-1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineKE-1.cfg
@@ -2,13 +2,8 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		%powerEffectName = Kerolox-Lower-F1
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     PLUME
     {
         name = Kerolox-Lower-F1

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-I2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-I2.cfg
@@ -1,16 +1,10 @@
 @PART[LiquidEngineRE-I2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 		%directThrottleEffectName = Hydrolox-Upper
 	}
-	@MODULE[ModuleEngineConfigs]
-    {
-		%type = ModuleEnginesRF
-    }
     PLUME
     {
         name = Hydrolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-J10.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRE-J10.cfg
@@ -2,12 +2,10 @@
 {
 	@MODULE[ModuleEngines*]
 	{
-		@name = ModuleEnginesRF
 		!runningEffectName = DELETE
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Hypergolic-Apollo-SM
@@ -24,4 +22,3 @@
         speed = 1
     }
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRK-7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRK-7.cfg
@@ -1,12 +1,7 @@
 @PART[LiquidEngineRK-7|LiquidEngineRK-7B]:BEFORE[RealPlume]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
 		@CONFIG,*
 		{
 			%powerEffectName = Kerolox-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRV-1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineRV-1.cfg
@@ -1,13 +1,7 @@
 @PART[LiquidEngineRV-1]:BEFORE[RealPlume]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
-
 		@CONFIG,*
 		{
 			%runningEffectName = Kerolox-Vernier

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-T91.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-T91.cfg
@@ -50,7 +50,6 @@
 
     @MODULE[ModuleEngines*]
     {
-        %powerEffectName = Hypergolic-Upper
         !fxOffset = NULL
     }
 

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-T91.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-T91.cfg
@@ -50,7 +50,6 @@
 
     @MODULE[ModuleEngines*]
     {
-		@name = ModuleEnginesRF
         %powerEffectName = Hypergolic-Upper
         !fxOffset = NULL
     }
@@ -61,20 +60,17 @@
         {
             %runningEffectName = Hypergolic-Upper
 			%powerEffectName = Hypergolic-Vernier
-			%type = ModuleEnginesRF
         }
 
         @CONFIG[LR91-AJ-3]
         {
             %runningEffectName = Kerolox-Upper
 			%powerEffectName = Kerolox-Vernier
-			%type = ModuleEnginesRF
         }
 		@CONFIG[LR91-AJ-9-Kero*]
         {
             %runningEffectName = Kerolox-Upper
 			%powerEffectName = Kerolox-Vernier
-			%type = ModuleEnginesRF
         }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-TX87.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/SquadExpansion/SquadLiquidEngineV-TX87.cfg
@@ -1,13 +1,7 @@
 @PART[LiquidEngineLV-TX87]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
 {
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
     {
-		%type = ModuleEnginesRF
-
 		@CONFIG,*
 		{
 			%powerEffectName = Hypergolic-Lower

--- a/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_MerlinPack_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_MerlinPack_Plume.cfg
@@ -11,17 +11,12 @@
         energy = 1
         speed = 1
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
-	{
-		%powerEffectName = Kerolox-Lower
-	}
+        {
+            %powerEffectName = Kerolox-Lower
+        }
     }
 }
 
@@ -37,16 +32,11 @@
         energy = 1
         speed = 1
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
-	@CONFIG,*
-	{
-		%powerEffectName = Kerolox-Upper
-	}
+        @CONFIG,*
+        {
+            %powerEffectName = Kerolox-Upper
+        }
     }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_Vinci_Plume.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/StarShineIndustries/RO_StarShine_Vinci_Plume.cfg
@@ -10,16 +10,11 @@
         energy = 1.2
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-        %type = ModuleEnginesRF
+    @MODULE[ModuleEngineConfigs]
+    {
         @CONFIG,*
         {
             %powerEffectName = Hydrolox-Upper
         }
-	}
+    }
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/n1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/n1.cfg
@@ -1,4 +1,4 @@
-@PART[LLV_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-33 x30
+@PART[LLV_Engine_A]:BEFORE[RealPlume] //NK-33 x30
 {
     PLUME
     {
@@ -12,13 +12,8 @@
         energy = 1.4
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
@@ -26,7 +21,7 @@
     }
 }
 
-@PART[LLV_Engine_B,LLV_Engine_C,LLV_Engine_D]:BEFORE[RealPlume]:NEEDS[SmokeScreen] //NK-43 x8 and others
+@PART[LLV_Engine_B,LLV_Engine_C,LLV_Engine_D]:BEFORE[RealPlume] //NK-43 x8 and others
 {
     PLUME
     {
@@ -40,13 +35,8 @@
         energy = 1.3
         speed = 1.5
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
@@ -54,7 +44,7 @@
     }
 }
 
-@PART[Libra_Engine_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Libra_Engine_B]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -67,13 +57,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/nerva_1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/nerva_1.cfg
@@ -10,17 +10,11 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		%type = ModuleEnginesRF
         @CONFIG,*
 		{
 			%powerEffectName = Hydrogen-NTR
 		}
 	}
 }
-

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/proton.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/proton.cfg
@@ -1,5 +1,5 @@
 //Proton first stage
-@PART[ALV_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[ALV_Engine_A]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -12,13 +12,8 @@
         speed = 2                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Lower
@@ -27,7 +22,7 @@
 }
 
 //RD-0210/0211
-@PART[ALV_Motor_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[ALV_Motor_A]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -40,13 +35,8 @@
         speed = 2                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper
@@ -55,7 +45,7 @@
 }
 
 //RD-0212/0213
-@PART[ALV_Motor_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[ALV_Motor_B]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -68,13 +58,8 @@
         speed = 2                      //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Hypergolic-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/r7.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/r7.cfg
@@ -1,5 +1,5 @@
 //RD-107/108
-@PART[TLV_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Engine_A]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -12,13 +12,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
@@ -26,7 +21,7 @@
 	}
 }
 
-@PART[TLV_Engine_RD108]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Engine_RD108]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -39,13 +34,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
@@ -53,7 +43,7 @@
 	}
 }
 
-@PART[TLV_Vernier]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Vernier]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -66,13 +56,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Lower
@@ -81,7 +66,7 @@
 }
 
 //RD-0110/0124
-@PART[TLV_Engine_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[TLV_Engine_B]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -94,13 +79,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
@@ -109,7 +89,7 @@
 }
 
 //RD-0105/0109
-@PART[Alto_Engine_A]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Alto_Engine_A]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -122,13 +102,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper
@@ -136,7 +111,7 @@
 	}
 }
 
-@PART[Alto_Engine_B]:BEFORE[RealPlume]:NEEDS[SmokeScreen,RealFuels]
+@PART[Alto_Engine_B]:BEFORE[RealPlume]
 {
     PLUME
     {
@@ -149,13 +124,8 @@
         speed = 1                       //Adjust speed on resize, 
                                         //generally close to 1:1 with scale.
     }
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
 	@MODULE[ModuleEngineConfigs]
 	{
-        %type = ModuleEnginesRF
         @CONFIG,*
         {
             %powerEffectName = Kerolox-Upper

--- a/GameData/RealismOverhaul/RealPlume_Configs/Tantares/soyuz_lok_lk.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/Tantares/soyuz_lok_lk.cfg
@@ -11,13 +11,8 @@
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*   //Add the effect to every engine config
         {
             %powerEffectName = Hypergolic-OMS-Red
@@ -38,13 +33,8 @@
         speed = 3                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*   //Add the effect to every engine config
         {
             %powerEffectName = Hypergolic-OMS-White
@@ -65,13 +55,8 @@
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.
     }
-    @MODULE[ModuleEngines*]
-    {
-        @name = ModuleEnginesRF
-    }
     @MODULE[ModuleEngineConfigs]
     {
-        %type = ModuleEnginesRF
         @CONFIG,*   //Add the effect to every engine config
         {
             %powerEffectName = Hypergolic-OMS-Red


### PR DESCRIPTION
Plume Configs: Don't set EngineType

Don't set ModuleEngines type to MERF in Plumes.
Don't set MEC type to MERF in Plumes.
Remove NEEDS{RealFuels] in Plumes configs [was used to guard setting ModuleEngines types]