### PR TITLE
Update/fix S5.23 TestFlight config, typos

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/S5_23_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_23_Config.cfg
@@ -71,7 +71,7 @@
 		CONFIG
 		{
 			name = S5.23
-			description = A.K.A 11D19, DU-49
+			description = A.K.A 11D49, DU-49
 			specLevel = operational
 			minThrust = 157.6
 			maxThrust = 157.6
@@ -105,35 +105,23 @@
 				key = 0 303
 				key = 1 150
 			}
+			//Kosmos 65S3: 8 flights, 2 failures (2 cycle?)
+			//Kosmos-3: 4 flights, 2 failures (1 cycle?, 1 unrelated)
+			//Kosmos-3M: 441 flights, 7 failures (1 ignition, 2 restart, 4 cycle)
+			//453 ignitions, 1 failure
+			//451 cycles, 5 failures
+			//446 restarts, 2 failures
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 1125	//assuming standard 3x margin
+				ratedBurnTime = 375
+				safeOverburn = true
+				ignitionReliabilityStart = 0.995833
+				ignitionReliabilityEnd = 0.999167
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.987279
+				cycleReliabilityEnd = 0.997456
+			}
 		}
-	}
-}
-
-//	==================================================
-//	TestFlight compatibility.
-//	==================================================
-
-//Kosmos 65S3: 8 flights, 2 failures (2 cycle?)
-//Kosmos-3: 4 flights, 2 failures (1 cycle?, 1 unrelated)
-//Kosmos-3M: 441 flights, 7 failures (1 ignition, 2 restart, 4 cycle)
-//453 ignitions, 1 failure
-//451 cycles, 5 failures
-//446 restarts, 2 failures
-@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[S5_23]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]:NEEDS[TestLite|TestFlight]
-{
-	TESTFLIGHT
-	{
-		name = S5-23
-		testedBurnTime = 1125	//assuming standard 3x margin
-		ratedBurnTime = 375
-		safeOverburn = true
-
-		ignitionReliabilityStart = 0.995833
-		ignitionReliabilityEnd = 0.999167
-		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.987279
-		cycleReliabilityEnd = 0.997456
-
-		@MODULE[ModuleEngineConfigs] { @CONFIG[S5_23] { %ratedBurnTime = #$/TESTFLIGHT[S5_23]/ratedBurnTime$ } }
 	}
 }

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -619,7 +619,7 @@ Localization
 		#roS2.253Desc = The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile and sounding rocket, based on the German Wasserfall engine. Better known by its western designation, Scud, later versions were exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
 		//		S5_23
 		#roS5_23Title = S5.23
-		#roS5_23Desc = A small gas-generator vacuum engine, developed as an upper stage for the R-16 to create the Kosmos-3 launch vehicle. Also known as the 11D49 or DU-49.
+		#roS5_23Desc = A small gas-generator vacuum engine, developed as an upper stage for the R-14 to create the Kosmos-3 launch vehicle. Also known as the 11D49 or DU-49.
 		//		S5_92
 		#roS5_92Title = S5.92
 		#roS5_92Desc = A gas generator cycle hypergolic vacuum engine used on the Fregat upper stage series.


### PR DESCRIPTION
Seems to have got lost in the mix, leaving the engine without TF support in-game (even though others with the older style, like the M-10, still work?). Also fixes a couple of typos (GRAU index 11D49, not 11D19, and Kosmos-3 based on R-14, not R-16).