### PR TITLE
Mk2 lander has rover variant again, slight weight reduction

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -530,7 +530,10 @@
 
 	@MODULE[ModulePartVariants]
 	{
-		!VARIANT[Rover] {}
+		@VARIANT[Rover] 
+		{
+			%mass = -0.5
+		}
 	}
 }
 


### PR DESCRIPTION
Slight weight reduction, tank size the same because "sidepods" are empty space