### PR TITLE
Deprecate the Engine Pre-cooler and Engine Nacelle.

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Structural.cfg
@@ -46,7 +46,7 @@
 @PART[radialEngineBody]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%deprecated = True
+	%RODeprecated = True
 	@category = Propulsion
 	@mass = 0.125
 	@MODULE[TweakScale]
@@ -65,7 +65,7 @@
 @PART[nacelleBody]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	%deprecated = True
+	%RODeprecated = True
 	@category = Propulsion
 	@mass = 0.125
 	@MODULE[TweakScale]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Structural.cfg
@@ -46,6 +46,7 @@
 @PART[radialEngineBody]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%deprecated = True
 	@category = Propulsion
 	@mass = 0.125
 	@MODULE[TweakScale]
@@ -64,6 +65,7 @@
 @PART[nacelleBody]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%deprecated = True
 	@category = Propulsion
 	@mass = 0.125
 	@MODULE[TweakScale]


### PR DESCRIPTION
These parts only function as fuel tanks and have incorrect descriptions implying they have functions that they do not. Lets hide these noob traps.