### PR TITLE
Add ejection seat functionality

### DIFF
--- a/GameData/RealismOverhaul/EVA.cfg
+++ b/GameData/RealismOverhaul/EVA.cfg
@@ -28,7 +28,7 @@
 	%thermalMassModifier = 4
 	%emissiveConstant = 0.89
 	%absorptiveConstant = 0.25
-	%gTolerance = 20
+	%gTolerance = 25
 	%maxPressure = 20000
 	!breakingForce = DEL
 	!breakingTorque = DEL

--- a/GameData/RealismOverhaul/Parts/AdvCapsule/ROAdvCapsule.cfg
+++ b/GameData/RealismOverhaul/Parts/AdvCapsule/ROAdvCapsule.cfg
@@ -367,6 +367,30 @@ PART
             maxAmount = 12
         }
     }
+	
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		maxEjectSpeed = 900
+		maxEjectAltitude = 30000
+
+		SEAT    // left
+		{
+			colliderOffset = -0.8, 0.35, -1.35
+			colliderRotAngles = -70.0, 0.0, 18.0
+			forceDir = -0.35, 0.4, -1.0
+			ejectDelay = 0
+		}
+
+		SEAT    // right
+		{
+			colliderOffset = 0.8, 0.35, -1.35
+			colliderRotAngles = -70.0, 0.0, -18.0
+			forceDir = 0.35, 0.4, -1.0
+			ejectDelay = 0
+		}
+	}
+	
 }
 
 @PART[ROAdvCapsule]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/Parts/FighterCockpit/fighterInlineCockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/FighterCockpit/fighterInlineCockpit.cfg
@@ -115,6 +115,19 @@ PART
 		evaOnlyStorage = True
 		storageRange = 1.3
 	}
+	
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.08
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.45, -1.6
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/Parts/OldFighterCockpit/oldFighterCockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/OldFighterCockpit/oldFighterCockpit.cfg
@@ -112,6 +112,19 @@ PART
 		evaOnlyStorage = True
 		storageRange = 1.3
 	}
+	
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.04
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.55, -1.35
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/Parts/X1Cockpit/X1Cockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/X1Cockpit/X1Cockpit.cfg
@@ -131,6 +131,19 @@ PART
 		storageRange = 1.3
 	}
 	
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.04
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.45, -0.9
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+	
 	// Ejection seat
 	MODULE:NEEDS[VanguardTechnologies]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -359,6 +359,19 @@
 		amount = 225
 		maxAmount = 225
 	}
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.08
+		IsEnabled = false
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.25, -1.4
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
 }
 
 @INTERNAL[kondorcockpit]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -797,6 +797,101 @@
 	}
 }
 
+@PART[Mark1Cockpit]:FOR[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.04
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.6, -1.05
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+}
+
+@PART[Mark2Cockpit]:FOR[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.04
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.2, -1.3
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+}
+
+@PART[mk2Cockpit_Standard]:FOR[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.08
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.85, -1.5
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+}
+
+@PART[mk2Cockpit_Inline]:FOR[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.08
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.75, -2.25
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+}
+
+@PART[RO-Mk1Cockpit]:FOR[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.08
+
+		SEAT
+		{
+			colliderOffset = 0.0, 1.1, -1.35
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+}
+
+@PART[RO-Mk1CockpitInline]:FOR[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ModuleROEjectionSeat
+		mass = 0.08
+
+		SEAT
+		{
+			colliderOffset = 0.0, 0.65, -2.0
+			colliderRotAngles = -90.0, 0.0, 0.0
+			forceDir = 0.0, 0.15, -1.0
+		}
+	}
+}
 
 // INTERNAL node manipulation
 +INTERNAL[mk1CockpitInternal]:FOR[RealismOverhaul]

--- a/Source/DebugTools/DebugDrawer.cs
+++ b/Source/DebugTools/DebugDrawer.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Conditional = System.Diagnostics.ConditionalAttribute;
+
+namespace RealismOverhaul
+{
+    /// <summary>
+    /// Borrowed from Sarbian's DebugStuff
+    /// </summary>
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    class DebugDrawer : MonoBehaviour
+    {
+        private static readonly List<Line> lines = new List<Line>();
+        private static readonly List<Point> points = new List<Point>();
+        private static readonly List<Trans> transforms = new List<Trans>();
+        public Material lineMaterial;
+
+        private struct Line
+        {
+            public readonly Vector3 start;
+            public readonly Vector3 end;
+            public readonly Color color;
+
+            public Line(Vector3 start, Vector3 end, Color color)
+            {
+                this.start = start;
+                this.end = end;
+                this.color = color;
+            }
+        }
+
+        private struct Point
+        {
+            public readonly Vector3 pos;
+            public readonly Color color;
+
+            public Point(Vector3 pos, Color color)
+            {
+                this.pos = pos;
+                this.color = color;
+            }
+        }
+
+        private struct Trans
+        {
+            public readonly Vector3 pos;
+            public readonly Vector3 up;
+            public readonly Vector3 right;
+            public readonly Vector3 forward;
+
+            public Trans(Vector3 pos, Vector3 up, Vector3 right, Vector3 forward)
+            {
+                this.pos = pos;
+                this.up = up;
+                this.right = right;
+                this.forward = forward;
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static void DebugLine(Vector3 start, Vector3 end, Color col)
+        {
+            lines.Add(new Line(start, end, col));
+        }
+
+        [Conditional("DEBUG")]
+        public static void DebugPoint(Vector3 start, Color col)
+        {
+            points.Add(new Point(start, col));
+        }
+
+        [Conditional("DEBUG")]
+        public static void DebugTransforms(Transform t)
+        {
+            transforms.Add(new Trans(t.position, t.up, t.right, t.forward));
+        }
+
+        [Conditional("DEBUG")]
+        private void Start()
+        {
+            DontDestroyOnLoad(this);
+            if (!lineMaterial)
+            {
+                Shader shader = Shader.Find("Hidden/Internal-Colored");
+                lineMaterial = new Material(shader);
+                lineMaterial.hideFlags = HideFlags.HideAndDontSave;
+                lineMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                lineMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                lineMaterial.SetInt("_Cull", (int)UnityEngine.Rendering.CullMode.Off);
+                lineMaterial.SetInt("_ZWrite", 0);
+                lineMaterial.SetInt("_ZWrite", (int)UnityEngine.Rendering.CompareFunction.Always);
+            }
+            StartCoroutine("EndOfFrameDrawing");
+        }
+
+        private IEnumerator EndOfFrameDrawing()
+        {
+            Debug.Log("DebugDrawer starting");
+            while (true)
+            {
+                yield return new WaitForEndOfFrame();
+
+                Camera cam = GetActiveCam();
+
+                if (cam == null) continue;
+
+                try
+                {
+                    transform.position = Vector3.zero;
+
+                    GL.PushMatrix();
+                    lineMaterial.SetPass(0);
+
+                    // In a modern Unity we would use cam.projectionMatrix.decomposeProjection to get the decomposed matrix
+                    // and Matrix4x4.Frustum(FrustumPlanes frustumPlanes) to get a new one
+
+                    // Change the far clip plane of the projection matrix
+                    Matrix4x4 projectionMatrix = Matrix4x4.Perspective(cam.fieldOfView, cam.aspect, cam.nearClipPlane, float.MaxValue);
+                    GL.LoadProjectionMatrix(projectionMatrix);
+                    GL.MultMatrix(cam.worldToCameraMatrix);
+                    //GL.Viewport(new Rect(0, 0, Screen.width, Screen.height));
+
+                    GL.Begin(GL.LINES);
+
+                    for (int i = 0; i < lines.Count; i++)
+                    {
+                        Line line = lines[i];
+                        DrawLine(line.start, line.end, line.color);
+                    }
+
+                    for (int i = 0; i < points.Count; i++)
+                    {
+                        Point point = points[i];
+                        DrawPoint(point.pos, point.color);
+                    }
+
+                    for (int i = 0; i < transforms.Count; i++)
+                    {
+                        Trans t = transforms[i];
+                        DrawTransform(t.pos, t.up, t.right, t.forward);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.Log("EndOfFrameDrawing Exception" + e);
+                }
+                finally
+                {
+                    GL.End();
+                    GL.PopMatrix();
+
+                    lines.Clear();
+                    points.Clear();
+                    transforms.Clear();
+                }
+            }
+        }
+
+        private static Camera GetActiveCam()
+        {
+            if (!HighLogic.fetch)
+                return Camera.main;
+
+            if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch)
+                return EditorLogic.fetch.editorCamera;
+
+            if (HighLogic.LoadedSceneIsFlight && PlanetariumCamera.fetch && FlightCamera.fetch)
+                return MapView.MapIsEnabled ? PlanetariumCamera.Camera : FlightCamera.fetch.mainCamera;
+
+            return Camera.main;
+        }
+
+        private static void DrawLine(Vector3 origin, Vector3 destination, Color color)
+        {
+            GL.Color(color);
+            GL.Vertex(origin);
+            GL.Vertex(destination);
+        }
+
+        private static void DrawRay(Vector3 origin, Vector3 direction, Color color)
+        {
+            GL.Color(color);
+            GL.Vertex(origin);
+            GL.Vertex(origin + direction);
+        }
+
+        private static void DrawTransform(Vector3 position, Vector3 up, Vector3 right, Vector3 forward, float scale = 1.0f)
+        {
+            DrawRay(position, up * scale, Color.green);
+            DrawRay(position, right * scale, Color.red);
+            DrawRay(position, forward * scale, Color.blue);
+        }
+
+        private static void DrawPoint(Vector3 position, Color color, float scale = 1.0f)
+        {
+            DrawRay(position + Vector3.up * (scale * 0.5f), -Vector3.up * scale, color);
+            DrawRay(position + Vector3.right * (scale * 0.5f), -Vector3.right * scale, color);
+            DrawRay(position + Vector3.forward * (scale * 0.5f), -Vector3.forward * scale, color);
+        }
+    }
+}

--- a/Source/DebugTools/DrawTools.cs
+++ b/Source/DebugTools/DrawTools.cs
@@ -1,0 +1,479 @@
+﻿using System.Reflection;
+using UnityEngine;
+
+namespace RealismOverhaul
+{
+    /// <summary>
+    /// Borrowed from Sarbian's DebugStuff
+    /// </summary>
+    public static class DrawTools
+    {
+        private static Material _material;
+
+        private static int glDepth = 0;
+
+        private static Material material
+        {
+            get
+            {
+                if (_material == null) _material = new Material(Shader.Find("Hidden/Internal-Colored"));
+                return _material;
+            }
+        }
+
+        // Ok that's cheap but I did not want to add a bunch 
+        // of try catch to make sure the GL calls ends.
+        public static void NewFrame()
+        {
+            if (glDepth > 0)
+                MonoBehaviour.print(glDepth);
+            glDepth = 0;
+        }
+
+        private static void GLStart()
+        {
+            if (glDepth == 0)
+            {
+                GL.PushMatrix();
+                material.SetPass(0);
+                GL.LoadPixelMatrix();
+                GL.Begin(GL.LINES);
+            }
+            glDepth++;
+        }
+
+        private static void GLEnd()
+        {
+            glDepth--;
+
+            if (glDepth == 0)
+            {
+                GL.End();
+                GL.PopMatrix();
+            }
+        }
+
+
+        private static Camera GetActiveCam()
+        {
+            Camera cam;
+            if (HighLogic.LoadedSceneIsEditor)
+                cam = EditorLogic.fetch.editorCamera;
+            else if (HighLogic.LoadedSceneIsFlight)
+                cam = MapView.MapIsEnabled ? PlanetariumCamera.Camera : FlightCamera.fetch.mainCamera;
+            else
+                cam = Camera.main;
+            return cam;
+        }
+
+        private static Vector3 Tangent(Vector3 normal)
+        {
+            Vector3 tangent = Vector3.Cross(normal, Vector3.right);
+            if (tangent.sqrMagnitude <= float.Epsilon)
+                tangent = Vector3.Cross(normal, Vector3.up);
+            return tangent;
+        }
+
+        private static void DrawLine(Vector3 origin, Vector3 destination, Color color)
+        {
+            Camera cam = GetActiveCam();
+
+            Vector3 screenPoint1 = cam.WorldToScreenPoint(origin);
+            Vector3 screenPoint2 = cam.WorldToScreenPoint(destination);
+
+            GL.Color(color);
+            GL.Vertex3(screenPoint1.x, screenPoint1.y, 0);
+            GL.Vertex3(screenPoint2.x, screenPoint2.y, 0);
+        }
+
+        private static void DrawRay(Vector3 origin, Vector3 direction, Color color)
+        {
+            Camera cam = GetActiveCam();
+
+            Vector3 screenPoint1 = cam.WorldToScreenPoint(origin);
+            Vector3 screenPoint2 = cam.WorldToScreenPoint(origin + direction);
+
+            GL.Color(color);
+            GL.Vertex3(screenPoint1.x, screenPoint1.y, 0);
+            GL.Vertex3(screenPoint2.x, screenPoint2.y, 0);
+        }
+
+        public static void DrawTransform(Transform t, float scale = 1.0f)
+        {
+            GLStart();
+
+            DrawRay(t.position, t.up * scale, Color.green);
+            DrawRay(t.position, t.right * scale, Color.red);
+            DrawRay(t.position, t.forward * scale, Color.blue);
+
+            GLEnd();
+        }
+        public static void DrawPoint(Vector3 position, Color color, float scale = 1.0f)
+        {
+            GLStart();
+            GL.Color(color);
+
+            DrawRay(position + Vector3.up * (scale * 0.5f), -Vector3.up * scale, color);
+            DrawRay(position + Vector3.right * (scale * 0.5f), -Vector3.right * scale, color);
+            DrawRay(position + Vector3.forward * (scale * 0.5f), -Vector3.forward * scale, color);
+
+            GLEnd();
+        }
+
+        public static void DrawArrow(Vector3 position, Vector3 direction, Color color)
+        {
+            GLStart();
+            GL.Color(color);
+
+            DrawRay(position, direction, color);
+
+            GLEnd();
+
+            DrawCone(position + direction, -direction * 0.333f, color, 15);
+        }
+
+        public static void DrawCone(Vector3 position, Vector3 direction, Color color, float angle = 45)
+        {
+            float length = direction.magnitude;
+
+            Vector3 forward = direction;
+            Vector3 up = Tangent(forward).normalized;
+            Vector3 right = Vector3.Cross(forward, up).normalized;
+
+            float radius = length * Mathf.Tan(Mathf.Deg2Rad * angle);
+
+            GLStart();
+            GL.Color(color);
+
+            DrawRay(position, direction + radius * up, color);
+            DrawRay(position, direction - radius * up, color);
+            DrawRay(position, direction + radius * right, color);
+            DrawRay(position, direction - radius * right, color);
+
+            GLEnd();
+
+            DrawCircle(position + forward, direction, color, radius);
+            DrawCircle(position + forward * 0.5f, direction, color, radius * 0.5f);
+        }
+
+        public static void DrawLocalMesh(Transform transform, Mesh mesh, Color color)
+        {
+            if (mesh == null || mesh.triangles == null || mesh.vertices == null)
+                return;
+            int[] triangles = mesh.triangles;
+            Vector3[] vertices = mesh.vertices;
+            GLStart();
+            GL.Color(color);
+
+            for (int i = 0; i < triangles.Length; i += 3)
+            {
+                Vector3 p1 = transform.TransformPoint(vertices[triangles[i]]);
+                Vector3 p2 = transform.TransformPoint(vertices[triangles[i + 1]]);
+                Vector3 p3 = transform.TransformPoint(vertices[triangles[i + 2]]);
+                DrawLine(p1, p2, color);
+                DrawLine(p2, p3, color);
+                DrawLine(p3, p1, color);
+            }
+
+            GLEnd();
+        }
+
+        public static void DrawBounds(Bounds bounds, Color color)
+        {
+            Vector3 center = bounds.center;
+
+            float x = bounds.extents.x;
+            float y = bounds.extents.y;
+            float z = bounds.extents.z;
+
+            Vector3 topa = center + new Vector3(x, y, z);
+            Vector3 topb = center + new Vector3(x, y, -z);
+            Vector3 topc = center + new Vector3(-x, y, z);
+            Vector3 topd = center + new Vector3(-x, y, -z);
+
+            Vector3 bota = center + new Vector3(x, -y, z);
+            Vector3 botb = center + new Vector3(x, -y, -z);
+            Vector3 botc = center + new Vector3(-x, -y, z);
+            Vector3 botd = center + new Vector3(-x, -y, -z);
+
+            GLStart();
+            GL.Color(color);
+
+            // Top
+            DrawLine(topa, topc, color);
+            DrawLine(topa, topb, color);
+            DrawLine(topc, topd, color);
+            DrawLine(topb, topd, color);
+
+            // Sides
+            DrawLine(topa, bota, color);
+            DrawLine(topb, botb, color);
+            DrawLine(topc, botc, color);
+            DrawLine(topd, botd, color);
+
+            // Bottom
+            DrawLine(bota, botc, color);
+            DrawLine(bota, botb, color);
+            DrawLine(botc, botd, color);
+            DrawLine(botd, botb, color);
+
+            GLEnd();
+        }
+
+        public static void DrawRectTransform(RectTransform rectTransform, Canvas canvas, Color color)
+        {
+
+            Vector3[] corners = new Vector3[4];
+            Vector3[] screenCorners = new Vector3[2];
+
+            rectTransform.GetWorldCorners(corners);
+
+            if (canvas.renderMode == RenderMode.ScreenSpaceCamera || canvas.renderMode == RenderMode.WorldSpace)
+            {
+                screenCorners[0] = RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, corners[1]);
+                screenCorners[1] = RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, corners[3]);
+            }
+            else
+            {
+                screenCorners[0] = RectTransformUtility.WorldToScreenPoint(null, corners[1]);
+                screenCorners[1] = RectTransformUtility.WorldToScreenPoint(null, corners[3]);
+            }
+
+            GLStart();
+            GL.Color(color);
+
+            GL.Vertex3(screenCorners[0].x, screenCorners[0].y, 0);
+            GL.Vertex3(screenCorners[0].x, screenCorners[1].y, 0);
+
+            GL.Vertex3(screenCorners[0].x, screenCorners[1].y, 0);
+            GL.Vertex3(screenCorners[1].x, screenCorners[1].y, 0);
+
+            GL.Vertex3(screenCorners[1].x, screenCorners[1].y, 0);
+            GL.Vertex3(screenCorners[1].x, screenCorners[0].y, 0);
+
+            GL.Vertex3(screenCorners[1].x, screenCorners[0].y, 0);
+            GL.Vertex3(screenCorners[0].x, screenCorners[0].y, 0);
+
+            GLEnd();
+        }
+
+
+        public static void DrawLocalCube(Transform transform, Vector3 size, Color color, Vector3 center = default(Vector3))
+        {
+            Vector3 topa = transform.TransformPoint(center + new Vector3(-size.x, size.y, -size.z) * 0.5f);
+            Vector3 topb = transform.TransformPoint(center + new Vector3(size.x, size.y, -size.z) * 0.5f);
+
+            Vector3 topc = transform.TransformPoint(center + new Vector3(size.x, size.y, size.z) * 0.5f);
+            Vector3 topd = transform.TransformPoint(center + new Vector3(-size.x, size.y, size.z) * 0.5f);
+
+            Vector3 bota = transform.TransformPoint(center + new Vector3(-size.x, -size.y, -size.z) * 0.5f);
+            Vector3 botb = transform.TransformPoint(center + new Vector3(size.x, -size.y, -size.z) * 0.5f);
+
+            Vector3 botc = transform.TransformPoint(center + new Vector3(size.x, -size.y, size.z) * 0.5f);
+            Vector3 botd = transform.TransformPoint(center + new Vector3(-size.x, -size.y, size.z) * 0.5f);
+
+            GLStart();
+            GL.Color(color);
+
+            //top
+            DrawLine(topa, topb, color);
+            DrawLine(topb, topc, color);
+            DrawLine(topc, topd, color);
+            DrawLine(topd, topa, color);
+
+            //Sides
+            DrawLine(topa, bota, color);
+            DrawLine(topb, botb, color);
+            DrawLine(topc, botc, color);
+            DrawLine(topd, botd, color);
+
+            //Bottom
+            DrawLine(bota, botb, color);
+            DrawLine(botb, botc, color);
+            DrawLine(botc, botd, color);
+            DrawLine(botd, bota, color);
+
+            GLEnd();
+        }
+
+        public static void DrawCapsule(Vector3 start, Vector3 end, Color color, float radius = 1)
+        {
+            int segments = 18;
+            float segmentsInv = 1f / segments;
+
+            Vector3 up = (end - start).normalized * radius;
+            Vector3 forward = Tangent(up).normalized * radius;
+            Vector3 right = Vector3.Cross(up, forward).normalized * radius;
+
+            float height = (start - end).magnitude;
+            float sideLength = Mathf.Max(0, height * 0.5f - radius);
+            Vector3 middle = (end + start) * 0.5f;
+
+            start = middle + (start - middle).normalized * sideLength;
+            end = middle + (end - middle).normalized * sideLength;
+
+            //Radial circles
+            DrawCircle(start, up, color, radius);
+            DrawCircle(end, -up, color, radius);
+
+            GLStart();
+            GL.Color(color);
+
+            //Side lines
+            DrawLine(start + right, end + right, color);
+            DrawLine(start - right, end - right, color);
+
+            DrawLine(start + forward, end + forward, color);
+            DrawLine(start - forward, end - forward, color);
+
+            for (int i = 1; i <= segments; i++)
+            {
+                float stepFwd = i * segmentsInv;
+                float stepBck = (i - 1) * segmentsInv;
+                //Start endcap
+                DrawLine(Vector3.Slerp(right, -up, stepFwd) + start, Vector3.Slerp(right, -up, stepBck) + start, color);
+                DrawLine(Vector3.Slerp(-right, -up, stepFwd) + start, Vector3.Slerp(-right, -up, stepBck) + start, color);
+                DrawLine(Vector3.Slerp(forward, -up, stepFwd) + start, Vector3.Slerp(forward, -up, stepBck) + start, color);
+                DrawLine(Vector3.Slerp(-forward, -up, stepFwd) + start, Vector3.Slerp(-forward, -up, stepBck) + start, color);
+
+                //End endcap
+                DrawLine(Vector3.Slerp(right, up, stepFwd) + end, Vector3.Slerp(right, up, stepBck) + end, color);
+                DrawLine(Vector3.Slerp(-right, up, stepFwd) + end, Vector3.Slerp(-right, up, stepBck) + end, color);
+                DrawLine(Vector3.Slerp(forward, up, stepFwd) + end, Vector3.Slerp(forward, up, stepBck) + end, color);
+                DrawLine(Vector3.Slerp(-forward, up, stepFwd) + end, Vector3.Slerp(-forward, up, stepBck) + end, color);
+            }
+
+            GLEnd();
+        }
+
+        public static void DrawCircle(Vector3 position, Vector3 up, Color color, float radius = 1.0f)
+        {
+            int segments = 36;
+            float step = Mathf.Deg2Rad * 360f / segments;
+
+            Vector3 upNormal = up.normalized * radius;
+            Vector3 forwardNormal = Tangent(upNormal).normalized * radius;
+            Vector3 rightNormal = Vector3.Cross(upNormal, forwardNormal).normalized * radius;
+
+            Matrix4x4 matrix = new Matrix4x4();
+
+            matrix[0] = rightNormal.x;
+            matrix[1] = rightNormal.y;
+            matrix[2] = rightNormal.z;
+
+            matrix[4] = upNormal.x;
+            matrix[5] = upNormal.y;
+            matrix[6] = upNormal.z;
+
+            matrix[8] = forwardNormal.x;
+            matrix[9] = forwardNormal.y;
+            matrix[10] = forwardNormal.z;
+
+            Vector3 lastPoint = position + matrix.MultiplyPoint3x4(Vector3.right);
+
+            GLStart();
+            GL.Color(color);
+
+            for (int i = 0; i <= segments; i++)
+            {
+                Vector3 nextPoint;
+                var angle = i * step;
+                nextPoint.x = Mathf.Cos(angle);
+                nextPoint.z = Mathf.Sin(angle);
+                nextPoint.y = 0;
+
+                nextPoint = position + matrix.MultiplyPoint3x4(nextPoint);
+
+                DrawLine(lastPoint, nextPoint, color);
+                lastPoint = nextPoint;
+            }
+            GLEnd();
+        }
+
+        public static void DrawSphere(Vector3 position, Color color, float radius = 1.0f)
+        {
+            int segments = 36;
+            float step = Mathf.Deg2Rad * 360f / segments;
+
+            Vector3 x = new Vector3(position.x, position.y, position.z + radius);
+            Vector3 y = new Vector3(position.x + radius, position.y, position.z);
+            Vector3 z = new Vector3(position.x + radius, position.y, position.z);
+
+            GLStart();
+            GL.Color(color);
+
+            for (int i = 1; i <= segments; i++)
+            {
+                float angle = step * i;
+                Vector3 nextX = new Vector3(position.x, position.y + radius * Mathf.Sin(angle), position.z + radius * Mathf.Cos(angle));
+                Vector3 nextY = new Vector3(position.x + radius * Mathf.Cos(angle), position.y, position.z + radius * Mathf.Sin(angle));
+                Vector3 nextZ = new Vector3(position.x + radius * Mathf.Cos(angle), position.y + radius * Mathf.Sin(angle), position.z);
+
+                DrawLine(x, nextX, color);
+                DrawLine(y, nextY, color);
+                DrawLine(z, nextZ, color);
+
+                x = nextX;
+                y = nextY;
+                z = nextZ;
+            }
+            GLEnd();
+        }
+
+        public static void DrawCylinder(Vector3 start, Vector3 end, Color color, float radius = 1)
+        {
+            Vector3 up = (end - start).normalized * radius;
+            Vector3 forward = Tangent(up);
+            Vector3 right = Vector3.Cross(up, forward).normalized * radius;
+
+            //Radial circles
+            DrawCircle(start, up, color, radius);
+            DrawCircle(end, -up, color, radius);
+            DrawCircle((start + end) * 0.5f, up, color, radius);
+
+            GLStart();
+            GL.Color(color);
+
+            //Sides
+            DrawLine(start + right, end + right, color);
+            DrawLine(start - right, end - right, color);
+
+            DrawLine(start + forward, end + forward, color);
+            DrawLine(start - forward, end - forward, color);
+
+            //Top
+            DrawLine(start - right, start + right, color);
+            DrawLine(start - forward, start + forward, color);
+
+            //Bottom
+            DrawLine(end - right, end + right, color);
+            DrawLine(end - forward, end + forward, color);
+            GLEnd();
+        }
+
+        private static FieldInfo jointMode;
+
+        public static void DrawJoint(PartJoint joint)
+        {
+            if (joint == null)
+                return;
+
+            if (joint.Host == null || joint.Child == null || joint.Parent == null)
+                return;
+
+            Color col = joint.Host == joint.Child ? Color.blue : Color.red;
+
+            if (jointMode == null)
+                jointMode = typeof(PartJoint).GetField("mode", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            float node = ((AttachModes)jointMode.GetValue(joint)) == AttachModes.STACK ? 1 : 0.6f;
+
+            GLStart();
+            GL.Color(col * node);
+
+            DrawLine(joint.Child.transform.position, joint.Parent.transform.position, col * node);
+
+            GLEnd();
+        }
+    }
+}

--- a/Source/EjectionSeat/CrewEjectionHandler.cs
+++ b/Source/EjectionSeat/CrewEjectionHandler.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace RealismOverhaul
+{
+    public class CrewEjectionHandler : MonoBehaviour
+    {
+        private const double HorzSpeedToEnsure = 3;
+        private const double MinSrfAltitudeForHorzSpeedCheck = 10;
+
+        public float EjectionForce;
+        public float EjectionForceDuration;
+        public float ChuteMinPressureOverride;
+        public float ChuteDeployAltitudeOverride;
+        public float ChuteDelay;
+        public Vector3 ForceDirection;
+
+        private ModuleEvaChute _evaChute;
+
+        public KerbalEVA KerbalEVA { get; private set; }
+
+        private static readonly List<CrewEjectionHandler> _instances = new List<CrewEjectionHandler>();
+
+        public static CrewEjectionHandler CreateInstance(KerbalEVA eva)
+        {
+            var go = new GameObject("ROCrewEjectionHandler");
+            var handler = go.AddComponent<CrewEjectionHandler>();
+            handler.KerbalEVA = eva;
+            _instances.Add(handler);
+            return handler;
+        }
+
+        public static bool TryGetInstanceForKerbalEVA(KerbalEVA eva, out CrewEjectionHandler handler)
+        {
+            handler = _instances.Find(i => i.KerbalEVA == eva);
+            return !ReferenceEquals(handler, null);
+        }
+
+        public void StartProcessing()
+        {
+            StartCoroutine(AddForcesRoutine());
+            StartCoroutine(DelayedDeployChuteRoutine());
+        }
+
+        /// <summary>
+        /// If horizontal speed drops too low then the kerbal will fall out of air like a brick.
+        /// </summary>
+        /// <returns>Whether the horizontal speed should be increased to avoid stalling</returns>
+        public bool ShouldIncreaseHorizontalSpeed()
+        {
+            return KerbalEVA != null && _evaChute != null &&
+                   _evaChute.deploymentState == ModuleParachute.deploymentStates.DEPLOYED &&
+                   KerbalEVA.vessel.horizontalSrfSpeed < HorzSpeedToEnsure &&
+                   KerbalEVA.vessel.radarAltitude > MinSrfAltitudeForHorzSpeedCheck;
+        }
+
+        internal void OnDestroy()
+        {
+            _instances.Remove(this);
+        }
+
+        private IEnumerator AddForcesRoutine()
+        {
+            while (!KerbalEVA.Ready)
+                yield return new WaitForFixedUpdate();
+
+            bool firstFrame = true;
+            float remainingTime = EjectionForceDuration;
+            while (remainingTime > 0)
+            {
+                float scale = remainingTime < Time.fixedDeltaTime ? remainingTime / Time.fixedDeltaTime : 1;
+                remainingTime -= Time.fixedDeltaTime;
+                float scaledForce = scale * EjectionForce;
+                KerbalEVA.part.AddForce(ForceDirection * scaledForce);
+
+                if (firstFrame)
+                {
+                    SetIgnoreGForcesFrames(0);
+                    firstFrame = false;
+                }
+
+                yield return new WaitForFixedUpdate();
+            }
+        }
+
+        private IEnumerator DelayedDeployChuteRoutine()
+        {
+            yield return new WaitForSeconds(ChuteDelay);
+
+            _evaChute = KerbalEVA.GetComponent<ModuleEvaChute>();
+            if (_evaChute != null && _evaChute.enabled && _evaChute.deploymentState == ModuleParachute.deploymentStates.STOWED)
+            {
+                // Will only pre-deploy when air pressure is above the threshold and fully deploy below a preset altitude
+                _evaChute.minAirPressureToOpen = ChuteMinPressureOverride;
+                _evaChute.deployAltitude = ChuteDeployAltitudeOverride;
+                _evaChute.Deploy();
+            }
+        }
+
+        /// <summary>
+        /// Gotta compress those spines! KSP will by default ignore 10 frames which means that the G-meter won't budge at all.
+        /// This is probably necessary as a workaround to the kerbals getting excessive amounts of forces applied to them on spawn.
+        /// 10 frames is too much though so we try to override it to a smaller value.
+        /// </summary>
+        /// <param name="frames">Value to set ignoreGeeforceFrames field to</param>
+        private void SetIgnoreGForcesFrames(int frames)
+        {
+            var fInf = typeof(Vessel).GetField("ignoreGeeforceFrames", BindingFlags.Instance | BindingFlags.NonPublic);
+            fInf.SetValue(KerbalEVA.vessel, frames);
+        }
+    }
+}

--- a/Source/EjectionSeat/ModuleROEjectionSeat.cs
+++ b/Source/EjectionSeat/ModuleROEjectionSeat.cs
@@ -1,0 +1,396 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace RealismOverhaul
+{
+    public class ModuleROEjectionSeat : PartModule, IPartMassModifier, IPartCostModifier
+    {
+        public const string GroupName = "ROEjectionSeat";
+        public const string GroupDisplayName = "Ejection Seat";
+
+        private const string GameObjName = "ModuleROEjectionSeat";
+
+        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "Ejection seat(s)", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_Toggle(disabledText = "<color=red><b>Disabled</b></color>", enabledText = "<color=green>Enabled</color>", scene = UI_Scene.Editor)]
+        public bool IsEnabled = true;
+
+        [KSPField(isPersistant = true, guiActive = true, guiName = "Has fired", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public bool hasFired = false;
+
+        [KSPField(guiName = "colliderSize", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public Vector3 colliderSize = new Vector3(0.2f, 0.2f, 0.2f);
+
+        /// <summary>
+        /// Offset of the collider on which the kerbal will spawn. Is calculated from the transform of the parent part.
+        /// </summary>
+        [KSPField(guiName = "colliderOffset", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public Vector3 colliderOffset = new Vector3(0, 0.4f, -1);
+
+        [KSPField(guiName = "colliderRotAngles", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public Vector3 colliderRotAngles = new Vector3(-90, 0, 0);
+
+        [KSPField(guiName = "forceDir", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public Vector3 forceDir = new Vector3(0, 0.15f, -1);
+
+        [KSPField(guiFormat = "F2", guiName = "chuteMinPressureOverride", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float chuteMinPressureOverride = 0.01f;
+
+        [KSPField(guiFormat = "F0", guiUnits = "m", guiName = "chuteDeployAltitudeOverride", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float chuteDeployAltitudeOverride = 1000f;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F0", guiUnits = "m/s", guiName = "Max ejection speed", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float maxEjectSpeed = 330f;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F0", guiUnits = "m", guiName = "Max ejection altitude", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float maxEjectAltitude = 15000f;
+
+        [KSPField(guiActiveEditor = true, guiFormat = "F0", guiName = "Added cost", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float cost = 0f;
+
+        [KSPField(guiActiveEditor = true, guiFormat = "F2", guiUnits = "t", guiName = "Added mass", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float mass = 0f;
+
+#if !DEBUG
+        // There are also debug copies of those fields to make them editable in PAW
+
+        /// <summary>
+        /// Ejection force measured in kN.
+        /// </summary>
+        [KSPField(guiFormat = "F1", guiUnits = "kN", guiName = "ejectionForce", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float ejectionForce = 27f;
+
+        /// <summary>
+        /// Time in seconds over which the ejection forces are applied.
+        /// </summary>
+        [KSPField(guiFormat = "F2", guiUnits = "s", guiName = "ejectionForceDuration", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float ejectionForceDuration = 0.125f;
+
+        /// <summary>
+        /// Delay between ejection and chute predeployment being armed.
+        /// </summary>
+        [KSPField(guiFormat = "F1", guiUnits = "s", guiName = "Chute deployment delay", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        public float chuteDelay = 0.8f;
+#endif
+
+        private List<SeatConfig> _seats;
+
+        public override string GetModuleDisplayName() => "Ejection seat";
+
+        public override string GetInfo()
+        {
+            return $"Max ejection speed: {maxEjectSpeed:N0} m/s\n" +
+                   $"Max ejection altitude: {maxEjectAltitude:N0} m";
+        }
+
+        public override void OnLoad(ConfigNode node)
+        {
+            base.OnLoad(node);
+
+            if (!PartLoader.Instance.IsReady())
+            {
+                _seats = new List<SeatConfig>();
+                foreach (ConfigNode n in node.GetNodes("SEAT"))
+                {
+                    var seatConfig = new SeatConfig();
+                    ConfigNode.LoadObjectFromConfig(seatConfig, n);
+                    _seats.Add(seatConfig);
+                }
+
+                if (_seats.Count == 0)
+                {
+                    _seats.Add(new SeatConfig());    // fallback with default values
+                }
+            }
+        }
+
+        public override void OnStart(StartState state)
+        {
+            if (PartLoader.Instance.IsReady())
+            {
+                _seats = part.partInfo.partPrefab.FindModuleImplementing<ModuleROEjectionSeat>()._seats;
+            }
+
+            Fields[nameof(IsEnabled)].uiControlEditor.onFieldChanged = OnEnabledChanged;
+            OnEnabledChanged(Fields[nameof(IsEnabled)], IsEnabled);
+
+#if DEBUG
+            SeatConfig seat = _seats[0];
+            colliderOffsetX = seat.colliderOffset.x;
+            colliderOffsetY = seat.colliderOffset.y;
+            colliderOffsetZ = seat.colliderOffset.z;
+
+            rotateAngleX = seat.colliderRotAngles.x;
+            rotateAngleY = seat.colliderRotAngles.y;
+            rotateAngleZ = seat.colliderRotAngles.z;
+
+            forceDirX = seat.forceDir.x;
+            forceDirY = seat.forceDir.y;
+            forceDirZ = seat.forceDir.z;
+#endif
+        }
+
+        public float GetModuleMass(float defaultMass, ModifierStagingSituation sit) => IsEnabled ? mass : 0;
+
+        public ModifierChangeWhen GetModuleMassChangeWhen() => ModifierChangeWhen.FIXED;
+
+        public float GetModuleCost(float defaultCost, ModifierStagingSituation sit) => IsEnabled ? cost : 0;
+
+        public ModifierChangeWhen GetModuleCostChangeWhen() => ModifierChangeWhen.FIXED;
+
+        [KSPAction("Eject!", KSPActionGroup.Abort)]
+        public void Eject(KSPActionParam param) => Eject();
+
+        [KSPEvent(guiName = "Eject!", guiActive = true, guiActiveEditor = false, groupName = GroupName)]
+        public virtual void Eject()
+        {
+            if (!IsEnabled) return;
+
+            if (hasFired)
+            {
+                Debug.Log("[ROEjectionSeat] Ejection seat has already fired");
+                return;
+            }
+
+            if (part.protoModuleCrew.Count == 0)
+            {
+                Debug.Log("[ROEjectionSeat] No crew to eject");
+                return;
+            }
+
+            if (!CheckSafeToEject()) return;
+
+#if DEBUG
+            if (_dbgCollider != null)
+                _dbgCollider.gameObject.DestroyGameObjectImmediate();
+#endif
+
+            StartCoroutine(DoStaggeredEjectionRoutine());
+        }
+
+        private IEnumerator DoStaggeredEjectionRoutine()
+        {
+            int curCrewIdx = 0;
+            while (part.protoModuleCrew.Count > 0)
+            {
+                ProtoCrewMember crew = part.protoModuleCrew[0];
+                SeatConfig curSeat = _seats[curCrewIdx % _seats.Count];
+                EjectCrewmember(crew, curSeat);
+                curCrewIdx++;
+
+                if (part.protoModuleCrew.Count > 0)
+                {
+                    SeatConfig nextSeat = _seats[curCrewIdx % _seats.Count];
+                    yield return new WaitForSeconds(nextSeat.ejectDelay);
+                }
+            }
+        }
+
+        private void EjectCrewmember(ProtoCrewMember crew, SeatConfig seat)
+        {
+            var go = new GameObject(GameObjName);
+            go.layer = 21;
+            var collider = go.AddComponent<BoxCollider>();
+            Transform partTransform = part.gameObject.transform;
+            collider.transform.SetParent(partTransform, false);
+            collider.transform.rotation = partTransform.rotation;
+            collider.size = colliderSize;
+            collider.transform.position += partTransform.rotation * seat.colliderOffset;
+            collider.transform.Rotate(seat.colliderRotAngles);
+
+            var landedBef = vessel.Landed;
+            var splashedBef = vessel.Splashed;
+            var sitBef = vessel.situation;
+            vessel.Landed = true;    // Force the vessel to be landed to bypass some weird frame skips in KSP code
+
+            KerbalEVA eva;
+            try
+            {
+                eva = FlightEVA.fetch.spawnEVA(crew, part, collider.transform);
+            }
+            finally
+            {
+                vessel.situation = sitBef;
+                vessel.Landed = landedBef;
+                vessel.Splashed = splashedBef;
+            }
+
+            if (eva == null)
+            {
+                Debug.Log("[ROEjectionSeat] It appears that nobody was EVA'd");
+                return;
+            }
+
+            eva.autoGrabLadderOnStart = false;
+
+            hasFired = true;
+            var forceVector = partTransform.rotation * seat.forceDir.normalized;
+            go.DestroyGameObjectImmediate();
+
+            var handler = CrewEjectionHandler.CreateInstance(eva);
+            handler.EjectionForce = ejectionForce;
+            handler.EjectionForceDuration = ejectionForceDuration;
+            handler.ChuteMinPressureOverride = chuteMinPressureOverride;
+            handler.ChuteDeployAltitudeOverride = chuteDeployAltitudeOverride;
+            handler.ChuteDelay = chuteDelay;
+            handler.ForceDirection = forceVector;
+            handler.StartProcessing();
+        }
+
+        private bool CheckSafeToEject()
+        {
+            bool isAllowed = true;
+            if (vessel.srfSpeed > maxEjectSpeed)
+            {
+                Debug.Log("[ROEjectionSeat] CheckSafeToEject: over speed limit");
+                ScreenMessages.PostScreenMessage($"Ejection not possible, vessel speed exceeds the limit of {maxEjectSpeed:F0} m/s", 10f, ScreenMessageStyle.UPPER_CENTER, XKCDColors.Red);
+                isAllowed = false;
+            }
+
+            if (vessel.altitude > maxEjectAltitude)
+            {
+                Debug.Log("[ROEjectionSeat] CheckSafeToEject: over altitude limit");
+                ScreenMessages.PostScreenMessage($"Ejection not possible, vessel altitude exceeds the limit of {maxEjectAltitude:F0} m", 10f, ScreenMessageStyle.UPPER_CENTER, XKCDColors.Red);
+                isAllowed = false;
+            }
+
+            return isAllowed;
+        }
+
+        private void OnEnabledChanged(BaseField field, object obj)
+        {
+            Fields[nameof(maxEjectSpeed)].guiActiveEditor = Fields[nameof(maxEjectSpeed)].guiActive = IsEnabled;
+            Fields[nameof(maxEjectAltitude)].guiActiveEditor = Fields[nameof(maxEjectAltitude)].guiActive = IsEnabled;
+            Fields[nameof(cost)].guiActiveEditor = IsEnabled;
+            Fields[nameof(mass)].guiActiveEditor = IsEnabled;
+            Fields[nameof(hasFired)].guiActive = IsEnabled;
+            Events[nameof(Eject)].guiActive = IsEnabled;
+        }
+
+#if DEBUG
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiFormat = "F1", guiUnits = "kN", guiName = "ejectionForce", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = 1f, maxValue = 200, stepIncrement = 1f)]
+        public float ejectionForce = 27f;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiUnits = "s", guiName = "ejectionForceDuration", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = 0.01f, maxValue = 0.5f, stepIncrement = 0.01f)]
+        public float ejectionForceDuration = 0.125f;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiFormat = "F1", guiUnits = "s", guiName = "Chute deployment delay", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = 0.1f, maxValue = 5f, stepIncrement = 0.1f)]
+        public float chuteDelay = 0.8f;
+
+        [KSPField(guiActive = true, guiName = "IsHit", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_Label]
+        public bool isHit = false;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Debug", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_Toggle]
+        public bool isDebug = true;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F0", guiName = "rotateAngleX", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -180, maxValue = 180, stepIncrement = 1f)]
+        public float rotateAngleX = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F0", guiName = "rotateAngleY", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -180, maxValue = 180, stepIncrement = 1f)]
+        public float rotateAngleY = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F0", guiName = "rotateAngleZ", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -180, maxValue = 180, stepIncrement = 1f)]
+        public float rotateAngleZ = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiName = "forceDirX", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -1, maxValue = 1, stepIncrement = 0.01f)]
+        public float forceDirX = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiName = "forceDirY", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -1, maxValue = 1, stepIncrement = 0.01f)]
+        public float forceDirY = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiName = "forceDirZ", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -1, maxValue = 1, stepIncrement = 0.01f)]
+        public float forceDirZ = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiName = "colliderOffsetX", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -5, maxValue = 5, stepIncrement = 0.05f)]
+        public float colliderOffsetX = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiName = "colliderOffsetY", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -5, maxValue = 5, stepIncrement = 0.05f)]
+        public float colliderOffsetY = 0;
+
+        [KSPField(guiActive = true, guiActiveEditor = true, guiFormat = "F2", guiName = "colliderOffsetZ", groupName = GroupName, groupDisplayName = GroupDisplayName)]
+        [UI_FloatRange(minValue = -5, maxValue = 5, stepIncrement = 0.05f)]
+        public float colliderOffsetZ = 0;
+
+        private BoxCollider _dbgCollider;
+
+        public void Update()
+        {
+            if (!isDebug || !IsEnabled)
+            {
+                if (_dbgCollider != null) _dbgCollider.gameObject.DestroyGameObjectImmediate();
+                return;
+            }
+
+            if (hasFired) return;
+
+            Transform partTransform = part.gameObject.transform;
+            if (_dbgCollider == null)
+            {
+                var go = new GameObject(GameObjName);
+                go.layer = 21;
+                _dbgCollider = go.AddComponent<BoxCollider>();
+                _dbgCollider.transform.SetParent(partTransform, false);
+            }
+            _dbgCollider.transform.localPosition = Vector3.zero;
+            _dbgCollider.size = colliderSize;
+
+            colliderOffset = new Vector3(colliderOffsetX, colliderOffsetY, colliderOffsetZ);
+            _dbgCollider.transform.position += partTransform.rotation * colliderOffset;
+
+            _dbgCollider.transform.rotation = partTransform.rotation;
+            colliderRotAngles = new Vector3(rotateAngleX, rotateAngleY, rotateAngleZ);
+            _dbgCollider.transform.Rotate(colliderRotAngles);
+
+            DebugDrawer.DebugTransforms(_dbgCollider.transform);
+            DrawTools.DrawLocalCube(_dbgCollider.transform, _dbgCollider.size, Color.magenta, _dbgCollider.center);
+            DebugDrawer.DebugTransforms(partTransform);
+
+            forceDir = new Vector3(forceDirX, forceDirY, forceDirZ);
+            Vector3 forceVector = partTransform.rotation * forceDir;
+            DebugDrawer.DebugLine(_dbgCollider.transform.position, _dbgCollider.transform.position + forceVector, Color.magenta);
+
+            Vector3 rayOrigin = _dbgCollider.transform.transform.position - 0.5f * (_dbgCollider.transform.position - part.transform.position).normalized;
+            Vector3 rayDir = (_dbgCollider.transform.position - part.transform.position).normalized;
+            DebugDrawer.DebugPoint(rayOrigin, Color.gray);
+            DebugDrawer.DebugLine(rayOrigin, rayOrigin + rayDir, Color.cyan);
+            int layer = LayerUtil.DefaultEquivalent | 0x8000 | 0x80000 | 0x4000000;
+            isHit = Physics.Raycast(rayOrigin, rayDir,
+                out var hitInfo, part.hatchObstructionCheckOutwardDistance + 0.5f,
+                layer, QueryTriggerInteraction.Ignore);
+            if (isHit)
+            {
+                DebugDrawer.DebugPoint(hitInfo.point, Color.black);
+            }
+            bool b = FlightEVA.hatchInsideFairing(part);
+            isHit |= b;
+
+            SeatConfig seat = _seats[0];
+            seat.colliderOffset.x = colliderOffsetX;
+            seat.colliderOffset.y = colliderOffsetY;
+            seat.colliderOffset.z = colliderOffsetZ;
+
+            seat.colliderRotAngles.x = rotateAngleX;
+            seat.colliderRotAngles.y = rotateAngleY;
+            seat.colliderRotAngles.z = rotateAngleZ;
+
+            seat.forceDir.x = forceDirX;
+            seat.forceDir.y = forceDirY;
+            seat.forceDir.z = forceDirZ;
+        }
+#endif
+    }
+}

--- a/Source/EjectionSeat/SeatConfig.cs
+++ b/Source/EjectionSeat/SeatConfig.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace RealismOverhaul
+{
+    public class SeatConfig
+    {
+        [Persistent]
+        public Vector3 colliderOffset = new Vector3(0, 0.4f, -1);
+
+        [Persistent]
+        public Vector3 colliderRotAngles = new Vector3(-90, 0, 0);
+
+        [Persistent]
+        public Vector3 forceDir = new Vector3(0, 0.15f, -1);
+
+        /// <summary>
+        /// Delay between the previous and current ejection.
+        /// No effect on the first ejection since that will always happen instantly.
+        /// </summary>
+        [Persistent]
+        public float ejectDelay = 0.5f;
+    }
+}

--- a/Source/Harmony/KerbalEVA.cs
+++ b/Source/Harmony/KerbalEVA.cs
@@ -1,0 +1,27 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace RealismOverhaul.Harmony
+{
+    [HarmonyPatch(typeof(KerbalEVA))]
+    internal class PatchKerbalEVA
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch("HandleMovementInput")]
+        internal static void Postfix_HandleMovementInput(KerbalEVA __instance, ref Vector3 ___parachuteInput)
+        {
+            if (__instance.vessel.state == Vessel.State.ACTIVE && ___parachuteInput.sqrMagnitude > 0)    // Do not override players inputs
+                return;
+
+            if (CrewEjectionHandler.TryGetInstanceForKerbalEVA(__instance, out CrewEjectionHandler handler) &&
+                handler.ShouldIncreaseHorizontalSpeed())
+            {
+                ___parachuteInput = new Vector3(1, 0, 0);    // Same as pressing the 'W' key
+            }
+            else
+            {
+                ___parachuteInput = Vector3.zero;
+            }
+        }
+    }
+}

--- a/Source/HarmonyPatcher.cs
+++ b/Source/HarmonyPatcher.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace RealismOverhaul
+{
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    public class HarmonyPatcher : MonoBehaviour
+    {
+        internal void Start()
+        {
+            var harmony = new HarmonyLib.Harmony("RO.HarmonyPatcher");
+            harmony.PatchAll();
+        }
+    }
+}

--- a/Source/RealismOverhaul.csproj
+++ b/Source/RealismOverhaul.csproj
@@ -33,8 +33,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AdjustableCoMShifter.cs" />
+    <Compile Include="DebugTools\DebugDrawer.cs" />
+    <Compile Include="DebugTools\DrawTools.cs" />
+    <Compile Include="EjectionSeat\CrewEjectionHandler.cs" />
     <Compile Include="EventHandlers.cs" />
+    <Compile Include="HarmonyPatcher.cs" />
+    <Compile Include="Harmony\KerbalEVA.cs" />
     <Compile Include="ModuleEngineText.cs" />
+    <Compile Include="EjectionSeat\ModuleROEjectionSeat.cs" />
+    <Compile Include="EjectionSeat\SeatConfig.cs" />
     <Compile Include="UpgradePipeline.cs" />
     <Compile Include="StartupPopup.cs" />
     <Compile Include="VesselModuleRotationRO.cs" />
@@ -49,16 +56,17 @@
     <Compile Include="DynamicPartHider\RDTechFixer.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(KSPPath)\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System">
-      <HintPath>$(KSPPath)\KSP_Data\Managed\System.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(KSPPath)\KSP_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -66,14 +74,16 @@
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Games\KSPDev\KSP_x64_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>$(KSPPath)\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RealFuels">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Only a handful of cockpits are currently configured. When the RO dll is built in debug mode then there are handy onscreen markers that help with nailing down collider rotations, offsets and force vectors.

Among other changes, this also ups the naut G tolerance from 20 to 25 since ejection seats aim for ~20G.

Configured parts:
* X-1
* X-15 standalone
* X-15 inline
* Mk1 standalone
* Mk1 inline
* Mk2/SR-71-alike standalone
* Mk2/SR-71-alike inline
* SXTBuzzard aka the Stuka

**#2765 should be merged before this.**