### PR TITLE
Disable extremely long restart windows

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -143,8 +143,9 @@
 				{
 					key = 0 0 0 0
 					key = 360 1 0 0		//6 minutes between restarts
-					key = 2.592e+07 1 0 0	//300 day limit
-					key = 3.000e+07 0 0 0		//drops to zero
+					//disable because extremely long interval crashes game on mouseover?
+					//key = 2.592e+07 1 0 0	//300 day limit
+					//key = 3.000e+07 0 0 0		//drops to zero
 				}
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
@@ -208,8 +209,9 @@
 				{
 					key = 0 0 0 0
 					key = 360 1 0 0		//6 minutes between restarts
-					key = 2.592e+07 1 0 0	//300 day limit
-					key = 3.000e+07 0 0 0		//drops to zero
+					//disable because extremely long interval crashes game on mouseover?
+					//key = 2.592e+07 1 0 0	//300 day limit
+					//key = 3.000e+07 0 0 0		//drops to zero
 				}
 
 				// assume roughly exponential relationship between chamber pressure and lifespan

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -113,8 +113,9 @@
 				{
 					key = 0 0 0 0
 					key = 360 1 0 0		//6 minutes between restarts
-					key = 2.592e+07 1 0 0	//300 day limit
-					key = 3.000e+07 0 0 0		//drops to zero
+					//disable because extremely long interval crashes game on mouseover?
+					//key = 2.592e+07 1 0 0	//300 day limit
+					//key = 3.000e+07 0 0 0		//drops to zero
 				}
 				ignitionReliabilityStart = 0.992435
 				ignitionReliabilityEnd = 0.999109


### PR DESCRIPTION
Due to a TF bug of unclear origin, extremely long (300 day) TF restart windows cause a game freeze when the part is moused over. Just disable them until a solution can be found.
Resolves #2736 