### PR TITLE
Fix non-restock support for new stock rcs blocks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
@@ -556,17 +556,19 @@
     %RSSROConfig = True
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
-    %rescaleFactor = 1.4
+    %rescaleFactor:NEEDS[!ReStock] = 0.5925
+    %rescaleFactor:NEEDS[ReStock] = 1.4
     @mass = 0.0028
     @cost = 10
     
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = True
 
-    @title = RCS Block [28/45 N Class]
+    @title = RCS Block [28/45 N Class] (elbows)
     @manufacturer = Generic
     @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for very small stages and spacecraft.
-    @category = Control
+    @category:NEEDS[ReStock] = Control
+    @category:NEEDS[!ReStock] = none
 
     @MODULE[ModuleRCS*]
     {
@@ -611,17 +613,19 @@
     %RSSROConfig = True
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
-    %rescaleFactor = 2.0
+    %rescaleFactor:NEEDS[!ReStock] = 0.9375
+    %rescaleFactor:NEEDS[ReStock] = 2
     @mass = 0.007
     @cost = 20
     
     %useRcsConfig = RCSBlockQuarter
     %useRcsMass = True
 
-    @title = RCS Block [69/111 N Class]
+    @title = RCS Block [69/111 N Class] (elbows)
     @manufacturer = Generic
     @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for rather small spacecraft or kick stages.
-    @category = Control
+    @category:NEEDS[ReStock] = Control
+    @category:NEEDS[!ReStock] = none
 
     @MODULE[ModuleRCS*]
     {
@@ -666,17 +670,19 @@
     %RSSROConfig = True
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
-    %rescaleFactor = 2.829
+    %rescaleFactor:NEEDS[!ReStock] = 1.326
+    %rescaleFactor:NEEDS[ReStock] = 2.829
     @mass = 0.011314
     @cost = 30
     
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
 
-    @title = RCS Block [138/223 N Class]
+    @title = RCS Block [138/223 N Class] (elbows)
     @manufacturer = Generic
     @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for small stages and spacecraft.
-    @category = Control
+    @category:NEEDS[ReStock] = Control
+    @category:NEEDS[!ReStock] = none
 
     @MODULE[ModuleRCS*]
     {
@@ -727,7 +733,9 @@
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
 
-    %rescaleFactor = 1.4
+    %rescaleFactor:NEEDS[!ReStock] = 0.9
+    %rescaleFactor:NEEDS[ReStock] = 1.4
+
     @mass = 0.004
 
     @title = RCS Thruster [28/45 N Class]
@@ -770,6 +778,8 @@
     !MODULE[TweakScale] {}
     
     %rescaleFactor = 2
+    %rescaleFactor:NEEDS[!ReStock] = 1.3
+    %rescaleFactor:NEEDS[ReStock] = 2
     @mass = 0.007
 
     @title = RCS Thruster [69/111 N Class]


### PR DESCRIPTION
- Without stock parts, RCSblock_01_small uses the same model
  as RCSBlock_v2; that means it should use the same rescale
  factor. Current rescaleFactor was only valid for restock's model

- Likewise the RCSLinearSmall rescaleFactor was good for restock
  but too big for stock. Eyeballed this one; the factor from
  the old Linear Thrusters isn't right either

- Give the _small parts a different title than the _v2 parts,
  because 2 different parts with the same title is confusing
  (better names welcome)

- And finally *hide* the RCSblock_01_small parts when restock
  isn't installed, because they end up exactly identical to the
  _v2 parts, making them completely redundant. We still want to
  create them (and scale them right) to allow creating a vessel
  with restock and loading it without restock.