### PR TITLE
Convert Star-17 to fuel-based curve

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Star17_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Star17_Config.cfg
@@ -83,8 +83,8 @@
 		{
 			name = STAR-17
 			specLevel = operational
-			minThrust = 12.343
-			maxThrust = 12.343
+			minThrust = 10.94
+			maxThrust = 10.94
 			heatProduction = 100
 			ullage = False
 			pressureFed = False
@@ -107,26 +107,26 @@
 			chamberNominalTemp	= 1800
 			maxEngineTemp = 2050
 			curveResource = CTPB
-			thrustCurveUseTime = True
+			thrustCurveUseTime = False
 
 			thrustCurve
 			{
-				key = 0 0.7316822 1.083973 1.083973
-				key = 0.3 1.056875 0 0
-				key = 0.6 0.9146029 0 0
-				key = 2 0.975576 0 0
-				key = 5 0.894278 0 0
-				key = 7 1.017856 0.05933428 0.05933428
-				key = 10.5 1.12801 0 0
-				key = 15 1.008095 -0.04215827 -0.04215827
-				key = 17 0.8069966 -0.2148403 -0.2148403
-				key = 18.4 0.2438941 -0.2323799 -0.2323799
-				key = 21 0.00913826 0 0
+				key = 1.000 0.7316822 1.083973 1.083973
+				key = 0.988 1.056875 0 0
+				key = 0.972 0.9146029 0 0
+				key = 0.904 0.975576 0 0
+				key = 0.750 0.894278 0 0
+				key = 0.655 1.017856 -1.0 -1.1
+				key = 0.467 1.12801 0 0
+				key = 0.122 1.008095 0.5 0.5
+				key = 0.020 0.8069966 6.0 5.0
+				key = 0.015 0.2438941 30 20
+				key = 0.001 0.00913826 0 0
 			}
 			//High reliability kick motor for military payloads
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 19
+				ratedBurnTime = 25	//to account for tail-off
 				ignitionReliabilityStart = 0.98
 				ignitionReliabilityEnd = 0.999
 				cycleReliabilityStart = 0.98


### PR DESCRIPTION
Convert star-17 config to use a fuel-based thrust curve instead of time-based, using some basic math and a little trial and error.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/2465