### PR TITLE
Correct Algol III ISP typo

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
@@ -99,7 +99,7 @@
 			
 			atmosphereCurve
 			{
-				key = 0 230.289
+				key = 0 260.289
 				key = 1 238
 			}
 			


### PR DESCRIPTION
Probably not supposed to be more efficient at sea level than in vacuum.