### PR TITLE
Rescale SAF B9PS subtypes when using the config tool

### DIFF
--- a/GameData/RealismOverhaul/RO_SAFConfig.cfg
+++ b/GameData/RealismOverhaul/RO_SAFConfig.cfg
@@ -48,6 +48,12 @@
 			{
 				@DATA
 				{
+					&scale = 1
+					@scale *= #$/ROSAFRescale$
+					@segmentLength *= #$/ROSAFRescale$
+					@shieldingCenter[*] *= #$/ROSAFRescale$
+					@shieldingBaseRadius *= #$/ROSAFRescale$
+					@editorOpenOffset[*] *= #$/ROSAFRescale$
 					@WALL_BASE
 					{
 						@CoM[*] *= #$/ROSAFRescale$


### PR DESCRIPTION
Fixes #2732 