### PR TITLE
Add RD-56 to KVD-1 title

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KVD1_Config.cfg
@@ -1,5 +1,5 @@
 //	==================================================
-//	KVD-1/CE-7.5 Engine
+//	RD-56/KVD-1/CE-7.5 Engine
 //
 //	Manufacturer: KB Khimavtomatiki (Kosberg)
 //
@@ -64,7 +64,7 @@
 //	==================================================
 @PART[*]:HAS[#engineType[KVD1]]:FOR[RealismOverhaulEngines]
 {
-	%title = KVD-1/CE-7.5
+	%title = RD-56/KVD-1/CE-7.5
 	%manufacturer = KB Khimavtomatiki (Kosberg) / ISRO
 	%description = Staged combustion hydrolox upper stage engine intended for use on the N-1M and considered for use on Proton and Angara, eventually licensed to India for its GSLV MkI and MkII.	Later versions were developed by India for domestic use on the as the CE-7.5.  The main engine bell is fixed in place, and two verniers are used to provide combined pitch-yaw-roll control; this leads to lower control authority than on stages where the main engine can gimbal.	 This engine runs with a somewhat higher than average O/F ratio, resulting in a denser than average hydrolox stage.
 


### PR DESCRIPTION
Add RD-56 to KVD-1 title for clarity (and so it shows up next to other Soviet engines)