### PR TITLE
More NTRs and Updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/BNTR25k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/BNTR25k_Config.cfg
@@ -1,0 +1,222 @@
+//	==================================================
+//	Bimodal NTR (25klbf)
+//
+//	Manufacturer: Aerojet Rocketdyne
+//
+//	=================================================================================
+//	BNTR
+//	Hydrogen Mode
+//
+//	Dry Mass: 3670 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 111.6 kN
+//	ISP: 380 SL / 894 Vac
+//	Burn Time: 3600/56700		1.75 hrs burn/mission * 9 mission expected lifetime
+//	Chamber Pressure: 6.89 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 389
+//	Ignitions: 60
+//	=================================================================================
+
+//	Sources:
+
+//		"Bimodal" Nuclear Thermal Rocket (BNTR) Propulsion:					   http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
+//		AIAA - TRITON (TRImodal Thrust Optimized Nuclear rocket engine):	   http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3863_TRITON.pdf
+//		Crewed Mars Mission using Bimodal Nuclear Thermal Electric Propulsion: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140009579.pdf
+//		LEU NTP Engine System Trades and Mission Options		http://anstd.ans.org/NETS-2019-Papers/Track-2--Mission-Concepts-and-Logistics/abstract-29-0.pdf
+
+//	Used by:
+
+//	Notes:
+//	Amalgamation of 25 klbf NTER and 25 klbf LEU NTP. Also with LOX augmentation because why not.
+//	Doesn't include mass of radiators/recuperators, not sure how to implement that.
+//	==================================================
+
+@PART[*]:HAS[#engineType[BNTR25k]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roBNTR25kTitle
+	%manufacturer = #roMfrAerojetRocketdyne
+	%description = #roBNTR25kDesc
+
+	@tags ^= :$: USA aerojet rocketdyne ajr bimodal ntr bntr 25k nuclear pump upper lqdhydrogen lqdoxygen
+
+	%specLevel = concept
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 3.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[Module*EngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleResourceConverter],*{}
+	!MODULE[ModuleHybridEngine],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleBimodalEngineConfigs
+		type = ModuleEngines
+		configuration = BNTR25k
+		modded = False
+		origMass = 3.470	//3670 kg - 200 kg fuel
+		
+		primaryDescription = Hydrogen NTR
+		secondaryDescription = LOX-Augmented NTR
+		toPrimaryText = Disable Thrust Augmentation
+		toSecondaryText = Engage Thrust Augmentation
+
+		CONFIG
+		{
+			name = BNTR25k
+			specLevel = concept
+			minThrust = 111.6
+			maxThrust = 111.6
+			massMult = 1.0
+			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
+			ullage = True
+			pressureFed = False
+			ignitions = 60
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = UraniumNitride
+				ratio = 1.0813e-15
+				DrawGauge = False
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 894
+				key = 1 300
+			}
+			//LANTR was abandonded by this point, but why not add it anyway...
+			SUBCONFIG
+			{
+				name = TRITON25k
+				specLevel = speculative
+				minThrust = 305.04
+				maxThrust = 305.04
+				
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 0.8430
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.1570
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = UraniumNitride
+					ratio = 1.0813e-15
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+
+				atmosphereCurve
+				{
+					key = 0 620
+					key = 1 320
+				}
+			}
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedContinuousBurnTime = 3600
+				ratedBurnTime = 56700
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+				
+				techTransfer = BNTR:20
+			}
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Brayton Generator
+		StartActionName = Start Brayton Generator
+		StopActionName = Stop Brayton Generator
+		AlwaysActive = False
+		FillAmount = 1.0
+		AutoShutdown = False
+		GeneratesHeat = True
+		TemperatureModifier = 2.0
+		UseSpecializationBonus = False
+		DefaultShutoffTemp = 0.75
+
+		INPUT_RESOURCE
+		{
+			ResourceName = UraniumNitride
+			Ratio = 2.163e-14
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 500.0
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 2.163e-14
+		}
+	}
+
+	RESOURCE
+	{
+		name = UraniumNitride
+		amount = 13.986	//~200 kg
+		maxAmount = 13.986
+		isTweakable = False
+	}
+
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 13.986
+		isTweakable = False
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/BNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/BNTR_Config.cfg
@@ -11,8 +11,8 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 66.72 kN
 //	ISP: 380 SL / 930 Vac
-//	Burn Time: 5400
-//	Chamber Pressure: ??? MPa
+//	Burn Time: 3600/36000	guess 10 hours lifespan?
+//	Chamber Pressure: 6.89 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Throttle: N/A
@@ -26,8 +26,8 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 182.37 kN
 //	ISP: ??? SL / 645 Vac
-//	Burn Time: 5400
-//	Chamber Pressure: ??? MPa
+//	Burn Time: ???
+//	Chamber Pressure: 6.89 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 3.0
 //	Throttle: N/A
@@ -71,7 +71,7 @@
 		%gimbalResponseSpeed = 16
 	}
 
-	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[Module*EngineConfigs],*{}
 	!MODULE[ModuleAlternator],*{}
 	!MODULE[ModuleResourceConverter],*{}
 	!MODULE[ModuleHybridEngine],*{}
@@ -79,11 +79,16 @@
 
 	MODULE
 	{
-		name = ModuleHybridEngine
+		name = ModuleBimodalEngineConfigs
 		type = ModuleEngines
 		configuration = BNTR
 		modded = False
-		origMass = 2.215
+		origMass = 2.160	//2215 kg - 55 kg fuel
+		
+		primaryDescription = Hydrogen NTR
+		secondaryDescription = LOX-Augmented NTR
+		toPrimaryText = Disable Thrust Augmentation
+		toSecondaryText = Engage Thrust Augmentation
 
 		CONFIG
 		{
@@ -124,53 +129,55 @@
 				key = 0 930
 				key = 1 380
 			}
-		}
-
-		CONFIG
-		{
-			name = TRITON
-			specLevel = concept
-			minThrust = 182.37
-			maxThrust = 182.37
-			massMult = 1.0
-			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
-
-			ullage = True
-			pressureFed = False
-			ignitions = 60
-
-			IGNITOR_RESOURCE
+			
+			SUBCONFIG
 			{
-				name = ElectricCharge
-				amount = 0.5
+				name = TRITON
+				minThrust = 182.37
+				maxThrust = 182.37
+				
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 0.8430
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.1570
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = EnrichedUranium
+					ratio = 1.0813e-15
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+
+				atmosphereCurve
+				{
+					key = 0 645
+					key = 1 390
+				}
 			}
-
-			PROPELLANT
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				name = LqdHydrogen
-				ratio = 0.8430
-				DrawGauge = True
-			}
+				ratedContinuousBurnTime = 3600
+				ratedBurnTime = 36000
 
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.1570
-				DrawGauge = False
-			}
-
-			PROPELLANT
-			{
-				name = EnrichedUranium
-				ratio = 1.0813e-15
-				DrawGauge = False
-				ignoreForIsp = True
-			}
-
-			atmosphereCurve
-			{
-				key = 0 645
-				key = 1 390
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
 			}
 		}
 	}
@@ -203,7 +210,7 @@
 
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName  = DepletedUranium
 			Ratio = 1.0813e-15
 		}
 	}
@@ -211,7 +218,7 @@
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 5
+		amount = 5	//54.85 kg
 		maxAmount = 5
 		isTweakable = False
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/INsTAR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/INsTAR_Config.cfg
@@ -1,0 +1,220 @@
+//	==================================================
+//	INsTAR
+//
+//	Manufacturer: Aerojet Rocketdyne
+//
+//	=================================================================================
+//	INsTAR
+//	
+//
+//	Dry Mass: 2900 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 266.89 kN
+//	ISP: ??? SL / 1082 Vac
+//	Burn Time: 3600/36000	guess, LEU should extend lifetime
+//	Chamber Pressure: 11.19 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 389
+//	Ignitions: 60
+//	=================================================================================
+
+//	Sources:
+
+//		"Bimodal" Nuclear Thermal Rocket (BNTR) Propulsion:					   http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf
+//		AIAA - TRITON (TRImodal Thrust Optimized Nuclear rocket engine):	   http://alternatewars.com/BBOW/Space_Engines/AIAA-2004-3863_TRITON.pdf
+//		Crewed Mars Mission using Bimodal Nuclear Thermal Electric Propulsion: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20140009579.pdf
+//		LEU NTP Engine System Trades and Mission Options		http://anstd.ans.org/NETS-2019-Papers/Track-2--Mission-Concepts-and-Logistics/abstract-29-0.pdf
+
+//	Used by:
+
+//	==================================================
+
+@PART[*]:HAS[#engineType[INsTAR]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roINsTARTitle
+	%manufacturer = #roMfrAerojetRocketdyne
+	%description = #roINsTARDesc
+
+	@tags ^= :$: USA aerojet rocketdyne ajr instar nuclear pump upper lqdhydrogen lqdoxygen
+
+	%specLevel = concept
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 3.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[Module*EngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleResourceConverter],*{}
+	!MODULE[ModuleHybridEngine],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleBimodalEngineConfigs
+		type = ModuleEngines
+		configuration = INsTAR
+		modded = False
+		origMass = 2.600	//2900 kg - 300 kg fuel
+		
+		primaryDescription = Hydrogen NTR
+		secondaryDescription = LOX-Augmented NTR
+		toPrimaryText = Disable Thrust Augmentation
+		toSecondaryText = Engage Thrust Augmentation
+
+		CONFIG
+		{
+			name = INsTAR
+			specLevel = concept
+			minThrust = 266.89
+			maxThrust = 266.89
+			massMult = 1.0
+			throttleResponseRate = 0.1 //derived from SNTP core, should be around 10 secs too fully ramp up to 100% from 0%?
+
+			ullage = True
+			pressureFed = False
+			ignitions = 60
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = UraniumNitride
+				ratio = 1.0813e-15
+				DrawGauge = False
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1082
+				key = 1 300
+			}
+			
+			//why not?
+			SUBCONFIG
+			{
+				name = LAINsTAR
+				specLevel = speculative
+				minThrust = 729.51
+				maxThrust = 729.51
+				
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 0.8430
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.1570
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = UraniumNitride
+					ratio = 1.0813e-15
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+
+				atmosphereCurve
+				{
+					key = 0 750
+					key = 1 390
+				}
+			}
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedContinuousBurnTime = 3600
+				ratedBurnTime = 36000
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+				
+				techTransfer = BNTR25k,SNTPPFE100,SNTPPFE100-Prototype:20
+			}
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Brayton Generator
+		StartActionName = Start Brayton Generator
+		StopActionName = Stop Brayton Generator
+		AlwaysActive = False
+		FillAmount = 1.0
+		AutoShutdown = False
+		GeneratesHeat = True
+		TemperatureModifier = 2.0
+		UseSpecializationBonus = False
+		DefaultShutoffTemp = 0.75
+
+		INPUT_RESOURCE
+		{
+			ResourceName = UraniumNitride
+			Ratio = 1.0813e-15
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 25.0
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName  = DepletedUranium
+			Ratio = 1.0813e-15
+		}
+	}
+
+	RESOURCE
+	{
+		name = UraniumNitride
+		amount = 20.979	//~300 kg
+		maxAmount = 20.979
+		isTweakable = False
+	}
+
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0.0
+		maxAmount = 20.979
+		isTweakable = False
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/KIWIA24_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/KIWIA24_Config.cfg
@@ -1,23 +1,23 @@
 //	==================================================
-//	NERVA NRX
+//	Kiwi A24
 //
 //	Manufacturer: Aerojet & Westinghouse
 //
 //	=================================================================================
-//	NERVA NRX
+//	Kiwi A24
 //
-//	Dry Mass: 11330 kg
-//	Thrust (SL): 243 kN
-//	Thrust (Vac): 190 kN
-//	ISP: 693 SL / 885 Vac
-//	Burn Time: 3720
-//	Chamber Pressure: 4.1 MPa
+//	Dry Mass: 12080 kg
+//	Thrust (SL): 29 kN
+//	Thrust (Vac): 21 kN
+//	ISP: 594 SL / 810 Vac
+//	Burn Time: 360
+//	Chamber Pressure: 1.4 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: 100
-//	Ignitions: 30
+//	Nozzle Ratio: 24
+//	Ignitions: 2
 //	=================================================================================
 
 //	Sources:
@@ -31,12 +31,12 @@
 //	
 //	==================================================
 
-@PART[*]:HAS[#engineType[NERVA_NRX]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[KIWIA24]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roNERVA_NRXTitle	//NERVA NRX
-	@manufacturer = #roMfrAerojet
+	@title = #roKIWIA24Title	//Kiwi A3 Atomic Rocket Motor
+	@manufacturer = #roMfrWestinghouse
 
-	@tags ^= :$: USA aerojet westinghouse nerva nrx nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA westinghouse aerojet kiwi a24 nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -44,20 +44,20 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = NERVA_NRX-Hydrogen
+		configuration = KIWIA24-Hydrogen
 		modded = false
-		origMass = 11.33
+		origMass = 12.0734	//12080 kg - 6.6 kg
 
-		CONFIG
+			CONFIG
 		{
-			name = NERVA_NRX-Hydrogen
+			name = KIWIA24-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 122
-			maxThrust = 243
-			massMult = 1			
-			ignitions = 30
+			minThrust = 4.2
+			maxThrust = 29.3
+			massMult = 1
+			ignitions = 2
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
 			%throttleStartedMult = 0.8
@@ -76,24 +76,23 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 885
-				key = 1 693
+				key = 0 810
+				key = 1 594
 			}
-			%chamberNominalTemp = 2555
-			%maxEngineTemp = 2870
+			%chamberNominalTemp = 2300
+			%maxEngineTemp = 2650
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 36000 // ~1 hours
-				ratedContinuousBurnTime = 3720 // ~1 hours
-
+				ratedBurnTime = 360 // 6 minutes
+				
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
 				{
 					key = 0.00 0.05 0 0
 					key = 1.00 1.00 3 3
 				}
-
+				
 				explicitDataRate = True
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999997
@@ -107,18 +106,17 @@
 			}
 		}
 	}
- 
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 3
-		maxAmount = 3
+		amount = 0.6	//6.582 kg
+		maxAmount = 0.6
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 3
+		maxAmount = 0.6
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/KIWIB48_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/KIWIB48_Config.cfg
@@ -1,42 +1,31 @@
 //	==================================================
-//	Phoebus 2A
+//	Kiwi A24
 //
 //	Manufacturer: Aerojet & Westinghouse
 //
 //	=================================================================================
-//	Phoebus 2A
+//	Kiwi A24
 //
-//	Dry Mass: 16970 kg
-//	Thrust (SL): 913 kN
-//	Thrust (Vac): 682 kN
-//	ISP: 632 SL / 846 Vac
-//	Burn Time: 2700
-//	Chamber Pressure: 3.8 MPa
+//	Dry Mass: 14890 kg
+//	Thrust (SL): 220 kN
+//	Thrust (Vac): 170 kN
+//	ISP: 695 SL / 898 Vac
+//	Burn Time: 750
+//	Chamber Pressure: 3.6 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: 100
-//	Ignitions: 8
+//	Nozzle Ratio: 66
+//	Ignitions: 4
 //	=================================================================================
 
-//	Sources:
-//	NASA - An Overview of Tested and Analyzed NTP Concepts:												https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19920001919.pdf
-//	Los Alamos National Laboratory - Experience Gained from the Space Nuclear Rocket Program (Rover):	https://fas.org/nuke/space/la-10062.pdf
-
-//	Used by:
-//	
-
-//	Notes:
-//	
-//	==================================================
-
-@PART[*]:HAS[#engineType[Phoebus2N100]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[KIWIB48]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roPhoebus2N100Title	//Phoebus 2A Atomic Rocket Motor
-	@manufacturer = #roMfrAerojet
+	@title = #roKIWIB48Title	//Kiwi B4E Atomic Rocket Motor
+	@manufacturer = #roMfrWestinghouse
 
-	@tags ^= :$: USA aerojet westinghouse phoebus 2a n100 nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA westinghouse aerojet kiwi b48 nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -44,20 +33,20 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Phoebus2N100-Hydrogen
+		configuration = KIWIB48-Hydrogen
 		modded = false
-		origMass = 16.97
+		origMass = 14.857	//14890 kg - 32.9 kg
 
-			CONFIG
+		CONFIG
 		{
-			name = Phoebus2N100-Hydrogen
+			name = KIWIB48-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 228
-			maxThrust = 913
-			massMult = 1
-			ignitions = 8
+			minThrust = 22
+			maxThrust = 220
+			massMult = 1			
+			ignitions = 4
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
 			%throttleStartedMult = 0.8
@@ -76,23 +65,24 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 846
-				key = 1 632
+				key = 0 898
+				key = 1 695
 			}
-			%chamberNominalTemp = 2245
-			%maxEngineTemp = 2870
+			%chamberNominalTemp = 2473
+			%maxEngineTemp = 2573
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 2700 //45 minutes (limited by hydrogen supply, assumed same as 1B)
-
+				ratedBurnTime = 2880 // 48 minutes
+				ratedContinuousBurnTime = 750		// 12 minutes
+				
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
 				{
 					key = 0.00 0.05 0 0
 					key = 1.00 1.00 3 3
 				}
-
+				
 				explicitDataRate = True
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999997
@@ -106,17 +96,18 @@
 			}
 		}
 	}
+ 
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 15
-		maxAmount = 15
+		amount = 3	//32.9 kg
+		maxAmount = 3
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 15
+		maxAmount = 3
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LRCLNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LRCLNTR_Config.cfg
@@ -1,0 +1,170 @@
+//	==================================================
+//	Lewis Research Center LNTR
+//
+//	Manufacturer: Lewis Research Center
+//
+//	=================================================================================
+//	LRCLNTR
+//	1968 Radiator LNTR - 2000 MW power
+//
+//	Dry Mass: 7424 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 145.6 kN
+//	ISP: ??? SL / 1400 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 20.0 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: ???
+//	=================================================================================
+
+//	Sources:
+
+//	https://ntrs.nasa.gov/citations/19670030774
+
+//	Used by:
+
+//	Notes:
+//	Core TWR of 3.2, for a 4640 kg core. Assuming same ratio of core mass to overall mass as Princeton LNTR
+//	(should be safe assumption, simpler design and larger), overall mass 7424 kg.
+
+//	Assuming same core mass ratio as Princeton LNTR (0.9)
+//	Mole fraction UC2 in NbC core 0.02
+//	4176 kg fuel and moderator in core
+//	UC2 load 193.688 kg, NbC moderator load 3982.312 kg
+//	==================================================
+
+@PART[*]:HAS[#engineType[LRCLNTR]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roLRCLNTRTitle	//LRC LNTR
+	%manufacturer = #roMfrJPL
+	%description = #roLRCLNTRDesc
+
+	@tags ^= :$: USA aerojet rocketdyne ajr lewis research center lrc lntr nuclear pump upper lqdhydrogen
+
+	%specLevel = concept
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 3.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[Module*EngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleResourceConverter],*{}
+	!MODULE[ModuleHybridEngine],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = LRCLNTR
+		modded = False
+		origMass = 3.248	//7424 kg - 193.7 kg uranium - 3982.3 kg core material
+
+		CONFIG
+		{
+			name = LRCLNTR
+			specLevel = concept
+			minThrust = 145.6
+			maxThrust = 145.6
+			massMult = 1.0
+			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
+			ullage = True
+			pressureFed = False
+			ignitions = 10
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 100.0
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = EnrichedUranium	//1:250 Uranium:Hydrogen flow
+				ratio = 0.00002583
+				DrawGauge = True
+				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
+			}
+
+			PROPELLANT
+			{
+				name = CoreModerator	//1:50 Core Material (including Uranium):Hydrogen flow
+				ratio = 0.00010333
+				DrawGauge = False
+				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1400
+				key = 1 500
+			}
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600
+				ratedBurnTime = 18000
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+			}
+		}
+	}
+
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 17.6572		//~193.7 kg
+		maxAmount = 17.6572
+		isTweakable = False
+	}
+	RESOURCE
+	{
+		name = CoreModerator
+		amount = 726	//~3982.3 kg core material, not including Uranium
+		maxAmount = 726
+		isTweakable = False
+	}
+	
+	//Allow refueling with NFE
+	//LNTRs relatively easy to refuel
+	MODULE:NEEDS[NearFutureElectrical]
+	{
+		name = RadioactiveStorageContainer
+		DangerousFuel = DepletedFuel
+		SafeFuel = EnrichedUranium
+		EngineerLevelForSafe = 1
+		EngineerLevelForDangerous = 1
+		MaxTempForTransfer = 450
+		HeatFluxPerWasteUnit = 5
+	}
+
+	//no depleted fuel. Poisons boil out of engine!
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVAII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVAII_Config.cfg
@@ -1,64 +1,67 @@
 //	==================================================
-//	PW100
+//	Nerva II
 //
 //	Manufacturer: Aerojet
 //
 //	=================================================================================
-//	Peewee
+//	Nerva II
 //
-//	Dry Mass: 2230 kg
-//	Thrust (SL): 111 kN
-//	Thrust (Vac): 83 kN
-//	ISP: 712 SL / 947 Vac
-//	Burn Time: 2400
+//	Dry Mass: 12940 kg
+//	Thrust (SL): 867 kN
+//	Thrust (Vac): 387 kN
+//	ISP: 380 SL / 850 Vac
+//	Burn Time: 36000 s (60m max per cycle)
 //	Chamber Pressure: 4.3 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
 //	Nozzle Ratio: 100
-//	Ignitions: 12
+//	Ignitions: 60
 //	=================================================================================
 
 //	Sources:
 //	NASA - An Overview of Tested and Analyzed NTP Concepts:												https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19920001919.pdf
 //	Los Alamos National Laboratory - Experience Gained from the Space Nuclear Rocket Program (Rover):	https://fas.org/nuke/space/la-10062.pdf
+//	http://fas.org/nuke/space/nerva-spec.pdf
+//	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680009779.pdf
 
 //	Used by:
-//	
+//	SXT
 
 //	Notes:
 //	
 //	==================================================
-@PART[*]:HAS[#engineType[PEWEE100]]:FOR[RealismOverhaulEngines]
+
+@PART[*]:HAS[#engineType[NERVAII]]:FOR[RealismOverhaulEngines]
 {
-	@title = Peewee 100 Atomic Rocket Motor
+	@title = #roNERVAIITitle	//NERVA II
 	@manufacturer = #roMfrAerojet
+	@description = #roNERVAIIDesc	//A later 70s atomic engine with relatively low TWR but high ISP and a power generation of 4200 MW. Derived from the Phoebus 2A ground demonstrator, tested in 1968.
 
-	@tags ^= :$: USA aerojet westinghouse nerva pewee 100 nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA aerojet nerva II nuclear pump upper lqdhydrogen
 
-	%specLevel = prototype
+	%specLevel = concept
 
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = PEWEE100-Hydrogen
+		configuration = NERVA-II
 		modded = false
-		origMass = 2.23
+		origMass = 12.775	//12940 kg - 165 kg fuel
 
-			CONFIG
+		CONFIG
 		{
-			name = PEWEE100-Hydrogen
-			specLevel = prototype
+			name = NERVA-II
+			specLevel = concept
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 22
-			maxThrust = 111
-			massMult = 1
-			heatProduction = 12
+			heatProduction = 100
+			minThrust = 750 //a bit of throttle, no sources
+			maxThrust = 867 //195000 lbf of thrust
 			
-			ignitions = 12
+			ignitions = 60
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
 			%throttleStartedMult = 0.8
@@ -77,16 +80,16 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 947
-				key = 1 712			
+				key = 0 850
+				key = 1 380
 			}
-			%chamberNominalTemp = 2750
-			%maxEngineTemp = 3000
+			%chamberNominalTemp = 2500
+			%maxEngineTemp = 2870
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 28800		//8 hours
-				ratedContinuousBurnTime = 2400 // 40 minutes
+				ratedBurnTime = 36000 // 10 hours
+				ratedContinuousBurnTime = 3600		//1 hour
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
@@ -108,18 +111,50 @@
 			}
 		}
 	}
-  
+	MODULE
+	{
+		name				   = ModuleResourceConverter
+		ConverterName		   = Turbine Generator
+		StartActionName		   = Start
+		StopActionName		   = Stop
+		AlwaysActive		   = true
+		FillAmount			   = 1.000
+		AutoShutdown		   = false
+		GeneratesHeat		   = false
+		TemperatureModifier	   = 2.000
+		UseSpecializationBonus = false
+		DefaultShutoffTemp	   = 0.500
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio		 = 3.1e-13
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio		 = 4.65
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedUranium
+			Ratio		 = 3.1e-13
+		}
+	}
+	
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 2
-		maxAmount = 2
+		amount = 15		//164.55 kg
+		maxAmount = 15
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 2
+		maxAmount = 15
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVANRX_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVANRX_Config.cfg
@@ -1,31 +1,42 @@
 //	==================================================
-//	Kiwi A24
+//	NERVA NRX
 //
 //	Manufacturer: Aerojet & Westinghouse
 //
 //	=================================================================================
-//	Kiwi A24
+//	NERVA NRX
 //
-//	Dry Mass: 14890 kg
-//	Thrust (SL): 220 kN
-//	Thrust (Vac): 170 kN
-//	ISP: 695 SL / 898 Vac
-//	Burn Time: 750
-//	Chamber Pressure: 3.6 MPa
+//	Dry Mass: 11330 kg
+//	Thrust (SL): 243 kN
+//	Thrust (Vac): 190 kN
+//	ISP: 693 SL / 885 Vac
+//	Burn Time: 3720
+//	Chamber Pressure: 4.1 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: 66
-//	Ignitions: 4
+//	Nozzle Ratio: 100
+//	Ignitions: 30
 //	=================================================================================
 
-@PART[*]:HAS[#engineType[KIWIB48]]:FOR[RealismOverhaulEngines]
-{
-	@title = #roKIWIB48Title	//Kiwi B4E Atomic Rocket Motor
-	@manufacturer = #roMfrWestinghouse
+//	Sources:
+//	NASA - An Overview of Tested and Analyzed NTP Concepts:												https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19920001919.pdf
+//	Los Alamos National Laboratory - Experience Gained from the Space Nuclear Rocket Program (Rover):	https://fas.org/nuke/space/la-10062.pdf
 
-	@tags ^= :$: USA westinghouse aerojet kiwi b48 nuclear pump upper lqdhydrogen
+//	Used by:
+//	
+
+//	Notes:
+//	
+//	==================================================
+
+@PART[*]:HAS[#engineType[NERVA_NRX]]:FOR[RealismOverhaulEngines]
+{
+	@title = #roNERVA_NRXTitle	//NERVA NRX
+	@manufacturer = #roMfrAerojet
+
+	@tags ^= :$: USA aerojet westinghouse nerva nrx nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -33,20 +44,20 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = KIWIB48-Hydrogen
+		configuration = NERVA_NRX-Hydrogen
 		modded = false
-		origMass = 14.89
+		origMass = 11.297	//11330 kg - 33 kg fuel
 
 		CONFIG
 		{
-			name = KIWIB48-Hydrogen
+			name = NERVA_NRX-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 22
-			maxThrust = 220
+			minThrust = 122
+			maxThrust = 243
 			massMult = 1			
-			ignitions = 4
+			ignitions = 30
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
 			%throttleStartedMult = 0.8
@@ -65,24 +76,24 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 898
-				key = 1 695
+				key = 0 885
+				key = 1 693
 			}
-			%chamberNominalTemp = 2473
-			%maxEngineTemp = 2573
+			%chamberNominalTemp = 2555
+			%maxEngineTemp = 2870
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 2880 // 48 minutes
-				ratedContinuousBurnTime = 750		// 12 minutes
-				
+				ratedBurnTime = 36000 // ~1 hours
+				ratedContinuousBurnTime = 3720 // ~1 hours
+
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
 				{
 					key = 0.00 0.05 0 0
 					key = 1.00 1.00 3 3
 				}
-				
+
 				explicitDataRate = True
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999997
@@ -100,7 +111,7 @@
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 3
+		amount = 3	//32.91 kg
 		maxAmount = 3
 	}
 	RESOURCE

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVAXE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVAXE_Config.cfg
@@ -1,23 +1,23 @@
 //	==================================================
-//	Kiwi A24
+//	NERVA XE Prime
 //
 //	Manufacturer: Aerojet & Westinghouse
 //
 //	=================================================================================
-//	Kiwi A24
+//	NERVA XE Prime
 //
-//	Dry Mass: 12080 kg
-//	Thrust (SL): 29 kN
-//	Thrust (Vac): 21 kN
-//	ISP: 594 SL / 810 Vac
-//	Burn Time: 360
-//	Chamber Pressure: 1.4 MPa
+//	Dry Mass: 10380 kg
+//	Thrust (SL): 239 kN
+//	Thrust (Vac): 178 kN
+//	ISP: 669 SL / 898 Vac
+//	Burn Time: 3720
+//	Chamber Pressure: 4.1 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: 24
-//	Ignitions: 2
+//	Nozzle Ratio: 100
+//	Ignitions: 60
 //	=================================================================================
 
 //	Sources:
@@ -31,12 +31,12 @@
 //	
 //	==================================================
 
-@PART[*]:HAS[#engineType[KIWIA24]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[NERVA_XE]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roKIWIA24Title	//Kiwi A3 Atomic Rocket Motor
-	@manufacturer = #roMfrWestinghouse
+	@title = #roNERVA_XETitle	//Nerva XE-Prime
+	@manufacturer = #roMfrAerojet
 
-	@tags ^= :$: USA westinghouse aerojet kiwi a24 nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA aerojet westinghouse nerva xe prime nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -44,20 +44,20 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = KIWIA24-Hydrogen
+		configuration = NERVA_XE-Hydrogen
 		modded = false
-		origMass = 12.08
+		origMass = 10.325	//10380 kg - 55 kg fuel
 
 			CONFIG
 		{
-			name = KIWIA24-Hydrogen
+			name = NERVA_XE-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 4.2
-			maxThrust = 29.3
+			minThrust = 119
+			maxThrust = 239
 			massMult = 1
-			ignitions = 2
+			ignitions = 60
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
 			%throttleStartedMult = 0.8
@@ -76,23 +76,22 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 810
-				key = 1 594
+				key = 0 898
+				key = 1 669
 			}
-			%chamberNominalTemp = 2300
-			%maxEngineTemp = 2650
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 360 // 6 minutes
-				
+				ratedBurnTime = 36000 // 10 hours
+				ratedContinuousBurnTime = 3600		//1 hour
+
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
 				{
 					key = 0.00 0.05 0 0
 					key = 1.00 1.00 3 3
 				}
-				
+
 				explicitDataRate = True
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999997
@@ -109,14 +108,14 @@
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 0.6
-		maxAmount = 0.6
+		amount = 5	//54.85 kg
+		maxAmount = 5
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 0.6
+		maxAmount = 5
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVA_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/NERVA_Config.cfg
@@ -1,17 +1,17 @@
 //	==================================================
-//	Nerva II
+//	Nerva I
 //
 //	Manufacturer: Aerojet
 //
 //	=================================================================================
-//	Nerva II
+//	Nerva I
 //
-//	Dry Mass: 12940 kg
-//	Thrust (SL): 867 kN
-//	Thrust (Vac): 387 kN
-//	ISP: 380 SL / 850 Vac
+//	Dry Mass: 10117 kg
+//	Thrust (SL): 334 kN
+//	Thrust (Vac): 153 kN
+//	ISP: 380 SL / 900 Vac	//estimated
 //	Burn Time: 36000 s (60m max per cycle)
-//	Chamber Pressure: 4.3 MPa
+//	Chamber Pressure: 3.1 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
@@ -24,42 +24,43 @@
 //	NASA - An Overview of Tested and Analyzed NTP Concepts:												https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19920001919.pdf
 //	Los Alamos National Laboratory - Experience Gained from the Space Nuclear Rocket Program (Rover):	https://fas.org/nuke/space/la-10062.pdf
 //	http://fas.org/nuke/space/nerva-spec.pdf
-//	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680009779.pdf
 
 //	Used by:
-//	SXT
+//	
 
 //	Notes:
-//	
+
+//	NERVA requirements specified 825s minimum Isp. However, NRX and XE tests demonstrated over 850 s.
+//	Considering flight NERVA engines were to run hotter, and use more efficient full-flow "topping"
+//	cycle, 900 seconds was estimated as the achievable performance.
 //	==================================================
 
-@PART[*]:HAS[#engineType[NERVAII]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[NERVA]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roNERVAIITitle	//NERVA II
+	@title = #roNERVATitle	//NERVA I
 	@manufacturer = #roMfrAerojet
-	@description = #roNERVAIIDesc	//A later 70s atomic engine with relatively low TWR but high ISP and a power generation of 4200 MW. Derived from the Phoebus 2A ground demonstrator, tested in 1968.
+	@description = #roNERVADesc	//A 1970s low TWR vacuum engine, the NERVA (Nuclear Engine for Rocket Vehicle Applications) is designed for orbital tugs and large rocket upper stages.
 
-	@tags ^= :$: USA aerojet nerva II nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA aerojet nerva nuclear pump upper lqdhydrogen
 
-	%specLevel = concept
+	%specLevel = prototype
 
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = NERVA-II
+		configuration = NERVA-I
 		modded = false
-		origMass = 12.94
-
+		origMass = 10.062	//10117 kg - 55 kg fuel
+		
 		CONFIG
 		{
-			name = NERVA-II
-			specLevel = concept
+			name = NERVA-I
+			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			heatProduction = 100
-			minThrust = 750 //a bit of throttle, no sources
-			maxThrust = 867 //195000 lbf of thrust
+			minThrust = 222 //can't find a good source, just gonna go with this.
+			maxThrust = 334
 			
 			ignitions = 60
 			%ullage = True
@@ -80,24 +81,26 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 850
+				key = 0 900
 				key = 1 380
 			}
-			%chamberNominalTemp = 2500
+			%chamberNominalTemp = 2360
 			%maxEngineTemp = 2870
 
+			// http://www.alternatewars.com/BBOW/Space_Engines/NERVA_PV.png
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
+				//design parameters called for very short time between starts, but most mission plans coasted for hours or days between restarts
 				ratedBurnTime = 36000 // 10 hours
 				ratedContinuousBurnTime = 3600		//1 hour
-
+				
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
 				{
 					key = 0.00 0.05 0 0
 					key = 1.00 1.00 3 3
 				}
-
+				
 				explicitDataRate = True
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999997
@@ -128,33 +131,33 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = EnrichedUranium
-			Ratio		 = 3.1e-13
+			Ratio		 = 1e-13
 		}
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio		 = 4.65
+			Ratio		 = 1.500
 		}
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = DepletedUranium
-			Ratio		 = 3.1e-13
+			Ratio		 = 1e-13
 		}
 	}
-	
+
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 15
-		maxAmount = 15
+		amount = 5	//54.85 kg
+		maxAmount = 5
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 15
+		maxAmount = 5
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/PEWEE100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/PEWEE100_Config.cfg
@@ -1,23 +1,23 @@
 //	==================================================
-//	Phoebus 1B
+//	PW100
 //
-//	Manufacturer: Aerojet & Westinghouse
+//	Manufacturer: Aerojet
 //
 //	=================================================================================
-//	Phoebus 1B
+//	Peewee
 //
-//	Dry Mass: 9140 kg
-//	Thrust (SL): 299 kN
-//	Thrust (Vac): 232 kN
-//	ISP: 643 SL / 828 Vac
-//	Burn Time: 2700
-//	Chamber Pressure: 3.8 MPa
+//	Dry Mass: 2230 kg
+//	Thrust (SL): 111 kN
+//	Thrust (Vac): 83 kN
+//	ISP: 712 SL / 947 Vac
+//	Burn Time: 2400
+//	Chamber Pressure: 4.3 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: 50
-//	Ignitions: 4
+//	Nozzle Ratio: 100
+//	Ignitions: 12
 //	=================================================================================
 
 //	Sources:
@@ -30,13 +30,12 @@
 //	Notes:
 //	
 //	==================================================
-
-@PART[*]:HAS[#engineType[Phoebus1N50]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[PEWEE100]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roPhoebus1N50Title	//Phoebus 1B Atomic Rocket Motor
+	@title = Peewee 100 Atomic Rocket Motor
 	@manufacturer = #roMfrAerojet
 
-	@tags ^= :$: USA aerojet westinghouse phoebus 1b n50 nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA aerojet westinghouse nerva pewee 100 nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -44,22 +43,24 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = Phoebus1N50-Hydrogen
+		configuration = PEWEE100-Hydrogen
 		modded = false
-		origMass = 9.14
+		origMass = 2.208	//2230 kg - 22 kg
 
 			CONFIG
 		{
-			name = Phoebus1N50-Hydrogen
+			name = PEWEE100-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 99
-			maxThrust = 299
+			minThrust = 22
+			maxThrust = 111
 			massMult = 1
-			ignitions = 4
+			heatProduction = 12
+			
+			ignitions = 12
 			%ullage = True
-			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
+			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
 			%throttleStartedMult = 0.8
 			%throttleStartupMult = 5.0
 			
@@ -76,15 +77,16 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 828
-				key = 1 643
+				key = 0 947
+				key = 1 712			
 			}
-			%chamberNominalTemp = 2255
-			%maxEngineTemp = 2870
+			%chamberNominalTemp = 2750
+			%maxEngineTemp = 3000
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 2700 //45 minutes
+				ratedBurnTime = 28800		//8 hours
+				ratedContinuousBurnTime = 2400 // 40 minutes
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
@@ -106,17 +108,18 @@
 			}
 		}
 	}
+  
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 4
-		maxAmount = 4
+		amount = 2	//21.94 kg
+		maxAmount = 2
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 4
+		maxAmount = 2
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/Phoebus1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/Phoebus1_Config.cfg
@@ -1,23 +1,23 @@
 //	==================================================
-//	NERVA XE Prime
+//	Phoebus 1B
 //
 //	Manufacturer: Aerojet & Westinghouse
 //
 //	=================================================================================
-//	NERVA XE Prime
+//	Phoebus 1B
 //
-//	Dry Mass: 11330 kg
-//	Thrust (SL): 239 kN
-//	Thrust (Vac): 178 kN
-//	ISP: 669 SL / 898 Vac
-//	Burn Time: 3720
-//	Chamber Pressure: 4.1 MPa
+//	Dry Mass: 9140 kg
+//	Thrust (SL): 299 kN
+//	Thrust (Vac): 232 kN
+//	ISP: 643 SL / 828 Vac
+//	Burn Time: 2700
+//	Chamber Pressure: 3.8 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
-//	Nozzle Ratio: 100
-//	Ignitions: 60
+//	Nozzle Ratio: 50
+//	Ignitions: 4
 //	=================================================================================
 
 //	Sources:
@@ -31,12 +31,12 @@
 //	
 //	==================================================
 
-@PART[*]:HAS[#engineType[NERVA_XE]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[Phoebus1N50]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roNERVA_XETitle	//Nerva XE-Prime
+	@title = #roPhoebus1N50Title	//Phoebus 1B Atomic Rocket Motor
 	@manufacturer = #roMfrAerojet
 
-	@tags ^= :$: USA aerojet westinghouse nerva xe prime nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA aerojet westinghouse phoebus 1b n50 nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -44,20 +44,20 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = NERVA_XE-Hydrogen
+		configuration = Phoebus1N50-Hydrogen
 		modded = false
-		origMass = 10.38
+		origMass = 9.096	//9140 kg - 44 kg fuel
 
 			CONFIG
 		{
-			name = NERVA_XE-Hydrogen
+			name = Phoebus1N50-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 119
-			maxThrust = 239
+			minThrust = 99
+			maxThrust = 299
 			massMult = 1
-			ignitions = 60
+			ignitions = 4
 			%ullage = True
 			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
 			%throttleStartedMult = 0.8
@@ -76,14 +76,15 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 898
-				key = 1 669
+				key = 0 828
+				key = 1 643
 			}
+			%chamberNominalTemp = 2255
+			%maxEngineTemp = 2870
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				ratedBurnTime = 36000 // 10 hours
-				ratedContinuousBurnTime = 3600		//1 hour
+				ratedBurnTime = 2700 //45 minutes
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
@@ -108,14 +109,14 @@
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 0.6
-		maxAmount = 0.6
+		amount = 4	//43.88 kg
+		maxAmount = 4
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 0.6
+		maxAmount = 4
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/Phoebus2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/Phoebus2_Config.cfg
@@ -1,29 +1,28 @@
 //	==================================================
-//	Nerva I
+//	Phoebus 2A
 //
-//	Manufacturer: Aerojet
+//	Manufacturer: Aerojet & Westinghouse
 //
 //	=================================================================================
-//	Nerva I
+//	Phoebus 2A
 //
-//	Dry Mass: 10117 kg
-//	Thrust (SL): 334 kN
-//	Thrust (Vac): 153 kN
-//	ISP: 380 SL / 825 Vac
-//	Burn Time: 36000 s (60m max per cycle)
-//	Chamber Pressure: 3.1 MPa
+//	Dry Mass: 16970 kg
+//	Thrust (SL): 913 kN
+//	Thrust (Vac): 682 kN
+//	ISP: 632 SL / 846 Vac
+//	Burn Time: 2700
+//	Chamber Pressure: 3.8 MPa
 //	Propellant: LH2
 //	Prop Ratio: N/A
 //	Engine Nozzle: ???
 //	Nozzle Exit Area: ???
 //	Nozzle Ratio: 100
-//	Ignitions: 60
+//	Ignitions: 8
 //	=================================================================================
 
 //	Sources:
 //	NASA - An Overview of Tested and Analyzed NTP Concepts:												https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19920001919.pdf
 //	Los Alamos National Laboratory - Experience Gained from the Space Nuclear Rocket Program (Rover):	https://fas.org/nuke/space/la-10062.pdf
-//	http://fas.org/nuke/space/nerva-spec.pdf
 
 //	Used by:
 //	
@@ -32,13 +31,12 @@
 //	
 //	==================================================
 
-@PART[*]:HAS[#engineType[NERVA]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[Phoebus2N100]]:FOR[RealismOverhaulEngines]
 {
-	@title = #roNERVATitle	//NERVA I
+	@title = #roPhoebus2N100Title	//Phoebus 2A Atomic Rocket Motor
 	@manufacturer = #roMfrAerojet
-	@description = #roNERVADesc	//A 1970s low TWR vacuum engine, the NERVA (Nuclear Engine for Rocket Vehicle Applications) is designed for orbital tugs and large rocket upper stages.
 
-	@tags ^= :$: USA aerojet nerva nuclear pump upper lqdhydrogen
+	@tags ^= :$: USA aerojet westinghouse phoebus 2a n100 nuclear pump upper lqdhydrogen
 
 	%specLevel = prototype
 
@@ -46,22 +44,22 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = NERVA-I
+		configuration = Phoebus2N100-Hydrogen
 		modded = false
-		
-		origMass = 10.117
-		CONFIG
+		origMass = 16.805	//16970 kg - 165 kg
+
+			CONFIG
 		{
-			name = NERVA-I
+			name = Phoebus2N100-Hydrogen
 			specLevel = prototype
 			exhaustDamage = True
 			ignitionThreshold = 0.1
-			minThrust = 222 //can't find a good source, just gonna go with this.
-			maxThrust = 334
-			
-			ignitions = 60
+			minThrust = 228
+			maxThrust = 913
+			massMult = 1
+			ignitions = 8
 			%ullage = True
-			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.
+			%throttleResponseRate = 0.035 //should be around 30 secs too fully ramp up to 100% from 0%.	 Actual ramp data may not be available.
 			%throttleStartedMult = 0.8
 			%throttleStartupMult = 5.0
 			
@@ -78,26 +76,23 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 825
-				key = 1 380
+				key = 0 846
+				key = 1 632
 			}
-			%chamberNominalTemp = 2360
+			%chamberNominalTemp = 2245
 			%maxEngineTemp = 2870
 
-			// http://www.alternatewars.com/BBOW/Space_Engines/NERVA_PV.png
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				//design parameters called for very short time between starts, but most mission plans coasted for hours or days between restarts
-				ratedBurnTime = 36000 // 10 hours
-				ratedContinuousBurnTime = 3600		//1 hour
-				
+				ratedBurnTime = 2700 //45 minutes (limited by hydrogen supply, assumed same as 1B)
+
 				// assume roughly exponential relationship between chamber pressure and lifespan
 				thrustModifier
 				{
 					key = 0.00 0.05 0 0
 					key = 1.00 1.00 3 3
 				}
-				
+
 				explicitDataRate = True
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999997
@@ -111,50 +106,17 @@
 			}
 		}
 	}
-	MODULE
-	{
-		name				   = ModuleResourceConverter
-		ConverterName		   = Turbine Generator
-		StartActionName		   = Start
-		StopActionName		   = Stop
-		AlwaysActive		   = true
-		FillAmount			   = 1.000
-		AutoShutdown		   = false
-		GeneratesHeat		   = false
-		TemperatureModifier	   = 2.000
-		UseSpecializationBonus = false
-		DefaultShutoffTemp	   = 0.500
-
-		INPUT_RESOURCE
-		{
-			ResourceName = EnrichedUranium
-			Ratio		 = 1e-13
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio		 = 1.500
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = DepletedUranium
-			Ratio		 = 1e-13
-		}
-	}
-
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 5
-		maxAmount = 5
+		amount = 15	//164.55 kg
+		maxAmount = 15
 	}
 	RESOURCE
 	{
 		name = DepletedUranium
 		amount = 0
-		maxAmount = 5
+		maxAmount = 15
 	}
 	
 	@MODULE[ModuleGimbal]

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/PrincetonLNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/PrincetonLNTR_Config.cfg
@@ -1,0 +1,231 @@
+//	==================================================
+//	Princeton LNTR
+//
+//	Manufacturer: Princeton, LANL
+//
+//	=================================================================================
+//	PrincetonLNTR-ZrC
+//	Original design with ZrC core. Limited to 4873 K due to fuel loss.
+//
+//	Dry Mass: 3629 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 39.03 kN
+//	ISP: ??? SL / 1350 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 10.0 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: ???
+//	=================================================================================
+//	PrincetonLNTR-WCH
+//	Original design with WCH core. Limited to 5023 K due to fuel loss.
+//
+//	Dry Mass: 3629 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 40.88 kN
+//	ISP: ??? SL / 1414 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 10.0 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: ???
+//	=================================================================================
+
+//	Sources:
+
+//	https://ntrs.nasa.gov/citations/19650026954
+//	https://arc.aiaa.org/doi/abs/10.2514/3.29423?journalCode=jsr
+
+
+//	Used by:
+
+//	Notes:
+//	Original fuel loss calculations for Princeton LNTR found to be off by several orders of magnitude.
+//	Correspondingly, fuel load must be increased and reactor temperature decreased.
+//	Replacing original ZrC-based core with WCH-based core increases boiling point and allows for higher temperatures.
+//	==================================================
+
+@PART[*]:HAS[#engineType[PrincetonLNTR]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roPrincetonLNTRTitle	//Princeton LNTR
+	%manufacturer = #roMfrJPL
+	%description = #roPrincetonLNTRDesc
+
+	@tags ^= :$: USA aerojet rocketdyne ajr princeton lntr nuclear pump upper lqdhydrogen
+
+	%specLevel = concept
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 3.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!MODULE[Module*EngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleResourceConverter],*{}
+	!MODULE[ModuleHybridEngine],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = PrincetonLNTR-ZrC
+		modded = False
+		origMass = 1.548	//3629 kg - 40 kg uranium - 2041 kg core material
+
+		CONFIG
+		{
+			name = PrincetonLNTR-ZrC
+			specLevel = concept
+			minThrust = 39.03
+			maxThrust = 39.03
+			massMult = 1.0
+			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
+			ullage = True
+			pressureFed = False
+			ignitions = 3	//limited restarts. Bubbler design makes restart difficult
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 100.0
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = EnrichedUranium	//1:250 Uranium:Hydrogen flow
+				ratio = 0.00002583
+				DrawGauge = True
+				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
+			}
+
+			PROPELLANT
+			{
+				name = CoreModerator	//1:50 Core Material (including Uranium):Hydrogen flow
+				ratio = 0.00010333
+				DrawGauge = False
+				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1350
+				key = 1 500
+			}
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+			}
+		}
+		CONFIG
+		{
+			name = PrincetonLNTR-WCH
+			specLevel = concept
+			minThrust = 40.88
+			maxThrust = 40.88
+			massMult = 1.0
+			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
+			ullage = True
+			pressureFed = False
+			ignitions = 3
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 100.0
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = EnrichedUranium	//1:250 Uranium:Hydrogen flow
+				ratio = 0.00002583
+				DrawGauge = True
+				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
+			}
+
+			PROPELLANT
+			{
+				name = CoreModerator	//1:50 Core Material (including Uranium):Hydrogen flow
+				ratio = 0.00010333
+				DrawGauge = False
+				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1414
+				key = 1 500
+			}
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+			}
+		}
+	}
+
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 7.2926		//~80 kg (increased fuel load due to fuel loss)
+		maxAmount = 7.2926
+		isTweakable = False
+	}
+	RESOURCE
+	{
+		name = CoreModerator
+		amount = 372	//~2041 kg core material, not including Uranium
+		maxAmount = 372
+		isTweakable = False
+	}
+
+	//no depleted fuel. Poisons boil out of engine!
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/RD0410MID_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/RD0410MID_Config.cfg
@@ -75,7 +75,7 @@
 		type = ModuleEngines
 		configuration = RD-0410MID-Hydrogen
 		modded = false
-		origMass = 2
+		origMass = 1.9967	//2000 kg - 3.3 kg
 
 		CONFIG
 		{
@@ -190,10 +190,42 @@
 			}
 		}
 	}
+	MODULE
+	{
+		name				   = ModuleResourceConverter
+		ConverterName		   = Turbine Generator
+		StartActionName		   = Start
+		StopActionName		   = Stop
+		AlwaysActive		   = true
+		FillAmount			   = 1.000
+		AutoShutdown		   = false
+		GeneratesHeat		   = false
+		TemperatureModifier	   = 2.000
+		UseSpecializationBonus = false
+		DefaultShutoffTemp	   = 0.500
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio		 = 1e-13
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio		 = 1.500
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedUranium
+			Ratio		 = 1e-13
+		}
+	}
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 0.3
+		amount = 0.3	//3.29 kg
 		maxAmount = 0.3
 	}
 	RESOURCE

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/SNTPPFE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/SNTPPFE_Config.cfg
@@ -64,7 +64,7 @@
 		type = ModuleEngines
 		configuration = SNTPPFE100-Prototype
 		modded = false
-		origMass = 1.50
+		origMass = 1.471	//1504 kg - 33 kg fuel
 
 		CONFIG
 		{
@@ -183,14 +183,14 @@
 				reliabilityMidH = 0.1
 				reliabilityMidTangentWeight = 0
 				//reliabilityDataRateMultiplier = 10 // due to the burn time
-				techTransfer = SNTPPFE100-Hydrogen:50
+				techTransfer = SNTPPFE100-Prototype:50
 			}
 		}
 	}
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 3
+		amount = 3	//32.91 kg
 		maxAmount = 3
 	}
 	RESOURCE

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -107,6 +107,9 @@ Localization
 		//		BNTR
 		#roBNTRTitle = Bimodal NTR
 		#roBNTRDesc = Low thrust pump-fed expander nuclear engine. Evolved from the original NERVA design, the Bimodal NTR, instead of wasting precious propellant mass on cooling the engine reactor, uses a Brayton cycle electricity generator unit to convert the waste thermal energy into useful electrical power. It also supports liquid oxygen injection (TRITON - trimodal operation) for increased thrust at the cost of lower overall efficiency.
+		//		BNTR 25k
+		#roBNTR25kTitle = Bimodal HALEU NTR (25klbf)
+		#roBNTR25kDesc = Moderate thrust pump-fed expander nuclear engine. Evolved from the original NERVA design, the Bimodal NTR, instead of wasting precious propellant mass on cooling the engine reactor, uses a Brayton cycle electricity generator unit to convert the waste thermal energy into useful electrical power. It also supports liquid oxygen injection (TRITON - trimodal operation) for increased thrust at the cost of lower overall efficiency. This is from a later study, and is larger than the original BNTR design. It also uses low-enriched uranium to reduce costs, and a much more powerful Brayton generator to power electrical propulsion systems.
 		//C
 		//		Cajun
 		#roCajunTitle = Cajun (2.8KS-8100)
@@ -210,6 +213,9 @@ Localization
 		#roHM7Title = HM-7
 		#roHM7Desc = A hydrolox gas generator upper stage engine, directly descended from the HM4 testbed engine and used on the upper stages of the Ariane launch vehicle family.
 		//I
+		//		INsTAR
+		#roINsTARTitle = INsTAR
+		#roINsTARDesc = Advanced NTR, based on the SNTP/Timberwind design. Higher temperature alloys and a sintered fuel element allow for extremely high temperature operation, with specific impulse exceeding 1000 seconds. The use of low-enriched uranium fuel reduces TWR as compared to Timberwind/SNTP designs, but allows for greatly increased core lifetime.
 		//J
 		//		J2
 		#roJ2Title = J-2
@@ -319,6 +325,9 @@ Localization
 		//		LRBE
 		#roLRBETitle = LRBE
 		#roLRBEDesc = Developed from the RS-25 SSME, the Liquid Rocket Booster Engine (LRBE) was a design concept for a liquid fueled Space Shuttle booster. Methane was chosen as a fuel, which increased density and thrust while still allowing fuel-rich staged combustion.
+		//		LRC LNTR
+		#roLRCLNTRTitle = Lewis Research Center LNTR
+		#roLRCLNTRDesc = A "radiator" liquid core nuclear thermal rocket developed by Lewis Research Center. Rather than bubbling hydrogen through the reactor core, it is used to regeneratively cool the reactor walls, then flow through the middle of the reactor to be heated by radiation. Although this is less efficient than a "bubbler" reactor, the reduced interaction with the reactor core allows for much higher mass flow rates without excessive fuel loss, resulting in a higher TWR. The simpler core design also means it can be reloaded with fuel on-orbit (requires Near Future Electrical).
 		//M
 		//		M1
 		#roM1Title = M-1
@@ -358,6 +367,7 @@ Localization
 		#roNERVA_NRXTitle = NERVA NRX
 		//		NERVA_XE
 		#roNERVA_XETitle = Nerva XE-Prime
+		#roNERVA_XEDesc = The "Nerva XE" series is a 1550MW reactor. A full flight test prototype originally based on the KIWI B4E. Its core is capable of starting up sixty times.  An integral Tungsten Boron composite shield is included and the whole assembly is regeneratively cooled. A secondary circuit runs the shut down gasses through a small heat engine to minimize fuel loss and provide basic alternator power. This engine should be mounted three to six meters from the closest fuel tank.  Fuel should shield any crew and crew positions when running should be eight to ten meters from the engine. Additional shielding such as a water tank or high density fuel can somewhat reduce this amount. This rocket represents the beginnings of a more powerful and capable series of rocket. This version features a fixed regeneratively cooled nozzle with a 100:1 expansion ratio. Nozzle Ae=100   Chamber Temp=2500   Ideal ISP=945  Reactor Power=1163MW(th)  TWR=2.34   Chamber Pressure=3806kPa   Ignitions =60   Tonnage including integral shadow shield: 10.38tons
 		//		Nike-M5E1
 		#roNike-M5E1Title = Nike M5E1
 		#roNike-M5E1Desc = A first stage solid rocket motor used on many sounding rockets including Nike-Deacon, Nike-Cajun, Nike-Apache, Nike-Aerobee170, Nike-Aerobee350, and more.
@@ -384,6 +394,9 @@ Localization
 		#roPhoebus1N50Title = Phoebus 1B Atomic Rocket Motor
 		//		Phoebus2N100
 		#roPhoebus2N100Title = Phoebus 2A Atomic Rocket Motor
+		//		Princeton LNTR
+		#roPrincetonLNTRTitle = Princeton LNTR
+		#roPrincetonLNTRDesc = A "Bubbler" liquid core nuclear thermal rocket. Hydrogen gas is bubbled through the liquid core of the reactor, resulting in extremely efficient heat transfer and high performance. Unfortunately, unexpected behavior in the hydrogen gas bubbles resulted in large amounts of fuel being lost from the reactor, and temperature and propellant flow had to be reduced, decreasing performance. A later redesign with a different fuel alloy allowed some performance to be restored.
 		//Q
 		//R
 		//		R4D11

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -892,6 +892,7 @@ PARTUPGRADE
 	%TANK[LithiumPeroxide] {}
 	%TANK[LithiumHydroxide] {}
 	%TANK[PotassiumSuperoxide] {}
+	%TANK[CoreModerator] {}
 
 	// Cryo resources in SM tanks get a dewar flask
 	// and the gas can be captured

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -54,6 +54,20 @@ RESOURCE_DEFINITION
   ksparpicon = RealFuels/Resources/ARPIcons/ASCENT
 }
 
+//Create core material
+RESOURCE_DEFINITION
+{
+  name = CoreModerator
+  density = 0.00548500000	//half of uranium fuel I guess
+  unitCost = 0.0001 //placeholder
+  //hsp = 4183	//FIXME: Aqueous, same as water I guess.
+  flowMode = STACK_PRIORITY_SEARCH
+  transfer = PUMP
+  isTweakable = True
+  isVisible = true
+  ksparpicon = RealFuels/Resources/ARPIcons/CoreMaterial
+}
+
 //Add Beryllium
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Some updates to NTRs and some new parts. Updates include: 

- Moved NTR configs to their own subfolder
- Added TF/TL support to BNTR
- Subtracted fuel mass from NTR dry mass
- Increased NERVA I ISP from 825 to 900 (825 was minimum design spec for NERVA. Seeing as we take fairly optimistic numbers for other NTRs, NERVA was predicted to perform much better than 825 s, and NERVA XE has an ISP of 898, use 900) 

New configs include:

- BNTR 25k, a later BNTR concept with higher thrust, HALEU fuel, and a much more powerful generator 
- INsTAR, a modern derivative of SNTP using HALEU and a higher temperature core 
- Princeton LNTR, a 1960s liquid-core nuclear thermal rocket concept 
- Lewis Research Center LNTR, a late 1960s liquid-core nuclear thermal rocket concept.