### PR TITLE
Provide a 2-nozzle rd-215 part

### DIFF
--- a/GameData/RealismOverhaul/Parts/Engines/rd215.cfg
+++ b/GameData/RealismOverhaul/Parts/Engines/rd215.cfg
@@ -1,0 +1,71 @@
++PART[liquidEngine2]:FIRST // why liquideEngine2? just to copy lr87-lh2
+{
+	@name = RO-RD215
+}
+
+@PART[RO-RD215]:FOR[RealismOverhaul]
+{
+	!mesh = DEL
+	MODEL
+	{
+		model = RealismOverhaul/Models/LR-91eng
+		scale = 0.95, 1.4, 0.95
+		position = 0, 0, -0.48
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/LR-91eng
+		scale = 0.95, 1.4, 0.95
+		position = 0, 0, 0.48
+	}
+	%RSSROConfig = True
+	%rescaleFactor = 1.0
+	%scale = 1.0
+	@node_stack_top = 0.0, 1.0101, 0.0, 0.0, 1.0, 0.0, 1
+	@node_stack_bottom = 0.0, -1.629, 0.0, 0.0, -1.0, 0.0, 1
+	%node_attach = 0.0, 1.0101, 0.0, 0.0, 1.0, 0.0, 1
+	@attachRules = 1,1,1,0,0
+	
+	%maxTemp = 500
+	%skinMaxTemp = 900
+	%stageOffset = 1
+	%childStageOffset = 1
+	%stagingIcon = LIQUID_ENGINE
+	
+	@title = RD-215 series
+	%author = RO
+
+	!MODULE[ModuleAlternator]{}
+	!MODULE[ModuleJettison]{}
+	!MODULE[ModuleSurfaceFX]{}
+	!MODULE[FXModuleAnimateThrottle]{}
+	!RESOURCE[ElectricCharge]{}
+	
+	%engineType = RD215
+	%engineTypeMult = 1
+	%clusterMultiplier = 1
+}
+
+// No gimbal; tsyklon's didn't have any (used rd855 verniers).
+// kosmos rd216 did have thrust vanes, but ROE's rd216 covers
+// that use case.
+// FIXME: does that mean this should be lighter, or ROE's heavier?
+//  probably in the noise.
+@PART[RO-RD215]:AFTER[RealismOverhaulEngines]
+{
+	!MODULE[ModuleGimbal] {}
+}
+
+@PART[RO-RD215]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	ROWaterfall
+	{
+		template = waterfall-hypergolic-UDMH-NTO-lower-1
+		audio = pump-fed-heavy-1
+		position = 0, 0, 1.15
+		rotation = 0, 0, 0
+		scale = 0.8, 0.8, 1
+		glow = _white
+	}
+}
+


### PR DESCRIPTION
Because it's weird that RO provides a stock-model part for the
tsyklon first-stage verniers but no main engine to go with it
ROE only provides a 4-nozzle kosmos-friendly RD-215

Using same model as lr87-lh2, squished into a shape roughly matching
ROE's rd-215 nozzles; because none of the stock model seemed like a
better fit.