### PR TITLE
RD-107/108 vernier (Making History Cub) fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Engine.cfg
@@ -321,8 +321,8 @@
 		%scale = .5, .75, .5
 	}
 	@scale = 0.5
-	%rescalFactor = 0.5
-	@mass = 1.238
+	%rescaleFactor = 0.5
+	@mass = 0.04
 	@manufacturer = NPO Energomash
 	@maxTemp = 1973.15
 	@title = RD107/108 Verniers

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Engine.cfg
@@ -316,12 +316,6 @@
 @PART[LiquidEngineRV-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@MODEL
-	{
-		%scale = .5, .75, .5
-	}
-	@scale = 0.5
-	%rescaleFactor = 0.5
 	@mass = 0.04
 	@manufacturer = NPO Energomash
 	@maxTemp = 1973.15


### PR DESCRIPTION
A single RD-107/108 vernier weighs as much as the entire RD-108. I've changed it to 40kg which makes sense from a vague "half the mass difference between the two" standpoint so it can actually be used as intended and also fixed a typo in rescaleFactor in the same config.