### PR TITLE
Update NFE reactor fuel types.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -40,13 +40,13 @@
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = EnrichedUranium
 	}
 	!RESOURCE[DepletedFuel] {}
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = #$../RESOURCE[EnrichedUranium]/maxAmount$
 	}
@@ -56,6 +56,14 @@
 	!MODULE[TweakScale]	{}
 	@attachRules = 1,0,1,0,0
 	MODULE[ModuleResourceConverter]:HAS[@OUTPUT_RESOURCE[EnrichedUranium]] {}
+}
+
+@PART[*]:HAS[@MODULE[RadioactiveStorageContainer]]:FOR[RealismOverhaul]
+{
+	@MODULE[RadioactiveStorageContainer]
+	{
+		@EngineerLevelForDangerous = 1
+	}
 }
 
 // RTGs
@@ -124,6 +132,7 @@
 		amount = 0
 		maxAmount = 45.7
 	}
+	//Uranium Nitride, 40% enriched?
 	RESOURCE
 	{
 		name = UraniumNitride
@@ -172,7 +181,7 @@
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = UraniumNitride
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
@@ -303,6 +312,7 @@
 		amount = 0
 		maxAmount = 27.35
 	}
+	//Uranium Nitride, enrichment unknown?
 	RESOURCE
 	{
 		name = UraniumNitride
@@ -472,10 +482,11 @@
 	!RESOURCE,* {}
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 2.461
 	}
+	//Uranium Oxide, 96% enriched
 	RESOURCE
 	{
 		name = EnrichedUranium
@@ -516,14 +527,14 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000019496
 			FlowMode = NO_FLOW
 		}
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = EnrichedUranium
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
@@ -609,7 +620,7 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000019496
 			DumpExcess = false
 			FlowMode = NO_FLOW
@@ -620,7 +631,7 @@
 	{
 		name = ModuleSystemHeatFissionFuelContainer
 		EngineerLevelForTransfer = 1
-		ResourceNames = EnrichedUranium, DepletedUranium
+		ResourceNames = EnrichedUranium, DepletedFuel
 	}
 }
 
@@ -634,7 +645,7 @@
 	@title = TOPAZ-I Nuclear Reactor
 	@manufacturer = Kurchatov Institute of Atomic Energy
 	@description = Thermionic reactor, used in the last 2 Soviet RORSAT satellites. Design lifetime of 1 year.
-	@mass = 0.320	//including shielding?
+	@mass = 0.320	//including shielding, not including power and radiator systems? 930 kg fully assembled?
 	
 	@MODEL
 	{
@@ -646,10 +657,11 @@
 	!RESOURCE,* {}
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 2.2789
 	}
+	//Uranium-Molybdenum alloy, 90% enriched
 	RESOURCE
 	{
 		name = EnrichedUranium
@@ -689,14 +701,14 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000072213
 			FlowMode = NO_FLOW
 		}
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = EnrichedUranium
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
@@ -782,7 +794,7 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000072213
 			DumpExcess = false
 			FlowMode = NO_FLOW
@@ -793,7 +805,7 @@
 	{
 		name = ModuleSystemHeatFissionFuelContainer
 		EngineerLevelForTransfer = 1
-		ResourceNames = EnrichedUranium, DepletedUranium
+		ResourceNames = EnrichedUranium, DepletedFuel
 	}
 }
 
@@ -806,7 +818,7 @@
 	%RSSROConfig = True
 	@title = BES-5 Nuclear Reactor
 	@description = Soviet nuclear reactor, used in the first 31 RORSAT satellites. Intended lifetime of 4 months at full power.
-	@mass = 0.385	//385 kg including shielding
+	@mass = 0.385	//385 kg including shielding, not including power and radiator systems?
 	
 	@MODEL
 	{
@@ -818,10 +830,11 @@
 	!RESOURCE,* {}
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 2.7347
 	}
+	//Uranium-Molybdenum alloy, 90% enriched
 	RESOURCE
 	{
 		name = EnrichedUranium
@@ -862,14 +875,14 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.00000026376
 			FlowMode = NO_FLOW
 		}
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = EnrichedUranium
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
@@ -955,7 +968,7 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.00000026376
 			DumpExcess = false
 			FlowMode = NO_FLOW
@@ -966,7 +979,7 @@
 	{
 		name = ModuleSystemHeatFissionFuelContainer
 		EngineerLevelForTransfer = 1
-		ResourceNames = EnrichedUranium, DepletedUranium
+		ResourceNames = EnrichedUranium, DepletedFuel
 	}
 }
 
@@ -995,10 +1008,11 @@
 	!RESOURCE,* {}
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 3.92
 	}
+	//Uranium-Molybdenum alloy, 93% enriched
 	RESOURCE
 	{
 		name = EnrichedUranium
@@ -1039,14 +1053,14 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000001055
 			FlowMode = NO_FLOW
 		}
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = EnrichedUranium
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
@@ -1132,7 +1146,7 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000001055
 			DumpExcess = false
 			FlowMode = NO_FLOW
@@ -1143,7 +1157,7 @@
 	{
 		name = ModuleSystemHeatFissionFuelContainer
 		EngineerLevelForTransfer = 1
-		ResourceNames = EnrichedUranium, DepletedUranium
+		ResourceNames = EnrichedUranium, DepletedFuel
 	}
 }
 
@@ -1174,6 +1188,7 @@
 		amount = 0
 		maxAmount = 12.76
 	}
+	//Uranium Nitride, unknown enrichment
 	RESOURCE
 	{
 		name = UraniumNitride
@@ -1344,10 +1359,11 @@
 	!RESOURCE,* {}
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 0.271
 	}
+	//Uranium-Zirconium-Hydride, unknown enrichment
 	RESOURCE
 	{
 		name = EnrichedUranium
@@ -1388,14 +1404,14 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000008592
 			FlowMode = NO_FLOW
 		}
 	}
 	@MODULE[RadioactiveStorageContainer]
 	{
-		@DangerousFuel = DepletedUranium
+		@DangerousFuel = DepletedFuel
 		@SafeFuel = EnrichedUranium
 	}
 	@MODULE[ModuleCoreHeatNoCatchup]
@@ -1481,7 +1497,7 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000000008592
 			DumpExcess = false
 			FlowMode = NO_FLOW
@@ -1492,6 +1508,6 @@
 	{
 		name = ModuleSystemHeatFissionFuelContainer
 		EngineerLevelForTransfer = 1
-		ResourceNames = EnrichedUranium, DepletedUranium
+		ResourceNames = EnrichedUranium, DepletedFuel
 	}
 }


### PR DESCRIPTION
Switch all reactor outputs to "depleted fuel". Depleted Uranium does not come from fast reactors.
Also reduce engineer level requirements for working on reactors, since RO/RP-1 doesn't really support Kerbal levels properly.