### PR TITLE
Let ignoreMass, massOffset, etc work for bimodal engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/EngineVariants_Config.cfg
@@ -5,7 +5,7 @@
 
 @PART[*]:HAS[#engineTypeMult[*],~minActiveEngines[*]]:FOR[RealismOverhaulEnginesPost]
 {
-	@MODULE[ModuleEngineConfigs]
+	@MODULE[Module*EngineConfigs]
 	{
 		@origMass *= #$../engineTypeMult$
 
@@ -34,7 +34,7 @@
 
 @PART[*]:HAS[#engineTypeMult[*],#minActiveEngines[*]]:FOR[RealismOverhaulEnginesPost]
 {
-    @MODULE[ModuleEngineConfigs]
+    @MODULE[Module*EngineConfigs]
     {
         @origMass *= #$../engineTypeMult$
 
@@ -63,7 +63,7 @@
 
 @PART[*]:HAS[#massOffset[*]]:FOR[RealismOverhaulEnginesPost]
 {
-	@MODULE[ModuleEngineConfigs]
+	@MODULE[Module*EngineConfigs]
 	{
 		@origMass += #$../massOffset$
 	}
@@ -76,7 +76,7 @@
 
 @PART[*]:HAS[#ignoreMass[*rue]]:FOR[RealismOverhaulEnginesPost]
 {
-	@MODULE[ModuleEngineConfigs]
+	@MODULE[Module*EngineConfigs]
 	{
 		!origMass = 0
 	}
@@ -88,7 +88,7 @@
 
 @PART[*]:HAS[#useVerniers[*rue]]:FOR[RealismOverhaulEnginesPost]
 {
-	@MODULE[ModuleEngineConfigs]
+	@MODULE[Module*EngineConfigs]
     {
 		@CONFIG,*
 		{
@@ -110,7 +110,7 @@
 
 @PART[*]:HAS[#engineTypeCostMult[*]]:FOR[RealismOverhaulEnginesPost]
 {
-	@MODULE[ModuleEngineConfigs]
+	@MODULE[Module*EngineConfigs]
 	{
 		@CONFIG,*
 		{
@@ -131,7 +131,7 @@
 
 @PART[*]:HAS[#engineTypeMassMult[*],~minActiveEngines[*]]:FOR[RealismOverhaulEnginesPost]
 {
-	@MODULE[ModuleEngineConfigs]
+	@MODULE[Module*EngineConfigs]
 	{
 		@origMass *= #$../engineTypeMassMult$
 	}


### PR DESCRIPTION
fixes #2794