### PR TITLE
Patch intakes, update B9, add NFA

### DIFF
--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -64,6 +64,11 @@
 	%RSSROConfig = True
 	
 	%engineType = CF6
+	
+	//Remove stock intake module and resources (because AJE doesn't)
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
 }
 @PART[turboFanSize2]:AFTER[RealismOverhaulEngines]
 {
@@ -161,6 +166,38 @@
 		model = RealismOverhaul/Models/EngineCore-Medium
 		scale = 1.6, 2.5, 1.6
 		position = 0.0, 1.4, 0.0
+	}
+	
+	//redo effects to look maybe a little better
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName2 = power_wet
+	}
+	
+	@EFFECTS
+	{
+		@running_turbine
+		{
+			!MODEL_MULTI_PARTICLE {}
+		}
+		power_wet
+		{
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/afterburner_flame
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.16 0.0
+				emission = 0.3 0.5
+				emission = 0.5 1.0
+				emission = 1.0 1.0
+				speed = 0.1 0.05
+				speed = 0.3 1.0
+				speed = 0.5 1.15
+				speed = 1.0 1.15
+				localPosition = 0, 0, 0.08
+			}
+		}
 	}
 
 	%engineType = J58
@@ -609,15 +646,6 @@
 	}
 
 	%engineType = Olympus593
-
-	//delete ugly stock effect
-	@EFFECTS
-	{
-		@running_turbine
-		{
-			!MODEL_MULTI_PARTICLE {}
-		}
-	}
 }
 
 //Clone J75 to be R-11F2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/B9Aerospace/Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/B9Aerospace/Engines.cfg
@@ -1,0 +1,224 @@
+//D-30 turbofan
+@PART[aje_d30]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	%rescaleFactor = 0.88
+	MODEL
+	{
+		model = B9_Aerospace/Parts/Engine_Jet_Turbojet/model
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.5, 5.5, 1.5
+	}
+	
+	%engineType = D30
+}
+//JT8D-2xx
+@PART[aje_jt8d]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	%rescaleFactor = 1.21
+	
+	%engineType = JT8D
+	
+	//Remove stock intake module and resources (because AJE doesn't)
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
+}
+//JT8D-1xx
++PART[aje_jt8d]:FOR[RealismOverhaul]
+{
+	@name = RO-jt8d1
+	%RSSROConfig = true
+	
+	%rescaleFactor = 0.9871
+	
+	%engineType = JT8D
+}
+//remove non-200 series configs
+@PART[aje_jt8d]:AFTER[RealismOverhaulEngines]
+{
+	@title = JT8D-200 Low-Bypass Turbofan
+	@MODULE[ModuleEngineConfigs]
+	{
+		!CONFIG:HAS[~name[*2??]] {}
+		@CONFIG,*
+		{
+			%intakeMatchArea = True
+		}
+	}
+}
+//remove 200-series configs
+@PART[RO-jt8d1]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		!CONFIG:HAS[#name[*2??]] {}
+		@CONFIG,*
+		{
+			%intakeMatchArea = True
+		}
+	}
+}
+//GEnx
+@PART[aje_GEnx]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	%rescaleFactor = 1.76
+	
+	%engineType = GEnx
+	
+	//Remove stock intake module and resources (because AJE doesn't)
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
+}
+@PART[aje_GEnx]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%intakeMatchArea = True
+		}
+	}
+}
+//Welland
+@PART[aje_welland]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		position = 0.0, 0.72, 0.0
+		scale = 1.25, 0.5, 1.25
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		position = 0.0, 0.76, 0.0
+		scale = 1.25, 0.5, 1.25
+		rotation = 180, 0, 0
+	}
+	
+	%engineType = Welland
+}
+//J93 turbojet
+@PART[B9_Engine_Jet_Turbojet]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	%rescaleFactor = 1.04
+	MODEL
+	{
+		model = B9_Aerospace/Parts/Engine_Jet_Turbojet/model
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.5, 4.0, 1.5
+	}
+	
+	%engineType = J93
+}
+//F119 turbofan
+@PART[B9_Engine_Jet_Turbofan_F119]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	MODEL
+	{
+		model = B9_Aerospace/Parts/Engine_Jet_Turbofan_F119/model
+	}
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 1.4, 2.5, 1.4
+	}
+	
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRangeXN = 20
+		%gimbalRangeXP = 20
+		%gimbalRangeYN = 0
+		%gimbalRangeYP = 0
+	}
+	
+	%engineType = F119
+}
+//TF/CF34
+@PART[B9_Engine_Jet_Pod_Small]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	%rescaleFactor = 1.25
+	
+	//Remove stock intake module and resources (because AJE doesn't)
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
+	
+	%engineType = CF34
+}
+@PART[B9_Engine_Jet_Pod_Small]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%intakeMatchArea = True
+		}
+	}
+}
+//NK-8
++PART[B9_Engine_Jet_Pod_Small]:FOR[RealismOverhaul]
+{
+	@name = RO-NK8
+	%RSSROConfig = true
+	
+	%rescaleFactor = 1.44
+	
+	%engineType = NK8
+}
+@PART[RO-NK8]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%intakeMatchArea = True
+		}
+	}
+}
+
+//CFM56
+@PART[B9_Engine_Jet_Pod_Medium]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	
+	%rescaleFactor = 1.0813
+	
+	%engineType = CFM56
+	
+	//Remove stock intake module and resources (because AJE doesn't)
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
+}
+@PART[B9_Engine_Jet_Pod_Medium]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		@CONFIG,*
+		{
+			%intakeMatchArea = True
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/B9Aerospace/Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/B9Aerospace/Intakes.cfg
@@ -1,0 +1,71 @@
+//Remove stock intake module and resources (because AJE doesn't)
+@PART[B9_Aero_Intake_CLR|B9_Aero_Intake_DSI|B9_Aero_Intake_DSIX|B9_Aero_Intake_RBM|B9_Aero_Intake_RNM|B9_Engine_VA1_Intake|B9_Engine_SABRE_Intake_S|B9_Engine_SABRE_Intake_M]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	!RESOURCE[IntakeAtm] {}
+	!MODULE[ModuleResourceIntake] {}
+}
+//Pitot
+@PART[B9_Aero_Intake_CLR]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.02
+}
+@PART[B9_Engine_VA1_Intake]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.02
+}
+//DSI
+@PART[B9_Aero_Intake_DSI]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.015
+}
+@PART[B9_Aero_Intake_DSIX]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.045
+}
+//Ramp
+@PART[B9_Aero_Intake_RBM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.05
+	%skinMaxTemp = 1144	//sure, inconel temps
+}
+@PART[B9_Aero_Intake_RNM]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.05
+	%skinMaxTemp = 1144	//sure, inconel temps
+}
+//Isentropic
+@PART[B9_Engine_SABRE_Intake_S]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//reentry capable, just give shuttle stats
+	@maxTemp = 773
+	%skinMaxTemp = 2000
+	%heatConductivity = 0.01		//all conductivity
+	%skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	%skinSkinConductionMult = 0.1
+	%emissiveConstant = 0.95		//matte black
+	
+	@mass = 0.1
+}
+@PART[B9_Engine_SABRE_Intake_M]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//reentry capable, just give shuttle stats
+	@maxTemp = 773
+	%skinMaxTemp = 2000
+	%heatConductivity = 0.01		//all conductivity
+	%skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	%skinSkinConductionMult = 0.1
+	%emissiveConstant = 0.95		//matte black
+	
+	@mass = 0.4
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/NearFutureAeronautics/RO_NearFutureAeronautics_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/NearFutureAeronautics/RO_NearFutureAeronautics_Engines.cfg
@@ -1,0 +1,156 @@
+//	===========================================================================
+//	Engines - Near Future Aeronautics
+//	===========================================================================
+
+@PART[nfa-turbojet-25-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	%rescaleFactor = 0.72	//1.8 m?
+	
+	%engineType = GE4
+	
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 3.1, 5.8, 3.1
+		position = 0.0, 1.472535, 0.0
+	}
+	
+	@MODULE[ModuleEnginesFX]
+	{
+		!runningEffectName = DEL
+		@spoolEffectName = running_thrust	//dry
+		@powerEffectName = running_turbine	//afterburner
+		%powerEffectName2 = shockDiamond	//maybe?
+	}
+	
+	@MODULE[FXModuleAnimateThrottle]
+	{
+		@name = ModuleAJEJetAnimateNozzleArea
+		!engineName = DEL
+		!dependOnEngineState = DEL
+		!dependOnThrottle = DEL
+		!weightOnOperational = DEL
+
+		%calculateAreas = true
+
+		%responseSpeed = 0.1
+
+		%useAnimCurve = true
+		animCurve
+		{
+			key = 0 1  0  -3
+			key = 1 0 -0.1 0
+		}
+	}
+	
+	//rescale effects to fit properly
+	@EFFECTS
+	{
+		@running_thrust
+		{
+			@PREFAB_PARTICLE
+			{
+				localScale = 0.72, 0.72, 0.72
+			}
+		}
+		@shockDiamond
+		{
+			@MODEL_MULTI_PARTICLE
+			{
+				localScale = 0.72, 0.72, 0.72
+			}
+		}
+		@running_turbine
+		{
+			@AUDIO
+			{
+				//NFA comes with lots of sound effects. Let's choose one a little meatier than the stock sounds.
+				@clip = NearFutureAeronautics/Sounds/broadswordrocket_loop
+			}
+			@MODEL_MULTI_PARTICLE
+			{
+				localScale = 0.72, 0.72, 0.72
+			}
+		}
+	}
+}
+
+@PART[nfa-turbofan-25-2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	%rescaleFactor = 0.6274		//Jet itself 1.22 m, but thrust reverser/nozzle was larger
+	%CoMOffset = 0.0,1.75, 0.0
+	
+	%engineType = Olympus593
+	
+	MODEL
+	{
+		model = RealismOverhaul/Models/EngineCore-Medium
+		scale = 2.3, 3.2, 2.3
+		position = 0.0, 1.075479, 0.0
+	}
+	
+	@MODULE[ModuleEnginesFX]
+	{
+		!runningEffectName = DEL
+		@spoolEffectName = running_thrust	//dry
+		@powerEffectName = running_turbine	//afterburner
+		%powerEffectName2 = shockDiamond	//afterburner
+	}
+	
+	//well we can't use the thrust reverser because it uses a separate set of transforms instead of just 
+	//moving the thrust transform.
+	//But we can animate it to simulate the ejector nozzle.
+	MODULE
+	{
+		name = ModuleAJEJetAnimateNozzleArea
+		animationName = ReverseThrust
+		Layer = 3
+		
+		calculateAreas = true
+		responseSpeed = 0.1
+		useAnimCurve = true
+		animCurve
+		{
+			key = 0 0.3  0  -3
+			key = 1 0 -0.1 0
+		}
+	}
+	
+	!MODULE[MultiModeEngine] {}
+	!MODULE[ModuleMultiStateEngine] {}
+	!MODULE[ModuleEnginesFX],1 {}
+	
+	@EFFECTS
+	{
+		@running_thrust
+		{
+			@PREFAB_PARTICLE
+			{
+				localScale = 0.6274, 0.6274, 0.6274
+			}
+		}
+		@shockDiamond
+		{
+			@MODEL_MULTI_PARTICLE
+			{
+				localScale = 0.6274, 0.6274, 0.6274
+			}
+		}
+		@running_turbine
+		{
+			@AUDIO
+			{
+				//NFA comes with lots of sound effects. Let's choose one a little meatier than the stock sounds.
+				@clip = NearFutureAeronautics/Sounds/broadswordrocket_loop
+			}
+			@MODEL_MULTI_PARTICLE
+			{
+				localScale = 0.6274, 0.6274, 0.6274
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_B9.cfg
@@ -3458,62 +3458,6 @@
 	//%maxTemp = 2273.15
 	%skinMaxTemp = 2500
 }
-@PART[B9_Aero_Intake_CLR]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.02
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-}
-@PART[B9_Aero_Intake_DSI]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.015
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-}
-@PART[B9_Aero_Intake_DSIX]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.045
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-}
-@PART[B9_Aero_Intake_RBM]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.05
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-}
-@PART[B9_Aero_Intake_RNM]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.05
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-}
-@PART[B9_Engine_VA1_Intake]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	@mass = 0.02
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-}
-@PART[B9_Engine_SABRE_Intake_S]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-	@mass = 0.1
-}
-@PART[B9_Engine_SABRE_Intake_M]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-	//%maxTemp = 2273.15
-	%skinMaxTemp = 2500
-	@mass = 0.4
-}
 @PART[B9_Engine_SABRE_S_Body]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
@@ -1,16 +1,15 @@
-@PART[SXTRadialAirIntakeShockCone]:FOR[RealismOverhaul]
+//Remove stock intake module and resources (because AJE doesn't)
+@PART[SXTRadialAirIntakeShockCone|SXTInlineAirIntakeTiny|SXTInlineAirIntake|LRadialAirIntake|SXTInlineAirIntakeTLarge]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	!RESOURCE[IntakeAtm] {}
+	!MODULE[ModuleResourceIntake] {}
 }
-@PART[SXTInlineAirIntakeTiny]:FOR[RealismOverhaul]
+
+@PART[SXTInlineAirIntakeTLarge]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-}
-@PART[SXTInlineAirIntake]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
-}
-@PART[LRadialAirIntake]:FOR[RealismOverhaul]
-{
-	%RSSROConfig = True
+	@MODULE[AJEInlet]
+	{
+		@Area = 2.92
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Jets.cfg
@@ -306,6 +306,11 @@
 	%RSSROConfig = True
 	
 	%engineType = D18
+	
+	//Remove stock intake module and resources (because AJE doesn't)
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
 }
 @PART[SXTKe90TurboJet]:AFTER[RealismOverhaulEngines]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
@@ -1,3 +1,11 @@
+//Remove stock intake module and resources (because AJE doesn't)
+@PART[IntakeRadialLong|shockConeIntake|airScoop|CircularIntake|miniIntake|ramAirIntake|MK1IntakeFuselage]:FOR[RealismOverhaul]
+{
+	!RESOURCE[IntakeAtm] {}
+	//keep IntakeAir though because it throws a NRE without it
+	!MODULE[ModuleResourceIntake] {}
+}
+
 @PART[IntakeRadialLong]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -33,6 +41,7 @@
 	@name = RO-shockConeIntake125
 	
 	@mass = 0.135
+	%skinMaxTemp = 1144	//sure, inconel temps
 	
 	@title = #roRO-shockConeIntake125Title	//1.25m Shock Cone Intake
 	@description = #roRO-shockConeIntake125Desc
@@ -55,6 +64,8 @@
 	}
 	
 	@mass = 0.064
+	%skinMaxTemp = 1144	//sure, inconel temps
+	
 	@title = #roRO-shockConeIntakeMigTitle	//0.86m Shock Cone Intake
 	@description = #roRO-shockConeIntakeMigDesc
 }
@@ -62,6 +73,7 @@
 @PART[shockConeIntake]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%skinMaxTemp = 1144	//sure, inconel temps
 	rescaleCube = 1
 	@DRAG_CUBE
 	{
@@ -110,6 +122,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.045
+	%skinMaxTemp = 1144	//sure, inconel temps
 	@title = Ramp Intake
 }
 


### PR DESCRIPTION
- Remove stock intake module and intakeatm resource from (most) AJE-configured parts. This will prevent two "open/close intake" buttons from appearing in the PAW, and remove the small but nonzero amount of mass intakeatm added to the part.
- Add some proper configs for B9 engines and migrate B9 intake configs into a dedicated folder. Also clone a few B9 parts to create the JT8D and NK-8, and add compressor models to engines which lacked them.
- Configure the SXT large inline intake.
- Modify the turboramjet (J58/Olympus/R-15) exhaust plume to look a little nicer.
- Configure the GE4 and Olympus 593 from Near Future Aeronautics.

needs https://github.com/KSP-RO/RealismOverhaul/pull/2797 for engine configs