### PR TITLE
Scud (and Véronique) revisions

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -1,4 +1,3 @@
-
 //	==================================================
 //	S2.253 and derivatives
 //
@@ -6,77 +5,79 @@
 //
 //	=================================================================================
 //	S2.253 (8D511)
-//	R-11 (Scud-A, 1953)
+//	 R-11 (Scud-A, 1953)
 //
-//	Dry Mass: 300 kg
+//	Dry Mass: 300 kg	guess
 //	Thrust (SL): 81.4 kN
-//	Thrust (Vac): 94.8 kN
-//	ISP: 219 SL / 251 Vac
-//	Burn Time: 90
-//	Chamber Pressure: ???
-//	Propellant: AK20 / Kerosene
-//	Prop Ratio: 3.07
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
-//	Nozzle Ratio: ???
+//	Thrust (Vac): 94.8 kN	[1], [3], [5]
+//	ISP: 219 SL / 255 Vac	All sources say 219 SL. Vac varies from 251 to 263. Going with 255 [3],[5] because it matches RPA the closest.
+//	Burn Time: 95	[2]
+//	Chamber Pressure: 2.5 MPa	[7]
+//	Propellant: AK20 / T-1	[1]
+//	Prop Ratio: 3.76	[2]
+//	Nozzle Ratio: 5.67		[7] 0.652 atm at nozzle exit
 //	Ignitions: 1
 //	=================================================================================
 //	S3.42T
 //	R-11MU, R-17 prototype (1958)
 //
-//	Dry Mass: 160 kg
-//	Thrust (SL): 111.7 kN
-//	Thrust (Vac): 127.5 kN
-//	ISP: 226 SL / 258 Vac
-//	Burn Time: 65
+//	Dry Mass: 160 kg	guess
+//	Thrust (SL): 115.1 kN
+//	Thrust (Vac): 127.5 kN	[1]
+//	ISP: 233 SL / 258 Vac	assuming same as S5.2
+//	Burn Time: 65	[1]
 //	Chamber Pressure: ??? MPa
-//	Propellant: AK27 / Kerosene
-//	Prop Ratio: 3.55	(calculated from fuel loading of R-17)
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
+//	Propellant: AK27 / TM-185
+//	Prop Ratio: 3.43	assuming same as S5.2
 //	Nozzle Ratio: ???
 //	Ignitions: 1
 //	=================================================================================
-//	S5.2
+//	S5.2 (9D21)
 //	R-17 (Scud-B, Scud-C)
 //
-//	Dry Mass: 160 kg
+//	Dry Mass: 160 kg	guess
 //	Thrust (SL): 132.1 kN
-//	Thrust (Vac): 146.3 kN
-//	ISP: 226 SL / 258 Vac
-//	Burn Time: 75
-//	Chamber Pressure: ??? MPa
-//	Propellant: AK27 / Kerosene
-//	Prop Ratio: 3.55
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
-//	Nozzle Ratio: 8.2
+//	Thrust (Vac): 146.3 kN	[1], [3], [5]
+//	ISP: 233 SL / 258 Vac	All sources say 258 vac, but SL numbers vary. Going with 233 [3] because it matches RPA the closest. Also supported by thrust values, which match best to 233/258.
+//	Burn Time: 75	[1]
+//	Chamber Pressure: 6.8 MPa	[3]
+//	Propellant: AK27 / TM-185	[1], [2], [3]
+//	Prop Ratio: 3.43	[2]
+//	Nozzle Ratio: 10.4	[3]
 //	Ignitions: 1
 //	=================================================================================
 //	Isayev-R17
 //	R-17MU (Scud-D)
 //
-//	Dry Mass: 160 kg
+//	Dry Mass: 160 kg	guess
 //	Thrust (SL): 149.9 kN
-//	Thrust (Vac): 165.5 kN
-//	ISP: 240 SL / 265 Vac
-//	Burn Time: 90
+//	Thrust (Vac): 165.5 kN	[1]
+//	ISP: 240 SL / 265 Vac	[1]
+//	Burn Time: 90	[1]
 //	Chamber Pressure: ??? MPa
-//	Propellant: AK27 / UDMH
-//	Prop Ratio: 2.32	//8.5 m2 UDMH, 10.46 m2 AK27, 1.23 volume
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
-//	Nozzle Ratio: 9.6
+//	Propellant: AK27 / UDMH	[1]
+//	Prop Ratio: 2.32	[1] 8.5 m2 UDMH, 10.46 m2 AK27, 1.23 volume
+//	Nozzle Ratio: 10.4?
 //	Ignitions: 1
+//	=================================================================================
 
 //	Sources:
-//	b14643 - The Soviet "Scud" missile family:													http://www.b14643.de/Spacerockets/Specials/Scud/
+//	[1] b14643 - The Soviet "Scud" missile family:													http://www.b14643.de/Spacerockets/Specials/Scud/
+//	[2] http://lpre.de/kbhm/index.htm
+//	[3] http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//	[4] http://www.astronautix.com/s/s2253.html
+//	[5] http://www.b14643.de/Spacerockets/Specials/KB-Isayev_engines/index.htm
+//	[6] http://www.kap-yar.ru/index.php?pg=224
+//	[7] http://militaryrussia.ru/blog/topic-635.html
 
 
 //	Used by:
 
 //	Notes:
 
+//	S2.253 appeared to use a pair of gas generators to generate fuel-rich and ox-rich gasses to pressurize
+//	it's fuel tanks. This is supported by the lack of large pressurized bottles in R-11 airframe.
+//	This is probably also the reason the S2.253 is really heavy.
 //	==================================================
 
 @PART[*]:HAS[#engineType[S2.253]]:FOR[RealismOverhaulEngines]
@@ -84,7 +85,7 @@
 	%category = Engine
 	%title = #roS2.253Title	//S2.253/S3.42/S5.2
 	%manufacturer = #roMfrOKB2
-	%description = #roS2.253Desc	//The S2.253 engine was developed for use in the R-11 Zemlya ballistic missile and sounding rocket, based on the German Wasserfall engine. Better known by its western designation, Scud, later versions were exported extensivley to many countries, eventually forming the basis of the Iranian and North Korean space programs.
+	%description = #roS2.253Desc
 
 	@tags ^= :$: USSR iran north korea okb-2 isayev s2.253 s3.42t s5.2 liquid pressure-fed pump booster kerosene udmh nitric acid
 
@@ -118,10 +119,10 @@
 		CONFIG
 		{
 			name = S2.253
-			description = Derived from the German Wasserfall engine, used on the R-11 (Scud-A)
+			description = Derived from the German Wasserfall engine, used on the R-11 (Scud-A).
 			specLevel = operational
-			minThrust = 93.3
-			maxThrust = 93.3
+			minThrust = 94.8
+			maxThrust = 94.8
 			heatProduction = 35
 			massMult = 1.0
 			ullage = True
@@ -139,30 +140,30 @@
 				amount = 1
 			}
 
-			PROPELLANT // 3.07 mixture ratio
+			PROPELLANT
 			{
 				name = Kerosene
-				ratio = 0.373
+				ratio = 0.3271
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = AK20
-				ratio = 0.627
+				ratio = 0.6729
 				DrawGauge = False
 			}
 
 			PROPELLANT
 			{
 				name = Nitrogen
-				ratio = 11.25		//pretty poor TWR, assume low-ish pressure (0.75 Mpa)
+				ratio = 3.75		//gas generator pressurization. Based on Juno IV 6k, pressurant usage should be about 10% of a conventional system?
 				ignoreForIsp = True
 			}
 
 			atmosphereCurve
 			{
-				key = 0 251
+				key = 0 255
 				key = 1 219
 			}
 
@@ -184,7 +185,7 @@
 		CONFIG
 		{
 			name = S3.42T
-			description = Pump-fed upgrade, used on the R-11MU and some R-17 prototypes. Never entered service
+			description = Pump-fed upgrade, used on the R-11MU and some R-17 prototypes. Never entered service.
 			specLevel = operational
 			minThrust = 127.5
 			maxThrust = 127.5
@@ -205,30 +206,32 @@
 				amount = 1
 			}
 
-			PROPELLANT // 3.55 mixture ratio
+			PROPELLANT // 3.43 mixture ratio
 			{
 				name = Kerosene
-				ratio = 0.339
+				ratio = 0.3469
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = AK27
-				ratio = 0.661
+				ratio = 0.6531
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
 				key = 0 258
-				key = 1 226
+				key = 1 233
 			}
 
 			//no data, assumed same as S5.2
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 65
+				testedBurnTime = 98		//Give 1.5 time
+				safeOverburn = true
 				ignitionReliabilityStart = 0.750000
 				ignitionReliabilityEnd = 0.960345
 				ignitionDynPresFailMultiplier = 1.5
@@ -242,7 +245,7 @@
 		CONFIG
 		{
 			name = S5.2
-			description = Upgrade, used on the Production R-17 and R-17M missile, A.K.A Scud-B and Scud-C. This was the most heavily exported variant, and copies were built by many countries.
+			description = Upgrade, used on the production R-17 and R-17M missile, A.K.A Scud-B and Scud-C. This was the most heavily exported variant, and copies were built by many countries.
 			specLevel = operational
 			minThrust = 146.3
 			maxThrust = 146.3
@@ -263,24 +266,24 @@
 				amount = 1
 			}
 
-			PROPELLANT // 3.55 mixture ratio
+			PROPELLANT // 3.43 mixture ratio
 			{
 				name = Kerosene
-				ratio = 0.339
+				ratio = 0.3469
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = AK27
-				ratio = 0.661
+				ratio = 0.6531
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
 				key = 0 258
-				key = 1 226
+				key = 1 233
 			}
 
 			//R-17 R&D: 25 flights, 5 failures
@@ -289,6 +292,8 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 75
+				testedBurnTime = 150	//Scud extensively modified, engine presumably fairly tolerant to uprating.
+				safeOverburn = true
 				ignitionReliabilityStart = 0.750000
 				ignitionReliabilityEnd = 0.960345
 				ignitionDynPresFailMultiplier = 1.5
@@ -321,14 +326,14 @@
 			PROPELLANT // 2.32 mixture ratio
 			{
 				name = UDMH
-				ratio = 0.4484
+				ratio = 0.4488
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = AK27
-				ratio = 0.5516
+				ratio = 0.5512
 				DrawGauge = False
 			}
 
@@ -342,6 +347,8 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 90
+				testedBurnTime = 270	//late 60s, 3x margin
+				safeOverburn = true
 				ignitionReliabilityStart = 0.750000
 				ignitionReliabilityEnd = 0.960345
 				ignitionDynPresFailMultiplier = 1.5

--- a/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Veronique_Config.cfg
@@ -13,10 +13,10 @@
 //	ISP: 198 SL / 249 Vac
 //	Burn Time: 45
 //	Chamber Pressure: 1.5 MPa	//assuming same as A-4/Wasserfall
-//	Propellant: IRFNA / RP1
-//	Prop Ratio: 3.07	//guess, from scud O/F ratio (also used a kerosene/nitric acid wassefall engine)
+//	Propellant: IRFNA / Diesel
+//	Prop Ratio: 3.76	//guess, from scud O/F ratio (also used a kerosene/nitric acid wassefall engine)
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 4.7?
 //	Ignitions: 1
 //	=================================================================================
 //	Véronique AGI
@@ -25,9 +25,9 @@
 //	Dry Mass: 150 Kg
 //	Thrust (SL): 39.2 kN
 //	Thrust (Vac): 49.3 kN
-//	ISP: 208 SL / 261 Vac	//5% improvement?
+//	ISP: 208 SL / 261 Vac	//5% improvement? 
 //	Burn Time: 49
-//	Chamber Pressure: 1.5 MPa	//assuming same as A-4/Wasserfall
+//	Chamber Pressure: 1.76 MPa	//assuming same as Vesta?
 //	Propellant: IWFNA / Turpentine
 //	Prop Ratio: 3.57	//Vesta O/F ratio
 //	Throttle: N/A
@@ -42,7 +42,7 @@
 //	Thrust (Vac): 73.8 kN
 //	ISP: 208 SL / 261 Vac	//5% improvement?
 //	Burn Time: 56
-//	Chamber Pressure: 1.5 MPa	//assuming same as A-4/Wasserfall
+//	Chamber Pressure: 1.76 MPa	//assuming same as Vesta?
 //	Propellant: IWFNA / Turpentine
 //	Prop Ratio: 3.57	//Vesta O/F ratio
 //	Throttle: N/A
@@ -120,17 +120,17 @@
 				amount = 1
 			}
 
-			PROPELLANT
+			PROPELLANT	//3.76
 			{
 				name = Kerosene
-				ratio = 0.3971
+				ratio = 0.3497
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = IRFNA-III
-				ratio = 0.6029
+				ratio = 0.6503
 			}
 
 			PROPELLANT
@@ -201,7 +201,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01381
+				ratio = 0.01620
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH
@@ -267,7 +267,7 @@
 			PROPELLANT
 			{
 				name = Water
-				ratio = 0.01381
+				ratio = 0.01620
 				ignoreForIsp = True
 				DrawGauge = False
 				resourceFlowMode = STACK_PRIORITY_SEARCH


### PR DESCRIPTION
Update Scud configs based on Russian sources (and also Véronique, because Véronique configs are based on Scud configs).
Changes include:

- Correct O/F ratio of S2.253, S3.42, S5.2, and Véronique.
- Update ISP of S2.253, S3.42 and S5.2.
- Decrease S2.253 pressurant usage (based on gas generator pressurization system)
- Increase Véronique AGI/61 chamber pressure.
These changes are, unfortunately, save-breaking, and so should be held until the next save-breaking update.