### PR TITLE
Change impact- and Q-tolerances to more sane values on all deployable parts

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -113,7 +113,6 @@
 	{
 		%impactResistance = 0.5			// m/s of relative velocity, default 2
 		%impactResistanceRetracted = 2	// m/s of relative velocity, default 5
-		%gResistance = 2				// vessel G-force, only applies to deployed parts, not used by default
 		%windResistance = 0.5			// dynamic pressure in kPa multiplied by AoA, only applies to deployed parts, default 3
 	}
 }
@@ -124,7 +123,6 @@
 	{
 		%impactResistance = 0.5
 		%impactResistanceRetracted = 2
-		%gResistance = 2
 		%windResistance = 0.5
 	}
 }

--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -107,6 +107,17 @@
 	%skinMaxTemp = 773.15
 }
 
+@PART:HAS[@MODULE[ModuleDeployable*]]:BEFORE[RealismOverhaul]
+{
+	@MODULE[ModuleDeployable*],*
+	{
+		%impactResistance = 0.5			// m/s of relative velocity, default 2
+		%impactResistanceRetracted = 2	// m/s of relative velocity, default 5
+		%gResistance = 2				// vessel G-force, only applies to deployed parts, not used by default
+		%windResistance = 0.5			// dynamic pressure in kPa multiplied by AoA, only applies to deployed parts, default 3
+	}
+}
+
 //  ==================================================
 //  Convert the engine modules to be compatible with
 //  RealFuels.

--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -118,6 +118,17 @@
 	}
 }
 
+@PART:HAS[@MODULE[ModuleROSolar]]:BEFORE[RealismOverhaul]
+{
+	@MODULE[ModuleROSolar],*
+	{
+		%impactResistance = 0.5
+		%impactResistanceRetracted = 2
+		%gResistance = 2
+		%windResistance = 0.5
+	}
+}
+
 //  ==================================================
 //  Convert the engine modules to be compatible with
 //  RealFuels.


### PR DESCRIPTION
This applies to all solar panels, radiators and antennas. If some part really needs higher tolerances then it's possible to overwrite this blanket-patch in `:FOR[RealismOverhaul]` pass.

Changed values:
* Impact resistance on deployed parts from 2 to 0.5 m/s
* Impact resistance on non-deployed parts from 5 to 2 m/s
* ~Max vessel acceleration on deployed parts from ♾️ to 2G~
* Max dynamic pressure from 3 to 0.5 kPa