### PR TITLE
Fix SXTAntenna

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -64,14 +64,13 @@
 	@manufacturer = NPO Energomash
 	@description = Small whip antenna for the Sputnik PS-1 satellite.
 
-	MODULE
+	@MODULE[ModuleDataTransmitter]
 	{
-		name = ModuleDataTransmitter
-		packetInterval = 0.6
-		packetSize = 2
-		packetResourceCost = 0.005
-		requiredResource = ElectricCharge
-		DeployFxModules = 0
+		@packetInterval = 0.6
+		@packetSize = 2
+		@packetResourceCost = 0.005
+		@requiredResource = ElectricCharge
+		@DeployFxModules = 0
 	}
 }
 


### PR DESCRIPTION
RO adds a second ModuleDataTransmitter to the PS-1 antenna instead of editing the existing one. This is not only messy, but also breaks RA compatibility. Change patches to edit existing antenna module instead.