### PR TITLE
Fix J47 MEC to have a maxThrust and specLevel

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J47_Config.cfg
@@ -71,6 +71,7 @@
 		{
 			name = J47-GE-27
 			description = J47, as used on the F-86E/F.
+			specLevel = operational
 			massMult = 1.00
 			
 			Area = 0.19		//Compressor Area
@@ -94,7 +95,7 @@
 			defaultTPR = 0.95
 			dryThrust = 26.47
 			wetThrust = 0.0
-			maxThrust = 0.0	//Just to let MEC know thrust
+			maxThrust = 26.47	//Just to let MEC know thrust
 			drySFC = 0.902
 			throttleResponseMultiplier = 0.18
 


### PR DESCRIPTION
The 0 maxThrust was causing the engine to report a 0.00/sec Max Kerosene usage and breaking MJ and KER deltaV stats. I didn't notice a problem from the missing specLevel inside the MEC but the single config Jets have it inside the MEC too.