### PR TITLE
Update RN Soyuz, Salyut and TKS configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
@@ -40,11 +40,11 @@
 	{
 	}
 	
-    !MODULE[ModuleCommand] {}
+	!MODULE[ModuleCommand] {}
 	MODULE
 	{
 		name = ModuleCommand
-		minimumCrew = 1
+		minimumCrew = 0
 		
 		RESOURCE
 		{
@@ -291,6 +291,13 @@
 			PacketResourceCost = 0.5
 		}
 	}
+}
+
+//LK lander landing platform RealAntennas config
+@PART[rn_lk_lander_legs]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %antennaDiameter = 0.75 }
 }
 
 @PART[rn_lk_lander_858]:FOR[RealismOverhaul]
@@ -670,7 +677,8 @@
 	!MODULE[LifeSupportRegeneratorModule]
 	{}
 }
-@PART[rn_lok_tdu]:NEEDS[!ProfileRealismOverhaul]:FOR[RealismOverhaul]
+//If Kerbalism is not present, edit stock module to create fuel cell
+@PART[rn_lok_tdu]:NEEDS[!Kerbalism]:FOR[RealismOverhaul]
 {
 	@MODULE[ModuleGenerator]
 	{
@@ -680,26 +688,32 @@
 		%efficiency = 1
 		INPUT_RESOURCE
 		{
-		   name = LqdHydrogen
-		   rate = 0.0007779060
+			name = LqdHydrogen
+			rate = 0.0007779060
 		}
 		INPUT_RESOURCE
 		{
-		   name = LqdOxygen
-		   rate = 0.0003864304
+			name = LqdOxygen
+			rate = 0.0003864304
 		}
 		OUTPUT_RESOURCE
 		{
-		   name = Water
-		   rate = 0.000496032
+			name = Water
+			rate = 0.000496032
 		}
 		OUTPUT_RESOURCE
 		{
-		   name = ElectricCharge
-		   rate = 1.5
+			name = ElectricCharge
+			rate = 1.5
 		}
 	}
 }
+//otherwise, remove stock generator module
+@PART[rn_lok_tdu]:NEEDS[Kerbalism]:FOR[RealismOverhaul]
+{
+	!MODULE[ModuleGenerator] {}
+}
+
 @PART[rn_lok_tdu]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
 	!MODULE[ModuleDataTransmitter]
@@ -721,6 +735,13 @@
 			PacketResourceCost = 0
 		}
 	}
+}
+
+//LOK Service Module RealAntennas config
+@PART[rn_lok_tdu]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
 @PART[rn_lok_bo]:FOR[RealismOverhaul]
@@ -823,6 +844,12 @@
 		}
 	}
 }
+//LOK orbital module RealAntennas config
+@PART[rn_lok_bo]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %antennaDiameter = 0.3 }
+}
 
 @PART[rn_lok_sa]:FOR[RealismOverhaul]
 {
@@ -851,6 +878,7 @@
 	
 	@MODULE[ModuleCommand]
 	{
+		@minimumCrew = 0
 		!RESOURCE,* {}
 		RESOURCE
 		{
@@ -982,6 +1010,10 @@
 		amount = 0
 		maxAmount = 15
 	}
+}
+//Do not add stock scrubber if Kerbalism is present
+@PART[rn_lok_sa]:NEEDS[!Kerbalism]:FOR[RealismOverhaul]
+{
 	MODULE
 	{
 		name = ModuleGenerator
@@ -993,22 +1025,22 @@
 		efficiency = 1
 		INPUT_RESOURCE
 		{
-		   name = PotassiumSuperoxide
-		   rate = 0.00001189
+			name = PotassiumSuperoxide
+			rate = 0.00001189
 		}
 		INPUT_RESOURCE
 		{
-		   name = CarbonDioxide
-		   rate = 0.006216
+			name = CarbonDioxide
+			rate = 0.006216
 		}
 		OUTPUT_RESOURCE
 		{
-		   name = Waste
-		   rate = 0.00003932
+			name = Waste
+			rate = 0.00003932
 		}
 	}
-
 }
+
 @PART[rn_lok_sa]:NEEDS[RemoteTech]:FOR[RealismOverhaul]
 {
 	!MODULE[ModuleDataTransmitter]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
@@ -1564,32 +1564,7 @@
 	
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 4.09
-		@maxThrust = 4.09
-		
-		@PROPELLANT[MonoPropellant]
-		{
-			@name = UDMH
-			@ratio = 0.42976765
-			%DrawGauge = True
-		}
-		%PROPELLANT
-		{
-			%name = AK27
-			%ratio = 0.57023235
-		}
-		//KTDU-35 used HTP decomposition to drive pumps
-		%PROPELLANT
-		{
-			%name = HTP
-			%ignoreForIsp = True
-			%ratio = 0.0153
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 278
-			@key,1 = 1 112
-		}
+		@name = ModuleEnginesRF
 	}
 	MODULE
 	{
@@ -2839,32 +2814,7 @@
 	
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 4.09
-		@maxThrust = 4.09
-		
-		@PROPELLANT[MonoPropellant]
-		{
-			@name = UDMH
-			@ratio = 0.42976765
-			%DrawGauge = True
-		}
-		%PROPELLANT
-		{
-			%name = AK27
-			%ratio = 0.57023235
-		}
-		//KTDU-35 used HTP decomposition to drive pumps
-		%PROPELLANT
-		{
-			%name = HTP
-			%ignoreForIsp = True
-			%ratio = 0.0153
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 278
-			@key,1 = 1 112
-		}
+		@name = ModuleEnginesRF
 	}
 	MODULE
 	{
@@ -2939,13 +2889,13 @@
 		{
 			name = UDMH
 			amount = Full
-			maxAmount = 276.2924
+			maxAmount = 332.162
 		}
 		TANK
 		{
 			name = NTO
 			amount = Full
-			maxAmount = 372.3691
+			maxAmount = 446.499
 		}
 		TANK
 		{
@@ -2987,25 +2937,7 @@
 	//KTUD-426, 317 kgf thrust. Pressurefed, shared tanks with DPO/DO RCS system
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 3.08
-		@maxThrust = 3.08
-		
-		@PROPELLANT[MonoPropellant]
-		{
-			@name = UDMH
-			@ratio = 0.42976765
-			%DrawGauge = True
-		}
-		%PROPELLANT
-		{
-			%name = NTO
-			%ratio = 0.57023235
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 292
-			@key,1 = 1 112
-		}
+		@name = ModuleEnginesRF
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
@@ -1,3 +1,5 @@
+//Source: Soyuz: A Universal Spacecraft on Google Books
+
 @PART[almaz3-5|rn_almaz_ops4]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -40,7 +42,8 @@
 		}
 	}
 	@MODULE[ModuleCommand]
-	{	
+	{
+		@minimumCrew = 0
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.95
@@ -160,6 +163,10 @@
 			}
 		}
 	}
+}
+//Remove if Kerbalism is installed, Kerbalism will perform it's own life support calculations
+@PART[almaz3-5|rn_almaz_ops4]:NEEDS[!Kerbalism]:FOR[RealismOverhaul]
+{
 	MODULE
 	{
 		name = ModuleGenerator
@@ -221,7 +228,7 @@
 	%skinMaxTemp = 873.15
 	@MODULE[ModuleDeployableSolarPanel]
 	{
-		@chargeRate = 1.55
+		@chargeRate = 3.1	//Given figures are average power generation. Double for peak power
 	}
 }
 @PART[almaz_pan_r]:FOR[RealismOverhaul]
@@ -237,7 +244,7 @@
 	%skinMaxTemp = 873.15
 	@MODULE[ModuleDeployableSolarPanel]
 	{
-		@chargeRate = 1.55
+		@chargeRate = 3.1	//Given figures are average power generation. Double for peak power
 	}
 }
 @PART[almaz_sample_return]:FOR[RealismOverhaul]
@@ -552,7 +559,8 @@
 		}
 	}
 	@MODULE[ModuleCommand]
-	{	
+	{
+		@minimumCrew = 0
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 1.0
@@ -710,6 +718,16 @@
 		}
 	}
 }
+//Salyut 4 solar array
+@PART[Kosmos_TKS_Solar_Array_rn2]:FOR[RealismOverhaul]
+{
+	@maxTemp = 773.15
+	%skinMaxTemp = 873.15
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 2.66	//Given figures are for average power generation. Double for peak power generation
+	}
+}
 @PART[salyut6]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -756,7 +774,8 @@
 		}
 	}
 	@MODULE[ModuleCommand]
-	{	
+	{
+		@minimumCrew = 0
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 1.545
@@ -923,7 +942,8 @@
 		}
 	}
 	@MODULE[ModuleCommand]
-	{	
+	{
+		@minimumCrew = 0
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 1.8
@@ -1080,7 +1100,27 @@
 		}
 	}
 }
-@PART[almaz3-5|salyut1-4|salyut6|salyut7]:NEEDS[RemoteTech]
+//Salyut 6 solar array
+@PART[Kosmos_TKS_Solar_Array_rn2_2]:FOR[RealismOverhaul]
+{
+	@maxTemp = 773.15
+	%skinMaxTemp = 873.15
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 2.76	//Given figures are for average power generation. Double for peak power generation
+	}
+}
+//Salyut 7 solar array
+@PART[Kosmos_Salyut_Solar_Array_rn]:FOR[RealismOverhaul]
+{
+	@maxTemp = 773.15
+	%skinMaxTemp = 873.15
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 3.00	//Given figures are for average power generation. Double for peak power generation
+	}
+}
+@PART[almaz3-5|rn_almaz_ops4|salyut1-4|salyut6|salyut7]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter]
 	{
@@ -1102,6 +1142,13 @@
 			PacketResourceCost = 0
 		}
 	}
+}
+
+//Salyut/Almaz RealAntennas config
+@PART[almaz3-5|rn_almaz_ops4|salyut1-4|salyut6|salyut7]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
 @PART[salyut_asas]:FOR[RealismOverhaul]
@@ -1168,7 +1215,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//10 kg thrust on Soyuz 1-40
 		PROPELLANT
 		{
 			name = HTP
@@ -1176,8 +1223,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150		//guess
+			key = 1 50
 		}
 	}
 	
@@ -1278,7 +1325,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//10 kg thrust on soyuz 1-40
 		PROPELLANT
 		{
 			name = HTP
@@ -1286,8 +1333,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -1502,7 +1549,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//10 kg on Soyuz 1-40
 		PROPELLANT
 		{
 			name = HTP
@@ -1510,8 +1557,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -1531,9 +1578,16 @@
 			%name = AK27
 			%ratio = 0.57023235
 		}
+		//KTDU-35 used HTP decomposition to drive pumps
+		%PROPELLANT
+		{
+			%name = HTP
+			%ignoreForIsp = True
+			%ratio = 0.0153
+		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 282
+			@key,0 = 0 278
 			@key,1 = 1 112
 		}
 	}
@@ -1560,17 +1614,19 @@
 				name = AK27
 				ratio = 0.57023235
 			}
+			//KTDU-35 used HTP decomposition to drive pumps
+			PROPELLANT
+			{
+				name = HTP
+				ignoreForIsp = True
+				ratio = 0.0153
+			}
 			atmosphereCurve
 			{
-				key = 0 282
+				key = 0 278
 				key = 1 112
 			}
 		}
-	}
-	MODULE
-	{
-		name = AdjustableCoMShifter
-		DescentModeCoM = 0, -1.5, 0
 	}
 }
 @PART[ok_para]:FOR[RealismOverhaul]
@@ -1732,7 +1788,8 @@
 	!RESOURCE[MonoPropellant]
 	{ }
 	@MODULE[ModuleCommand]
-	{	
+	{
+		@minimumCrew = 0
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.7
@@ -1821,6 +1878,7 @@
 		}
 	}
 }
+
 @PART[rn_zond_sa]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -1862,7 +1920,8 @@
 	!RESOURCE[MonoPropellant]
 	{ }
 	@MODULE[ModuleCommand]
-	{	
+	{
+		@minimumCrew = 0
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.7
@@ -1980,8 +2039,8 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 290
-			@key,1 = 1 144.1
+			@key,0 = 0 150
+			@key,1 = 1 50
 		}
 	}
 }
@@ -2155,7 +2214,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//10 kg thrust on Soyuz 1-40
 		PROPELLANT
 		{
 			name = HTP
@@ -2163,8 +2222,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -2261,7 +2320,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//10 kg thrust on Soyuz 1-40
 		PROPELLANT
 		{
 			name = HTP
@@ -2269,8 +2328,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -2366,7 +2425,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//Mockup in Air and Space Museum appears to use monopropellant DPO thrusters
 		PROPELLANT
 		{
 			name = HTP
@@ -2374,8 +2433,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -2519,6 +2578,12 @@
 	%skinMaxTemp = 873.15
 	stackSymmetry = 1
 }
+//Zond avionics package RealAntennas config
+@PART[rn_zond_top]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %antennaDiameter = 1.2 }
+}
 @PART[tg_bo]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -2540,7 +2605,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//7K-TG appeared to use propulsion from 7K-T
 		PROPELLANT
 		{
 			name = HTP
@@ -2548,8 +2613,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -2756,7 +2821,7 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.098	//10 kg thrust on Soyuz 1-40
 		PROPELLANT
 		{
 			name = HTP
@@ -2764,8 +2829,8 @@
 		}
 		atmosphereCurve
 		{
-			key = 0 290
-			key = 1 144.1
+			key = 0 150
+			key = 1 50
 		}
 	}
 	
@@ -2788,9 +2853,16 @@
 			%name = AK27
 			%ratio = 0.57023235
 		}
+		//KTDU-35 used HTP decomposition to drive pumps
+		%PROPELLANT
+		{
+			%name = HTP
+			%ignoreForIsp = True
+			%ratio = 0.0153
+		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 282
+			@key,0 = 0 278
 			@key,1 = 1 112
 		}
 	}
@@ -2817,9 +2889,16 @@
 				name = AK27
 				ratio = 0.57023235
 			}
+			//KTDU-35 used HTP decomposition to drive pumps
+			PROPELLANT
+			{
+				name = HTP
+				ignoreForIsp = True
+				ratio = 0.0153
+			}
 			atmosphereCurve
 			{
-				key = 0 282
+				key = 0 278
 				key = 1 112
 			}
 		}
@@ -2874,12 +2953,6 @@
 			amount = Full
 			maxAmount = 90000
 		}
-		TANK
-		{
-			name = HTP
-			amount = Full
-			maxAmount = 130
-		}
 	}
 	
 	!MODULE[ModuleRCS*]
@@ -2890,15 +2963,20 @@
 		name = ModuleRCSFX
 		thrusterTransformName = RCSthruster
 		resourceFlowMode = STACK_PRIORITY_SEARCH
-		thrusterPower = 0.1305
+		thrusterPower = 0.132	//13.5 kg thruster used on Soyuz-T, drew from main fuel tanks
 		PROPELLANT
 		{
-			name = HTP
-			ratio = 1.0
+			name = UDMH
+			ratio = 0.42976765
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.57023235
 		}
 		atmosphereCurve
 		{
-			key = 0 290
+			key = 0 251
 			key = 1 144.1
 		}
 	}
@@ -2906,10 +2984,11 @@
 	!MODULE[ModuleGenerator]
 	{ }
 	
+	//KTUD-426, 317 kgf thrust. Pressurefed, shared tanks with DPO/DO RCS system
 	@MODULE[ModuleEngines*]
 	{
-		@minThrust = 4.09
-		@maxThrust = 4.09
+		@minThrust = 3.08
+		@maxThrust = 3.08
 		
 		@PROPELLANT[MonoPropellant]
 		{
@@ -2924,7 +3003,7 @@
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 282
+			@key,0 = 0 292
 			@key,1 = 1 112
 		}
 	}
@@ -2937,8 +3016,8 @@
 		CONFIG
 		{
 			name = Soyuz T Service Module
-			minThrust = 4.09
-			maxThrust = 4.09
+			minThrust = 3.08
+			maxThrust = 3.08
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -2953,7 +3032,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 282
+				key = 0 292
 				key = 1 112
 			}
 		}
@@ -2962,29 +3041,6 @@
 	{
 		name = AdjustableCoMShifter
 		DescentModeCoM = 0, -1.5, 0
-	}
-}
-
-@PART[ok_bo_fem|ok_bo_male|t_bo|rn_astp_bo|tg_bo]:NEEDS[RemoteTech]
-{
-	!MODULE[ModuleDataTransmitter]
-	{
-	}
-	MODULE
-	{
-		name = ModuleSPU
-		IsRTCommandStation = false
-	}
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		OmniRange = 375000
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 0.4
-			PacketResourceCost = 0
-		}
 	}
 }
 
@@ -3008,6 +3064,13 @@
 			PacketResourceCost = 0
 		}
 	}
+}
+
+//RealAntennas config for Soyuz/Progress orbital modules
+@PART[ok_bo_fem|ok_bo_male|t_bo|rn_astp_bo|tg_bo]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
 @PART[ok_pao|t_pao|t_pao2|ok_tft]:NEEDS[RemoteTech]
@@ -3030,6 +3093,13 @@
 			PacketResourceCost = 0
 		}
 	}
+}
+
+//RealAntennas config for for Soyuz/Progress service modules
+@PART[ok_pao|t_pao|t_pao2|ok_tft]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
 @PART[ok_hs|ok_dec|rn_zond_dec|ok_tft]:AFTER[zzzRealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_TKS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_TKS.cfg
@@ -157,6 +157,10 @@
 		closeSndPath = KIS/Sounds/containerClose
 		defaultMoveSndPath = KIS/Sounds/itemMove
 	}
+}
+//Remove if Kerbalism is installed, Kerbalism will perform it's own life support calculations
+@PART[rn_tks]:NEEDS[!Kerbalism]:FOR[RealismOverhaul]
+{
 	MODULE
 	{
 		name = ModuleGenerator
@@ -190,6 +194,25 @@
 		}
 	}
 }
+
+//FGB/TKS RealAntennas config
+@PART[rn_tks]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
+}
+
+//TKS solar array
+@PART[Kosmos_TKS_Solar_Array_rn]:FOR[RealismOverhaul]
+{
+	@maxTemp = 773.15
+	%skinMaxTemp = 873.15
+	@MODULE[ModuleDeployableSolarPanel]
+	{
+		@chargeRate = 2.66	//Given figures are for average power generation. Double for peak power generation
+	}
+}
+
 @PART[rn_va_capsule]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter]
@@ -250,6 +273,10 @@
 	!RESOURCE[AblativeShielding] {}
 	!MODULE[ModuleGenerator]
 	{
+	}
+	@MODULE[ModuleCommand]
+	{
+		@minimumCrew = 0
 	}
 	@MODULE[ModuleRCS*]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Vostok_Voskhod.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Vostok_Voskhod.cfg
@@ -565,6 +565,13 @@
 		}
 	}
 }
+
+@PART[rn_vostok_tdu|rn_voskhod_tdu]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	%MODULE[ModuleRealAntenna] { %referenceGain = 2.0 }
+}
+
 @PART[rn_vostok_sc]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/Ships/VAB/RO RN Soyuz-T.craft
+++ b/Ships/VAB/RO RN Soyuz-T.craft
@@ -5040,8 +5040,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 372.3691
-			maxAmount = 372.3691
+			amount = 446.499
+			maxAmount = 446.499
 		}
 		TANK
 		{
@@ -5054,8 +5054,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 276.29239999999999
-			maxAmount = 276.29239999999999
+			amount = 332.162
+			maxAmount = 332.162
 		}
 		TANK
 		{
@@ -5110,8 +5110,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 130
-			maxAmount = 130
+			amount = 0
+			maxAmount = 0
 		}
 		TANK
 		{
@@ -6047,8 +6047,8 @@ PART
 	RESOURCE
 	{
 		name = NTO
-		amount = 372.3691
-		maxAmount = 372.3691
+		amount = 446.499
+		maxAmount = 446.499
 		flowState = True
 		isTweakable = True
 		hideFlow = False
@@ -6058,19 +6058,8 @@ PART
 	RESOURCE
 	{
 		name = UDMH
-		amount = 276.29239999999999
-		maxAmount = 276.29239999999999
-		flowState = True
-		isTweakable = True
-		hideFlow = False
-		isVisible = True
-		flowMode = Both
-	}
-	RESOURCE
-	{
-		name = HTP
-		amount = 130
-		maxAmount = 130
+		amount = 332.162
+		maxAmount = 332.162
 		flowState = True
 		isTweakable = True
 		hideFlow = False


### PR DESCRIPTION
Update RN Soyuz, Salyut and TKS configs. Many changes, including:

- Add RealAntenna support patches
- Remove stock fuel cells/life support modules when Kerbalism is present
- Remove crew requirement from command modules and stations. Soviet spacecraft were extensively automated, and should be able to perform basic maneuvers with no crew present.
- Update Soyuz DPO/KTDU thruster performance according to "Soyuz: A Universal Spacecraft" and http://lpre.de/kbhm/index.htm. This includes dropping HTP RCS ISP numbers to sane values, dropping RCS thruster power to 10 kgf for all Soyuz 7K variants, adding HTP consumption to the KTDU-35 to drive turbopumps, and switching Soyuz-T RCS to 13.5 kgf biprop thrusters.
- Double power output of Salyut, Almaz and TKS solar panels. The given values seem to have been for average power output, resulting in stations being severely underpowered, and solar panels with unusually low power outputs for their mass and size compared to contemporaries

Resolves https://github.com/KSP-RO/SalyutStations/issues/8#issuecomment-1094538364