### PR TITLE
Run build job when secret is available

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -15,6 +15,16 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has-password: ${{ steps.has-password.outputs.defined }}
+    steps:
+      - id: has-password
+        if: "${{ env.KSP_ZIP_PASSWORD != '' }}"
+        run: echo "::set-output name=defined::true"
+        env:
+            KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
   validate-cfg-files:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +37,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    needs: [check-secret]
+    if: needs.check-secret.outputs.has-password == 'true'
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout


### PR DESCRIPTION
This prevents the build process from failing if the secret isn't available and instead just skips the job.