### PR TITLE
Habtech2 configs for RO 

### DIFF
--- a/HT2_RO.cfg
+++ b/HT2_RO.cfg
@@ -1,0 +1,1905 @@
+//	=========================================================================================================
+//	Benjee10 Habtech Configs for Realism Overhaul, also includes cormorant MMU configs & Habtech2 Robotics
+//	=========================================================================================================
+//  Configs by Raptor
+//  =========================================================================================================
+
+
+@PART[ht2_handrail]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS EVA/Service handrail
+	@manufacturer = NASA
+	@description = Handrails serve as mobility and stability aids for astronauts during extravehicular activity. Handrails are installed to define a safe path and provide sturdy anchors for the astronauts to use while they are working outside the spacecraft.
+	@mass = 0.001
+}
+@PART[ht2_P3_SAW]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 15.865
+	@title = ISS P4-P6/S4-S6
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@maxTemp = 1073.15 
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 30
+		retractable = true
+		isBreakable = true
+		animationName = SAW_array2Deploy
+		impactResistance = 4
+		impactResistanceRetracted = 20
+		pivotName = array1_solarPivot
+		raycastTransformName = array1_sunCatcher
+		extendActionName = Extend Solar Array 1
+		retractActionName = Retract Solar Array 1
+		extendpanelsActionName = Toggle Solar Array 1
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 30
+		retractable = true
+		isBreakable = true
+		animationName = SAW_array1Deploy
+		impactResistance = 4
+		impactResistanceRetracted = 20
+		pivotName = array2_solarPivot
+		raycastTransformName = array2_sunCatcher
+		extendActionName = Extend Solar Array 2
+		retractActionName = Retract Solar Array 2
+		extendpanelsActionName = Toggle Solar Array 2
+	}
+}
+
+@PART[ht2_ITS_S0]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 13.970
+	@title = ISS S0 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The S0 truss, (also called the Center Integrated Truss Assembly Starboard 0 Truss) forms the center backbone of the Space Station. It was attached on the top of the Destiny Laboratory Module during STS-110 in April 2002. S0 is used to route power to the pressurized station modules and conduct heat away from the modules to the S1 and P1 Trusses. 
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 3000
+		%maxAmount = 3000
+	}
+}
+
+@PART[ht2_SAW_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 1.6
+	@title = ISS Single solar array
+	@manufacturer = Boeing 
+	@description = a single solar array for the ISS
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 3000
+		%maxAmount = 3000
+	}
+	
+		MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 65
+		retractable = true
+		animationName = ISS_solarArray_solo_Deploy
+		pivotName = solarPivot
+		raycastTransformName = sunCatcher
+		extendActionName = Extend Solar Array
+		retractActionName = Retract Solar Array
+		extendpanelsActionName = Toggle Solar Array
+	}
+}
+
+@PART[ht2_ITS_S1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 9.24
+	@title = ISS S1/P1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The P1 and S1 trusses (also called the Port and Starboard Side Thermal Radiator Trusses) are attached to the S0 truss, and contain carts to transport the Canadarm2 and astronauts to worksites along the space station. They each flow 290 kg (637 lb) of anhydrous ammonia through three heat rejection radiators. The S1 truss was launched on STS-112 in October 2002 and the P1 truss was launched on STS-113 in November 2002. 
+	@maxTemp = 1073.15 
+	@RESOURCE[ElectricCharge]
+	{
+		@name = ElectricCharge
+		%amount = 2500
+		%maxAmount = 2500
+	}
+	
+	MODULE
+	{
+		name = ModuleRealAntenna
+        	antennaDiameter = 1.0
+	}
+}
+
+@PART[ht2_radiatorTriple_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 3.4
+	@title = Triple HRS radiators
+	@manufacturer = Lockheed Martin 
+	@description = The three HRS radiators on S1 weigh approximately 7,500 pounds, which is almost 30 percent of the payload on the Space Shuttle Atlantis.
+	%breakingForce = 250
+	%breakingTorque = 250	
+	%fuelCrossFeed = False
+	%radiatorHeadroom = 0.29 // 0.2702 sets the limit to 17C, or 290K
+	@maxTemp = 1073.15
+
+	@MODULE[ModuleActiveRadiator]
+	{
+        	@maxEnergyTransfer = 1750
+        	@overcoolFactor = 0.0186367
+
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 1.545
+        }
+    }		
+}
+@PART[ht2_PMA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 1.25
+	@title = ISS Pressurized Mating Adapter
+	@manufacturer = Boeing
+	@description = The International Space Station (ISS) uses three Pressurized Mating Adapters (PMAs) to interconnect spacecraft and modules with different docking mechanisms. The first two PMAs were launched with the Unity module in 1998 aboard STS-88. The third was launched in 2000 aboard STS-92. 
+	@maxTemp = 1073.15	
+
+}
+@PART[ht2_JEM_EF]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 3.5
+	@title = JEM-EF 
+	@manufacturer = ??? 
+	@description = The JEM-EF is an external platform for conducting scientific observations, Earth observations, and experiments in an environment exposed to space. 
+	@maxTemp = 1073.15 
+}
+@PART[ht2_moduleColumbus]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 10.3
+	@title = ISS Columbus
+	@manufacturer = Thales Alenia Space/ EADS 
+	@description = Columbus is a science laboratory that is part of the International Space Station (ISS) and is the largest single contribution to the ISS made by the European Space Agency (ESA). Like the Harmony and Tranquility modules, the Columbus laboratory was constructed in Turin, Italy by Rome based Alcatel Alenia Space with respect to structures and thermal control. The functional architecture (including software) of the lab was designed by EADS in Bremen, Germany where it was also integrated before being flown to the Kennedy Space Center (KSC) in Florida in an Airbus Beluga. It was launched aboard Space Shuttle Atlantis on February 7, 2008 on flight STS-122. It is designed for ten years of operation. The module is controlled by the Columbus Control Centre, located at the German Space Operations Centre, part of the German Aerospace Center in Oberpfaffenhofen near Munich, Germany.
+	@maxTemp = 1073.15  
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 8.0
+		}
+	}
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 50000
+			maxAmount = 50000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
+}
+@PART[ht2_moduleCupola]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 1.83
+	@category = Utility
+	@title = ISS Cupola
+	@manufacturer = Boeing/ ASI
+	@description = The Cupola is an ESA-built observatory module of the International Space Station (ISS). Its seven windows are used to conduct experiments, dockings and observations of Earth. It was launched aboard Space Shuttle mission STS-130 on 8 February 2010 and attached to the Tranquility (Node 3) module. With the Cupola attached, ISS assembly reached 85 percent completion. The Cupolas 80 cm (31 in) window is the largest ever used in space.
+	@maxTemp = 1073.15
+	@vesselType = Station
+	@MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 5.5
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 5000
+			maxAmount = 5000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 300
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 600
+		}
+		TANK
+		{
+			name = Food
+			amount = 500
+			maxAmount = 500
+		}
+		TANK
+		{
+			name = Water
+			amount = 500
+			maxAmount = 500
+		}
+		TANK
+		{
+			name = LithiumHydroxide 
+			amount = 1200
+			maxAmount = 1200
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = CO2 Filter
+		StartActionName = Start CO2 Filter
+		StopActionName = Stop CO2 Filter
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0	
+
+		INPUT_RESOURCE
+		{
+			ResourceName = CarbonDioxide
+			Ratio = 0.00625
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.01
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = LithiumHydroxide
+			Ratio = 0.0000085683
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.0000046828
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.0000257297
+			DumpExcess = False
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Water Recycling System
+		StartActionName = Start Water Recycling System
+		StopActionName = Stop Water Recycling System
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = WasteWater
+			Ratio = 0.000040597
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.1
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00003
+			DumpExcess = False
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Waste
+			Ratio = 0.00000538667
+			DumpExcess = False
+		}
+	}
+}
+
+@PART[ht2_moduleDestiny]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 14.415
+	@title = ISS Destiny
+	@manufacturer = Boeing
+	@description = The Destiny module is the primary operating facility for U.S. research payloads aboard the International Space Station (ISS). It was berthed to the Unity module and activated over a period of five days in February, 2001. Destiny is NASAs first permanent operating orbital research station since Skylab was vacated in February 1974. 
+	@maxTemp = 1073.15 
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 9.8
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+	MODULE:NEEDS[TacLifeSupport]
+	{
+		name = TacGenericConverter
+		converterName = Oxygen Generator (Electrolysis)
+		StartActionName = Start Oxygen Generator (Electrolysis)
+		StopActionName = Stop Oxygen Generator (Electrolysis)
+		tag = Life Support
+		GeneratesHeat = False
+		UseSpecialistBonus = True
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+		conversionRate = 7.0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0000053129
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.006612957
+			DumpExcess = True
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 0.003116887
+			DumpExcess = True
+		}
+	}
+}
+@PART[ht2_moduleHarmony]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 16.644
+	@title = ISS Harmony (Node 2)
+	@manufacturer = Thales Alenia Space 
+	@description = Harmony, also known as Node 2, is the "utility hub" of the International Space Station. The hub contains four racks that provide electrical power, plus electronic data, and act as a central connecting point for several other components via its six Common Berthing Mechanisms (CBMs). Harmony added 2,666 cubic feet (75.5 m3) to the station's living volume, an increase of almost 20 percent, from 15,000 cu ft (420 m3) to 17,666 cu ft (500.2 m3) The successful installation of Harmony meant that from NASA's perspective, the station was "U.S. Core Complete". Harmony was successfully launched into space aboard Space Shuttle flight STS-120 on October 23, 2007. After temporarily being attached to the port side of the Unity node, it was moved to its permanent location on the forward end of the Destiny laboratory on November 14, 2007.
+	@maxTemp = 1073.15 
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
+}
+@PART[ht2_moduleJEMlogistics]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 8.386
+	@title = ISS JEM ELM-PS
+	@manufacturer = IHI AEROSPACE
+	@description = The Japanese Experiment Logistics Module, Pressurized Section (ELM-PS), also called the JLP, is a pressurized addition to the PM. The module is a storage facility that provides storage space for experiment payloads, samples and spare items.
+	@maxTemp = 1073.15 
+        MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Food
+			amount = 1300
+			maxAmount = 1300
+		}
+		TANK
+		{
+			name = Water
+			amount = 750
+			maxAmount = 750
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 750
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 1000
+		}
+
+	}
+
+}
+@PART[ht2_ELC]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 1.81
+	@title = ISS ELC
+	@manufacturer = NASA Goddard 
+	@description = The ELC are four un-pressurized attached payloads, some designed by the Brazilian Space Agency,[2] for the International Space Station (ISS) that provides mechanical mounting surfaces, electrical power, and command and data handling services for science experiments on the ISS.
+	@maxTemp = 1073.15 
+}
+@PART[ht2_moduleKibo]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 15.9
+	@title = ISS Kibo (JEM Pressurized Module)
+	@manufacturer =  Mitsubishi Heavy Industries 
+	@description = The Japanese Experiment Module (JEM), also known with the nickname Kibo (Hope), is a Japanese science module for the International Space Station (ISS) developed by JAXA. It is the largest single ISS module. The first two pieces of the module were launched on Space Shuttle missions STS-123 and STS-124. The third and final components were launched on STS-127. The Pressurized Module (PM) is the core component connected to the port hatch of the Node 2 Module. It is cylindrical in shape and contains twenty-three International Standard Payload Racks (ISPRs), ten of which are dedicated to science experiments while the remaining 13 are dedicated to Kibos systems and storage. The racks are placed 6-6-6-5 along the four walls of the module. The end of the JEM-PM has an airlock and two window hatches. The Exposed Facility, Experiment Logistics Module and the Remote Manipulator System all connect to the pressurized module. Kibo is also the location for many of the press conferences that take place on board the station.
+	@maxTemp = 1073.15  
+	%MODULE[ModuleCommand]
+	{
+		%RESOURCE[ElectricCharge]
+		{
+			%rate = 10.2
+		}
+	}
+
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Food
+			amount = 350
+			maxAmount = 350
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 250
+		}
+
+	}
+
+}
+@PART[ht2_MPLM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 4.082
+	@title = ISS Leonardo PMM 
+	@manufacturer = ASI 
+	@description = The Leonardo Permanent Multipurpose Module (PMM) is a module of the International Space Station. It was flown into space aboard the Space Shuttle on STS-133 on 24 February 2011 and installed on 1 March. Leonardo is primarily used for storage of spares, supplies and waste on the ISS, which is currently stored in many different places within the space station. The Leonardo PMM was a Multi-Purpose Logistics Module (MPLM) before 2011, but was modified into its current configuration. It was formerly one of three MPLM used for bringing cargo to and from the ISS with the Space Shuttle. The module was named for Italian polymath Leonardo da Vinci.
+	@maxTemp = 1073.15 
+         	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Food
+			amount = 350
+			maxAmount = 350
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 250
+		}
+	}
+}
+@PART[ht2_moduleQuest]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 6.014
+	@title = ISS Quest Joint Airlock
+	@manufacturer = Boeing 
+	@description = The Quest Joint Airlock, previously known as the Joint Airlock Module, is the primary airlock for the International Space Station. Quest was designed to host spacewalks with both Extravehicular Mobility Unit (EMU) spacesuits and Orlan space suits. The airlock was launched on STS-104 on July 14, 2001. Before Quest was attached, Russian spacewalks using Orlan suits could only be done from the Zvezda service module and American spacewalks using EMUs were only possible when a Space Shuttle was docked. The arrival of Pirs docking compartment on September 16, 2001 provided another airlock from which Orlan spacewalks can be conducted.
+	@maxTemp = 1073.15 
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 100000
+			maxAmount = 100000
+		}
+	}
+
+}
+@PART[ht2_moduleUnity]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 11.612
+	@title = ISS Unity (Node 1)
+	@manufacturer = Boeing
+	@description = The Unity connecting module was the first U.S.-built component of the International Space Station. It is cylindrical in shape, with six berthing locations (forward, aft, port, starboard, zenith, and nadir) facilitating connections to other modules. Unity was built for NASA by Boeing in a manufacturing facility at the Marshall Space Flight Center in Huntsville, Alabama. Sometimes referred to as Node 1, Unity was the first of the three connecting modules; the other two are Harmony and Tranquility.
+	@maxTemp = 1073.15
+	@CrewCapacity = 1
+	!RESOURCE,* {}
+	!MODULE[ModuleCommand] {}
+	!MODULE[ModuleFuelTanks],* {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 200
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 200000
+			maxAmount = 200000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+}
+@PART[ht2_questRack]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Quest Resource pod rack
+	@manufacturer = Boeing
+	@description = A specially designed rack to hold the Quest resource pod.
+	@mass = 0.002
+}
+@PART[ht2_questPod]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Quest Resource pod
+	@manufacturer = Boeing
+	@description = Nitrogen filled resource pods used to maintain total pressure within the cabin. Nitrogen is also required to support on-board experiments and medical equipment.
+	@mass = 0.002
+	@maxTemp = 1073.15
+	!MODULE[ModuleB9PartSwitch],2 {}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = Nitrogen
+			amount = 1000
+			maxAmount = 1000
+		}
+	}
+}
+@PART[ht2_radialTrussPort]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor{}
+	%rescaleFactor = 1.81
+	@title = S0 radial truss connector
+	@manufacturer = Boeing
+	@description = A radially-attachable mechanism designed for connecting the S0 truss to the ISS.
+}
+@PART[ht2_ITS_truss01]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 0.28
+	@title = ISS P3 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The P3/S3 primary structure is made of a hexagonal shaped aluminum structure and includes four bulkheads and six longerons. 
+	@maxTemp = 1073.15	
+}
+@PART[ht2_truss_Z1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 8.755
+	@title = ISS Z1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The first truss piece, the Z1 truss, launched aboard STS-92 in October 2000. It contains the control moment gyroscope (CMG) assemblies, electrical wiring, communications equipment, and two plasma contactors designed to neutralize the static electrical charge of the space station. Another objective of the Z1 truss was to serve as a temporary mounting position for the "P6 truss and solar array" until its relocation to the end of the P5 truss during STS-120. Though not a part of the main truss, the Z1 truss was the first permanent lattice-work structure for the ISS, very much like a girder, setting the stage for the future addition of the stations major trusses or backbones.
+	@maxTemp = 1073.15 
+	@MODULE[ModuleReactionWheel]
+    {
+		name = ModuleReactionWheel
+	
+		PitchTorque = 5
+		YawTorque = 5
+		RollTorque = 5
+	
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.8
+		}
+    }
+    MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 100
+		}
+	}
+	
+		MODULE
+	{
+		name = ModuleInventoryPart
+		InventorySlots = 2
+		packedVolumeLimit = 100000
+	}
+}
+
+@PART[ht2_truss_Z1_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 8.755
+	@title = ISS Z1 Truss Segment 
+	@manufacturer = Boeing 
+	@description = The first truss piece, the Z1 truss, launched aboard STS-92 in October 2000. It contains the control moment gyroscope (CMG) assemblies, electrical wiring, communications equipment, and two plasma contactors designed to neutralize the static electrical charge of the space station. Another objective of the Z1 truss was to serve as a temporary mounting position for the "P6 truss and solar array" until its relocation to the end of the P5 truss during STS-120. Though not a part of the main truss, the Z1 truss was the first permanent lattice-work structure for the ISS, very much like a girder, setting the stage for the future addition of the stations major trusses or backbones.
+	@maxTemp = 1073.15 
+	@MODULE[ModuleReactionWheel]
+    {
+		name = ModuleReactionWheel
+	
+		PitchTorque = 5
+		YawTorque = 5
+		RollTorque = 5
+	
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.8
+		}
+    }
+    MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 20000
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 100
+		}
+	}
+	
+		MODULE
+	{
+		name = ModuleInventoryPart
+		InventorySlots = 2
+		packedVolumeLimit = 100000
+	}
+}
+
+@PART[ht2_TTS_circle]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.81
+	@mass = 0.05
+	@title = ISS Truss Docking Port circle
+	@manufacturer = Boeing 
+	@description = Docking port to connect the truss segments for the Integrated Truss Structure which contains the large solar arrays and radiators for the International Space Station.
+	@maxTemp = 1073.15 
+}
+
+@PART[ht2_TTS_compact]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.81
+	@mass = 0.05
+	@title = Compact Truss docking port
+	@manufacturer = Boeing 
+	@description = Docking port to connect the truss segments for the Integrated Truss Structure which contains the large solar arrays and radiators for the International Space Station.
+	@maxTemp = 1073.15 
+}
+
+@PART[ht2_TTS_hex]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.81
+	@mass = 0.05
+	@title = Hex Truss docking port
+	@manufacturer = Boeing 
+	@description = Docking port to connect the truss segments for the Integrated Truss Structure which contains the large solar arrays and radiators for the International Space Station.
+	@maxTemp = 1073.15 
+}
+
+@PART[ht2_TTS_semiHex]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.81
+	@mass = 0.05
+	@title = SemiHex Truss docking port
+	@manufacturer = Boeing 
+	@description = Docking port to connect the truss segments for the Integrated Truss Structure which contains the large solar arrays and radiators for the International Space Station.
+	@maxTemp = 1073.15 
+}
+
+@PART[ht2_S6_SAW]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 2.75
+	@title = ISS Solar Arrays
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@maxTemp = 1073.15 
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 30
+		retractable = true
+		isBreakable = true
+		animationName = SAW_array2Deploy
+		impactResistance = 4
+		impactResistanceRetracted = 20
+		pivotName = array1_solarPivot
+		raycastTransformName = array1_sunCatcher
+	}
+}	
+
+@PART[ht2_SAW_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 2.75
+	@title = ISS Solar Arrays
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@maxTemp = 1073.15 
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 30
+		retractable = true
+		isBreakable = true
+		animationName = SAW_array2Deploy
+		impactResistance = 4
+		impactResistanceRetracted = 20
+		pivotName = array1_solarPivot
+		raycastTransformName = array1_sunCatcher
+	}
+}	
+
+@PART[ht2_iROSA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 2.75
+	@title = ISS Roll Out Solar Array (iROSA)
+	@manufacturer = Redwire Aerospace
+	@description = iROSA roll out solar array used to provide additional power to the ISS
+	@maxTemp = 1073.15 
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		isBreakable = true
+		resourceName = ElectricCharge
+		sunTracking = true
+		chargeRate = 35
+		retractable = true
+		animationName = iROSA_deploy
+		pivotName = iROSA_solarPivot
+		raycastTransformName = iROSA_suncatcher
+		extendActionName = Extend Solar Array
+		retractActionName = Retract Solar Array
+		extendpanelsActionName = Toggle Solar Array
+		breakName = iROSAbreakTransform
+	}
+}
+
+@PART[ht2_P3_SAW]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 2.75
+	@title = ISS Solar Array Truss P3 SAW
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@maxTemp = 1073.15 
+	
+		MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		showStatus = false
+		isBreakable = true
+		sunTracking = true
+		chargeRate = 65
+		retractable = true
+		animationName = P6_unlock
+		pivotName = solarPivot
+		raycastTransformName = P6_suncatcher
+		extendActionName = Unlock Secondary Axis
+		retractActionName = Lock Secondary Axis
+		extendpanelsActionName = Toggle Secondary Axis
+		breakName = P6_suncatcher
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		isBreakable = false
+		sunTracking = true
+		chargeRate = 65
+		retractable = true
+		animationName = solarA_deploy
+		pivotName = pivot001
+		raycastTransformName = suncatcherA
+		extendActionName = Extend Solar Array A
+		retractActionName = Retract Solar Array A
+		extendpanelsActionName = Toggle Solar Array A
+		breakName = pivot001
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		isBreakable = false
+		sunTracking = true
+		chargeRate = 65
+		retractable = true
+		animationName = solarB_deploy
+		pivotName = pivot002
+		raycastTransformName = suncatcher002
+		extendActionName = Extend Solar Array B
+		retractActionName = Retract Solar Array B
+		extendpanelsActionName = Toggle Solar Array B
+		breakName = pivot002
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableRadiator
+		animationName = radiatorDeploy
+		showStatus = false
+		retractable = true
+		isBreakable = true
+		impactResistance = 2
+		impactResistanceRetracted = 20
+		pivotName = base hinge
+		trackingSpeed = 0
+		windResistance = 2.5
+		raycastTransformName = radiatorCatcher
+		extendActionName = Extend Radiator
+		retractActionName = Retract Radiator
+		extendpanelsActionName = Toggle Radiator
+	}
+}
+
+@PART[ht2_P6_SAW]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 2.75
+	@title = ISS Solar Array Truss P3 SAW
+	@manufacturer = Boeing 
+	@description = The International Space Station's main source of energy is from three of the four large U.S.-made photovoltaic arrays currently on the station, sometimes referred to as the Solar Array Wings (SAW). The first pair of arrays are attached to the P6 truss segment, which was launched and installed on top of Z1 in late 2000 during STS-97. The P6 segment was relocated to its final position, bolted to the P5 truss segment, in November 2007 during STS-120. The second pair of arrays was launched and installed in September 2006 during STS-115, but they didn't provide electricity until STS-116 in December 2006 when the station got an electrical rewiring. A third pair of arrays was installed during STS-117 in June 2007. A final pair arrived mid March 2009 on STS-119. More solar power was to have been available via the Russian-built Science Power Platform, but it was canceled. 
+	@maxTemp = 1073.15 
+	
+		MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		showStatus = false
+		isBreakable = true
+		sunTracking = true
+		chargeRate = 0
+		retractable = true
+		animationName = P6_unlock
+		pivotName = solarPivot
+		raycastTransformName = P6_suncatcher
+		extendActionName = Unlock Secondary Axis
+		retractActionName = Lock Secondary Axis
+		extendpanelsActionName = Toggle Secondary Axis
+		breakName = P6_suncatcher
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		isBreakable = false
+		sunTracking = true
+		chargeRate = 65
+		retractable = true
+		animationName = solarA_deploy
+		pivotName = pivot001
+		raycastTransformName = suncatcherA
+		extendActionName = Extend Solar Array A
+		retractActionName = Retract Solar Array A
+		extendpanelsActionName = Toggle Solar Array A
+		breakName = pivot001
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableSolarPanel
+		resourceName = ElectricCharge
+		isBreakable = false
+		sunTracking = true
+		chargeRate = 65
+		retractable = true
+		animationName = solarB_deploy
+		pivotName = pivot002
+		raycastTransformName = suncatcher002
+		extendActionName = Extend Solar Array B
+		retractActionName = Retract Solar Array B
+		extendpanelsActionName = Toggle Solar Array B
+		breakName = pivot002
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableRadiator
+		animationName = radiatorDeploy
+		showStatus = false
+		retractable = true
+		isBreakable = true
+		impactResistance = 2
+		impactResistanceRetracted = 20
+		pivotName = base hinge
+		trackingSpeed = 0
+		windResistance = 2.5
+		raycastTransformName = radiatorCatcher
+		extendActionName = Extend Radiator
+		retractActionName = Retract Radiator
+		extendpanelsActionName = Toggle Radiator
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableRadiator
+		animationName = radiator1_deploy
+		showStatus = false
+		retractable = true
+		isBreakable = true
+		impactResistance = 2
+		impactResistanceRetracted = 20
+		pivotName = base hinge002
+		trackingSpeed = 0
+		windResistance = 2.5
+		raycastTransformName = radiatorCatcher1
+		extendActionName = Extend Trailing Radiator
+		retractActionName = Retract Trailing Radiator
+		extendpanelsActionName = Toggle Trailing Radiator
+	}
+
+	MODULE
+	{
+		name = ModuleDeployableRadiator
+		animationName = radiator2_deploy
+		showStatus = false
+		retractable = true
+		isBreakable = true
+		impactResistance = 2
+		impactResistanceRetracted = 20
+		pivotName = base hinge003
+		trackingSpeed = 0
+		windResistance = 2.5
+		raycastTransformName = radiatorCatcher2
+		extendActionName = Extend Starboard Radiator
+		retractActionName = Retract Starboard Radiator
+		extendpanelsActionName = Toggle Starboard Radiator
+	}
+}
+
+@PART[ht2_battery]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS EVA/Service handrail
+	@manufacturer = NASA
+	@description = External battery pack for the ISS, placed on the Truss structure 
+	@mass = 0.001
+}
+
+@PART[ht2_ATA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS EVA/Service handrail
+	@manufacturer = NASA
+	@mass = 0.001
+
+        
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 25000
+	}
+
+}
+
+
+@PART[ht2_bipod_strut]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = ISS Bipod
+	@manufacturer = NASA
+	@description = Bipod for the S0 Truss segment
+	@mass = 0.01
+}
+
+@PART[ht2_AMS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS Alpha Magnetic Spectrometer Experiment
+	@manufacturer = NASA
+	@description = 
+	@mass = 1.5
+}
+
+@PART[ht2_propModule]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Truss Fuel Module 
+	@manufacturer = NASA
+	@mass = 0.4
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 2500
+		type = ServiceModule
+		basemass = -1
+	}
+}
+
+@PART[ht2_bishop]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS Bishop Airlock
+	@manufacturer = Nanoracks 
+	@mass = 0.6
+}
+
+@PART[ht2_MBS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@manufacturer = MacDonald, Dettwiler and Associates 
+	@mass = 1.5
+}
+
+@PART[ht2_MT]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@manufacturer = MacDonald, Dettwiler and Associates 
+	@mass = 0.6
+}
+
+@PART[ht2_MTS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@manufacturer = MacDonald, Dettwiler and Associates 
+	@mass = 0.124
+}
+
+@PART[ht2_MTS_adapter]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@manufacturer = MacDonald, Dettwiler and Associates 
+	@mass = 0.1
+}
+
+// Misc bits & JEM
+
+@PART[ht2_S-band]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS S-Band antenna 
+	@manufacturer = NASA
+	@description = 
+	@mass = 0.04525
+}
+
+@PART[ht2_SGANT_boomFixed]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS SGANT Boom (fixed)
+	@manufacturer = Boeing
+	@description = The International Space Station (ISS) Space-to-Ground Antenna (SGANT) is used for ISS communication with earth through the Tracking and Data Relay Satellite (TDRSS).
+	@mass = 1.448
+}
+
+@PART[ht2_SGANT_boomSwing]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS SGANT Boom (Swing)
+	@manufacturer = Boeing
+	@description = The International Space Station (ISS) Space-to-Ground Antenna (SGANT) is used for ISS communication with earth through the Tracking and Data Relay Satellite (TDRSS).
+	@mass = 1.448
+}
+
+@PART[ht2_SGANT_dish]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS SGANT KU-band Dish 
+	@manufacturer = Boeing 
+	@description = The external Ku-Band Antennas were designed for transport to the ISS in the shuttle cargo bay and thus are not suitable for manifesting on any current cargo vehicle. The original intent was to stow two spare antennas on orbit in a protective container until such time as they were needed to replace a failing unit which is a long and complicated process due to the complexity of the removal and replacement procedure
+	@mass = 0.8
+}
+
+@PART[ht2_SGANT_servo]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = ISS SGANT Servo
+	@manufacturer = Boeing
+	@description = 
+	@mass = 0.18
+}
+
+@PART[ht2_JEM_ICS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM ICS (Inter-orbit Communication System)
+	@manufacturer = JAXA.
+	@description = Inter-Orbit Communication System (ICS) provides an independent intercommunications network between Kibo and the Tsukuba Space Center 
+	@mass = 0.2172
+}
+
+@PART[ht2_JEM_MCE]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM MCE(Multi-mission Consolidated Equipment)
+	@manufacturer = JAXA.
+	@description = MCE was launched on July 21, 2012, aboard the H-II Transfer Vehicle KOUNOTORI3 (HTV3 mission) and installed to the EP on August 9, 2012. Onboard five mission payloads listed below are all selected missions thorough deliberation and evaluation by the ISS/JEM Utilization Advisory Committee and JEM-FE sub-committee.
+	@mass = 0.2172
+}
+
+@PART[ht2_JEM_MCE]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM MCE(Multi-mission Consolidated Equipment)
+	@manufacturer = JAXA.
+	@description = MCE was launched on July 21, 2012, aboard the H-II Transfer Vehicle KOUNOTORI3 (HTV3 mission) and installed to the EP on August 9, 2012. Onboard five mission payloads listed below are all selected missions thorough deliberation and evaluation by the ISS/JEM Utilization Advisory Committee and JEM-FE sub-committee.
+	@mass = 0.2172
+}
+
+@PART[ht2_JEM_NR]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Nanoracks External Platform (NREP)
+	@manufacturer = Nanoracks
+	@description = The Nanoracks External Platform (NREP) provides turnkey communication, power, and operations to hosted payloads mounted on the outside of the International Space Station (ISS).
+	@mass = 0.1448
+}
+
+@PART[ht2_JEM_port]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM Port
+	@manufacturer = JAXA
+	@description = 
+	@mass = 0.1448
+}
+
+@PART[ht2_JEM_SCI]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM SCI (Scientific Data Collector)
+	@manufacturer = JAXA
+	@description = 
+	@mass = 0.2715
+}
+
+@PART[ht2_JEM_SEDA-AP]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM SEDA (Space Environment Data Acquisition Experiment)
+	@manufacturer = JAXA
+	@description = 
+	@mass = 0.2715
+}
+
+// MMU Bits
+
+@PART[CAMMU]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = MMU (Manned Manuevering Unit)
+	@manufacturer = Martin Marietta 
+	@description = The Manned Maneuvering Unit (MMU) is an astronaut propulsion unit that was used by NASA on three Space Shuttle missions in 1984. The MMU allowed the astronauts to perform untethered extravehicular spacewalks at a distance from the shuttle.
+	@mass = 0.148
+	
+	!MODULE[ModuleReactionWheel]
+	{
+	}
+	!RESOURCE[MonoPropellant]
+	{
+	}
+	!RESOURCE[ElectricCharge]
+	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 132.058
+		type = Cryogenic
+		basemass = -1
+		TANK
+		{
+			name = Nitrogen
+			amount = 32.058
+			maxAmount = 132.058
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 100
+			maxAmount = 100
+		}
+	}
+	
+	@MODULE[ModuleRCSFX],*
+	{
+		!resourceName = DELETE
+		@thrusterPower = 0.075 // https://ntrs.nasa.gov/citations/19820063384
+		PROPELLANT
+		{
+			name = Nitrogen
+			ratio = 1
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 306
+			@key,1 = 1 110
+		}
+	}
+}	
+
+@PART[CA_MMUport]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = MMU Docking port
+	@manufacturer = Martin Marietta 
+	@mass = 0.015
+}	
+
+@PART[MMUrack]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = MMU Rack
+	@manufacturer = Martin Marietta 
+	@mass = 0.015
+}	
+
+@PART[MMUrackE]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@title = MMU Rack E
+	@manufacturer = Martin Marietta 
+	@mass = 0.015
+}	
+
+// New Truss bits 
+
+@PART[ht2_ITS_adapter]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 1.2
+	@title = ISS ITS Adapter
+	@manufacturer = Boeing 
+	@description = 
+	@maxTemp = 1073.15	
+}
+
+@PART[ht2_ITS_half_short]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 1
+	@title = ISS ITS Half (Short)
+	@manufacturer = Boeing 
+	@description = 
+	@maxTemp = 1073.15	
+}
+
+@PART[ht2_ITS_hex]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 2.5
+	@title = ISS ITS Hex
+	@manufacturer = Boeing 
+	@description = 
+	@maxTemp = 1073.15	
+}
+
+@PART[ht2_ITS_hex_half]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@mass = 0.6
+	@title = ISS ITS Hex (Half) 
+	@manufacturer = Boeing 
+	@description = 
+	@maxTemp = 1073.15	
+}
+
+// IVA Stuff, Free IVA recommended: https://github.com/pizzaoverhead/FreeIva
+
+@INTERNAL[ht2_cupolaIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_beamIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_genericMediumIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_genericShortIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_harmonyIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_kiboIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_questIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+@INTERNAL[ht2_unityIVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.81, 1.81, 1.81
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.81, 1.81, 1.81
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+//	=================================================================================
+//	Benjee10 Habtech2 Robotics configs
+//	=================================================================================
+//  Configs by Raptor
+//  =================================================================================
+
+
+// Canadarm 2
+
+
+@PART[ht_canadarm2_boom]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Canadarm2 Structural boom
+	@manufacturer = Spar Aerospace  
+	@description = The structural boom of the Canadarm2 robotic arm
+	@mass = 0.078125
+}
+
+@PART[ht_canadarm2_LEE]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Canadarm2 Latching End Effector
+	@manufacturer = Spar Aerospace  
+	@description = The Latching End Effector or the (LEE) for canadarm2 
+	@mass = 0.09375
+	
+		MODULE
+	{
+		name = ModuleDockingNode
+		referenceAttachNode = dockingNode
+		nodeType = PDGF
+		undockEjectionForce = 0
+		acquireForce = 0.4
+		acquireTorque = 0.4
+		acquireRange = 0.6
+
+		gendered = True
+		genderFemale = False
+		stagingEnabled = False
+	}
+}
+
+@PART[ht_canadarm2_servo]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Canadarm2 Rotational servo 
+	@manufacturer = Spar Aerospace  
+	@description = The rotational servo for canadarm2 (bosh)
+	@mass = 0.078125
+	
+}
+
+// stuff 
+
+@PART[ht_PDGF]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Canadarm2 PDGF
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.078125
+	
+	@MODULE
+	{
+		name = ModuleDockingNode
+		referenceAttachNode = dockingNode
+		nodeType = PDGF
+		undockEjectionForce = 0
+		acquireForce = 0.6
+		acquireTorque = 0.4
+		acquireRange = 0.6
+		gendered = True
+		genderFemale = True
+		stagingEnabled = False
+	}
+}
+
+//	=================================================================================
+//	Benjee10 Habtech2 Robotics configs
+//	=================================================================================
+//  Configs by Raptor
+//  =================================================================================
+
+// canadarm
+
+@PART[ht_C1_boom]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Canadarm Structural boom
+	@manufacturer = Spar Aerospace  
+	@description = The structural boom of the Canadarm robotic arm
+	@mass = 0.078
+}
+
+@PART[ht_C1_elbow]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = canadarm elbow joint
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.025
+}
+
+
+@PART[ht_C1_LEE]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = canadarm LEE
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.025
+}
+
+@PART[ht_C1_pitch]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = canadarm pitch joint 
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.025
+}
+
+@PART[ht_C1_rotator]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = canadarm rotator joint 
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.025
+}
+
+@PART[ht_PDGF]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = canadarm PDGF
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.02
+}
+
+@PART[ht_grappleFixture]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = Canadarm2 PDGF
+	@manufacturer = Spar Aerospace  
+	@description = 
+	@mass = 0.078125
+	
+	@MODULE
+	{
+		name = ModuleDockingNode
+		referenceAttachNode = dockingNode
+		nodeType = PDGF
+		undockEjectionForce = 0
+		acquireForce = 0.6
+		acquireTorque = 0.4
+		acquireRange = 0.6
+		gendered = True
+		genderFemale = True
+		stagingEnabled = False
+	}
+}
+
+// JEM RMS 
+
+@PART[ht_JEM_RMS_boom]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM RMS Boom 
+	@manufacturer = JAXA 
+	@description = 
+	@mass = 0.0543
+}
+
+@PART[ht_JEM_RMS_servo]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 1.81
+	@title = JEM RMS Boom 
+	@manufacturer = JAXA 
+	@description = 
+	@mass = 0.0543
+}

--- a/RO-SharedAssets.cfg
+++ b/RO-SharedAssets.cfg
@@ -1,0 +1,368 @@
+//	================================================================================
+//	Shared Assets Configs
+//	================================================================================
+//  Configs by SkyPhoenix999
+//  CBM By Raptor
+//  ================================================================================
+
+// IDA
+@PART[B10_IDA]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor,* = DEL
+	%rescaleFactor = 1.81
+	@mass = 0.526
+	@title = International Docking Adapter
+	@description = The IDA is designed to the International Docking System Standard, compatable with ports using the IDS Standard and the NASA Docking System (Can dock to the IDA, NDS, and APAS-95)
+	@manufacturer = Boeing
+	@MODULE[ModuleDockingNode]
+	{
+		@name = ModuleDockingNode
+		%nodeType = APAS8995
+		%gendered = false
+		%genderFemale = false
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}
+
+// NDS
+@PART[B10_NDS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor,* = DEL
+	%rescaleFactor = 1.81
+	@mass = 0.15
+	@title = NASA Docking System
+	@description = The NASA Docking System is an upgraded and modernized version of APAS-95, compatable with itself and the International Docking System Standard (Can dock to the IDA, NDS, and APAS-95)
+	@manufacturer = NASA
+	@MODULE[ModuleDockingNode]
+	{
+		@name = ModuleDockingNode
+		%nodeType = APAS8995
+		%gendered = false
+		%genderFemale = false
+		%acquireForce = 0.5 // 2
+		%acquireMinFwdDot = 0.8 // 0.7
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25 // 0.5
+		%acquireTorque = 0.5 // 2.0
+		%captureMaxRvel = 0.1 // 0.3
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05 // 0.06
+		%minDistanceToReEngage = 0.25 // 1.0
+		%undockEjectionForce = 0.1 // 10
+	}
+}
+
+// AJ10
+@PART[benjee10_AJ10_v2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor,* = DEL
+	%rescaleFactor = 1.81
+	@mass = 0.8
+	@title = AJ10 OME
+	@description = AJ10 190 OMS engine for Space shuttle and Orion spacecraft.
+	@manufacturer = Aerojet Rocketdyne
+	@tags ^= :$: USA aerojet rocketdyne ajr aj10-190 oms liquid pressure-fed upper mmh nto
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleEngineConfigs],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 6.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	!EFFECTS{}
+
+	EFFECTS
+	{
+		running
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.75
+				pitch = 1.0 0.95
+				loop = true
+			}
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_exhaustFlame_yellow_tiny_Z
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 1.0 1.0
+				speed = 0.0 0.8
+				speed = 1.0 1.0
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				loop = false
+			}
+		}
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = AJ10-190-OMS
+		origMass = 0.125
+
+		CONFIG
+		{
+			name = AJ10-190-OMS
+			specLevel = operational
+			minThrust = 26.7
+			maxThrust = 26.7
+			heatProduction = 28
+			massMult = 1.0
+			ullage = False
+			pressureFed = True
+			ignitions = 500
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
+
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4943
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.5057
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 12.9
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 100
+			}
+
+			//134 successful shuttle launches
+			//Assuming an average of 3 OMS burns per flight * 2 OMS engines
+			//268 engines flown, 804 ignitions, 0 failures(?)
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedContinuousBurnTime = 1250
+				ratedBurnTime = 54000
+				//restartWindowPenalty		//2 seconds for purge
+				//{
+				//	key = 0 1 0 0		//immediate restart before purge has small penalty
+				//	key = 0.3 1 0 0		//purge valves open after 0.36 seconds
+				//	key = 0.36 0.25 0 0		//restart attempt during purge has serious penalty
+				//	key = 2.36 1 0 0
+				//}
+				ignitionReliabilityStart = 0.998820
+				ignitionReliabilityEnd = 0.999814
+				cycleReliabilityStart = 0.996468
+				cycleReliabilityEnd = 0.999442
+				techTransfer = AJ10-138,AJ10-137,AJ10-118K,AJ10-118F,AJ10-118,AJ10-142,AJ10-42,AJ10-37:50
+			}
+		}
+		CONFIG
+		{
+			name = AJ10-190-Orion
+			specLevel = operational	//technically hasn't flown yet, but design frozen and will soon
+			minThrust = 33.4
+			maxThrust = 33.4
+			massMult = 1.0
+			ullage = False
+			pressureFed = True
+			ignitions = 500
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
+
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4943
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = MON3
+				ratio = 0.5057
+				DrawGauge = False
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 16.1
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 316
+				key = 1 100
+			}
+
+			//no data, never flown
+			//assumed to be the same as shuttle OMS
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedContinuousBurnTime = 1250
+				ratedBurnTime = 54000
+				//restartWindowPenalty		//2 seconds for purge
+				//{
+				//	key = 0 1 0 0		//immediate restart before purge has small penalty
+				//	key = 0.3 1 0 0		//purge valves open after 0.36 seconds
+				//	key = 0.36 0.25 0 0		//restart attempt during purge has serious penalty
+				//	key = 2.36 1 0 0
+				//}
+				ignitionReliabilityStart = 0.998820
+				ignitionReliabilityEnd = 0.999814
+				cycleReliabilityStart = 0.996468
+				cycleReliabilityEnd = 0.999442
+				techTransfer = AJ10-190-OMS,AJ10-138,AJ10-137,AJ10-118K,AJ10-118F,AJ10-118,AJ10-142,AJ10-42,AJ10-37:50
+			}
+		}
+	}
+	!MODULE[ModuleWaterfallFX]
+}
+
+//CBM
+
+@PART[ht2_CBM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor{}
+	%rescaleFactor = 1.81
+	@mass = 0.2 
+	@title = ISS CBM (Passive)
+	@manufacturer = Boeing
+	@description = The common berthing mechanism (CBM) is a berthing mechanism used to connect all non-Russian pressurized modules of the International Space Station. It was developed by Boeing at the Marshall Space Flight Center (MSFC) in Huntsville, Alabama while under contract to the National Aeronautics and Space Administration (NASA). 
+	@maxTemp = 1073.15
+	@MODULE[ModuleDockingNode]
+	{ 
+		@nodeType = ht2_CBM
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1 
+	}
+}
+
+@PART[ht2_CBM_active1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor{}
+	%rescaleFactor = 1.81
+	@mass = 0.2 
+	@title = ISS CBM (Active)
+	@manufacturer = Boeing
+	@description = The common berthing mechanism (CBM) is a berthing mechanism used to connect all non-Russian pressurized modules of the International Space Station. It was developed by Boeing at the Marshall Space Flight Center (MSFC) in Huntsville, Alabama while under contract to the National Aeronautics and Space Administration (NASA). 
+	@maxTemp = 1073.15
+	@MODULE[ModuleDockingNode]
+	{ 
+		@nodeType = ht2_CBM
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1 
+	}
+}
+
+@PART[ht2_CBM_active2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!rescaleFactor{}
+	%rescaleFactor = 1.81
+	@mass = 0.2 
+	@title = ISS CBM (Active)
+	@manufacturer = Boeing
+	@description = The common berthing mechanism (CBM) is a berthing mechanism used to connect all non-Russian pressurized modules of the International Space Station. It was developed by Boeing at the Marshall Space Flight Center (MSFC) in Huntsville, Alabama while under contract to the National Aeronautics and Space Administration (NASA). 
+	@maxTemp = 1073.15
+	@MODULE[ModuleDockingNode]
+	{ 
+		@nodeType = ht2_CBM
+		%acquireForce = 0.5
+		%acquireMinFwdDot = 0.8
+		%acquireminRollDot = -3.40282347E+38
+		%acquireRange = 0.25
+		%acquireTorque = 0.5
+		%captureMaxRvel = 0.1
+		%captureMinFwdDot = 0.998
+		%captureMinRollDot = -3.40282347E+38
+		%captureRange = 0.05
+		%minDistanceToReEngage = 0.25
+		%undockEjectionForce = 0.1 
+	}
+}


### PR DESCRIPTION
RO configs for Habtech2, which include all of Habtech2, IVAs, Habtech Robotics, and MMU configs from cormorant