### PR TITLE
Add more RCS configs, add ASCENT, add electric RCS configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/Electric_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/Electric_RCS_Config.cfg
@@ -10,7 +10,7 @@
 		minTechLevel = 2
 		origTechLevel = 2
 		engineType = L
-		configuration = Hydrazine-Arcjet
+		configuration = Hydrazine-Electrothermal
 		modded = false
 		
 		origMass = 0.137

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/Electric_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/Electric_RCS_Config.cfg
@@ -1,0 +1,87 @@
+// RCS generic config
+@PART[*]:HAS[#engineType[ElectricRCSGeneric]]:FOR[RealismOverhaulEngines]
+{	
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleRCS
+		thrustRating = thrusterPower
+		techLevel = 2
+		minTechLevel = 2
+		origTechLevel = 2
+		engineType = L
+		configuration = Hydrazine-Arcjet
+		modded = false
+		
+		origMass = 0.137
+		
+		CONFIG
+		{
+			name = Hydrazine-Electrothermal
+			specLevel = operational
+			thrusterPower = 0.045
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Hydrazine
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 15.0
+				ignoreForIsp = True
+			}
+			
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 3257
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.30
+			IspV = 0.9006
+		}
+
+		CONFIG
+		{
+			name = Hydrazine-Arcjet
+			specLevel = operational
+			thrusterPower = 0.0045
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Hydrazine
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 15.0
+				ignoreForIsp = True
+			}
+			
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 24559
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.5
+			IspV = 1.76205
+		}
+	}
+}
+@PART[*]:HAS[~useRcsMass[True],#engineType[ElectricRCSGeneric]]:FOR[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS]]
+	{
+		-origMass = NULL
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -21,6 +21,7 @@
 		CONFIG
 		{
 			name = HTP
+			specLevel = operational
 			thrusterPower = 0.255
 			PROPELLANT
 			{
@@ -43,6 +44,7 @@
 		CONFIG
 		{
 			name = Hydrazine
+			specLevel = operational
 			thrusterPower = 0.275
 			PROPELLANT
 			{
@@ -65,6 +67,7 @@
 		CONFIG
 		{
 			name = NitrousOxide
+			specLevel = prototype	//has this actually flown?
 			thrusterPower = 0.265
 			PROPELLANT
 			{
@@ -79,6 +82,7 @@
 		CONFIG
 		{
 			name = Helium
+			specLevel = operational
 			thrusterPower = 0.072
 			PROPELLANT
 			{
@@ -93,6 +97,7 @@
 		CONFIG
 		{
 			name = Nitrogen
+			specLevel = operational
 			thrusterPower = 0.114
 			PROPELLANT
 			{
@@ -107,6 +112,7 @@
 		CONFIG
 		{
 			name = MMH+NTO
+			specLevel = operational
 			thrusterPower = 0.445
 			PROPELLANT
 			{
@@ -134,6 +140,7 @@
 		CONFIG
 		{
 			name = MMH+MON3
+			specLevel = operational
 			thrusterPower = 0.445
 			PROPELLANT
 			{
@@ -160,6 +167,7 @@
 		CONFIG
 		{
 			name = MMH+MON10
+			specLevel = operational
 			thrusterPower = 0.445
 			PROPELLANT
 			{
@@ -187,6 +195,7 @@
 		CONFIG
 		{
 			name = UDMH+NTO
+			specLevel = operational
 			thrusterPower = 0.442
 			PROPELLANT
 			{
@@ -214,6 +223,7 @@
 		CONFIG
 		{
 			name = Aerozine50+NTO
+			specLevel = operational
 			thrusterPower = 0.455
 			PROPELLANT
 			{
@@ -238,9 +248,142 @@
 			IspV = 0.955
 		}
 
+		//Source: https://www.niimashspace.ru/files/2020/NIIMash-production-2019.pdf
+		//Buran RCS used low expansion ratio. Correct ISP based on similar UDMH/NTO thrusters
+		CONFIG
+		{
+			name = Kerosene+O2
+			specLevel = operational
+			thrusterPower = 0.420
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.0006
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Oxygen
+				ratio = 0.9994
+			}
+
+			IspSL = 0.343
+			IspV = 0.895
+		}
+
+		CONFIG
+		{
+			name = Syntin+O2
+			specLevel = operational
+			thrusterPower = 0.426
+			PROPELLANT
+			{
+				name = Syntin
+				ratio = 0.0006
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Oxygen
+				ratio = 0.9994
+			}
+
+			IspSL = 0.348
+			IspV = 0.908
+		}
+
+		CONFIG
+		{
+			name = Ethanol+O2
+			specLevel = prototype
+			thrusterPower = 0.421
+			PROPELLANT
+			{
+				name = Ethanol75
+				ratio = 0.0008
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Oxygen
+				ratio = 0.9992
+			}
+
+			IspSL = 0.341
+			IspV = 0.898	//superior performance because ethanols better thermal properties lets thrusters run closer to optimal O/F
+		}
+
+		//Source: https://www.sciencedirect.com/science/article/pii/S0094576509000630
+		//Mostly just calculated with RPA
+		CONFIG
+		{
+			name = CH4+O2
+			specLevel = prototype
+			thrusterPower = 0.410
+			PROPELLANT
+			{
+				name = Methane
+				ratio = 0.7369
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Oxygen
+				ratio = 0.2631
+			}
+
+			IspSL = 0.386
+			IspV = 1.008
+		}
+
+		CONFIG
+		{
+			name = H2+O2
+			specLevel = prototype
+			thrusterPower = 0.210
+			PROPELLANT
+			{
+				name = Hydrogen
+				ratio = 0.7369
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Oxygen
+				ratio = 0.2631
+			}
+
+			IspSL = 0.372
+			IspV = 1.274
+		}
+
+		CONFIG
+		{
+			name = ASCENT	//HAN AF-M315E
+			specLevel = operational
+			thrusterPower = 0.413
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = ASCENT
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+
+			IspSL = 0.301
+			IspV = 0.7914	//Theoretical ISP 9.9% higher than Hydrazine
+		}
+
 		CONFIG
 		{
 			name = Cavea-B
+			specLevel = concept
 			thrusterPower = 0.425
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -114,7 +114,7 @@
 			name = MMH+NTO
 			specLevel = operational
 			thrusterPower = 0.445
-			PROPELLANT
+			PROPELLANT	//O/F: 1.65
 			{
 				name = MMH
 				ratio = 0.5
@@ -197,7 +197,7 @@
 			name = UDMH+NTO
 			specLevel = operational
 			thrusterPower = 0.442
-			PROPELLANT
+			PROPELLANT	//O/F: 2.6
 			{
 				name = UDMH
 				ratio = 0.413
@@ -225,7 +225,7 @@
 			name = Aerozine50+NTO
 			specLevel = operational
 			thrusterPower = 0.455
-			PROPELLANT
+			PROPELLANT	//O/F: 1.625
 			{
 				name = Aerozine50
 				ratio = 0.502
@@ -249,13 +249,13 @@
 		}
 
 		//Source: https://www.niimashspace.ru/files/2020/NIIMash-production-2019.pdf
-		//Buran RCS used low expansion ratio. Correct ISP based on similar UDMH/NTO thrusters
+		//Mostly just calculated with RPA, existing RCS configs are fairly optimistic
 		CONFIG
 		{
 			name = Kerosene+O2
 			specLevel = operational
-			thrusterPower = 0.420
-			PROPELLANT
+			thrusterPower = 0.362
+			PROPELLANT	//O/F: 2.62
 			{
 				name = Kerosene
 				ratio = 0.0006
@@ -265,18 +265,19 @@
 			{
 				name = Oxygen
 				ratio = 0.9994
+				resourceFlowMode = STACK_PRIORITY_SEARCH
 			}
 
-			IspSL = 0.343
-			IspV = 0.895
+			IspSL = 0.384
+			IspV = 1.002
 		}
 
 		CONFIG
 		{
 			name = Syntin+O2
 			specLevel = operational
-			thrusterPower = 0.426
-			PROPELLANT
+			thrusterPower = 0.367
+			PROPELLANT	//O/F: 2.62
 			{
 				name = Syntin
 				ratio = 0.0006
@@ -286,31 +287,33 @@
 			{
 				name = Oxygen
 				ratio = 0.9994
+				resourceFlowMode = STACK_PRIORITY_SEARCH
 			}
 
-			IspSL = 0.348
-			IspV = 0.908
+			IspSL = 0.389
+			IspV = 1.016
 		}
 
 		CONFIG
 		{
 			name = Ethanol+O2
 			specLevel = prototype
-			thrusterPower = 0.421
-			PROPELLANT
+			thrusterPower = 0.344
+			PROPELLANT	//O/F: 1.5
 			{
 				name = Ethanol75
-				ratio = 0.0008
+				ratio = 0.0011
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = Oxygen
-				ratio = 0.9992
+				ratio = 0.9989
+				resourceFlowMode = STACK_PRIORITY_SEARCH
 			}
 
-			IspSL = 0.341
-			IspV = 0.898	//superior performance because ethanols better thermal properties lets thrusters run closer to optimal O/F
+			IspSL = 0.361
+			IspV = 0.951
 		}
 
 		//Source: https://www.sciencedirect.com/science/article/pii/S0094576509000630
@@ -319,8 +322,8 @@
 		{
 			name = CH4+O2
 			specLevel = prototype
-			thrusterPower = 0.410
-			PROPELLANT
+			thrusterPower = 0.344
+			PROPELLANT	//O/F: 2.8
 			{
 				name = Methane
 				ratio = 0.7369
@@ -330,38 +333,41 @@
 			{
 				name = Oxygen
 				ratio = 0.2631
+				resourceFlowMode = STACK_PRIORITY_SEARCH
 			}
 
-			IspSL = 0.386
-			IspV = 1.008
+			IspSL = 0.401
+			IspV = 1.047
 		}
 
 		CONFIG
 		{
 			name = H2+O2
 			specLevel = prototype
-			thrusterPower = 0.210
-			PROPELLANT
+			thrusterPower = 0.275
+			PROPELLANT	//O/F: 5.6
 			{
 				name = Hydrogen
 				ratio = 0.7369
 				DrawGauge = True
+				resourceFlowMode = STACK_PRIORITY_SEARCH
 			}
 			PROPELLANT
 			{
 				name = Oxygen
 				ratio = 0.2631
+				resourceFlowMode = STACK_PRIORITY_SEARCH
 			}
 
-			IspSL = 0.372
-			IspV = 1.274
+			IspSL = 0.388
+			IspV = 1.329
 		}
 
 		CONFIG
 		{
 			name = ASCENT	//HAN AF-M315E
 			specLevel = operational
-			thrusterPower = 0.413
+			thrusterPower = 0.275
 			PROPELLANT
 			{
 				ratio = 1.0

--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -383,7 +383,7 @@
 			}
 
 			IspSL = 0.301
-			IspV = 0.7914	//Theoretical ISP 9.9% higher than Hydrazine
+			IspV = 0.7553	//Theoretical ISP 4.8% higher than Hydrazine
 		}
 
 		CONFIG

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -855,11 +855,13 @@ PARTUPGRADE
 	%TANK[Nitrogen]     { %utilization = 200 }
 	%TANK[Helium]       { %utilization = 200 }
 	%TANK[CaveaB]       {}
+	%TANK[ASCENT]       {}
 	%TANK[ArgonGas]     { %utilization = 100 }
 	%TANK[KryptonGas]   { %utilization = 100 }
 	%TANK[XenonGas]     { %utilization = 100 }
 	%TANK[Ammonia]      { %utilization = 100 }
 	%TANK[NitrousOxide] { %utilization = 100 }
+	%TANK[Methane]      { %utilization = 100 }
 
 	//pressure increases bp of liquids. Assuming 10 bar vapor over liquids
 	@TANK[LqdAmmonia] { @temperature = 298.06 }

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -39,6 +39,21 @@ RESOURCE_DEFINITION
   ksparpicon = RealFuels/Resources/ARPIcons/Aniline
 }
 
+//Create ASCENT (Advanced SpaceCraft Energetic Non-Toxic)
+//HAN AF-M315E
+RESOURCE_DEFINITION
+{
+  name = ASCENT
+  density = 0.001466	//FIXME: 46% higher than Hydrazine?
+  unitCost = 0.0001 //placeholder
+  hsp = 4183	//FIXME: Aqueous, same as water I guess.
+  flowMode = STACK_PRIORITY_SEARCH
+  transfer = PUMP
+  isTweakable = True
+  isVisible = true
+  ksparpicon = RealFuels/Resources/ARPIcons/ASCENT
+}
+
 //Add Beryllium
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Add kerosene, syntin, methane, hydrogen, and ASCENT RCS configs, add speclevels to RCS configs, and add electric RCS configs.

New RCS configs stats (at TL2)
Kerosene + Oxygen: 296 s ISP
Syntin + Oxygen: 300 s ISP
Ethanol + Oxygen: 280 s ISP
Methane + Oxygen: 308 s ISP
Hydrogen + Oxygen: 392 s ISP
ASCENT (HAN AF-M315E): 233 s ISP

New Electric RCS configs stats (at TL6)
Hydrazine electrothermal: 299 s ISP @ 1.1 kW/Newton
Hydrazine arcjet: 585 s ISP @ 4.3 kW/Newton

ASCENT has also been added as a resource, and methane gas added as an option for HP fuel tanks.

Needs: https://github.com/KSP-RO/RP-0/pull/1852