### PR TITLE
Change Jet Engine MEC default to first non upgrade in RP-0

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL31_Config.cfg
@@ -111,7 +111,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = AL-31FM
+		configuration = AL-31F
 		modded = false
 		origMass = 1.520
 

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar09_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar09_Config.cfg
@@ -84,7 +84,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = Atar09K-50
+		configuration = Atar09B
 		modded = false
 		origMass = 1.582
 

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
@@ -127,7 +127,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
 		useConfigAsTitle = false
-		configuration = Avon302
+		configuration = Avon107
 		origMass = 1.300
 		
 		CONFIG

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CF6_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CF6_Config.cfg
@@ -129,7 +129,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = CF6-50E2
+		configuration = CF6-6
 		modded = false
 		origMass = 3.709
 

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F100_Config.cfg
@@ -127,7 +127,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = F100-PW-229
+		configuration = F100-PW-100
 		modded = false
 		origMass = 1.442
 

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F404_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F404_Config.cfg
@@ -106,7 +106,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = F404-GE-402
+		configuration = F404-GE-400
 		modded = false
 		origMass = 0.991
 

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J57_Config.cfg
@@ -106,7 +106,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
 		useConfigAsTitle = false
-		configuration = J57-P-21
+		configuration = J57-P-8
 		origMass = 2.155
 		
 		CONFIG

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J75_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J75_Config.cfg
@@ -105,7 +105,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = J75-P-19
+		configuration = J75-P-17
 		modded = false
 		origMass = 2.665
 

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J79_Config.cfg
@@ -211,7 +211,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = J79-GE-17
+		configuration = J79-GE-3A
 		modded = false
 		origMass = 1.508
 


### PR DESCRIPTION
Most of these were set to configs that unlocked in later nodes than the config they have been changed to. For the F100 and J75, the original default config and the new default unlock in the same node, but the originals were flagged as upgrades and the new default is the first entry in the MEC GUI and not flagged as an upgrade.