### PR TITLE
Unbreak Mk1-3 rcs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -193,7 +193,7 @@
 		//name = ModuleRCS
 		name = ModuleRCSFX
 		runningEffectName = running
-		thrusterTransformName = RCSthruster
+		thrusterTransformName = thrustTransform
 		thrusterPower = 0.4448222
 		PROPELLANT
 		{


### PR DESCRIPTION
Restock model uses thrustTransform. RO used to have a restock-specific patch to use the right name, got lost in one of the vens-vs-restock refactors. BUT the Squad model also uses thrustTransform, and Ven's doesn't seem to have a Mk1-3 model, so this was just broken everywhere? Guessing the stock model changed at some point.

Fixes #2566