### PR TITLE
Fix thrustmodifiers, remove quick-fix

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AMBR_Config.cfg
@@ -418,6 +418,14 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 3600
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
 				ignitionReliabilityStart = 0.98
 				ignitionReliabilityEnd = 0.995
 				cycleReliabilityStart = 0.98

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -640,6 +640,14 @@
 				testedBurnTime = 4500	//1.25 hours lifespan according to Martin Marietta OTV study
 				ratedBurnTime = 550
 				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
 				ignitionReliabilityStart = 0.967445
 				ignitionReliabilityEnd = 0.994860
 				cycleReliabilityStart = 0.982075
@@ -843,13 +851,6 @@
 				testedBurnTime = 4500		//assume same 1.25 hr as -3-3A
 				ratedBurnTime = 402
 				safeOverburn = true
-
-				// assume roughly exponential relationship between chamber pressure and lifespan
-				thrustModifier
-				{
-					key = 0.00 0.05 0 0
-					key = 1.00 1.00 3 3
-				}
 				ignitionReliabilityStart = 0.995540
 				ignitionReliabilityEnd = 0.999296
 				cycleReliabilityStart = 0.991121
@@ -1060,6 +1061,14 @@
 				testedBurnTime = 4500		//assume same 1.25 hr as -3-3A
 				ratedBurnTime = 430
 				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
 				ignitionReliabilityStart = 0.983333
 				ignitionReliabilityEnd = 0.996667
 				cycleReliabilityStart = 0.961111

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -182,9 +182,6 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 245		//245 seconds at full throttle
-				testedBurnTime = 330	//FIXME: Since throttle-based burn time limits are broken, add this so DIVH core will survive
-				overburnPenalty = 1.0	//FIXME: Just to increase life at low throttle, Ablator will provide hard limit
-				safeOverburn = true
 
 				// ablative, linear relationship between thrust and lifespan
 				thrustModifier
@@ -246,9 +243,6 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 245		//245 seconds at full throttle
-				testedBurnTime = 330	//FIXME: Since throttle-based burn time limits are broken, add this so DIVH core will survive
-				overburnPenalty = 1.0	//FIXME: Just to increase life at low throttle, Ablator will provide hard limit
-				safeOverburn = true
 
 				// ablative, linear relationship between thrust and lifespan
 				thrustModifier


### PR DESCRIPTION
Add thrustmodifiers to a few engines I missed, and remove the RS-68 burn time quick-fix since thrustmodifiers have been fixed in TF (see https://github.com/KSP-RO/TestFlight/pull/252)

fixes https://github.com/KSP-RO/RealismOverhaul/issues/2748