### PR TITLE
Revise Viking and Vikas

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
@@ -1,99 +1,173 @@
-//  ==================================================
-//  Vikas series global engine configuration.
+//	==================================================
+//	Vikas Series Engine
+//
+//	Manufacturer: Godrej & Boyce (G&B)
+//
+//	=================================================================================
+//	Vikas 1
+//	GSLV Mk1
+//
+//	Dry Mass: 876? Kg	same as Viking 5?
+//	Thrust (SL): 600.5 kN
+//	Thrust (Vac): 680.5 kN	[1]
+//	ISP: 247.9 SL / 280.9 Vac	[1]
+//	Burn Time: 154
+//	Chamber Pressure: 5.44 MPa	Based on RPA, same as Viking 5?
+//	Propellant: NTO / UDMH	[1]
+//	Prop Ratio: 1.86	[1]
+//	Throttle: N/A
+//	Nozzle Ratio: 10.46	Based on RPA, same as Viking 5?
+//	Ignitions: 1
+//	=================================================================================
+//	Vikas 1+
+//	GSLV Mk2
+//
+//	Dry Mass: 876? Kg
+//	Thrust (SL): 677.7 kN
+//	Thrust (Vac): 765.5 kN	[1]
+//	ISP: 254.9 SL / 289.7 Vac	[1]
+//	Burn Time: 154
+//	Chamber Pressure: 5.44 MPa	Based on RPA, same as Viking 5?
+//	Propellant: NTO / UDMH	[1] states UH25, but considering O/F ratio, probably still UDMH. [A] also stated ISRO was still using UDMH circa 2006.
+//	Prop Ratio: 1.87	[1]
+//	Throttle: N/A
+//	Nozzle Ratio: 10.46	Based on RPA, same as Viking 5?
+//	Ignitions: 1
+//	=================================================================================
+//	Vikas X
+//	GLSV Mk3/LVM3
+//
+//	Dry Mass: 876? Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 821.0 kN	[1]
+//	ISP: 250 SL / 292.9 Vac	//[1], using RPA to calculate for SL. Values in [1] for SL refer to altitude performance?
+//	Burn Time: 203	[4]
+//	Chamber Pressure: 6.2 MPa	[4]
+//	Propellant: NTO / UH25	[1]
+//	Prop Ratio: 1.71?	same as Viking 5C?
+//	Throttle: N/A
+//	Nozzle Ratio: 15?	guess, designed for airstart
+//	Ignitions: 1
+//	=================================================================================
+//	Vikas 2
+//	PSLV, GSLV Mk1
+//
+//	Dry Mass: 905? Kg	same as Viking 4?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 725.0 kN	[1]
+//	ISP: 202 SL / 295.9 Vac	[1], SL calculated with RPA
+//	Burn Time: 133
+//	Chamber Pressure: 5.85 MPa	[1]
+//	Propellant: NTO / UDMH	[1]
+//	Prop Ratio: 1.86
+//	Throttle: N/A
+//	Nozzle Ratio: 30.83?	same as Viking 4?
+//	Ignitions: 1
+//	=================================================================================
+//	Vikas 2B
+//	GSLV Mk2
+//
+//	Dry Mass: 905? Kg	same as Viking 4?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 804.5 kN	[1]
+//	ISP: 208 SL / 301.9 Vac	[1], SL calculated with RPA
+//	Burn Time: 149
+//	Chamber Pressure: 5.85 MPa	[1]
+//	Propellant: NTO / UDMH	[1] states UH25, but according to [A] ISRO was still using UDMH circa 2006.
+//	Prop Ratio: 1.86	same as Vikas 2?
+//	Throttle: N/A
+//	Nozzle Ratio: 30.83?	same as Viking 4?
+//	Ignitions: 1
+//	=================================================================================
 
-//  Inert Mass: 900 Kg
-//  Throttle Range: N/A
-//  Burn Time: 158 s
-//  O/F Ratio: 1.86 (Vikas-1/1+/2), 1.71 (Vikas-2/2B).
+//	Sources:
 
-//  Sources:
+// [1] https://web.archive.org/web/20180225103202/http://www.b14643.de/Spacerockets_1/India/Vikas/Vikas.htm
+// [2] http://spaceflight101.com/spacerockets/pslv/
+// [3] https://en.wikipedia.org/wiki/Vikas_(rocket_engine)
+// [4] https://en.wikipedia.org/wiki/LVM_3
+// [A] History of Liquid Propellant Rocket Engines, George P. Sutton
 
-//  http://www.b14643.de/Spacerockets_1/India/Vikas/Vikas.htm
-//  http://spaceflight101.com/spacerockets/pslv/
-//  History of Liquid Propellant Rocket Engines, George P. Sutton
+//	Used by:
 
-//  Used by:
-
-//  Real Scale Boosters
-//  ==================================================
+//	Real Scale Boosters
+//	==================================================
 
 @PART[*]:HAS[#engineType[Vikas]]:FOR[RealismOverhaulEngines]
 {
-    %title = #roVikasTitle	//Vikas
-    %manufacturer = #roMfrGB
-    %description = #roVikasDesc	//A high thrust hypergolic vacuum engine. Derived from the European Viking engines that were used on the early Ariane launch vehicles for booster or sustainer roles. ISRO adapted them as a vacuum engine for the second stage of the Polar Satellite Launch Vehicle (PSLV) and the Geosynchronous Satellite Launch Vehicle (GSLV) families.
+	%title = #roVikasTitle	//Vikas
+	%manufacturer = #roMfrGB
+	%description = #roVikasDesc
 
 	@tags ^= :$: france india godrej boyce mtar vikas liquid pump booster udmh nto
 
 	%specLevel = operational
 
-    @MODULE[ModuleEngines*]
-    {
-        %EngineType = LiquidFuel
-    }
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
 
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        type = ModuleEngines
-        configuration = Vikas-1
-        origMass = 0.9
-        modded = False
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = Vikas-1
+		origMass = 0.876
+		modded = False
 
-        //  The Vikas-1 and Vikas-1+ use the exact same hardware as the European Viking-5 engine.
-
-        CONFIG
-        {
-            name = Vikas-1
+		CONFIG
+		{
+			name = Vikas-1
 			description = License built copy of the European Viking-5 engine.
 			specLevel = operational
-            minThrust = 689
-            maxThrust = 689
-            heatProduction = 100
-            massMult = 0.9178
+			minThrust = 680.5
+			maxThrust = 680.5
+			heatProduction = 100
+			massMult = 1.0
 
-            ullage = True
-            pressureFed = False
-            ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.5
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 
-            PROPELLANT
-            {
-                name = UDMH
-                ratio = 0.4963
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4964
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.5037
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5036
+				DrawGauge = False
+			}
 			
 			PROPELLANT
-            {
-                name = Water
-                ratio = 0.01
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
-                DrawGauge = False
+				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
+			}
 
-            atmosphereCurve
-            {
-                key = 0 281
-                key = 1 248
-            }
+			atmosphereCurve
+			{
+				key = 0 280.9
+				key = 1 247.9
+			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
 				ratedBurnTime = 154
 				safeOverburn = true
 				ignitionReliabilityStart = 0.95
@@ -101,60 +175,60 @@
 				cycleReliabilityStart = 0.94
 				cycleReliabilityEnd = 0.985
 			}
-        }
+		}
 
-        CONFIG
-        {
-            name = Vikas-1+
+		CONFIG
+		{
+			name = Vikas-1+
 			description = Uprated version of the Vikas-1.
 			specLevel = operational
-            minThrust = 765.5
-            maxThrust = 765.5
-            heatProduction = 100
-            massMult = 0.9178
+			minThrust = 765.5
+			maxThrust = 765.5
+			heatProduction = 100
+			massMult = 1.0
 
-            ullage = True
-            pressureFed = False
-            ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.5
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 
-            PROPELLANT
-            {
-                name = UDMH
-                ratio = 0.4963
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4950
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.5037
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5050
+				DrawGauge = False
+			}
 			
 			PROPELLANT
-            {
-                name = Water
-                ratio = 0.01
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
-                DrawGauge = False
+				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
+			}
 
-            atmosphereCurve
-            {
-                key = 0 288
-                key = 1 255
-            }
+			atmosphereCurve
+			{
+				key = 0 289.7
+				key = 1 254.9
+			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
 				ratedBurnTime = 154
 				safeOverburn = true
 				ignitionReliabilityStart = 0.98
@@ -163,60 +237,122 @@
 				cycleReliabilityEnd = 0.995
 				techTransfer = Vikas-1:50
 			}
-        }
+		}
 
-        CONFIG
-        {
-            name = Vikas-2
-			description = License built copy of the Viking-4 vacuum engine.
+		CONFIG
+		{
+			name = Vikas-X
+			description = Uprated version of the Vikas-1, designed for air-start.
 			specLevel = operational
-            minThrust = 725
-            maxThrust = 725
-            heatProduction = 100
-            massMult = 1.0
+			minThrust = 821.0
+			maxThrust = 821.0
+			heatProduction = 100
+			massMult = 1.0
 
-            ullage = True
-            pressureFed = False
-            ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.5
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 
-            PROPELLANT
-            {
-                name = UDMH
-                ratio = 0.4963
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.4991
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.5037
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5009
+				DrawGauge = False
+			}
 			
 			PROPELLANT
-            {
-                name = Water
-                ratio = 0.01
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
-                DrawGauge = False
+				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
+			}
 
-            atmosphereCurve
-            {
-                key = 0 296
-                key = 1 261
-            }
+			atmosphereCurve
+			{
+				key = 0 292.9
+				key = 1 250
+			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
+				ratedBurnTime = 203
+				safeOverburn = true
+				ignitionReliabilityStart = 0.98
+				ignitionReliabilityEnd = 0.9965
+				cycleReliabilityStart = 0.98
+				cycleReliabilityEnd = 0.995
+				techTransfer = Vikas-1:50
+			}
+		}
+
+		CONFIG
+		{
+			name = Vikas-2
+			description = License built copy of the Viking-4 vacuum engine.
+			specLevel = operational
+			minThrust = 725
+			maxThrust = 725
+			heatProduction = 100
+			massMult = 1.0331
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4964
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5036
+				DrawGauge = False
+			}
+			
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
+				ignoreForIsp = True
+				DrawGauge = False
+				resourceFlowMode = STACK_PRIORITY_SEARCH
+			}
+
+			atmosphereCurve
+			{
+				key = 0 295.9
+				key = 1 202
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 477
 				ratedBurnTime = 133
 				safeOverburn = true
 				ignitionReliabilityStart = 0.95
@@ -224,61 +360,61 @@
 				cycleReliabilityStart = 0.94
 				cycleReliabilityEnd = 0.985
 			}
-        }
+		}
 
-        CONFIG
-        {
-            name = Vikas-2B
+		CONFIG
+		{
+			name = Vikas-2B
 			description = Uprated version of the Vikas-2.
 			specLevel = operational
-            minThrust = 804.5
-            maxThrust = 804.5
-            heatProduction = 100
-            massMult = 1.0
+			minThrust = 804.5
+			maxThrust = 804.5
+			heatProduction = 100
+			massMult = 1.0331
 
-            ullage = True
-            pressureFed = False
-            ignitions = 1
+			ullage = True
+			pressureFed = False
+			ignitions = 1
 
-            IGNITOR_RESOURCE
-            {
-                name = ElectricCharge
-                amount = 0.5
-            }
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 
-            PROPELLANT
-            {
-                name = UH25
-                ratio = 0.5056
-                DrawGauge = True
-            }
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4964
+				DrawGauge = True
+			}
 
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.4944
-                DrawGauge = False
-            }
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5036
+				DrawGauge = False
+			}
 			
 			PROPELLANT
-            {
-                name = Water
-                ratio = 0.01
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
-                DrawGauge = False
+				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
+			}
 
-            atmosphereCurve
-            {
-                key = 0 302
-                key = 1 261
-            }
+			atmosphereCurve
+			{
+				key = 0 301.9
+				key = 1 208
+			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
-				ratedBurnTime = 140
+				testedBurnTime = 477
+				ratedBurnTime = 149
 				safeOverburn = true
 				ignitionReliabilityStart = 0.98
 				ignitionReliabilityEnd = 0.9965
@@ -286,17 +422,17 @@
 				cycleReliabilityEnd = 0.995
 				techTransfer = Vikas-2:50
 			}
-        }
-    }
+		}
+	}
 
-    @MODULE[ModuleGimbal]
-    {
-        %gimbalRange = 4.0
-        %useGimbalResponseSpeed = True
-        %gimbalResponseSpeed = 16
-    }
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 4.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
 
-    !MODULE[ModuleAlternator]{}
+	!MODULE[ModuleAlternator]{}
 
-    !RESOURCE,*{}
+	!RESOURCE,*{}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vikas_Config.cfg
@@ -153,7 +153,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -214,7 +214,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -276,7 +276,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -338,7 +338,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -399,7 +399,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -5,100 +5,135 @@
 //
 //	=================================================================================
 //	Viking 2
-//	
+//	M60, Ariane ground tests (squinting at engineering cam footage, Ariane 1 first launch had bell nozzles)
 //
 //	Dry Mass: 776 Kg
-//	Thrust (SL): 611 kN
-//	Thrust (Vac): 690 kN
-//	ISP: 248 SL / 281 Vac
+//	Thrust (SL): 591 kN
+//	Thrust (Vac): 698 kN	from [3]
+//	ISP: 239.3 SL / 282.4 Vac	from [3]
 //	Burn Time: 145
-//	Chamber Pressure: 5.5 MPa
+//	Chamber Pressure: 5.345 MPa	from [3]
 //	Propellant: NTO / UDMH
-//	Prop Ratio: 1.86
+//	Prop Ratio: 1.86	from [1]
 //	Throttle: N/A
-//	Nozzle Ratio: 11
+//	Nozzle Ratio: 13.9	from [1], best match for performance from [3] according to RPA
 //	Ignitions: 1
-//	===================================================================================
-//	Viking 2B
-//	UH25 fuel for increased performance
+//	=================================================================================
+//	Viking 5
+//	Viking 2 with bell nozzle, Ariane 1
 //
-//	Dry Mass: 776 kg
-//	Thrust (SL): 642 kN
-//	Thrust (vac): 720 kN
-//	ISP: 248 SL / 278 vac
-//	Burn Time: 205
-//	Chamber Pressure: 5.9 MPa
-//	Propellant: NTO / UH25
-///	Prop Ratio: 1.70
+//	Dry Mass: 876 Kg
+//	Thrust (SL): 611 kN
+//	Thrust (Vac): 692.8 kN	from [3]
+//	ISP: 247.5 SL / 280.6 Vac	from [3]
+//	Burn Time: 145
+//	Chamber Pressure: 5.44 MPa	from [3]
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 1.86	from [1]
 //	Throttle: N/A
-//	Nozzle Ratio: 11
+//	Nozzle Ratio: 10.46	from [3]
 //	Ignitions: 1
 //	===================================================================================
 //	Viking 4
-//	Vac version
+//	Vac version, Ariane 1
 //
-//	Dry Mass: 826 Kg
+//	Dry Mass: 905 Kg	from [3]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 721 kN
-//	ISP: 200 SL / 295 Vac
+//	Thrust (Vac): 721.4 kN	from [3]
+//	ISP: 200 SL / 289.9 Vac	from [1], SL calculated with RPA
 //	Burn Time: 132
-//	Chamber Pressure: 5.26 MPa
+//	Chamber Pressure: 5.236 MPa	from [3]
 //	Propellant: NTO / UDMH
-//	Prop Ratio: 1.70
+//	Prop Ratio: 1.86	from [2]
 //	Throttle: N/A
-//	Nozzle Ratio: 31
+//	Nozzle Ratio: 30.83	from [3]
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 5B
+//	UH25 fuel for increased performance, Ariane 2/3
+//
+//	Dry Mass: 826 kg	from [4], assuming same as Viking 5C
+//	Thrust (SL): 650.9 kN
+//	Thrust (vac): 748.2 kN	from [3], assuming 8% thrust growth over Viking 5
+//	ISP: 242.3 SL / 278.5 vac	from [4], same as Viking 5C?
+//	Burn Time: 205
+//	Chamber Pressure: 5.85 MPa	from [4]
+//	Propellant: NTO / UH25
+///	Prop Ratio: 1.71	from [1], [4]
+//	Throttle: N/A
+//	Nozzle Ratio: 10.46	from [3]
 //	Ignitions: 1
 //	===================================================================================
 //	Viking 4B
-//	UH25 fuel for increased performance
+//	UH25 fuel for increased performance, Ariane 2/3
 //
-//	Dry Mass: 826 kg
+//	Dry Mass: 886 Kg	from [4], same as Viking 4C?
 //	Thrust (SL): ??? kN
-//	Thrust (vac): 805 kN
-//	ISP: 210 SL / 296 vac
+//	Thrust (vac): 784.8 kN	from [1]
+//	ISP: 206 SL / 290.7 vac	from [1], SL calculated with RPA
 //	Burn Time: 125
-//	Chamber Pressure: 5.85 MPa
+//	Chamber Pressure: 5.85 MPa	from [4]
 //	Propellant: NTO / UH25
-///	Prop Ratio: 1.70
+///	Prop Ratio: 1.71	from [1], [4]
 //	Throttle: N/A
-//	Nozzle Ratio: 31
+//	Nozzle Ratio: 30.83	from [3], [4]
 //	Ignitions: 1
 //	===================================================================================
 //	Viking 5C
-//	UH25 fuel for increased performance
+//	Thrust increased for Ariane 4
 //
-//	Dry Mass: 776 kg
-//	Thrust (SL): 678 kN
-//	Thrust (vac): 758 kN
-//	ISP: 248 SL / 278 vac
+//	Dry Mass: 826 kg	from [4]
+//	Thrust (SL): ??? kN
+//	Thrust (vac): 760 kN	from [1], [2], [4]
+//	ISP: 242.3 SL / 278.5 vac	from [4]
 //	Burn Time: 205
-//	Chamber Pressure: 5.8 MPa
+//	Chamber Pressure: 5.85 MPa	from [4]
 //	Propellant: NTO / UH25
-///	Prop Ratio: 1.70
+///	Prop Ratio: 1.71	from [1], [4]
 //	Throttle: N/A
-//	Nozzle Ratio: 11
+//	Nozzle Ratio: 10.46	from [3]
+//	Ignitions: 1
+//	===================================================================================
+//	Viking 4C
+//	Thrust increased for Ariane 4
+//
+//	Dry Mass: 886 Kg	from [4]
+//	Thrust (SL): ??? kN
+//	Thrust (vac): 808 kN	from [1], [2], [4]
+//	ISP: 208 SL / 292.7 vac	from [1], [2], [4], SL calculated with RPA
+//	Burn Time: 125
+//	Chamber Pressure: 5.85 MPa	from [4]
+//	Propellant: NTO / UH25
+///	Prop Ratio: 1.71	from [1], [4]
+//	Throttle: N/A
+//	Nozzle Ratio: 30.83	from [3], [4]
 //	Ignitions: 1
 //	===================================================================================
 //	Viking 6
 //	Booster version
 //
-//	Dry Mass: 776 kg
-//	Thrust (SL): 678 kN
-//	Thrust (vac): 758 kN
-//	ISP: 248 SL / 278 vac
+//	Dry Mass: 826 kg	from [4]
+//	Thrust (SL): 680 kN
+//	Thrust (vac): 760 kN	from [4]
+//	ISP: 242.3 SL / 278.3 vac	from [4]
 //	Burn Time: 142
-//	Chamber Pressure: 5.8 MPa
+//	Chamber Pressure: 5.85 MPa	from [4]
 //	Propellant: NTO / UH25
-///	Prop Ratio: 1.71
+///	Prop Ratio: 1.71	from [4]
 //	Throttle: N/A
-//	Nozzle Ratio: 11
+//	Nozzle Ratio: 10.46	from [3]
 //	Ignitions: 1
 //	=================================================================================
 //
-//	SOURCES
-//	Wikipedia - Viking (rocket engine):																		https://en.wikipedia.org/wiki/Viking_(rocket_engine)
-//	History of Liquid Propellant Rocket Engines:															https://books.google.com/books/about/History_of_Liquid_Propellant_Rocket_Engi.html?id=s1C9Oo2I4VYC
-//	Astronautix - Viking 2:																					http://www.astronautix.com/v/viking2.html
+//	SOURCES:
+
+//	[1] https://web.archive.org/web/20151222161122/http://www.b14643.de/Spacerockets_1/India/Vikas/Vikas.htm
+//	[2] https://www.bernd-leitenberger.de/ariane.shtml
+//	[3] http://www.capcomespace.net/dossiers/espace_europeen/ariane/ariane1/moteur_viking.htm
+//	[4] http://www.capcomespace.net/dossiers/espace_europeen/ariane/ariane4/moteur_viking.htm
+//	[5] http://www.capcomespace.net/dossiers/espace_europeen/ariane/ariane1/essais_moteurs/essais_ensemble_propulsif.htm
+//	[6] Wikipedia - Viking (rocket engine):																		https://fr.wikipedia.org/wiki/Viking_(moteur-fus%C3%A9e)
+//	[7] Astronautix - Viking 2:																					http://www.astronautix.com/v/viking2.html
 //  [A] History of Liquid Propellant Rocket Engines, George P. Sutton
 //      Sub-Sources:
 //          Page 791 Table 10-1
@@ -111,7 +146,7 @@
 {
 	%title = #roVikingTitle	//Viking
 	%manufacturer = #roMfrSEP
-	%description = #roVikingDesc	//A hypergolic booster engine developed for the European Ariane launch vehicle. Used as both a first stage engine and second stage engine when equipped with an extended nozzle. A version was also created for the Ariane 4 strap-on liquid boosters. Average performance compared to its contemporaries, but reliable.
+	%description = #roVikingDesc
 
 	@tags ^= :$: france europe sep société européenne de propulsion viking liquid pump booster udmh uh25 nto
 
@@ -134,15 +169,15 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = Viking-2
-		origMass = 0.776  // See above for reference information on the S-3D weight
+		origMass = 0.776
 
 		CONFIG
 		{
 			name = Viking-2
-			description = First stage engine for Ariane 1
-			specLevel = operational
-			minThrust = 690
-			maxThrust = 690
+			description = Prototype, used for Ariane 1 ground stage tests.
+			specLevel = prototype
+			minThrust = 698
+			maxThrust = 698
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -173,7 +208,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -181,32 +216,96 @@
 
 			atmosphereCurve
 			{
-				key = 0 281
-				key = 1 248
+				key = 0 282.4
+				key = 1 239.3
+			}
+
+			//no data, never flew
+			//early vikings had combustion stability issues
+			//S-3D reliability I guess
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 477	//longest burn of Viking engine during ground tests? [5]
+				ratedBurnTime = 145
+				safeOverburn = true
+				ignitionReliabilityStart = 0.806481
+				ignitionReliabilityEnd = 0.969444
+				cycleReliabilityStart = 0.806481
+				cycleReliabilityEnd = 0.969444
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-5
+			description = First stage engine for Ariane 1.
+			specLevel = operational
+			minThrust = 692.8
+			maxThrust = 692.8
+			heatProduction = 100
+			massMult = 1.1289
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4964
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5036
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
+				ignoreForIsp = True
+				DrawGauge = False
+				resourceFlowMode = STACK_PRIORITY_SEARCH
+			}
+
+			atmosphereCurve
+			{
+				key = 0 280.6
+				key = 1 247.5
 			}
 
 			//Ariane 1: 11 flights, 1 failures
 			//43 engines, 1 failure
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477	//longest burn of Viking engine during ground tests? [5]
 				ratedBurnTime = 145
 				safeOverburn = true
 				ignitionReliabilityStart = 0.960227
 				ignitionReliabilityEnd = 0.992045
 				cycleReliabilityStart = 0.960227
 				cycleReliabilityEnd = 0.992045
-				techTransfer = Viking-4:50
+				techTransfer = Viking-4,Viking-2:50
 			}
 		}
 
 		CONFIG
 		{
 			name = Viking-4
-			description = Second stage engine for Ariane 1
+			description = Second stage engine for Ariane 1.
 			specLevel = operational
-			minThrust = 721
-			maxThrust = 721
+			minThrust = 721.4
+			maxThrust = 721.4
 			heatProduction = 100
 			massMult = 1.064
 			gimbalRange = 5.0
@@ -237,7 +336,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -245,7 +344,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 295
+				key = 0 289.9
 				key = 1 200
 			}
 
@@ -253,24 +352,157 @@
 			//10 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
 				ratedBurnTime = 132
 				safeOverburn = true
 				ignitionReliabilityStart = 0.931818
 				ignitionReliabilityEnd = 0.986364
 				cycleReliabilityStart = 0.931818
 				cycleReliabilityEnd = 0.986364
-				techTransfer = Viking-2:50
+				techTransfer = Viking-5,Viking-2:50
 			}
 		}
 
 		CONFIG
 		{
-			name = Viking-2B
+			name = Viking-5B
 			description = First stage engine for Ariane 2/3. Uses UH25 for extra performance.
 			specLevel = operational
-			minThrust = 720
-			maxThrust = 720
+			minThrust = 748.2
+			maxThrust = 748.2
+			heatProduction = 100
+			massMult = 1.0644
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.4991
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5009
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
+				ignoreForIsp = True
+				DrawGauge = False
+				resourceFlowMode = STACK_PRIORITY_SEARCH
+			}
+
+			atmosphereCurve
+			{
+				key = 0 278.5
+				key = 1 242.3
+			}
+
+			//Ariane 2: 6 flights, 0 failures
+			//Ariane 3: 11 flights, 0 failures
+			//68 engines, 0 failures
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 477
+				ratedBurnTime = 205
+				safeOverburn = true
+				ignitionReliabilityStart = 0.986232
+				ignitionReliabilityEnd = 0.997826
+				cycleReliabilityStart = 0.986232
+				cycleReliabilityEnd = 0.997826
+				techTransfer = Viking-4B,Viking-5,Viking-4,Viking-2:50
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-4B
+			description = Second stage engine for Ariane 2/3. Uses UH25 for extra performance.
+			specLevel = operational
+			minThrust = 784.8
+			maxThrust = 784.8
+			heatProduction = 100
+			massMult = 1.1418
+			gimbalRange = 5.0
+			
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UH25
+				ratio = 0.4991
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5009
+			}
+
+			PROPELLANT
+			{
+				name = Water
+				ratio = 0.0153	//~4 kg/s water
+				ignoreForIsp = True
+				DrawGauge = False
+				resourceFlowMode = STACK_PRIORITY_SEARCH
+			}
+
+			atmosphereCurve
+			{
+				key = 0 290.7
+				key = 1 206
+			}
+
+			//share data with 4C because of low sample size
+			//Ariane 2: 6 flights, 0 failures
+			//Ariane 3: 11 flights, 0 failures
+			//Ariane 4: 115 flights, 0 failures
+			//132 ignitions, 0 failures
+			//132 cycles, 0 failures
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 477
+				ratedBurnTime = 125
+				safeOverburn = true
+				ignitionReliabilityStart = 0.992857
+				ignitionReliabilityEnd = 0.998872
+				cycleReliabilityStart = 0.992857
+				cycleReliabilityEnd = 0.998872
+				techTransfer = Viking-5B,Viking-5,Viking-4,Viking-2:50
+			}
+		}
+
+		CONFIG
+		{
+			name = Viking-5C
+			description = First stage engine for Ariane 4.
+			specLevel = operational
+			minThrust = 760
+			maxThrust = 760
 			heatProduction = 100
 			massMult = 1.0
 			gimbalRange = 5.0
@@ -288,20 +520,20 @@
 			PROPELLANT
 			{
 				name = UH25
-				ratio = 0.5071
+				ratio = 0.4991
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.4929
+				ratio = 0.5009
 			}
 
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -309,35 +541,34 @@
 
 			atmosphereCurve
 			{
-				key = 0 278
-				key = 1 248
+				key = 0 278.5
+				key = 1 242.3
 			}
 
-			//Ariane 2: 6 flights, 0 failures
-			//Ariane 3: 11 flights, 0 failures
-			//68 engines, 0 failures
+			//Ariane 4: 116 flights, 1 failures
+			//464 engines, 1 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
 				ratedBurnTime = 205
 				safeOverburn = true
-				ignitionReliabilityStart = 0.986232
-				ignitionReliabilityEnd = 0.997826
-				cycleReliabilityStart = 0.986232
-				cycleReliabilityEnd = 0.997826
-				techTransfer = Viking-2,Viking-4,Viking-4B:50
+				ignitionReliabilityStart = 0.995233
+				ignitionReliabilityEnd = 0.999247
+				cycleReliabilityStart = 0.995233
+				cycleReliabilityEnd = 0.999247
+				techTransfer = Viking-4C,Viking-5B,Viking-4B,Viking-5,Viking-4,Viking-2:50
 			}
 		}
 
 		CONFIG
 		{
-			name = Viking-4B
-			description = Second stage engine for Ariane 2/3/4. Uses UH25 for extra performance.
+			name = Viking-4C
+			description = Second stage engine for Ariane 4. Uses UH25 for extra performance.
 			specLevel = operational
-			minThrust = 805
-			maxThrust = 805
+			minThrust = 808
+			maxThrust = 808
 			heatProduction = 100
-			massMult = 1.064
+			massMult = 1.1418
 			gimbalRange = 5.0
 			
 			ullage = True
@@ -353,20 +584,20 @@
 			PROPELLANT
 			{
 				name = UH25
-				ratio = 0.5071
+				ratio = 0.4991
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.4929
+				ratio = 0.5009
 			}
 
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -374,8 +605,8 @@
 
 			atmosphereCurve
 			{
-				key = 0 296
-				key = 1 210
+				key = 0 292.7
+				key = 1 208
 			}
 
 			//Ariane 2: 6 flights, 0 failures
@@ -385,78 +616,14 @@
 			//132 cycles, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
 				ratedBurnTime = 125
 				safeOverburn = true
 				ignitionReliabilityStart = 0.992857
 				ignitionReliabilityEnd = 0.998872
 				cycleReliabilityStart = 0.992857
 				cycleReliabilityEnd = 0.998872
-				techTransfer = Viking-2,Viking-4,Viking-2B:50
-			}
-		}
-
-		CONFIG
-		{
-			name = Viking-5C
-			description = First stage engine for Ariane 4
-			specLevel = operational
-			minThrust = 758
-			maxThrust = 758
-			heatProduction = 100
-			massMult = 1.0
-			gimbalRange = 5.0
-			
-			ullage = True
-			pressureFed = False
-			ignitions = 1
-
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-
-			PROPELLANT
-			{
-				name = UH25
-				ratio = 0.5071
-				DrawGauge = True
-			}
-
-			PROPELLANT
-			{
-				name = NTO
-				ratio = 0.4929
-			}
-
-			PROPELLANT
-			{
-				name = Water
-				ratio = 0.01
-				ignoreForIsp = True
-				DrawGauge = False
-				resourceFlowMode = STACK_PRIORITY_SEARCH
-			}
-
-			atmosphereCurve
-			{
-				key = 0 278
-				key = 1 248
-			}
-
-			//Ariane 4: 116 flights, 1 failures
-			//464 engines, 1 failures
-			TESTFLIGHT:NEEDS[TestLite|TestFlight]
-			{
-				testedBurnTime = 400
-				ratedBurnTime = 205
-				safeOverburn = true
-				ignitionReliabilityStart = 0.995233
-				ignitionReliabilityEnd = 0.999247
-				cycleReliabilityStart = 0.995233
-				cycleReliabilityEnd = 0.999247
-				techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B:50
+				techTransfer = Viking-5C,Viking-5B,Viking-4B,Viking-5,Viking-4,Viking-2:50
 			}
 		}
 
@@ -465,10 +632,10 @@
 			name = Viking-6
 			description = Booster engine for Ariane 4
 			specLevel = operational
-			minThrust = 758
-			maxThrust = 758
+			minThrust = 760
+			maxThrust = 760
 			heatProduction = 100
-			massMult = 1.0
+			massMult = 1.0644
 			gimbalRange = 0.0
 			
 			ullage = True
@@ -484,20 +651,20 @@
 			PROPELLANT
 			{
 				name = UH25
-				ratio = 0.5057
+				ratio = 0.4991
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.4943
+				ratio = 0.5009
 			}
 
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01
+				ratio = 0.0153	//~4 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -505,22 +672,22 @@
 
 			atmosphereCurve
 			{
-				key = 0 278
-				key = 1 248
+				key = 0 278.3
+				key = 1 242.3
 			}
 
-			//Ariane 4 Liquid Boostwer: 238 flights, 0 failures.
+			//Ariane 4 Liquid Booster: 238 flights, 0 failures.
 			//238 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 400
+				testedBurnTime = 477
 				ratedBurnTime = 142
 				safeOverburn = true
 				ignitionReliabilityStart = 0.996025
 				ignitionReliabilityEnd = 0.999372
 				cycleReliabilityStart = 0.996025
 				cycleReliabilityEnd = 0.999372
-				techTransfer = Viking-2,Viking-4,Viking-2B,Viking-4B,Viking-5C:50
+				techTransfer = Viking-5C,Viking-4C,Viking-5B,Viking-4B,Viking-5,Viking-4,Viking-2:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Viking_Config.cfg
@@ -208,7 +208,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -272,7 +272,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -336,7 +336,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -400,7 +400,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -465,7 +465,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -533,7 +533,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -597,7 +597,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -664,7 +664,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.0153	//~4 kg/s water
+				ratio = 0.0153	//~3.7 kg/s water
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -83,6 +83,13 @@ RESOURCE_DEFINITION
     isVisible = true
 }
 
+//modify UH25 properties (should be moved to CRP at some point)
+@RESOURCE_DEFINITION[UH25]
+{ 
+	@density = 0.0008511	//UH25 is 25% Hydrazine Hydrate, not Hydrazine. Hydrate density source: https://www.fishersci.com/shop/products/hydrazine-hydrate-100-hydrazine-64-thermo-scientific/AC196711000
+	@hsp = 2923		//roughly 75% UDMH, 16% Hydrazine, 9% water by mass
+}
+
 @TANK_DEFINITION[Default|Structural|Balloon|BalloonCryo|Cryogenic]:FOR[RealismOverhaul]:NEEDS[RealFuels]
 {
 	TANK


### PR DESCRIPTION
Revise the performance of the Viking and Vikas engines based on French sources. Also adjust the properties of UH25.
Changes include:

- Adjust ISP and thrust of all Viking configs based on French sources and RPA calculations
- Add Viking 5, 5B and 4C configs, and remove 2B config
- Revise and reorganize Vikas configs
- Adjust density and Hsp of UH25 to be more accurate

This is, unfortunately, mildly save breaking, so it should be held until the next save-breaking update (release of PLC?)
