### PR TITLE
Fix stock rd-58 nodes

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -161,7 +161,6 @@
 		model = Squad/Parts/Engine/liquidEngineLV-T45/model
 		scale = 1.2154, 1, 1.2154
 	}
-	@scale = 1.0
 	%rescaleFactor = 1.625
 }
 


### PR DESCRIPTION
Broken in #2300 refactoring: scale was changed from 0.1 to 1.0,
nodes were left unchanged and end up meters off.

Don't change the scale and everything lines up.
:HAS[mesh] ensures this only affects the non-restock, non-ven's case;
both replace the mesh with a MODEL.