### PR TITLE
BDB Able configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
@@ -49,8 +49,8 @@
 	@manufacturer = Aerojet
 	@description = Lightweight 1m fuel tank for the Thor-Able upper stage.
 	@mass = 0.25
-	@maxTemp = 900
-	@skinMaxTemp = 2000
+	maxTemp = 773.15
+	skinMaxTemp = 873.15
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]] {}
 	!RESOURCE,* {}
 	MODULE
@@ -112,8 +112,8 @@
 	@manufacturer = Aerojet
 	@description = Stretched version of the Able upper stage tank. Used on Delta B, C and C1.
 	@mass = 0.38
-	@maxTemp = 900
-	@skinMaxTemp = 2000
+	maxTemp = 773.15
+	skinMaxTemp = 873.15
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]] {}
 	!MODULE[ModuleSAS] {}
 	!RESOURCE,* {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
@@ -51,7 +51,7 @@
 	@mass = 0.25
 	@maxTemp = 900
 	@skinMaxTemp = 2000
-	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]]{}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]] {}
 	!RESOURCE,* {}
 	MODULE
 	{
@@ -114,7 +114,7 @@
 	@mass = 0.38
 	@maxTemp = 900
 	@skinMaxTemp = 2000
-	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]]{}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]] {}
 	!MODULE[ModuleSAS] {}
 	!RESOURCE,* {}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
@@ -1,0 +1,179 @@
+//	================================================================================
+//	Able Configs
+//	================================================================================
+
+
+// Thor Able Avionics
+@PART[bluedog_ThorAble_Guidance]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	@title = Thor Able Guidance Unit
+	@manufacturer = Aerojet
+	@description = Guidance core for the Thor Able upper stage as used on Thor Able and early Delta rockets. Goes on top of the Able second stage tank.
+	@mass = 0.11
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.05
+		}
+	}
+	@MODULE[ModuleSAS]
+	{
+		%SASServiceLevel = 1
+	}
+	!MODULE[ModuleFuelTanks] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1
+		basemass = -1
+		type = ServiceModule
+		TANK
+		{
+			name = ElectricCharge
+			amount = 2000
+			maxAmount = 2000
+		}
+	}
+}
+
+
+// Thor Able
+@PART[bluedog_ThorAble_Tank]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	@title = Able Tank (Delta A)
+	@manufacturer = Aerojet
+	@description = Lightweight 1m fuel tank for the Thor-Able upper stage.
+	@mass = 0.25
+	@maxTemp = 900
+	@skinMaxTemp = 2000
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]]{}
+	!RESOURCE,* {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 1320
+		basemass = -1
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 2500
+		maxAmount = 2500
+	}
+	@MODULE[ModuleRCSFX],0
+    {
+        @thrusterPower = 0.05
+        !resourceName = DELETE
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 1.0
+        }
+		@atmosphereCurve
+        {
+            @key,0 = 0 167
+            @key,1 = 1 57
+            !key,4 = DELETE
+        }
+    }
+	@MODULE[ModuleRCSFX],1
+    {
+        @thrusterPower = 0.05
+        !resourceName = DELETE
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 1.0
+        }
+		@atmosphereCurve
+        {
+            @key,0 = 0 167
+            @key,1 = 1 57
+            !key,4 = DELETE
+        }
+    }
+}
+
+
+// Delta B
+@PART[bluedog_DeltaB_Tank]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	@title = Able Tank (Delta-B)
+	@manufacturer = Aerojet
+	@description = Stretched version of the Able upper stage tank. Used on Delta B, C and C1.
+	@mass = 0.38
+	@maxTemp = 900
+	@skinMaxTemp = 2000
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]]{}
+	!MODULE[ModuleSAS] {}
+	!RESOURCE,* {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 1865
+		basemass = -1
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 5000
+		maxAmount = 5000
+	}
+	@MODULE[ModuleRCSFX],0
+    {
+        @thrusterPower = 0.05
+        !resourceName = DELETE
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 1.0
+        }
+		@atmosphereCurve
+        {
+            @key,0 = 0 167
+            @key,1 = 1 57
+            !key,4 = DELETE
+        }
+    }
+	@MODULE[ModuleRCSFX],1
+    {
+        @thrusterPower = 0.05
+        !resourceName = DELETE
+        @resourceFlowMode = STACK_PRIORITY_SEARCH
+        PROPELLANT
+        {
+            name = Nitrogen
+            ratio = 1.0
+        }
+		@atmosphereCurve
+        {
+            @key,0 = 0 167
+            @key,1 = 1 57
+            !key,4 = DELETE
+        }
+    }
+}
+
+
+// Interstage
+@PART[bluedog_ThorDelta_Interstage]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	@title = Thor Able/Delta Interstage
+	@manufacturer = Aerojet
+	@description = A 1.5m to 1m interstage adapter/decoupler for the Thor and Delta rockets. Note that it decouples from the bottom, leaving a small section of the top part of the shroud attached to protect the engine.
+	@mass = 0.03
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
@@ -1,7 +1,7 @@
 //	================================================================================
 //	Able Configs
 //	================================================================================
- source: https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=11323.0;attach=276498;sess=0
+//	source: https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=11323.0;attach=276498;sess=0
 
 // Thor Able Avionics
 @PART[bluedog_ThorAble_Guidance]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
@@ -67,39 +67,39 @@
 		maxAmount = 2500
 	}
 	@MODULE[ModuleRCSFX],0
-    {
-        @thrusterPower = 0.05
-        !resourceName = DELETE
-        @resourceFlowMode = STACK_PRIORITY_SEARCH
-        PROPELLANT
-        {
-            name = Nitrogen
-            ratio = 1.0
-        }
+	{
+		@thrusterPower = 0.05
+		!resourceName = DELETE
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		PROPELLANT
+		{
+			name = Nitrogen
+			ratio = 1.0
+		}
 		@atmosphereCurve
-        {
-            @key,0 = 0 167
-            @key,1 = 1 57
-            !key,4 = DELETE
-        }
-    }
+		{
+			@key,0 = 0 167
+			@key,1 = 1 57
+			!key,4 = DELETE
+		}
+	}
 	@MODULE[ModuleRCSFX],1
-    {
-        @thrusterPower = 0.05
-        !resourceName = DELETE
-        @resourceFlowMode = STACK_PRIORITY_SEARCH
-        PROPELLANT
-        {
-            name = Nitrogen
-            ratio = 1.0
-        }
+	{
+		@thrusterPower = 0.05
+		!resourceName = DELETE
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		PROPELLANT
+		{
+			name = Nitrogen
+			ratio = 1.0
+		}
 		@atmosphereCurve
-        {
-            @key,0 = 0 167
-            @key,1 = 1 57
-            !key,4 = DELETE
-        }
-    }
+		{
+			@key,0 = 0 167
+			@key,1 = 1 57
+			!key,4 = DELETE
+		}
+	}
 }
 
 
@@ -131,39 +131,39 @@
 		maxAmount = 5000
 	}
 	@MODULE[ModuleRCSFX],0
-    {
-        @thrusterPower = 0.05
-        !resourceName = DELETE
-        @resourceFlowMode = STACK_PRIORITY_SEARCH
-        PROPELLANT
-        {
-            name = Nitrogen
-            ratio = 1.0
-        }
+	{
+		@thrusterPower = 0.05
+		!resourceName = DELETE
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		PROPELLANT
+		{
+			name = Nitrogen
+			ratio = 1.0
+		}
 		@atmosphereCurve
-        {
-            @key,0 = 0 167
-            @key,1 = 1 57
-            !key,4 = DELETE
-        }
-    }
+		{
+			@key,0 = 0 167
+			@key,1 = 1 57
+			!key,4 = DELETE
+		}
+	}
 	@MODULE[ModuleRCSFX],1
-    {
-        @thrusterPower = 0.05
-        !resourceName = DELETE
-        @resourceFlowMode = STACK_PRIORITY_SEARCH
-        PROPELLANT
-        {
-            name = Nitrogen
-            ratio = 1.0
-        }
+	{
+		@thrusterPower = 0.05
+		!resourceName = DELETE
+		@resourceFlowMode = STACK_PRIORITY_SEARCH
+		PROPELLANT
+		{
+			name = Nitrogen
+			ratio = 1.0
+		}
 		@atmosphereCurve
-        {
-            @key,0 = 0 167
-            @key,1 = 1 57
-            !key,4 = DELETE
-        }
-    }
+		{
+			@key,0 = 0 167
+			@key,1 = 1 57
+			!key,4 = DELETE
+		}
+	}
 }
 
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able.cfg
@@ -1,7 +1,7 @@
 //	================================================================================
 //	Able Configs
 //	================================================================================
-
+ source: https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=11323.0;attach=276498;sess=0
 
 // Thor Able Avionics
 @PART[bluedog_ThorAble_Guidance]:FOR[RealismOverhaul]
@@ -9,14 +9,18 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	@title = Thor Able Guidance Unit
-	@manufacturer = Aerojet
+	@manufacturer = #roMfrAerojet
 	@description = Guidance core for the Thor Able upper stage as used on Thor Able and early Delta rockets. Goes on top of the Able second stage tank.
-	@mass = 0.11
+
+	@mass = 0.16
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
+
 	@MODULE[ModuleCommand]
 	{
 		@RESOURCE[ElectricCharge]
 		{
-			@rate = 0.05
+			@rate = 0.10
 		}
 	}
 	@MODULE[ModuleSAS]
@@ -33,8 +37,8 @@
 		TANK
 		{
 			name = ElectricCharge
-			amount = 2000
-			maxAmount = 2000
+			amount = 1000
+			maxAmount = 1000
 		}
 	}
 }
@@ -46,57 +50,72 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	@title = Able Tank (Delta A)
-	@manufacturer = Aerojet
+	@manufacturer = #roMfrAerojet
 	@description = Lightweight 1m fuel tank for the Thor-Able upper stage.
-	@mass = 0.25
-	maxTemp = 773.15
-	skinMaxTemp = 873.15
+	
+	@mass = 0.188		//stage dry mass ~605 kg
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+	
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]] {}
 	!RESOURCE,* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
-		type = ServiceModule
-		volume = 1320
-		basemass = -1
-	}
-	RESOURCE
-	{
-		name = Nitrogen
-		amount = 2500
-		maxAmount = 2500
+		type = Tank-Sep-Al2-HP
+		volume = 1382.475
+		basemass = 0.188
+		
+		TANK
+		{
+			name = UDMH
+			amount = 501.1
+			maxAmount = 501.1
+		}
+		TANK
+		{
+			name = IWFNA
+			amount = 732.3
+			maxAmount = 732.3
+		}
+		TANK
+		{
+			name = Helium
+			amount = 29815
+			maxAmount = 29815
+		}
 	}
 	@MODULE[ModuleRCSFX],0
 	{
-		@thrusterPower = 0.05
+		@thrusterPower = 0.01
 		!resourceName = DELETE
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		PROPELLANT
 		{
-			name = Nitrogen
+			name = Helium
 			ratio = 1.0
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 167
-			@key,1 = 1 57
+			@key,0 = 0 134
+			@key,1 = 1 54
 			!key,4 = DELETE
 		}
 	}
 	@MODULE[ModuleRCSFX],1
 	{
-		@thrusterPower = 0.05
+		@thrusterPower = 0.01
 		!resourceName = DELETE
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		PROPELLANT
 		{
-			name = Nitrogen
+			name = Helium
 			ratio = 1.0
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 167
-			@key,1 = 1 57
+			@key,0 = 0 134
+			@key,1 = 1 54
 			!key,4 = DELETE
 		}
 	}
@@ -109,58 +128,73 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	@title = Able Tank (Delta-B)
-	@manufacturer = Aerojet
+	@manufacturer = #roMfrAerojet
 	@description = Stretched version of the Able upper stage tank. Used on Delta B, C and C1.
-	@mass = 0.38
-	maxTemp = 773.15
-	skinMaxTemp = 873.15
+	
+	@mass = 0.188	//same as Delta? Just let tanks add extra mass
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+	
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[volumeSwitch]] {}
 	!MODULE[ModuleSAS] {}
 	!RESOURCE,* {}
 	MODULE
 	{
 		name = ModuleFuelTanks
-		type = ServiceModule
-		volume = 1865
-		basemass = -1
-	}
-	RESOURCE
-	{
-		name = Nitrogen
-		amount = 5000
-		maxAmount = 5000
+		type = Tank-Sep-Al2-HP
+		volume = 1767.655
+		basemass = 0.188
+		
+		TANK
+		{
+			name = UDMH
+			amount = 652.5
+			maxAmount = 652.5
+		}
+		TANK
+		{
+			name = IRFNA-III
+			amount = 924.0
+			maxAmount = 924.0
+		}
+		TANK
+		{
+			name = Helium
+			amount = 38231
+			maxAmount = 38231
+		}
 	}
 	@MODULE[ModuleRCSFX],0
 	{
-		@thrusterPower = 0.05
+		@thrusterPower = 0.01
 		!resourceName = DELETE
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		PROPELLANT
 		{
-			name = Nitrogen
+			name = Helium
 			ratio = 1.0
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 167
-			@key,1 = 1 57
+			@key,0 = 0 134
+			@key,1 = 1 54
 			!key,4 = DELETE
 		}
 	}
 	@MODULE[ModuleRCSFX],1
 	{
-		@thrusterPower = 0.05
+		@thrusterPower = 0.01
 		!resourceName = DELETE
 		@resourceFlowMode = STACK_PRIORITY_SEARCH
 		PROPELLANT
 		{
-			name = Nitrogen
+			name = Helium
 			ratio = 1.0
 		}
 		@atmosphereCurve
 		{
-			@key,0 = 0 167
-			@key,1 = 1 57
+			@key,0 = 0 134
+			@key,1 = 1 54
 			!key,4 = DELETE
 		}
 	}
@@ -173,7 +207,10 @@
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
 	@title = Thor Able/Delta Interstage
-	@manufacturer = Aerojet
+	@manufacturer = #roMfrAerojet
 	@description = A 1.5m to 1m interstage adapter/decoupler for the Thor and Delta rockets. Note that it decouples from the bottom, leaving a small section of the top part of the shroud attached to protect the engine.
-	@mass = 0.03
+	
+	@mass = 0.08
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
@@ -14,7 +14,6 @@
 @PART[bluedog_Able_Engine]:AFTER[RealismOverhaulEngines]
 {
 	@title = AJ10-37
-	@manufacturer = Aerojet
 	@description = Early version of the venerable AJ10 pressure fed upper stage engine using storable propellants. Used on the Able upper stage with the Vanguard and Thor-Able rockets. An upgrade is available for the AJ10-118D as used on Delta B,C,C1 and D.
 }
 
@@ -30,6 +29,5 @@
 @PART[bluedog_Ablestar_Engine]:AFTER[RealismOverhaulEngines]
 {
 	@title = AJ10-104
-	@manufacturer = Aerojet
 	@description = An uprated version of the Able AJ10 engine for the Thor-Ablestar. Would later be upgraded to the AJ10-118E for use on Thrust Augmented Improved Delta.
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
@@ -8,9 +8,6 @@
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
-	@title = AJ10-37
-	@manufacturer = Aerojet
-	@description = Early version of the venerable AJ10 pressure fed upper stage engine using storable propellants. Used on the Able upper stage with the Vanguard and Thor-Able rockets. An upgrade is available for the AJ10-118D as used on Delta B,C,C1 and D.
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
 	%engineType = AJ10_Early
 }
@@ -27,9 +24,6 @@
 {
 	%RSSROConfig = True
 	%rescaleFactor = 1.6
-	@title = AJ10-104
-	@manufacturer = Aerojet
-	@description = An uprated version of the Able AJ10 engine for the Thor-Ablestar. Would later be upgraded to the AJ10-118E for use on Thrust Augmented Improved Delta.
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
 	%engineType = AJ10_Mid
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
@@ -11,7 +11,7 @@
 	@title = AJ10-37
 	@manufacturer = Aerojet
 	@description = Early version of the venerable AJ10 pressure fed upper stage engine using storable propellants. Used on the Able upper stage with the Vanguard and Thor-Able rockets. An upgrade is available for the AJ10-118D as used on Delta B,C,C1 and D.
-	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]{}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
 	%engineType = AJ10_Early
 }
 @PART[bluedog_Able_Engine]:AFTER[RealismOverhaulEngines]
@@ -30,7 +30,7 @@
 	@title = AJ10-104
 	@manufacturer = Aerojet
 	@description = An uprated version of the Able AJ10 engine for the Thor-Ablestar. Would later be upgraded to the AJ10-118E for use on Thrust Augmented Improved Delta.
-	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]{}
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
 	%engineType = AJ10_Mid
 }
 @PART[bluedog_Ablestar_Engine]:AFTER[RealismOverhaulEngines]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
@@ -1,0 +1,41 @@
+//	================================================================================
+//	Able Configs
+//	================================================================================
+
+
+// AJ10-37
+@PART[bluedog_Able_Engine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	@title = AJ10-37
+	@manufacturer = Aerojet
+	@description = Early version of the venerable AJ10 pressure fed upper stage engine using storable propellants. Used on the Able upper stage with the Vanguard and Thor-Able rockets. An upgrade is available for the AJ10-118D as used on Delta B,C,C1 and D.
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]{}
+	%engineType = AJ10_Early
+}
+@PART[bluedog_Able_Engine]:AFTER[RealismOverhaulEngines]
+{
+	@title = AJ10-37
+	@manufacturer = Aerojet
+	@description = Early version of the venerable AJ10 pressure fed upper stage engine using storable propellants. Used on the Able upper stage with the Vanguard and Thor-Able rockets. An upgrade is available for the AJ10-118D as used on Delta B,C,C1 and D.
+}
+
+
+// AJ10-104
+@PART[bluedog_Ablestar_Engine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%rescaleFactor = 1.6
+	@title = AJ10-104
+	@manufacturer = Aerojet
+	@description = An uprated version of the Able AJ10 engine for the Thor-Ablestar. Would later be upgraded to the AJ10-118E for use on Thrust Augmented Improved Delta.
+	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]]{}
+	%engineType = AJ10_Mid
+}
+@PART[bluedog_Ablestar_Engine]:AFTER[RealismOverhaulEngines]
+{
+	@title = AJ10-104
+	@manufacturer = Aerojet
+	@description = An uprated version of the Able AJ10 engine for the Thor-Ablestar. Would later be upgraded to the AJ10-118E for use on Thrust Augmented Improved Delta.
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Able_Engines.cfg
@@ -2,7 +2,6 @@
 //	Able Configs
 //	================================================================================
 
-
 // AJ10-37
 @PART[bluedog_Able_Engine]:FOR[RealismOverhaul]
 {
@@ -11,12 +10,6 @@
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
 	%engineType = AJ10_Early
 }
-@PART[bluedog_Able_Engine]:AFTER[RealismOverhaulEngines]
-{
-	@title = AJ10-37
-	@description = Early version of the venerable AJ10 pressure fed upper stage engine using storable propellants. Used on the Able upper stage with the Vanguard and Thor-Able rockets. An upgrade is available for the AJ10-118D as used on Delta B,C,C1 and D.
-}
-
 
 // AJ10-104
 @PART[bluedog_Ablestar_Engine]:FOR[RealismOverhaul]
@@ -25,9 +18,4 @@
 	%rescaleFactor = 1.6
 	!MODULE[ModuleB9PartSwitch]:HAS[#moduleID[engineSwitch]] {}
 	%engineType = AJ10_Mid
-}
-@PART[bluedog_Ablestar_Engine]:AFTER[RealismOverhaulEngines]
-{
-	@title = AJ10-104
-	@description = An uprated version of the Able AJ10 engine for the Thor-Ablestar. Would later be upgraded to the AJ10-118E for use on Thrust Augmented Improved Delta.
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Waterfall_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Waterfall_Able.cfg
@@ -6,57 +6,56 @@
 // AJ10-37
 @PART[bluedog_Able_Engine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-    ROWaterfall
-    {
-        template = waterfall-hypergolic-white-upper-1
-        audio = pressure-fed-1
-        position = 0,0,0
-        rotation = 0, 0, 0
-        scale = 0.37, 0.37, 0.37
-    	ExtraTemplate
+	ROWaterfall
+	{
+		template = waterfall-hypergolic-white-upper-1
+		audio = pressure-fed-1
+		position = 0,0,0
+		rotation = 0, 0, 0
+		scale = 0.37, 0.37, 0.37
+		ExtraTemplate
 		{
 			template = rowaterfall-glow-hypergolic-white
-            position = 0,0,0
-            rotation = 0, 0, 0
-            scale = 0.41, 0.41, 0.7
+			position = 0,0,0
+			rotation = 0, 0, 0
+			scale = 0.41, 0.41, 0.7
 		}
-        MainPlumeVariant:NEEDS[B9PartSwitch]
-        {
-            name = udmh-irfna
-            template = waterfall-hypergolic-IRFNA-UDMH-upper-1
-            position = 0,0,0
-            rotation = 0, 0, 0
-            scale = 0.37, 0.37, 0.37
-            glowRecolor = _orange
-        }
-    }
-
-    @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
-    {
-        @CONFIG[AJ10-118D]
-        {
-            %rowaterfallVariant = udmh-irfna
-        }
-    }
+		MainPlumeVariant:NEEDS[B9PartSwitch]
+		{
+			name = udmh-irfna
+			template = waterfall-hypergolic-IRFNA-UDMH-upper-1
+			position = 0,0,0
+			rotation = 0, 0, 0
+			scale = 0.37, 0.37, 0.37
+			glowRecolor = _orange
+		}
+	}
+	@MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
+	{
+		@CONFIG[AJ10-118D]
+		{
+			%rowaterfallVariant = udmh-irfna
+		}
+	}
 }
 
 
 // AJ10-104
 @PART[bluedog_Ablestar_Engine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
-    ROWaterfall
-    {
-        template = waterfall-hypergolic-IRFNA-UDMH-upper-1
-        audio = pressure-fed-1
-        position = 0,0,0
-        rotation = 0, 0, 0
-        scale = 0.5, 0.5, 0.5
-    	ExtraTemplate
+	ROWaterfall
+	{
+		template = waterfall-hypergolic-IRFNA-UDMH-upper-1
+		audio = pressure-fed-1
+		position = 0,0,0
+		rotation = 0, 0, 0
+		scale = 0.5, 0.5, 0.5
+		ExtraTemplate
 		{
 			template = waterfall-nozzle-glow-orange-1
-            position = 0,0,0
-            rotation = 0, 0, 0
-            scale = 0.54, 0.54, 0.54
+			position = 0,0,0
+			rotation = 0, 0, 0
+			scale = 0.54, 0.54, 0.54
 		}
-    }
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Waterfall_Able.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Bluedog_DB/Able/RO_Waterfall_Able.cfg
@@ -1,0 +1,62 @@
+//	================================================================================
+//	RO Waterfall Configs
+//	================================================================================
+
+
+// AJ10-37
+@PART[bluedog_Able_Engine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-white-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.37, 0.37, 0.37
+    	ExtraTemplate
+		{
+			template = rowaterfall-glow-hypergolic-white
+            position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 0.41, 0.41, 0.7
+		}
+        MainPlumeVariant:NEEDS[B9PartSwitch]
+        {
+            name = udmh-irfna
+            template = waterfall-hypergolic-IRFNA-UDMH-upper-1
+            position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 0.37, 0.37, 0.37
+            glowRecolor = _orange
+        }
+    }
+
+    @MODULE[ModuleEngineConfigs]:NEEDS[B9PartSwitch]
+    {
+        @CONFIG[AJ10-118D]
+        {
+            %rowaterfallVariant = udmh-irfna
+        }
+    }
+}
+
+
+// AJ10-104
+@PART[bluedog_Ablestar_Engine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-IRFNA-UDMH-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.5, 0.5, 0.5
+    	ExtraTemplate
+		{
+			template = waterfall-nozzle-glow-orange-1
+            position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 0.54, 0.54, 0.54
+		}
+    }
+}


### PR DESCRIPTION
Includes Configs for the BDB Able Folder of Parts

If you wish to use the engines, then remove the PatchManager folder from ROEngines to allow the engines to appear.