### PR TITLE
Fix RD-191 Burn Time

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD191_Config.cfg
@@ -266,8 +266,8 @@
 	{
 		name = RD-191
 		//Copied from RD-180
-		testedBurnTime = 255
-		ratedBurnTime = 1590		//tested up to 1590 seconds
+		testedBurnTime = 1590		//tested up to 1590 seconds
+		ratedBurnTime = 255
 		safeOverburn = true
 		overburnPenalty = 1.5
 		ignitionReliabilityStart = 0.976910


### PR DESCRIPTION
Switch the `testBurnTime` and `ratedBurnTime` to match other configs.