### PR TITLE
Fix oxygen on F-10x cockpits

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AviationCockpits/Cockpits.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AviationCockpits/Cockpits.cfg
@@ -288,11 +288,11 @@
 			amount = 10800
 			maxAmount = 10800
 		}
-		TANK
+		UNMANAGED_RESOURCE
 		{
 			name = Oxygen
-			amount = 46
-			maxAmount = 46
+			amount = 50
+			maxAmount = 50
 		}
 		TANK
 		{
@@ -460,7 +460,7 @@
 			amount = 21600
 			maxAmount = 21600
 		}
-		TANK
+		UNMANAGED_RESOURCE
 		{
 			name = Oxygen
 			amount = 100


### PR DESCRIPTION
Based on similar fix for X-15. A MFT Tank of O2 is unavailable in
RP-1 until the first Life Support node is unlocked; an
UMANAGED_RESOURCE works.