### PR TITLE
Fix NFE config patching order

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -103,7 +103,7 @@
 //	=================================================================================
 //	RAPID-L reactor
 //	=================================================================================
-@PART[reactor-25]:FOR[zzzRealismOverhaul]
+@PART[reactor-25]:FOR[RealismOverhaul]
 {
 	@title = USDOE RAPID-L Nuclear Reactor
 	@manufacturer = Japan Atomic Energy Research Institute
@@ -132,7 +132,7 @@
 	}
 }
 
-@PART[reactor-25]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[reactor-25]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	// reactor parameters
 	@MODULE[FissionGenerator]
@@ -195,6 +195,7 @@
 	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
 	//if they have not, then the reactor will not be configured
 	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
 	
 	!MODULE[ModuleSystemHeat] {}
 	!MODULE[ModuleSystemHeatFissionReactor] {}
@@ -263,8 +264,8 @@
 			DumpExcess = false
 			FlowMode = NO_FLOW
 		}
-
 	}
+
 	MODULE
 	{
 		name = ModuleSystemHeatFissionFuelContainer
@@ -276,7 +277,7 @@
 //	=================================================================================
 //	SNAP-50 - main source: https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-50/ and references
 //	=================================================================================
-+PART[reactor-25]:FOR[zzzRealismOverhaul]
++PART[reactor-25]:FOR[RealismOverhaul]
 {
 	@name = RO-reactor-snap50
 	%RSSROConfig = True
@@ -309,7 +310,7 @@
 		maxAmount = 21
 	}
 }
-@PART[RO-reactor-snap50]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[RO-reactor-snap50]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	// reactor parameters
 	@MODULE[FissionGenerator]
@@ -366,45 +367,86 @@
 	!MODULE[FissionGenerator] {}
 	!MODULE[ModuleCoreHeatNoCatchup] {}
 	!MODULE[RadioactiveStorageContainer] {}
-	//Since we're cloning a part that already has systemheat modules, edit them rather than make new ones
 	
-	@MODULE[ModuleSystemHeatFissionReactor]
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
 	{
-		@HeatGeneration
+		name = ModuleSystemHeat
+		volume = 10
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
 		{
-			@key,1 = 100 2200
+			key = 0 0 0 0
+			key = 100 2200 0 0
 		}
 
 		// Above this temp, risky
-		@NominalTemperature = 1366
+		NominalTemperature = 1366
 		// Above this temp, reactor takes damage
-		@CriticalTemperature = 1400
+		CriticalTemperature = 1400
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
 
 		// -- Electrical stuff
 		// Power generated
-		@ElectricalGeneration
+		ElectricalGeneration
 		{
-			@key,1 = 100 300
+			key = 0 0
+			key = 100 300
 		}
 
 		// --- Fuel stuff
 		// Base lifetime calculations off this resource
-		@FuelName = UraniumNitride
+		FuelName = UraniumNitride
 
-		@INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
-			@ResourceName = UraniumNitride
-			@Ratio = 0.000000332725 // 2 years of operation
+			ResourceName = UraniumNitride
+			Ratio = 0.000000332725 // 2 years of operation
+			FlowMode = NO_FLOW
 		}
 		@OUTPUT_RESOURCE
 		{
-			@ResourceName = DepletedFuel
-			@Ratio = 0.0000004337254
+			ResourceName = DepletedFuel
+			Ratio = 0.0000004337254
+			DumpExcess = false
+			FlowMode = NO_FLOW
 		}
 	}
-	@MODULE[ModuleSystemHeatFissionFuelContainer]
+
+	MODULE
 	{
-		@ResourceNames = UraniumNitride, DepletedFuel
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = UraniumNitride, DepletedFuel
 	}
 }
 //	=================================================================================
@@ -412,7 +454,7 @@
 //	=================================================================================
 //	TOPAZ-II reactor - main source: http://fti.neep.wisc.edu/neep602/SPRING00/lecture35.pdf
 //	=================================================================================
-@PART[reactor-125]:FOR[zzzRealismOverhaul]
+@PART[reactor-125]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@title = TOPAZ-II Nuclear Reactor
@@ -442,7 +484,7 @@
 	}
 }
 
-@PART[reactor-125]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[reactor-125]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	@MODULE[FissionGenerator]
 	{
@@ -503,6 +545,7 @@
 	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
 	//if they have not, then the reactor will not be configured
 	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
 	
 	!MODULE[ModuleSystemHeat] {}
 	!MODULE[ModuleSystemHeatFissionReactor] {}
@@ -584,7 +627,7 @@
 //	=================================================================================
 //	TOPAZ-I reactor - main source: https://inis.iaea.org/collection/NCLCollectionStore/_Public/25/070/25070118.pdf
 //	=================================================================================
-+PART[reactor-125]:FOR[zzzRealismOverhaul]
++PART[reactor-125]:FOR[RealismOverhaul]
 {
 	@name = RO-reactor-TOPAZI
 	%RSSROConfig = True
@@ -614,7 +657,7 @@
 		maxAmount = 2.2789
 	}
 }
-@PART[RO-reactor-TOPAZI]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[RO-reactor-TOPAZI]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	@MODULE[FissionGenerator]
 	{
@@ -671,46 +714,93 @@
 	!MODULE[FissionGenerator] {}
 	!MODULE[ModuleCoreHeatNoCatchup] {}
 	!MODULE[RadioactiveStorageContainer] {}
-	//Since we're cloning a part that already has systemheat modules, edit them rather than make new ones
 	
-	@MODULE[ModuleSystemHeatFissionReactor]
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
 	{
-		@HeatGeneration
+		name = ModuleSystemHeat
+		volume = 1
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+	
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
 		{
-			@key,1 = 100 100
+			key = 0 0 0 0
+			key = 100 100 0 0
 		}
 
 		// Above this temp, risky
-		@NominalTemperature = 970
+		NominalTemperature = 970
 		// Above this temp, reactor takes damage
-		@CriticalTemperature = 1073
+		CriticalTemperature = 1073
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
 
 		// -- Electrical stuff
 		// Power generated
-		@ElectricalGeneration
+		ElectricalGeneration
 		{
-			@key,1 = 100 5
+			key = 0 0
+			key = 100 5
 		}
 
 		// --- Fuel stuff
 		// Base lifetime calculations off this resource
-		@FuelName = EnrichedUranium
+		FuelName = EnrichedUranium
 
-		@INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
-			@Ratio = 0.000000072213 // 1 years of operation
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000072213 // 1 years of operation
+			FlowMode = NO_FLOW
 		}
-		@OUTPUT_RESOURCE
+		OUTPUT_RESOURCE
 		{
-			@Ratio = 0.000000072213
+			ResourceName = DepletedUranium
+			Ratio = 0.000000072213
+			DumpExcess = false
+			FlowMode = NO_FLOW
 		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedUranium
 	}
 }
 
 //	=================================================================================
 //	BES-5 reactor - main source: http://www.svengrahn.pp.se/trackind/RORSAT/RORSAT.html
 //	=================================================================================
-+PART[reactor-125]:FOR[zzzRealismOverhaul]
++PART[reactor-125]:FOR[RealismOverhaul]
 {
 	@name = RO-reactor-BES5
 	%RSSROConfig = True
@@ -740,7 +830,7 @@
 	}
 }
 
-@PART[RO-reactor-BES5]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[RO-reactor-BES5]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	@MODULE[FissionGenerator]
 	{
@@ -797,47 +887,93 @@
 	!MODULE[FissionGenerator] {}
 	!MODULE[ModuleCoreHeatNoCatchup] {}
 	!MODULE[RadioactiveStorageContainer] {}
-	//Since we're cloning a part that already has systemheat modules, edit them rather than make new ones
 	
-	@MODULE[ModuleSystemHeatFissionReactor]
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
 	{
+		name = ModuleSystemHeat
+		volume = 1
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+	
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
 		// Heat kW
-		@HeatGeneration
+		HeatGeneration
 		{
-			@key,1 = 100 100
+			key = 0 0 0 0
+			key = 100 100 0 0
 		}
 
 		// Above this temp, risky
-		@NominalTemperature = 823
+		NominalTemperature = 823
 		// Above this temp, reactor takes damage
-		@CriticalTemperature = 1073
+		CriticalTemperature = 1073
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
 
 		// -- Electrical stuff
 		// Power generated
-		@ElectricalGeneration
+		ElectricalGeneration
 		{
-			@key,1 = 100 3
+			key = 0 0
+			key = 100 3
 		}
 
 		// --- Fuel stuff
 		// Base lifetime calculations off this resource
-		@FuelName = EnrichedUranium
+		FuelName = EnrichedUranium
 
-		@INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
-			@Ratio = 0.00000026376 // 4 months of operation
+			ResourceName = EnrichedUranium
+			Ratio = 0.00000026376 // 4 months of operation
+			FlowMode = NO_FLOW
 		}
-		@OUTPUT_RESOURCE
+		OUTPUT_RESOURCE
 		{
-			@Ratio = 0.00000026376
+			ResourceName = DepletedUranium
+			Ratio = 0.00000026376
+			DumpExcess = false
+			FlowMode = NO_FLOW
 		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedUranium
 	}
 }
 
 //	=================================================================================
 //	Kilopower - main source: http://anstd.ans.org/NETS-2019-Papers/Track-4--Space-Reactors/abstract-96-0.pdf
 //	=================================================================================
-+PART[reactor-125]:FOR[zzzRealismOverhaul]
++PART[reactor-125]:FOR[RealismOverhaul]
 {
 	@name = RO-reactor-kilopower
 	%RSSROConfig = True
@@ -870,7 +1006,7 @@
 		maxAmount = 3.92
 	}
 }
-@PART[RO-reactor-kilopower]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[RO-reactor-kilopower]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	// reactor parameters
 	@MODULE[FissionGenerator]
@@ -928,39 +1064,86 @@
 	!MODULE[FissionGenerator] {}
 	!MODULE[ModuleCoreHeatNoCatchup] {}
 	!MODULE[RadioactiveStorageContainer] {}
-	//Since we're cloning a part that already has systemheat modules, edit them rather than make new ones
 	
-	@MODULE[ModuleSystemHeatFissionReactor]
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
 	{
-		@HeatGeneration
+		name = ModuleSystemHeat
+		volume = 1
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+	
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
 		{
-			@key,1 = 100 40
+			key = 0 0 0 0
+			key = 100 40 0 0
 		}
 
 		// Above this temp, risky
-		@NominalTemperature = 1073
+		NominalTemperature = 1073
 		// Above this temp, reactor takes damage
-		@CriticalTemperature = 1273
+		CriticalTemperature = 1273
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
 
 		// -- Electrical stuff
 		// Power generated
-		@ElectricalGeneration
+		ElectricalGeneration
 		{
-			@key,1 = 100 10
+			key = 0 0
+			key = 100 10
 		}
 
 		// --- Fuel stuff
 		// Base lifetime calculations off this resource
-		@FuelName = EnrichedUranium
+		FuelName = EnrichedUranium
 
-		@INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
-			@Ratio = 0.000000001055 // around 24MWh in 1g of U235 - only 4% of U235 undergoes fission before fuel is considered depleted
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000001055 // around 24MWh in 1g of U235 - only 4% of U235 undergoes fission before fuel is considered depleted
+			FlowMode = NO_FLOW
 		}
-		@OUTPUT_RESOURCE
+		OUTPUT_RESOURCE
 		{
-			@Ratio = 0.000000001055
+			ResourceName = DepletedUranium
+			Ratio = 0.000000001055
+			DumpExcess = false
+			FlowMode = NO_FLOW
 		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedUranium
 	}
 }
 
@@ -969,7 +1152,7 @@
 //	=================================================================================
 //	SAFE-400 - main source: https://aip.scitation.org/doi/abs/10.1063/1.1449775
 //	=================================================================================
-@PART[reactor-0625]:FOR[zzzRealismOverhaul]
+@PART[reactor-0625]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@title = NASA SAFE-400 Nuclear Reactor
@@ -998,7 +1181,7 @@
 		maxAmount = 9.79
 	}
 }
-@PART[reactor-0625]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[reactor-0625]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	// reactor parameters
 	@MODULE[FissionGenerator]
@@ -1142,7 +1325,7 @@
 //	=================================================================================
 //	SNAP-10A - main source: https://apps.dtic.mil/dtic/tr/fulltext/u2/a146831.pdf
 //	=================================================================================
-+PART[reactor-0625]:FOR[zzzRealismOverhaul]
++PART[reactor-0625]:FOR[RealismOverhaul]
 {
 	@name = RO-reactor-snap10a
 	%RSSROConfig = True
@@ -1172,7 +1355,7 @@
 		maxAmount = 0.271
 	}
 }
-@PART[RO-reactor-snap10a]:FOR[zzzRealismOverhaul]:NEEDS[!SystemHeat]
+@PART[RO-reactor-snap10a]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	// reactor parameters
 	@MODULE[FissionGenerator]
@@ -1230,44 +1413,85 @@
 	!MODULE[FissionGenerator] {}
 	!MODULE[ModuleCoreHeatNoCatchup] {}
 	!MODULE[RadioactiveStorageContainer] {}
-	//Since we're cloning a part that already has systemheat modules, edit them rather than make new ones
 	
-	@MODULE[ModuleSystemHeatFissionReactor]
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
 	{
-		@HeatGeneration
+		name = ModuleSystemHeat
+		volume = 1
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+	
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
 		{
-			@key,1 = 100 30
+			key = 0 0 0 0
+			key = 100 30 0 0
 		}
 
 		// Above this temp, risky
-		@NominalTemperature = 846
+		NominalTemperature = 846
 		// Above this temp, reactor takes damage
-		@CriticalTemperature = 866
+		CriticalTemperature = 866
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
 
 		// -- Electrical stuff
 		// Power generated
-		@ElectricalGeneration
+		ElectricalGeneration
 		{
-			@key,1 = 100 0.59
+			key = 0 0
+			key = 100 0.59
 		}
 
 		// --- Fuel stuff
 		// Base lifetime calculations off this resource
-		@FuelName = EnrichedUranium
+		FuelName = EnrichedUranium
 
-		@INPUT_RESOURCE
+		INPUT_RESOURCE
 		{
-			@ResourceName = EnrichedUranium
-			@Ratio = 0.000000008592 // 1 year
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000008592 // 1 year
+			FlowMode = NO_FLOW
 		}
-		@OUTPUT_RESOURCE
+		OUTPUT_RESOURCE
 		{
-			@ResourceName = DepletedUranium
-			@Ratio = 0.000000008592
+			ResourceName = DepletedUranium
+			Ratio = 0.000000008592
+			DumpExcess = false
+			FlowMode = NO_FLOW
 		}
 	}
-	@MODULE[ModuleSystemHeatFissionFuelContainer]
+
+	MODULE
 	{
-		@ResourceNames = EnrichedUranium, DepletedUranium
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedUranium
 	}
 }


### PR DESCRIPTION
Adjust patching order of NFE configs so they are properly assigned tech nodes if RP-1 is installed. The previous patches tried to be overly clever and avoid patching things that SystemHeat already patches for us, but this resulted in them creating parts after RP-1 ran, leading to said parts not being properly assigned tech nodes. The new patches just erase everything and write configs from scratch after SystemHeat runs.