### PR TITLE
Add 'not supported' to descriptionless parts too

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -257,6 +257,7 @@
     %category:NEEDS[FilterExtensions] = 97
     %category:NEEDS[!FilterExtensions,NoNonRO] = -1
     @title ^=:^:non RO - :
+    &description = 
     @description ^=:$: (PART NOT SUPPORTED BY RO):
 }
 
@@ -265,6 +266,7 @@
     %category:NEEDS[FilterExtensions] = 96
     %category:NEEDS[!FilterExtensions,NoNonRO] = -1
     @title ^=:^:WIP RO - :
+    &description = 
     @description ^=:$: (PART IN PROGRESS, MAY NOT WORK):
 }
 


### PR DESCRIPTION
@x ^=  is a no-op if x doesn't exist

Not too important for RO by itself, the 'non RO' title is just as informative; but being nonRO and descriptionless then breaks RP-0's "replace non-RO by non-RO-and-RP0 in description". Since rp0 _replaces_ nonRO with nonRP0 in the title, this was leaving no indication that a non-RP0 part also lacks RO configs.

Noticed while poking around CMES parts, a bunch of which have no description set.

RP0's own patching could probably use a similar fix, but I haven't run across a case where it matters.