### PR TITLE
Better temp settings for Aviation Cockpits fighters

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AviationCockpits/Cockpits.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AviationCockpits/Cockpits.cfg
@@ -248,7 +248,7 @@
 	}
 }
 
-// ******* Hopefully by this point you have life support unlocked! ****
+
 
 // Generic Century Fighter Cockpit
 @PART[Trainer?Cockpit]:FOR[RealismOverhaul]
@@ -264,7 +264,9 @@
 	@breakingForce = 2000
 	@breakingTorque = 2000
 	%maxTemp = 400
-	%skinMaxTemp = 900 // Mach 3
+	%skinMaxTemp = 600
+	%skinInternalConductionMult = 0.1
+
 	
 	@MODULE[ModuleCommand]
 	{
@@ -350,7 +352,8 @@
 	@breakingForce = 2000
 	@breakingTorque = 2000
 	%maxTemp = 400
-	%skinMaxTemp = 900 // Mach 3
+	%skinMaxTemp = 600
+	%skinInternalConductionMult = 0.1
 	
 	@MODULE[ModuleCommand]
 	{
@@ -374,11 +377,11 @@
 			amount = 10800
 			maxAmount = 10800
 		}
-		TANK
+		UNMANAGED_RESOURCE
 		{
 			name = Oxygen
-			amount = 46
-			maxAmount = 46
+			amount = 50
+			maxAmount = 50
 		}
 		TANK
 		{
@@ -436,7 +439,8 @@
 	@breakingForce = 2000
 	@breakingTorque = 2000
 	%maxTemp = 450
-	%skinMaxTemp = 950 // Mach 3
+	%skinMaxTemp = 600
+	%skinInternalConductionMult = 0.1
 	
 	@MODULE[ModuleCommand]
 	{
@@ -514,6 +518,8 @@
 	}
 }
 
+// ******* Hopefully by this point you have life support unlocked! ****
+
 //Sukhoi Su30
 @PART[Mk1?Su30?Cockpit]:FOR[RealismOverhaul]
 {
@@ -533,7 +539,9 @@
 	@breakingForce = 2000
 	@breakingTorque = 2000
 	%maxTemp = 450
-	%skinMaxTemp = 950 // Mach 3
+	%skinMaxTemp = 600
+	%skinInternalConductionMult = 0.1
+
 	@MODULE[ModuleCommand]
 	{
 		RESOURCE
@@ -617,7 +625,8 @@
 	@breakingForce = 2000
 	@breakingTorque = 2000
 	%maxTemp = 450
-	%skinMaxTemp = 950 // Mach 3
+	%skinMaxTemp = 600
+	%skinInternalConductionMult = 0.1
 	
 	!RESOURCE[IntakeAir] {}
 	@MODULE[ModuleCommand]
@@ -708,7 +717,8 @@
 	@breakingForce = 2000
 	@breakingTorque = 2000
 	%maxTemp = 400
-	%skinMaxTemp = 900 // Mach 3
+	%skinMaxTemp = 600
+	%skinInternalConductionMult = 0.1
 	!RESOURCE[IntakeAir] {}
 	@MODULE[ModuleCommand]
 	{


### PR DESCRIPTION
"skinMaxTemp = 900 // mach 3" is nonsense; sustained mach 3 flight at 18km on the Century Fighter cockpit only goes up to 560K skin temp, but going up to mach 3 for even 1 second is enough to bring Int temp over 400K before the skin can cool down

- Bring skinMaxTemp down to 600K, to avoid creating false expectations
- Reduce skin->int soak to allow spending at least a bit of time (tested 3 minutes) at mach 3 without melting down

400K is enough to stay at ~mach 2.2 indefinitely; seems adequate, so unchanged.

Mainly tested on Century Fighter cockpit, but applied to all fighters for consistency.

Also here: apply oxygen fix to f-104, to match Century and Voodoo