### PR TITLE
Fix oxygen on early AirplanePlus cockpits

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/AirplanePlus/Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/AirplanePlus/Command.cfg
@@ -95,7 +95,7 @@
 			maxAmount = 2900	//34 amp-hours at 24 volts
 		}
 
-		TANK
+		UNMANAGED_RESOURCE
 		{
 			name = Oxygen
 			amount = 46 // 2hrs 


### PR DESCRIPTION
for rp-1 compatibility: oxygen in a TANK is unavailable until life support is researched.

(this matches what was done to the new RO p-40, as well as x-1, etc)