### PR TITLE
Add X-405H-2, revise reliability

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -22,7 +22,7 @@
 //	X-405H
 //	Vega
 //
-//	Dry Mass: 219 Kg
+//	Dry Mass: 217 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 156.3 kN
 //	ISP: ??? SL / 311.9 Vac
@@ -32,12 +32,27 @@
 //	Prop Ratio: 2.40
 //	Throttle: N/A
 //	Nozzle Ratio: 25
-//	Ignitions: 3
+//	Ignitions: 1
+//	=================================================================================
+//	X-405H-2
+//	Vega
+//
+//	Dry Mass: 235 Kg	//Vega lost about 100 lbs in 1959. Assuming about half of that was restart equipment
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 156.3 kN
+//	ISP: ??? SL / 311.9 Vac
+//	Burn Time: 245
+//	Chamber Pressure: ??? MPa
+//	Propellant: LOX / Kerosene
+//	Prop Ratio: 2.40
+//	Throttle: N/A
+//	Nozzle Ratio: 25
+//	Ignitions: 1
 //	=================================================================================
 //	X-405H-3
 //	Vega
 //
-//	Dry Mass: 220 Kg
+//	Dry Mass: 240 Kg	//adding a bit more weight for bigger nozzle
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 161.86 kN
 //	ISP: ??? SL / 323 Vac
@@ -52,7 +67,7 @@
 //	X-405H-4
 //	Vega
 //
-//	Dry Mass: 220 Kg
+//	Dry Mass: 240 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 186.42 kN
 //	ISP: ??? SL / 323.5 Vac
@@ -195,12 +210,82 @@
 			minThrust = 150.5
 			maxThrust = 150.5
 			heatProduction = 78
-			massMult = 1.141
+			massMult = 1.13
+			ullage = True
+			pressureFed = False
+			
+			ignitions = 1
+			description = Engine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
+			
+            gimbalRange = 8.0 // H series engines have 3 degrees more gimbal than base X-405
+                
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+			
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 3
+			}
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.367
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.633 // 2.4*0.00082 / (2.4*0.00082+0.001141)
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				// no ignoreForIsp - data from Convair's report is consistent with HTP being counted in Isp, yields 208.5/311.9
+				// But for RF, we need biprop. So we ignoreForIsp and increase Isp.
+				ignoreForIsp = True
+				ratio = 0.0153
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 318.68 // 311.9
+				key = 1 213.03 //208.5
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350
+				ratedBurnTime = 245
+				safeOverburn = true
+				ignitionReliabilityStart = 0.80
+				ignitionReliabilityEnd = 0.95	//worse, since it now has to air-start
+				cycleReliabilityStart = 0.86
+				cycleReliabilityEnd = 0.97
+				techTransfer = X-405,XLR10-RM-2:50
+			}
+		}
+		CONFIG
+		{
+			name = X-405H-2
+			specLevel = prototype
+			minThrust = 150.5
+			maxThrust = 150.5
+			heatProduction = 78
+			massMult = 1.22
 			ullage = True
 			pressureFed = False
 			
 			ignitions = 3
-			description = Engine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
+			description = X-405H with restart capability. Although restart was eliminated from the Atlas-Vega test vehicles due to the presence of the JPL 3rd stage, the capability was retained for potential future missions.
 			
             gimbalRange = 8.0 // H series engines have 3 degrees more gimbal than base X-405
                 
@@ -251,11 +336,11 @@
 				testedBurnTime = 350
 				ratedBurnTime = 245
 				safeOverburn = true
-				ignitionReliabilityStart = 0.80
-				ignitionReliabilityEnd = 0.95
-				cycleReliabilityStart = 0.86
-				cycleReliabilityEnd = 0.97
-				techTransfer = X-405,XLR10-RM-2:50
+				ignitionReliabilityStart = 0.85
+				ignitionReliabilityEnd = 0.97
+				cycleReliabilityStart = 0.90
+				cycleReliabilityEnd = 0.98
+				techTransfer = X-405H,X-405,XLR10-RM-2:50
 			}
 		}
 		CONFIG
@@ -266,7 +351,7 @@
 			minThrust = 161.86
 			maxThrust = 161.86
 			heatProduction = 78
-			massMult = 1.15
+			massMult = 1.25
 			ullage = True
 			pressureFed = False
             gimbalRange = 8.0
@@ -315,15 +400,15 @@
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				// Copied from H-1.
+				// Copied from LR91-AJ-5
 				testedBurnTime = 350
 				ratedBurnTime = 245
 				safeOverburn = true
-				ignitionReliabilityStart = 0.89
-				ignitionReliabilityEnd = 0.97
-				cycleReliabilityStart = 0.93
-				cycleReliabilityEnd = 0.988
-				techTransfer = X-405H,X-405,XLR10-RM-2:50
+				ignitionReliabilityStart = 0.989674
+				ignitionReliabilityEnd = 0.998370
+				cycleReliabilityStart = 0.948370
+				cycleReliabilityEnd = 0.991848
+				techTransfer = X-405H-2,X-405H,X-405,XLR10-RM-2:50
 			}
 		}
 		CONFIG
@@ -334,7 +419,7 @@
 			minThrust = 186.42
 			maxThrust = 186.42
 			heatProduction = 78
-			massMult = 1.15
+			massMult = 1.25
 			ullage = True
 			pressureFed = False
 			gimbalRange = 8.0
@@ -382,15 +467,15 @@
 
 			TESTFLIGHT
 			{
-				// Copied from H-1b.
+				// Copied from LR91-AJ-11
 				testedBurnTime = 350
 				ratedBurnTime = 245
 				safeOverburn = true
-				ignitionReliabilityStart = 0.94
-				ignitionReliabilityEnd = 0.99
-				cycleReliabilityStart = 0.95
-				cycleReliabilityEnd = 0.994
-				techTransfer = X-405H-3,X-405H,X-405,XLR10-RM-2:50
+				ignitionReliabilityStart = 0.991441
+				ignitionReliabilityEnd = 0.998649
+				cycleReliabilityStart = 0.980030
+				cycleReliabilityEnd = 0.996847
+				techTransfer = X-405H-3,X-405H-2,X-405H,X-405,XLR10-RM-2:50
 			}
 		}
 	}


### PR DESCRIPTION
New PR, since I broke the last one:

Split X-405H proposals into one config without restart, and one with restart. Also adjust mass a bit based on Convair documents.

After rereading the Convair final report, it seems that while restart was eliminated from Atlas-Vega due to the presence of the third stage, the engine still possessed the capability, and there was still interest in a two-stage Atlas-Vega with restart capability. I split the X-405H into two configs, the basic X-405H without restart as was to be flown on the first Atlas-Vega launches, and the X-405H-2 with restart, with mass guesstimated based on mass breakdowns of the 3-stage and 2-stage proposals.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/1819
Needs https://github.com/KSP-RO/RP-0/pull/1649