### PR TITLE
Hide the bugged miniLandingLeg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -105,9 +105,9 @@
 @PART[miniLandingLeg]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-        %category = none
-        %subcategory = 0
-        %TechHidden = True
+        %category:NEEDS[ReStock] = none
+        %subcategory:NEEDS[ReStock] = 0
+        %TechHidden:NEEDS[ReStock] = True
 	@mass = 0.01
 }
 @PART[largeAdapter]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -105,6 +105,9 @@
 @PART[miniLandingLeg]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+        %category = none
+        %subcategory = 0
+        %TechHidden = True
 	@mass = 0.01
 }
 @PART[largeAdapter]:FOR[RealismOverhaul]


### PR DESCRIPTION
Hide the bugged miniLandingLeg from the parts list in VAB/SPH and from R&D building