### PR TITLE
Fix engines using mainsail model w/ ReStock

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -18,9 +18,9 @@
 +PART[microEngine_v2]:FIRST { @name = RO-1kN-Thruster }
 
 +PART[liquidEngine]:BEFORE[RealismOverhaul] { @name = RO-LR79 }
-+PART[liquidEngine1-2]:BEFORE[RealismOverhaul] { @name = RO-E1 }
-+PART[liquidEngine1-2]:BEFORE[RealismOverhaul] { @name = RO-H1-RS27 }
-+PART[liquidEngine1-2]:BEFORE[RealismOverhaul] { @name = RO-LR-89 }
++PART[liquidEngineMainsail_v2]:BEFORE[RealismOverhaul] { @name = RO-E1 }
++PART[liquidEngineMainsail_v2]:BEFORE[RealismOverhaul] { @name = RO-H1-RS27 }
++PART[liquidEngineMainsail_v2]:BEFORE[RealismOverhaul] { @name = RO-LR-89 }
 +PART[liquidEngine3_v2]:BEFORE[RealismOverhaul] { @name = RO-RD-0105 }
 +PART[liquidEngine2-2]:BEFORE[RealismOverhaul] { @name = RO-RD-0210 }	// ReStock now does not handle this part.  Only _v2.
 +PART[liquidEngine2-2_v2]:BEFORE[RealismOverhaul] { @name = RO-RD-0124 }
@@ -54,10 +54,10 @@
 +PART[liquidEngineMini_v2]:BEFORE[RealismOverhaul]:NEEDS[!ReStock] { @name = RO-LMAE }
 +PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO-LMAE }
 
-+PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO_KVD1 }
++PART[liquidEngineMainsail_v2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO_KVD1 }
 +PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[!ReStock] { @name = RO_KVD1 }
 
-+PART[liquidEngine1-2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO-KTDU417 }
++PART[liquidEngineMainsail_v2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO-KTDU417 }
 +PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[!ReStock] { @name = RO-KTDU417 }
 
 
@@ -1283,7 +1283,7 @@
 
 
 !PART[liquidEngine]:FOR[RealismOverhaul] {}
-!PART[liquidEngine1-2]:FOR[RealismOverhaul] {}
+!PART[liquidEngineMainsail_v2]:FOR[RealismOverhaul] {}
 !PART[liquidEngine2]:FOR[RealismOverhaul] {}
 !PART[liquidEngine2-2_v2]:FOR[RealismOverhaul] {}
 


### PR DESCRIPTION
Switch engines using the old mainsail model to the new mainsail model when ReStock is installed.

Tested with both ReStock and VSR based installs, everything seems to work correctly.