### PR TITLE
Tweak Heatsink TPS template

### DIFF
--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -129,10 +129,11 @@
 	%thermalMassModifier = 2.8 // 2.28125 = 1825 J/kg-K, correct for Beryllium. But we're boosting it a bit.
 	%skinThermalMassModifier = 1.0 // all one material
 	%skinMassPerArea = 50.0 // 50kg/m^2, so basically half the mass is skin thermal mass, for a heatsink-only part.
-	%skinInternalConductionMult = 0.25
+	%skinInternalConductionMult = 1000
+	%skinSkinConductionMult = 1
 	%emissiveConstant = 0.95
 	
-	%heatConductivity = 0.03 // default is 0.12
+	%heatConductivity = 0.0025 // default is 0.12
 	
 	%heatShieldNoAblator = true
 


### PR DESCRIPTION
These values should work better when used as a separate HS part instead of on the RP-1 Sample Return Capsule.