### PR TITLE
Fix XLR35 testedBurnTime

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
@@ -443,7 +443,6 @@
 	TESTFLIGHT // No data except for 2 failures on 3 test flights, keeping same
 	{
 		name = XLR35-RM-1
-		testedBurnTime = 3600
 		ratedBurnTime = 220   // Not listed, assuming slightly longer than base XLR11
 		safeOverburn = true
 		testedBurnTime = 900 // guess


### PR DESCRIPTION
2 testedBurnTime values provided, first one wins, second one is "correct"

Confirmed fix in MM cache: a key=3600 becomes key=900