### PR TITLE
Add speculative RD-0203 upgrade

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0203_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0203_Config.cfg
@@ -20,6 +20,21 @@
 //	Nozzle Ratio: 29.8
 //	Ignitions: 1
 //	=================================================================================
+//	RD-0203U
+//	Speculative upgrade, based on RD-0210 (RD-0208/0210 were the same as RD-0203, just vacuum optimized)
+//
+//	Dry Mass: 408 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 569.2 kN
+//	ISP: 278 SL / 311 Vac
+//	Burn Time: 150
+//	Chamber Pressure: 14.7 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.6
+//	Throttle: N/A
+//	Nozzle Ratio: 29.8
+//	Ignitions: 1
+//	=================================================================================
 
 //	Sources:
 
@@ -105,6 +120,45 @@
 				key = 1 278
 			}
 		}
+		CONFIG
+		{
+			name = RD-0203U
+			description = Speculative upgrade, assuming upgrades from RD-0210 carried back to RD-0203
+			specLevel = speculative
+			minThrust = 558.9
+			maxThrust = 558.9
+			gimbalRange = 3.25
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			massMult = 1.047
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4135
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5865
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 311
+				key = 1 278
+			}
+		}
 	}
 }
 
@@ -132,4 +186,26 @@
 		reliabilityDataRateMultiplier = 0.5
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0203] { %ratedBurnTime = #$/TESTFLIGHT[RD-0203]/ratedBurnTime$ } }
+}
+
+//Using RD-0210 data
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-0203U]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-0203U
+		testedBurnTime = 450
+		ratedBurnTime = 140
+		safeOverburn = true
+		ignitionReliabilityStart = 0.998242
+		ignitionReliabilityEnd = 0.999722
+		ignitionDynPresFailMultiplier = 0.1
+		cycleReliabilityStart = 0.992197
+		cycleReliabilityEnd = 0.998768
+		techTransfer = RD-0203,RD-0213,RD-0212,RD-0208:50
+		
+		reliabilityMidH = 0.7
+		reliabilityDataRateMultiplier = 0.5
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-0203U] { %ratedBurnTime = #$/TESTFLIGHT[RD-0203U]/ratedBurnTime$ } }
 }


### PR DESCRIPTION
Since the UR-200 first stage engines (RD-0203) and UR-500 second stage engines (RD-0208) were almost identical, add a speculative upgrade for the UR-200 by incorporating the upgrades from the RD-0210 back into the RD-0203.