### PR TITLE
Put restock spin motor CoM in a sensible place

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -411,6 +411,12 @@
 	%rescaleFactor = 0.5
 }
 
+@PART[ROSmallSpinMotor]:FOR[RealismOverhaul]:NEEDS[ReStock]
+{
+	// restock offsets the "body" and thrust vector but not the CoM
+	%CoMOffset = 0, 0, 0.1
+}
+
 // Use RO-provided model instead of stock or Restock
 @PART[sepMotor1]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Restock adds legs, moving the SRB (and thrust transform) away from
the origin; yet it leaves the CoM basically at the surface attachment
point. Move it closer to the thrust axis.

before
![](https://user-images.githubusercontent.com/5061230/183721293-1620729a-cc0b-48c5-9d64-2051b3b3e752.png)

after
![](https://user-images.githubusercontent.com/5061230/183721287-d40f4e46-b512-4890-8759-b0ecde39d5da.png)
