### PR TITLE
Add some early tech transfer to RD-100, RD-200, and RD-107/108

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -425,7 +425,7 @@
 		ignitionDynPresFailMultiplier = 2.0
 		cycleReliabilityStart = 0.8
 		cycleReliabilityEnd = 0.92
-		techTransfer = RD-101:50
+		techTransfer = RD-100:25&RD-101:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-102] { %ratedBurnTime = #$/TESTFLIGHT[RD-102]/ratedBurnTime$ } }
@@ -442,7 +442,7 @@
 		ignitionDynPresFailMultiplier = 2.0
 		cycleReliabilityStart = 0.82
 		cycleReliabilityEnd = 0.91
-		techTransfer = RD-102:50
+		techTransfer = RD-100:25&RD-102,RD-101:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-103] { %ratedBurnTime = #$/TESTFLIGHT[RD-103]/ratedBurnTime$ } }
@@ -459,7 +459,7 @@
 		ignitionDynPresFailMultiplier = 2.0
 		cycleReliabilityStart = 0.84
 		cycleReliabilityEnd = 0.92
-		techTransfer = RD-103:50
+		techTransfer = RD-102,RD-101,RD-100:25&RD-103:50
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-103M] { %ratedBurnTime = #$/TESTFLIGHT[RD-103M]/ratedBurnTime$ } }

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -760,7 +760,7 @@
 		ignitionReliabilityEnd = 0.982061
 		cycleReliabilityStart = 0.886387
 		cycleReliabilityEnd = 0.982061
-		techTransfer = RD-200:25
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25
 		
 		reliabilityMidH = 0.6
 		reliabilityDataRateMultiplier = 0.4
@@ -782,7 +782,7 @@
 		ignitionReliabilityEnd = 0.986364
 		cycleReliabilityStart = 0.913636
 		cycleReliabilityEnd = 0.986364
-		techTransfer = RD-200:25&RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D74:50
 		
 		reliabilityMidH = 0.55
 		reliabilityDataRateMultiplier = 0.4
@@ -804,7 +804,7 @@
 		ignitionReliabilityEnd = 0.968182
 		cycleReliabilityStart = 0.798485
 		cycleReliabilityEnd = 0.968182
-		techTransfer = RD-200:25&RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -826,7 +826,7 @@
 		ignitionReliabilityEnd = 0.985606
 		cycleReliabilityStart = 0.908838
 		cycleReliabilityEnd = 0.985606
-		techTransfer = RD-200:25&RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -847,7 +847,7 @@
 		ignitionReliabilityEnd = 0.997727
 		cycleReliabilityStart = 0.985606
 		cycleReliabilityEnd = 0.997727
-		techTransfer = RD-200:25&RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -869,7 +869,7 @@
 		ignitionReliabilityEnd = 0.999794
 		cycleReliabilityStart = 0.998693
 		cycleReliabilityEnd = 0.999794
-		techTransfer = RD-200:25&RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -895,7 +895,7 @@
 		ignitionReliabilityEnd = 0.999893
 		cycleReliabilityStart = 0.999322
 		cycleReliabilityEnd = 0.999893
-		techTransfer = RD-200:25&RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -916,7 +916,7 @@
 		ignitionReliabilityEnd = 0.999807
 		cycleReliabilityStart = 0.998776
 		cycleReliabilityEnd = 0.999807
-		techTransfer = RD-200:25&RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -937,7 +937,7 @@
 		ignitionReliabilityEnd = 0.999584
 		cycleReliabilityStart = 0.997368
 		cycleReliabilityEnd = 0.999584
-		techTransfer = RD-200:25&RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}
@@ -960,7 +960,7 @@
 		ignitionReliabilityEnd = 0.999660
 		cycleReliabilityStart = 0.997846
 		cycleReliabilityEnd = 0.999660
-		techTransfer = RD-200:25&RD-107-11D511P,RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-107-11D511P,RD-107-11D511,RD-107-8D728,RD-107-8D74K,RD-107-8D74-1959,RD-107-8D74-1958,RD-107-8D76,RD-107-8D74PS,RD-107-8D74:50
 		
 		reliabilityDataRateMultiplier = 0.4
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -768,7 +768,7 @@
 		ignitionReliabilityEnd = 0.982061
 		cycleReliabilityStart = 0.886387
 		cycleReliabilityEnd = 0.982061
-		techTransfer = RD-200:25
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25
 		
 		reliabilityMidH = 0.6
 	}
@@ -789,7 +789,7 @@
 		ignitionReliabilityEnd = 0.986364
 		cycleReliabilityStart = 0.913636
 		cycleReliabilityEnd = 0.986364
-		techTransfer = RD-200:25&RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D75:50
 		
 		reliabilityMidH = 0.55
 	}
@@ -810,7 +810,7 @@
 		ignitionReliabilityEnd = 0.968182
 		cycleReliabilityStart = 0.798485
 		cycleReliabilityEnd = 0.968182
-		techTransfer = RD-200:25&RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D77] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D77]/ratedBurnTime$ } }
 }
@@ -830,7 +830,7 @@
 		ignitionReliabilityEnd = 0.985606
 		cycleReliabilityStart = 0.908838
 		cycleReliabilityEnd = 0.985606
-		techTransfer = RD-200:25&RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75-1958] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75-1958]/ratedBurnTime$ } }
 }
@@ -849,7 +849,7 @@
 		ignitionReliabilityEnd = 0.997727
 		cycleReliabilityStart = 0.985606
 		cycleReliabilityEnd = 0.997727
-		techTransfer = RD-200:25&RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75-1959] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75-1959]/ratedBurnTime$ } }
 }
@@ -869,7 +869,7 @@
 		ignitionReliabilityEnd = 0.999794
 		cycleReliabilityStart = 0.998693
 		cycleReliabilityEnd = 0.999794
-		techTransfer = RD-200:25&RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D75K] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D75K]/ratedBurnTime$ } }
 }
@@ -893,7 +893,7 @@
 		ignitionReliabilityEnd = 0.999893
 		cycleReliabilityStart = 0.999322
 		cycleReliabilityEnd = 0.999893
-		techTransfer = RD-200:25&RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-8D727] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-8D727]/ratedBurnTime$ } }
 }
@@ -912,7 +912,7 @@
 		ignitionReliabilityEnd = 0.999807
 		cycleReliabilityStart = 0.998776
 		cycleReliabilityEnd = 0.999807
-		techTransfer = RD-200:25&RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-11D512] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-11D512]/ratedBurnTime$ } }
 }
@@ -931,7 +931,7 @@
 		ignitionReliabilityEnd = 0.999584
 		cycleReliabilityStart = 0.997368
 		cycleReliabilityEnd = 0.999584
-		techTransfer = RD-200:25&RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108-11D512P] { %ratedBurnTime = #$/TESTFLIGHT[RD-108-11D512P]/ratedBurnTime$ } }
 }
@@ -952,7 +952,7 @@
 		ignitionReliabilityEnd = 0.999660
 		cycleReliabilityStart = 0.997846
 		cycleReliabilityEnd = 0.999660
-		techTransfer = RD-200:25&RD-108-11D512P,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
+		techTransfer = RD-102,RD-101,RD-100:10&RD-200,RD-103:25&RD-108-11D512P,RD-108-11D512,RD-108-8D727,RD-108-8D75K,RD-108-8D75-1959,RD-108-8D75-1958,RD-108-8D77,RD-108-8D75PS,RD-108-8D75:50
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-108A-14D21] { %ratedBurnTime = #$/TESTFLIGHT[RD-108A-14D21]/ratedBurnTime$ } }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
@@ -127,7 +127,7 @@
 		ignitionDynPresFailMultiplier = 2.0
 		cycleReliabilityStart = 0.78
 		cycleReliabilityEnd = 0.93
-		techTransfer = RD-100:25
+		techTransfer = RD-100:10&RD-102,RD-101:25
 		reliabilityDataRateMultiplier = 1
 	}
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RD-200] { %ratedBurnTime = #$/TESTFLIGHT[RD-200]/ratedBurnTime$ } }


### PR DESCRIPTION
Submitting this for review to get more eyes on it and input. DO NOT MERGE YET.

RD-100 series: Keep 50% transfer from previous config, add 25% transfer from other earlier configs
RD-200: Change 25% transfer from the RD-100 to the RD-102 simply because ECMs have the RD-200 as a direct descendant of the RD-102. Add 10% transfer from pre RD-102 configs.
RD-107/108: Add 10% transfer from the RD-102,RD-103,RD-103M. I did not add transfer from the 100 or 101 as I modeled this partially on how the US line does DU transfer. This decision was more for game balance than historical accuracy.

The value of 10% was just arbitrarily chosen when I made the changes as a value less than 25%.

The RD-211 and beyond all have ECM links to the RD-200 but haven't been changed yet.