### PR TITLE
Configure restock's Angled RCS Blocks

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ReStock/RO_Restock_RCS.cfg
@@ -6,3 +6,98 @@
         maskTransform = 4Mask
     }
 }
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_275
+	%rescaleFactor = 1.875
+	useRcsMultiConfig = RCSBlock
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_28
+	%rescaleFactor = 0.5925
+	useRcsMultiConfig = RCSBlockTenth
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_69
+	%rescaleFactor = 0.9375
+	useRcsMultiConfig = RCSBlockQuarter
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_138
+	%rescaleFactor = 1.326
+	useRcsMultiConfig = RCSBlockHalf
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_413
+	%rescaleFactor = 2.296
+	useRcsMultiConfig = RCSBlock15x
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_550
+	%rescaleFactor = 2.652
+	useRcsMultiConfig = RCSBlock2x
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_825
+	%rescaleFactor = 3.1
+	useRcsMultiConfig = RCSBlock3x
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_1100
+	%rescaleFactor = 3.75
+	useRcsMultiConfig = RCSBlock4x
+}
+
++PART[restock-rcs-block-multi-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_2200
+	%rescaleFactor = 5.303
+	useRcsMultiConfig = RCSBlock8x
+}
+
++PART[restock-rcs-block-multi-mini-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_mini_28
+	%rescaleFactor = 1.5
+	useRcsMultiConfig = RCSBlockTenth
+}
+
++PART[restock-rcs-block-multi-mini-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_mini_69
+	%rescaleFactor = 2.3
+	useRcsMultiConfig = RCSBlockQuarter
+}
+
++PART[restock-rcs-block-multi-mini-2]:FOR[RealismOverhaul]
+{
+	@name = RO_RCSBlock_restock_mini_138
+	%rescaleFactor = 3.2
+	useRcsMultiConfig = RCSBlockHalf
+}
+
+@PART[RO_RCSBlock_restock_*]:AFTER[RealismOverhaulEngines]
+{
+	@title ^= :^:Angled :
+}
+
+@PART[RO_RCSBlock_restock_mini_*]:AFTER[RealismOverhaulEngines]
+{
+	@title ^= :$: (elbows):
+}
+

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
@@ -1,25 +1,112 @@
 +PART[RCSBlock_v2]:FOR[RealismOverhaul]
 {
 	@name = RCSBlock_275
+	%rescaleFactor = 1.875		//match R-4D nozzle diameter of 15 cm
+	useRcsMultiConfig = RCSBlock
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_28
+	%rescaleFactor = 0.5925
+	useRcsMultiConfig = RCSBlockTenth
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_69
+	%rescaleFactor = 0.9375
+	useRcsMultiConfig = RCSBlockQuarter
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_138
+	%rescaleFactor = 1.326
+	useRcsMultiConfig = RCSBlockHalf
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_413
+	%rescaleFactor = 2.296
+	useRcsMultiConfig = RCSBlock15x
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_550
+	%rescaleFactor = 2.652
+	useRcsMultiConfig = RCSBlock2x
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_825
+	%rescaleFactor = 3.1
+	useRcsMultiConfig = RCSBlock3x
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_1100
+	%rescaleFactor = 3.75
+	useRcsMultiConfig = RCSBlock4x
+}
+
++PART[RCSBlock_v2]:FOR[RealismOverhaul]
+{
+	@name = RCSBlock_2200
+	%rescaleFactor = 5.303
+	useRcsMultiConfig = RCSBlock8x
+}
+
+// "Small" RCS block: not actually smaller, just a different model
++PART[RCSblock_01_small]:FOR[RealismOverhaul]
+{
+    @name = RCSBlockSmall_28
+    %rescaleFactor:NEEDS[!ReStock] = 0.5925
+    %rescaleFactor:NEEDS[ReStock] = 1.4
+    useRcsMultiConfig = RCSBlockTenth
+}
+
++PART[RCSblock_01_small]:FOR[RealismOverhaul]
+{
+    @name = RCSBlockSmall_69
+    %rescaleFactor:NEEDS[!ReStock] = 0.9375
+    %rescaleFactor:NEEDS[ReStock] = 2
+    useRcsMultiConfig = RCSBlockQuarter
+}
+
++PART[RCSblock_01_small]:FOR[RealismOverhaul]
+{
+    @name = RCSBlockSmall_138
+    %rescaleFactor:NEEDS[!ReStock] = 1.326
+    %rescaleFactor:NEEDS[ReStock] = 2.829
+    useRcsMultiConfig = RCSBlockHalf
+}
+
+
+// useRcsMultiConfig is similar to useRcsConfig (and uses it), but takes over
+// more responsibilities from the individual parts - and makes more assumptions
+// about those parts.
+
+// First, the bits common to ALL users of useRcsMultiConfig...
+@PART:HAS[#useRcsMultiConfig]:AFTER[RealismOverhaul]
+{
 	%RSSROConfig = True
 	@PhysicsSignificance = 0
 	!MODULE[TweakScale] {}
-	%rescaleFactor = 1.875		//match R-4D nozzle diameter of 15 cm
-	@mass = 0.016
-	@cost = 40
-	
-	%useRcsConfig = RCSBlock
+	%useRcsConfig = #$useRcsMultiConfig$
 	%useRcsMass = True
-
-	@title = RCS Block [275/445 N Class]
+	@title = RCS Block
+	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage.
 	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
 	@category = Control
 
 	@MODULE[ModuleRCS*]
 	{
 		@name = ModuleRCS
-		@thrusterPower = 0.275
 		!resourceName = DELETE
 		PROPELLANT
 		{
@@ -31,6 +118,21 @@
 			@key,0 = 0 254
 			@key,1 = 1 82.08
 		}
+	}
+}
+
+
+// ... then the bits that are thruster-size-specific
+@PART:HAS[#useRcsMultiConfig[RCSBlock]]:AFTER[RealismOverhaul]
+{
+	@title ^= :$: [ 275/445 N Class]:
+	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
+	@mass = 0.016
+	@cost = 40
+
+	@MODULE[ModuleRCS]
+	{
+		@thrusterPower = 0.275
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -53,39 +155,17 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlockTenth]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_28
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 0.5925
-	@mass = 0.0028
-	@cost = 10
-	
-	%useRcsConfig = RCSBlockTenth
-	%useRcsMass = True
-
-	@title = RCS Block [28/45 N Class]
-	@manufacturer = Generic
+	@title ^= :$: [  28/45 N Class]:
 	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for very small stages and spacecraft.
 	@category = Control
+	@mass = 0.0028
+	@cost = 10
 
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.0275
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -108,39 +188,17 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlockQuarter]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_69
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 0.9375
+	@title ^= :$: [  69/111 N Class]:
+	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for rather small spacecraft or kick stages.
 	@mass = 0.007
 	@cost = 20
-	
-	%useRcsConfig = RCSBlockQuarter
-	%useRcsMass = True
 
-	@title = RCS Block [69/111 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for rather small spacecraft or kick stages.
-	@category = Control
 
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.06875
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -163,39 +221,16 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlockHalf]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_138
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 1.326
+	@title ^= :$: [ 138/223 N Class]:
+	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for small stages and spacecraft.
 	@mass = 0.011314
 	@cost = 30
-	
-	%useRcsConfig = RCSBlockHalf
-	%useRcsMass = True
 
-	@title = RCS Block [138/223 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for small stages and spacecraft.
-	@category = Control
-
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.1375
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -218,39 +253,15 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlock15x]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_413
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 2.296
-	@mass = 0.0196
+	@title ^= :$: [ 413/668 N Class]:
 	@cost = 45
-	
-	%useRcsConfig = RCSBlock15x
-	%useRcsMass = True
+	@mass = 0.0196
 
-	@title = RCS Block [413/668 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage.
-	@category = Control
-
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.4125
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -273,39 +284,15 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlock2x]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_550
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 2.652
+	@title ^= :$: [ 550/890 N Class]:
 	@mass = 0.0226
 	@cost = 50
-	
-	%useRcsConfig = RCSBlock2x
-	%useRcsMass = True
 
-	@title = RCS Block [550/890 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage.
-	@category = Control
-
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.550
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -328,39 +315,15 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlock3x]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_825
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 2.652
+	@title ^= :$: [ 825/1335 N Class]:
 	@mass = 0.0226
 	@cost = 60
-	
-	%useRcsConfig = RCSBlock3x
-	%useRcsMass = True
 
-	@title = RCS Block [825/1335 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage.
-	@category = Control
-
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 0.825
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -383,39 +346,15 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlock4x]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_1100
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 3.75
+	@title ^= :$: [1100/1780 N Class]:
 	@mass = 0.032
 	@cost = 150
-	
-	%useRcsConfig = RCSBlock4x
-	%useRcsMass = True
 
-	@title = RCS Block [1100/1780 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage.
-	@category = Control
-
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 1.1
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -438,39 +377,15 @@
 	}
 }
 
-+PART[RCSBlock_v2]:FOR[RealismOverhaul]
+@PART:HAS[#useRcsMultiConfig[RCSBlock8x]]:AFTER[RealismOverhaul]
 {
-	@name = RCSBlock_2200
-	%RSSROConfig = True
-	@PhysicsSignificance = 0
-	!MODULE[TweakScale] {}
-	%rescaleFactor = 5.303
+	@title ^= :$: [2200/3560 N Class]:
 	@mass = 0.0452
 	@cost = 300
-	
-	%useRcsConfig = RCSBlock8x
-	%useRcsMass = True
 
-	@title = RCS Block [2200/3560 N Class]
-	@manufacturer = Generic
-	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage.
-	@category = Control
-
-	@MODULE[ModuleRCS*]
+	@MODULE[ModuleRCS]
 	{
-		@name = ModuleRCS
 		@thrusterPower = 2.2
-		!resourceName = DELETE
-		PROPELLANT
-		{
-			ratio = 1.0
-			name = Hydrazine
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 254
-			@key,1 = 1 82.08
-		}
 	}
 	
 	@MODULE[ModulePartVariants]
@@ -493,6 +408,22 @@
 	}
 }
 
+@PART:HAS[#useRcsMultiConfig]:AFTER[RealismOverhaul]
+{
+	!useRcsMultiConfig = DELETE
+}
+
+@PART[RCSBlockSmall_*]:AFTER[RealismOverhaul]
+{
+	@title ^= :$: (elbows):
+	// without restock, there's no difference between RCSBlockSmall_* and RCSBlock_*,
+	// so only show one of the two in the VAB.
+	@category:NEEDS[ReStock] = Control
+	@category:NEEDS[!ReStock] = none
+}
+
+
+// deprecated parts don't deserve to get refactored
 @PART[RCSBlock_v2]:FOR[RealismOverhaul]
 {
 	@name = RCSBlock
@@ -547,178 +478,6 @@
 			@cost = -16
 		}
 	}
-}
-
-// Small RCS block
-+PART[RCSblock_01_small]:FOR[RealismOverhaul]
-{
-    @name = RCSBlockSmall_28
-    %RSSROConfig = True
-    @PhysicsSignificance = 0
-    !MODULE[TweakScale] {}
-    %rescaleFactor:NEEDS[!ReStock] = 0.5925
-    %rescaleFactor:NEEDS[ReStock] = 1.4
-    @mass = 0.0028
-    @cost = 10
-    
-    %useRcsConfig = RCSBlockTenth
-    %useRcsMass = True
-
-    @title = RCS Block [28/45 N Class] (elbows)
-    @manufacturer = Generic
-    @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for very small stages and spacecraft.
-    @category:NEEDS[ReStock] = Control
-    @category:NEEDS[!ReStock] = none
-
-    @MODULE[ModuleRCS*]
-    {
-        @name = ModuleRCS
-        @thrusterPower = 0.0275
-        !resourceName = DELETE
-        PROPELLANT
-        {
-            ratio = 1.0
-            name = Hydrazine
-        }
-        @atmosphereCurve
-        {
-            @key,0 = 0 254
-            @key,1 = 1 82.08
-        }
-    }
-    
-    @MODULE[ModulePartVariants]
-    {
-        @VARIANT[5Horn]
-        {
-            @mass = 0.001124
-            @cost = 2
-        }
-        @VARIANT[3Horn]
-        {
-            @mass = -0.00112
-            @cost = -2
-        }
-        @VARIANT[2Horn]
-        {
-            @mass = -0.00225
-            @cost = -4
-        }
-    }
-}
-
-+PART[RCSblock_01_small]:FOR[RealismOverhaul]
-{
-    @name = RCSBlockSmall_69
-    %RSSROConfig = True
-    @PhysicsSignificance = 0
-    !MODULE[TweakScale] {}
-    %rescaleFactor:NEEDS[!ReStock] = 0.9375
-    %rescaleFactor:NEEDS[ReStock] = 2
-    @mass = 0.007
-    @cost = 20
-    
-    %useRcsConfig = RCSBlockQuarter
-    %useRcsMass = True
-
-    @title = RCS Block [69/111 N Class] (elbows)
-    @manufacturer = Generic
-    @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for rather small spacecraft or kick stages.
-    @category:NEEDS[ReStock] = Control
-    @category:NEEDS[!ReStock] = none
-
-    @MODULE[ModuleRCS*]
-    {
-        @name = ModuleRCS
-        @thrusterPower = 0.06875
-        !resourceName = DELETE
-        PROPELLANT
-        {
-            ratio = 1.0
-            name = Hydrazine
-        }
-        @atmosphereCurve
-        {
-            @key,0 = 0 254
-            @key,1 = 1 82.08
-        }
-    }
-    
-    @MODULE[ModulePartVariants]
-    {
-        @VARIANT[5Horn]
-        {
-            @mass = 0.001778
-            @cost = 4
-        }
-        @VARIANT[3Horn]
-        {
-            @mass = -0.00178
-            @cost = -4
-        }
-        @VARIANT[2Horn]
-        {
-            @mass = -0.00356
-            @cost = -8
-        }
-    }
-}
-
-+PART[RCSblock_01_small]:FOR[RealismOverhaul]
-{
-    @name = RCSBlockSmall_138
-    %RSSROConfig = True
-    @PhysicsSignificance = 0
-    !MODULE[TweakScale] {}
-    %rescaleFactor:NEEDS[!ReStock] = 1.326
-    %rescaleFactor:NEEDS[ReStock] = 2.829
-    @mass = 0.011314
-    @cost = 30
-    
-    %useRcsConfig = RCSBlockHalf
-    %useRcsMass = True
-
-    @title = RCS Block [138/223 N Class] (elbows)
-    @manufacturer = Generic
-    @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for small stages and spacecraft.
-    @category:NEEDS[ReStock] = Control
-    @category:NEEDS[!ReStock] = none
-
-    @MODULE[ModuleRCS*]
-    {
-        @name = ModuleRCS
-        @thrusterPower = 0.1375
-        !resourceName = DELETE
-        PROPELLANT
-        {
-            ratio = 1.0
-            name = Hydrazine
-        }
-        @atmosphereCurve
-        {
-            @key,0 = 0 254
-            @key,1 = 1 82.08
-        }
-    }
-    
-    @MODULE[ModulePartVariants]
-    {
-        @VARIANT[5Horn]
-        {
-            @mass = 0.002514
-            @cost = 6
-        }
-        @VARIANT[3Horn]
-        {
-            @mass = -0.00251
-            @cost = -6
-        }
-        @VARIANT[2Horn]
-        {
-            @mass = -0.00503
-            @cost = -12
-        }
-    }
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
@@ -556,17 +556,19 @@
     %RSSROConfig = True
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
-    %rescaleFactor = 1.4
+    %rescaleFactor:NEEDS[!ReStock] = 0.5925
+    %rescaleFactor:NEEDS[ReStock] = 1.4
     @mass = 0.0028
     @cost = 10
     
     %useRcsConfig = RCSBlockTenth
     %useRcsMass = True
 
-    @title = RCS Block [28/45 N Class]
+    @title = RCS Block [28/45 N Class] (elbows)
     @manufacturer = Generic
     @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for very small stages and spacecraft.
-    @category = Control
+    @category:NEEDS[ReStock] = Control
+    @category:NEEDS[!ReStock] = none
 
     @MODULE[ModuleRCS*]
     {
@@ -611,17 +613,19 @@
     %RSSROConfig = True
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
-    %rescaleFactor = 2.0
+    %rescaleFactor:NEEDS[!ReStock] = 0.9375
+    %rescaleFactor:NEEDS[ReStock] = 2
     @mass = 0.007
     @cost = 20
     
     %useRcsConfig = RCSBlockQuarter
     %useRcsMass = True
 
-    @title = RCS Block [69/111 N Class]
+    @title = RCS Block [69/111 N Class] (elbows)
     @manufacturer = Generic
     @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for rather small spacecraft or kick stages.
-    @category = Control
+    @category:NEEDS[ReStock] = Control
+    @category:NEEDS[!ReStock] = none
 
     @MODULE[ModuleRCS*]
     {
@@ -666,17 +670,19 @@
     %RSSROConfig = True
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
-    %rescaleFactor = 2.829
+    %rescaleFactor:NEEDS[!ReStock] = 1.326
+    %rescaleFactor:NEEDS[ReStock] = 2.829
     @mass = 0.011314
     @cost = 30
     
     %useRcsConfig = RCSBlockHalf
     %useRcsMass = True
 
-    @title = RCS Block [138/223 N Class]
+    @title = RCS Block [138/223 N Class] (elbows)
     @manufacturer = Generic
     @description = A generic RCS block with variants. Use this for attitude control or translation/ullage for small stages and spacecraft.
-    @category = Control
+    @category:NEEDS[ReStock] = Control
+    @category:NEEDS[!ReStock] = none
 
     @MODULE[ModuleRCS*]
     {
@@ -727,7 +733,9 @@
     @PhysicsSignificance = 0
     !MODULE[TweakScale] {}
 
-    %rescaleFactor = 1.4
+    %rescaleFactor:NEEDS[!ReStock] = 0.9
+    %rescaleFactor:NEEDS[ReStock] = 1.4
+
     @mass = 0.004
 
     @title = RCS Thruster [28/45 N Class]
@@ -770,6 +778,8 @@
     !MODULE[TweakScale] {}
     
     %rescaleFactor = 2
+    %rescaleFactor:NEEDS[!ReStock] = 1.3
+    %rescaleFactor:NEEDS[ReStock] = 2
     @mass = 0.007
 
     @title = RCS Thruster [69/111 N Class]

--- a/GameData/RealismOverhaul/Waterfall_Configs/ReStockPlus/restockplus_rcs.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/ReStockPlus/restockplus_rcs.cfg
@@ -1,7 +1,7 @@
 // ReStock Plus Squad-style thrusters.
 // Note that the glob used here also covers ReStock Plus mini thrusters, those are patched
 // separately below.
-@PART[RO-RestockPlus-RCS-*|restock-rcs-*]:HAS[#RSSROConfig]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[RO-RestockPlus-RCS-*|restock-rcs-*|RO_RCSBlock_restock_*]:HAS[#RSSROConfig]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     ROWaterfall
     {
@@ -16,7 +16,7 @@
 }
 
 // ReStock Plus mini thrusters.
-@PART[RO-RestockPlus-RCS-*-28|restock-rcs-*-mini-*]:HAS[#RSSROConfig]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[RO-RestockPlus-RCS-*-28|restock-rcs-*-mini-*|RO_RCSBlock_restock_mini_*]:HAS[#RSSROConfig]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     !ROWaterfall {}
     ROWaterfall

--- a/GameData/RealismOverhaul/Waterfall_Configs/Squad/rcs.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/Squad/rcs.cfg
@@ -1,5 +1,5 @@
 // Squad quad thrusters.
-@PART[RCSBlock|RCSBlockQuarter|SquadRCSBlock*]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[RCSBlock|RCSBlock_*|RCSBlockQuarter|SquadRCSBlock*]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     %ROWaterfall:NEEDS[ReStock]
     {


### PR DESCRIPTION
With some refactoring to reduce the existing duplication instead
of doubling it up.

Also here:
- tweak part titles to give a better sort order
- apply waterfall configs to RCSBlock_*

PR also includes #2647 because this reshuffles the code that touches

New parts on top rows, existing parts on bottom rows:
![Screen Shot 2022-05-05 at 21 41 52](https://user-images.githubusercontent.com/5061230/167055570-ae8afd86-e8fb-4ced-891f-c22b76d5db5a.png)
