### PR TITLE
Increase max temp of potatoroids

### DIFF
--- a/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
+++ b/GameData/RealismOverhaul/RealismOverhaul_Global_Config.cfg
@@ -262,6 +262,11 @@
 {
 	%RSSROConfig = True
 }
+//just add some temp numbers to asteroids/comets so they don't burn up too quickly on reentry
+@PART[PotatoComet|PotatoRoid]:FOR[zzzRealismOverhaul]
+{
+	%skinMaxTemp = 2000	//offgassing should act like ablator and sort of protect them
+}
 
 //  ==================================================
 //  RSS/RO generic stuff.


### PR DESCRIPTION
Increase the skin temp of asteroids/comets a little bit so they don't burn up quite so quickly. They probably still shouldn't survive reentry.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/2798