### PR TITLE
Add optional restart kits to Agena & J2

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -377,30 +377,30 @@
 
 		CONFIG
 		{
-			name			= XLR81-BA-11
-			description		= Model 8096, Agena D. Cannot restart between 15 minutes and 3 hours after shutdown.
-			specLevel		= operational
-			maxThrust		= 71.17
-			minThrust		= 71.17
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False
-			ignitions		= 2
-			massMult		= 1.0572
-			gimbalRange		= 5
+			name = XLR81-BA-11
+			description = Model 8096, Agena D. Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel = operational
+			maxThrust = 71.17
+			minThrust = 71.17
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False
+			ignitions = 2
+			massMult = 1.0572
+			gimbalRange = 5
 
 			PROPELLANT
 			{
-				name		= UDMH
-				ratio		= 0.4281
-				DrawGauge	= False
+				name = UDMH
+				ratio = 0.4281
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= IRFNA-III
-				ratio		= 0.5719
-				DrawGauge	= True
+				name = IRFNA-III
+				ratio = 0.5719
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -411,44 +411,44 @@
 
 			IGNITOR_RESOURCE
 			{
-				name		= ElectricCharge
-				amount		= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 			SUBCONFIG
 			{
 				name = StartTanks
-				description	= A.K.A. XLR81-BA-13. Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
-				massMult	= 1.0808	//start tanks add ~3 kg
-				ignitions	= 15
-				costOffset	= 100
+				description = A.K.A. XLR81-BA-13, or Model 8247. Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
+				massMult = 1.0808	//start tanks add ~3 kg
+				ignitions = 15
+				costOffset = 100
 			}
 		}
 		CONFIG
 		{
-			name			= Model8096-39
-			description		= Improved propellant, using high density acid (HDA). Cannot restart between 15 minutes and 3 hours after shutdown.
-			specLevel		= operational
-			maxThrust		= 75.62 //17 klbf
-			minThrust		= 75.62
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False
-			ignitions		= 3
-			massMult		= 1.0572
-			gimbalRange		= 5
+			name = Model8096-39
+			description = Improved propellant, using high density acid (HDA). Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel = operational
+			maxThrust = 75.62 //17 klbf
+			minThrust = 75.62
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False
+			ignitions = 3
+			massMult = 1.0572
+			gimbalRange = 5
 
 			PROPELLANT
 			{
-				name		= UDMH
-				ratio		= 0.4618
-				DrawGauge	= False
+				name = UDMH
+				ratio = 0.4618
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= IRFNA-IV
-				ratio		= 0.5382
-				DrawGauge	= True
+				name = IRFNA-IV
+				ratio = 0.5382
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -459,44 +459,44 @@
 
 			IGNITOR_RESOURCE
 			{
-				name		= ElectricCharge
-				amount		= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 			SUBCONFIG
 			{
 				name = StartTanks
-				description	= Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
-				massMult	= 1.0808	//start tanks add ~3 kg
-				ignitions	= 15
-				costOffset	= 100
+				description = Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
+				massMult = 1.0808	//start tanks add ~3 kg
+				ignitions = 15
+				costOffset = 100
 			}
 		}
 		CONFIG
 		{
-			name			= Model8096A // (5)
-			description		= Higher expansion ratio nozzle prototype. Cannot restart between 15 minutes and 3 hours after shutdown.
-			specLevel		= prototype
-			maxThrust		= 78.3
-			minThrust		= 78.3
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False
-			ignitions		= 3
-			massMult		= 1.1280
-			gimbalRange		= 5
+			name = Model8096A // (5)
+			description = Higher expansion ratio nozzle prototype. Cannot restart between 15 minutes and 3 hours after shutdown.
+			specLevel = prototype
+			maxThrust = 78.3
+			minThrust = 78.3
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False
+			ignitions = 3
+			massMult = 1.1280
+			gimbalRange = 5
 
 			PROPELLANT
 			{
-				name		= UDMH
-				ratio		= 0.4838
-				DrawGauge	= False
+				name = UDMH
+				ratio = 0.4838
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= IRFNA-IV
-				ratio		= 0.5161
-				DrawGauge	= True
+				name = IRFNA-IV
+				ratio = 0.5161
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -507,44 +507,44 @@
 
 			IGNITOR_RESOURCE
 			{
-				name		= ElectricCharge
-				amount		= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 			SUBCONFIG
 			{
 				name = StartTanks
-				description	= Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
-				massMult	= 1.1517	//start tanks add ~3 kg
-				ignitions	= 15
-				costOffset	= 100
+				description = Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
+				massMult = 1.1517	//start tanks add ~3 kg
+				ignitions = 15
+				costOffset = 100
 			}
 		}
 		CONFIG
 		{
-			name			= Model8096L // (6)
-			description		= Reusable Agena for STS
-			specLevel		= concept
-			maxThrust		= 71.1 //16 klbf
-			minThrust		= 71.1
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False
-			ignitions		= 15 // '10 to 100' depending on cert; go with 8247 for now.
-			massMult		= 1.2225
-			gimbalRange		= 5
+			name = Model8096L // (6)
+			description = Reusable Agena for STS
+			specLevel = concept
+			maxThrust = 71.1 //16 klbf
+			minThrust = 71.1
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False
+			ignitions = 15 // '10 to 100' depending on cert; go with 8247 for now.
+			massMult = 1.2225
+			gimbalRange = 5
 
 			PROPELLANT // (6) - 2.03 ratio for HDA/MMH
 			{
-				name		= MMH
-				ratio		= 0.5276
-				DrawGauge	= False
+				name = MMH
+				ratio = 0.5276
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= IRFNA-IV
-				ratio		= 0.4724
-				DrawGauge	= True
+				name = IRFNA-IV
+				ratio = 0.4724
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -555,36 +555,36 @@
 
 			IGNITOR_RESOURCE
 			{
-				name		= ElectricCharge
-				amount		= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 		}
 		CONFIG
 		{
-			name			= Model8096C // (6)
-			description		= Growth Agena option, sacrificing thrust for improved effeciency
-			specLevel		= concept
-			maxThrust		= 53.4 //12 klbf
-			minThrust		= 53.4
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False
-			ignitions		= 15 // '10 to 100' depending on cert; go with 8247 for now.
-			massMult		= 0.6638
-			gimbalRange		= 5
+			name = Model8096C // (6)
+			description = Growth Agena option, sacrificing thrust for improved effeciency
+			specLevel = concept
+			maxThrust = 53.4 //12 klbf
+			minThrust = 53.4
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False
+			ignitions = 15 // '10 to 100' depending on cert; go with 8247 for now.
+			massMult = 0.6638
+			gimbalRange = 5
 
 			PROPELLANT // (6) - 1.88 ratio for NTO/MMH
 			{
-				name		= MMH
-				ratio		= 0.4671
-				DrawGauge	= False
+				name = MMH
+				ratio = 0.4671
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= NTO
-				ratio		= 0.5329
-				DrawGauge	= True
+				name = NTO
+				ratio = 0.5329
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -595,36 +595,36 @@
 
 			IGNITOR_RESOURCE
 			{
-				name		= ElectricCharge
-				amount		= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 		}
 		CONFIG
 		{
-			name			= Agena-2000	//(7)
-			description		= Agena upgrade for proposed Atlas V upper stage. Tested, but cancelled when studies showed it would be more economical to use single engine centaur instead.
-			specLevel		= prototype
-			maxThrust		= 67.5 //15170 lbf
-			minThrust		= 67.5
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False
-			ignitions		= 15
-			massMult		= 1.0394
-			gimbalRange		= 5
+			name = Agena-2000	//(7)
+			description = Agena upgrade for proposed Atlas V upper stage. Tested, but cancelled when studies showed it would be more economical to use single engine centaur instead.
+			specLevel = prototype
+			maxThrust = 67.5 //15170 lbf
+			minThrust = 67.5
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False
+			ignitions = 15
+			massMult = 1.0394
+			gimbalRange = 5
 
 			PROPELLANT // (6) - 1.83 ratio for MON3/MMH
 			{
-				name		= MMH
-				ratio		= 0.4691
-				DrawGauge	= False
+				name = MMH
+				ratio = 0.4691
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= MON3
-				ratio		= 0.5309
-				DrawGauge	= True
+				name = MON3
+				ratio = 0.5309
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -635,23 +635,23 @@
 
 			IGNITOR_RESOURCE
 			{
-				name	= ElectricCharge
-				amount	= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 		}
 		CONFIG
 		{
-			name			= XLR81-LF2-SPS // (5)
-			description		= Liquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
-			specLevel		= prototype
-			maxThrust		= 53.7 //12 klbf
-			minThrust		= 17.7 //3.98 klbf
-			heatProduction	= 100
-			ullage			= False //(1) p 1-4
-			pressureFed		= False	//Because engine was intended to be used mostly in pump-fed mode, pressurization system is included in engine mass
-			ignitions		= 15
-			massMult		= 1.1811	//Including mass of pressurization system that allowed it to function in HP mode
-			gimbalRange		= 5
+			name = XLR81-LF2-SPS // (5)
+			description = Liquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
+			specLevel = prototype
+			maxThrust = 53.7 //12 klbf
+			minThrust = 17.7 //3.98 klbf
+			heatProduction = 100
+			ullage = False //(1) p 1-4
+			pressureFed = False	//Because engine was intended to be used mostly in pump-fed mode, pressurization system is included in engine mass
+			ignitions = 15
+			massMult = 1.1811	//Including mass of pressurization system that allowed it to function in HP mode
+			gimbalRange = 5
 
 			//Only 2 thrust settings, 12 klbf in pump-fed mode or 4 klbf in pressurefed mode
 			throttleCurve
@@ -664,16 +664,16 @@
 
 			PROPELLANT // (5) - 11.92 ratio for LF2/LH2
 			{
-				name		= LqdFluorine
-				ratio		= 0.3599
-				DrawGauge	= False
+				name = LqdFluorine
+				ratio = 0.3599
+				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
-				name		= LqdHydrogen
-				ratio		= 0.6401
-				DrawGauge	= True
+				name = LqdHydrogen
+				ratio = 0.6401
+				DrawGauge = True
 			}
 
 			atmosphereCurve
@@ -684,8 +684,8 @@
 
 			IGNITOR_RESOURCE
 			{
-				name		= ElectricCharge
-				amount		= 0.2
+				name = ElectricCharge
+				amount = 0.2
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -83,12 +83,12 @@
 //	XLR81-BA-13
 //	Bell Model 8247, Gemini ATV
 //
-//	Dry Mass: 132 Kg
+//	Dry Mass: 137.26 Kg		//start tanks added about 3 kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 71.2 kN	//Thrust increase proportional with ISP increase
-//	ISP: ??? SL / 291 Vac
+//	Thrust (Vac): 71.17 kN
+//	ISP: ??? SL / 290.5 Vac
 //	Burn Time: 240
-//	Chamber Pressure: 3.4 MPa
+//	Chamber Pressure: 3.48 MPa
 //	Propellant: IRFNA-III / UDMH
 //	Prop Ratio: 2.8
 //	Throttle: N/A
@@ -97,7 +97,7 @@
 //	=================================================================================
 //	Bell Model 8096-39, Agena D HDA
 //
-//	Dry Mass: 132 Kg
+//	Dry Mass: 134.26 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 75.62 kN
 //	ISP: ??? SL / 300 Vac
@@ -111,7 +111,7 @@
 //	=================================================================================
 //	Bell Model 8096A, Agena Growth Option
 //
-//	Dry Mass: 132 Kg
+//	Dry Mass: 143.26 Kg		//~9kg for 75:1 nozzle?
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 78.3 kN	//Thrust increase proportional with ISP increase
 //	ISP: ??? SL / 312 Vac
@@ -125,7 +125,7 @@
 //	=================================================================================
 //	Bell Model 8096L, Reusable Agena for STS
 //
-//	Dry Mass: 132 Kg	//guess
+//	Dry Mass: 155.26 Kg		//18 kg for 150:1 nozzle, 3 kg for start tanks
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 71.1 kN
 //	ISP: ??? SL / 324 Vac
@@ -139,7 +139,7 @@
 //	=================================================================================
 //	Bell Model 8096C, Agena Growth Option
 //
-//	Dry Mass: 84.3 Kg
+//	Dry Mass: 84.3 Kg		//redesigned to reduce mass for use on tug
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 53.4 kN
 //	ISP: ??? SL / 336 Vac
@@ -196,6 +196,13 @@
 
 //	Notes:
 
+//	The Agena start tanks were developed for use on the Gemini-Agena Target vehicle, to increase the number of restarts available for Agena. A pair of pressurized bladder tanks
+//	were added to the XLR81, containing fuel and oxidizer. Pressurized propellants from these tanks would be used to spin up the XLR81 turbopump. Once the engine was started, 
+//	propellant would be tapped off from the turbopumps to refill the tanks for the next start. This system allowed for up to 15 restarts of the XLR81 engine. Although developed
+//	for GATV, the start tanks could be added to any Agena upon customer request.
+
+//	XLR81-BA-13 config eliminated, as it is identical to the BA-11 other than the addition of the start tanks.
+//	Start tanks added ~3 kg to the overall mass of the engine (elimination of the solid starter cartridges offset weight of start tanks).
 //	==================================================
 @PART[*]:HAS[#engineType[Agena]]:FOR[RealismOverhaulEngines]
 {
@@ -379,8 +386,8 @@
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
 			ignitions		= 2
-			massMult = 1.0394
-			gimbalRange = 5
+			massMult		= 1.0572
+			gimbalRange		= 5
 
 			PROPELLANT
 			{
@@ -407,43 +414,13 @@
 				name		= ElectricCharge
 				amount		= 0.2
 			}
-		}
-		CONFIG
-		{
-			name = XLR81-BA-13
-			description = Model 8247, Gemini ATV. Cannot restart between 15 minutes and 3 hours after shutdown.
-			specLevel = operational
-			maxThrust = 71.2
-			minThrust = 71.2
-			heatProduction = 100
-			massMult = 1.0394
-			gimbalRange = 5
-
-			PROPELLANT
+			SUBCONFIG
 			{
-				name		= UDMH
-				ratio		= 0.4281
-				DrawGauge	= False
-			}
-
-			PROPELLANT
-			{
-				name		= IRFNA-III
-				ratio		= 0.5719
-				DrawGauge	= True
-			}
-			atmosphereCurve
-			{
-				key = 0 291
-				key = 1 100
-			}
-			ullage = False //(3) p 14-7
-			pressureFed = False
-			ignitions = 15 //(2) p 1-1, (3) p 14-7
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.050
+				name = StartTanks
+				description	= A.K.A. XLR81-BA-13. Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
+				massMult	= 1.0808	//start tanks add ~3 kg
+				ignitions	= 15
+				costOffset	= 100
 			}
 		}
 		CONFIG
@@ -457,8 +434,8 @@
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
 			ignitions		= 3
-			massMult =		1.0394
-			gimbalRange =	5
+			massMult		= 1.0572
+			gimbalRange		= 5
 
 			PROPELLANT
 			{
@@ -485,6 +462,14 @@
 				name		= ElectricCharge
 				amount		= 0.2
 			}
+			SUBCONFIG
+			{
+				name = StartTanks
+				description	= Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
+				massMult	= 1.0808	//start tanks add ~3 kg
+				ignitions	= 15
+				costOffset	= 100
+			}
 		}
 		CONFIG
 		{
@@ -496,9 +481,9 @@
 			heatProduction	= 100
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
-			ignitions		= 3 // (6)
-			massMult =		1.0394
-			gimbalRange =	5
+			ignitions		= 3
+			massMult		= 1.1280
+			gimbalRange		= 5
 
 			PROPELLANT
 			{
@@ -525,6 +510,14 @@
 				name		= ElectricCharge
 				amount		= 0.2
 			}
+			SUBCONFIG
+			{
+				name = StartTanks
+				description	= Add reusable start tanks, developed for GATV, to allow for up to 14 restarts of the XLR81.
+				massMult	= 1.1517	//start tanks add ~3 kg
+				ignitions	= 15
+				costOffset	= 100
+			}
 		}
 		CONFIG
 		{
@@ -537,8 +530,8 @@
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
 			ignitions		= 15 // '10 to 100' depending on cert; go with 8247 for now.
-			massMult =		1.0394
-			gimbalRange =	5
+			massMult		= 1.2225
+			gimbalRange		= 5
 
 			PROPELLANT // (6) - 2.03 ratio for HDA/MMH
 			{
@@ -577,8 +570,8 @@
 			ullage			= False //(1) p 1-4
 			pressureFed		= False
 			ignitions		= 15 // '10 to 100' depending on cert; go with 8247 for now.
-			massMult =		0.6638
-			gimbalRange =	5
+			massMult		= 0.6638
+			gimbalRange		= 5
 
 			PROPELLANT // (6) - 1.88 ratio for NTO/MMH
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -85,6 +85,30 @@
 //	Source 9: https://commons.erau.edu/cgi/viewcontent.cgi?article=2883&amp;context=space-congress-proceedings
 //  [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 434
 //  [B] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 408 Table 7.8-1
+
+//	Notes:
+
+//	SIVB-500 was ~1100 kg heavier than SIVB-200, due to the requirement for restart. Although all J-2 engines were identical and theoretically capable of restart,
+//	the engines used aboard SIVB-500s had additional accessories to facilitate restart.
+
+//	The Continous Vent System (CVS) used hydrogen boiloff to keep the stage ullaged and helped condition the J-2. It added ~45 kg (100 lbs) to the stage mass.
+
+//	The O2/H2 burner started prior to engine start, and preheated the helium tanks used to pressurize the stage and actuate the J-2 pneumatics. It also
+//	contributed to ullage thrust. After J-2 start, heat and hydrogen bleed from the J-2 was used to maintain tank pressurization instead. Mass of the O2/H2 
+//	burner system unkown. Guess 100 kg?
+
+//	Remaining mass due to extra APS thrusters (800 lbs/363 kg), APS propellant load (1200 lbs/544 kg) and extra LH2 load (40 lbs/18 kg)
+
+//	Engine start tank contained 7257 cui of hydrogen and 1000 cui of helium. Hydrogen was refilled by turbopump bleed after engine start, but helium could not
+//	be replenished, limiting engine to 3 starts.
+
+//	J-2 engine rated for up to 30 starts, although during AAP testing, engines tolerated over 100 starts between overhaul.
+
+//	J-2S was instead limited by the 3 starter cartridges.
+
+//	J-2S had idle mode of roughly 5% thrust for rapid engine cooldown and low power maneuvering. This was achieved by routing oxidizer through a special idle 
+//	injector that greatly restricted flow while maintaining combustion stability at a low thrust level. 6:1 throttling was achieved by a throttle valve in the
+//	combustion chamber tap-off system.
 //	==================================================
 @PART[*]:HAS[#engineType[J2]]:FOR[RealismOverhaulEngines]
 {
@@ -145,13 +169,23 @@
 				key = 1 100	 // Flow separation caused damage to the bell
 			}
 
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 3	// Confirmed, S-II Engines only had 1 Restart, S-IVB had 3
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			SUBCONFIG
+			{
+				name = EngineConditioningKit
+				description = Adds CVS propellant management system and O2/H2 burner preheater, to allow for on-orbit engine conditioning and restarts.
+				specLevel = operational
+				massMult = 1.093
+				ignitions = 3
+				ullage = False	//CVS system kept tanks ullaged even at minimum setting
+				costOffset = 150
 			}
 		}
 		CONFIG
@@ -180,13 +214,23 @@
 				key = 1 100	 // Flow separation caused damage to the bell
 			}
 
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 3	// Confirmed, S-II Engines only had 1 Restart, S-IVB had 3 - S-IVB only had 2 burns, not clear if 3 capable but only used 2
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			SUBCONFIG
+			{
+				name = EngineConditioningKit
+				description = Adds CVS propellant management system and O2/H2 burner preheater, to allow for on-orbit engine conditioning and restarts.
+				specLevel = operational
+				massMult = 1.093
+				ignitions = 3
+				ullage = False	//CVS system kept tanks ullaged even at minimum setting
+				costOffset = 150
 			}
 		}
 		CONFIG
@@ -215,13 +259,23 @@
 				key = 1 100	 // Flow separation caused damage to the bell
 			}
 
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 3	// Confirmed, S-II Engines only had 1 Restart, S-IVB had 3 - S-IVB only had 2 burns, not clear if 3 ignitions capable but only used 2
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
 				amount = 0.500
+			}
+			SUBCONFIG
+			{
+				name = EngineConditioningKit
+				description = Adds CVS propellant management system and O2/H2 burner preheater, to allow for on-orbit engine conditioning and restarts.
+				specLevel = operational
+				massMult = 1.093
+				ignitions = 3
+				ullage = False	//CVS system kept tanks ullaged even at minimum setting
+				costOffset = 150
 			}
 		}
 		CONFIG
@@ -249,10 +303,20 @@
 				key = 0 436
 				key = 1 100	 // FIXME: No idea where 320 number came from. J-2S has higher chamber pressure, but also higher expansion ratio (nozzle exit pressure similar to SSME). Assume suffers same flow sep? (Try running through RPA)
 			}
+			
+			//6:1 throttling, and idle mode at 5% thrust
+			throttleCurve
+			{
+				key = 0.000 0.050 0.00 0.00
+				key = 0.099 0.050 0.00 0.00
+				key = 0.100 0.166 0.00 0.00
+				key = 0.166 0.166 0.00 1.00
+				key = 1.000 1.000 1.00 1.00
+			}
 
-			%ullage = True
-			%pressureFed = False
-			%ignitions = 3	// Confirmed three ignitions
+			ullage = False	//assume CVS system is included by default with J-2S?
+			pressureFed = False
+			ignitions = 3	// Confirmed three ignitions
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/UpgradeData.cfg
+++ b/GameData/RealismOverhaul/UpgradeData.cfg
@@ -7,4 +7,8 @@ ROMECCONFIGUPGRADES
 		//If there is a $ in the config, anything after that is the subconfig name.
 		LR87-AJ-9-Kero-15AR = LR87-AJ-9-Kero$15AR
 	}
+	14.18.0
+	{
+		XLR81-BA-13 = XLR81-BA-11$StartTanks
+	}
 }


### PR DESCRIPTION
Add restart kits to Agena and J2. 
Agena has optional start tanks as developed for GATV, which could be installed on Agena at the customer's request.

J-2 itself supported restarting in all configurations, but engine ullage, conditioning, and pressurization systems were only installed on SIVB-500s.