### PR TITLE
Fix old Juno IV configs, add new ones

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -38,6 +38,8 @@
 //	Sources:
 
 //	Source: JPL 20-123 Juno IV Rocket Vehicle System: https://archive.org/details/nasa_techdoc_19730064143
+//	https://www.si.edu/media/NASM/NASM-NASM.2020.0031-Interim_Report_to_the_Special_Committee_on_Space_Technology_box1_folder4-000002.pdf
+//	http://libarchstor2.uah.edu/digitalcollections/items/show/11031
 
 //	Used by:
 

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -4,17 +4,32 @@
 //	Manufacturer: JPL
 //
 //	===============================================================
-//	Juno 45K Engine
+//	Juno 45K Engine Block I
 //	Second Stage for Juno IV
 //
 //	Dry Mass: 113 kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 200.1699 kN
-//	ISP: ??? SL / 304 Vac
+//	ISP: 127 SL / 304 Vac		SL calculated with RPA
 //	Burn Time: 135 s
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.38 MPa
 //	Propellant: NTO / Hydrazine
 //	Prop Ratio: 1.10
+//	Throttle: N/A
+//	Nozzle Ratio: 25
+//	Ignitions: 1
+//	===============================================================
+//	Juno 45K Engine Block II
+//	Growth option, converted to ClF3
+//
+//	Dry Mass: 113 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 200.1699 kN
+//	ISP: 127 SL / 305 Vac		SL calculated with RPA
+//	Burn Time: 135 s
+//	Chamber Pressure: 1.38 MPa
+//	Propellant: ClF3 / Hydrazine
+//	Prop Ratio: 2.60
 //	Throttle: N/A
 //	Nozzle Ratio: 25
 //	Ignitions: 1
@@ -28,6 +43,12 @@
 
 //	Notes:
 
+//	0.925 ft^3 of helium pressurant at 3000 psi, 1.774 lbs = 0.805 kg Helium
+//	Helium preheated and used to drive hydrazine gas generator, which then pressurizes fuel tanks
+//	153.1 lbs of hydrazine used in gas generator system probably included in overall O/F ratio.
+//	Heated helium used to pressurize oxidizer tanks (unknown mass?).
+//	Assuming same ratio as Juno 6k, 29.144 lbs = 13.219 kg helium for oxidizer tank pressurization
+//	14.024 kg helium overall (for 135 second burn)
 //	==================================================
 
 @PART[*]:HAS[#engineType[Juno45k]]:FOR[RealismOverhaulEngines]
@@ -66,6 +87,63 @@
 		CONFIG
 		{
 			name = Juno45k
+			description = Deprecated
+			specLevel = sciFi	//Just to hide it
+			minThrust = 200.17
+			maxThrust = 200.17
+			heatProduction = 100
+			
+			PROPELLANT
+			{
+				name = Hydrazine
+				ratio = 0.56765
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.43235
+				DrawGauge = False
+			}
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 7.0		//Should be 8.932
+				ignoreForIsp = True
+			}
+
+			%ullage = True
+			%ignitions = 1
+			%pressureFed = True
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
+
+			atmosphereCurve
+			{
+				key = 0 304
+				key = 1 127
+			}
+
+			//no data, never flew
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 180		//Assuming built to same 130% margin as early AJ10
+				ratedBurnTime = 135
+				safeOverburn = true
+				ignitionReliabilityStart = 0.90
+				ignitionReliabilityEnd = 0.98
+				cycleReliabilityStart = 0.84
+				cycleReliabilityEnd = 0.985
+			}
+		}
+		CONFIG
+		{
+			name = Juno45k-BI
+			description = Juno IV Block I second stage.
 			specLevel = concept
 			minThrust = 200.17
 			maxThrust = 200.17
@@ -86,7 +164,7 @@
 			PROPELLANT
 			{
 				name = Helium
-				ratio = 7.0		//Heated helium, assume 3:1 pressure ratio
+				ratio = 8.932
 				ignoreForIsp = True
 			}
 
@@ -103,7 +181,63 @@
 			atmosphereCurve
 			{
 				key = 0 304
-				key = 1 260
+				key = 1 127
+			}
+
+			//no data, never flew
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 180		//Assuming built to same 130% margin as early AJ10
+				ratedBurnTime = 135
+				safeOverburn = true
+				ignitionReliabilityStart = 0.90
+				ignitionReliabilityEnd = 0.98
+				cycleReliabilityStart = 0.84
+				cycleReliabilityEnd = 0.985
+			}
+		}
+		CONFIG
+		{
+			name = Juno45k-BII
+			description = Juno IV Block II second stage, converted to use ClF3 to increase performance.
+			specLevel = concept
+			minThrust = 200.17
+			maxThrust = 200.17
+			heatProduction = 100
+			
+			PROPELLANT
+			{
+				name = Hydrazine
+				ratio = 0.4041
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ClF3
+				ratio = 0.5959
+				DrawGauge = False
+			}
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 8.932
+				ignoreForIsp = True
+			}
+
+			%ullage = True
+			%ignitions = 1
+			%pressureFed = True
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.1
+			}
+
+			atmosphereCurve
+			{
+				key = 0 305
+				key = 1 127
 			}
 
 			//no data, never flew

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -248,9 +248,10 @@
 				ratedBurnTime = 135
 				safeOverburn = true
 				ignitionReliabilityStart = 0.90
-				ignitionReliabilityEnd = 0.98
-				cycleReliabilityStart = 0.84
-				cycleReliabilityEnd = 0.985
+				ignitionReliabilityEnd = 0.988
+				cycleReliabilityStart = 0.89
+				cycleReliabilityEnd = 0.994
+				techTransfer = Juno45k-BI:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -87,8 +87,9 @@
 		CONFIG
 		{
 			name = Juno45k
-			description = Deprecated
-			specLevel = sciFi	//Just to hide it
+			description = Deprecated, do not use this.
+			RODeprecated = true
+			specLevel = concept
 			minThrust = 200.17
 			maxThrust = 200.17
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -38,6 +38,8 @@
 //	Sources:
 
 //	Source: JPL 20-123 Juno IV Rocket Vehicle System: https://archive.org/details/nasa_techdoc_19730064143
+//	https://www.si.edu/media/NASM/NASM-NASM.2020.0031-Interim_Report_to_the_Special_Committee_on_Space_Technology_box1_folder4-000002.pdf
+//	http://libarchstor2.uah.edu/digitalcollections/items/show/11031
 
 //	Used by:
 

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -4,19 +4,34 @@
 //	Manufacturer: JPL
 //
 //	===============================================================
-//	Juno 6K Engine
+//	Juno 6K Engine Block I
 //	Third stage for Juno IV and Atlas-Vega
 //
 //	Dry Mass: 83.9 kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 26.68932 kN
-//	ISP: 258 SL / 300 vac
+//	ISP: 110 SL / 300 vac		SL calculated with RPA
 //	Burn Time: 450 s
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.03 MPa
 //	Propellant: NTO / Hydrazine
 //	Prop Ratio: 1.0
 //	Throttle: N/A
-//	Nozzle Ratio: 4.64
+//	Nozzle Ratio: 20.8
+//	Ignitions: 3
+//	===============================================================
+//	Juno 6K Engine Block II
+//	Growth option, converted to ClF3
+//
+//	Dry Mass: 83.9 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 26.68932 kN
+//	ISP: 110 SL / 302 vac		SL calculated with RPA
+//	Burn Time: 450 s
+//	Chamber Pressure: 1.03 MPa
+//	Propellant: ClF3 / Hydrazine
+//	Prop Ratio: 2.6
+//	Throttle: N/A
+//	Nozzle Ratio: 20.8
 //	Ignitions: 3
 //	=================================================================================
 
@@ -28,6 +43,9 @@
 
 //	Notes:
 
+//	0.7 lbs helium pressurant for gas generator system to pressurize fuel tanks (and 38.3 lbs hydrazine?)
+//	11.5 lbs helium pressurant for oxidizer tank
+//	5.534 kg helium overall (for 450 second burn)
 //	==================================================
 
 @PART[*]:HAS[#engineType[Juno6k]]:FOR[RealismOverhaulEngines]
@@ -66,7 +84,8 @@
 		CONFIG
 		{
 			name = Juno6k
-			specLevel = prototype
+			description = Deprecated
+			specLevel = sciFi	//Just to hide it
 			minThrust = 26.68932
 			maxThrust = 26.68932
 			heatProduction = 100
@@ -74,20 +93,20 @@
 			PROPELLANT
 			{
 				name = Hydrazine
-				ratio = 0.5
+				ratio = 0.5	//should be 0.5909
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5
+				ratio = 0.5	//should be 0.4091
 				DrawGauge = False
 			}
 			
 			PROPELLANT
 			{
 				name = Helium
-				ratio = 7.0		//Heated helium, assume 3:1 pressure ratio
+				ratio = 7.0	//should be 9.0385
 				ignoreForIsp = True
 			}
 			
@@ -104,7 +123,128 @@
 			atmosphereCurve
 			{
 				key = 0 300
-				key = 1 258
+				key = 1 110
+			}
+
+			// no data, never flew
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 585		//Assuming built to same 130% margin as early AJ10
+				ratedBurnTime = 450
+				safeOverburn = true
+				ignitionReliabilityStart = 0.9
+				ignitionReliabilityEnd = 0.98
+				cycleReliabilityStart = 0.78
+				cycleReliabilityEnd = 0.98
+				techTransfer =	AJ10-142,AJ10-42,AJ10-37:20
+			}
+		}
+		CONFIG
+		{
+			name = Juno6k-BI
+			description = Juno IV Block I and Atlas-Vega third stage.
+			specLevel = prototype
+			minThrust = 26.68932
+			maxThrust = 26.68932
+			heatProduction = 100
+			
+			PROPELLANT
+			{
+				name = Hydrazine
+				ratio = 0.5909
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.4091
+				DrawGauge = False
+			}
+			
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 9.0385
+				ignoreForIsp = True
+			}
+			
+			varyIsp = 0.01
+			varyMixture = 0.025
+			varyFlow = 0.015
+			ullage = True
+			ignitions = 3
+			pressureFed = True
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 300
+				key = 1 110
+			}
+
+			// no data, never flew
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 585		//Assuming built to same 130% margin as early AJ10
+				ratedBurnTime = 450
+				safeOverburn = true
+				ignitionReliabilityStart = 0.9
+				ignitionReliabilityEnd = 0.98
+				cycleReliabilityStart = 0.78
+				cycleReliabilityEnd = 0.98
+				techTransfer =	AJ10-142,AJ10-42,AJ10-37:20
+			}
+		}
+		CONFIG
+		{
+			name = Juno6k-BII
+			description = Juno IV Block II second stage, converted to use ClF3 to increase performance.
+			specLevel = concept
+			minThrust = 26.68932
+			maxThrust = 26.68932
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Hydrazine
+				ratio = 0.4041
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = ClF3
+				ratio = 0.5959
+				DrawGauge = False
+			}
+			
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 9.0385
+				ignoreForIsp = True
+			}
+			
+			varyIsp = 0.01
+			varyMixture = 0.025
+			varyFlow = 0.015
+			ullage = True
+			ignitions = 3
+			pressureFed = True
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.2
+			}
+			
+			atmosphereCurve
+			{
+				key = 0 302
+				key = 1 110
 			}
 
 			// no data, never flew

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -84,8 +84,9 @@
 		CONFIG
 		{
 			name = Juno6k
-			description = Deprecated
-			specLevel = sciFi	//Just to hide it
+			description = Deprecated, do not use this.
+			RODeprecated = true
+			specLevel = prototype
 			minThrust = 26.68932
 			maxThrust = 26.68932
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -249,16 +249,17 @@
 			}
 
 			// no data, never flew
+			// Using AJ10-118D data
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 585		//Assuming built to same 130% margin as early AJ10
 				ratedBurnTime = 450
 				safeOverburn = true
-				ignitionReliabilityStart = 0.9
-				ignitionReliabilityEnd = 0.98
-				cycleReliabilityStart = 0.78
-				cycleReliabilityEnd = 0.98
-				techTransfer =	AJ10-142,AJ10-42,AJ10-37:20
+				ignitionReliabilityStart = 0.920833
+				ignitionReliabilityEnd = 0.987500
+				cycleReliabilityStart = 0.964815
+				cycleReliabilityEnd = 0.994444
+				techTransfer =	Juno6k-BI:50&AJ10-142,AJ10-42,AJ10-37:20
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -37,7 +37,7 @@
 //	=================================================================================
 //	S-3DH
 //	Converted to run on UDMH for Juno IV
-//	Lower performance than orignal Hydrazine proposal, but much easier to build due to the properties of UDMH being much closer to Hydrazine
+//	Lower performance than orignal Hydrazine proposal, but much easier to build due to the properties of UDMH being much closer to Kerosene
 //
 //	Dry Mass: 945.3 kg (Source #4)
 //	Thrust (SL): 667.233 kN
@@ -46,7 +46,7 @@
 //	Burn Time: 182 (burn time for Jupiter)
 //	Chamber Pressure: 3.61 MPa
 //	Propellant: LOX / UDMH
-//	Ratio: 1.5
+//	Ratio: 1.5		Roughly same fuel and oxidizer load as normal Jupiter
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -326,17 +326,18 @@
 				key = 1 266.1
 			}
 
-			//Assuming same as S-3D
+			//Using LR79-NA-11 data, assuming improvements from Thor would be applied to Jupiter if Juno
+			//program was continued
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 350
 				ratedBurnTime = 182
 				safeOverburn = true
-				ignitionReliabilityStart = 0.806481
-				ignitionReliabilityEnd = 0.969444
-				cycleReliabilityStart = 0.806481
-				cycleReliabilityEnd = 0.969444
-				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&S-3D,S-3,XLR43-NA-3:50
+				ignitionReliabilityStart = 0.911562
+				ignitionReliabilityEnd = 0.986036
+				cycleReliabilityStart = 0.911562
+				cycleReliabilityEnd = 0.986036
+				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR79-NA-11,LR79-NA-9,S-3D,S-3,XLR43-NA-3:50
 			}
 		}
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -35,6 +35,22 @@
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	=================================================================================
+//	S-3DH
+//	Converted to run on UDMH for Juno IV
+//	Lower performance than orignal Hydrazine proposal, but much easier to build due to the properties of UDMH being much closer to Hydrazine
+//
+//	Dry Mass: 945.3 kg (Source #4)
+//	Thrust (SL): 667.233 kN
+//	Thrust (vac): 766.345 kN	same overall vehicle weight, same thrust
+//	ISP: 266.1 SL / 308.7 vac		Calculated with RPA, using estimate with straight hydrazine as correction factor
+//	Burn Time: 182 (burn time for Jupiter)
+//	Chamber Pressure: 3.61 MPa
+//	Propellant: LOX / UDMH
+//	Ratio: 1.5
+//	Throttle: N/A
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//	=================================================================================
 //	LR79-NA-9
 //	Thor MB-3 Block I
 //	Data from Source #5
@@ -262,6 +278,65 @@
 				cycleReliabilityStart = 0.806481
 				cycleReliabilityEnd = 0.969444
 				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&S-3,XLR43-NA-3:50
+			}
+		}
+
+		CONFIG
+		{
+			name = S-3DH
+			description = Main engine proposal for the Juno IV launch vehicle.
+			specLevel = concept
+			minThrust = 766.34
+			maxThrust = 766.34
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.5098
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4902
+			}
+
+			atmosphereCurve
+			{
+				key = 0 308.7
+				key = 1 266.1
+			}
+
+			//Assuming same as S-3D
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350
+				ratedBurnTime = 182
+				safeOverburn = true
+				ignitionReliabilityStart = 0.806481
+				ignitionReliabilityEnd = 0.969444
+				cycleReliabilityStart = 0.806481
+				cycleReliabilityEnd = 0.969444
+				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&S-3D,S-3,XLR43-NA-3:50
 			}
 		}
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -81,7 +81,7 @@
 //	Dry Mass: ???
 //	Thrust (SL): 165,453 lbf = 735.9713437 kN
 //	Thrust (Vac): 190,998 lbf = 849.6011236 kN
-//	ISP: 266.1 SL / 308.7 vac		Calculated with RPA, using estimate with straight hydrazine as correction factor
+//	ISP: 266.1 SL / 305.5 vac		Calculated with RPA, using estimate with straight hydrazine as correction factor
 //	Burn Time: 182 (burn time for Jupiter)
 //	Chamber Pressure: 3.69 MPa
 //	Propellant: LOX / UDMH
@@ -485,7 +485,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 308.7
+				key = 0 305.5
 				key = 1 266.1
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -35,22 +35,6 @@
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	=================================================================================
-//	S-3DH
-//	Converted to run on UDMH for Juno IV
-//	Lower performance than orignal Hydrazine proposal, but much easier to build due to the properties of UDMH being much closer to Kerosene
-//
-//	Dry Mass: 945.3 kg (Source #4)
-//	Thrust (SL): 667.233 kN
-//	Thrust (vac): 766.345 kN	same overall vehicle weight, same thrust
-//	ISP: 266.1 SL / 308.7 vac		Calculated with RPA, using estimate with straight hydrazine as correction factor
-//	Burn Time: 182 (burn time for Jupiter)
-//	Chamber Pressure: 3.61 MPa
-//	Propellant: LOX / UDMH
-//	Ratio: 1.5		Roughly same fuel and oxidizer load as normal Jupiter
-//	Throttle: N/A
-//	Nozzle Ratio: 8
-//	Ignitions: 1
-//	=================================================================================
 //	LR79-NA-9
 //	Thor MB-3 Block I
 //	Data from Source #5
@@ -84,6 +68,25 @@
 //	Throttle: N/A
 //	Engine Nozzle: 1.16 m diameter
 //	Nozzle Exit Area: 1640 in^2 = 41.656 m^2
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//	=================================================================================
+//	S-3FH
+//	Converted to run on UDMH for Juno IV
+//	Juno IV called for 165klbf engine ready by 1961. LR79-NA-11 fits this description, so use it as basis.
+//	If LR79-NA-9 is S-3E, LR79-NA-11 is S-3F?
+//	Lower performance than orignal Hydrazine proposal, but much easier to build due to the properties of 
+//	UDMH being much closer to Kerosene.
+//
+//	Dry Mass: ???
+//	Thrust (SL): 165,453 lbf = 735.9713437 kN
+//	Thrust (Vac): 190,998 lbf = 849.6011236 kN
+//	ISP: 266.1 SL / 308.7 vac		Calculated with RPA, using estimate with straight hydrazine as correction factor
+//	Burn Time: 182 (burn time for Jupiter)
+//	Chamber Pressure: 3.69 MPa
+//	Propellant: LOX / UDMH
+//	Ratio: 1.5		Roughly same fuel and oxidizer load as normal Jupiter
+//	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	=================================================================================
@@ -283,66 +286,6 @@
 
 		CONFIG
 		{
-			name = S-3DH
-			description = Main engine proposal for the Juno IV launch vehicle.
-			specLevel = concept
-			minThrust = 766.34
-			maxThrust = 766.34
-			heatProduction = 100
-			massMult = 1.0
-
-			ullage = True
-			pressureFed = False
-			ignitions = 0
-
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 1
-			}
-
-			PROPELLANT
-			{
-				name = UDMH
-				ratio = 0.5098
-				DrawGauge = True
-			}
-
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.4902
-			}
-
-			atmosphereCurve
-			{
-				key = 0 308.7
-				key = 1 266.1
-			}
-
-			//Using LR79-NA-11 data, assuming improvements from Thor would be applied to Jupiter if Juno
-			//program was continued
-			TESTFLIGHT:NEEDS[TestLite|TestFlight]
-			{
-				testedBurnTime = 350
-				ratedBurnTime = 182
-				safeOverburn = true
-				ignitionReliabilityStart = 0.911562
-				ignitionReliabilityEnd = 0.986036
-				cycleReliabilityStart = 0.911562
-				cycleReliabilityEnd = 0.986036
-				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR79-NA-11,LR79-NA-9,S-3D,S-3,XLR43-NA-3:50
-			}
-		}
-
-		CONFIG
-		{
 			name = LR79-NA-9
 			description = Main engine for MB-3-I propulsion system
 			specLevel = operational
@@ -496,6 +439,68 @@
 				cycleReliabilityStart = 0.911562
 				cycleReliabilityEnd = 0.986036
 				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR79-NA-9,S-3D,S-3,XLR43-NA-3:50
+			}
+		}
+
+		CONFIG
+		{
+			name = S-3FH
+			description = Main engine proposal for the Juno IV launch vehicle.
+			specLevel = concept
+			minThrust = 850
+			maxThrust = 850
+			heatProduction = 100
+			// Linear steps from S-3 to LR79-NA-9 to LR79-NA-11 to LR79-NA-13
+			// Only known two masses are S-3 and LR79-NA-13
+			massMult = 0.977
+
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.5098
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4902
+			}
+
+			atmosphereCurve
+			{
+				key = 0 308.7
+				key = 1 266.1
+			}
+
+			//Using LR79-NA-11 data, assuming improvements from Thor would be applied to Jupiter if Juno
+			//program was continued
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350
+				ratedBurnTime = 182
+				safeOverburn = true
+				ignitionReliabilityStart = 0.911562
+				ignitionReliabilityEnd = 0.986036
+				cycleReliabilityStart = 0.911562
+				cycleReliabilityEnd = 0.986036
+				techTransfer = A-7,A-6H,A-6,XLR43-NA-1:20&LR79-NA-11,LR79-NA-9,S-3D,S-3,XLR43-NA-3:50
 			}
 		}
 


### PR DESCRIPTION
Deprecate old Juno 6k and 45k configs and create new, more accurate ones. Also add configs for Juno IV growth options, including ClF3 upper stages and UDMH/LOX S-3D.

Needs https://github.com/KSP-RO/RealismOverhaul/pull/2838