### PR TITLE
Add HP warning to generic RCS description

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -1,6 +1,6 @@
 // RCS generic config
 @PART[*]:HAS[#engineType[RCSGeneric]]:FOR[RealismOverhaulEngines]
-{	
+{
 	MODULE
 	{
 		name = ModuleEngineConfigs
@@ -260,6 +260,11 @@
 			IspV = 0.939
 		}
 	}
+}
+@PART[*]:HAS[#engineType[RCSGeneric],!MODULE[ModuleEngines*]]:FOR[RealismOverhaulEngines]
+{
+	//FIXME: This should probably be shown in PAW, similar to MERF
+	@description ^= :$: <b><color=red> RCS requires High-Pressure tanks to function.</color></b>
 }
 @PART[*]:HAS[~useRcsMass[True],#engineType[RCSGeneric]]:FOR[RealismOverhaulEngines]
 {


### PR DESCRIPTION
Add warning to description of Generic RCS about high-pressure tanks. Since RCS does not use MERF, it does not get any of the PAW warnings other engines get. I do not feel confident in my ability to create a new module at the moment, but appending a warning to the part description will hopefully help a little.