### PR TITLE
Remove ModuleDataTrasmitter from MK1CrewCabin

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -643,6 +643,7 @@
 		volume	 = 200
 		basemass = -1
 	}
+	!MODULE[ModuleDataTransmitter],*:NEEDS[RealAntennas|RemoteTech] {}
 }
 
 @PART:HAS[#TACSupplyMultiplier]:FOR[RealismOverhaul]


### PR DESCRIPTION
This part is not a command module and not caught by RealAntennas for conversion. A crew cabin that is not a command module has little need for an antenna of its own.