### PR TITLE
Update RL10 ignitions, add A-3-3B

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -17,7 +17,7 @@
 //	Prop Ratio: 5.0
 //	Throttle: N/A
 //	Nozzle Ratio: 40
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-3-1
 //	Atlas-Centaur D, Saturn-1 block II
@@ -32,7 +32,7 @@
 //	Prop Ratio: 5.0
 //	Throttle: N/A
 //	Nozzle Ratio: 40
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-3-3
 //	Atlas-Centaur D
@@ -47,7 +47,7 @@
 //	Prop Ratio: 5.0
 //	Throttle: N/A
 //	Nozzle Ratio: 61
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-3-3-Lunex
 //	Lunex
@@ -62,7 +62,7 @@
 //	Prop Ratio: 5.0
 //	Throttle: 100% to 16.6%
 //	Nozzle Ratio: ???
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-3-3A
 //	Centaur D1AR, D1B, D2
@@ -77,7 +77,22 @@
 //	Prop Ratio: 5.0
 //	Throttle: N/A
 //	Nozzle Ratio: 61
-//	Ignitions: 10
+//	Ignitions: 20
+//	=================================================================================
+//	RL10A-3-3B
+//	Shuttle-Centaur
+//
+//	Dry Mass: 141 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 66.7 kN
+//	ISP: ??? SL / 440 Vac
+//	Burn Time: 550
+//	Chamber Pressure: 2.86 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 6.0
+//	Throttle: N/A
+//	Nozzle Ratio: 61
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-4
 //	Centaur D2A
@@ -92,7 +107,7 @@
 //	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 61
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-4N
 //	Centaur D2AN
@@ -107,7 +122,7 @@
 //	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 84
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-4-1 and RL10A-4-2 (represented as RL10A-4-1-2)
 //	Centaur D2A1/D3B-SEC
@@ -122,7 +137,7 @@
 //	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 61
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-4-1N
 //	Centaur D2A1N/D3A-SEC/D3B-DEC
@@ -137,7 +152,7 @@
 //	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 84
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-4-2N
 //	Centaur D5/III
@@ -152,7 +167,7 @@
 //	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 84
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10A-5
 //	DC-X
@@ -167,7 +182,7 @@
 //	Prop Ratio: 6.0
 //	Throttle: 100% to 30%
 //	Nozzle Ratio: 4.3
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10B-2
 //	DCSS
@@ -197,7 +212,7 @@
 //	Prop Ratio: 5.88
 //	Throttle: N/A
 //	Nozzle Ratio: 130
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10C-1-1
 //	Centaur V
@@ -212,7 +227,7 @@
 //	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 155
-//	Ignitions: 10
+//	Ignitions: 20
 //	=================================================================================
 //	RL10C-2-1
 //	DCSS
@@ -305,6 +320,7 @@
 //	http://www.astronautix.com/l/lunex.html - Lunex data sheet
 //	https://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
 //	https://www.asme.org/wwwasmeorg/media/resourcefiles/aboutasme/who%20we%20are/engineering%20history/landmarks/36-rl-10-rocket-engine.pdf
+//	https://ntrs.nasa.gov/citations/19910004173
 //  History of Liquid Propellant Rocket Engines, George P. Sutton
 
 //	Used by:
@@ -371,7 +387,7 @@
 			massMult = 0.785
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -405,7 +421,7 @@
 			massMult = 0.785
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -439,7 +455,7 @@
 			massMult = 0.785
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -473,7 +489,7 @@
 			massMult = 1.0	//Increased mass for extra equipment
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -507,7 +523,41 @@
 			massMult = 0.845
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = RL10A-3-3B
+			specLevel = prototype
+			minThrust = 66.7
+			maxThrust = 66.7
+			heatProduction = 100
+			description = RL10A-3-3A modified to operate with an O/F ratio of 6.0 for Shuttle-Centaur. This reduces performance, but increases the average propellant density, allowing for greater fuel load in the Shuttle cargo bay.
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7286
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2714 //6.0
+			}
+			atmosphereCurve
+			{
+				key = 0 440
+				key = 1 255
+			}
+			massMult = 0.845
+
+			%ullage = True
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -541,7 +591,7 @@
 			massMult = 0.86
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -575,7 +625,7 @@
 			massMult = 1.01
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -609,7 +659,7 @@
 			massMult = 0.85
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -643,7 +693,7 @@
 			massMult = 1.00
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -677,7 +727,7 @@
 			massMult = 1.02
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -712,7 +762,7 @@
 			massMult = 0.8563
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -780,7 +830,7 @@
 			massMult = 1.1437
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -814,7 +864,7 @@
 			massMult = 1.1272
 
 			%ullage = True
-			%ignitions = 10
+			%ignitions = 20
 			%IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
@@ -1120,6 +1170,26 @@
 	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3A] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3A]/ratedBurnTime$ } }
 }
 
+//Assuming same as A-3-3A
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RL10A-3-3B]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]:NEEDS[TestLite|TestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RL10A-3-3B
+		testedBurnTime = 4500	//1.25 hours lifespan according to Martin Marietta OTV study
+		ratedBurnTime = 550
+		safeOverburn = true
+		ignitionReliabilityStart = 0.967445
+		ignitionReliabilityEnd = 0.994860
+		cycleReliabilityStart = 0.982075
+		cycleReliabilityEnd = 0.997170
+
+		ignitionDynPresFailMultiplier = 0.1
+
+		techTransfer = RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+	}
+	@MODULE[ModuleEngineConfigs] { @CONFIG[RL10A-3-3B] { %ratedBurnTime = #$/TESTFLIGHT[RL10A-3-3B]/ratedBurnTime$ } }
+}
 //Atlas-2A: 23 flights, 0 failures
 //Atlas-2AS: 30 flights, 0 failures
 //106 ignitions, 0 failures


### PR DESCRIPTION
Update RL10 ignitions to 20 (can't find 10 quoted anywhere, but 1966 P&W Manual and 1984 Martin Marietta OTV study both state 20) on most engines.

Added RL10A-3-3B, for Shuttle-Centaur.

Needs: https://github.com/KSP-RO/RP-0/pull/1735