### PR TITLE
Add MR-1 Meteo engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/R103_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R103_Config.cfg
@@ -36,7 +36,9 @@
 	%title = R-103
 	%manufacturer = Kostin Bureau
 	%description = Post-war Russian version of German Taifun anti-aircraft barrage rocket. Developed and tested in 1947-1951 but abandoned in favor of the R-110. A cluster of 8 of these rockets formed the first stage of the MR-1 sounding rocket. Length without payload - 1.81 meters. 
-	
+
+	%specLevel = operational
+
 	@MODULE[ModuleEngines*]
 	{
 		%EngineType = SolidBooster
@@ -97,10 +99,6 @@
 			}
 			
 			curveResource = NGNC
-			
-			chamberNominalTemp	= 1500
-			maxEngineTemp = 2040
-			
 			thrustCurve
 			{
 				key = 1.00 0.90

--- a/GameData/RealismOverhaul/Engine_Configs/R103_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/R103_Config.cfg
@@ -1,0 +1,155 @@
+//	==================================================
+//	R-103
+//
+//	Manufacturer: Kostin Bureau
+//
+//	=================================================================================
+//	R-103 (2.07 x 0.1 m)
+//	MR-1 Booster (cluster of 8)
+//
+//	Dry Mass: 8 kg					//literally a steel tube filled with solid fuel (24 kg full - 1 kg warhead - 11.6 kg fuel)
+//	Dimensions: 1.81 x 0.1 m 		(without warhead, tank lenght 1.44m - 69.5% of total 2.07 m usable)
+//	Thrust (SL): 10.175 kN
+//	Thrust (Vac): 11.192 kN
+//	ISP: 200 SL / 220 Vac
+//	Burn Time: 2.92 s
+//	Chamber Pressure: 5.2689 MPa	(52 atm)
+//	Propellant: solid
+//	Prop Ratio: 4.0 (liquid)
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Sources:	http://www.astronautix.com/r/r-103.html
+//				https://second.wiki/wiki/r-103_misil
+//				http://www.astronautix.com/r/r-110.html
+//				https://ru.wikipedia.org/wiki/Тайфун_(зенитная_ракета)
+//				https://en.wikipedia.org/wiki/Taifun_(rocket)
+//				https://www.airplanesandrockets.com/rockets/soviet-mr-1-meteo-rocket-march-1967-american-modeler.htm
+//	
+//	Used by:
+//	Notes:
+//	propellant load 10.25 kg
+//	==================================================
+@PART[*]:HAS[#engineType[R103]]:FOR[RealismOverhaulEngines]
+{
+	%title = R-103
+	%manufacturer = Kostin Bureau
+	%description = Post-war Russian version of German Taifun anti-aircraft barrage rocket. Developed and tested in 1947-1951 but abandoned in favor of the R-110. A cluster of 8 of these rockets formed the first stage of the MR-1 sounding rocket. Length without payload - 1.81 meters. 
+	
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = SolidBooster
+		%allowShutdown = False
+		%throttleLocked = True
+		%autoVariationScale = 3
+	}
+	
+	!MODULE[ModuleGimbal] {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 6.41
+		type = NGNC
+		basemass = -1
+		TANK
+		{
+			name = NGNC
+			amount = 6.41
+			maxAmount = 6.41
+		}
+	}
+	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = R-103
+		origMass = 0.008
+		
+		CONFIG
+		{
+			name = R-103
+			minThrust = 11.192
+			maxThrust = 11.192
+			heatProduction = 100
+			massMult = 1.0
+			
+			ullage = False
+			pressureFed = False
+			ignitions = 1
+			
+			PROPELLANT
+			{
+				name = NGNC
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 220	 // Guess
+				key = 1 200
+			}
+			
+			curveResource = NGNC
+			
+			chamberNominalTemp	= 1500
+			maxEngineTemp = 2040
+			
+			thrustCurve
+			{
+				key = 1.00 0.90
+				key = 0.99 0.95
+				key = 0.96 1.0
+				key = 0.92 0.999
+				key = 0.89 0.998
+				key = 0.63 0.960
+				key = 0.37 0.810
+				key = 0.10 0.314
+				key = 0.00 0.03
+			}
+		}
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[R-103]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = R-103
+		ratedBurnTime = 4	//account for thrust tail-off
+		ignitionReliabilityStart = 0.98 // starts higher than expected
+		ignitionReliabilityEnd = 0.9999 // literal steel tube of explosives, thousands built and used in pacific theatre
+		ignitionDynPresFailMultiplier = 50	//started life as anti-ship rocket
+		// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.
+		cycleReliabilityStart = 0.999 // starts higher than expected
+		cycleReliabilityEnd = 0.9997
+		reliabilityDataRateMultiplier = 1.5
+		isSolid = True
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[R-103] { %ratedBurnTime = #$/TESTFLIGHT[R-103]/ratedBurnTime$ } }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[R-103-17kN]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = R-103-17kN
+		ratedBurnTime = 3	//account for thrust tail-off
+		ignitionReliabilityStart = 0.98 // starts higher than expected
+		ignitionReliabilityEnd = 0.9999 // literal steel tube of explosives, thousands built and used in pacific theatre
+		ignitionDynPresFailMultiplier = 50	//started life as anti-ship rocket
+		// Because the fail chance is 10x during the first 5 seconds of burn, this needs to be 10x as reliable as you'd think.
+		cycleReliabilityStart = 0.999 // starts higher than expected
+		cycleReliabilityEnd = 0.9997
+		reliabilityDataRateMultiplier = 1.5
+		isSolid = True
+		techTransfer = R-103:80
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[R-103-17kN] { %ratedBurnTime = #$/TESTFLIGHT[R-103-17kN]/ratedBurnTime$ } }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
@@ -108,8 +108,8 @@
 
 			PROPELLANT
 			{
-				ratio = 0.67286
 				name = AK20
+				ratio = 0.67286
 			}
 
 			PROPELLANT
@@ -155,8 +155,8 @@
 
 			PROPELLANT
 			{
-				ratio = 0.67804
 				name = AK20
+				ratio = 0.67804
 			}
 
 			PROPELLANT
@@ -202,8 +202,8 @@
 
 			PROPELLANT
 			{
-				ratio = 0.67518
 				name = AK20
+				ratio = 0.67518
 			}
 
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
@@ -1,0 +1,286 @@
+//	==================================================
+//	U-1250 Series Engine
+//
+//	Manufacturer: OKB-2 (Isayev)
+//
+//	=================================================================================
+//	U-1250 (?)
+//	MR-1 Meteo
+//
+//	Dry Mass: 14.7 kg				//similar TWR to WAC-Corporal
+//	Thrust (SL): 12.722 kN
+//	Thrust (Vac): 14.417 kN
+//	ISP: 204.8 SL / 232.1 Vac		//SL calculated from thrust and mass flow, Vac from RPA
+//	Burn Time: 60					//380 kg propellant/6.333 kg/s
+//	Chamber Pressure: 2.1 MPa
+//	Propellant: AK20 / Kerosene (T-1)
+//	Prop Ratio: 3.76				//2970 Kelvin
+//	Throttle: N/A
+//	Nozzle Ratio: 3.5
+//	Ignitions: 1
+//	Reaction Efficieny: 92.58%		//Rocket Propulsion Analysis Lite
+//	=================================================================================
+//	U-1700 (made up name)
+//	Speculative Upgrade
+//
+//	Dry Mass: 14.7 kg				//similar TWR to XASR-1
+//	Thrust (SL): 16.955 kN
+//	Thrust (Vac): 19.411 kN
+//	ISP: 206.5 SL / 236.4 Vac
+//	Burn Time: 48
+//	Chamber Pressure: 2.2 MPa
+//	Propellant: AK20 / Kerosene (T-1)
+//	Prop Ratio: 3.85				//3000 Kelvin
+//	Throttle: N/A
+//	Nozzle Ratio: 4
+//	Ignitions: 1
+//	Reaction Efficieny: 92.6%
+//	=================================================================================
+//	U-2000
+//	(made up, but just happens to almost perfectly match a real engine)
+//	Sustainer for R-112 SAM. May or may not be related to U-1250/MR-1 Meteo
+//
+//	Dry Mass: 12.9 kg				//similar TWR to AJ10-27
+//	Thrust (SL): 19.60 kN
+//	Thrust (Vac): 23.00 kN
+//	ISP: 205.6 SL / 241.3 Vac
+//	Burn Time: 60
+//	Chamber Pressure: 2.3 MPa
+//	Propellant: AK20 / Kerosene (T-1)
+//	Prop Ratio: 3.8					//2988 Kelvin
+//	Throttle: N/A
+//	Nozzle Ratio: 5
+//	Ignitions: 1
+//	Reaction Efficieny: 92.59%
+//	=================================================================================
+//	Sources:	https://ru.wikipedia.org/wiki/МР-1
+//				https://www.airplanesandrockets.com/rockets/soviet-mr-1-meteo-rocket-march-1967-american-modeler.htm
+
+//	Used by:
+
+//	Notes:
+//	Stats are mostly guessed sanity checked by Rocket Propulsion Analysis, there's very little solid information.
+//	===============================================================
+
+@PART[*]:HAS[#engineType[U1250]]:FOR[RealismOverhaulEngines]
+{
+	%title = U-1250
+	%manufacturer = OKB-2 (Isayev)
+	%description = Small sustainer for MR-1 Meteo sounding rockets, developed in response to the American Aerobee. Pressure-fed. Used after a small solid booster.
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleGimbal] {}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.0147
+		configuration = U-1250
+		modded = false
+		
+		CONFIG
+		{
+			name = U-1250
+			description = Isayev engine that powered the Soviet MR-1 sounding rocket.
+			specLevel = operational
+			maxThrust = 14.417
+			minThrust = 14.417
+			massMult = 1.0
+			heatProduction = 40
+			autoVariationScale = 1.5
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.32714
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				ratio = 0.67286
+				name = AK20
+			}
+
+			PROPELLANT
+			{
+				name = Nitrogen
+				ratio = 31.5
+				ignoreForIsp = true
+			}
+
+			atmosphereCurve
+			{
+				key = 0 232.1
+				key = 1 204.8
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Tonka250
+				amount = 1
+			}
+
+			ullage = True
+			ignitions = 1
+			pressureFed = True
+		}
+		CONFIG
+		{
+			name = U-1700
+			description = Speculative upgrade for the U-1250
+			specLevel = altHist
+			maxThrust = 19.411
+			minThrust = 19.411
+			massMult = 1.0
+			heatProduction = 40
+			autoVariationScale = 1.3
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.32196
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				ratio = 0.67804
+				name = AK20
+			}
+
+			PROPELLANT
+			{
+				name = Nitrogen
+				ratio = 33.0
+				ignoreForIsp = true
+			}
+
+			atmosphereCurve
+			{
+				key = 0 236.4
+				key = 1 206.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Tonka250
+				amount = 1
+			}
+
+			ullage = True
+			ignitions = 1
+			pressureFed = True
+		}
+		CONFIG
+		{
+			name = U-2000
+			description = Sustainer engine for the R-112 SAM. Tested, but never entered service.
+			specLevel = operational
+			maxThrust = 23.00
+			minThrust = 23.00
+			massMult = 0.88
+			heatProduction = 40
+			autoVariationScale = 1.2
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.32482
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				ratio = 0.67518
+				name = AK20
+			}
+
+			PROPELLANT
+			{
+				name = Nitrogen
+				ratio = 34.5
+				ignoreForIsp = true
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = Tonka250
+				amount = 1
+			}
+
+			atmosphereCurve
+			{
+				key = 0 241.3
+				key = 1 205.6
+			}
+
+			ullage = True
+			ignitions = 1
+			pressureFed = True
+		}
+	}
+
+	RESOURCE
+	{
+		name = Tonka250
+		amount = 1
+		maxAmount = 1
+	}
+}
+//using Aerobee reliability numbers
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[U-1250]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+			name = U-1250
+			ratedBurnTime = 60
+			ignitionReliabilityStart = 0.90
+			ignitionReliabilityEnd = 0.96
+			cycleReliabilityStart = 0.86
+			cycleReliabilityEnd = 0.93
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[U-1250] { %ratedBurnTime = #$/TESTFLIGHT[U-1250]/ratedBurnTime$ } }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[U-1700]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+			name = U-1700
+			ratedBurnTime = 48
+			ignitionReliabilityStart = 0.93
+			ignitionReliabilityEnd = 0.97
+			cycleReliabilityStart = 0.91
+			cycleReliabilityEnd = 0.955
+
+			techTransfer = U-1250:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[U-1700] { %ratedBurnTime = #$/TESTFLIGHT[U-1700]/ratedBurnTime$ } }
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[U-2000]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+			name = U-2000
+			ratedBurnTime = 60
+			ignitionReliabilityStart = 0.95
+			ignitionReliabilityEnd = 0.98
+			cycleReliabilityStart = 0.95
+			cycleReliabilityEnd = 0.96
+
+			techTransfer = U-1700,U-1250:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[U-2000] { %ratedBurnTime = #$/TESTFLIGHT[U-2000]/ratedBurnTime$ } }
+}


### PR DESCRIPTION
Add the U-1250 and R-103, sustainer and booster for the Soviet MR-1 Meteo. This was a sounding rocket, roughly equivalent to the American Aerobee.

Engine configs mostly written by @scorpuu, I just did some more research to find the manufacturer's designations.

Co-Authored-By: Scorpuu <29466395+Scorpuu@users.noreply.github.com>