### PR TITLE
Create a unified Deprecation method that can be shared across RO mods

### DIFF
--- a/GameData/RealismOverhaul/Filter_Extensions_Configs/non_WIP_RO_FE_config.cfg
+++ b/GameData/RealismOverhaul/Filter_Extensions_Configs/non_WIP_RO_FE_config.cfg
@@ -8,9 +8,30 @@
 {
     @SUBCATEGORIES
     {
+		list = 95,RO-DEPRECATED
         list = 96,WIP-RO
         list = 97,non-RO
     }
+}
+
+//  ==================================================
+//  Create the RO-DEPRECATED category.
+//  ==================================================
+
+SUBCATEGORY
+{
+	name = RO-DEPRECATED
+	displayName = RO-DEPRECATED
+	icon = R&D_node_icon_nuclearpropulsion
+
+	FILTER
+	{
+		CHECK
+		{
+			type = title
+			value = (DEPRECATED)
+		}
+	}
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/Filter_Extensions_Configs/non_WIP_RO_FE_config.cfg
+++ b/GameData/RealismOverhaul/Filter_Extensions_Configs/non_WIP_RO_FE_config.cfg
@@ -8,7 +8,7 @@
 {
     @SUBCATEGORIES
     {
-		list = 95,RO-DEPRECATED
+        list = 95,RO-DEPRECATED
         list = 96,WIP-RO
         list = 97,non-RO
     }

--- a/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
+++ b/GameData/RealismOverhaul/Parts/Probes/ProbeVanguardXray.cfg
@@ -24,7 +24,7 @@
 	!MODULE[TweakScale]{}
 
 	%RSSROConfig = true
-	%deprecated:NEEDS[RP-0] = True
+	%RODeprecated:NEEDS[RP-0] = True
 
 	@mass = 0.01
 	@maxTemp = 773.15

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -301,7 +301,8 @@
 
 	@mass = 1.582	//Guess
 
-	@title = Deprecated	//Atar 09B Turbojet
+	%RODeprecated = True
+	@title = Atar 09B Turbojet
 	@manufacturer = #roMfrSNECMA
 	@description = #roRO-Atar09BDesc
 
@@ -357,7 +358,8 @@
 	@mass = 1.3	//Guess
 	//%CoMOffset = 0, 2.5, 0
 
-	@title = Deprecated	//Avon RA.4 Mk.107 Turbojet
+	%RODeprecated = True
+	@title = Avon RA.4 Mk.107 Turbojet
 	@manufacturer = #roMfrRR
 	@description = #roRO-Avon107Desc
 	
@@ -413,7 +415,8 @@
 	@mass = 1.4	//Guess
 	//%CoMOffset = 0, 2.5, 0
 
-	@title = Deprecated	//Avon RA.24R Mk.200R Turbojet
+	%RODeprecated = True
+	@title = Avon RA.24R Mk.200R Turbojet
 	@manufacturer = #roMfrRR
 	@description = #roRO-Avon200Desc
 	
@@ -541,7 +544,8 @@
 	%RSSROConfig = True
 	@name = RO-J57P8
 
-	@title = Deprecated	//J57-P-8 Turbojet
+	%RODeprecated = True
+	@title = J57-P-8 Turbojet
 	@manufacturer = #roMfrPW
 	@description = #roRO-J57P8Desc
 	

--- a/GameData/RealismOverhaul/RO_Deprecation.cfg
+++ b/GameData/RealismOverhaul/RO_Deprecation.cfg
@@ -1,15 +1,12 @@
 @PART:HAS[#RODeprecated[?rue]]:FOR[zzzRealismOverhaul]
 {
-	@TechRequired:NEEDS[NoRODeprecated,RP-0] = ORPHANS
 	@category:NEEDS[FilterExtensions] = 95
-	@category:NEEDS[!FilterExtensions,NoRODeprecated] = -1
 	@title ^=:$: (DEPRECATED):
 	&description = 
 	@description ^=:^:<b>(DEPRECATED BY RO)</b> :
 }
-!PART:HAS[#RSSROConfig,#RODeprecated[?rue]]:BEFORE[zzzTagCleanup]:NEEDS[HardRemoveRODeprecated] {}
 
-@PART:HAS[#RODeprecated[?rue]]:FOR[zzzTagCleanup]
+@PART:HAS[#RODeprecated]:FOR[zzzTagCleanup]
 {
     !RODeprecated = NULL
 }

--- a/GameData/RealismOverhaul/RO_Deprecation.cfg
+++ b/GameData/RealismOverhaul/RO_Deprecation.cfg
@@ -1,6 +1,15 @@
-@PART[*]:HAS[#deprecated[?rue]]:LAST[RealismOverhaul]
+@PART:HAS[#RODeprecated[?rue]]:FOR[zzzRealismOverhaul]
 {
-	%TechHidden = True
-	%category = -1
-	!deprecated = DEL
+	@TechRequired:NEEDS[NoRODeprecated,RP-0] = ORPHANS
+	@category:NEEDS[FilterExtensions] = 95
+	@category:NEEDS[!FilterExtensions,NoRODeprecated] = -1
+	@title ^=:$: (DEPRECATED):
+	&description = 
+	@description ^=:^:<b>(DEPRECATED BY RO)</b> :
+}
+!PART:HAS[#RSSROConfig,#RODeprecated[?rue]]:BEFORE[zzzTagCleanup]:NEEDS[HardRemoveRODeprecated] {}
+
+@PART:HAS[#RODeprecated[?rue]]:FOR[zzzTagCleanup]
+{
+    !RODeprecated = NULL
 }

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -36,7 +36,7 @@
 			@RESOURCE[ElectricCharge] { @unitsPerT = 265000 }
 		}
 	}
-	%deprecated = True // use the SM tanks instead
+	%RODeprecated = True // use the SM tanks instead
 }
 
 @PART[proceduralStructural]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROTanks.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROTanks.cfg
@@ -126,9 +126,8 @@
 //  (TODO: give more useful title & description)
 @PART[ROT-*Tank]:FOR[RealismOverhaul]
 {
-	@title = #$/title$ (Deprecated)
 	@description = Don't use this tank.
 	%RSSROConfig = true
-	%deprecated = true
+	%RODeprecated = true
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_USRockets.cfg
@@ -2387,12 +2387,12 @@
 	%rescaleFactor = 1.0
 	
 	
-	@title = Vanguard X-405 Turbopump Exhaust Jet (DEPRECATED)
+	@title = Vanguard X-405 Turbopump Exhaust Jet
 	@manufacturer = General Electric
 	@description = NO LONGER USED, MERGED INTO MAIN ENGINE PART. First stage vernier engine used on the Vanguard launch vehicle.
 	@mass = 0.001
 	@maxTemp = 1073.15
-	%deprecated = True
+	%RODeprecated = True
 	@MODULE[ModuleEngines*]
 	{
 		%maxThrust = 0.267
@@ -5503,10 +5503,10 @@
 	
 	@mass = 0.005
 	@maxTemp = 1073.15
-	@title = LR-91 Turbopump Exhaust Vernier (DEPRECATED)
+	@title = LR-91 Turbopump Exhaust Vernier
 	@manufacturer = Aerojet
 	@description = THIS PART HAS BEEN COMBINED WITH THE MAIN MODEL AND IS NO LONGER REQUIRED. The upper stage vernier for the Titan I through Titan IV series of rockets.
-	%deprecated = True
+	%RODeprecated = True
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 2.37

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Vanguard.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_Vanguard.cfg
@@ -168,8 +168,9 @@
 	%breakingTorque = 250
 	@maxTemp = 1073.15
 	@category = none
-	@title = (DEPRECATED) Vanguard Third Stage (Altair)
-	@description = DEPRECATED This part is no longer in use and will be removed from later versions.
+	@title = Vanguard Third Stage (Altair)
+	@description = This part is no longer in use and will be removed from later versions.
+	%RODeprecated = True
 	!RESOURCE[SolidFuel]
 	{
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SCANSat/RO_SCANsat.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SCANSat/RO_SCANsat.cfg
@@ -16,10 +16,10 @@
 {
 	%RSSROConfig = True
 	
-	%category = -1
 	@mass = 0.05
 	
-	@description = DEPRECATED, do not use
+	@description = do not use
+	%RODeprecated = True
 	@MODULE[SCANsat]
 	{
 		@RESOURCE[ElectricCharge]
@@ -35,10 +35,10 @@
 {
 	%RSSROConfig = True
 	
-	%category = -1
 	@mass = 0.15
 	
-	@description = DEPRECATED, do not use
+	@description = do not use
+	%RODeprecated = True
 	
 	@MODULE[SCANsat]
 	{
@@ -55,10 +55,10 @@
 {
 	%RSSROConfig = True
 	
-	%category = -1
 	@mass = 0.15
 	
-	@description = DEPRECATED, do not use
+	@description = do not use
+	%RODeprecated = True
 	
 	@MODULE[SCANsat]
 	{
@@ -75,10 +75,10 @@
 {
 	%RSSROConfig = True
 	
-	%category = -1
 	@title = SCAN Anomaly Scanner
 	
-	@description = DEPRECATED, do not use
+	@description = do not use
+	%RODeprecated = True
 	
 	@MODULE[SCANsat]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -285,8 +285,7 @@
 
 @PART[HighGainAntenna5]:FOR[RealismOverhaul]
 {
-    %deprecated = True
-    @title = HG-5 Retractable Parabolic Antenna (Deprecated)
+    %RODeprecated = True
 }
 
 //  ==================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_RCSnew.cfg
@@ -437,11 +437,10 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 
-	@title = (Deprecated) RCS Block [275/445 N Class]
+	@title = RCS Block [275/445 N Class]
 	@manufacturer = Generic
 	@description = A generic RCS block with variants. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
-    %category = none
-    %TechHidden = True
+	%RODeprecated = True
 
 	@MODULE[ModuleRCS*]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -105,9 +105,7 @@
 @PART[miniLandingLeg]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-        %category:NEEDS[ReStock] = none
-        %subcategory:NEEDS[ReStock] = 0
-        %TechHidden:NEEDS[ReStock] = True
+	%RODeprecated:NEEDS[ReStock] = True
 	@mass = 0.01
 }
 @PART[largeAdapter]:FOR[RealismOverhaul]


### PR DESCRIPTION
Set ROdeprecated = True on parts to have them automatically renamed and their description updated. If a folder exists in GameData named NoRODeprecated then soft hide all deprecated parts the same as NoNonRO and NoNonRP0 would do. If a folder exists in GameData named HardRemoveRODeprecated thend hard remove all deprecated parts the same as HardRemoveNonRO and HardRemoveNonRP0 would do. ROdeprecated can be used in other RO mods so that deprecation behavior is uniform across all the RO mods instead of the current behavior.