### PR TITLE
Add maxThrust to Avon MEC

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
@@ -236,6 +236,7 @@
 			defaultTPR = 0.85
 			dryThrust = 50.04
 			wetThrust = 63.92
+			maxThrust = 63.92	//Just to let MEC know thrust
 			drySFC = 0.88
 			throttleResponseMultiplier = 0.30	//60s double-spool, 0.30
 			
@@ -274,6 +275,7 @@
 			defaultTPR = 0.85
 			dryThrust = 56.45
 			wetThrust = 72.77
+			maxThrust = 72.77	//Just to let MEC know thrust
 			drySFC = 0.85
 			throttleResponseMultiplier = 0.30	//60s double-spool, 0.30
 			


### PR DESCRIPTION
The MEC picker showed Unknown Thrust for these configs without a maxThrust set