### PR TITLE
Update HM-7 config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HM7_Config.cfg
@@ -7,16 +7,16 @@
 //	HM-7
 //	Ariane 1
 //
-//	Dry Mass: 165 Kg
+//	Dry Mass: 150 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 63 kN
-//	ISP: ??? SL / 444 Vac
+//	Thrust (Vac): 62.4 kN
+//	ISP: ??? SL / 440.8 Vac
 //	Burn Time: 570
-//	Chamber Pressure: 3.5 MPa
+//	Chamber Pressure: 3.0 MPa	//Sutton numbers seem to associated to the incorrect engines. Use "Performance Characteristics of the HM7 Rocket Engine for the Ariane Launcher" for HM-7 and HM-7B
 //	Propellant: LOX / LH2
-//	Prop Ratio: 4.30
+//	Prop Ratio: 4.61
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 63.5
 //	Ignitions: 1
 //	=================================================================================
 //	HM-7B
@@ -25,13 +25,13 @@
 //	Dry Mass: 165 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 64.2 kN
-//	ISP: ??? SL / 446 Vac
-//	Burn Time: 570
-//	Chamber Pressure: 3.7 MPa
+//	ISP: ??? SL / 443.2 Vac
+//	Burn Time: 730
+//	Chamber Pressure: 3.5 MPa	//Sutton numbers seem to associated to the incorrect engines. Use "Performance Characteristics of the HM7 Rocket Engine for the Ariane Launcher" for HM-7 and HM-7B
 //	Propellant: LOX / LH2
-//	Prop Ratio: 4.51
+//	Prop Ratio: 4.61
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 74.1
 //	Ignitions: 1
 //	=================================================================================
 //	HM-7B+
@@ -40,9 +40,9 @@
 //	Dry Mass: 165 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 64.6 kN
-//	ISP: ??? SL / 444.2 Vac
-//	Burn Time: 570
-//	Chamber Pressure: 3.43 MPa
+//	ISP: ??? SL / 446 Vac
+//	Burn Time: 780
+//	Chamber Pressure: 3.7 MPa	//Sutton HM-7B numbers seem to actually be HM-7B+
 //	Propellant: LOX / LH2
 //	Prop Ratio: 4.61
 //	Throttle: N/A
@@ -56,7 +56,7 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 64.8 kN
 //	ISP: ??? SL / 445.6 Vac
-//	Burn Time: 570
+//	Burn Time: 980
 //	Chamber Pressure: 3.66 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 4.86
@@ -64,12 +64,6 @@
 //	Nozzle Ratio: 83.1
 //	Ignitions: 1
 //	=================================================================================
-//	HM-7 series engine global engine configuration.
-
-//	Inert Mass: 165 Kg
-//	Throttle Range: N/A
-//	Burn Time: 570 s (HM-7), 950 s (HM-7B)
-//	O/F Ratio: 5.0 (on average, varies between 4.5 and 5.15)
 
 //	Sources:
 //		http://www.space-propulsion.com/launcher-propulsion/rocket-engines/hm7b-rocket-engine.html
@@ -138,21 +132,21 @@
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.7893
+				ratio = 0.7774
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.2107
+				ratio = 0.2226
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
-				key = 0 440.0
-				key = 1 308
+				key = 0 440.8
+				key = 1 200
 			}
 		}
 
@@ -178,21 +172,21 @@
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.7812
+				ratio = 0.7774
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.2188
+				ratio = 0.2226
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
-				key = 0 444
-				key = 1 310
+				key = 0 443.2
+				key = 1 200
 			}
 		}
 		
@@ -232,7 +226,7 @@
 			atmosphereCurve
 			{
 				key = 0 446
-				key = 1 310
+				key = 1 200
 			}
 		}
 		
@@ -285,7 +279,9 @@
 	TESTFLIGHT
 	{
 		name = HM-7
+		testedBurnTime = 1000	//~1000 seconds before creep failure
 		ratedBurnTime = 570
+		safeOverburn = true
 		ignitionReliabilityStart = 0.931818
 		ignitionReliabilityEnd = 0.986364
 		cycleReliabilityStart = 0.840909
@@ -314,7 +310,9 @@
 	TESTFLIGHT
 	{
 		name = HM-7B
+		testedBurnTime = 1300	//~1300 seconds before creep failure
 		ratedBurnTime = 730
+		safeOverburn = true
 		ignitionReliabilityStart = 0.941944
 		ignitionReliabilityEnd = 0.990833
 		cycleReliabilityStart = 0.961782
@@ -337,7 +335,9 @@
 	TESTFLIGHT
 	{
 		name = HM-7B+
-		ratedBurnTime = 980
+		testedBurnTime = 2000	//~2000 seconds before creep failure target
+		ratedBurnTime = 780
+		safeOverburn = true
 		ignitionReliabilityStart = 0.987162
 		ignitionReliabilityEnd = 0.997973
 		cycleReliabilityStart = 0.970045
@@ -356,7 +356,9 @@
 	TESTFLIGHT
 	{
 		name = HM-7B++
-		ratedBurnTime = 980
+		testedBurnTime = 2000	//~2000 seconds before creep failure target
+		ratedBurnTime = 950
+		safeOverburn = true
 		ignitionReliabilityStart = 0.987333
 		ignitionReliabilityEnd = 0.998000
 		cycleReliabilityStart = 0.987162


### PR DESCRIPTION
Update and clean up HM-7 config. Based on information from "Performance Characteristics of the HM7 Rocket Engine for the Ariane Launcher" published by Societe Europeenne de Propulsion, it seems like Sutton mixed performance data of the HM-7B and HM-7B+ models. The configs have been updated to use Societe Europeenne de Propulsion data for the HM-7 and HM-7B, and Sutton data for the HM-7B+ and B++.