### PR TITLE
Add MR-1 Meteo sustainer (U-1250)

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
@@ -244,7 +244,7 @@
 	TESTFLIGHT
 	{
 			name = U-1250
-			ratedBurnTime = 60
+			ratedBurnTime = 44
 			ignitionReliabilityStart = 0.90
 			ignitionReliabilityEnd = 0.96
 			cycleReliabilityStart = 0.86

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -30,6 +30,7 @@
 
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = ROAJ10-137 }
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = ROAerobeeSustainer }
++PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = ROMeteoSustainer }
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = RO-2kN-Thruster }
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = RO-RangerRetro }
 +PART[RO-1kN-Thruster]:BEFORE[RealismOverhaul] { @name = RO-KDU414 }
@@ -269,6 +270,12 @@
 @PART[ROAerobeeSustainer]:BEFORE[RealismOverhaul]
 {
 	@MODEL { @scale = 1.19, 1, 1.19 }  // Model is 1.3m tall, .8m at bell.  Convert to .41m tall, .3m bell
+	%rescaleFactor = 0.315
+}
+
+@PART[ROMeteoSustainer]:BEFORE[RealismOverhaul]
+{
+	@MODEL { @scale = 1.19, 1, 1.19 }  // Assume same size as aerobee
 	%rescaleFactor = 0.315
 }
 
@@ -638,7 +645,7 @@
 }
 
 
-@PART[Size3AdvancedEngine|nuclearEngine|SSME|RO-RD-0124|ROAerobeeSustainer|omsEngine|ROAJ10-137|radialEngineMini|radialLiquidEngine1-2|smallRadialEngine]:FOR[RealismOverhaul]
+@PART[Size3AdvancedEngine|nuclearEngine|SSME|RO-RD-0124|ROAerobeeSustainer|ROMeteoSustainer|omsEngine|ROAJ10-137|radialEngineMini|radialLiquidEngine1-2|smallRadialEngine]:FOR[RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -808,6 +815,12 @@
 {
 	%RSSROConfig = True
 	%engineType = Aerobee
+}
+
+@PART[ROMeteoSustainer]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = U1250
 }
 
 //  AJ10-190 (radial).

--- a/GameData/RealismOverhaul/RealPlume_Configs/RO/ROMeteoSustainer.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/RO/ROMeteoSustainer.cfg
@@ -1,0 +1,30 @@
+//	==================================================
+//	U-1250 / Meteo plume setup
+//	==================================================
+
+@PART[ROMeteoSustainer]:BEFORE[RealPlume]
+{
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Hypergolic_LowerOrangeShock
+	}
+	PLUME
+	{
+		name = Hypergolic_LowerOrangeShock
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+
+		flarePosition = 0,0,-0.2
+		flareScale = 0.04
+
+		plumePosition = 0,0,0.2
+		plumeScale = 0.25
+
+		fumePosition = 0,0,0.2
+		fumeScale = 0.3
+
+		blazePosition = 0,0,0
+		blazeScale = 0.2
+	}
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/Self/meteoSustainer.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/Self/meteoSustainer.cfg
@@ -1,0 +1,14 @@
+@PART[ROMeteoSustainer]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    !EFFECTS {}
+    ROWaterfall
+    {
+        template = waterfall-kerosene-nitric-acid-lower-1
+        audio = pump-fed-light-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.22, 0.2475, 0.26
+        glow = _yellow
+        glowStretch = 0.8
+    }
+}


### PR DESCRIPTION
Add MR-1 Meteo sustainer (U-1250) using a stock engine model.
The MR-1 Meteo was a small sounding rocket created in response to the WAC-Corporal.

RP-0 PR: https://github.com/KSP-RO/RP-0/pull/1760