### PR TITLE
RF TankTypes Use PartUpgrades

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -617,7 +617,7 @@ PARTUPGRADE
 }
 
 //Isogrid
-PARTUPGRADE
+disabledPARTUPGRADE
 {
 	name = RFTech-Tank-Int-Al
 	partIcon = RFTank-I
@@ -683,7 +683,7 @@ PARTUPGRADE
 }
 
 //Balloon tanks
-PARTUPGRADE
+disabledPARTUPGRADE
 {
 	name = RFTech-Tank-Balloon-SteelAl
 	partIcon = RFTank-I

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -698,7 +698,7 @@ PARTUPGRADE
 
 PARTUPGRADE
 {
-	name = RFTech-Balloon-SteelAlCu
+	name = RFTech-Tank-Balloon-SteelAlCu
 	partIcon = RFTank-I
 	techRequired = materialsScienceSpaceplanes
 	entryCost = 0
@@ -711,7 +711,7 @@ PARTUPGRADE
 
 PARTUPGRADE
 {
-	name = RFTech-Balloon-SteelAlLi
+	name = RFTech-Tank-Balloon-SteelAlLi
 	partIcon = RFTank-I
 	techRequired = materialsScienceInternational
 	entryCost = 0

--- a/GameData/RealismOverhaul/RO_RealFuels_PartConfigs.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels_PartConfigs.cfg
@@ -44,18 +44,58 @@
         type = Tank-Sep-Steel
         typeAvailable = Tank-Sep-Steel
         typeAvailable = Tank-Sep-Steel-HP
-        typeAvailable = Tank-Sep-Al
-        typeAvailable = Tank-Sep-Al-HP
-        typeAvailable = Tank-Sep-Al2
-        typeAvailable = Tank-Sep-Al2-HP
-        typeAvailable = Tank-Sep-AlCu
-        typeAvailable = Tank-Sep-AlCu-HP
-        typeAvailable = Tank-Sep-AlLi
-        typeAvailable = Tank-Sep-AlLi-HP
-        typeAvailable = Tank-Sep-Stir
-        typeAvailable = Tank-Sep-Stir-HP
-        typeAvailable = Tank-Sep-Starship
-        typeAvailable = Tank-Sep-Starship-HP
+
+        %UPGRADES
+        {
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Sep-Al
+                description__ = You can now use Aluminum Fuselage tanks.
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Sep-Al
+                typeAvailable = Tank-Sep-Al-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Sep-Al2
+                description__ = You can now use Aluminum Stringer tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Sep-Al2
+                typeAvailable = Tank-Sep-Al2-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Sep-AlCu
+                description__ = You can now use Aluminum-Copper Alloy Stringer tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Sep-AlCu
+                typeAvailable = Tank-Sep-AlCu-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Sep-AlLi
+                description__ = You can now use Aluminum-Lithium Alloy Stringer tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Sep-AlLi
+                typeAvailable = Tank-Sep-AlLi-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Sep-Stir
+                description__ = You can now use stir-welded Aluminum-Lithium Alloy Stringer tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Sep-Stir
+                typeAvailable = Tank-Sep-Stir-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Sep-Starship
+                description__ = You can now use stir-welded Steel Alloy Stringer tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Sep-Starship
+                typeAvailable = Tank-Sep-Starship-HP
+            }
+        }
     }
 }
 
@@ -68,12 +108,40 @@
         type = Tank-Int-Al
         typeAvailable = Tank-Int-Al
         typeAvailable = Tank-Int-Al-HP
-        typeAvailable = Tank-Int-AlCu
-        typeAvailable = Tank-Int-AlCu-HP
-        typeAvailable = Tank-Int-AlLi
-        typeAvailable = Tank-Int-AlLi-HP
-        typeAvailable = Tank-Int-Comp
-        typeAvailable = Tank-Int-Magic
+
+        %UPGRADES
+        {
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Int-AlCu
+                description__ = You can now use Aluminum-Copper Alloy gridded tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Int-AlCu
+                typeAvailable = Tank-Int-AlCu-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Int-AlLi
+                description__ = You can now use Aluminum-Lithium Alloy gridded tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Int-AlLi
+                typeAvailable = Tank-Int-AlLi-HP
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Int-Comp
+                description__ = You can now use Carbon Composite tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Int-Comp
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Int-Magic
+                description__ = You can now use Advanced Carbon Composite tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Int-Magic
+            }
+        }
     }
 }
 
@@ -85,8 +153,23 @@
     {
         type = Tank-Balloon-SteelAl
         typeAvailable = Tank-Balloon-SteelAl
-        typeAvailable = Tank-Balloon-SteelAlCu
-        typeAvailable = Tank-Balloon-SteelAlLi
+        %UPGRADES
+        {
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Balloon-SteelAlCu
+                description__ = You can now use Steel & Aluminum-Copper Alloy balloon tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Balloon-SteelAlCu
+            }
+            UPGRADE
+            {
+                name__ = RFTech-Tank-Balloon-SteelAlLi
+                description__ = You can now use Steel & Aluminum-Lithium Alloy balloon tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = Tank-Balloon-SteelAlLi
+            }
+        }
     }
 }
 
@@ -110,9 +193,30 @@
     {
         type = SM-I
         typeAvailable = SM-I
-        typeAvailable = SM-II
-        typeAvailable = SM-III
-        typeAvailable = SM-IV
+        %UPGRADES
+        {
+            UPGRADE
+            {
+                name__ = RFTech-SM-II
+                description__ = You can now use level II Service Module tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = SM-II
+            }
+            UPGRADE
+            {
+                name__ = RFTech-SM-III
+                description__ = You can now use level III Service Module tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = SM-III
+            }
+            UPGRADE
+            {
+                name__ = RFTech-SM-IV
+                description__ = You can now use level IV Service Module tanks
+                IsAdditiveUpgrade__ = true
+                typeAvailable = SM-IV
+            }
+        }
     }
 }
 

--- a/Source/DynamicPartHider/DynamicPartHider.cs
+++ b/Source/DynamicPartHider/DynamicPartHider.cs
@@ -20,7 +20,7 @@ namespace RealismOverhaul
             AttachFilters();
         }
 
-        public void Destroy()
+        public void OnDestroy()
         {
             GameEvents.onLevelWasLoadedGUIReady.Remove(OnLevelLoaded);
             RDTechTree.OnTechTreeSpawn.Remove(OnUpdateRnD);


### PR DESCRIPTION
Instead of declaring all tank definitions in typeAvailable, use the PartUpgrade system to unlock/apply them

Requires <https://github.com/NathanKell/ModularFuelSystem/pull/287>.
Groundwork already completed in terms of establishing and placing the PartUpgrade nodes themselves.  Need the features in the RF PR to properly use them, and this PR to attach them to the Tank PartModule.