### PR TITLE
Fix ROT-MiscTank-Shielded temperatures

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROTanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROTanks.cfg
@@ -97,6 +97,12 @@
 	%roTankType = spaceplane
 }
 
+@PART[ROT-*-Shielded]:HAS[#roTankType[spaceplane]]:FOR[RealismOverhaul]
+{
+        %skinMaxTemp = 2473.15
+        %maxTemp = 1473.15
+}
+
 // part 3: common bits and cleanup
 @PART[ROT-*]:HAS[#wantROTankTypes,#roTankType]:BEFORE[RealismOverhaul]
 {


### PR DESCRIPTION
I thought there was already something that takes care of it for all roTankType=spaceplane parts; there isn't.

FOR[RO] because RealismOverhaul_Global_Config.cfg sets temps to 1073 BEFORE[RO]