### PR TITLE
Add Soyuz 7K-OKS, Soyuz-T parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
@@ -2274,6 +2274,10 @@
 @PART[t_bo]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	
+	@title = Soyuz 7K-OKS/7K-T Orbital Module
+	@description = Orbital module for the Soyuz 7K-OKS and 7K-T.
+	
 	@MODEL
 	{
 		@scale = 1.0, 1.0, 1.0
@@ -2376,9 +2380,62 @@
 		}
 	}
 }
++PART[t_bo]:FOR[RealismOverhaul]
+{
+	@name = t_bo2
+	@title = Soyuz-T Orbital Module
+	@description = Orbital Module for Soyuz-T
+	
+	@MODULE[ModuleFuelTanks]
+	{
+		!TANK[HTP] {}
+		TANK
+		{
+			name = UDMH
+			amount = 8.5953
+			maxAmount = 8.5953
+		}
+		TANK
+		{
+			name = NTO
+			amount = 11.4046
+			maxAmount = 11.4046
+		}
+	}
+	
+	!MODULE[ModuleRCS*]
+	{ }
+	
+	MODULE
+	{
+		name = ModuleRCSFX
+		thrusterTransformName = RCSthruster
+		resourceFlowMode = STACK_PRIORITY_SEARCH
+		thrusterPower = 0.132	//13.5 kg thruster used on Soyuz-T, drew from main fuel tanks
+		PROPELLANT
+		{
+			name = UDMH
+			ratio = 0.42976765
+		}
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.57023235
+		}
+		atmosphereCurve
+		{
+			key = 0 251
+			key = 1 144.1
+		}
+	}
+}
 @PART[rn_astp_bo]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	
+	@title = Soyuz ASTP (7K-TM) Orbital Module
+	@description = Orbital module for Soyuz 7K-TM, used for ASTP.
+	
 	@MODEL
 	{
 		@scale = 1.0, 1.0, 1.0
@@ -2857,6 +2914,129 @@
 	}
 }
 
+//copy before we patch the original t_pao2 to make a Soyuz 7K-OKS/7K-TM module
++PART[t_pao2]:FOR[RealismOverhaul]
+{
+	@name = t_pao3
+	@title = Soyuz 7K-OKS/7K-TM Service Module
+	@description = Service module for Soyuz 7K-OKS, later used on Soyuz 7K-TM for ASTP.
+	
+	%RSSROConfig = True
+	@MODEL
+	{
+		@scale = 1.0, 1.0, 1.0
+	}
+	@scale = 1
+	@rescaleFactor = 1
+	@mass = 1.816
+	@maxTemp = 773.15
+	%skinMaxTemp = 873.15
+	%CoMOffset = 0.0, -1.2, 0.0
+	!RESOURCE[MonoPropellant]
+	{ }
+	
+	!RESOURCE[ElectricCharge]
+	{ }
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 698.0513
+		type = ServiceModule
+		basemass = -1
+		TANK
+		{
+			name = UDMH
+			amount = Full
+			maxAmount = 183.9724
+		}
+		TANK
+		{
+			name = AK27
+			amount = Full
+			maxAmount = 244.0789
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = Full
+			maxAmount = 90000	//assuming 7K-OK batteries, since this version still retained solar panels
+		}
+		TANK
+		{
+			name = HTP
+			amount = Full
+			maxAmount = 130
+		}
+	}
+	
+	!MODULE[ModuleRCS*]
+	{ }
+	
+	MODULE
+	{
+		name = ModuleRCSFX
+		thrusterTransformName = RCSthruster
+		resourceFlowMode = STACK_PRIORITY_SEARCH
+		thrusterPower = 0.098	//10 kg thrust on Soyuz 1-40
+		PROPELLANT
+		{
+			name = HTP
+			ratio = 1.0
+		}
+		atmosphereCurve
+		{
+			key = 0 150
+			key = 1 50
+		}
+	}
+	
+	!MODULE[ModuleGenerator]
+	{ }
+	
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Soyuz 7K-OKS Service Module
+		modded = false
+		CONFIG
+		{
+			name = Soyuz 7K-OKS Service Module
+			minThrust = 4.09
+			maxThrust = 4.09
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.42976765
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = AK27
+				ratio = 0.57023235
+			}
+			//KTDU-35 used HTP decomposition to drive pumps
+			PROPELLANT
+			{
+				name = HTP
+				ignoreForIsp = True
+				ratio = 0.0153
+			}
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 112
+			}
+		}
+	}
+}
+
 @PART[t_pao2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -2973,7 +3153,7 @@
 	}
 }
 
-@PART[ok_bo_fem|ok_bo_male|t_bo|rn_astp_bo|tg_bo]:NEEDS[RemoteTech]
+@PART[ok_bo_fem|ok_bo_male|t_bo|t_bo2|rn_astp_bo|tg_bo]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter]
 	{
@@ -2996,13 +3176,13 @@
 }
 
 //RealAntennas config for Soyuz/Progress orbital modules
-@PART[ok_bo_fem|ok_bo_male|t_bo|rn_astp_bo|tg_bo]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+@PART[ok_bo_fem|ok_bo_male|t_bo|t_bo2|rn_astp_bo|tg_bo]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
-@PART[ok_pao|t_pao|t_pao2|ok_tft]:NEEDS[RemoteTech]
+@PART[ok_pao|t_pao|t_pao2|t_pao3|ok_tft]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter]
 	{
@@ -3025,7 +3205,7 @@
 }
 
 //RealAntennas config for for Soyuz/Progress service modules
-@PART[ok_pao|t_pao|t_pao2|ok_tft]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+@PART[ok_pao|t_pao|t_pao2|t_pao3|ok_tft]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Salyut_Soyuz.cfg
@@ -2917,7 +2917,7 @@
 //copy before we patch the original t_pao2 to make a Soyuz 7K-OKS/7K-TM module
 +PART[t_pao2]:FOR[RealismOverhaul]
 {
-	@name = t_pao3
+	@name = oks_pao
 	@title = Soyuz 7K-OKS/7K-TM Service Module
 	@description = Service module for Soyuz 7K-OKS, later used on Soyuz 7K-TM for ASTP.
 	
@@ -3182,7 +3182,7 @@
 	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
-@PART[ok_pao|t_pao|t_pao2|t_pao3|ok_tft]:NEEDS[RemoteTech]
+@PART[ok_pao|t_pao|t_pao2|oks_pao|ok_tft]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter]
 	{
@@ -3205,7 +3205,7 @@
 }
 
 //RealAntennas config for for Soyuz/Progress service modules
-@PART[ok_pao|t_pao|t_pao2|t_pao3|ok_tft]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
+@PART[ok_pao|t_pao|t_pao2|oks_pao|ok_tft]:FOR[RealismOverhaul]:NEEDS[RealAntennas]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	%MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }

--- a/Ships/VAB/RO RN Soyuz 7K-OKS.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-OKS.craft
@@ -1816,8 +1816,8 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	link = t.pao3_4292875794
-	attN = bottom,t.pao3_4292875794
+	link = oks.pao_4292875794
+	attN = bottom,oks.pao_4292875794
 	attN = top,ok.hs_4292103196
 	EVENTS
 	{
@@ -4772,7 +4772,7 @@ PART
 }
 PART
 {
-	part = t.pao3_4292875794
+	part = oks.pao_4292875794
 	partName = Part
 	pos = 5.76972961E-05,38.3801079,0.000538468361
 	attPos = 0,-3.35271835,0
@@ -6113,7 +6113,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao3_4292875794
+	srfN = srfAttach,oks.pao_4292875794
 	EVENTS
 	{
 	}
@@ -6229,7 +6229,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao3_4292875794
+	srfN = srfAttach,oks.pao_4292875794
 	EVENTS
 	{
 	}
@@ -6346,7 +6346,7 @@ PART
 	modMass = 0
 	modSize = 0,0,0
 	link = rn.r7.blok.i.3_4292638144
-	attN = top,t.pao3_4292875794
+	attN = top,oks.pao_4292875794
 	attN = bottom,rn.r7.blok.i.3_4292638144
 	EVENTS
 	{

--- a/Ships/VAB/RO RN Soyuz 7K-OKS.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-OKS.craft
@@ -1816,8 +1816,8 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	link = t.pao2_4292875794
-	attN = bottom,t.pao2_4292875794
+	link = t.pao3_4292875794
+	attN = bottom,t.pao3_4292875794
 	attN = top,ok.hs_4292103196
 	EVENTS
 	{
@@ -4772,7 +4772,7 @@ PART
 }
 PART
 {
-	part = t.pao2_4292875794
+	part = t.pao3_4292875794
 	partName = Part
 	pos = 5.76972961E-05,38.3801079,0.000538468361
 	attPos = 0,-3.35271835,0
@@ -4980,7 +4980,7 @@ PART
 		_numberOfAddedMLILayers = 0
 		partPrevTemperature = -1
 		stagingEnabled = True
-		volume = 868.66150000000005
+		volume = 698
 		EVENTS
 		{
 		}
@@ -5040,8 +5040,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 372.3691
-			maxAmount = 372.3691
+			amount = 0
+			maxAmount = 0
 		}
 		TANK
 		{
@@ -5054,8 +5054,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 276.29239999999999
-			maxAmount = 276.29239999999999
+			amount = 183.9724
+			maxAmount = 183.9724
 		}
 		TANK
 		{
@@ -5558,8 +5558,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 0
-			maxAmount = 0
+			amount = 244.0789
+			maxAmount = 244.0789
 		}
 		TANK
 		{
@@ -5922,8 +5922,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 90000
-			maxAmount = 90000
+			amount = 140000
+			maxAmount = 140000
 		}
 		TANK
 		{
@@ -6005,7 +6005,7 @@ PART
 	{
 		name = ModuleEngineConfigs
 		isEnabled = True
-		configuration = Soyuz T Service Module
+		configuration = Soyuz 7K-OKS Service Module
 		techLevel = -1
 		thrustRating = maxThrust
 		modded = False
@@ -6046,9 +6046,9 @@ PART
 	}
 	RESOURCE
 	{
-		name = NTO
-		amount = 372.3691
-		maxAmount = 372.3691
+		name = AK27
+		amount = 244.0789
+		maxAmount = 244.0789
 		flowState = True
 		isTweakable = True
 		hideFlow = False
@@ -6058,8 +6058,8 @@ PART
 	RESOURCE
 	{
 		name = UDMH
-		amount = 276.29239999999999
-		maxAmount = 276.29239999999999
+		amount = 183.9724
+		maxAmount = 183.9724
 		flowState = True
 		isTweakable = True
 		hideFlow = False
@@ -6113,7 +6113,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao2_4292875794
+	srfN = srfAttach,t.pao3_4292875794
 	EVENTS
 	{
 	}
@@ -6229,7 +6229,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao2_4292875794
+	srfN = srfAttach,t.pao3_4292875794
 	EVENTS
 	{
 	}
@@ -6346,7 +6346,7 @@ PART
 	modMass = 0
 	modSize = 0,0,0
 	link = rn.r7.blok.i.3_4292638144
-	attN = top,t.pao2_4292875794
+	attN = top,t.pao3_4292875794
 	attN = bottom,rn.r7.blok.i.3_4292638144
 	EVENTS
 	{

--- a/Ships/VAB/RO RN Soyuz 7K-TM.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-TM.craft
@@ -3152,8 +3152,8 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	link = t.pao3_4292633008
-	attN = bottom,t.pao3_4292633008
+	link = oks.pao_4292633008
+	attN = bottom,oks.pao_4292633008
 	attN = top,ok.hs_4291673790
 	EVENTS
 	{
@@ -4754,7 +4754,7 @@ PART
 }
 PART
 {
-	part = t.pao3_4292633008
+	part = oks.pao_4292633008
 	partName = Part
 	pos = -2.77161598E-06,37.8701477,3.41236591E-06
 	attPos = 0,-3.75782013,0
@@ -6095,7 +6095,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao3_4292633008
+	srfN = srfAttach,oks.pao_4292633008
 	EVENTS
 	{
 	}
@@ -6211,7 +6211,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao3_4292633008
+	srfN = srfAttach,oks.pao_4292633008
 	EVENTS
 	{
 	}
@@ -6328,7 +6328,7 @@ PART
 	modMass = 0
 	modSize = 0,0,0
 	link = rn.r7.blok.i.5_4293077218
-	attN = top,t.pao3_4292633008
+	attN = top,oks.pao_4292633008
 	attN = bottom,rn.r7.blok.i.5_4293077218
 	EVENTS
 	{

--- a/Ships/VAB/RO RN Soyuz 7K-TM.craft
+++ b/Ships/VAB/RO RN Soyuz 7K-TM.craft
@@ -3152,8 +3152,8 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	link = t.pao2_4292633008
-	attN = bottom,t.pao2_4292633008
+	link = t.pao3_4292633008
+	attN = bottom,t.pao3_4292633008
 	attN = top,ok.hs_4291673790
 	EVENTS
 	{
@@ -4754,7 +4754,7 @@ PART
 }
 PART
 {
-	part = t.pao2_4292633008
+	part = t.pao3_4292633008
 	partName = Part
 	pos = -2.77161598E-06,37.8701477,3.41236591E-06
 	attPos = 0,-3.75782013,0
@@ -4962,7 +4962,7 @@ PART
 		_numberOfAddedMLILayers = 0
 		partPrevTemperature = -1
 		stagingEnabled = True
-		volume = 868.66150000000005
+		volume = 698
 		EVENTS
 		{
 		}
@@ -5022,8 +5022,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 372.3691
-			maxAmount = 372.3691
+			amount = 0
+			maxAmount = 0
 		}
 		TANK
 		{
@@ -5036,8 +5036,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 276.29239999999999
-			maxAmount = 276.29239999999999
+			amount = 183.9724
+			maxAmount = 183.9724
 		}
 		TANK
 		{
@@ -5540,8 +5540,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 0
-			maxAmount = 0
+			amount = 244.0789
+			maxAmount = 244.0789
 		}
 		TANK
 		{
@@ -5987,7 +5987,7 @@ PART
 	{
 		name = ModuleEngineConfigs
 		isEnabled = True
-		configuration = Soyuz T Service Module
+		configuration = Soyuz 7K-OKS Service Module
 		techLevel = -1
 		thrustRating = maxThrust
 		modded = False
@@ -6028,9 +6028,9 @@ PART
 	}
 	RESOURCE
 	{
-		name = NTO
-		amount = 372.3691
-		maxAmount = 372.3691
+		name = AK27
+		amount = 244.0789
+		maxAmount = 244.0789
 		flowState = True
 		isTweakable = True
 		hideFlow = False
@@ -6040,8 +6040,8 @@ PART
 	RESOURCE
 	{
 		name = UDMH
-		amount = 276.29239999999999
-		maxAmount = 276.29239999999999
+		amount = 183.9724
+		maxAmount = 183.9724
 		flowState = True
 		isTweakable = True
 		hideFlow = False
@@ -6095,7 +6095,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao2_4292633008
+	srfN = srfAttach,t.pao3_4292633008
 	EVENTS
 	{
 	}
@@ -6211,7 +6211,7 @@ PART
 	modCost = 0
 	modMass = 0
 	modSize = 0,0,0
-	srfN = srfAttach,t.pao2_4292633008
+	srfN = srfAttach,t.pao3_4292633008
 	EVENTS
 	{
 	}
@@ -6328,7 +6328,7 @@ PART
 	modMass = 0
 	modSize = 0,0,0
 	link = rn.r7.blok.i.5_4293077218
-	attN = top,t.pao2_4292633008
+	attN = top,t.pao3_4292633008
 	attN = bottom,rn.r7.blok.i.5_4293077218
 	EVENTS
 	{

--- a/Ships/VAB/RO RN Soyuz-T.craft
+++ b/Ships/VAB/RO RN Soyuz-T.craft
@@ -31,8 +31,8 @@ PART
 	link = ok.hs_4292103196
 	link = ok-sa-rcs_4292605232
 	link = ok.para_4292027242
-	link = t.bo_4293076906
-	attN = top,t.bo_4293076906
+	link = t.bo2_4293076906
+	attN = top,t.bo2_4293076906
 	attN = bottom,ok.hs_4292103196
 	attN = para,ok.para_4292027242
 	attN = rcs,ok-sa-rcs_4292605232
@@ -2220,7 +2220,7 @@ PART
 }
 PART
 {
-	part = t.bo_4293076906
+	part = t.bo2_4293076906
 	partName = Part
 	pos = 5.76972961E-05,43.0042038,0.000538468361
 	attPos = 0,0,0
@@ -2487,8 +2487,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 0
-			maxAmount = 0
+			amount = 11.4046
+			maxAmount = 11.4046
 		}
 		TANK
 		{
@@ -2501,8 +2501,8 @@ PART
 			temperature = 300
 			fillable = True
 			techRequired = 
-			amount = 0
-			maxAmount = 0
+			amount = 8.5953
+			maxAmount = 8.5953
 		}
 		TANK
 		{
@@ -3467,9 +3467,20 @@ PART
 	}
 	RESOURCE
 	{
-		name = HTP
-		amount = 19.999999805502064
-		maxAmount = 19.999999805502064
+		name = NTO
+		amount = 11.4046
+		maxAmount = 11.4046
+		flowState = True
+		isTweakable = True
+		hideFlow = False
+		isVisible = True
+		flowMode = Both
+	}
+	RESOURCE
+	{
+		name = UDMH
+		amount = 8.5953
+		maxAmount = 8.5953
 		flowState = True
 		isTweakable = True
 		hideFlow = False
@@ -3579,7 +3590,7 @@ PART
 	modMass = 0
 	modSize = 0,0,0
 	link = rn.r7.les.okt_4292914756
-	attN = bottom,t.bo_4293076906
+	attN = bottom,t.bo2_4293076906
 	attN = top,rn.r7.les.okt_4292914756
 	EVENTS
 	{
@@ -3980,7 +3991,7 @@ PART
 	modSize = 0,0,0
 	link = rn.r7.soyuz.fairing2.srb_4292907856
 	sym = rn.r7.soyuz.fairing2_4292717332
-	attN = top,t.bo_4293076906
+	attN = top,t.bo2_4293076906
 	attN = srb,rn.r7.soyuz.fairing2.srb_4292907856
 	EVENTS
 	{
@@ -4388,7 +4399,7 @@ PART
 	modSize = 0,0,0
 	link = rn.r7.soyuz.fairing2.srb_4292717116
 	sym = rn.r7.soyuz.fairing2_4292929420
-	attN = top,t.bo_4293076906
+	attN = top,t.bo2_4293076906
 	attN = srb,rn.r7.soyuz.fairing2.srb_4292717116
 	EVENTS
 	{


### PR DESCRIPTION
Clone parts to create the Soyuz 7K-OKS/7K-TM Service Module, and Soyuz-T orbital module. Also rename some Soyuz parts to make their intended Soyuz version clearer.

Also fix the corresponding craft files (Soyuz 7K-OKS, Soyuz 7K-TM and Soyuz-T)