### PR TITLE
Larch prototype configs for Gamma

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma2_Config.cfg
@@ -12,11 +12,26 @@
 //	Thrust (Vac): 68.236 kN
 //	ISP: ??? SL / 267 Vac
 //	Burn Time: 140
-//	Chamber Pressure: 4.7 MPa
+//	Chamber Pressure: 4.1 MPa
 //	Propellant: HTP / RP1
 //	Prop Ratio: 8.2
 //	Throttle: N/A
-//	Nozzle Ratio: 15
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Larch 2
+//	
+//
+//	Dry Mass: ???
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 75.1 kN calculated from RPA exhaust velocity and information on mass flow rate
+//	ISP: ??? SL / 279.4 Vac speculative based on RPA analysis
+//	Burn Time: ???
+//	Chamber Pressure: 6.9 MPa
+//	Propellant: HTP / RP1
+//	Prop Ratio: 7.7
+//	Throttle: N/A
+//	Nozzle Ratio: 32 speculative
 //	Ignitions: 1
 //	=================================================================================
 
@@ -24,6 +39,8 @@
 
 // C. N. Hill - A Vertical Empire:				http://epizodsspace.airbase.ru/bibl/inostr-yazyki/A_Vertical_Empire.pdf
 // Encyclopedia Astronautica - Gamma 2:			http://www.astronautix.com/g/gamma2.html
+// E. Wernimont, M. Ventura, G. Garboden and P. Mullens - Past and Present Uses of Rocket Grade Hydrogen Peroxide:	https://hydrogen-peroxide.us/history-UK/H2O2_Conf_1999-Past_Present_Uses_of_Rocket_Grade_Hydrogen_Peroxide.pdf	
+// David Andrews and Harry Sunley - The Gamma Rocket Engines for Black Knight
 
 //	Used by:
 
@@ -62,9 +79,11 @@
 		modded = false
 		configuration = Gamma-2
 		origMass = 0.173
+
 		CONFIG
 		{
 			name = Gamma-2
+			description = Original Gamma-2 used on all Black Arrow launches
 			specLevel = operational
 			minThrust = 68.236
 			maxThrust = 68.236
@@ -84,6 +103,41 @@
 			{
 				key = 0 267
 				key = 1 189
+			}
+		
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+		}
+		CONFIG
+		{
+			name = Larch-2
+			description = Speculative vacuum Larch based on Gamma-2
+			specLevel = speculative
+			minThrust = 75.1
+			maxThrust = 75.1
+			heatProduction = 100
+			massMult = 0.95		//mass is known to be slightly lower than Gamma
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.18477
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.81523
+			}
+			atmosphereCurve
+			{
+				key = 0 279.4
+				key = 1 200
 			}
 		
 			ullage = True
@@ -119,4 +173,22 @@
 		techTransfer = Gamma-8,Gamma-301,Gamma-201:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-2] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-2]/ratedBurnTime$ } }
+}
+
+// no data, assume same as Gamma 2
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Larch-2]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Larch-2
+		testedBurnTime = 330
+		ratedBurnTime = 140		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		safeOverburn = true
+		ignitionReliabilityStart = 0.968333
+		ignitionReliabilityEnd = 0.995000
+		cycleReliabilityStart = 0.883889
+		cycleReliabilityEnd = 0.981667
+		techTransfer = Gamma-8,Gamma-301,Gamma-201,Gamma-2,Larch-8,Larch-4:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Larch-2] { %ratedBurnTime = #$/TESTFLIGHT[Larch-2]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma301_Config.cfg
@@ -7,39 +7,56 @@
 //	Gamma-201
 //	
 //
-//	Dry Mass: ??? Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 71.17 kN
-//	ISP: 215.39 SL / 240 Vac
+//	Dry Mass: 204 Kg
+//	Thrust (SL): 72.95 kN
+//	Thrust (Vac): 84.3 kN
+//	ISP: 205 SL / 226.9 Vac
 //	Burn Time: 145
 //	Chamber Pressure: 3.28 MPa
 //	Propellant: HTP / RP1
 //	Prop Ratio: 8.2
 //	Throttle: N/A
-//	Nozzle Ratio: 15
+//	Nozzle Ratio: ???
 //	Ignitions: 1
 //	=================================================================================
 //	Gamma-301
 //	
 //
 //	Dry Mass: ??? Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 96.97 kN
+//	Thrust (SL): 75.62-96.08 kN
+//	Thrust (Vac): 96.97 kN dubious- investigate later
 //	ISP: 214.8 SL / 251 Vac
 //	Burn Time: 145
 //	Chamber Pressure: 4.1 MPa
 //	Propellant: HTP / RP1
 //	Prop Ratio: 8.2
 //	Throttle: Throttleable from 96.97 kN to 76.95 kN
-//	Nozzle Ratio: 60
+//	Nozzle Ratio: 15
 //	Ignitions: 1
-///	=================================================================================
+//	=================================================================================
+//	Larch 4
+//	
+//
+//	Dry Mass: ??? Kg
+//	Thrust (SL): ???
+//	Thrust (Vac): 133.447 kN
+//	ISP: 226 SL / 269 Vac
+//	Burn Time: 145
+//	Chamber Pressure: 6.9 MPa
+//	Propellant: HTP / RP1
+//	Prop Ratio: 7.7
+//	Throttle: N/A
+//	Nozzle Ratio: 15
+//	Ignitions: 1
+//	=================================================================================
 
 //	Sources:
 
+//	C. N. Hill - A Vertical Empire:			http://epizodsspace.airbase.ru/bibl/inostr-yazyki/A_Vertical_Empire.pdf
 //	Wikipedia - Bristol Siddeley Gamma:													https://en.wikipedia.org/wiki/Bristol_Siddeley_Gamma#Gamma_201
 //	ukspace.org:																		http://www.spaceuk.org/index.html
 //  [A] History of Liquid Propellant Rocket Engines, George P. Sutton, PageS 852, 856
+//	David Andrews and Harry Sunley - The Gamma Rocket Engines for Black Knight
 
 //	Used by:
 
@@ -76,13 +93,14 @@
 		type = ModuleEngines
 		modded = false
 		configuration = Gamma-201
-		origMass = 0.171	//Assumed half of Gamma-8
+		origMass = 0.204
 		CONFIG
 		{
 			name = Gamma-201
+			description = Early Gamma used on first 14 Black Knight launches, developed from Walter 109-509
 			specLevel = operational
-			minThrust = 71.17
-			maxThrust = 71.17
+			minThrust = 84.3
+			maxThrust = 84.3
 			heatProduction = 100
 			PROPELLANT
 			{
@@ -97,8 +115,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 240
-				key = 1 215.39
+				key = 0 226.9
+				key = 1 205
 			}
 			
 			ullage = True
@@ -110,14 +128,15 @@
 				amount = 0.5
 			}
 		}
-
 		CONFIG
 		{
 			name = Gamma-301
 			specLevel = operational
+			description = Substantially upgraded Gamma based on Stentor sustainer chamber, used on last 8 Black Knight launches and Black Arrow
 			minThrust = 76.95
 			maxThrust = 96.97
 			heatProduction = 100
+			massMult = 1.05		//mass is noted to be a little higher than -201 but no value is given, so this is an estimate
 			PROPELLANT
 			{
 				name = Kerosene
@@ -133,6 +152,40 @@
 			{
 				key = 0 251
 				key = 1 214.8
+			}
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = Larch-4
+			specLevel = prototype
+			description = Improved engine developed by Bristol Siddeley as a replacement for Gamma
+			minThrust = 133.447
+			maxThrust = 133.447
+			heatProduction = 100	//Larch weights less than Gamma-301, so it is assumed here that weight "cancels out"
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.18477
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.81523
+			}
+			atmosphereCurve
+			{
+				key = 0 269
+				key = 1 226
 			}
 			
 			ullage = True
@@ -184,4 +237,22 @@
 		techTransfer = Gamma-201:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-301] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-301]/ratedBurnTime$ } }
+}
+
+// no data, assume same as Gamma 301
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Larch-4]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Larch-4
+		testedBurnTime = 330
+		ratedBurnTime = 145		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		safeOverburn = true
+		ignitionReliabilityStart = 0.968333
+		ignitionReliabilityEnd = 0.995000
+		cycleReliabilityStart = 0.883889
+		cycleReliabilityEnd = 0.981667
+		techTransfer = Gamma-201,Gamma-301,Larch-2,Larch-8:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Larch-4] { %ratedBurnTime = #$/TESTFLIGHT[Larch-4]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Gamma8_Config.cfg
@@ -12,18 +12,34 @@
 //	Thrust (Vac): 256.395 kN
 //	ISP: 217 SL / 251 Vac
 //	Burn Time: 142
-//	Chamber Pressure: 4.7 MPa
+//	Chamber Pressure: 4.1 MPa
 //	Propellant: HTP / RP1
 //	Prop Ratio: 8.2
 //	Throttle: N/A
 //	Nozzle Ratio: 15
 //	Ignitions: 1
-///	=================================================================================
+//	=================================================================================
+//	Larch 8
+//	
+//
+//	Dry Mass: ???
+//	Thrust (SL): ???
+//	Thrust (Vac): 266.893 kN
+//	ISP: 226 SL / 269 Vac
+//	Burn Time: ???
+//	Chamber Pressure: 6.9 MPa
+//	Propellant: HTP / RP1
+//	Prop Ratio: 7.7
+//	Throttle: N/A
+//	Nozzle Ratio: 15
+//	Ignitions: 1
+//	=================================================================================
 
 //	Sources:
 
 // C. N. Hill - A Vertical Empire:			http://epizodsspace.airbase.ru/bibl/inostr-yazyki/A_Vertical_Empire.pdf
-// Encyclopedia Astronautica - Gamma 8:		http://www.astronautix.com/g/gamma8.html
+// E. Wernimont, M. Ventura, G. Garboden and P. Mullens - Past and Present Uses of Rocket Grade Hydrogen Peroxide:	https://hydrogen-peroxide.us/history-UK/H2O2_Conf_1999-Past_Present_Uses_of_Rocket_Grade_Hydrogen_Peroxide.pdf
+// David Andrews and Harry Sunley - The Gamma Rocket Engines for Black Knight
 
 //	Used by:
 
@@ -61,9 +77,11 @@
 		modded = false
 		configuration = Gamma-8
 		origMass = 0.342
+
 		CONFIG
 		{
 			name = Gamma-8
+			description = Original Gamma-8 used on flown Black Arrows
 			specLevel = operational
 			minThrust = 256.395
 			maxThrust = 256.395
@@ -83,6 +101,41 @@
 			{
 				key = 0 251
 				key = 1 217
+			}
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+		}
+                CONFIG
+		{
+			name = Larch-8
+			description = Improved engine developed by Bristol Siddeley as a replacement for Gamma
+			specLevel = prototype
+			minThrust = 266.893
+			maxThrust = 266.893
+			heatProduction = 100
+			massMult = 0.95		//mass is known to be slightly lower than Gamma
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.18477
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.81523
+			}
+			atmosphereCurve
+			{
+				key = 0 269
+				key = 1 226
 			}
 			
 			ullage = True
@@ -117,4 +170,22 @@
 		techTransfer = Gamma-2,Gamma-301,Gamma-201:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[Gamma-8] { %ratedBurnTime = #$/TESTFLIGHT[Gamma-8]/ratedBurnTime$ } }
+}
+
+// no data, assume same as Gamma 8
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[Larch-8]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = Larch-8
+		testedBurnTime = 330
+		ratedBurnTime = 140		//HTP-Kero burns relatively cool and clean, shouldn't have issues overburning
+		safeOverburn = true
+		ignitionReliabilityStart = 0.968333
+		ignitionReliabilityEnd = 0.995000
+		cycleReliabilityStart = 0.883889
+		cycleReliabilityEnd = 0.981667
+		techTransfer = Gamma-2,Gamma-301,Gamma-201,Gamma-8,Larch-2,Larch-4:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[Larch-8] { %ratedBurnTime = #$/TESTFLIGHT[Larch-8]/ratedBurnTime$ } }
 }


### PR DESCRIPTION
Adds prototype Larch configs to all the Gamma engines and corrects stats on Gamma-201/301