### PR TITLE
Updated rescale factors for non-generic MLP launch pads.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
@@ -1,7 +1,7 @@
 @PART[AM_MLP*|MountPlatform_MLP]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.61
-    %RSSROConfig = True
+	%rescaleFactor = 1.61
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -14,12 +14,7 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 @PART[AM_MLP*|MountPlatform_MLP]:HAS[@MODULE[LaunchClamp]]:FOR[RealismOverhaul]
 {
@@ -30,13 +25,13 @@
 	%skinInternalConductionMult = 0.25
 }
 
-// Custom rescale factors added by hallucinogender
+// Custom rescale factors:
 
 // Atlas
 @PART[AM_MLP_Atlas*,AM_MLP_LaunchStandCrewElevatorAtlas,AM_MLP_CrewElevatorAtlasUmbilical,AM_MLP_LaunchStandCrewWalkwayMercury]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.6
-    %RSSROConfig = True
+	%rescaleFactor = 1.6
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -49,19 +44,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Atlas V
 @PART[AM_MLP_GeneralTowerAtlasV,AM_MLP_SpecialServiceTowerAtlasV*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.524
-    %RSSROConfig = True
+	%rescaleFactor = 1.524
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -74,19 +64,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Delta IV
 @PART[AM_MLP_Delta4*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.632
-    %RSSROConfig = True
+	%rescaleFactor = 1.632
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -99,19 +84,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Energia
 @PART[AM_MLP_LaunchPlateEnergia]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.55
-    %RSSROConfig = True
+	%rescaleFactor = 1.55
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -124,19 +104,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // N1
 @PART[AM_MLP_LaunchPlateN1]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.575
-    %RSSROConfig = True
+	%rescaleFactor = 1.575
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -149,19 +124,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Redstone
 @PART[AM_MLP_LaunchStandCrewElevatorMercury,AM_MLP_JupiterPetalCover,AM_MLP_RedstoneLaunchStand,AM_MLP_LaunchStandSmallPole]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.424
-    %RSSROConfig = True
+	%rescaleFactor = 1.424
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -174,20 +144,15 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Saturn
 // Apollo and the different Saturn stages have slightly different scale factors. I am currently using the Apollo factor.
 @PART[AM_MLP_LargeLaunchStand,AM_MLP_Saturn*,AM_MLP_HoldArmSaturn*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.56
-    %RSSROConfig = True
+	%rescaleFactor = 1.56
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -200,19 +165,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Shuttle
 @PART[AM_MLP_Shuttle*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.733333333
-    %RSSROConfig = True
+	%rescaleFactor = 1.733333333
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -225,19 +185,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Soyuz
 @PART[AM_MLP_SoyuzLaunchBase*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.43
-    %RSSROConfig = True
+	%rescaleFactor = 1.43
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -250,19 +205,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Thor
 @PART[AM_MLP_GeneralTowerDeltaII,AM_MLP_SpecialServiceTowerDeltaII*,AM_MLP_Thor*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.626666667
-    %RSSROConfig = True
+	%rescaleFactor = 1.626666667
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -275,19 +225,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Titan
 @PART[AM_MLP_GeneralServiceTowerXL*,AM_MLP_Titan*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.626666667
-    %RSSROConfig = True
+	%rescaleFactor = 1.626666667
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -300,19 +245,14 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }
 
 // Vanguard
 @PART[AM_MLP_Vanguard*]:FOR[RealismOverhaul]
 {
-    %rescaleFactor = 1.216
-    %RSSROConfig = True
+	%rescaleFactor = 1.216
+	%RSSROConfig = True
 	@MODULE[ModuleB9PartSwitch],*
 	{
 		@SUBTYPE,*
@@ -325,10 +265,5 @@
 			}
 		}
 	}
-	!MODULE[ModuleGenerator] {}
-	
-	@MODULE[ModuleAnimatedDecoupler],*
-    {
-        @name = ModuleStagedAnimation
-    }
+	!MODULE[ModuleGenerator] {}	
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
@@ -30,9 +30,7 @@
 	%skinInternalConductionMult = 0.25
 }
 
-// Custom rescale factors
-// Subject to future change
-// I think every launch pad with a real rocket is covered except the N1 (because I am unsure of the scale factor for it), but if any parts are missing please let me know so I can fix them.
+// Custom rescale factors added by hallucinogender
 
 // Atlas
 @PART[AM_MLP_Atlas*,AM_MLP_LaunchStandCrewElevatorAtlas,AM_MLP_CrewElevatorAtlasUmbilical,AM_MLP_LaunchStandCrewWalkwayMercury]:FOR[RealismOverhaul]
@@ -123,6 +121,31 @@
 				@position,*[0,,] /= 1.55
 				@position,*[1,,] /= 1.55
 				@position,*[2,,] /= 1.55
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// N1
+@PART[AM_MLP_LaunchPlateN1]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.575
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.575
+				@position,*[1,,] /= 1.575
+				@position,*[2,,] /= 1.575
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
@@ -30,3 +30,282 @@
 	%skinInternalConductionMult = 0.25
 }
 
+// Custom rescale factors
+// Subject to future change
+// I think every launch pad with a real rocket is covered except the N1 (because I am unsure of the scale factor for it), but if any parts are missing please let me know so I can fix them.
+
+// Atlas
+@PART[AM_MLP_Atlas*,AM_MLP_LaunchStandCrewElevatorAtlas,AM_MLP_CrewElevatorAtlasUmbilical,AM_MLP_LaunchStandCrewWalkwayMercury]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.6
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.6
+				@position,*[1,,] /= 1.6
+				@position,*[2,,] /= 1.6
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Atlas V
+@PART[AM_MLP_GeneralTowerAtlasV,AM_MLP_SpecialServiceTowerAtlasV*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.524
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.524
+				@position,*[1,,] /= 1.524
+				@position,*[2,,] /= 1.524
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Delta IV
+@PART[AM_MLP_Delta4*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.632
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.632
+				@position,*[1,,] /= 1.632
+				@position,*[2,,] /= 1.632
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Energia
+@PART[AM_MLP_LaunchPlateEnergia]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.55
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.55
+				@position,*[1,,] /= 1.55
+				@position,*[2,,] /= 1.55
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Redstone
+@PART[AM_MLP_LaunchStandCrewElevatorMercury,AM_MLP_JupiterPetalCover,AM_MLP_RedstoneLaunchStand,AM_MLP_LaunchStandSmallPole]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.424
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.424
+				@position,*[1,,] /= 1.424
+				@position,*[2,,] /= 1.424
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Saturn
+// Apollo and the different Saturn stages have slightly different scale factors. I am currently using the Apollo factor.
+@PART[AM_MLP_LargeLaunchStand,AM_MLP_Saturn*,AM_MLP_HoldArmSaturn*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.56
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.56
+				@position,*[1,,] /= 1.56
+				@position,*[2,,] /= 1.56
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Shuttle
+@PART[AM_MLP_Shuttle*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.733333333
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.733333333
+				@position,*[1,,] /= 1.733333333
+				@position,*[2,,] /= 1.733333333
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Soyuz
+@PART[AM_MLP_SoyuzLaunchBase*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.43
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.43
+				@position,*[1,,] /= 1.43
+				@position,*[2,,] /= 1.43
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Thor
+@PART[AM_MLP_GeneralTowerDeltaII,AM_MLP_SpecialServiceTowerDeltaII*,AM_MLP_Thor*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.626666667
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.626666667
+				@position,*[1,,] /= 1.626666667
+				@position,*[2,,] /= 1.626666667
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Titan
+@PART[AM_MLP_GeneralServiceTowerXL*,AM_MLP_Titan*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.626666667
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.626666667
+				@position,*[1,,] /= 1.626666667
+				@position,*[2,,] /= 1.626666667
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}
+
+// Vanguard
+@PART[AM_MLP_Vanguard*]:FOR[RealismOverhaul]
+{
+    %rescaleFactor = 1.216
+    %RSSROConfig = True
+	@MODULE[ModuleB9PartSwitch],*
+	{
+		@SUBTYPE,*
+		{
+			@NODE,*
+			{
+				@position,*[0,,] /= 1.216
+				@position,*[1,,] /= 1.216
+				@position,*[2,,] /= 1.216
+			}
+		}
+	}
+	!MODULE[ModuleGenerator] {}
+	
+	@MODULE[ModuleAnimatedDecoupler],*
+    {
+        @name = ModuleStagedAnimation
+    }
+}


### PR DESCRIPTION
Patched unique rescale factors for non-generic MLP launch pads. Every MLP part associated with a specific vehicle (with the current exception of the N1 pad) now has a unique rescale factor that should be correct for the real vehicle scale, unless I have erroneously missed something. Apologies if I have made some error with submitting this pull request, as this is my first time doing so.