### PR TITLE
Remove ullage from 11D58

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -133,6 +133,8 @@
 //		https://en.wikipedia.org/wiki/List_of_R-7_launches
 //		http://s001.radikal.ru/i196/1109/b8/202f80f773b3.jpg
 //		http://www.buran.ru/htm/gud%2025.htm
+//		http://buran.ru/htm/48-3.htm
+//		http://buran.ru/htm/bigbook2.htm
 
 //	Used by:
 //		Squad
@@ -611,7 +613,7 @@
 			heatProduction = 100
 			massMult = 1.5333		// 230 kg
 
-			ullage = True
+			ullage = False
 			pressureFed = False
 			ignitions = 15
 


### PR DESCRIPTION
According to known data (added in links), Buran OMS was fitted with fuel scoop. Given that for late Agena it gives "no ullage", it would be reasonable to also grant 11D58 with "no ullage" status, at least until someone will develop proper scoop system for tanks themselves.