### PR TITLE
Update LR105 data inheritance

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -590,7 +590,7 @@
 		ignitionReliabilityEnd = 0.993636
 		cycleReliabilityStart = 0.963661
 		cycleReliabilityEnd = 0.993636
-		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-6,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-6,LR105-NA-5,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.1] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.1]/ratedBurnTime$ } }
 }
@@ -608,7 +608,7 @@
 		ignitionReliabilityEnd = 0.993636
 		cycleReliabilityStart = 0.963661
 		cycleReliabilityEnd = 0.993636
-		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-7.1,LR105-NA-6,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
+		techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR105-NA-7.1,LR105-NA-6,LR105-NA-5,LR105-NA-3,LR43-NA-5,XLR43-NA-3:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[LR105-NA-7.2] { %ratedBurnTime = #$/TESTFLIGHT[LR105-NA-7.2]/ratedBurnTime$ } }
 }


### PR DESCRIPTION
Change LR105-NA-7.1 and 7.2 configs to inherit test data from LR105-NA-5 config.

These get data from the NA-3 and NA-6 configs, so I'm assuming it was a copy/paste error or oversight that they don't pull data from the NA-5 config.