### PR TITLE
Give LR101 tankfed mode

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -211,6 +211,7 @@
 			minThrust = 5.304
 			maxThrust = 5.304
 			heatProduction = 10
+			massMult = 0.9083
 
 			ullage = True
 			pressureFed = False
@@ -299,7 +300,7 @@
 			minThrust = 2.976
 			maxThrust = 2.976
 			heatProduction = 10
-			massMult = 0.8
+			massMult = 0.7938
 
 			ullage = True
 			pressureFed = False

--- a/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR101_Config.cfg
@@ -4,20 +4,32 @@
 //	Manufacturer: Rocketdyne
 //
 //	=================================================================================
+//	LR101-NA-3
+//	Early Atlas and Thor
+//
+//	Dry Mass: ???
+//	Thrust (SL): 4.448 kN Pump Fed		3.869 kN Tank Fed (Guess)
+//	Thrust (Vac): 5.114 kN Pump Fed		4.448 kN Tank Fed
+//	ISP (SL): 207.7 Pump Fed			197 Tank Fed
+//	ISP (Vac): 238 Pump Fed				233 Tank Fed (Guess)
+//	Burn Time: ???
+//	Chamber Pressure: 2.48 MPa Pump Fed
+//	Propellant: LOX / RP1
+//	Prop Ratio: ???
+//	Nozzle Ratio: 5
+//	=================================================================================
 //	LR101-NA-9
 //	Thor MB-3 Block I
 //
 //	Dry Mass: ???
-//	Thrust (SL): 1000 lbf Pump Fed
-//	Thrust (Vac): 1150 lbf Pump Fed		1000 Tank Fed
-//	ISP (SL): 207.7 Pump Fed
+//	Thrust (SL): 4.448 kN Pump Fed		3.869 kN Tank Fed (Guess)
+//	Thrust (Vac): 5.114 kN Pump Fed		4.448 kN Tank Fed
+//	ISP (SL): 207.7 Pump Fed			197 Tank Fed
 //	ISP (Vac): 240 Pump Fed				235 Tank Fed
 //	Burn Time: ???
-//	Chamber Pressure: 360 psia
+//	Chamber Pressure: 2.48 MPa Pump Fed
 //	Propellant: LOX / RP1
-//	Ratio: ???
-//	Engine Nozzle: 0.0945 m diameter
-//	Nozzle Exit Area: 10.5 in^2 = 0.007 m^2
+//	Prop Ratio: ???
 //	Nozzle Ratio: 5
 //	==================================================================================
 //	LR101-NA-11
@@ -25,22 +37,36 @@
 //
 //	Data from Source #1
 //	Dry Mass: 21.8 kg
-//	Thrust (SL): 830 lbf Tank Fed		1017 lbf Pump Fed
+//	Thrust (SL): 4.524 kN Pump Fed		3.692 kN Tank Fed
 //	Thrust (Vac): 
-//	ISP: 198.7 Tank Fed					209.8 Pump Fed
-//	Burn Time: 
-//	Chamber Pressure:					378 psia Pump Fed
+//	ISP (SL): 209.8 Pump Fed			198.7 Tank Fed
+//	ISP (Vac): 246 Pump Fed				241 Tank Fed (Guess)
+//	Burn Time: ???
+//	Chamber Pressure: 2.5 MPa Pump Fed	2.11 MPa Tank Fed
 //	Propellant: LOX / RP1
-//	Ratio: 1.80
-//	Engine Nozzle: 
-//	Nozzle Exit Area: 
-//	Nozzle Ratio: 
+//	Prop Ratio: 1.803
+//	Nozzle Ratio: 5.6
+//	==================================================================================
+//	LR101-NA-15 Mod 1
+//	Atlas MA-5
+//
+//	Data from Source #2
+//	Dry Mass: 19.05 kg
+//	Thrust (SL): 2.976 kN Pump Fed		2.340 kN Tank Fed
+//	Thrust (Vac): 
+//	ISP (SL): 190.5 Pump Fed			183.9 Tank Fed
+//	ISP (Vac): 
+//	Burn Time: ???
+//	Chamber Pressure: 1.77 MPa Pump Fed	1.49 MPa Tank Fed
+//	Propellant: LOX / RP1
+//	Prop Ratio: 1.803
+//	Nozzle Ratio: ???
 //	=================================================================================
 
 //	Sources:
 
-//	http://heroicrelics.org/info/lr-101/lr-101.html
 //	#1: Design Information Report for the LV-2A Propulsion System (LR-79-NA-13 & LR-101-NA-11) - Rocketdyne (1963): http://www.alternatewars.com/BBOW/Space_Engines/YLR-79-NA-13_Specs.pdf
+//	#2: http://heroicrelics.org/info/lr-101/lr-101.html
 
 //	Used by:
 
@@ -51,7 +77,7 @@
 {
 	%title = #roLR101Title	//LR101
 	%manufacturer = #roMfrRocketdyne
-	%description = #roLR101Desc	//A pump or pressure-fed kerolox vernier engine. Used for attitude control and final velocity adjustment in the MA-x system (2x LR89 + LR105 + 2x LR101) on Atlas, and MB-x system (LR79 or RS-27 + 2xLR101) on Thor-Able, Thor-Agena, Thor-Delta, and Delta.
+	%description = #roLR101Desc
 
 	@tags ^= :$: USA rocketdyne lr101 ma mb liquid pump booster kerosene lqdoxygen
 
@@ -78,11 +104,18 @@
 
 	MODULE
 	{
-		name = ModuleEngineConfigs
+		name = ModuleBimodalEngineConfigs
 		type = ModuleEngines
 		modded = false
 		configuration = LR101-NA-3
 		origMass = 0.024
+		literalZeroIgnitions = True
+
+		primaryDescription = Pump-fed
+		secondaryDescription = Tank-fed
+		toPrimaryText = Switch to Pump Feed
+		toSecondaryText = Switch to Tank Feed
+		//thrustLerpTime = 1
 
 		CONFIG
 		{
@@ -95,7 +128,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 0	//pyrotechnic start
 
 			IGNITOR_RESOURCE
 			{
@@ -123,6 +156,43 @@
 				key = 1 207
 			}
 
+			SUBCONFIG
+			{
+				name = LR101-NA-3-TankFed
+				
+				minThrust = 4.448
+				maxThrust = 4.448
+				
+				pressureFed = True
+				ignitions = 1
+				
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.3821
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.6179
+					DrawGauge = False
+				}
+				PROPELLANT
+				{
+					name = Nitrogen
+					ratio = 31.35
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+				
+				atmosphereCurve
+				{
+					key = 0 233
+					key = 1 197
+				}
+			}
+
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 400		//was run off tank pressure after engine cut-off to trim orbit on launches without upper stage, give a little extra margin
@@ -138,13 +208,13 @@
 			name = LR101-NA-11
 			description = Developed for later, larger Thor variants, with improved performance
 			specLevel = operational
-			minThrust = 5.369
-			maxThrust = 5.369
+			minThrust = 5.304
+			maxThrust = 5.304
 			heatProduction = 10
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 1	//Hypergolic start?
 
 			IGNITOR_RESOURCE
 			{
@@ -168,8 +238,45 @@
 
 			atmosphereCurve
 			{
-				key = 0 249
+				key = 0 246
 				key = 1 209.8
+			}
+			
+			SUBCONFIG
+			{
+				name = LR101-NA-11-TankFed
+				
+				minThrust = 4.329
+				maxThrust = 4.329
+				
+				pressureFed = True
+				ignitions = 1
+				
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.3821
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.6179
+					DrawGauge = False
+				}
+				PROPELLANT
+				{
+					name = Nitrogen
+					ratio = 31.65
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+				
+				atmosphereCurve
+				{
+					key = 0 241
+					key = 1 198.7
+				}
 			}
 
 			// http://www.asi.org/adb/04/03/09/01/bna.html
@@ -196,7 +303,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 1
+			ignitions = 1	//Hypergolic start?
 
 			IGNITOR_RESOURCE
 			{
@@ -220,8 +327,45 @@
 
 			atmosphereCurve
 			{
-				key = 0 224.3
+				key = 0 247
 				key = 1 190.5
+			}
+
+			SUBCONFIG
+			{
+				name = LR101-NA-15-TankFed
+				
+				minThrust = 3.079
+				maxThrust = 3.079
+				
+				pressureFed = True
+				ignitions = 1
+				
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.3821
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.6179
+					DrawGauge = False
+				}
+				PROPELLANT
+				{
+					name = Nitrogen
+					ratio = 22.35
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+				
+				atmosphereCurve
+				{
+					key = 0 242
+					key = 1 183.9
+				}
 			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -64,7 +64,7 @@
 //	Burn Time: 165
 //	Chamber Pressure: 3.69 MPa
 //	Propellant: LOX / RP1
-//	Ratio: 2.15
+//	Ratio: 2.156 (2.15 including verniers)
 //	Throttle: N/A
 //	Engine Nozzle: 1.16 m diameter
 //	Nozzle Exit Area: 1640 in^2 = 41.656 m^2
@@ -82,7 +82,7 @@
 //	Burn Time: 165
 //	Chamber Pressure: 3.79 MPa
 //	Propellant: LOX / RP1
-//	Ratio: 2.15 +/- 1.02%
+//	Ratio: 2.156 (2.15 including verniers) +/- 1.02%
 //	Throttle: N/A
 //	Engine Nozzle: 1.16 m diameter
 //	Nozzle Exit Area: 1640 in^2 = 41.656 m^2


### PR DESCRIPTION
Convert LR101 to use bimodal engine, capable of switching from pumpfed to tankfed mode.

LR101-NA-3 in pumpfed mode requires ground clamps to start, as early LR101s used pyrotechnic starters. All others can airstart.

This should discourage LR101 upper stages, as the LR101 in tank-fed mode performs worse and requires substantial pressurization.