### PR TITLE
Change plane cockpits to Plane vesselType

### DIFF
--- a/GameData/RealismOverhaul/Parts/NoseconeCockpit/Nosecone_cockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/NoseconeCockpit/Nosecone_cockpit.cfg
@@ -54,7 +54,7 @@ PART
 	breakingTorque = 2000
 	
 	
-	vesselType = Ship
+	vesselType = Plane
 
 	// --- internal setup ---
 	CrewCapacity = 1

--- a/GameData/RealismOverhaul/Parts/X1Cockpit/X1Cockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/X1Cockpit/X1Cockpit.cfg
@@ -54,7 +54,7 @@ PART
 	skinInternalConductionMult = 0.25
 	
 	
-	vesselType = Ship
+	vesselType = Plane
 
 	// --- internal setup ---
 	CrewCapacity = 1

--- a/GameData/RealismOverhaul/REWORK/RO_SXT_fuselage.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_SXT_fuselage.cfg
@@ -62,6 +62,7 @@
 	@description =  Cockpit of the Antonov An-124, diameter is 6.75m.
 	@mass = 9
 	@rescaleFactor = 1.8
+	%vesselType = Plane
 }
 
 @PART[SXTOsualRadCockpit]:AFTER[RealFuels]
@@ -71,6 +72,7 @@
 	@description =  Radial Cockpit of the Antonov An-124
 	@mass = 5
 	@rescaleFactor = 1.8
+	%vesselType = Plane
 }
 
 @PART[SXTOsualRadHull]:AFTER[RealFuels]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Bonanza.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Bonanza.cfg
@@ -87,6 +87,7 @@
 	@maxTemp = 405
 	%skinMaxTemp = 415
 	//@CrewCapacity = 6
+	%vesselType = Plane
 	
 	@RESOURCE[ElectricCharge]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -339,6 +339,7 @@
 	@mass = 0.4
 	@maxTemp = 405
 	%skinMaxTemp = 415
+	%vesselType = Plane
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 7200
@@ -382,6 +383,7 @@
 	// Rescale to 5.9m x 4.0m x 3.3m
 	@node_stack_bottom = 0.0, -1.3125, 0.0, 0, -1, 0, 3
 	@mass = 3.5 //total guess
+	%vesselType = Plane
 	@MODEL
 	{
 		%scale = 1.05, 1.05, 1.04
@@ -413,6 +415,7 @@
 	// Rescale to 15,0m x 3,1m x 3,1m
 	@node_stack_bottom = 0.0, -4.9, 0.0, 0, -1, 0, 2
 	@mass = 3.5 //total guess
+	%vesselType = Plane
 	@MODEL
 	{
 		%scale = 1.24, 1.40, 1.24
@@ -446,6 +449,7 @@
 	@node_stack_bottom = 0.0, -0.85, 0.0, 0, -1, 0, 2
 	@maxTemp = 405
 	%skinMaxTemp = 415
+	%vesselType = Plane
 	@MODEL
 	{
 		%scale = 1.36, 1.36, 1.36
@@ -496,6 +500,7 @@
 	@mass = 2.8 // total guess
 	// Rescale from 2.5m to 3.8m. 
 	@node_stack_bottom = 0.0, -1.91, 0.0, 0, -1, 0, 2
+	%vesselType = Plane
 	@MODEL
 	{
 		%scale = 1.504, 1.625, 1.504
@@ -541,6 +546,7 @@
 	@mass = 0.7 // guess based on DHC-3 Otter empty mass
 	@maxTemp = 405 // same as Bonanza
 	%skinMaxTemp = 415 // same as Bonanza
+	%vesselType = Plane
 	@RESOURCE[ElectricCharge]
 	{
 		@amount = 7200


### PR DESCRIPTION
Make the usual plane cockpits start as a plane instead of a ship. This helps with some other mods that use vessel type. Example SpeedUnitAnnex.