### PR TITLE
Add RL10A-3-9, adjust RL10 SL ISP

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -712,6 +712,14 @@
 				testedBurnTime = 4000		//4000 seconds according to P&W 1966 RL10 Handbook
 				ratedBurnTime = 470
 				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+				
 				ignitionReliabilityStart = 0.988146
 				ignitionReliabilityEnd = 0.998128
 				cycleReliabilityStart = 0.976667

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -10,7 +10,7 @@
 //	Dry Mass: 131 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 65.6 kN
-//	ISP: ??? SL / 422 Vac
+//	ISP: 182 SL / 422 Vac	SL calculated with RPA
 //	Burn Time: 430
 //	Chamber Pressure: 2.07 MPa
 //	Propellant: LOX / LH2
@@ -25,7 +25,7 @@
 //	Dry Mass: 131 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 66.7 kN
-//	ISP: ??? SL / 427 Vac
+//	ISP: 187 SL / 427 Vac	SL calculated with RPA
 //	Burn Time: 470
 //	Chamber Pressure: 2.07 MPa
 //	Propellant: LOX / LH2
@@ -40,7 +40,7 @@
 //	Dry Mass: 131 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 70.05 kN
-//	ISP: ??? SL / 442.2 Vac
+//	ISP: 186 SL / 442.2 Vac		SL calculated with RPA
 //	Burn Time: 470
 //	Chamber Pressure: 2.72 MPa
 //	Propellant: LOX / LH2
@@ -70,7 +70,7 @@
 //	Dry Mass: 204 Kg	//900 lbs/2 engines
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 66.7 kN	//calibrated to 15klbf
-//	ISP: ??? SL / 442.2 Vac	//Same as A-3-3
+//	ISP: 186 SL / 442.2 Vac	//Same as A-3-3
 //	Burn Time: ???
 //	Chamber Pressure: 2.72 MPa
 //	Propellant: LOX / LH2
@@ -79,13 +79,28 @@
 //	Nozzle Ratio: 61
 //	Ignitions: 20
 //	=================================================================================
+//	RL10A-3-9
+//	McDonnell Mach 12 Rocket Airplane
+//
+//	Dry Mass: 205 Kg	guess
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 101 kN
+//	ISP: 240 SL / 424 Vac
+//	Burn Time: ???
+//	Chamber Pressure: 2.72 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 6.0
+//	Throttle: 100% to 30%
+//	Nozzle Ratio: 32
+//	Ignitions: 20
+//	=================================================================================
 //	RL10A-3-3A
 //	Centaur D1AR, D1B, D2
 //
 //	Dry Mass: 141 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 73.4 kN
-//	ISP: ??? SL / 444.4 Vac
+//	ISP: 217 SL / 444.4 Vac		SL calculated with RPA
 //	Burn Time: 550
 //	Chamber Pressure: 3.28 MPa
 //	Propellant: LOX / LH2
@@ -100,7 +115,7 @@
 //	Dry Mass: 141 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 66.7 kN
-//	ISP: ??? SL / 440 Vac
+//	ISP: 191 SL / 440 Vac		SL calculated with RPA
 //	Burn Time: 550
 //	Chamber Pressure: 2.86 MPa
 //	Propellant: LOX / LH2
@@ -115,7 +130,7 @@
 //	Dry Mass: 143 Kg		(guess, nozzle extension weighs ~25 kg)
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 91.2 kN
-//	ISP: ??? SL / 446.4 Vac
+//	ISP: 243 SL / 446.4 Vac		SL calculated with RPA
 //	Burn Time: 406
 //	Chamber Pressure: 3.98 MPa
 //	Propellant: LOX / LH2
@@ -130,7 +145,7 @@
 //	Dry Mass: 168 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 92.5 kN
-//	ISP: ??? SL / 448.9 Vac
+//	ISP: 207 SL / 448.9 Vac		SL calculated with RPA
 //	Burn Time: 402
 //	Chamber Pressure: 3.98 MPa
 //	Propellant: LOX / LH2
@@ -145,7 +160,7 @@
 //	Dry Mass: 142 Kg		(guess, nozzle extension weighs ~25 kg)
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 97.9 kN
-//	ISP: ??? SL / 446.4 Vac
+//	ISP: 249 SL / 446.4 Vac		SL calculated with RPA
 //	Burn Time: 850
 //	Chamber Pressure: 4.20 MPa
 //	Propellant: LOX / LH2
@@ -160,7 +175,7 @@
 //	Dry Mass: 167 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 99.2 kN
-//	ISP: ??? SL / 450.5 Vac
+//	ISP: 216 SL / 450.5 Vac		SL calculated with RPA
 //	Burn Time: 740
 //	Chamber Pressure: 4.20 MPa
 //	Propellant: LOX / LH2
@@ -175,7 +190,7 @@
 //	Dry Mass: 168 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 99.2 kN
-//	ISP: ??? SL / 451.0 Vac
+//	ISP: 217 SL / 451.0 Vac		SL calculated with RPA
 //	Burn Time: 894
 //	Chamber Pressure: 4.20 MPa
 //	Propellant: LOX / LH2
@@ -190,12 +205,12 @@
 //	Dry Mass: 143 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 64.75 kN
-//	ISP: 316 SL / 368.0 Vac
+//	ISP: 341 SL / 368.0 Vac		316 s ISP appears to actually refer to SL ISP *while throttled*. Using RPA to calculate SL ISP at full throttle, to match other engines.
 //	Burn Time: 430
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 3.91 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
-//	Throttle: 100% to 30%
+//	Throttle: 100% to 27%	increase throttle range to compensate for the fact RL10 lost significant amounts of ISP and (therefore thrust) at lower throttle settings
 //	Nozzle Ratio: 4.3
 //	Ignitions: 20
 //	=================================================================================
@@ -205,7 +220,7 @@
 //	Dry Mass: 277 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 110.1 kN
-//	ISP: ??? SL / 465.5 Vac
+//	ISP: 42 SL / 465.5 Vac		SL calculated with RPA
 //	Burn Time: 1130
 //	Chamber Pressure: 4.44 MPa
 //	Propellant: LOX / LH2
@@ -220,11 +235,11 @@
 //	Dry Mass: 191 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 101.85 kN
-//	ISP: ??? SL / 449.7 Vac
+//	ISP: 154 SL / 449.7 Vac		SL calculated with RPA
 //	Burn Time: 1130
 //	Chamber Pressure: 4.36 MPa
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.88
+//	Prop Ratio: 5.5
 //	Throttle: N/A
 //	Nozzle Ratio: 130
 //	Ignitions: 20
@@ -235,7 +250,7 @@
 //	Dry Mass: 188 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 105.9 kN
-//	ISP: ??? SL / 453.8 Vac
+//	ISP: 123 SL / 453.8 Vac		SL calculated with RPA
 //	Burn Time: 1200
 //	Chamber Pressure: 4.36 MPa
 //	Propellant: LOX / LH2
@@ -250,7 +265,7 @@
 //	Dry Mass: 277 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 111.2 kN
-//	ISP: ??? SL / 465.5 Vac
+//	ISP: 42 SL / 465.5 Vac		SL calculated with RPA
 //	Burn Time: 1130
 //	Chamber Pressure: 4.44 MPa
 //	Propellant: LOX / LH2
@@ -265,7 +280,7 @@
 //	Dry Mass: 230 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 108.5 kN
-//	ISP: ??? SL / 460.1 Vac
+//	ISP: 52 SL / 460.1 Vac
 //	Burn Time: 1350
 //	Chamber Pressure: 4.44 MPa
 //	Propellant: LOX / LH2
@@ -337,6 +352,7 @@
 //	https://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
 //	https://www.asme.org/wwwasmeorg/media/resourcefiles/aboutasme/who%20we%20are/engineering%20history/landmarks/36-rl-10-rocket-engine.pdf
 //	https://ntrs.nasa.gov/citations/19910004173
+//	https://ntrs.nasa.gov/citations/19710025908
 //  History of Liquid Propellant Rocket Engines, George P. Sutton
 
 //	Used by:
@@ -400,7 +416,7 @@
 			atmosphereCurve
 			{
 				key = 0 422
-				key = 1 200
+				key = 1 182
 			}
 			massMult = 0.785
 
@@ -451,7 +467,7 @@
 			atmosphereCurve
 			{
 				key = 0 427
-				key = 1 255
+				key = 1 187
 			}
 			massMult = 0.785
 
@@ -503,7 +519,7 @@
 			atmosphereCurve
 			{
 				key = 0 442.2
-				key = 1 255
+				key = 1 186
 			}
 			massMult = 0.785
 
@@ -559,7 +575,7 @@
 			atmosphereCurve
 			{
 				key = 0 440	//Some performance loss from extra baffling and hydrogen bleed assumed
-				key = 1 255
+				key = 1 186
 			}
 			massMult = 1.0	//Increased mass for extra equipment
 
@@ -615,7 +631,7 @@
 			atmosphereCurve
 			{
 				key = 0 442.4
-				key = 1 255
+				key = 1 186
 			}
 			throttleCurve
 			{
@@ -658,6 +674,54 @@
 		}
 		CONFIG
 		{
+			name = RL10A-3-9
+			specLevel = concept
+			minThrust = 30.3
+			maxThrust = 101
+			heatProduction = 100
+			description = RL10 with increased throat size, reducing expansion ratio and ISP to increase thrust. Five were intended to power the McDonnell Mach 12 Rocketplane.
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7286
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2714 //6.0
+			}
+			atmosphereCurve
+			{
+				key = 0 424
+				key = 1 240
+			}
+			massMult = 1.2275
+
+			%ullage = False	//propellant sumps
+			%ignitions = 20
+			%IGNITOR_RESOURCE
+			{
+				%name = ElectricCharge
+				%amount = 0.5
+			}
+
+			//Assuming same as RL10A-3-3
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 4000		//4000 seconds according to P&W 1966 RL10 Handbook
+				ratedBurnTime = 470
+				safeOverburn = true
+				ignitionReliabilityStart = 0.988146
+				ignitionReliabilityEnd = 0.998128
+				cycleReliabilityStart = 0.976667
+				cycleReliabilityEnd = 0.996316
+				ignitionDynPresFailMultiplier = 10	//airlaunched
+				techTransfer = RL10A-3-3,RL10A-3-1,RL10A-1:50
+			}
+		}
+		CONFIG
+		{
 			name = RL10A-3-3A
 			specLevel = operational
 			minThrust = 73.4
@@ -678,7 +742,7 @@
 			atmosphereCurve
 			{
 				key = 0 444.4
-				key = 1 255
+				key = 1 217
 			}
 			massMult = 0.845
 
@@ -732,7 +796,7 @@
 			atmosphereCurve
 			{
 				key = 0 440
-				key = 1 255
+				key = 1 191
 			}
 			massMult = 0.845
 
@@ -780,7 +844,7 @@
 			atmosphereCurve
 			{
 				key = 0 446.4
-				key = 1 255
+				key = 1 243
 			}
 			massMult = 0.86
 
@@ -833,7 +897,7 @@
 			atmosphereCurve
 			{
 				key = 0 448.9
-				key = 1 255
+				key = 1 207
 			}
 			massMult = 1.01
 
@@ -881,7 +945,7 @@
 			atmosphereCurve
 			{
 				key = 0 446.4
-				key = 1 255
+				key = 1 249
 			}
 			massMult = 0.85
 
@@ -945,7 +1009,7 @@
 			atmosphereCurve
 			{
 				key = 0 450.5
-				key = 1 255
+				key = 1 216
 			}
 			massMult = 1.00
 
@@ -992,7 +1056,7 @@
 			atmosphereCurve
 			{
 				key = 0 451.0
-				key = 1 255
+				key = 1 217
 			}
 			massMult = 1.02
 
@@ -1021,7 +1085,7 @@
 		{
 			name = RL10A-5
 			specLevel = operational
-			minThrust = 19.4
+			minThrust = 17.48
 			maxThrust = 64.75
 			gimbalRange = 8.5 //average of 8 and 9 from 2 sources.
 			heatProduction = 100
@@ -1040,7 +1104,7 @@
 			atmosphereCurve
 			{
 				key = 0 368
-				key = 1 316
+				key = 1 341
 			}
 			massMult = 0.8563
 
@@ -1098,7 +1162,7 @@
 			atmosphereCurve
 			{
 				key = 0 465.5
-				key = 1 235
+				key = 1 42
 			}
 			massMult = 1.659
 
@@ -1159,7 +1223,7 @@
 			atmosphereCurve
 			{
 				key = 0 449.7
-				key = 1 255
+				key = 1 154
 			}
 			massMult = 1.1437
 
@@ -1219,7 +1283,7 @@
 			atmosphereCurve
 			{
 				key = 0 453.8
-				key = 1 255
+				key = 1 123
 			}
 			massMult = 1.1272
 
@@ -1268,9 +1332,9 @@
 			atmosphereCurve
 			{
 				key = 0 465.5
-				key = 1 235
+				key = 1 42
 			}
-			massMult = 1.799
+			massMult = 1.659
 
 			%ullage = True
 			%ignitions = 15
@@ -1317,7 +1381,7 @@
 			atmosphereCurve
 			{
 				key = 0 460.1
-				key = 1 235
+				key = 1 52
 			}
 			massMult = 1.38
 


### PR DESCRIPTION
Add the RL10A-3-9 from the McDonnell Mach 12 rocketplane concept, and use RPA to calculate the SL ISP of RL10s.

The RL10A-5 received a significant increase in SL ISP. This is because the quoted ISP values appear to refer to ISP at low throttle settings. This has been changed to the calculated ISP at full throttle, and other performance values adjusted correspondingly.

needs https://github.com/KSP-RO/RP-0/pull/1884