### PR TITLE
Updating RD-119 config according to new data

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -41,6 +41,7 @@
 //	JBIS Vol. 54 - Rocket Engines from the Glushko Design Bureau:							https://faculty.fordham.edu/siddiqi/writings/p17_siddiqi_glushko_rocket_engines_2001.pdf
 //	astronautix - RD-109:																	http://www.astronautix.com/r/rd-109.html
 //	Google Books - "Satan" and "Governor". The most formidable nuclear weapon in the world:	https://books.google.by/books?id=D-c5DQAAQBAJ&pg=PA53&lpg=PA53&dq=11%D0%B449+%D1%82%D1%80%D0%B5%D1%85%D1%80%D0%B5%D0%B6%D0%B8%D0%BC%D0%BD%D1%8B%D0%B9&source=bl&ots=GUOLiPbCo3&sig=ACfU3U2kM4lIDRQ_7y0XDznHmJ8oxRZFcg&hl=ru&sa=X&ved=2ahUKEwj1m-2qsInnAhXIMewKHcv4AfUQ6AEwAHoECAoQAQ#v=onepage&q=11%D0%B449%20%D1%82%D1%80%D0%B5%D1%85%D1%80%D0%B5%D0%B6%D0%B8%D0%BC%D0%BD%D1%8B%D0%B9&f=false
+//	N.K. MATVEEV, A.A. SEMENOV, RD-119 ENGINE DESIGN (Russian paper, 'Н.К. МАТВЕЕВ, А.А. СЕМЁНОВ, УСТРОЙСТВО ДВИГАТЕЛЯ РД-119'): http://library.voenmeh.ru/cnau/elr03216.pdf
 
 //	Used by:
 
@@ -116,8 +117,8 @@
 			name = RD-119-8D710
 			description = Upper stage for Kosmos-2 (11K63). Warning: only rated for 90 minutes before restart.
 			specLevel = operational
-			minThrust = 105.5
-			maxThrust = 105.5
+			minThrust = 96.43
+			maxThrust = 100.5
 			massMult = 0.8	//168 kg
 			heatProduction = 100
 			PROPELLANT
@@ -133,7 +134,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 352
+				key = 0 362
 				key = 1 220
 			}
 			


### PR DESCRIPTION
According to new data source, RD-119 should have 362 s isp and 100,5 kn of thrust (instead of current 352 and 105,5), as well as 5% throttle range.
Taking into account the bibliographic list and the authority of the paper ('Н.К. МАТВЕЕВ, А.А. СЕМЁНОВ, УСТРОЙСТВО ДВИГАТЕЛЯ РД-119'), these data can be considered more reliable than the available ones (current config contains links to aggregators of lower reliability and foreign sources).