### PR TITLE
Support new HG-5 antenna model

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -236,7 +236,7 @@
 //  Squad added a new model in 1.11, called it HighGainAntenna5_v2, and deprecated the old model HighGainAntenna5. We will do the same.
 //  ==================================================
 
-@PART[HighGainAntenna5_v2]:FOR[RealismOverhaul]
+@PART[HighGainAntenna5_v2|HighGainAntenna5]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = HG-5 Retractable Parabolic Antenna
@@ -255,12 +255,12 @@
     }
 }
 
-@PART[HighGainAntenna5_v2]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+@PART[HighGainAntenna5_v2|HighGainAntenna5]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
 {
     %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
     @mass = 0.001
 }
-@PART[HighGainAntenna5_v2]:AFTER[RemoteTech]
+@PART[HighGainAntenna5_v2|HighGainAntenna5]:AFTER[RemoteTech]
 {
     @description ^=:$: Wide angle and reasonable bandwidth among the inner planets. <b><color=#00eaf0>Effective range to Earth DSN [400 Gm] — Power Consumption [30 Watts] — Maximum Data Rate [1 Mbit/s] — Use Case [Mars, Vesta (not at Conjunction), Ceres (not at Conjunction)]</color></b>
 
@@ -285,50 +285,8 @@
 
 @PART[HighGainAntenna5]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
     %deprecated = True
     @title = HG-5 Retractable Parabolic Antenna (Deprecated)
-    @description = A retractable, short range parabolic antenna for high speed telecommunications.
-    @mass = 0.02
-
-    @MODULE[ModuleDataTransmitter]
-    {
-        @antennaType = DIRECT
-        @antennaCombinable = True
-        %antennaCombinableExponent = 2.0
-        @antennaPower = 1.6e9
-        @packetInterval = 1.0
-        @packetSize = 1.0
-        @packetResourceCost = 0.01
-    }
-}
-
-@PART[HighGainAntenna5]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
-{
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
-    @mass = 0.001
-}
-@PART[HighGainAntenna5]:AFTER[RemoteTech]
-{
-    @description ^=:$: Wide angle and reasonable bandwidth among the inner planets. <b><color=#00eaf0>Effective range to Earth DSN [400 Gm] — Power Consumption [30 Watts] — Maximum Data Rate [1 Mbit/s] — Use Case [Mars, Vesta (not at Conjunction), Ceres (not at Conjunction)]</color></b>
-
-    @MODULE[ModuleRTAntenna]
-    {
-        @Mode0DishRange = 0
-        @Mode1DishRange = 1.4e9
-        @EnergyCost = 0.03
-        %MaxQ = 6000
-        @DishAngle = 7.0
-        %DeployFxModules = 0
-        %ProgressFxModules = 1
-
-        @TRANSMITTER
-        {
-            @PacketInterval = 1.0
-            @PacketSize = 1.024
-            @PacketResourceCost = 0.01
-        }
-    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -233,7 +233,7 @@
 
 //  Dimensions: 0.8 m x 2.1 m (retracted)
 //  Inert Mass: 1 kg (RA) / 20 kg (RT)
-//  Squad added a new model in 1.11, called it HighGainAntenna5_v2 and deprecated it. We will do the same.
+//  Squad added a new model in 1.11, called it HighGainAntenna5_v2, and deprecated the old model HighGainAntenna5. We will do the same.
 //  ==================================================
 
 @PART[HighGainAntenna5_v2]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -7,7 +7,7 @@
 //  Antenna mass differences between RT and RA: RA will assign additional weight based on electronics configuration
 
 // Antenna Common Patches
-@PART[SurfAntenna|longAntenna|mediumDishAntenna|HighGainAntenna|HighGainAntenna5|RelayAntenna5|commDish|RelayAntenna50|RelayAntenna100]:FOR[RealismOverhaul]
+@PART[SurfAntenna|longAntenna|mediumDishAntenna|HighGainAntenna|HighGainAntenna5|HighGainAntenna5_v2|RelayAntenna5|commDish|RelayAntenna50|RelayAntenna100]:FOR[RealismOverhaul]
 {
     @crashTolerance = 8
     %breakingForce = 250
@@ -233,12 +233,61 @@
 
 //  Dimensions: 0.8 m x 2.1 m (retracted)
 //  Inert Mass: 1 kg (RA) / 20 kg (RT)
+//  Squad added a new model in 1.11, called it HighGainAntenna5_v2 and deprecated it. We will do the same.
 //  ==================================================
+
+@PART[HighGainAntenna5_v2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = HG-5 Retractable Parabolic Antenna
+    @description = A retractable, short range parabolic antenna for high speed telecommunications.
+    @mass = 0.02
+
+    @MODULE[ModuleDataTransmitter]
+    {
+        @antennaType = DIRECT
+        @antennaCombinable = True
+        %antennaCombinableExponent = 2.0
+        @antennaPower = 1.6e9
+        @packetInterval = 1.0
+        @packetSize = 1.0
+        @packetResourceCost = 0.01
+    }
+}
+
+@PART[HighGainAntenna5_v2]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
+    @mass = 0.001
+}
+@PART[HighGainAntenna5_v2]:AFTER[RemoteTech]
+{
+    @description ^=:$: Wide angle and reasonable bandwidth among the inner planets. <b><color=#00eaf0>Effective range to Earth DSN [400 Gm] — Power Consumption [30 Watts] — Maximum Data Rate [1 Mbit/s] — Use Case [Mars, Vesta (not at Conjunction), Ceres (not at Conjunction)]</color></b>
+
+    @MODULE[ModuleRTAntenna]
+    {
+        @Mode0DishRange = 0
+        @Mode1DishRange = 1.4e9
+        @EnergyCost = 0.03
+        %MaxQ = 6000
+        @DishAngle = 7.0
+        %DeployFxModules = 0
+        %ProgressFxModules = 1
+
+        @TRANSMITTER
+        {
+            @PacketInterval = 1.0
+            @PacketSize = 1.024
+            @PacketResourceCost = 0.01
+        }
+    }
+}
 
 @PART[HighGainAntenna5]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = HG-5 Retractable Parabolic Antenna
+    %deprecated = True
+    @title = HG-5 Retractable Parabolic Antenna (Deprecated)
     @description = A retractable, short range parabolic antenna for high speed telecommunications.
     @mass = 0.02
 


### PR DESCRIPTION
Fix the issue mentioned in https://discord.com/channels/319857228905447436/512556137380315139/964727589581258802.
Duplicate the configs for `HighGainAntenna5` to be used for `HighGainAntenna5_v2` and deprecate the former.