### PR TITLE
Decrease maximum speed for large landing gear

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
@@ -19,7 +19,7 @@
 		suspensionTravel = 0.25
 		// Three of these should carry A340
 		maxLoadRating = 130
-		maxSpeed = 300
+		maxSpeed = 150
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
@@ -19,7 +19,7 @@
 		suspensionTravel = 0.2
 		// Two such struts should be able to carry A321
 		maxLoadRating = 40
-		maxSpeed = 300
+		maxSpeed = 150
 	}
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
@@ -20,7 +20,7 @@
 		// Assume, four of this gears should carry fully loaded A380
 		// or just two of them - B777
 		maxLoadRating = 180
-		maxSpeed = 300
+		maxSpeed = 150
 	}
 	MODULE
 	{


### PR DESCRIPTION
Large landing gear have maximum speed of 300m/s, which is completely unrealistic. The tyres would be instantly destroyed.
This is a proposal to decrease maxSpeed to 150m/s, based on the fastest landing speeds I could find:
X-37 (unmanned drone) - 134m/s
Emergency landing of a damaged F-15 - 133m/s  (https://theaviationist.com/2014/09/15/f-15-lands-with-one-wing/)
Emergency landing of a damaged F-104 - 120m/s   (02 June 1965)
Space Shuttle, Buran - about 100m/s

!!! 150m/s allows some resizing of the gear, but much less than before, which will unfortunately break some craft.