### PR TITLE
More jets and rebalance

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/000JetTemplate_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/000JetTemplate_Config.cfg
@@ -67,6 +67,12 @@
 //	60s 1-spool: 0.20
 //	60s 2-spool/variable vanes: 0.30
 //	70s: 0.60
+
+//	Afterburner temp: Thrust ratio of an afterburner is equal to the square root of the afterburner temp over
+//	the turbine outlet temp.
+//	Based on a limited sample size (J79 and GE4), turbine outlet temp ~= TIT * 0.77
+//	For a Turbofan, turbine gas is diluted by bypass air before combustion, reducing effective outlet temp.
+//	So, TAB = (0.77 * (TIT *((1 + BPR) / (1 + BPR)) + 250 * (BPR / (1 + BPR))) * Thrust(Wet)^2)/(Thrust(Dry)^2)
 //	==================================================
 @PART[*]:HAS[#engineType[EXAMPLE]]:FOR[RealismOverhaulEngines]:NEEDS[DONOTRUNME]
 {

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/000JetTemplate_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/000JetTemplate_Config.cfg
@@ -86,7 +86,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/000JetTemplate_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/000JetTemplate_Config.cfg
@@ -73,6 +73,7 @@
 //	Based on a limited sample size (J79 and GE4), turbine outlet temp ~= TIT * 0.77
 //	For a Turbofan, turbine gas is diluted by bypass air before combustion, reducing effective outlet temp.
 //	So, TAB = (0.77 * (TIT *((1 + BPR) / (1 + BPR)) + 250 * (BPR / (1 + BPR))) * Thrust(Wet)^2)/(Thrust(Dry)^2)
+//	Source: https://www.jet-x.org/a6.html
 //	==================================================
 @PART[*]:HAS[#engineType[EXAMPLE]]:FOR[RealismOverhaulEngines]:NEEDS[DONOTRUNME]
 {

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL31_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL31_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL31_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1665 K		//Combustion peak temp
-//	TAB: 2082 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2377* K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1665 K		//Combustion peak temp
-//	TAB: 2082 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2665* K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +62,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1745 K		//Combustion peak temp
-//	TAB: 2200 K		//Afterburner peak temp
-//	maxT3: 1100 K	//Turbine max temperature
+//	TAB: 2575* K		//Afterburner peak temp
+//	maxT3: 1000 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -118,7 +118,7 @@
 		CONFIG
 		{
 			name = AL-31F
-			description = AL-31F, as used on the Su-27, Su-30M/MKI, and J-11A.
+			description = AL-31F, as used on the Su-27, Su-30M/MKI, and J-11A. Temperature Mach limit at 15 km: 2.7.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -133,8 +133,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1665		//Combustion peak temp
-			TAB = 2082		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2377		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 240
@@ -158,7 +158,7 @@
 		CONFIG
 		{
 			name = AL-31FM
-			description = AL-31FM with thrust vectoring, as used on the Su-27SM, Su-30 and Su-34.
+			description = AL-31FM with thrust vectoring, as used on the Su-27SM, Su-30 and Su-34. Temperature Mach limit at 15 km: 2.7.
 			specLevel = operational
 			massMult = 1.0243
 			
@@ -173,8 +173,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1665		//Combustion peak temp
-			TAB = 2082		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2665		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 240
@@ -198,7 +198,7 @@
 		CONFIG
 		{
 			name = AL-41F-1S
-			description = AL-41F-1S with thrust vectoring, as used in the Su-35 and Su-30SM2.
+			description = AL-41F-1S with thrust vectoring, as used in the Su-35 and Su-30SM2. Temperature Mach limit at 15 km: 2.67.
 			specLevel = operational
 			massMult = 1.0553
 			
@@ -213,8 +213,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1745		//Combustion peak temp
-			TAB = 2200		//Afterburner temp?
-			maxT3 = 1100		//Turbine max temperature
+			TAB = 2575		//Afterburner temp?
+			maxT3 = 1000		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 280

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL7_Config.cfg
@@ -11,7 +11,7 @@
 //	Thrust (Dry): 66.7 kN
 //	Thrust (Wet): 88.8 kN
 //	SFC (Dry): 0.99 lb/lbf-hr
-//	Area: 0.26 m^2	//Compressor Area
+//	Area: 0.53 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 9.5		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -20,7 +20,7 @@
 //	eta_n: 0.70		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J	//Fuel heat of burning
 //	TIT: 1133 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
+//	TAB: 1546* K		//Afterburner peak temp
 //	maxT3: 750 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -32,7 +32,7 @@
 //	Thrust (Dry): 68.6 kN
 //	Thrust (Wet): 94.1 kN
 //	SFC (Dry): 0.977 lb/lbf-hr
-//	Area: 0.26 m^2	//Compressor Area
+//	Area: 0.53 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 9.1		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -41,7 +41,7 @@
 //	eta_n: 0.70		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J		//Fuel heat of burning
 //	TIT: 1203 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
+//	TAB: 1743* K		//Afterburner peak temp
 //	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -53,7 +53,7 @@
 //	Thrust (Dry): 68.6 kN
 //	Thrust (Wet): 94.1 kN
 //	SFC (Dry): 0.91 lb/lbf-hr
-//	Area: 0.26 m^2	//Compressor Area
+//	Area: 0.53 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 9.3		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -62,7 +62,7 @@
 //	eta_n: 0.70		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J		//Fuel heat of burning
 //	TIT: 1203 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
+//	TAB: 1743* K		//Afterburner peak temp
 //	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -113,7 +113,7 @@
 		CONFIG
 		{
 			name = AL-7F
-			description = Early afterburning AL-7, as used on the Su-7.
+			description = Early afterburning AL-7, as used on the Su-7. Temperature Mach limit at 15 km: 2.48.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -128,7 +128,7 @@
 			eta_n = 0.70	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1133		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
+			TAB = 1546		//Afterburner temp?
 			maxT3 = 750		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -152,7 +152,7 @@
 		CONFIG
 		{
 			name = AL-7F-1
-			description = Afterburning AL-7, as used on Su-7B/BM/BMK and Su-9.
+			description = Afterburning AL-7, as used on Su-7B/BM/BMK and Su-9. Temperature Mach limit at 15 km: 2.75.
 			specLevel = operational
 			massMult = 0.8776	//2100 kg?
 			
@@ -167,7 +167,7 @@
 			eta_n = 0.70	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1203		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
+			TAB = 1743		//Afterburner temp?
 			maxT3 = 800		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -191,7 +191,7 @@
 		CONFIG
 		{
 			name = AL-7F-2
-			description = Afterburning AL-7, used on Tu-128 and Su-11.
+			description = Afterburning AL-7, used on Tu-128 and Su-11. Temperature Mach limit at 15 km: 2.74.
 			specLevel = operational
 			massMult = 0.8776	//2100 kg
 			
@@ -206,7 +206,7 @@
 			eta_n = 0.70	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1203		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
+			TAB = 1743		//Afterburner temp?
 			maxT3 = 800		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL7_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/AL7_Config.cfg
@@ -117,7 +117,7 @@
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.26		//Compressor Area
+			Area = 0.53		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 9.5		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -156,7 +156,7 @@
 			specLevel = operational
 			massMult = 0.8776	//2100 kg?
 			
-			Area = 0.26	//Compressor Area
+			Area = 0.53	//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 9.1		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -195,7 +195,7 @@
 			specLevel = operational
 			massMult = 0.8776	//2100 kg
 			
-			Area = 0.26	//Compressor Area
+			Area = 0.53	//Compressor Area
 			BPR = 0		//Bypass Ratio
 			CPR = 9.3		//Compressor Pressure Ratio
 			FPR = 0		//Fan Ratio

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar09_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar09_Config.cfg
@@ -20,7 +20,7 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 29000000 J	//Fuel heat of burning
 //	TIT: 1300 K		//Combustion peak temp
-//	TAB: 2000 K		//Afterburner peak temp
+//	TAB: 2070* K		//Afterburner peak temp
 //	maxT3: 700 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -41,8 +41,8 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J		//Fuel heat of burning
 //	TIT: 1360 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 700 K	//Turbine max temperature
+//	TAB: 2158* K		//Afterburner peak temp
+//	maxT3: 750 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -91,7 +91,7 @@
 		CONFIG
 		{
 			name = Atar09B
-			description = Early Atar 09, as used on the Mirage IIIA.
+			description = Early Atar 09, as used on the Mirage IIIA. Temperature Mach limit at 15 km: 2.62.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -106,7 +106,7 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 29000000	//Fuel heat of burning (joules?)
 			TIT = 1300		//Combustion peak temp
-			TAB = 2000		//Afterburner temp?
+			TAB = 2070		//Afterburner temp?
 			maxT3 = 700	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -130,7 +130,7 @@
 		CONFIG
 		{
 			name = Atar09K-50
-			description = Ultimate Atar 09, as used on the Mirage 5S, Mirage 50, Mirage IVA/P/R, and Mirage F1C.
+			description = Ultimate Atar 09, as used on the Mirage 5S, Mirage 50, Mirage IVA/P/R, and Mirage F1C. Temperature Mach limit at 15 km: 2.79.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -145,8 +145,8 @@
 			eta_n = 0.8	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1360		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 700	//Turbine max temperature
+			TAB = 2158		//Afterburner temp?
+			maxT3 = 750	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 150

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar09_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar09_Config.cfg
@@ -67,7 +67,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar101_Config.cfg
@@ -46,7 +46,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar101_Config.cfg
@@ -11,7 +11,7 @@
 //	Thrust (Dry): 29.42 kN
 //	Thrust (Wet): 0.0 kN
 //	SFC (Dry): 1.089 lb/lbf-hr
-//	Area: 0.19 m^2	//Compressor Area
+//	Area: 0.206 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 4.5		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -21,7 +21,7 @@
 //	FHV: 27000000 J	//Fuel heat of burning
 //	TIT: 1080 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 600 K	//Turbine max temperature
+//	maxT3: 550 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -70,11 +70,11 @@
 		CONFIG
 		{
 			name = Atar101D
-			description = Atar 101, as used on the Vautour IA and early Vautour IIB.
+			description = Atar 101, as used on the Vautour IA and early Vautour IIB. Temperature Mach limit at 15 km: 1.99.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.19		//Compressor Area
+			Area = 0.206		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 4.5		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -86,7 +86,7 @@
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1080		//Combustion peak temp
 			TAB = 0		//Afterburner temp?
-			maxT3 = 600		//Turbine max temperature
+			maxT3 = 550		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 60

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
@@ -109,7 +109,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Avon_Config.cfg
@@ -41,7 +41,7 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J	//Fuel heat of burning
 //	TIT: 1100 K		//Combustion peak temp
-//	TAB: 1500 K		//Afterburner peak temp
+//	TAB: 1359* K		//Afterburner peak temp
 //	maxT3: 690 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -62,8 +62,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 29000000 J	//Fuel heat of burning
 //	TIT: 1200 K		//Combustion peak temp
-//	TAB: 1750 K		//Afterburner peak temp
-//	maxT3: 800 K	//Turbine max temperature
+//	TAB: 1508* K		//Afterburner peak temp
+//	maxT3: 740 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -83,7 +83,7 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 29000000 J	//Fuel heat of burning
 //	TIT: 1250 K		//Combustion peak temp
-//	TAB: 1800 K		//Afterburner peak temp
+//	TAB: 1600* K		//Afterburner peak temp
 //	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -133,7 +133,7 @@
 		CONFIG
 		{
 			name = Avon107
-			description = Avon RA.4 Mk.107. Early Avon, as used on the Hunter Prototype.
+			description = Avon RA.4 Mk.107. Early Avon, as used on the Hunter Prototype. Temperature Mach limit at 15 km: 2.05.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -172,7 +172,7 @@
 		CONFIG
 		{
 			name = Avon114R
-			description = Avon RA.7R Mk.114R. Early afterburning Avon, as used on the Super Mystère B1 and Hunter Mk.3.
+			description = Avon RA.7R Mk.114R. Early afterburning Avon, as used on the Super Mystère B1 and Hunter Mk.3. Temperature Mach limit at 15 km: 2.42.
 			specLevel = operational
 			massMult = 1.0769
 			
@@ -187,7 +187,7 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1100		//Combustion peak temp
-			TAB = 1500		//Afterburner temp?
+			TAB = 1359		//Afterburner temp?
 			maxT3 = 690	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -211,7 +211,7 @@
 		CONFIG
 		{
 			name = Avon200R
-			description = Avon RA.24R Mk.200R. Afterburning Avon, as used on the Lightning F.1.
+			description = Avon RA.24R Mk.200R. Afterburning Avon, as used on the Lightning F.1. Temperature Mach limit at 15 km: 2.6.
 			specLevel = operational
 			massMult = 1.0769
 			
@@ -226,8 +226,8 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 29000000	//Fuel heat of burning (joules?)
 			TIT = 1200		//Combustion peak temp
-			TAB = 1750		//Afterburner temp?
-			maxT3 = 800	//Turbine max temperature
+			TAB = 1508		//Afterburner temp?
+			maxT3 = 740	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 125
@@ -249,7 +249,7 @@
 		CONFIG
 		{
 			name = Avon302
-			description = Avon RB.146 Mk.302. Ultimate afterburning Avon, as used on the Lightning F.6.
+			description = Avon RB.146 Mk.302. Ultimate afterburning Avon, as used on the Lightning F.6. Temperature Mach limit at 15 km: 2.8.
 			specLevel = operational
 			massMult = 1.0
 			
@@ -264,7 +264,7 @@
 			eta_n = 0.8	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 29000000	//Fuel heat of burning (joules?)
 			TIT = 1250		//Combustion peak temp
-			TAB = 1800		//Afterburner temp?
+			TAB = 1600		//Afterburner temp?
 			maxT3 = 800	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CF34_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CF34_Config.cfg
@@ -112,7 +112,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CF6_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CF6_Config.cfg
@@ -112,7 +112,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CFM56_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CFM56_Config.cfg
@@ -1,0 +1,232 @@
+//	==================================================
+//	Engine: CFM56
+//
+//	Manufacturer: CFM International
+//
+//	=================================================================================
+//	CFM56-2A2
+//	1980, E-3D, E-6B
+//
+//	Dry Mass: 2186 kg
+//	Thrust (Dry): 106.76 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.370 lb/lbf-hr
+//	Area: 0.35 m^2	//Compressor Area
+//	BPR: 5.9		//Bypass Ratio
+//	CPR: 25.4		//Compressor Pressure Ratio
+//	FPR: 1.8		//Fan Ratio?
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1400 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	CFM56-5A1
+//	1988, A320-111/211
+//
+//	Dry Mass: 2270 kg
+//	Thrust (Dry): 111.2 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.332 lb/lbf-hr?
+//	Area: 0.35 m^2	//Compressor Area
+//	BPR: 6.0		//Bypass Ratio
+//	CPR: 31.3		//Compressor Pressure Ratio
+//	FPR: 1.8		//Fan Ratio?
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1400 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	CFM56-5B3
+//	1997, A321-211
+//
+//	Dry Mass: 2380 kg
+//	Thrust (Dry): 142.3 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.354 lb/lbf-hr?
+//	Area: 0.35 m^2	//Compressor Area
+//	BPR: 5.4		//Bypass Ratio
+//	CPR: 33.7		//Compressor Pressure Ratio
+//	FPR: 1.8		//Fan Ratio?
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1400 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.jet-engine.net/miltfspec.htm
+//	https://en.wikipedia.org/wiki/CFM_International_CFM56
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[CFM56]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roCFM56Title	//CFM56 High-Bypass Turbofan
+	%manufacturer = #roMfrCFM
+	%description = #roCFM56Desc
+
+	@tags ^= :$: usa cfm international general electric ge safran cfm56 high bypass turbofan
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = CFM56-5B3
+		modded = false
+		origMass = 2.186
+
+		CONFIG
+		{
+			name = CFM56-2A2
+			description = Early CFM56, A.K.A. F108-CF-102, as used on the E-3D and E-6B.
+			specLevel = operational
+			massMult = 1.0
+			
+			Area = 0.35		//Compressor Area
+			BPR = 5.9		//Bypass Ratio
+			CPR = 25.4		//Compressor Pressure Ratio
+			FPR = 1.8		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1400		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 150
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 106.76
+			wetThrust = 0.0
+			maxThrust = 106.76	//Just to let MEC know thrust
+			drySFC = 0.370
+			throttleResponseMultiplier = 0.80
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = CFM56-5A1
+			description = CFM56, as used on the A320-111/211.
+			specLevel = operational
+			massMult = 1.0384
+			
+			Area = 0.35		//Compressor Area
+			BPR = 6.0		//Bypass Ratio
+			CPR = 31.3		//Compressor Pressure Ratio
+			FPR = 1.8		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1400		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 160
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 111.2
+			wetThrust = 0.0
+			maxThrust = 111.2	//Just to let MEC know thrust
+			drySFC = 0.332
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = CFM56-5B3
+			description = CFM56, as used on the A321-211.
+			specLevel = operational
+			massMult = 1.0887
+			
+			Area = 0.35		//Compressor Area
+			BPR = 5.4		//Bypass Ratio
+			CPR = 33.7		//Compressor Pressure Ratio
+			FPR = 1.8		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1400		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 200
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 142.3
+			wetThrust = 0.0
+			maxThrust = 142.3	//Just to let MEC know thrust
+			drySFC = 0.354
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CFM56_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/CFM56_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/D18_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/D18_Config.cfg
@@ -47,7 +47,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/D30_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/D30_Config.cfg
@@ -47,7 +47,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Derwent_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Derwent_Config.cfg
@@ -68,7 +68,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Derwent_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Derwent_Config.cfg
@@ -92,7 +92,7 @@
 		CONFIG
 		{
 			name = DerwentV
-			description = Derwent V RD.7. Centrifugal Nene derivative, as used on Meteor F.4 and Nord 1601.
+			description = Derwent V RD.7. Centrifugal Nene derivative, as used on Meteor F.4 and Nord 1601. Temperature Mach limit at 15 km: 1.83.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -132,7 +132,7 @@
 		CONFIG
 		{
 			name = RD-500
-			description = OKB-300 (Tumansky) license-built copy of the Derwent V, used on the Yak-23/25/30 and La-15.
+			description = OKB-300 (Tumansky) license-built copy of the Derwent V, used on the Yak-23/25/30 and La-15. Temperature Mach limit at 15 km: 1.83.
 			specLevel = operational
 			massMult = 1.0309
 			

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F100_Config.cfg
@@ -111,7 +111,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F100_Config.cfg
@@ -20,7 +20,7 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1673 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
+//	TAB: 2005 K		//Afterburner peak temp
 //	maxT3: 1000 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1673 K		//Combustion peak temp
-//	TAB: 2850 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2005 K		//Afterburner peak temp
+//	maxT3: 1010 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,7 +62,7 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1755 K		//Combustion peak temp
-//	TAB: 2850 K		//Afterburner peak temp
+//	TAB: 2864* K		//Afterburner peak temp
 //	maxT3: 1100 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
@@ -83,8 +83,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1755 K		//Combustion peak temp
-//	TAB: 3000 K		//Afterburner peak temp
-//	maxT3: 1200 K	//Turbine max temperature
+//	TAB: 3576* K		//Afterburner peak temp
+//	maxT3: 1150 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -93,6 +93,7 @@
 
 //	http://www.leteckemotory.cz/motory/f100/
 //	https://www.jet-engine.net/miltfspec.htm
+//	https://www.nasa.gov/centers/dryden/pdf/88117main_H-1449.pdf
 
 //	Used by:
 
@@ -134,7 +135,7 @@
 		CONFIG
 		{
 			name = F100-PW-100
-			description = Early F100, as used in the F-15A/B.
+			description = Early F100, as used in the F-15A/B. Temperature Mach limit at 15 km: 2.8.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -149,7 +150,7 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1673		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
+			TAB = 2005		//Afterburner temp?
 			maxT3 = 1000		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
@@ -173,7 +174,7 @@
 		CONFIG
 		{
 			name = F100-PW-220
-			description = Upgrade of F100-PW-100, as used in the F-15C/D/E, F-16C/D Block 25, and YA-7F.
+			description = Upgrade of F100-PW-100, as used in the F-15C/D/E, F-16C/D Block 25, and YA-7F. Temperature Mach limit at 15 km: 2.83.
 			specLevel = operational
 			massMult = 1.0062
 			
@@ -188,8 +189,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1755		//Combustion peak temp
-			TAB = 2850		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2005		//Afterburner temp?
+			maxT3 = 1010		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 220
@@ -212,7 +213,7 @@
 		CONFIG
 		{
 			name = F100-PW-229
-			description = F100 redesign with larger, more powerful core, as used in the F-15E/I/S, F-16C/D Block 52/52+, F-16I Block 52, and F-16V Block 70.
+			description = F100 redesign with larger, more powerful core, as used in the F-15E/I/S, F-16C/D Block 52/52+, F-16I Block 52, and F-16V Block 70. Temperature Mach limit at 15 km: 2.99.
 			specLevel = operational
 			massMult = 1.1657
 			
@@ -227,7 +228,7 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1755		//Combustion peak temp
-			TAB = 2850		//Afterburner temp?
+			TAB = 2864		//Afterburner temp?
 			maxT3 = 1100		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
@@ -251,7 +252,7 @@
 		CONFIG
 		{
 			name = F100-PW-229EEP
-			description = F100 Engine Enhancement Package, integrating technology from the F119 and F135 programs, as used in the F-16V Block 70.
+			description = F100 Engine Enhancement Package, integrating technology from the F119 and F135 programs, as used in the F-16V Block 70. Temperature Mach limit at 15 km: 3.11.
 			specLevel = operational
 			massMult = 1.1657
 			
@@ -266,8 +267,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1755		//Combustion peak temp
-			TAB = 3000		//Afterburner temp?
-			maxT3 = 1200		//Turbine max temperature
+			TAB = 3576		//Afterburner temp?
+			maxT3 = 1150		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 260

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F119_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F119_Config.cfg
@@ -47,7 +47,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F119_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F119_Config.cfg
@@ -1,26 +1,26 @@
 //	==================================================
-//	Engine: D-30
+//	Engine: F119
 //
-//	Manufacturer: Soloviev
+//	Manufacturer: Pratt & Whitney
 //
 //	=================================================================================
-//	D-30F6
-//	1975, MiG-31
+//	F119-PW-100
+//	1997, F-22A
 //
-//	Dry Mass: 2416 kg
-//	Thrust (Dry): 93.2 kN
-//	Thrust (Wet): 152 kN
-//	SFC (Dry): 0.706 lb/lbf-hr
-//	Area: 0.44 m^2	//Compressor Area
-//	BPR: 0.57		//Bypass Ratio
-//	CPR: 21.5		//Compressor Pressure Ratio
+//	Dry Mass: 1770 kg
+//	Thrust (Dry): 115.65 kN
+//	Thrust (Wet): 155.69 kN
+//	SFC (Dry): 0.75 lb/lbf-hr	//best guess
+//	Area: 0.35 m^2	//Compressor Area
+//	BPR: 0.45		//Bypass Ratio
+//	CPR: 35.0		//Compressor Pressure Ratio
 //	FPR: 3.0		//Fan Ratio
 //	Mdes: 0.9 M		//Mach Design Point
 //	Tdes: 250 K		//Temp Design Point
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 22000000 J	//Fuel heat of burning
-//	TIT: 1660 K		//Combustion peak temp
-//	TAB: 3400* K		//Afterburner peak temp
+//	FHV: 27000000 J	//Fuel heat of burning
+//	TIT: 1970 K		//Combustion peak temp
+//	TAB: 2048* K		//Afterburner peak temp
 //	maxT3: 1100 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
@@ -28,7 +28,7 @@
 
 //	Sources:
 
-//	http://www.leteckemotory.cz/motory/d-30f6/
+//	https://en.wikipedia.org/wiki/Pratt_%26_Whitney_F119
 //	https://www.jet-engine.net/miltfspec.htm
 
 //	Used by:
@@ -36,14 +36,14 @@
 //	Notes:
 
 //	==================================================
-@PART[*]:HAS[#engineType[D30]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[F119]]:FOR[RealismOverhaulEngines]
 {
 
-	%title = #roD30Title	//D-30 Turbofan
-	%manufacturer = #roMfrSoloviev
-	%description = #roD30Desc
+	%title = #roF119Title	//F119 Low-Bypass Turbofan
+	%manufacturer = #roMfrPW
+	%description = #roF119Desc
 
-	@tags ^= :$: ussr soloviev d30 d-30 afterburning turbofan
+	@tags ^= :$: usa pratt whitney p&w f119 afterburning low bypass turbofan
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
@@ -58,47 +58,50 @@
 		}
 	}
 
-	!MODULE[ModuleGimbal]{}
+	@MODULE[ModuleGimbal]
+	{
+		@gimbalRange = 20
+	}
 
 	MODULE
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = D-30F6
+		configuration = F119-PW-100
 		modded = false
-		origMass = 2.416
+		origMass = 1.770
 
 		CONFIG
 		{
-			name = D-30F6
-			description = Afterburning D-30, as used on MiG-31. Temperature Mach limit at 15 km: 3.35.
+			name = F119-PW-100
+			description = F119, as used on the F-22A. Temperature Mach limit at 15 km: 2.89.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.44	//Compressor Area
-			BPR = 0.57		//Bypass Ratio
-			CPR = 21.5		//Compressor Pressure Ratio
+			Area = 0.35		//Compressor Area
+			BPR = 0.45		//Bypass Ratio
+			CPR = 35.0		//Compressor Pressure Ratio
 			FPR = 3.0		//Fan Ratio
 			Mdes = 0.9		//Mach Design Point
 			Tdes = 250		//Temp Design Point
 			eta_c = 0.95	//Efficiency at burner inlet
 			eta_t = 0.98	//Efficiency at burner exit
-			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
-			FHV = 22000000	//Fuel heat of burning (joules?)
-			TIT = 1660		//Combustion peak temp
-			TAB = 3400		//Afterburner temp?
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 27000000	//Fuel heat of burning (joules?)
+			TIT = 1970		//Combustion peak temp
+			TAB = 2048		//Afterburner temp?
 			maxT3 = 1100	//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
-			thrustUpperLimit = 250
+			thrustUpperLimit = 310
 			
 			// Engine fitting params
 			defaultTPR = 0.85
-			dryThrust = 93.2
-			wetThrust = 152
-			maxThrust = 152	//Just to let MEC know thrust
-			drySFC = 0.706
-			throttleResponseMultiplier = 0.60
+			dryThrust = 115.65
+			wetThrust = 155.69
+			maxThrust = 155.69	//Just to let MEC know thrust
+			drySFC = 0.75
+			throttleResponseMultiplier = 0.9
 
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F135_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F135_Config.cfg
@@ -68,7 +68,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F135_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F135_Config.cfg
@@ -20,13 +20,13 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 24000000 J	//Fuel heat of burning
 //	TIT: 2260 K		//Combustion peak temp
-//	TAB: 2650 K		//Afterburner peak temp
-//	maxT3: 1200 K	//Turbine max temperature
-//	Exhaust Mixer: false
+//	TAB: 2842* K		//Afterburner peak temp
+//	maxT3: 1100 K	//Turbine max temperature
+//	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
-//	F135-PW-100
-//	2006, F-35A/C
+//	F135-PW-600
+//	2006, F-35B
 //
 //	Dry Mass: 1850 kg	//assume nozzle gimbal and fan drive adds some weight
 //	Thrust (Dry): 120 kN
@@ -41,9 +41,9 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 24000000 J	//Fuel heat of burning
 //	TIT: 2260 K		//Combustion peak temp
-//	TAB: 2650 K		//Afterburner peak temp
-//	maxT3: 1200 K	//Turbine max temperature
-//	Exhaust Mixer: false
+//	TAB: 2800* K		//Afterburner peak temp
+//	maxT3: 1100 K	//Turbine max temperature
+//	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
 
@@ -90,7 +90,7 @@
 		CONFIG
 		{
 			name = F135-PW-100
-			description = F135, as used on the F-35A/C.
+			description = F135, as used on the F-35A/C. Temperature Mach limit at 15 km: 3.11.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -105,9 +105,9 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 24000000	//Fuel heat of burning (joules?)
 			TIT = 2260		//Combustion peak temp
-			TAB = 2650		//Afterburner temp?
-			maxT3 = 1200		//Turbine max temperature
-			exhaustMixer = False
+			TAB = 2842		//Afterburner temp?
+			maxT3 = 1100		//Turbine max temperature
+			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 400
 			
@@ -129,7 +129,7 @@
 		CONFIG
 		{
 			name = F135-PW-600
-			description = F135 with gimbal, as used on the F-35B.
+			description = F135 with gimbal, as used on the F-35B. Temperature Mach limit at 15 km: 3.11.
 			specLevel = operational
 			massMult = 1.0882
 			
@@ -144,9 +144,9 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 24000000	//Fuel heat of burning (joules?)
 			TIT = 2260		//Combustion peak temp
-			TAB = 2650		//Afterburner temp?
-			maxT3 = 1200		//Turbine max temperature
-			exhaustMixer = False
+			TAB = 2800		//Afterburner temp?
+			maxT3 = 1100		//Turbine max temperature
+			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 400
 			

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F404_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F404_Config.cfg
@@ -20,7 +20,7 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1621 K		//Combustion peak temp
-//	TAB: 2200 K		//Afterburner peak temp
+//	TAB: 2298* K		//Afterburner peak temp
 //	maxT3: 1000 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1717 K		//Combustion peak temp
-//	TAB: 2300 K		//Afterburner peak temp
-//	maxT3: 1100 K	//Turbine max temperature
+//	TAB: 2398* K		//Afterburner peak temp
+//	maxT3: 1000 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +62,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22500000 J	//Fuel heat of burning
 //	TIT: 1717 K		//Combustion peak temp
-//	TAB: 2300 K		//Afterburner peak temp
-//	maxT3: 1100 K	//Turbine max temperature
+//	TAB: 2371* K		//Afterburner peak temp
+//	maxT3: 1025 K	//Turbine max temperature
 //	Exhaust Mixer: true
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -113,7 +113,7 @@
 		CONFIG
 		{
 			name = F404-GE-400
-			description = Early F404, as used in F/A-18A/B.
+			description = Early F404, as used in F/A-18A/B. Temperature Mach limit at 15 km: 2.79.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -128,7 +128,7 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1621		//Combustion peak temp
-			TAB = 2200		//Afterburner temp?
+			TAB = 2298		//Afterburner temp?
 			maxT3 = 1000		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
@@ -152,7 +152,7 @@
 		CONFIG
 		{
 			name = F404-GE-402
-			description = F404, as used in F/A-18C/D.
+			description = F404, as used in F/A-18C/D. Temperature Mach limit at 15 km: 2.75.
 			specLevel = operational
 			massMult = 1.0444
 			
@@ -167,8 +167,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1717		//Combustion peak temp
-			TAB = 2300		//Afterburner temp?
-			maxT3 = 1100		//Turbine max temperature
+			TAB = 2398		//Afterburner temp?
+			maxT3 = 1000		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 160
@@ -191,7 +191,7 @@
 		CONFIG
 		{
 			name = RM12
-			description = F404 variant developed by Volvo, as used in the JAS-39 Gripen.
+			description = F404 variant developed by Volvo, as used in the JAS-39 Gripen. Temperature Mach limit at 15 km: 2.83.
 			specLevel = operational
 			massMult = 1.0646
 			
@@ -206,8 +206,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22500000	//Fuel heat of burning (joules?)
 			TIT = 1717		//Combustion peak temp
-			TAB = 2300		//Afterburner temp?
-			maxT3 = 1100		//Turbine max temperature
+			TAB = 2371		//Afterburner temp?
+			maxT3 = 1025		//Turbine max temperature
 			exhaustMixer = True
 			adjustableNozzle = True
 			thrustUpperLimit = 160

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F404_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/F404_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GE4_Config.cfg
@@ -86,13 +86,13 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = GE4/J5P
+		configuration = GE4-J5P
 		modded = false
 		origMass = 5.1
 
 		CONFIG
 		{
-			name = GE4/J5P
+			name = GE4-J5P
 			description = GE4/J5P afterburning turbojet, intended to power the B2707. Temperature Mach limit at 15 km: 3.55.
 			specLevel = prototype
 			massMult = 1.00
@@ -131,7 +131,7 @@
 		}
 		CONFIG
 		{
-			name = GE4/J6H
+			name = GE4-J6H
 			description = GE4/J6H turbojet, designed after tests revealed the afterburners of the GE4 would make the 2707 too loud to use most airports. The revised engine has slightly superior performance, but is much heavier. Temperature Mach limit at 15 km: 3.56.
 			specLevel = concept
 			massMult = 1.10

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GE4_Config.cfg
@@ -1,0 +1,174 @@
+//	==================================================
+//	Engine: GE4
+//
+//	Manufacturer: General Electric
+//
+//	=================================================================================
+//	GE4/J5P
+//	1973, 2707
+//
+//	Dry Mass: 5100 kg
+//	Thrust (Dry): 220 kN
+//	Thrust (Wet): 281 kN
+//	SFC (Dry): 1.04 lb/lbf-hr
+//	Area: 0.7 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 12.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 1.0 M		//Mach Design Point
+//	Tdes: 280 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 36000000 J	//Fuel heat of burning
+//	TIT: 1533 K		//Combustion peak temp
+//	TAB: 1966 K		//Afterburner peak temp
+//	maxT3: 1100 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	GE4/J6H
+//	1975, 2707
+//
+//	Dry Mass: 5610 kg?
+//	Thrust (Dry): 297 kN
+//	Thrust (Wet): 0 kN
+//	SFC (Dry): 1.0 lb/lbf-hr
+//	Area: 0.75 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 12.4		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 1.0 M		//Mach Design Point
+//	Tdes: 280 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 36000000 J	//Fuel heat of burning
+//	TIT: 1656 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 1100 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+
+//	Sources:
+
+//	https://en.wikipedia.org/wiki/General_Electric_GE4
+//	https://www.secretprojects.co.uk/threads/ge4-turbojet-boeing-2207-sst.486/
+//	https://archive.org/details/NASA_NTRS_Archive_19770011052/page/n369/mode/1up
+//	https://web.archive.org/web/20101003014616/http://www.dtic.mil/cgi-bin/GetTRDoc?AD=AD378492&Location=U2&doc=GetTRDoc.pdf
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[GE4]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roGE4Title	//GE4 Turbojet
+	%manufacturer = #roMfrGE
+	%description = #roGE4Desc
+
+	@tags ^= :$: usa general electric ge ge4 j5p j6h afterburning turbojet
+
+	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = GE4/J5P
+		modded = false
+		origMass = 5.1
+
+		CONFIG
+		{
+			name = GE4/J5P
+			description = GE4/J5P afterburning turbojet, intended to power the B2707. Temperature Mach limit at 15 km: 3.55.
+			specLevel = prototype
+			massMult = 1.00
+			
+			Area = 0.7		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 12.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 1.0		//Mach Design Point
+			Tdes = 280		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 36000000	//Fuel heat of burning (joules?)
+			TIT = 1533		//Combustion peak temp
+			TAB = 1966		//Afterburner temp?
+			maxT3 = 1100		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 550
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 220
+			wetThrust = 281
+			maxThrust = 281	//Just to let MEC know thrust
+			drySFC = 1.04
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = GE4/J6H
+			description = GE4/J6H turbojet, designed after tests revealed the afterburners of the GE4 would make the 2707 too loud to use most airports. The revised engine has slightly superior performance, but is much heavier. Temperature Mach limit at 15 km: 3.56.
+			specLevel = concept
+			massMult = 1.10
+			
+			Area = 0.75		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 12.4		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 1.0		//Mach Design Point
+			Tdes = 280		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 36000000	//Fuel heat of burning (joules?)
+			TIT = 1656		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 1100		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 550
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 297
+			wetThrust = 0
+			maxThrust = 297	//Just to let MEC know thrust
+			drySFC = 1.0
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GE4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GE4_Config.cfg
@@ -70,7 +70,6 @@
 
 	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GEnx_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GEnx_Config.cfg
@@ -48,7 +48,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GEnx_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/GEnx_Config.cfg
@@ -1,49 +1,50 @@
 //	==================================================
-//	Engine: D-18
+//	Engine: GEnx
 //
-//	Manufacturer: Ivchenko-Progress
+//	Manufacturer: GE
 //
 //	=================================================================================
-//	D-18T
-//	1982, An-124, An-225
+//	GEnx-2B67B
+//	2011, 747-8
 //
-//	Dry Mass: 4100 kg
-//	Thrust (Dry): 229.8 kN
+//	Dry Mass: 5613 kg
+//	Thrust (Dry): 295.81 kN
 //	Thrust (Wet): 0.0 kN
-//	SFC (Dry): 0.360 lb/lbf-hr
-//	Area: 0.49 m^2	//Compressor Area
-//	BPR: 5.7		//Bypass Ratio
-//	CPR: 27.5		//Compressor Pressure Ratio
-//	FPR: 1.8		//Fan Ratio
-//	Mdes: 0.3 M		//Mach Design Point
-//	Tdes: 270 K		//Temp Design Point
+//	SFC (Dry): 0.320 lb/lbf-hr
+//	Area: 0.62 m^2	//Compressor Area
+//	BPR: 8.0		//Bypass Ratio
+//	CPR: 44.7		//Compressor Pressure Ratio
+//	FPR: 1.7		//Fan Ratio?
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 30000000 J	//Fuel heat of burning
-//	TIT: 1600 K		//Combustion peak temp
+//	FHV: 32000000 J	//Fuel heat of burning
+//	TIT: 1800 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	maxT3: 1100 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: false
 //	=================================================================================
 
 //	Sources:
 
-//	http://www.leteckemotory.cz/motory/r-25/
 //	https://www.jet-engine.net/miltfspec.htm
+//	https://en.wikipedia.org/wiki/General_Electric_GEnx#Specifications
+//	https://www.easa.europa.eu/en/downloads/7641/en
 
 //	Used by:
 
 //	Notes:
 
 //	==================================================
-@PART[*]:HAS[#engineType[D18]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[GEnx]]:FOR[RealismOverhaulEngines]
 {
 
-	%title = #roD18Title	//D-18 Turbofan
-	%manufacturer = #roMfrIvchenko
-	%description = #roD18Desc
+	%title = #roGEnxTitle	//GEnx High-Bypass Turbofan
+	%manufacturer = #roMfrGE
+	%description = #roGEnxDesc
 
-	@tags ^= :$: ussr okb478 ivchenko progress zmkb d18 d-18 high bypass turbofan
+	@tags ^= :$: usa general electric ge genx high bypass turbofan
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
@@ -64,40 +65,40 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = D-18T
+		configuration = GEnx-2B67B
 		modded = false
-		origMass = 4.100
+		origMass = 5.613
 
 		CONFIG
 		{
-			name = D-18T
-			description = D-18T, as used on the An-125 and An-225.
+			name = GEnx-2B67B
+			description = GEnx, with a smaller fan to allow it to be installed on the B747-8.
 			specLevel = operational
-			massMult = 1.00
+			massMult = 1.0
 			
-			Area = 0.49		//Compressor Area
-			BPR = 5.7		//Bypass Ratio
-			CPR = 27.5		//Compressor Pressure Ratio
-			FPR = 1.8		//Fan Ratio
-			Mdes = 0.3		//Mach Design Point
-			Tdes = 270		//Temp Design Point
+			Area = 0.62		//Compressor Area
+			BPR = 8.0		//Bypass Ratio
+			CPR = 44.7		//Compressor Pressure Ratio
+			FPR = 1.7		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
 			eta_c = 0.95	//Efficiency at burner inlet
 			eta_t = 0.98	//Efficiency at burner exit
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
-			FHV = 30000000	//Fuel heat of burning (joules?)
-			TIT = 1600		//Combustion peak temp
+			FHV = 32000000	//Fuel heat of burning (joules?)
+			TIT = 1800		//Combustion peak temp
 			TAB = 0		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			maxT3 = 1100		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = False
 			thrustUpperLimit = 400
 			
 			// Engine fitting params
 			defaultTPR = 0.95
-			dryThrust = 229.8
+			dryThrust = 295.81
 			wetThrust = 0.0
-			maxThrust = 229.8	//Just to let MEC know thrust
-			drySFC = 0.36
+			maxThrust = 295.81	//Just to let MEC know thrust
+			drySFC = 0.320
 			throttleResponseMultiplier = 1.0
 
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J35_Config.cfg
@@ -11,7 +11,7 @@
 //	Thrust (Dry): 16.68 kN
 //	Thrust (Wet): 0.0 kN
 //	SFC (Dry): 1.12 lb/lbf-hr
-//	Area: 0.19 m^2	//Compressor Area
+//	Area: 0.20 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 4.0		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -23,7 +23,7 @@
 //	TAB: 0 K		//Afterburner peak temp
 //	maxT3: 500 K	//Turbine max temperature
 //	Exhaust Mixer: false
-//	Adjustable Nozzle: true
+//	Adjustable Nozzle: false
 //	=================================================================================
 //	J35-A-17
 //	1951, F-84D, XF4D-1, X-5
@@ -32,7 +32,7 @@
 //	Thrust (Dry): 21.80 kN
 //	Thrust (Wet): 0.0 kN
 //	SFC (Dry): 1.08 lb/lbf-hr
-//	Area: 0.19 m^2	//Compressor Area
+//	Area: 0.20 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 4.7		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -44,7 +44,7 @@
 //	TAB: 0 K		//Afterburner peak temp
 //	maxT3: 520 K	//Turbine max temperature
 //	Exhaust Mixer: false
-//	Adjustable Nozzle: true
+//	Adjustable Nozzle: false
 //	=================================================================================
 
 //	Sources:
@@ -92,11 +92,11 @@
 		CONFIG
 		{
 			name = J35-A-11
-			description = J35, as used on the B-45A and D558-1.
+			description = J35, as used on the B-45A and D558-1. Temperature Mach limit at 15 km: 1.77.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.19		//Compressor Area
+			Area = 0.20		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 4.0		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -131,11 +131,11 @@
 		CONFIG
 		{
 			name = J35-A-17
-			description = J35, as used on the F-84D, XF4D-1, and X-5.
+			description = J35, as used on the F-84D, XF4D-1, and X-5. Temperature Mach limit at 15 km: 1.76.
 			specLevel = operational
 			massMult = 0.9209
 			
-			Area = 0.19		//Compressor Area
+			Area = 0.20		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 4.7		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J35_Config.cfg
@@ -68,7 +68,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J47_Config.cfg
@@ -88,7 +88,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J47_Config.cfg
@@ -4,6 +4,27 @@
 //	Manufacturer: General Electric
 //
 //	=================================================================================
+//	J47-GE-15
+//	1950, RB-45C
+//
+//	Dry Mass: 1141 kg
+//	Thrust (Dry): 23.13 kN
+//	Thrust (Wet): 26.69 kN
+//	SFC (Dry): 1.12 lb/lbf-hr
+//	Area: 0.19 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 4.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.3 M		//Mach Design Point
+//	Tdes: 280 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 29000000 J	//Fuel heat of burning
+//	TIT: 1080 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 500 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
 //	J47-GE-27
 //	1952, F-86E/F
 //
@@ -22,6 +43,27 @@
 //	TIT: 1080 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
 //	maxT3: 520 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	J47-GE-25A
+//	1953, B-47E
+//
+//	Dry Mass: 1158 kg
+//	Thrust (Dry): 25.22 kN
+//	Thrust (Wet): 32.03 kN
+//	SFC (Dry): 0.902 lb/lbf-hr
+//	Area: 0.19 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 5.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.3 M		//Mach Design Point
+//	Tdes: 280 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 29000000 J	//Fuel heat of burning
+//	TIT: 1080 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 550 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -61,16 +103,83 @@
 
 	MODULE
 	{
-		name = ModuleEngineConfigs
+		name = ModuleBimodalEngineConfigs
 		type = ModuleEnginesAJEJet
 		configuration = J47-GE-27
 		modded = false
 		origMass = 1.158
+		
+		primaryDescription = Water Injection Off
+		secondaryDescription = Water Injection On
+		toPrimaryText = Disengage Water Injection
+		toSecondaryText = Engage Water Injection
 
 		CONFIG
 		{
+			name = J47-GE-15
+			description = J47 with water injection, as used on the RB-45C. Temperature Mach limit at 15 km: 1.68.
+			massMult = 0.9853
+			
+			Area = 0.19		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 4.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.3		//Mach Design Point
+			Tdes = 280		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 29000000	//Fuel heat of burning (joules?)
+			TIT = 1080		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 500		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 50
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 23.13
+			wetThrust = 0.0
+			maxThrust = 23.13	//Just to let MEC know thrust
+			drySFC = 1.12
+			throttleResponseMultiplier = 0.18
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+			SUBCONFIG
+			{
+				name = J47-GE-15-Augmented
+				
+				TIT = 880
+				
+				dryThrust = 26.69
+				maxThrust = 26.69
+				drySFC = 1.15
+
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.90
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = Water
+					ratio = 0.10
+					DrawGauge = True
+					resourceFlowMode = STACK_PRIORITY_SEARCH
+				}
+			}
+		}
+		CONFIG
+		{
 			name = J47-GE-27
-			description = J47, as used on the F-86E/F.
+			description = J47, as used on the F-86E/F. Temperature Mach limit at 15 km: 1.62.
 			massMult = 1.00
 			
 			Area = 0.19		//Compressor Area
@@ -103,6 +212,68 @@
 				name = Kerosene
 				ratio = 1.0
 				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = J47-GE-25A
+			description = Late J47 with water injection, as used on the B-47E. Temperature Mach limit at 15 km: 1.84.
+			massMult = 1.00
+			
+			Area = 0.19		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 5.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.3		//Mach Design Point
+			Tdes = 280		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 29000000	//Fuel heat of burning (joules?)
+			TIT = 1080		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 550		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 55
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 25.22
+			wetThrust = 0.0
+			maxThrust = 25.22	//Just to let MEC know thrust
+			drySFC = 0.902
+			throttleResponseMultiplier = 0.18
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+			SUBCONFIG
+			{
+				name = J47-GE-25A-Augmented
+				
+				TIT = 880
+				
+				dryThrust = 32.03
+				maxThrust = 32.03
+				drySFC = 0.932
+
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.90
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = Water
+					ratio = 0.10
+					DrawGauge = True
+					resourceFlowMode = STACK_PRIORITY_SEARCH
+				}
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J48_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J48_Config.cfg
@@ -68,7 +68,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J48_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J48_Config.cfg
@@ -20,7 +20,7 @@
 //	eta_n: 0.85		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J	//Fuel heat of burning
 //	TIT: 1050 K		//Combustion peak temp
-//	TAB: 1300 K		//Afterburner peak temp
+//	TAB: 1384 K		//Afterburner peak temp
 //	maxT3: 520 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: false
@@ -41,8 +41,8 @@
 //	eta_n: 0.85		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J	//Fuel heat of burning
 //	TIT: 1100 K		//Combustion peak temp
-//	TAB: 1300 K		//Afterburner peak temp
-//	maxT3: 600 K	//Turbine max temperature
+//	TAB: 1167 K		//Afterburner peak temp
+//	maxT3: 550 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: false
 //	=================================================================================
@@ -92,7 +92,7 @@
 		CONFIG
 		{
 			name = J48-P-5
-			description = Early afterburning J48, as used in the F-94C.
+			description = Early afterburning J48, as used in the F-94C. Temperature Mach limit at 15 km: 1.81.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -107,7 +107,7 @@
 			eta_n = 0.85	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1050		//Combustion peak temp
-			TAB = 1300		//Afterburner temp?
+			TAB = 1384		//Afterburner temp?
 			maxT3 = 520	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = False
@@ -132,7 +132,7 @@
 		CONFIG
 		{
 			name = J48-P-8
-			description = Afterburning J48, as used in the F9F-6 and most F9F-7s (F-9F and F-9H).
+			description = Afterburning J48, as used in the F9F-6 and most F9F-7s (F-9F and F-9H). Temperature Mach limit at 15 km: 1.99.
 			specLevel = operational
 			massMult = 1.001
 			
@@ -147,8 +147,8 @@
 			eta_n = 0.85	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
 			TIT = 1100		//Combustion peak temp
-			TAB = 1300		//Afterburner temp?
-			maxT3 = 600		//Turbine max temperature
+			TAB = 1167		//Afterburner temp?
+			maxT3 = 550		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = False
 			isCentrifugalFlow = true

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J57_Config.cfg
@@ -4,13 +4,34 @@
 //	Manufacturer: Pratt & Whitney
 //
 //	=================================================================================
+//	J57-P-1W
+//	1952, XB-52
+//
+//	Dry Mass: 1991 kg?
+//	Thrust (Dry): 40.03 kN
+//	Thrust (Wet): 50.71 kN
+//	SFC (Dry): 0.78 lb/lbf-hr
+//	Area: 0.24 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 10.0		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 260 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 29000000 J	//Fuel heat of burning
+//	TIT: 1080 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 705 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
 //	J57-P-8
 //	1951, F4D
 //
 //	Dry Mass: 2155 kg?
 //	Thrust (Dry): 45.3 kN
 //	Thrust (Wet): 64.5 kN
-//	SFC (Dry): 0.90 lb/lbf-hr	//assume a little worse than later J57s
+//	SFC (Dry): 0.80 lb/lbf-hr	//assume a little worse than later J57s
 //	Area: 0.24 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 11.7		//Compressor Pressure Ratio
@@ -20,7 +41,7 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 29000000 J	//Fuel heat of burning
 //	TIT: 1080 K		//Combustion peak temp
-//	TAB: 2800 K		//Afterburner peak temp
+//	TAB: 1685* K		//Afterburner peak temp
 //	maxT3: 705 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -41,10 +62,73 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 35000000 J	//Fuel heat of burning
 //	TIT: 1330 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
+//	TAB: 2825* K		//Afterburner peak temp
 //	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
+//	=================================================================================
+//	J57-P-7A
+//	1955, U-2A
+//
+//	Dry Mass: 1900 kg?
+//	Thrust (Dry): 49.82 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.77 lb/lbf-hr
+//	Area: 0.24 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 13.0		//Compressor Pressure Ratio?
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 260 K		//Temp Design Point
+//	eta_n: 0.95		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 35000000 J	//Fuel heat of burning
+//	TIT: 1330 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	J57-P-43WA
+//	1957, B-52E/F
+//
+//	Dry Mass: 1959 kg
+//	Thrust (Dry): 49.82 kN
+//	Thrust (Wet): 61.16 kN
+//	SFC (Dry): 0.77 lb/lbf-hr
+//	Area: 0.24 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 12.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 35000000 J	//Fuel heat of burning
+//	TIT: 1330 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	JT3C-6
+//	1957, B707-120, DC-8-10
+//
+//	Dry Mass: 1921 kg
+//	Thrust (Dry): 49.82 kN
+//	Thrust (Wet): 60.05 kN
+//	SFC (Dry): 0.785 lb/lbf-hr
+//	Area: 0.24 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 12.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 260 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 35000000 J	//Fuel heat of burning
+//	TIT: 1330 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
 //	=================================================================================
 //	J57-P-20A
 //	1960, F-8E/J
@@ -62,8 +146,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 35000000 J	//Fuel heat of burning
 //	TIT: 1330 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
-//	maxT3: 850 K	//Turbine max temperature
+//	TAB: 3129* K		//Afterburner peak temp
+//	maxT3: 810 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -71,6 +155,9 @@
 //	Sources:
 
 //	https://www.jet-engine.net/miltfspec.htm
+//	https://en.wikipedia.org/wiki/Pratt_%26_Whitney_J57
+//	https://www.thisdayinaviation.com/tag/pratt-whitney-jt3c-6/
+//	https://aircorpslibrary.com/jt3c-4-and-jt3c-6/
 
 //	Used by:
 
@@ -103,16 +190,85 @@
 
 	MODULE
 	{
-		name = ModuleEngineConfigs
+		name = ModuleBimodalEngineConfigs
 		type = ModuleEnginesAJEJet
 		useConfigAsTitle = false
 		configuration = J57-P-21
 		origMass = 2.155
 		
+		primaryDescription = Water Injection Off
+		secondaryDescription = Water Injection On
+		toPrimaryText = Disengage Water Injection
+		toSecondaryText = Engage Water Injection
+		
+		CONFIG
+		{
+			name = J57-P-1W
+			description = Early J57 with water injection, as used on the XB-52 and XB-60. Temperature Mach limit at 15 km: 2.18.
+			specLevel = operational
+			massMult = 0.9239
+			
+			Area = 0.24	//Compressor Area
+			BPR = 0		//Bypass Ratio
+			CPR = 10.0		//Compressor Pressure Ratio
+			FPR = 0		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 260		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.90	//Efficiency at afterburner rear / nozzle entrance
+			FHV = 29000000	//Fuel heat of burning (joules?)
+			TIT = 1080		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 705	//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 100
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 40.03
+			wetThrust = 0
+			maxThrust = 40.03	//Just to let MEC know thrust
+			drySFC = 0.78
+			throttleResponseMultiplier = 0.2	//50s double-spool, 0.2
+			
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			SUBCONFIG
+			{
+				name = J57-P-1W-Augmented
+				
+				TIT = 880
+				
+				dryThrust = 50.71
+				maxThrust = 50.71
+				drySFC = 0.96
+
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.90
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = Water
+					ratio = 0.10
+					DrawGauge = True
+					resourceFlowMode = STACK_PRIORITY_SEARCH
+				}
+			}
+		}
 		CONFIG
 		{
 			name = J57-P-8
-			description = Early afterburning J57, as used on the F4D and F5D.
+			description = Early afterburning J57, as used on the F4D and F5D. Temperature Mach limit at 15 km: 2.01.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -127,7 +283,7 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 29000000	//Fuel heat of burning (joules?)
 			TIT = 1080		//Combustion peak temp
-			TAB = 2800		//Afterburner temp?
+			TAB = 1685		//Afterburner temp?
 			maxT3 = 705	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -138,7 +294,7 @@
 			dryThrust = 45.3
 			wetThrust = 64.5
 			maxThrust = 64.5	//Just to let MEC know thrust
-			drySFC = 0.90
+			drySFC = 0.80
 			throttleResponseMultiplier = 0.2	//50s double-spool, 0.2
 			
 			PROPELLANT
@@ -151,7 +307,7 @@
 		CONFIG
 		{
 			name = J57-P-21
-			description = Afterburning J57, as used on the F100C/D/F.
+			description = Afterburning J57, as used on the F100C/D/F. Temperature Mach limit at 15 km: 2.45.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -166,7 +322,7 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 35000000	//Fuel heat of burning (joules?)
 			TIT = 1330		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
+			TAB = 2825		//Afterburner temp?
 			maxT3 = 800	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -189,8 +345,175 @@
 		}
 		CONFIG
 		{
+			name = J57-P-7A
+			description = J57 with high-altitude nozzle, as used on the U-2A. Temperature Mach limit at 15 km: 2.44.
+			specLevel = operational
+			massMult = 0.8817
+			
+			Area = 0.24	//Compressor Area
+			BPR = 0		//Bypass Ratio
+			CPR = 13.0		//Compressor Pressure Ratio
+			FPR = 0		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 260		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.95	//Efficiency at afterburner rear / nozzle entrance
+			FHV = 35000000	//Fuel heat of burning (joules?)
+			TIT = 1330		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 800	//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 120
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 49.82
+			wetThrust = 0
+			maxThrust = 49.82	//Just to let MEC know thrust
+			drySFC = 0.77
+			throttleResponseMultiplier = 0.2	//50s double-spool, 0.2
+			
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = J57-P-43WA
+			description = J57 with water injection, as used on the B-52E/F. Temperature Mach limit at 15 km: 2.48.
+			specLevel = operational
+			massMult = 0.9090
+			
+			Area = 0.24	//Compressor Area
+			BPR = 0		//Bypass Ratio
+			CPR = 12.5		//Compressor Pressure Ratio
+			FPR = 0		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 260		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.90	//Efficiency at afterburner rear / nozzle entrance
+			FHV = 35000000	//Fuel heat of burning (joules?)
+			TIT = 1330		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 800	//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 120
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 49.82
+			wetThrust = 0
+			maxThrust = 49.82	//Just to let MEC know thrust
+			drySFC = 0.77
+			throttleResponseMultiplier = 0.2	//50s double-spool, 0.2
+			
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			SUBCONFIG
+			{
+				name = J57-P-43WA-Augmented
+				
+				TIT = 1130
+				
+				dryThrust = 61.16
+				maxThrust = 61.16
+				drySFC = 0.95
+
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.90
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = Water
+					ratio = 0.10
+					DrawGauge = True
+					resourceFlowMode = STACK_PRIORITY_SEARCH
+				}
+			}
+		}
+		CONFIG
+		{
+			name = JT3C-6
+			description = Civilian J57 with water injection, as used on the B707-120 and DC-8-10. Temperature Mach limit at 15 km: 2.48.
+			specLevel = operational
+			massMult = 0.8914
+			
+			Area = 0.24	//Compressor Area
+			BPR = 0		//Bypass Ratio
+			CPR = 12.5		//Compressor Pressure Ratio
+			FPR = 0		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 260		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.90	//Efficiency at afterburner rear / nozzle entrance
+			FHV = 35000000	//Fuel heat of burning (joules?)
+			TIT = 1330		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 800	//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 120
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 49.82
+			wetThrust = 0
+			maxThrust = 49.82	//Just to let MEC know thrust
+			drySFC = 0.785
+			throttleResponseMultiplier = 0.2	//50s double-spool, 0.2
+			
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			SUBCONFIG
+			{
+				name = JT3C-6-Augmented
+				
+				TIT = 1130
+				
+				dryThrust = 60.05
+				maxThrust = 60.05
+				drySFC = 0.965
+
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.90
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = Water
+					ratio = 0.10
+					DrawGauge = True
+					resourceFlowMode = STACK_PRIORITY_SEARCH
+				}
+			}
+		}
+		CONFIG
+		{
 			name = J57-P-20A
-			description = Ultimate afterburning J57, as used on the F-8E/J.
+			description = Ultimate afterburning J57, as used on the F-8E/J. Temperature Mach limit at 15 km: 2.5.
 			massMult = 1.00
 			
 			Area = 0.24	//Compressor Area
@@ -204,8 +527,8 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 35000000	//Fuel heat of burning (joules?)
 			TIT = 1330		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
-			maxT3 = 850	//Turbine max temperature
+			TAB = 3129		//Afterburner temp?
+			maxT3 = 810	//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 160

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J57_Config.cfg
@@ -175,7 +175,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J58_Config.cfg
@@ -90,7 +90,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J58_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1363 K		//Combustion peak temp
-//	TAB: 3200 K		//Afterburner peak temp
-//	maxT3: 1200 K	//Turbine max temperature
+//	TAB: 1940* K		//Afterburner peak temp
+//	maxT3: 1000 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -41,8 +41,8 @@
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1405 K		//Combustion peak temp
-//	TAB: 3242 K		//Afterburner peak temp
-//	maxT3: 1250 K	//Turbine max temperature
+//	TAB: 2000* K		//Afterburner peak temp
+//	maxT3: 1050 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +62,8 @@
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32500000 J	//Fuel heat of burning
 //	TIT: 1405 K		//Combustion peak temp
-//	TAB: 3300 K		//Afterburner peak temp
-//	maxT3: 1250 K	//Turbine max temperature
+//	TAB: 2357* K		//Afterburner peak temp
+//	maxT3: 1050 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -119,7 +119,7 @@
 		CONFIG
 		{
 			name = J58-P-4
-			description = JT11D-20, as used on the SR-71A/B and YF-12A.
+			description = JT11D-20, as used on the SR-71A/B and YF-12A. Temperature Mach limit at 15 km: 3.6.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -134,8 +134,8 @@
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1363		//Combustion peak temp
-			TAB = 3200		//Afterburner temp?
-			maxT3 = 1200		//Turbine max temperature
+			TAB = 1940		//Afterburner temp?
+			maxT3 = 1000		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 300
@@ -158,7 +158,7 @@
 		CONFIG
 		{
 			name = J58-P-4A
-			description = J58, uprated for NASA to allow for increased payload.
+			description = J58, uprated for NASA to allow for increased payload. Temperature Mach limit at 15 km: 3.75.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -173,8 +173,8 @@
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1405		//Combustion peak temp
-			TAB = 3242		//Afterburner temp?
-			maxT3 = 1250		//Turbine max temperature
+			TAB = 2000		//Afterburner temp?
+			maxT3 = 1050		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 300
@@ -197,7 +197,7 @@
 		CONFIG
 		{
 			name = J58-P-4B
-			description = J58 concept, uprated and with added nitrous oxide injection for NASA to allow for increased payload.
+			description = J58 concept, uprated and with added nitrous oxide injection for NASA to allow for increased payload. Temperature Mach limit at 15 km: 3.75.
 			specLevel = concept
 			massMult = 1.0071
 			
@@ -212,8 +212,8 @@
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32500000	//Fuel heat of burning (joules?)
 			TIT = 1405		//Combustion peak temp
-			TAB = 3300		//Afterburner temp?
-			maxT3 = 1250		//Turbine max temperature
+			TAB = 2000		//Afterburner temp?
+			maxT3 = 1050		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 350
@@ -237,7 +237,7 @@
 			{
 				name = J58-P-4B-N2O
 				
-				TAB = 3300
+				TAB = 2357
 				
 				wetThrust = 172.4
 				maxThrust = 172.4

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J75_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J75_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1150 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 1797* K		//Afterburner peak temp
+//	maxT3: 825 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1200 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 2200* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +62,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1200 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 2717* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -103,16 +103,21 @@
 
 	MODULE
 	{
-		name = ModuleEngineConfigs
+		name = ModuleBimodalEngineConfigs
 		type = ModuleEnginesAJEJet
 		configuration = J75-P-19
 		modded = false
 		origMass = 2.665
+		
+		primaryDescription = Water Injection Off
+		secondaryDescription = Water Injection On
+		toPrimaryText = Disengage Water Injection
+		toSecondaryText = Engage Water Injection
 
 		CONFIG
 		{
 			name = J75-P-17
-			description = J75, as used on the F-106A/B.
+			description = J75, as used on the F-106A/B. Temperature Mach limit at 15 km: 2.65.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -127,8 +132,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1150		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 1797		//Afterburner temp?
+			maxT3 = 825		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 220
@@ -151,7 +156,7 @@
 		CONFIG
 		{
 			name = J75-P-19
-			description = J75, as used on the F-105B.
+			description = J75, as used on the F-105B. Temperature Mach limit at 15 km: 2.65.
 			specLevel = operational
 			massMult = 1.0143
 			
@@ -166,8 +171,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1200		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 2200		//Afterburner temp?
+			maxT3 = 825		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 220
@@ -186,11 +191,38 @@
 				ratio = 1.0
 				DrawGauge = True
 			}
+			
+			SUBCONFIG
+			{
+				name = J75-P-19W
+				
+				TIT = 1000
+				TAB = 2000
+				
+				dryThrust = 76.51
+				wetThrust = 117.88
+				maxThrust = 117.88
+				drySFC = 0.96
+
+				PROPELLANT
+				{
+					name = Kerosene
+					ratio = 0.90
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = Water
+					ratio = 0.10
+					DrawGauge = True
+					resourceFlowMode = STACK_PRIORITY_SEARCH
+				}
+			}
 		}
 		CONFIG
 		{
 			name = J75-P-5A
-			description = Ultimate J75, as used on the XF8U-3.
+			description = Ultimate J75, as used on the XF8U-3. Temperature Mach limit at 15 km: 2.77.
 			specLevel = operational
 			massMult = 1.0143
 			
@@ -205,8 +237,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1200		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 2717		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 260

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J75_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J75_Config.cfg
@@ -88,7 +88,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J79_Config.cfg
@@ -236,7 +236,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J79_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1150 K		//Combustion peak temp
-//	TAB: 2400 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 2075* K		//Afterburner peak temp
+//	maxT3: 775 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -41,8 +41,50 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1200 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 2250* K		//Afterburner peak temp
+//	maxT3: 775 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	CJ805-3B
+//	1960, CV880
+//
+//	Dry Mass: 1457 kg
+//	Thrust (Dry): 51.82 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.784 lb/lbf-hr
+//	Area: 0.29 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 13.0		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 260 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1205 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	J79-GE-5C
+//	1960, B-58
+//
+//	Dry Mass: 1642 kg?
+//	Thrust (Dry): 45.81 kN
+//	Thrust (Wet): 69.39 kN
+//	SFC (Dry): 0.843 lb/lbf-hr
+//	Area: 0.29 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 12.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1200 K		//Combustion peak temp
+//	TAB: 2120* K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +104,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1200 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2247* K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -83,8 +125,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1200 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2307* K		//Afterburner peak temp
+//	maxT3: 810 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -104,8 +146,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1261 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2198* K		//Afterburner peak temp
+//	maxT3: 825 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -125,8 +167,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1261 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2208* K		//Afterburner peak temp
+//	maxT3: 825 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -146,8 +188,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1261 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 2255* K		//Afterburner peak temp
+//	maxT3: 825 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -167,8 +209,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1276 K		//Combustion peak temp
-//	TAB: 2850 K		//Afterburner peak temp
-//	maxT3: 1100 K	//Turbine max temperature
+//	TAB: 2316* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -190,7 +232,7 @@
 	%manufacturer = #roMfrGE
 	%description = #roJ79Desc
 
-	@tags ^= :$: usa general electric ge j79 afterburning turbojet
+	@tags ^= :$: usa general electric ge j79 cj805 afterburning turbojet
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
@@ -218,7 +260,7 @@
 		CONFIG
 		{
 			name = J79-GE-3A
-			description = Early J79, as used on the F-104A/B.
+			description = Early J79, as used on the F-104A/B. Temperature Mach limit at 15 km: 2.4.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -233,8 +275,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1150		//Combustion peak temp
-			TAB = 2400		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 2075		//Afterburner temp?
+			maxT3 = 775		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 130
@@ -257,7 +299,7 @@
 		CONFIG
 		{
 			name = J79-GE-2A
-			description = Early J79, as used on the F4H-1F and A3J-1 (F-4A and A-5A).
+			description = Early J79, as used on the F4H-1F and A3J-1 (F-4A and A-5A). Temperature Mach limit at 15 km: 2.36.
 			specLevel = operational
 			massMult = 1.0889
 			
@@ -272,8 +314,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1200		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 2250		//Afterburner temp?
+			maxT3 = 775		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 140
@@ -295,8 +337,86 @@
 		}
 		CONFIG
 		{
+			name = CJ805-3B
+			description = Civilian J79 without afterburner, as used on the Convair 880. Temperature Mach limit at 15 km: 2.44.
+			specLevel = operational
+			massMult = 0.9662
+			
+			Area = 0.29		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 13.0		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 260		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1205		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 800		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 100
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 51.82
+			wetThrust = 0
+			maxThrust = 51.82	//Just to let MEC know thrust
+			drySFC = 0.784
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = J79-GE-5C
+			description = J79, as used on the B-58. Temperature Mach limit at 15 km: 2.49.
+			specLevel = operational
+			massMult = 1.0889
+			
+			Area = 0.29		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 12.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1200		//Combustion peak temp
+			TAB = 2120		//Afterburner temp?
+			maxT3 = 800		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 140
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 45.81
+			wetThrust = 69.39
+			maxThrust = 69.39	//Just to let MEC know thrust
+			drySFC = 0.843
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
 			name = J79-GE-8
-			description = J79, as used on the F-4B and A-5B.
+			description = J79, as used on the F-4B and A-5B. Temperature Mach limit at 15 km: 2.46.
 			specLevel = operational
 			massMult = 1.1041
 			
@@ -311,8 +431,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1200		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2247		//Afterburner temp?
+			maxT3 = 800		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 150
@@ -335,7 +455,7 @@
 		CONFIG
 		{
 			name = J79-GE-11
-			description = J79, as used on the F-104G, RF-104G, and TF-104G.
+			description = J79, as used on the F-104G, RF-104G, and TF-104G. Temperature Mach limit at 15 km: 2.51.
 			specLevel = operational
 			massMult = 1.0710
 			
@@ -350,7 +470,7 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1200		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
+			TAB = 2307		//Afterburner temp?
 			maxT3 = 1000		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -374,7 +494,7 @@
 		CONFIG
 		{
 			name = J79-GE-10
-			description = J79, as used on the F-4J and RA-5C.
+			description = J79, as used on the F-4J and RA-5C. Temperature Mach limit at 15 km: 2.55.
 			specLevel = operational
 			massMult = 1.1598
 			
@@ -389,8 +509,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1261		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2198		//Afterburner temp?
+			maxT3 = 825		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 140
@@ -413,7 +533,7 @@
 		CONFIG
 		{
 			name = J79-GE-17
-			description = J79, as used on the F-4E/G.
+			description = J79, as used on the F-4E/G. Temperature Mach limit at 15 km: 2.54.
 			specLevel = operational
 			massMult = 1.1538
 			
@@ -428,8 +548,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1261		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2208		//Afterburner temp?
+			maxT3 = 825		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 140
@@ -452,7 +572,7 @@
 		CONFIG
 		{
 			name = J79-MTU-J1K
-			description = License-built J79, created by MTU for the F-104G.
+			description = License-built J79, created by MTU for the F-104G. Temperature Mach limit at 15 km: 2.62.
 			specLevel = operational
 			massMult = 1.0710
 			
@@ -467,8 +587,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1261		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 2255		//Afterburner temp?
+			maxT3 = 825		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 140
@@ -491,7 +611,7 @@
 		CONFIG
 		{
 			name = J79-GE-119
-			description = Ultimate J79, created for the F-16/79.
+			description = Ultimate J79, created for the F-16/79. Temperature Mach limit at 15 km: 2.68.
 			specLevel = operational
 			massMult = 1.1572
 			
@@ -506,8 +626,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1276		//Combustion peak temp
-			TAB = 2850		//Afterburner temp?
-			maxT3 = 1100		//Turbine max temperature
+			TAB = 2316		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 160

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J85_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J85_Config.cfg
@@ -21,7 +21,7 @@
 //	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1250 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 700 K	//Turbine max temperature
+//	maxT3: 650 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: false
 //	=================================================================================
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J		//Fuel heat of burning
 //	TIT: 1250 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
-//	maxT3: 700 K	//Turbine max temperature
+//	TAB: 1987* K		//Afterburner peak temp
+//	maxT3: 650 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +62,8 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 28000000 J		//Fuel heat of burning
 //	TIT: 1300 K		//Combustion peak temp
-//	TAB: 3140 K		//Afterburner peak temp
-//	maxT3: 800 K	//Turbine max temperature
+//	TAB: 1927* K		//Afterburner peak temp
+//	maxT3: 700 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -112,7 +112,7 @@
 		CONFIG
 		{
 			name = J85-GE-4
-			description = Early J85, as used on the T-2C.
+			description = Early J85, as used on the T-2C. Temperature Mach limit at 15 km: 2.34.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -128,7 +128,7 @@
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1250		//Combustion peak temp
 			TAB = 0		//Afterburner temp?
-			maxT3 = 700	//Turbine max temperature
+			maxT3 = 650		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = False
 			thrustUpperLimit = 20
@@ -151,7 +151,7 @@
 		CONFIG
 		{
 			name = J85-GE-5
-			description = Afterburning J85, as used on the T-38A and YF-5A (and on A-37A, XV-5, X-14A without afterburner).
+			description = Afterburning J85, as used on the T-38A and YF-5A (and on A-37A, XV-5, X-14A without afterburner). Temperature Mach limit at 15 km: 2.27.
 			specLevel = operational
 			massMult = 1.4481
 			
@@ -166,8 +166,8 @@
 			eta_n = 0.7	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1250		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
-			maxT3 = 700	//Turbine max temperature
+			TAB = 1987		//Afterburner temp?
+			maxT3 = 650		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 30
@@ -190,7 +190,7 @@
 		CONFIG
 		{
 			name = J85-GE-21
-			description = Late afterburning J85, as used on the F-5E/F.
+			description = Late afterburning J85, as used on the F-5E/F. Temperature Mach limit at 15 km: 2.36.
 			specLevel = operational
 			massMult = 1.5850
 			
@@ -205,8 +205,8 @@
 			eta_n = 0.8	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1300		//Combustion peak temp
-			TAB = 3140		//Afterburner temp?
-			maxT3 = 800	//Turbine max temperature
+			TAB = 1927		//Afterburner temp?
+			maxT3 = 700		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 40

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J85_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J85_Config.cfg
@@ -88,7 +88,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J93_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J93_Config.cfg
@@ -1,0 +1,111 @@
+//	==================================================
+//	Engine: J93
+//
+//	Manufacturer: General Electric
+//
+//	=================================================================================
+//	J93-GE-3
+//	1964, XB-70
+//
+//	Dry Mass: 2368 kg
+//	Thrust (Dry): 97.86 kN
+//	Thrust (Wet): 137.89 kN
+//	SFC (Dry): 0.7 lb/lbf-hr
+//	Area: 0.6 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 9.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.3 M		//Mach Design Point
+//	Tdes: 280 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 22500000 J	//Fuel heat of burning
+//	TIT: 1422 K		//Combustion peak temp
+//	TAB: 2174* K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.jet-engine.net/miltfspec.htm
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[J93]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roJ93Title	//J93 Turbojet
+	%manufacturer = #roMfrGE
+	%description = #roJ93Desc
+
+	@tags ^= :$: usa general electric ge j93 afterburning turbojet
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = J93-GE-3
+		modded = false
+		origMass = 2.368
+
+		CONFIG
+		{
+			name = J93-GE-3
+			description = J93-GE-3, as used on the XB-70. Temperature Mach limit at 15 km: 3.35.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.6		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 9.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.3		//Mach Design Point
+			Tdes = 280		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 22500000	//Fuel heat of burning (joules?)
+			TIT = 1422		//Combustion peak temp
+			TAB = 2174		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 300
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 97.86
+			wetThrust = 137.89
+			maxThrust = 137.89	//Just to let MEC know thrust
+			drySFC = 0.7
+			throttleResponseMultiplier = 0.20
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J93_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/J93_Config.cfg
@@ -46,7 +46,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/JT8D_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/JT8D_Config.cfg
@@ -1,114 +1,112 @@
 //	==================================================
-//	Engine: TF/CF34
+//	Engine: JT8D
 //
-//	Manufacturer: General Electric
+//	Manufacturer: Pratt & Whitney
 //
 //	=================================================================================
-//	TF34-GE-100
-//	1972, A-10
+//	JT8D-1
+//	1963, B727, DC-9-15
 //
-//	Dry Mass: 653 kg
-//	Thrust (Dry): 40.32 kN
+//	Dry Mass: 1454 kg
+//	Thrust (Dry): 62.275 kN
 //	Thrust (Wet): 0.0 kN
-//	SFC (Dry): 0.370 lb/lbf-hr
-//	Area: 0.135 m^2	//Compressor Area
-//	BPR: 6.24		//Bypass Ratio
-//	CPR: 20.0		//Compressor Pressure Ratio
-//	FPR: 1.5		//Fan Ratio
+//	SFC (Dry): 0.585 lb/lbf-hr
+//	Area: 0.40 m^2	//Compressor Area
+//	BPR: 1.07		//Bypass Ratio
+//	CPR: 15.4		//Compressor Pressure Ratio
+//	FPR: 1.93		//Fan Ratio
 //	Mdes: 0.8 M		//Mach Design Point
 //	Tdes: 250 K		//Temp Design Point
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 32000000 J	//Fuel heat of burning
-//	TIT: 1250 K		//Combustion peak temp
-//	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
-//	Exhaust Mixer: false
-//	Adjustable Nozzle: false
-//	=================================================================================
-//	TF34-GE-400A
-//	1976, S-3B, S-72
-//
-//	Dry Mass: 670 kg
-//	Thrust (Dry): 41.25 kN
-//	Thrust (Wet): 0.0 kN
-//	SFC (Dry): 0.363 lb/lbf-hr
-//	Area: 0.135 m^2	//Compressor Area
-//	BPR: 6.24		//Bypass Ratio
-//	CPR: 21.0		//Compressor Pressure Ratio
-//	FPR: 1.5		//Fan Ratio
-//	Mdes: 0.8 M		//Mach Design Point
-//	Tdes: 250 K		//Temp Design Point
-//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 32000000 J	//Fuel heat of burning
-//	TIT: 1250 K		//Combustion peak temp
-//	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
-//	Exhaust Mixer: false
-//	Adjustable Nozzle: false
-//	=================================================================================
-//	CF34-1A
-//	1983, Challenger 601
-//
-//	Dry Mass: 737 kg
-//	Thrust (Dry): 40.66 kN
-//	Thrust (Wet): 0.0 kN
-//	SFC (Dry): 0.360 lb/lbf-hr
-//	Area: 0.135 m^2	//Compressor Area
-//	BPR: 6.24		//Bypass Ratio
-//	CPR: 21.0		//Compressor Pressure Ratio
-//	FPR: 1.5		//Fan Ratio
-//	Mdes: 0.8 M		//Mach Design Point
-//	Tdes: 250 K		//Temp Design Point
-//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 32000000 J	//Fuel heat of burning
+//	FHV: 28000000 J	//Fuel heat of burning
 //	TIT: 1300 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	maxT3: 800 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: false
 //	=================================================================================
-//	CF34-3B
-//	1995, Challenger 604/605
+//	JT8D-17
+//	1974, B737-100/200, DC-9-32/41/51, YC-15A
 //
-//	Dry Mass: 757 kg
-//	Thrust (Dry): 41.01 kN
+//	Dry Mass: 1560 kg
+//	Thrust (Dry): 71.17 kN
 //	Thrust (Wet): 0.0 kN
-//	SFC (Dry): 0.346 lb/lbf-hr
-//	Area: 0.135 m^2	//Compressor Area
-//	BPR: 6.24		//Bypass Ratio
-//	CPR: 21.0		//Compressor Pressure Ratio
-//	FPR: 1.5		//Fan Ratio
+//	SFC (Dry): 0.6 lb/lbf-hr
+//	Area: 0.40 m^2	//Compressor Area
+//	BPR: 0.96		//Bypass Ratio
+//	CPR: 16.9		//Compressor Pressure Ratio
+//	FPR: 1.91		//Fan Ratio
 //	Mdes: 0.8 M		//Mach Design Point
 //	Tdes: 250 K		//Temp Design Point
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 32000000 J	//Fuel heat of burning
-//	TIT: 1350 K		//Combustion peak temp
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1300 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 825 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	JT8D-209
+//	1979, MD-80, Super 27
+//
+//	Dry Mass: 2081 kg
+//	Thrust (Dry): 84.07 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.5 lb/lbf-hr?
+//	Area: 0.50 m^2	//Compressor Area
+//	BPR: 1.74		//Bypass Ratio
+//	CPR: 21.0		//Compressor Pressure Ratio
+//	FPR: 1.92		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1500 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
 //	maxT3: 900 K	//Turbine max temperature
-//	Exhaust Mixer: false
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	JT8D-219
+//	1985, MD-80, Super 27, E-8C
+//
+//	Dry Mass: 2150 kg
+//	Thrust (Dry): 93.41 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.519 lb/lbf-hr
+//	Area: 0.50 m^2	//Compressor Area
+//	BPR: 1.72		//Bypass Ratio
+//	CPR: 20.0		//Compressor Pressure Ratio
+//	FPR: 1.9		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1500 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 900 K	//Turbine max temperature
+//	Exhaust Mixer: true
 //	Adjustable Nozzle: false
 //	=================================================================================
 
 //	Sources:
 
 //	https://www.jet-engine.net/miltfspec.htm
-//	https://compareprivateplanes.com/engines/general-electric/cf34-1a-engine
-//	https://www.geaerospace.com/propulsion/commercial/cf34
-//	https://www.easa.europa.eu/en/downloads/65434/en
+//	https://www.thisdayinaviation.com/tag/pratt-whitney-jt8d-1/
 
 //	Used by:
 
 //	Notes:
 
 //	==================================================
-@PART[*]:HAS[#engineType[CF34]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[JT8D]]:FOR[RealismOverhaulEngines]
 {
 
-	%title = #roCF34Title	//TF/CF34 High-Bypass Turbofan
-	%manufacturer = #roMfrGE
-	%description = #roCF34Desc
+	%title = #roJT8DTitle	//JT8D Low-Bypass Turbofan
+	%manufacturer = #roMfrPW
+	%description = #roJT8DDesc
 
-	@tags ^= :$: usa general electric ge cf34 high bypass turbofan
+	@tags ^= :$: usa pratt whitney p&w jt8d high bypass turbofan
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
@@ -129,118 +127,79 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = CF34-1A
+		configuration = JT8D-219
 		modded = false
-		origMass = 0.737
+		origMass = 1.454
 
 		CONFIG
 		{
-			name = TF34-GE-100
-			description = Early TF34, as used on the A-10A.
-			specLevel = operational
-			massMult = 0.886
-			
-			Area = 0.135		//Compressor Area
-			BPR = 6.24		//Bypass Ratio
-			CPR = 20.0		//Compressor Pressure Ratio
-			FPR = 1.5		//Fan Ratio
-			Mdes = 0.8		//Mach Design Point
-			Tdes = 250		//Temp Design Point
-			eta_c = 0.95	//Efficiency at burner inlet
-			eta_t = 0.98	//Efficiency at burner exit
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
-			FHV = 32000000	//Fuel heat of burning (joules?)
-			TIT = 1250		//Combustion peak temp
-			TAB = 0		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
-			exhaustMixer = False
-			adjustableNozzle = False
-			thrustUpperLimit = 60
-			
-			// Engine fitting params
-			defaultTPR = 0.95
-			dryThrust = 40.32
-			wetThrust = 0.0
-			maxThrust = 40.32	//Just to let MEC know thrust
-			drySFC = 0.370
-			throttleResponseMultiplier = 0.60
-
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 1.0
-				DrawGauge = True
-			}
-		}
-		CONFIG
-		{
-			name = TF34-GE-400A
-			description = TF34, as used on the S-3B and S-72.
-			specLevel = operational
-			massMult = 0.9090
-			
-			Area = 0.135		//Compressor Area
-			BPR = 6.24		//Bypass Ratio
-			CPR = 21.0		//Compressor Pressure Ratio
-			FPR = 1.5		//Fan Ratio
-			Mdes = 0.8		//Mach Design Point
-			Tdes = 250		//Temp Design Point
-			eta_c = 0.95	//Efficiency at burner inlet
-			eta_t = 0.98	//Efficiency at burner exit
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
-			FHV = 32000000	//Fuel heat of burning (joules?)
-			TIT = 1250		//Combustion peak temp
-			TAB = 0		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
-			exhaustMixer = False
-			adjustableNozzle = False
-			thrustUpperLimit = 60
-			
-			// Engine fitting params
-			defaultTPR = 0.95
-			dryThrust = 41.25
-			wetThrust = 0.0
-			maxThrust = 41.25	//Just to let MEC know thrust
-			drySFC = 0.363
-			throttleResponseMultiplier = 0.60
-
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 1.0
-				DrawGauge = True
-			}
-		}
-		CONFIG
-		{
-			name = CF34-1A
-			description = Early CF34, as used on the Challenger 601.
+			name = JT8D-1
+			description = Early JT8D, as used on the B727 and DC-9-15. Temperature Mach limit at 15 km: 2.34.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.135		//Compressor Area
-			BPR = 6.24		//Bypass Ratio
-			CPR = 21.0		//Compressor Pressure Ratio
-			FPR = 1.5		//Fan Ratio
+			Area = 0.40		//Compressor Area
+			BPR = 1.07		//Bypass Ratio
+			CPR = 15.4		//Compressor Pressure Ratio
+			FPR = 1.93		//Fan Ratio
 			Mdes = 0.8		//Mach Design Point
 			Tdes = 250		//Temp Design Point
 			eta_c = 0.95	//Efficiency at burner inlet
 			eta_t = 0.98	//Efficiency at burner exit
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
-			FHV = 32000000	//Fuel heat of burning (joules?)
+			FHV = 28000000	//Fuel heat of burning (joules?)
 			TIT = 1300		//Combustion peak temp
 			TAB = 0		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			maxT3 = 800		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = False
-			thrustUpperLimit = 60
+			thrustUpperLimit = 100
 			
 			// Engine fitting params
 			defaultTPR = 0.95
-			dryThrust = 40.66
+			dryThrust = 62.28
 			wetThrust = 0.0
-			maxThrust = 40.66	//Just to let MEC know thrust
-			drySFC = 0.360
+			maxThrust = 62.28	//Just to let MEC know thrust
+			drySFC = 0.585
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = JT8D-17
+			description = JT8D, as used on the B737-100/200, DC-9-32/41/51, and YC-15A. Temperature Mach limit at 15 km: 2.38.
+			specLevel = operational
+			massMult = 1.0729
+			
+			Area = 0.40		//Compressor Area
+			BPR = 0.96		//Bypass Ratio
+			CPR = 16.9		//Compressor Pressure Ratio
+			FPR = 1.91		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1300		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 825		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = False
+			thrustUpperLimit = 110
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 71.17
+			wetThrust = 0.0
+			maxThrust = 71.17	//Just to let MEC know thrust
+			drySFC = 0.6
 			throttleResponseMultiplier = 0.60
 
 			PROPELLANT
@@ -252,35 +211,74 @@
 		}
 		CONFIG
 		{
-			name = CF34-3B
-			description = CF34, as used on the Challenger 604/605.
+			name = JT8D-209
+			description = 200-series JT8D with higher bypass ratio, as used on the MD-80 series and Super 27. Temperature Mach limit at 15 km: 2.55.
 			specLevel = operational
-			massMult = 1.0271
+			massMult = 1.4312
 			
-			Area = 0.135		//Compressor Area
-			BPR = 6.24		//Bypass Ratio
+			Area = 0.50		//Compressor Area
+			BPR = 1.74		//Bypass Ratio
 			CPR = 21.0		//Compressor Pressure Ratio
-			FPR = 1.5		//Fan Ratio
+			FPR = 1.92		//Fan Ratio
 			Mdes = 0.8		//Mach Design Point
 			Tdes = 250		//Temp Design Point
 			eta_c = 0.95	//Efficiency at burner inlet
 			eta_t = 0.98	//Efficiency at burner exit
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
-			FHV = 32000000	//Fuel heat of burning (joules?)
-			TIT = 1350		//Combustion peak temp
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1500		//Combustion peak temp
 			TAB = 0		//Afterburner temp?
 			maxT3 = 900		//Turbine max temperature
-			exhaustMixer = False
+			exhaustMixer = True
 			adjustableNozzle = False
-			thrustUpperLimit = 60
+			thrustUpperLimit = 140
 			
 			// Engine fitting params
 			defaultTPR = 0.95
-			dryThrust = 41.01
+			dryThrust = 84.07
 			wetThrust = 0.0
-			maxThrust = 41.01	//Just to let MEC know thrust
-			drySFC = 0.346
+			maxThrust = 84.07	//Just to let MEC know thrust
+			drySFC = 0.5
 			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = JT8D-219
+			description = 200-series JT8D with higher bypass ratio, as used on the MD-80 series, Super 27, and E-8C. Temperature Mach limit at 15 km: 2.6.
+			specLevel = operational
+			massMult = 1.4787
+			
+			Area = 0.50		//Compressor Area
+			BPR = 1.72		//Bypass Ratio
+			CPR = 20.0		//Compressor Pressure Ratio
+			FPR = 1.90		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1500		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 900		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 150
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 93.41
+			wetThrust = 0.0
+			maxThrust = 93.41	//Just to let MEC know thrust
+			drySFC = 0.519
+			throttleResponseMultiplier = 0.80
 
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/JT8D_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/JT8D_Config.cfg
@@ -110,7 +110,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Model304_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Model304_Config.cfg
@@ -46,7 +46,6 @@
 
 	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Model304_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Model304_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 98000000 J	//Fuel heat of burning
 //	TIT: 1500 K		//Combustion peak temp
-//	TAB: 4180 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 4049* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -69,7 +69,8 @@
 		CONFIG
 		{
 			name = Model304-2
-			description = Ultimate Model 304 developed before project cancellation.
+			description = Ultimate Model 304 developed before project cancellation. Temperature Mach limit at 15 km: 3.3.
+			specLevel = prototype
 			massMult = 1.00
 			
 			Area = 0.24		//Compressor Area
@@ -83,9 +84,9 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 98000000	//Fuel heat of burning (joules?)
 			TIT = 1500		//Combustion peak temp
-			TAB = 4180		//Afterburner temp?
-			maxT3 = 1000	//Turbine max temperature
-			%tt7_max = 5000	//manually override solver max temp to get hydrogen engines to work
+			TAB = 4049		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
+			tt7_max = 5000	//manually override solver max temp to get hydrogen engines to work
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 150

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK22_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK22_Config.cfg
@@ -90,7 +90,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK22_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK22_Config.cfg
@@ -1,0 +1,233 @@
+//	==================================================
+//	Engine: NK-22/144
+//
+//	Manufacturer: Kuznetsov
+//
+//	=================================================================================
+//	NK-144
+//	1968, Tu-144
+//
+//	Dry Mass: 3540 kg
+//	Thrust (Dry): 127.49 kN
+//	Thrust (Wet): 171.62 kN
+//	SFC (Dry): 0.965 lb/lbf-hr
+//	Area: 0.72 m^2	//Compressor Area
+//	BPR: 0.6		//Bypass Ratio
+//	CPR: 14.2		//Compressor Pressure Ratio?
+//	FPR: 2.45		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1360 K		//Combustion peak temp
+//	TAB: 1355* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	NK-144A
+//	1973, Tu-144S
+//
+//	Dry Mass: 3540 kg
+//	Thrust (Dry): 147.10 kN
+//	Thrust (Wet): 196.13 kN
+//	SFC (Dry): 0.925 lb/lbf-hr	//1.81 lb/lbf-hr @ M2.07, 16 km
+//	Area: 0.72 m^2	//Compressor Area
+//	BPR: 0.53		//Bypass Ratio
+//	CPR: 14.75		//Compressor Pressure Ratio?
+//	FPR: 2.45		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1390 K		//Combustion peak temp
+//	TAB: 1397* K		//Afterburner peak temp
+//	maxT3: 900 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	NK-22
+//	1969, Tu-22M
+//
+//	Dry Mass: 3540 kg
+//	Thrust (Dry): 127.49 kN
+//	Thrust (Wet): 215.75 kN
+//	SFC (Dry): 0.917 lb/lbf-hr
+//	Area: 0.72 m^2	//Compressor Area
+//	BPR: 0.6		//Bypass Ratio
+//	CPR: 14.75		//Compressor Pressure Ratio?
+//	FPR: 2.45		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1390 K		//Combustion peak temp
+//	TAB: 2183* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: true
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.jet-engine.net/miltfspec.htm
+//	http://www.leteckemotory.cz/motory/nk-32/
+//	http://www.tu144sst.com/techspecs/powerplant.html
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[NK22]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roNK22Title	//NK-22 Low-Bypass Turbofan
+	%manufacturer = #roMfrNPOKuznetstov
+	%description = #roNK22Desc
+
+	@tags ^= :$: ussr kuznetsov nk-22 nk-144 nk22 nk155 afterburning low bypass turbofan
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = NK-144
+		modded = false
+		origMass = 3.540
+
+		CONFIG
+		{
+			name = NK-144
+			description = NK-144, as used on the Tu-144 prototypes. Temperature Mach limit at 15 km: 2.63.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.6		//Compressor Area
+			BPR = 0.6		//Bypass Ratio
+			CPR = 14.2		//Compressor Pressure Ratio
+			FPR = 2.45		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1360		//Combustion peak temp
+			TAB = 1355		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = True
+			thrustUpperLimit = 350
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 127.49
+			wetThrust = 171.62
+			maxThrust = 171.62	//Just to let MEC know thrust
+			drySFC = 0.965
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-144A
+			description = Upgraded NK-144, as used on the production Tu-144S. Temperature Mach limit at 15 km: 2.83.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.6		//Compressor Area
+			BPR = 0.53		//Bypass Ratio
+			CPR = 14.75		//Compressor Pressure Ratio
+			FPR = 2.45		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1390		//Combustion peak temp
+			TAB = 1397		//Afterburner temp?
+			maxT3 = 900		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = True
+			thrustUpperLimit = 400
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 147.10
+			wetThrust = 196.13
+			maxThrust = 196.13	//Just to let MEC know thrust
+			drySFC = 0.92
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-22
+			description = Modified NK-144, as used on the Tu-22M0/M1/M2. Temperature Mach limit at 15 km: 2.59.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.6		//Compressor Area
+			BPR = 0.6		//Bypass Ratio
+			CPR = 14.75		//Compressor Pressure Ratio
+			FPR = 2.45		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1390		//Combustion peak temp
+			TAB = 2183		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = True
+			thrustUpperLimit = 400
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 127.49
+			wetThrust = 215.75
+			maxThrust = 215.75	//Just to let MEC know thrust
+			drySFC = 0.917
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK25_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK25_Config.cfg
@@ -1,0 +1,232 @@
+//	==================================================
+//	Engine: NK-25/32
+//
+//	Manufacturer: Kuznetsov
+//
+//	=================================================================================
+//	NK-25
+//	1977, Tu-22M3
+//
+//	Dry Mass: 3575 kg
+//	Thrust (Dry): 142.20 kN
+//	Thrust (Wet): 245.17 kN
+//	SFC (Dry): 0.70 lb/lbf-hr
+//	Area: 0.72 m^2	//Compressor Area
+//	BPR: 1.45		//Bypass Ratio
+//	CPR: 25.9		//Compressor Pressure Ratio?
+//	FPR: 1.85		//Fan Ratio	(assuming 14:1 is compressor and 25.9:1 is overall)
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1597 K		//Combustion peak temp
+//	TAB: 1891* K		//Afterburner peak temp
+//	maxT3: 1000 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	NK-32
+//	1981, Tu-160, Tu-144LL
+//
+//	Dry Mass: 3650 kg
+//	Thrust (Dry): 137.29 kN
+//	Thrust (Wet): 245.17 kN
+//	SFC (Dry): 0.658 lb/lbf-hr	//1.70 lb/lbf-hr @ M2.17 16 km cruise
+//	Area: 0.72 m^2	//Compressor Area
+//	BPR: 1.36		//Bypass Ratio
+//	CPR: 28.2		//Compressor Pressure Ratio?
+//	FPR: 1.85		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1630 K		//Combustion peak temp
+//	TAB: 2133* K		//Afterburner peak temp
+//	maxT3: 1025 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	NK-32-02
+//	2020, Tu-160M2
+//
+//	Dry Mass: 3650 kg
+//	Thrust (Dry): 137.29 kN
+//	Thrust (Wet): 245.17 kN
+//	SFC (Dry): 0.638 lb/lbf-hr?
+//	Area: 0.72 m^2	//Compressor Area
+//	BPR: 1.36		//Bypass Ratio
+//	CPR: 28.2		//Compressor Pressure Ratio?
+//	FPR: 1.85		//Fan Ratio
+//	Mdes: 0.7 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1650 K		//Combustion peak temp
+//	TAB: 2133* K		//Afterburner peak temp
+//	maxT3: 1100 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: true
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.jet-engine.net/miltfspec.htm
+//	http://www.leteckemotory.cz/motory/nk-32/
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[NK25]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roNK25Title	//NK-25 Low-Bypass Turbofan
+	%manufacturer = #roMfrNPOKuznetstov
+	%description = #roNK25Desc
+
+	@tags ^= :$: ussr kuznetsov nk-25 nk-32 nk-321 nk25 nk32 nk321 afterburning low bypass turbofan
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = NK-25
+		modded = false
+		origMass = 3.575
+
+		CONFIG
+		{
+			name = NK-25
+			description = NK-25, as used on the Tu-22M3. Temperature Mach limit at 15 km: 2.76.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.72		//Compressor Area
+			BPR = 1.45		//Bypass Ratio
+			CPR = 25.9		//Compressor Pressure Ratio
+			FPR = 1.85		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1597		//Combustion peak temp
+			TAB = 1891		//Afterburner temp?
+			maxT3 = 1000		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = True
+			thrustUpperLimit = 490
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 142.2
+			wetThrust = 245.17
+			maxThrust = 245.17	//Just to let MEC know thrust
+			drySFC = 0.70
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-32
+			description = NK-32, as used on the Tu-160, and Tu-144LL as the NK-321. Temperature Mach limit at 15 km: 2.78.
+			specLevel = operational
+			massMult = 1.0210
+			
+			Area = 0.72		//Compressor Area
+			BPR = 1.36		//Bypass Ratio
+			CPR = 28.2		//Compressor Pressure Ratio
+			FPR = 1.85		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1630		//Combustion peak temp
+			TAB = 2113		//Afterburner temp?
+			maxT3 = 1025		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = True
+			thrustUpperLimit = 490
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 137.29
+			wetThrust = 245.17
+			maxThrust = 245.17	//Just to let MEC know thrust
+			drySFC = 0.658
+			throttleResponseMultiplier = 0.80
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-32-02
+			description = NK-32 Stage II, as used on the Tu-160M2. Temperature Mach limit at 15 km: 3.11.
+			specLevel = operational
+			massMult = 1.0210
+			
+			Area = 0.72		//Compressor Area
+			BPR = 1.36		//Bypass Ratio
+			CPR = 28.2		//Compressor Pressure Ratio
+			FPR = 1.85		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1650		//Combustion peak temp
+			TAB = 2133		//Afterburner temp?
+			maxT3 = 1100		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = True
+			thrustUpperLimit = 490
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 137.29
+			wetThrust = 245.17
+			maxThrust = 245.17	//Just to let MEC know thrust
+			drySFC = 0.638
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK8_Config.cfg
@@ -153,7 +153,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK8_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/NK8_Config.cfg
@@ -1,0 +1,413 @@
+//	==================================================
+//	Engine: NK-8
+//
+//	Manufacturer: Kuznetsov
+//
+//	=================================================================================
+//	NK-8
+//	1964, Il-62
+//
+//	Dry Mass: 2498 kg
+//	Thrust (Dry): 93.16 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.628 lb/lbf-hr
+//	Area: 0.5 m^2	//Compressor Area
+//	BPR: 1.00		//Bypass Ratio
+//	CPR: 19.4		//Compressor Pressure Ratio?
+//	FPR: 2.15		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1143 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 800 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	NK-8-2
+//	1968, Tu-154
+//
+//	Dry Mass: 2100 kg
+//	Thrust (Dry): 93.16 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.576 lb/lbf-hr
+//	Area: 0.5 m^2	//Compressor Area
+//	BPR: 1.00		//Bypass Ratio
+//	CPR: 21.5		//Compressor Pressure Ratio
+//	FPR: 2.15		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1143 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	NK-8-2U
+//	1973, Tu-154A/B
+//
+//	Dry Mass: 2100 kg
+//	Thrust (Dry): 102.97 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.569 lb/lbf-hr
+//	Area: 0.5 m^2	//Compressor Area
+//	BPR: 1.05		//Bypass Ratio
+//	CPR: 23.2		//Compressor Pressure Ratio
+//	FPR: 2.15		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1143 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	NK-86
+//	1976, Il-86
+//
+//	Dry Mass: 2750 kg
+//	Thrust (Dry): 127.49 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.520 lb/lbf-hr
+//	Area: 0.6 m^2	//Compressor Area
+//	BPR: 1.18		//Bypass Ratio
+//	CPR: 27.8		//Compressor Pressure Ratio
+//	FPR: 2.15		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24000000 J	//Fuel heat of burning
+//	TIT: 1260 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 900 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	NK-88
+//	1980, Tu-155
+//
+//	Dry Mass: 2300 kg
+//	Thrust (Dry): 102.97 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.222 lb/lbf-hr
+//	Area: 0.5 m^2	//Compressor Area
+//	BPR: 1.05		//Bypass Ratio
+//	CPR: 23.2		//Compressor Pressure Ratio
+//	FPR: 2.15		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 98000000 J	//Fuel heat of burning
+//	TIT: 1700 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 900 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+//	NK-89
+//	1989, Tu-155
+//
+//	Dry Mass: 2100 kg
+//	Thrust (Dry): 102.97 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 0.556 lb/lbf-hr
+//	Area: 0.5 m^2	//Compressor Area
+//	BPR: 1.05		//Bypass Ratio
+//	CPR: 23.2		//Compressor Pressure Ratio
+//	FPR: 2.15		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 29000000 J	//Fuel heat of burning
+//	TIT: 1243 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 900 K	//Turbine max temperature
+//	Exhaust Mixer: true
+//	Adjustable Nozzle: false
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.jet-engine.net/miltfspec.htm
+//	http://www.leteckemotory.cz/motory/nk-8/
+//	https://www.redstar.gr/index.php?option=com_content&view=article&id=4396:kuznetsov-nk-86-turbofan-engine&catid=469&lang=en&Itemid=535
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[NK8]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roNK8Title	//NK-8 Low-Bypass Turbofan
+	%manufacturer = #roMfrNPOKuznetstov
+	%description = #roNK8Desc
+
+	@tags ^= :$: ussr kuznetsov nk-8 nk-86 nk-88 nk-89 nk8 nk86 nk88 nk89 low bypass turbofan
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = NK-8
+		modded = false
+		origMass = 2.498
+
+		CONFIG
+		{
+			name = NK-8
+			description = Early NK-8, as used on the Il-62. Temperature Mach limit at 15 km: 2.09.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.5		//Compressor Area
+			BPR = 1.00		//Bypass Ratio
+			CPR = 19.4		//Compressor Pressure Ratio
+			FPR = 2.15		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1143		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 800		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 150
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 93.16
+			wetThrust = 0.0
+			maxThrust = 93.16	//Just to let MEC know thrust
+			drySFC = 0.628
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-8-2
+			description = NK-8, as used on the Tu-154. Temperature Mach limit at 15 km: 2.26.
+			specLevel = operational
+			massMult = 0.8407
+			
+			Area = 0.5		//Compressor Area
+			BPR = 1.00		//Bypass Ratio
+			CPR = 21.5		//Compressor Pressure Ratio
+			FPR = 2.15		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1143		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 150
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 93.16
+			wetThrust = 0.0
+			maxThrust = 93.16	//Just to let MEC know thrust
+			drySFC = 0.576
+			throttleResponseMultiplier = 0.30
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-8-2U
+			description = NK-8, as used on the Tu-154A. Temperature Mach limit at 15 km: 2.17.
+			specLevel = operational
+			massMult = 0.8407
+			
+			Area = 0.5		//Compressor Area
+			BPR = 1.05		//Bypass Ratio
+			CPR = 23.2		//Compressor Pressure Ratio
+			FPR = 2.15		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1143		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 160
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 102.97
+			wetThrust = 0.0
+			maxThrust = 102.97	//Just to let MEC know thrust
+			drySFC = 0.569
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-86
+			description = Late NK-8, as used on the Il-86. Temperature Mach limit at 15 km: 2.22.
+			specLevel = operational
+			massMult = 1.1009
+			
+			Area = 0.6		//Compressor Area
+			BPR = 1.18		//Bypass Ratio
+			CPR = 27.8		//Compressor Pressure Ratio
+			FPR = 2.15		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24000000	//Fuel heat of burning (joules?)
+			TIT = 1260		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 900		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 180
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 127.49
+			wetThrust = 0.0
+			maxThrust = 127.49	//Just to let MEC know thrust
+			drySFC = 0.520
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-88
+			description = NK-8-2U modified to run on LH2, as used on the Tu-155. Temperature Mach limit at 15 km: 2.43.
+			specLevel = operational
+			massMult = 0.9207
+			
+			Area = 0.5		//Compressor Area
+			BPR = 1.05		//Bypass Ratio
+			CPR = 23.2		//Compressor Pressure Ratio
+			FPR = 2.15		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 98000000	//Fuel heat of burning (joules?)
+			TIT = 1700		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 900		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 160
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 102.97
+			wetThrust = 0.0
+			maxThrust = 102.97	//Just to let MEC know thrust
+			drySFC = 0.222
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = NK-89
+			description = NK-8-2U modified to run on LNG, as used on the Tu-155. Temperature Mach limit at 15 km: 2.44.
+			specLevel = operational
+			massMult = 0.8407
+			
+			Area = 0.5		//Compressor Area
+			BPR = 1.05		//Bypass Ratio
+			CPR = 23.2		//Compressor Pressure Ratio
+			FPR = 2.15		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 29000000	//Fuel heat of burning (joules?)
+			TIT = 1243		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 900		//Turbine max temperature
+			exhaustMixer = True
+			adjustableNozzle = False
+			thrustUpperLimit = 160
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 102.97
+			wetThrust = 0.0
+			maxThrust = 102.97	//Just to let MEC know thrust
+			drySFC = 0.556
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Olympus593_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Olympus593_Config.cfg
@@ -46,7 +46,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Olympus593_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Olympus593_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.9		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 29000000 J	//Fuel heat of burning
 //	TIT: 1467 K		//Combustion peak temp
-//	TAB: 2000 K		//Afterburner peak temp
-//	maxT3: 1000 K	//Turbine max temperature
+//	TAB: 1664 K		//Afterburner peak temp
+//	maxT3: 950 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -70,7 +70,7 @@
 		CONFIG
 		{
 			name = Olympus593-610
-			description = Olympus 593 Mk.610, as used on all production Concordes.
+			description = Olympus 593 Mk.610, as used on all production Concordes. Temperature Mach limit at 15 km: 3.0.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -85,8 +85,8 @@
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 29000000	//Fuel heat of burning (joules?)
 			TIT = 1467		//Combustion peak temp
-			TAB = 2000		//Afterburner temp?
-			maxT3 = 1000		//Turbine max temperature
+			TAB = 1664		//Afterburner temp?
+			maxT3 = 950		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 350

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R11_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1150 K		//Combustion peak temp
-//	TAB: 2400 K		//Afterburner peak temp
-//	maxT3: 800 K	//Turbine max temperature
+//	TAB: 1925* K		//Afterburner peak temp
+//	maxT3: 750 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1150 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 2238* K		//Afterburner peak temp
+//	maxT3: 750 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -62,8 +62,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1150 K		//Combustion peak temp
-//	TAB: 2500 K		//Afterburner peak temp
-//	maxT3: 950 K	//Turbine max temperature
+//	TAB: 2218* K		//Afterburner peak temp
+//	maxT3: 750 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -113,7 +113,7 @@
 		CONFIG
 		{
 			name = R-11F-300
-			description = Early afterburning R-11, as used on the MiG-21F.
+			description = Early afterburning R-11, as used on the MiG-21F. Temperature Mach limit at 15 km: 2.54.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -128,8 +128,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1150		//Combustion peak temp
-			TAB = 2400		//Afterburner temp?
-			maxT3 = 800		//Turbine max temperature
+			TAB = 1925		//Afterburner temp?
+			maxT3 = 750		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 120
@@ -152,7 +152,7 @@
 		CONFIG
 		{
 			name = R-11F2-300
-			description = Afterburning R-11, as used on the MiG-21PF.
+			description = Afterburning R-11, as used on the MiG-21PF. Temperature Mach limit at 15 km: 2.55.
 			specLevel = operational
 			massMult = 1.0244
 			
@@ -167,8 +167,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1150		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 2238		//Afterburner temp?
+			maxT3 = 750		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 120
@@ -191,7 +191,7 @@
 		CONFIG
 		{
 			name = R-11F2S-300
-			description = Afterburning R-11, as used on the MiG-21PFM and Su-15.
+			description = Afterburning R-11, as used on the MiG-21PFM and Su-15. Temperature Mach limit at 15 km: 2.53.
 			specLevel = operational
 			massMult = 1.0419
 			
@@ -206,8 +206,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1150		//Combustion peak temp
-			TAB = 2500		//Afterburner temp?
-			maxT3 = 950		//Turbine max temperature
+			TAB = 2218		//Afterburner temp?
+			maxT3 = 750		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 120

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R11_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R15_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R15_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1215 K		//Combustion peak temp
-//	TAB: 3200 K		//Afterburner peak temp
-//	maxT3: 730 K	//Turbine max temperature
+//	TAB: 2086* K		//Afterburner peak temp
+//	maxT3: 750 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -41,7 +41,7 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1215 K		//Combustion peak temp
-//	TAB: 3200 K		//Afterburner peak temp
+//	TAB: 1514* K		//Afterburner peak temp
 //	maxT3: 850 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
@@ -62,8 +62,8 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32000000 J	//Fuel heat of burning
 //	TIT: 1315 K		//Combustion peak temp
-//	TAB: 3300 K		//Afterburner peak temp
-//	maxT3: 950 K	//Turbine max temperature
+//	TAB: 2129* K		//Afterburner peak temp
+//	maxT3: 900 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -113,7 +113,7 @@
 		CONFIG
 		{
 			name = R-15B-300
-			description = Early afterburning R-15, as used on the MiG-25 and MiG-25FP.
+			description = Early afterburning R-15, as used on the MiG-25 and MiG-25FP. Temperature Mach limit at 15 km: 2.96.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -128,8 +128,8 @@
 			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1215		//Combustion peak temp
-			TAB = 3200		//Afterburner temp?
-			maxT3 = 730		//Turbine max temperature
+			TAB = 2086		//Afterburner temp?
+			maxT3 = 750		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 220
@@ -152,7 +152,7 @@
 		CONFIG
 		{
 			name = R-15BD-300
-			description = Afterburning R-15, as used on the MiG-25RB and retrofitted to many earlier variants.
+			description = Afterburning R-15, as used on the MiG-25RB and retrofitted to many earlier variants. Temperature Mach limit at 15 km: 3.35.
 			specLevel = operational
 			massMult = 1.0
 			
@@ -167,7 +167,7 @@
 			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1215		//Combustion peak temp
-			TAB = 3200		//Afterburner temp?
+			TAB = 1514		//Afterburner temp?
 			maxT3 = 850		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
@@ -191,7 +191,7 @@
 		CONFIG
 		{
 			name = R-15BF2-300
-			description = Afterburning R-15, as used on the E-155M/MiG-25M. Cancelled in favor of MiG-31.
+			description = Afterburning R-15, as used on the E-155M/MiG-25M. Cancelled in favor of MiG-31. Temperature Mach limit at 15 km: 3.51.
 			specLevel = operational
 			massMult = 1.0
 			
@@ -206,8 +206,8 @@
 			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32000000	//Fuel heat of burning (joules?)
 			TIT = 1315		//Combustion peak temp
-			TAB = 3300		//Afterburner temp?
-			maxT3 = 950		//Turbine max temperature
+			TAB = 2129		//Afterburner temp?
+			maxT3 = 900		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 300

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R15_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R15_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R25_Config.cfg
@@ -20,8 +20,8 @@
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 30000000 J	//Fuel heat of burning
 //	TIT: 1313 K		//Combustion peak temp
-//	TAB: 2850 K		//Afterburner peak temp
-//	maxT3: 900 K	//Turbine max temperature
+//	TAB: 5000* K		//Afterburner peak temp
+//	maxT3: 850 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -71,7 +71,7 @@
 		CONFIG
 		{
 			name = R-25-300
-			description = R-25, as used on the MiG-21Bis and Su-15Bis.
+			description = R-25, as used on the MiG-21Bis and Su-15Bis. Temperature Mach limit at 15 km: 2.94.
 			specLevel = operational
 			massMult = 1.00
 			
@@ -86,8 +86,9 @@
 			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 30000000	//Fuel heat of burning (joules?)
 			TIT = 1313		//Combustion peak temp
-			TAB = 2850		//Afterburner temp?
-			maxT3 = 900		//Turbine max temperature
+			TAB = 5000		//Afterburner temp?
+			maxT3 = 850		//Turbine max temperature
+			tt7_max = 5000	//manually override solver max temp to get extra-power afterburner to work
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 190

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/R25_Config.cfg
@@ -47,7 +47,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD36_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD36_Config.cfg
@@ -48,7 +48,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD36_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD36_Config.cfg
@@ -1,0 +1,113 @@
+//	==================================================
+//	Engine: RD-36
+//
+//	Manufacturer: KB Rybinsk Motor
+//
+//	=================================================================================
+//	RD-36-51A
+//	1978, Tu-144D
+//
+//	Dry Mass: 4125 kg
+//	Thrust (Dry): 158.4 kN
+//	Thrust (Wet): 196.1 kN
+//	SFC (Dry): 0.747 lb/lbf-hr	//1.26 lb/lbf-hr @ M2.0 16km cruise
+//	Area: 0.63 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 15.8		//Compressor Pressure Ratio?
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 28000000 J	//Fuel heat of burning
+//	TIT: 1355 K		//Combustion peak temp
+//	TAB: 1600* K		//Afterburner peak temp
+//	maxT3: 1000 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.jet-engine.net/miltfspec.htm
+//	http://www.leteckemotory.cz/motory/nk-32/
+//	http://www.tu144sst.com/techspecs/powerplant.html
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[RD36]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roRD36Title	//RD-36 Turbojet
+	%manufacturer = #roMfrRKBM
+	%description = #roRD36Desc
+
+	@tags ^= :$: ussr kolesov rybinsk motor rd-36 rd36 afterburning turbojet
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!RESOURCE,*{}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJEJet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = RD-36-51A
+		modded = false
+		origMass = 4.125
+
+		CONFIG
+		{
+			name = RD-36-51A
+			description = RD-36, as used on the production Tu-144D. Temperature Mach limit at 15 km: 3.19.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.63		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 15.8		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.9		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 28000000	//Fuel heat of burning (joules?)
+			TIT = 1355		//Combustion peak temp
+			TAB = 1600		//Afterburner temp?
+			maxT3 = 1000		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 400
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 158.4
+			wetThrust = 196.1
+			maxThrust = 196.1	//Just to let MEC know thrust
+			drySFC = 0.747
+			throttleResponseMultiplier = 0.60
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD9_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD9_Config.cfg
@@ -11,7 +11,7 @@
 //	Thrust (Dry): 25.5 kN
 //	Thrust (Wet): 31.9 kN
 //	SFC (Dry): 0.96 lb/lbf-hr
-//	Area: 0.24 m^2	//Compressor Area
+//	Area: 0.14 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 7.14		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -20,8 +20,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22000000 J	//Fuel heat of burning
 //	TIT: 1133 K		//Combustion peak temp
-//	TAB: 1250 K		//Afterburner peak temp
-//	maxT3: 655 K	//Turbine max temperature
+//	TAB: 1365* K		//Afterburner peak temp
+//	maxT3: 630 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -32,7 +32,7 @@
 //	Thrust (Dry): 29.4 kN
 //	Thrust (Wet): 36.9 kN
 //	SFC (Dry): 1.02 lb/lbf-hr
-//	Area: 0.24 m^2	//Compressor Area
+//	Area: 0.14 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 7.2		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -41,8 +41,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22000000 J	//Fuel heat of burning
 //	TIT: 1133 K		//Combustion peak temp
-//	TAB: 1250 K		//Afterburner peak temp
-//	maxT3: 850 K	//Turbine max temperature
+//	TAB: 1374* K		//Afterburner peak temp
+//	maxT3: 700 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -53,7 +53,7 @@
 //	Thrust (Dry): 29.4 kN
 //	Thrust (Wet): 37.2 kN
 //	SFC (Dry): 1.02 lb/lbf-hr
-//	Area: 0.24 m^2	//Compressor Area
+//	Area: 0.14 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 7.2		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -62,8 +62,8 @@
 //	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 22000000 J	//Fuel heat of burning
 //	TIT: 1133 K		//Combustion peak temp
-//	TAB: 1500 K		//Afterburner peak temp
-//	maxT3: 850 K	//Turbine max temperature
+//	TAB: 1397* K		//Afterburner peak temp
+//	maxT3: 700 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
@@ -113,11 +113,11 @@
 		CONFIG
 		{
 			name = RD-9B
-			description = Early afterburning RD-9, as used on the MiG-19/S/PF/PM.
+			description = Early afterburning RD-9, as used on the MiG-19/S/PF/PM. Temperature Mach limit at 15 km: 2.0.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.24		//Compressor Area
+			Area = 0.14		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 7.14		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -128,8 +128,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22000000	//Fuel heat of burning (joules?)
 			TIT = 1133		//Combustion peak temp
-			TAB = 1250		//Afterburner temp?
-			maxT3 = 655		//Turbine max temperature
+			TAB = 1365		//Afterburner temp?
+			maxT3 = 630		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 60
@@ -152,11 +152,11 @@
 		CONFIG
 		{
 			name = RD-9BF-811
-			description = Afterburning RD-9, as used on the MiG-19R/SF.
+			description = Afterburning RD-9, as used on the MiG-19R/SF. Temperature Mach limit at 15 km: 2.4.
 			specLevel = operational
 			massMult = 1.0791
 			
-			Area = 0.24		//Compressor Area
+			Area = 0.14		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 7.2		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -167,8 +167,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22000000	//Fuel heat of burning (joules?)
 			TIT = 1133		//Combustion peak temp
-			TAB = 1250		//Afterburner temp?
-			maxT3 = 850		//Turbine max temperature
+			TAB = 1374		//Afterburner temp?
+			maxT3 = 700		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 60
@@ -191,11 +191,11 @@
 		CONFIG
 		{
 			name = RD-9AF2-300
-			description = Afterburning RD-9, as used on the Yak-27R/V.
+			description = Afterburning RD-9, as used on the Yak-27R/V. Temperature Mach limit at 15 km: 2.4.
 			specLevel = operational
 			massMult = 1.0791
 			
-			Area = 0.24		//Compressor Area
+			Area = 0.14		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 7.2		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -206,8 +206,8 @@
 			eta_n = 0.7		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 22000000	//Fuel heat of burning (joules?)
 			TIT = 1133		//Combustion peak temp
-			TAB = 1500		//Afterburner temp?
-			maxT3 = 850		//Turbine max temperature
+			TAB = 1397		//Afterburner temp?
+			maxT3 = 700		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = True
 			thrustUpperLimit = 60

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD9_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD9_Config.cfg
@@ -89,7 +89,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Sapphire_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Sapphire_Config.cfg
@@ -67,7 +67,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Sapphire_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Sapphire_Config.cfg
@@ -11,7 +11,7 @@
 //	Thrust (Dry): 36.9 kN
 //	Thrust (Wet): 0.0 kN
 //	SFC (Dry): 0.9 lb/lbf-hr
-//	Area: 0.30 m^2	//Compressor Area
+//	Area: 0.28 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 7.0		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -32,7 +32,7 @@
 //	Thrust (Dry): 48.9 kN
 //	Thrust (Wet): 0.0 kN
 //	SFC (Dry): 0.885 lb/lbf-hr
-//	Area: 0.30 m^2	//Compressor Area
+//	Area: 0.28 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
 //	CPR: 7.0		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
@@ -91,11 +91,11 @@
 		CONFIG
 		{
 			name = Sapphire101
-			description = Sapphire ASSa.6 Mk.101, as used on the Hunter F.2/F.5.
+			description = Sapphire ASSa.6 Mk.101, as used on the Hunter F.2/F.5. Temperature Mach limit at 15 km: 2.2.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.30		//Compressor Area
+			Area = 0.28		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 7.0		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
@@ -130,11 +130,11 @@
 		CONFIG
 		{
 			name = Sapphire203
-			description = Sapphire ASSa.7 Mk.203, as used on the Javelin FAW.7.
+			description = Sapphire ASSa.7 Mk.203, as used on the Javelin FAW.7. Temperature Mach limit at 15 km: 2.46.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.30		//Compressor Area
+			Area = 0.28		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
 			CPR = 7.0		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/VK1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/VK1_Config.cfg
@@ -47,7 +47,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Welland_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Welland_Config.cfg
@@ -46,7 +46,6 @@
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
-	!RESOURCE,*{}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesAJEJet

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Welland_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Welland_Config.cfg
@@ -1,34 +1,33 @@
 //	==================================================
-//	Engine: VK-1
+//	Engine: Welland
 //
-//	Manufacturer: OKB-117
+//	Manufacturer: Rolls-Royce
 //
 //	=================================================================================
-//	VK-1
-//	1949, MiG-15Bis, MiG-17, Il-28
+//	Welland
+//	1943, Meteor F.1
 //
-//	Dry Mass: 814 kg
-//	Thrust (Dry): 26.47 kN
+//	Dry Mass: 386 kg
+//	Thrust (Dry): 7.21 kN
 //	Thrust (Wet): 0.0 kN
-//	SFC (Dry): 1.069 lb/lbf-hr
-//	Area: 0.20 m^2	//Compressor Area
+//	SFC (Dry): 1.118 lb/lbf-hr
+//	Area: 0.083 m^2	//Compressor Area
 //	BPR: 0.0		//Bypass Ratio
-//	CPR: 4.4		//Compressor Pressure Ratio
+//	CPR: 3.8		//Compressor Pressure Ratio
 //	FPR: 0.0		//Fan Ratio
-//	Mdes: 0.8 M		//Mach Design Point
-//	Tdes: 260 K		//Temp Design Point
+//	Mdes: 0.3 M		//Mach Design Point
+//	Tdes: 280 K		//Temp Design Point
 //	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 27000000 J	//Fuel heat of burning
-//	TIT: 1148 K		//Combustion peak temp
+//	TIT: 923 K		//Combustion peak temp
 //	TAB: 0 K		//Afterburner peak temp
-//	maxT3: 520 K	//Turbine max temperature
+//	maxT3: 500 K	//Turbine max temperature
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: false
 //	=================================================================================
 
 //	Sources:
 
-//	http://www.leteckemotory.cz/motory/vk-1/
 //	https://www.jet-engine.net/miltfspec.htm
 
 //	Used by:
@@ -36,14 +35,14 @@
 //	Notes:
 
 //	==================================================
-@PART[*]:HAS[#engineType[VK1]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[Welland]]:FOR[RealismOverhaulEngines]
 {
 
-	%title = #roVK1Title	//VK-1 Turbojet
-	%manufacturer = #roMfrOKB117
-	%description = #roVK1Desc
+	%title = #roWellandTitle	//Welland Turbojet
+	%manufacturer = #roMfrRR
+	%description = #roWellandDesc
 
-	@tags ^= :$: uk okb-117 kilmov vk1 turbojet
+	@tags ^= :$: uk rolls-royce welland turbojet
 
 	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
@@ -64,41 +63,41 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEnginesAJEJet
-		configuration = VK-1
+		configuration = Welland
 		modded = false
-		origMass = 0.814
+		origMass = 0.386
 
 		CONFIG
 		{
-			name = VK-1
-			description = VK-1, as used on the MiG-15Bis, MiG-17, and Il-28. Temperature Mach limit at 15 km: 1.81.
+			name = Welland
+			description = Welland RB.23. Reverse-flow centrifugal jet, as used on Meteor F.1. Temperature Mach limit at 15 km: 1.79.
 			specLevel = operational
 			massMult = 1.00
 			
-			Area = 0.20		//Compressor Area
+			Area = 0.083		//Compressor Area
 			BPR = 0.0		//Bypass Ratio
-			CPR = 4.4		//Compressor Pressure Ratio
+			CPR = 4.0		//Compressor Pressure Ratio
 			FPR = 0.0		//Fan Ratio
-			Mdes = 0.8		//Mach Design Point
-			Tdes = 260		//Temp Design Point
+			Mdes = 0.3		//Mach Design Point
+			Tdes = 280		//Temp Design Point
 			eta_c = 0.95	//Efficiency at burner inlet
 			eta_t = 0.98	//Efficiency at burner exit
 			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 27000000	//Fuel heat of burning (joules?)
-			TIT = 1148		//Combustion peak temp
+			TIT = 1168		//Combustion peak temp
 			TAB = 0		//Afterburner temp?
-			maxT3 = 520		//Turbine max temperature
+			maxT3 = 500		//Turbine max temperature
 			exhaustMixer = False
 			adjustableNozzle = False
 			isCentrifugalFlow = true
-			thrustUpperLimit = 50
+			thrustUpperLimit = 15
 			
 			// Engine fitting params
-			defaultTPR = 0.95
-			dryThrust = 26.47
+			defaultTPR = 0.85
+			dryThrust = 7.21
 			wetThrust = 0.0
-			maxThrust = 26.47	//Just to let MEC know thrust
-			drySFC = 1.069
+			maxThrust = 7.21	//Just to let MEC know thrust
+			drySFC = 1.118
 			throttleResponseMultiplier = 0.15
 
 			PROPELLANT

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -890,7 +890,6 @@ Localization
 		//		GEnx
 		#roGEnxTitle = GEnx High-Bypass Turbofan
 		#roGEnxDesc = The GEnx is a 2000s large, high-bypass turbfan, developed from the GE90 to power the B787. It is used in most 787 variants, as well as in the 747-8.
-		#roGE4
 		//		J35
 		#roJ35Title = J35 Turbojet
 		#roJ35Desc = Allison/General Electric J35. An axial flow turbojet, and one of the first turbojets natively designed in the United States. Although not as well known as it's later derivative, the J47, it still powered many late 40s aircraft such as the FJ-1, F-84, F-89, XP-86, XB-45, XB-47, X-5, and D-558.

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -858,8 +858,11 @@ Localization
 		#roCF6Title = CF6 High-Bypass Turbofan
 		#roCF6Desc = The CF6 high bypass turbofan was developed from the TF39, the first high-bypass turbofan developed. It powered many large aircraft, including the A300, A310, A330, B747, B767, DC-10, KC-10, MD-11, E-4, C-2, and C-5M.
 		//		CF34
-		#roCF34Title = CF34 High-Bypass Turbofan
-		#roCF34Desc = The CF34 is a 1980s high-bypass turbofan developed from the TF34. It powered many large private jets and regional airliners such as the Challenger 600 Series, Challenger 850, CRJ100/200/440/700/900, and the Embraer 170/175/190/195.
+		#roCF34Title = TF/CF34 High-Bypass Turbofan
+		#roCF34Desc = The TF34 is a 1970s high-bypass turbofan. It powered the S-3, S-72, and A-10, while it's civilian derivative, the CF34, powered many large private jets and regional airliners such as the Challenger 600 Series, Challenger 850, CRJ100/200/440/700/900, and the Embraer 170/175/190/195.
+		//		CFM56
+		#roCFM56Title = CFM56 High-Bypass Turbofan
+		#roCFM56Desc = The CFM56 is a 1970s high-bypass turbofan, developed from the F101. Created in a collaboration between GE and Snecma, the CFM56 is the most successful high-bypass turbofan ever made, with over 30,000 built. It powered the Airbus A320 and A340 series, B737 Classic and Next Gen series, DC-8-70, and was used to re-engine many 707-based aircraft such as the E-3, E-6, and KC/RC-135.
 		//		D-18
 		#roD18Title = D-18 High-Bypass Turbofan
 		#roD18Desc = The D-18 was the largest high-bypass turbofan developed in the Soviet Union, created in the 1980s for the An-124 and An-225.
@@ -872,12 +875,22 @@ Localization
 		//		F100
 		#roF100Title = F100 Low-Bypass Turbofan
 		#roF100Desc = The F100 is a 1970s low-bypass turbofan designed for the F-15 and F-16. It's advanced design and high power allowed the F-15 and F-16 to achieve a thrust to weight ratio greater than one. It was used in all F-15 and most F-16 variants.
+		//		F119
+		#roF119Title = F119 Low-Bypass Turbofan
+		#roF119Desc = The F119 is a 1990s low-bypass turbofan designed for the Advance Tactical Fighter program. Designed for supercruise capability, it has unusually high dry thrust for it's size, and it has a 2D thrust-vectoring nozzle for increased maneuverability. It was used in the F-22, YF-23, X-32 and X-35.
 		//		F135
 		#roF135Title = F135 Low-Bypass Turbofan
 		#roF135Desc = The F135 is a 2000s low-bypass turbofan designed for the F-35. Two variants exist, with a conventional nozzle for the F-35A/C, and one with a forward PTO shaft and gimbaled nozzle for the VTOL capable F-35B.
 		//		F404
 		#roF404Title = F404 Low-Bypass Turbofan
 		#roF404Desc = The F404 is a 1970s low-bypass turbofan designed for the F/A-18. It was designed for reliability rather than performance, in order to replace the notoriously unreliable F-4s and F-14s used by the US Navy and Marines at the time. It was used in the F/A-18A/B/C/D, F-20A, F-117A, T-7A, T-50, JAS-39, and Tejas.
+		//		GE4
+		#roGE4Title = GE4 Turbojet
+		#roGE4Desc = The GE4 was a 1970s turbojet developed to power the Boeing 2707 supersonic transport at speeds up to Mach 2.7. The most powerful turbojet ever made, the GE4 was tested extensively, but ultimately cancelled with the rest of the 2707 project.
+		//		GEnx
+		#roGEnxTitle = GEnx High-Bypass Turbofan
+		#roGEnxDesc = The GEnx is a 2000s large, high-bypass turbfan, developed from the GE90 to power the B787. It is used in most 787 variants, as well as in the 747-8.
+		#roGE4
 		//		J35
 		#roJ35Title = J35 Turbojet
 		#roJ35Desc = Allison/General Electric J35. An axial flow turbojet, and one of the first turbojets natively designed in the United States. Although not as well known as it's later derivative, the J47, it still powered many late 40s aircraft such as the FJ-1, F-84, F-89, XP-86, XB-45, XB-47, X-5, and D-558.
@@ -902,9 +915,24 @@ Localization
 		//		J85
 		#roJ85Title = J85 Turbojet
 		#roJ85Desc = The J85 was developed as a small, disposable jet engine to power decoys and drones, but was later upgraded for use on manned aircraft. It powered many small aircraft, including the F-5, CF-5, G.91Y, T-2, T-38, and A-37.
+		//		J93
+		#roJ93Title = J93 Turbojet
+		#roJ93Desc = Derived from the J79, the J93 was developed for Mach 3 performance to power the B-70 and F-108.
+		//		JT8D
+		#roJT8DTitle = JT8D Low-Bypass Turbofan
+		#roJT8DDesc = Derived from the J52, the JT8D was an early low bypass turbofan, used on many second-generation jetliners like the Boeing 727, 737, and DC-9. It recieved a substantial redesign in the 1970s, creating the JT8D-200 series, which powered the Super 27, MD-80 series, and was used to upgrade many 707-based aircraft like the E-8C.
 		//		Model 304
 		#roModel304Title = Model 304 Turbojet
 		#roModel304Desc = Late 50s turbojet. Based on the Pratt & Whitney J57, the Model 304-2 was a liquid-hydrogen fueled turbojet, designed for project SUNTAN, a high performance replacement for the U-2 spyplane. The project required the development of large-scale Liquid Hydrogen production and handling techniques, at the cost of hundreds of millions of dollars, but the results were impressive. Pratt & Whitney were able to convert various jet engines to hydrogen power, where they showed incredible stability and efficiency. This information, along with many of the engineers involved in the project, were later transferred to working on the Pratt & Whitney RL-10, where the information gained proved invaluable. The Model 304 and project SUNTAN, however, were ultimately cancelled, as the conventionally fueled A-12/SR-71 was showing much greater promise.
+		//		NK-8
+		#roNK8Title = NK-8 Low-Bypass Turbofan
+		#roNK8Desc = The NK-8 was a 1960s low-bypass turbofan, created to power the Il-62 and Tu-154. It was later modified for improved performance to power the Il-86, and modified to run on alternate fuels for the Tu-155 project. It powered the A-90, Il-62, Il-62M, Tu-154, Tu-154A/B and Tu-155.
+		//		NK-22/144
+		#roNK22Title = NK-22/144 Low-Bypass Turbofan
+		#roNK22Desc = The NK-144 was a 1960s low-bypass turbofan developed from the NK-8 to power the Tu-144 supersonic transport. The NK-144 was unable to meet perfomance requirements and was replaced by the RD-36, but found new life as the NK-22, which powered the Tu-22M0/M1/M2.
+		//		NK-25/32
+		#roNK25Title = NK-25/32 Low-Bypass Turbofan
+		#roNK25Desc = The NK-25 was a 1970s low-bypass turbofan, developed from the earlier NK-22. It is the most powerful supersonic jet engine ever flown, and was used to power the Tu-22M3, Tu-160, Tu-160M and Tu-144LL.
 		//		Olympus 593
 		#roOlympus593Title = Olympus 593 Turbojet
 		#roOlympus593Desc = Late 1960s turbojet. The ultimate version of the Olympus turbojet, designed for sustained Mach 2 operation to power Concorde. Although thirsty at sea level, when mated to a well-optimized intake this engine can supercruise at Mach 2, achieving relatively good efficiency.
@@ -920,11 +948,17 @@ Localization
 		//		RD-9
 		#roRD9Title = RD-9 Turbojet
 		#roRD9Desc = Early 50s turbojet. Developed as a scaled down Mikulin AM-3, the RD-9 was designed for fighter aircraft, and powered the Yak-25, 26, 27, 28, and MiG-19.
+		//		RD-36
+		#roRD36Title = RD-36 Turbojet
+		#roRD36Desc = The RD-36 was a 1970s turbojet, developed to power the Tu-144. The RD-36 replaced the underperforming NK-144 engines, allowing the Tu-144 to achieve it's intended range. Ultimately, the Tu-144 was taken out of service shortly after being upgraded due to costs. The RD-36 powered the Tu-144D and M-17.
 		//		Sapphire
 		#roSapphireTitle = Sapphire Turbojet
 		#roSapphireDesc = Early 1950s turbojet. Derived from the MetroVick F.2, the first axial-flow jet developed in Britain, the Sapphire powered the Hawker Hunter, Handley Page Victor, and Gloster Javelin.
 		//		VK-1
 		#roVK1Title = VK-1 Turbojet
 		#roVK1Desc = A Soviet-built derivative of the Nene used in many early Soviet jet aircraft, including the MiG-15, MiG-17, Tu-14, and Il-28.
+		//		Welland
+		#roWellandTitle = Welland Turbojet
+		#roWellandDesc = The Welland was an early 1940s turbojet, developed from Frank Whittle's original jet engine, the W.1. It was used on the Meteor F.1, but was quickly replaced by later, more powerful jet engines.
 	}
 }

--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -97,6 +97,7 @@ Localization
 		//	============================================================================
 		//Soviet/Russian/Ukranian Manufacturers
 		//	source: Challenge to Apollo: The Soviet Union and the Space Race, 1945-1974
+		//	https://www.secretprojects.co.uk/threads/okb-36-dobrynin-kolesov-rybinsk-jet-engines.12885/
 		//NII-88
 		#roMfrNII88 = Scientific Research Institute 88 (NII-88)	//(1946-1967) head of all Soviet space R&D. Most OKBs spun off from it's various departments in the early 1950s. Renamed to Central Scientific Research Institute (TsNIIMash)
 		#roMfrTsNIIMash = Central Research Institute of Machine Building (TsNIIMash)	//(1967-present)
@@ -117,9 +118,12 @@ Localization
 		#roMfrAviadvigatel = OJSC Aviadvigatel	//(1989-2003?) merged with Perm Engine Company, renamed to UEC-Aviadvigatel JSC
 		#roMfrUECAviadvigatel = UEC-Aviadvigatel JSC	//(2003?-present)
 		//Myasishchev (OKB-23)
-		#roMfrOKB23 = OKB-23 (Myasishchev)	(1951-1988) renamed to Salyut design Bureau
+		#roMfrOKB23 = OKB-23 (Myasishchev)	//(1951-1988) renamed to Salyut design Bureau
 		#roMfrSalyut = KB Salyut	//(1988-1993) merged with Khrunichev Plant
 		#roMfrKhrunichev = Khrunichev State Research and Production Space Center	//(1993-present)
+		//Kolesov (OKB-36)
+		#roMfrOKB36 = OKB-36 (Kolesov)	//(1943-1966) renamed to Rybinsk Motor Design Bureau
+		#roMfrRKBM = KB Rybinsk Motor (RKBM)	//(1966-2001) merged with NPO Saturn to become UEC Saturn
 		//Chelomi (OKB-52)
 		#roMfrOKB52 = OKB-52 (Chelomi)	//(1955-1966) renamed to NPO Mashinostroyeniya in 1966
 		#roMfrNPOMash = NPO Mashinostroyeniya	//(1966-present)
@@ -135,10 +139,10 @@ Localization
 		#roMfrOKB165 = OKB-165 (Lyulka)	//(1946-1966) renamed to NPO Saturn
 		#roMfrNPOSaturn = NPO Saturn	//(1966-2001) merged with Rybinsk Motors to become UEC Saturn
 		#roMfrUECSaturn = UEC NPO Saturn	//(2001-present)
-		//Kuznetstov (OKB-276)
-		#roMfrOKB276 = OKB-276 (Kuznetstov)	//(1946-1966) renamed to NPO Kuznetstov (NPO Trud)
-		#roMfrNPOKuznetstov = NPO Kuznetstov	//(1966-2009) merged into JSC Kuznetstov in 2009
-		#roMfrJSCKuznetstov = JSC Kuznetstov	//(2009-present)
+		//Kuznetsov (OKB-276)
+		#roMfrOKB276 = OKB-276 (Kuznetsov)	//(1946-1966) renamed to NPO Kuznetsov (NPO Trud)
+		#roMfrNPOKuznetstov = NPO Kuznetsov	//(1966-2009) merged into JSC Kuznetsov in 2009
+		#roMfrJSCKuznetstov = JSC Kuznettov	//(2009-present)
 		//Tumansky (OKB-300)
 		#roMfrOKB300 = OKB-300 (Tumansky)	//(1943-1966) renamed to MNZ Soyuz 1966
 		#roMfrMNZSoyuz = MNZ Soyuz	//(1966-1981) defunct?

--- a/GameData/RealismOverhaul/Parts/OldFighterCockpit/oldFighterCockpit.cfg
+++ b/GameData/RealismOverhaul/Parts/OldFighterCockpit/oldFighterCockpit.cfg
@@ -117,6 +117,7 @@ PART
 	{
 		name = ModuleROEjectionSeat
 		mass = 0.04
+		IsEnabled = false
 
 		SEAT
 		{

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -152,6 +152,14 @@
 	//add engine configs
 	engineType = J57
 }
+@PART[aje_j57]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[Module*EngineConfigs]
+	{
+		@name = ModuleEngineConfigs	//nothing this model uses has water injection, just revert to MEC
+		!CONFIG:HAS[#TAB[0]] {}
+	}
+}
 //J58-P-4
 @PART[turboFanEngine]:FOR[RealismOverhaul]
 {
@@ -540,6 +548,31 @@
 		{
 			@name = Kerosene
 		}
+	}
+}
+
+//Clone J57 to be J57 (no afterburner)
++PART[miniJetEngine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-JT3C
+	
+	@rescaleFactor = 1.6
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 0.75, 1.75, 0.75
+	}
+	%CoMOffset = 0, 2.0, 0
+
+	%engineType = J57
+}
+@PART[RO-JT3C]:AFTER[RealismOverhaulEngines]
+{
+	@title = J57 Turbojet (No Afterburner)
+	@MODULE[Module*EngineConfigs]
+	{
+		@configuration = J57-P-1W
+		!CONFIG:HAS[~TAB[0]] {}
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -551,7 +551,7 @@
 	}
 }
 
-//Clone J57 to be J57 (no afterburner)
+//Clone J85 to be J57 (no afterburner)
 +PART[miniJetEngine]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -697,7 +697,7 @@
 
 //Clone J57 to be RD-9B
 //source: http://www.leteckemotory.cz/motory/rd-9b/
-+PART[RO-J57P8]:FOR[RealismOverhaul]
++PART[aje_j57]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@name = RO-RD9B


### PR DESCRIPTION
Add more jet configs, and rebalance jet engines. Balance changes include revising afterburner temp, area, and maxT3 of most engines. Balance changes primarily effect post-1960 engines (they previously weren't really balanced at all).
Configs added:

- CF34: Added TF34 configs
- CFM56
- F119
- GE4
- GEnx
- J47: Added GE-15 (RB-45C) and GE-25A (B-47E) configs with water injection.
- J57: Added P-1W (B-52), P-7A (U-2), P-43WA (B-52E), and JT3C (707) configs.
- J75: Added water injection to P-19 config.
- J79: Added CJ805 (Convair 880) and GE-5C (B-58) configs.
- J93
- JT8D
- NK-22/144
- NK-25/32
- NK-8
- RD-36
- Welland

Parts Added

- J57 Turbojet (no afterburner): New J57 part for afterburner-less J57 configs.

Changes include:

- All configs no longer have a patch to delete all resources in the part. In jet engines with the intake integrated, this deletes the IntakeAir resource, which breaks AJE and causes a NRE. Resource removal can be done on a part-by-part basis if required.
- All configs (except high-bypass turbofans) now list (mostly accurate) Mach temperature limits at 15 km in the config description.
- In cases where afterburner temp is not documented, calculate it based on information from https://www.jet-x.org/a6.html. This only effects engine SFC, engine performance is unchanged.
- Engine Area of the AL-7, Atar 101, J35, RD-9, Sapphire and VK-1 have been adjusted to more closely match the real engine.
- maxT3 balance: maxT3 on many engines has been decreased to be more consistent. Mach 3+ flight will now require engines designed for Mach 3, and the J58 can no longer go Mach 4 (easily). Early game engines are untouched, I already balanced those previously in an attempt to prevent Mach 2 flight with the first two plane nodes.