### PR TITLE
Improve SSME configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LRBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LRBE_Config.cfg
@@ -5,17 +5,17 @@
 //
 //	=================================================================================
 //	LRBE
-//	Block I Phase II baseline
+//	Phase I baseline
 //
 //	Dry Mass: 3370 Kg
 //	Thrust (SL): 2224 kN
 //	Thrust (Vac): 2429 kN
-//	ISP: 323 SL / 351 Vac
+//	ISP: 325 SL / 355 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 22.27 MPa
+//	Chamber Pressure: 22.27 MPa (@ 109% throttle)
 //	Propellant: LOX / CH4
 //	Prop Ratio: 3.5
-//	Throttle: 100% to 67%
+//	Throttle: 109% to 67%
 //	Nozzle Ratio: 35
 //	Ignitions: 1
 //	=================================================================================
@@ -24,10 +24,10 @@
 //
 //	Dry Mass: 3586 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2592 kN
-//	ISP: 323 SL / 351 Vac
+//	Thrust (Vac): 2473.5 kN
+//	ISP: 327.7 SL / 352.7 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 19.48 MPa
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
 //	Propellant: LOX / CH4
 //	Prop Ratio: 3.5
 //	Throttle: 100% to 67%
@@ -48,6 +48,7 @@
 
 //	Notes:
 
+//	Since methane propellant needs less volume flow than standard SSME, I will allow 109% throttle in Phase I.
 //	==================================================
 @PART[*]:HAS[#engineType[LRBE]]:FOR[RealismOverhaulEngines]
 {
@@ -89,7 +90,7 @@
 			name = LRBE
 			description = Block I Phase II baseline LRBE.
 			specLevel = concept
-			minThrust = 1579
+			minThrust = 1493
 			maxThrust = 2429
 			PROPELLANT
 			{
@@ -104,8 +105,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 351
-				key = 1 323
+				key = 0 355
+				key = 1 325
 			}
 
 			%ullage = True
@@ -121,14 +122,22 @@
 			//	189 engines, 3 ignition failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 4615		//Same as SSME
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.975000
-				ignitionReliabilityEnd = 0.996053
-				cycleReliabilityStart = 0.975000
-				cycleReliabilityEnd = 0.999211
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954918
+				ignitionReliabilityEnd = 0.990984
+				cycleReliabilityStart = 0.971311
+				cycleReliabilityEnd = 0.994262
 			}
 		}
 		CONFIG
@@ -136,8 +145,8 @@
 			name = LRBE-BlockII
 			description = Block II baseline LRBE.
 			specLevel = speculative
-			minThrust = 1579
-			maxThrust = 2592
+			minThrust = 1493
+			maxThrust = 2473.5
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -152,8 +161,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 351
-				key = 1 323
+				key = 0 352.7
+				key = 1 327.7
 			}
 
 			%ullage = True
@@ -170,14 +179,22 @@
 			//	93 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 4615		//Same as SSME
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.989362
-				ignitionReliabilityEnd = 0.997872
-				cycleReliabilityStart = 0.989362
-				cycleReliabilityEnd = 0.997872
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.989894
+				ignitionReliabilityEnd = 0.998404
+				cycleReliabilityStart = 0.989894
+				cycleReliabilityEnd = 0.998404
 				techTransfer = LRBE:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/SSBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSBE_Config.cfg
@@ -5,17 +5,17 @@
 //
 //	=================================================================================
 //	SSBE
-//	Block I Phase II
+//	Phase I
 //
 //	Dry Mass: 3655 Kg
 //	Thrust (SL): 2077 kN	//467000 klbf sea level
-//	Thrust (Vac): 2254 kN
-//	ISP: 329 SL / 357 Vac
+//	Thrust (Vac): 2265 kN
+//	ISP: 331 SL / 361 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 21.1 MPa
-//	Propellant: LOX / LH2
+//	Chamber Pressure: 22.58 MPa (@ 109% throttle)
+//	Propellant: LOX / RP-1 / LH2
 //	Prop Ratio: 2.8
-//	Throttle: 104% to 67%
+//	Throttle: 109% to 67%
 //	Nozzle Ratio: 35
 //	Ignitions: 1
 //	=================================================================================
@@ -24,11 +24,11 @@
 //
 //	Dry Mass: 3889 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2405 kN
-//	ISP: 329 SL / 357 Vac
+//	Thrust (Vac): 2306 kN
+//	ISP: 333.8 SL / 358.7 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.5 MPa
-//	Propellant: LOX / LH2
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
+//	Propellant: LOX / RP-1 / LH2
 //	Prop Ratio: 2.8
 //	Throttle: 111% to 67%
 //	Nozzle Ratio: 31.2
@@ -44,10 +44,9 @@
 
 //	Notes:
 
-//	The paper used for reference is dated 1978-1980, and seems to use the preproduction SSME as reference.
-//	I have extrapolated the performance of this to the SSME upgrades.
-//	Since preproduction SSME got 456 s vac instead of 452, I have subtracted 4s from the vacuum performance of all engines
-//	SL ISP was 463 instead of 461, so 2 s has been subtracted from the SL performance.
+//	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME at 109% as reference.
+//	Since the tripropellant nature means it needs to supply less volume flow than a standard SSME to achieve
+//	this thrust level, I will allow it to remain at 109%.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.
 
 //	Tripropellant, using LH2 to cool engine and maintain stable combustion in preburners.
@@ -61,7 +60,7 @@
 {
 	%title = #roSSBETitle	//SSBE
 	%manufacturer = #roMfrRocketdyne
-	%description = #roSSBEDesc	//Developed from the RS-25 SSME, the Space Shuttle Booster Engine (SSBE) was a concept for a kerolox fueled Space Shuttle booster. The engine used three fuel-rich preburners, burning a mixture of LH2 and RP-1 to minimize coking. The LH2 was also used to cool the combustion chamber, allowing unmodified SSME components to be used.
+	%description = #roSSBEDesc
 
 	@tags ^= :$: USA rocketdyne ssbe liquid pump booster lqdhydrogen kerosene lqdoxygen
 
@@ -95,10 +94,10 @@
 		CONFIG
 		{
 			name = SSBE
-			description = Block I Phase II baseline SSBE.
+			description = Phase I baseline SSBE. Rated for sustained operation at 109% thrust.
 			specLevel = concept
-			minThrust = 1452
-			maxThrust = 2254
+			minThrust = 1392
+			maxThrust = 2265
 			PROPELLANT
 			{
 				name = Kerosene
@@ -117,8 +116,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 357
-				key = 1 329
+				key = 0 361
+				key = 1 331
 			}
 
 			ullage = True
@@ -130,28 +129,36 @@
 				amount = 0.5
 			}
 
-			//	RS-25A(B) flew on 63 flights with 3 ignition failures
-			//	189 engines, 3 ignition failures
+			//	RS-25 flew on 20 flights with 2 ignition failures and 1 other failure
+			//	60 engines, 2 ignition failures, 1 other
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.984127
-				ignitionReliabilityEnd = 0.996825
-				cycleReliabilityStart = 0.994737
-				cycleReliabilityEnd = 0.998947
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954918
+				ignitionReliabilityEnd = 0.990984
+				cycleReliabilityStart = 0.971311
+				cycleReliabilityEnd = 0.994262
 			}
 
 		}
 		CONFIG
 		{
 			name = SSBE-BlockII
-			description = Block II baseline SSBE.
+			description = Block II baseline SSBE. Rated for sustained operation at 111% thrust.
 			specLevel = speculative
-			minThrust = 1452
-			maxThrust = 2405
+			minThrust = 1392
+			maxThrust = 2306
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -171,8 +178,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 357
-				key = 1 329
+				key = 0 358.7
+				key = 1 333.8
 			}
 
 			ullage = True
@@ -188,15 +195,23 @@
 			//	93 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.989362
-				ignitionReliabilityEnd = 0.997872
-				cycleReliabilityStart = 0.989362
-				cycleReliabilityEnd = 0.997872
-				techTransfer = SSBE:50
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.989894
+				ignitionReliabilityEnd = 0.998404
+				cycleReliabilityStart = 0.989894
+				cycleReliabilityEnd = 0.998404
+				techTransfer = RS-25C,RS-25A,RS-25:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/SSME150_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME150_Config.cfg
@@ -10,14 +10,14 @@
 //
 //	Dry Mass: 4400 Kg	//extrapolating mass, should weight 3899 kg. Adding 500 kg for vacuum start equipment
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2127 kN
-//	ISP: 200 SL / 460 Vac
+//	Thrust (Vac): 2130 kN
+//	ISP: 340 SL / 464 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 22.88 MPa
+//	Chamber Pressure: 20.48 MPa (@ 100% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 100% to 67%
-//	Nozzle Ratio: 133.2
+//	Nozzle Ratio: 150
 //	Ignitions: 3
 //	=================================================================================
 //	SSME-150
@@ -25,10 +25,10 @@
 //
 //	Dry Mass: 4400 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2212 kN
-//	ISP: 200 SL / 460 Vac
+//	Thrust (Vac): 2215.8 kN
+//	ISP: 340 SL / 462.3 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 21.64 MPa
+//	Chamber Pressure: 21.55 MPa (@ 104% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 104% to 67%
@@ -40,10 +40,10 @@
 //
 //	Dry Mass: 4686 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2318 kN
-//	ISP: 200 SL / 460 Vac
+//	Thrust (Vac): 2321.9 kN
+//	ISP: 345 SL / 461 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa
+//	Chamber Pressure: 20.74 MPa (@ 109% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 109% to 67%
@@ -55,10 +55,10 @@
 //
 //	Dry Mass: 4686 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2361 kN
-//	ISP: 200 SL / 460 Vac
+//	Thrust (Vac): 2364.5 kN
+//	ISP: 345 SL / 461 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%
@@ -75,14 +75,15 @@
 
 //	Notes:
 
-//	The paper used for reference is dated 1978-1980, and seems to use the preproduction SSME as reference.
-//	I have extrapolated the performance of this to the SSME upgrades.
-//	Since preproduction SSME got 456 s vac instead of 452, I have subtracted 4s from the vacuum performance of all engines
-//	SL ISP was 463 instead of 461, so 2 s has been subtracted from the SL performance.
+///	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME as reference.
+//	The performance of alternate nozzle configurations have been corrected to match the relative performance
+//	of their "base" configs.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.
-//
+///
+//	Regarding SSME-150:
 //	This engine has a 150:1 nozzle ratio and a restart kit.
 //	The engine is otherwise assumed to have identical performance to a standard SSME.
+//	The restart kit is assumed to add 500 kg, based on ~1000 kg J-2 restart kit, with weight reduction due to technological improvement.
 
 //	This config is technically deprecated, but will still be used by SSME-150 only parts (until someone can figure out MM wizardry to make the combined config work for that)
 //	==================================================
@@ -123,8 +124,8 @@
 			name = RS-25-150
 			description = Phase I SSME
 			specLevel = concept
-			minThrust = 1425
-			maxThrust = 2127
+			minThrust = 1427
+			maxThrust = 2130
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -138,8 +139,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 460
-				key = 1 200
+				key = 0 464
+				key = 1 340
 			}
 
 			%ullage = True
@@ -155,14 +156,22 @@
 			//	60 engines, 2 ignition failures, 1 other
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.966667
-				ignitionReliabilityEnd = 0.993333
-				cycleReliabilityStart = 0.983333
-				cycleReliabilityEnd = 0.996667
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954918
+				ignitionReliabilityEnd = 0.990984
+				cycleReliabilityStart = 0.971311
+				cycleReliabilityEnd = 0.994262
 				techTransfer = RS-25:50
 			}
 		}
@@ -171,8 +180,8 @@
 			name = RS-25A-150 //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
 			specLevel = speculative
-			minThrust = 1425
-			maxThrust = 2212
+			minThrust = 1427
+			maxThrust = 2215.8
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -186,8 +195,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 460
-				key = 1 200
+				key = 0 462.3
+				key = 1 340
 			}
 
 			%ullage = True
@@ -203,14 +212,22 @@
 			//	189 engines, 3 ignition failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.984127
-				ignitionReliabilityEnd = 0.996825
-				cycleReliabilityStart = 0.994737
-				cycleReliabilityEnd = 0.998947
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.975000
+				ignitionReliabilityEnd = 0.996053
+				cycleReliabilityStart = 0.975000
+				cycleReliabilityEnd = 0.999211
 				techTransfer = RS-25A,RS-25-150,RS-25:50
 			}
 		}
@@ -219,8 +236,8 @@
 			name = RS-25C-150 //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
 			specLevel = speculative
-			minThrust = 1425
-			maxThrust = 2318
+			minThrust = 1427
+			maxThrust = 2321.9
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -235,8 +252,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 460
-				key = 1 200
+				key = 0 461
+				key = 1 345
 			}
 
 			%ullage = True
@@ -252,14 +269,22 @@
 			//	48 engines, 1 failure.
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.979592
-				ignitionReliabilityEnd = 0.995918
-				cycleReliabilityStart = 0.979167
-				cycleReliabilityEnd = 0.995833
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954762
+				ignitionReliabilityEnd = 0.996939
+				cycleReliabilityStart = 0.954762
+				cycleReliabilityEnd = 0.992857
 				techTransfer = RS-25C,RS-25A-150,RS-25A,RS-25-150,RS-25:50
 			}
 		}
@@ -268,8 +293,8 @@
 			name = RS-25D-150 //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
 			specLevel = speculative
-			minThrust = 1425
-			maxThrust = 2361
+			minThrust = 1427
+			maxThrust = 2364.5
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -284,8 +309,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 460
-				key = 1 200
+				key = 0 461
+				key = 1 345
 			}
 
 			%ullage = True
@@ -301,14 +326,22 @@
 			//	93 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.989362
-				ignitionReliabilityEnd = 0.997872
-				cycleReliabilityStart = 0.989362
-				cycleReliabilityEnd = 0.997872
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.989894
+				ignitionReliabilityEnd = 0.998404
+				cycleReliabilityStart = 0.989894
+				cycleReliabilityEnd = 0.998404
 				techTransfer = RS-25D-E,RS-25C-150,RS-25C,RS-25A-150,RS-25A,RS-25-150,RS-25:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/SSME35_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME35_Config.cfg
@@ -5,30 +5,30 @@
 //
 //	=================================================================================
 //	SSME-35
-//	Block I Phase I
+//	Phase I
 //	Baseline
 //
 //	Dry Mass: 3372 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2151 kN
-//	ISP: 404 SL / 441 Vac
+//	Thrust (Vac): 2043 kN
+//	ISP: 406 SL / 445 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 22.3 MPa
+//	Chamber Pressure: 20.48 MPa (@ 100% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 100% to 67%
-//	Nozzle Ratio: 31.1
+//	Nozzle Ratio: 35
 //	Ignitions: 1
 //	=================================================================================
 //	SSME-35
-//	Block I Phase II
+//	Phase II
 //
 //	Dry Mass: 3372 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2237 kN
-//	ISP: 404 SL / 441 Vac
+//	Thrust (Vac): 2124.7 kN
+//	ISP: 404.1 SL / 443.3 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 21.1 MPa
+//	Chamber Pressure: 21.55 MPa (@ 104% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 104% to 67%
@@ -40,10 +40,10 @@
 //
 //	Dry Mass: 3589 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2345 kN
-//	ISP: 404 SL / 441 Vac
+//	Thrust (Vac): 2227.2 kN
+//	ISP: 409.5 SL / 442.2 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.5 MPa
+//	Chamber Pressure: 20.74 MPa (@ 109% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 109% to 67%
@@ -55,10 +55,10 @@
 //
 //	Dry Mass: 3589 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2388 kN
-//	ISP: 404 SL / 441 Vac
+//	Thrust (Vac): 2268.1 kN
+//	ISP: 409.5 SL / 442.2 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.5 MPa
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%
@@ -75,14 +75,16 @@
 
 //	Notes:
 
-//	The paper used for reference is dated 1978-1980, and seems to use the preproduction SSME as reference.
-//	I have extrapolated the performance of this to the SSME upgrades.
-//	Since preproduction SSME got 456 s vac instead of 452, I have subtracted 4s from the vacuum performance of all engines
-//	SL ISP was 463 instead of 461, so 2 s has been subtracted from the SL performance.
+//	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME as reference.
+//	The performance of alternate nozzle configurations have been corrected to match the relative performance
+//	of their "base" configs.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.
 //
-//	This engine has both a larger throat (as shown by the reduced chamber pressure), which results in increased thrust with the standard SSME pumps.
-//	Everything above the throat is identical to a standard SSME.
+//	Regarding SSME-35:
+//	This engine appears to have baseline performance defined as running at 109% throttle.
+//	Considering the difficulty experienced in achieving reliable operation at those power levels, I have 
+//	downrated it back to the same power level as it's "base" config.
+//	Everything above the nozzle is identical to a standard SSME.
 
 //	This config is technically deprecated, but will still be used by SSME-35 only parts (until someone can figure out MM wizardry to make the combined config work for that)
 //	==================================================
@@ -124,8 +126,8 @@
 			name = RS-25-35
 			description = Phase I SSME
 			specLevel = prototype
-			minThrust = 1441
-			maxThrust = 2151
+			minThrust = 1369
+			maxThrust = 2043
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -139,8 +141,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 441
-				key = 1 404
+				key = 0 445
+				key = 1 406
 			}
 
 			%ullage = True
@@ -156,14 +158,22 @@
 			//	60 engines, 2 ignition failures, 1 other
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.966667
-				ignitionReliabilityEnd = 0.993333
-				cycleReliabilityStart = 0.983333
-				cycleReliabilityEnd = 0.996667
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954918
+				ignitionReliabilityEnd = 0.990984
+				cycleReliabilityStart = 0.971311
+				cycleReliabilityEnd = 0.994262
 				techTransfer = RS-25:50
 			}
 		}
@@ -172,8 +182,8 @@
 			name = RS-25A-35 //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
 			specLevel = concept
-			minThrust = 1441
-			maxThrust = 2237
+			minThrust = 1369
+			maxThrust = 2124.7
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -187,8 +197,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 441
-				key = 1 404
+				key = 0 443.3
+				key = 1 404.1
 			}
 
 			%ullage = True
@@ -204,14 +214,22 @@
 			//	189 engines, 3 ignition failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.984127
-				ignitionReliabilityEnd = 0.996825
-				cycleReliabilityStart = 0.994737
-				cycleReliabilityEnd = 0.998947
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.975000
+				ignitionReliabilityEnd = 0.996053
+				cycleReliabilityStart = 0.975000
+				cycleReliabilityEnd = 0.999211
 				techTransfer = RS-25A,RS-25-35,RS-25:50
 			}
 		}
@@ -220,8 +238,8 @@
 			name = RS-25C-35 //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
 			specLevel = concept
-			minThrust = 1441
-			maxThrust = 2345
+			minThrust = 1369
+			maxThrust = 2227.2
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -236,8 +254,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 441
-				key = 1 404
+				key = 0 442.2
+				key = 1 409.5
 			}
 
 			%ullage = True
@@ -253,14 +271,22 @@
 			//	48 engines, 1 failure.
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.979592
-				ignitionReliabilityEnd = 0.995918
-				cycleReliabilityStart = 0.979167
-				cycleReliabilityEnd = 0.995833
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954762
+				ignitionReliabilityEnd = 0.996939
+				cycleReliabilityStart = 0.954762
+				cycleReliabilityEnd = 0.992857
 				techTransfer = RS-25C,RS-25A-35,RS-25A,RS-25-35,RS-25:50
 			}
 		}
@@ -269,8 +295,8 @@
 			name = RS-25D-35 //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
 			specLevel = concept
-			minThrust = 1441
-			maxThrust = 2388
+			minThrust = 1369
+			maxThrust = 2268.1
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -285,8 +311,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 441
-				key = 1 404
+				key = 0 442.2
+				key = 1 409.5
 			}
 
 			%ullage = True
@@ -302,14 +328,22 @@
 			//	93 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.989362
-				ignitionReliabilityEnd = 0.997872
-				cycleReliabilityStart = 0.989362
-				cycleReliabilityEnd = 0.997872
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.989894
+				ignitionReliabilityEnd = 0.998404
+				cycleReliabilityStart = 0.989894
+				cycleReliabilityEnd = 0.998404
 				techTransfer = RS-25D-E,RS-25C-35,RS-25C,RS-25A-35,RS-25A,RS-25-35,RS-25:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/SSME50X_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME50X_config.cfg
@@ -5,18 +5,18 @@
 //
 //	=================================================================================
 //	SSME-50X
-//	Block I Phase II
+//	Phase I
 //
 //	Dry Mass: 4203 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2212 kN
-//	ISP: 389 SL / 446 Vac (retracted)
-//	ISP: 200 SL / 460 Vac (extended)
+//	Thrust (Vac): 2130 kN
+//	ISP: 391 SL / 450 Vac (retracted)
+//	ISP: 340? SL / 464 Vac (extended)
 //	Burn Time: 500
-//	Chamber Pressure: 21.64 MPa (higher?)
+//	Chamber Pressure: 20.48 MPa (@ 100% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
-//	Throttle: 104% to 67%
+//	Throttle: 100% to 67%
 //	Nozzle Ratio: 50/150
 //	Ignitions: 3
 //	=================================================================================
@@ -25,11 +25,11 @@
 //
 //	Dry Mass: 4476 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2361 kN
-//	ISP: 389 SL / 446 Vac (retracted)
-//	ISP: 200 SL / 460 Vac (extended)
+//	Thrust (Vac): 2364.5 kN
+//	ISP: 394.3 SL / 447.1 Vac (retracted)
+//	ISP: 345 SL / 461 Vac (extended)
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa (higher?)
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%
@@ -46,21 +46,19 @@
 
 //	Notes:
 
-//	The paper used for reference is dated 1978-1980, and seems to use the preproduction SSME as reference.
+//	The paper used for reference is dated 1978-1980, and seems to use the Phase I SSME as reference.
 //	I have extrapolated the performance of this to the SSME upgrades.
-//	Since preproduction SSME got 456 s vac instead of 452, I have subtracted 4s from the vacuum performance of all engines
-//	SL ISP was 463 instead of 461, so 2 s has been subtracted from the SL performance.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.
 //
 //	This engine has an extendable 50:1/150:1 nozzle
 //	Everything above the nozzle is identical to a standard SSME.
-//	Assuming longer development time for extendable nozzle, skipping intermediat configs (Phase I and Block IIA)
+//	Assuming longer development time for extendable nozzle, skipping intermediate configs (Phase II and Block IIA)
 //	==================================================
 @PART[*]:HAS[#engineType[SSME50X]]:FOR[RealismOverhaulEngines]
 {
 	%title = #roSSME50XTitle	//RS-25-50X (SSME-50X)
 	%manufacturer = #roMfrRocketdyne
-	%description = #roSSME50XDesc	//The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. This version uses an extendable nozzle, allowing the SSME to switch from a 50:1 sea level nozzle to a 150:1 vacuum nozzle mid-flight. Intended for SSTO use, where the extending nozzle would allow for the required performance at sea level and vacuum.
+	%description = #roSSME50XDesc
 
 	@tags ^= :$: USA rocketdyne ssme-50x rs25-50x liquid pump sustainer lqdhydrogen lqdoxygen
 
@@ -93,11 +91,11 @@
 		
 		CONFIG
 		{
-			name = RS-25A-50X //104% thrust
-			description = Phase II SSME. Rated for sustained operation at 104% thrust.
+			name = RS-25A-50X //100% thrust
+			description = Phase I SSME.
 			specLevel = concept
-			minThrust = 1381
-			maxThrust = 2145
+			minThrust = 1384
+			maxThrust = 2066
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -111,8 +109,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 446
-				key = 1 389
+				key = 0 450
+				key = 1 391
 			}
 
 			%ullage = True
@@ -127,22 +125,21 @@
 			{
 				name = RS-25A-50X-Extended
 				
-				minThrust = 1425
-				maxThrust = 2212
+				minThrust = 1427
+				maxThrust = 2130
 				
 				atmosphereCurve
 				{
-					key = 0 460
-					key = 1 200
+					key = 0 464
+					key = 1 340
 				}
 			}
 
-			//	RS-25A(B) flew on 63 flights with 3 ignition failures
-			//	189 engines, 3 ignition failures
+			//	RS-25 flew on 20 flights with 2 ignition failures and 1 other failure
+			//	60 engines, 2 ignition failures, 1 other
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				name = RS-25A-50X
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
@@ -154,11 +151,10 @@
 					key = 1.00 1.00 3 3
 				}
 
-				ignitionReliabilityStart = 0.984127
-				ignitionReliabilityEnd = 0.996825
-				cycleReliabilityStart = 0.994737
-				cycleReliabilityEnd = 0.998947
-				techTransfer = RS-25A,RS-25:50
+				ignitionReliabilityStart = 0.954918
+				ignitionReliabilityEnd = 0.990984
+				cycleReliabilityStart = 0.971311
+				cycleReliabilityEnd = 0.994262
 			}
 		}
 		CONFIG
@@ -166,8 +162,8 @@
 			name = RS-25D-50X //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency.
 			specLevel = speculative
-			minThrust = 1381
-			maxThrust = 2289
+			minThrust = 1384
+			maxThrust = 2293.2
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -182,8 +178,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 446
-				key = 1 389
+				key = 0 447.1
+				key = 1 394.3
 			}
 
 			%ullage = True
@@ -198,13 +194,13 @@
 			{
 				name = RS-25D-50X-Extended
 				
-				minThrust = 1425
-				maxThrust = 2361
+				minThrust = 1427
+				maxThrust = 2364.5
 				
 				atmosphereCurve
 				{
-					key = 0 460
-					key = 1 200
+					key = 0 461
+					key = 1 345
 				}
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/SSME50_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME50_Config.cfg
@@ -5,30 +5,30 @@
 //
 //	=================================================================================
 //	SSME-50
-//	Block I Phase I
+//	Phase I
 //	Baseline
 //
 //	Dry Mass: 3440 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2062 kN
-//	ISP: 389 SL / 446 Vac
+//	Thrust (Vac): 2066 kN
+//	ISP: 391 SL / 450 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 22.88 MPa
+//	Chamber Pressure: 20.48 MPa (@ 100% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 100% to 67%
-//	Nozzle Ratio: 44.4
+//	Nozzle Ratio: 50
 //	Ignitions: 1
 //	=================================================================================
 //	SSME-50
-//	Block I Phase II
+//	Phase II
 //
 //	Dry Mass: 3440 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2145 kN
-//	ISP: 389 SL / 446 Vac
+//	Thrust (Vac): 2148.7 kN
+//	ISP: 387.2 SL / 448.3 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 21.64 MPa
+//	Chamber Pressure: 21.55 MPa (@ 104% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 104% to 67%
@@ -40,10 +40,10 @@
 //
 //	Dry Mass: 3664 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2248 kN
-//	ISP: 389 SL / 446 Vac
+//	Thrust (Vac): 2251.9 kN
+//	ISP: 394.3 SL / 447.1 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa
+//	Chamber Pressure: 20.74 MPa (@ 109% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 109% to 67%
@@ -55,10 +55,10 @@
 //
 //	Dry Mass: 3664 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2289 kN
-//	ISP: 389 SL / 446 Vac
+//	Thrust (Vac): 2293.2 kN
+//	ISP: 394.3 SL / 447.1 Vac
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%
@@ -75,15 +75,15 @@
 
 //	Notes:
 
-//	The paper used for reference is dated 1978-1980, and seems to use the preproduction SSME as reference.
-//	I have extrapolated the performance of this to the SSME upgrades.
-//	Since preproduction SSME got 456 s vac instead of 452, I have subtracted 4s from the vacuum performance of all engines
-//	SL ISP was 463 instead of 461, so 2 s has been subtracted from the SL performance.
+/	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME as reference.
+//	The performance of alternate nozzle configurations have been corrected to match the relative performance
+//	of their "base" configs.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.
 //
+//	Regarding SSME-50:
 //	This engine has a 50:1 nozzle ratio, and no further modifications.
 //	Everything above the nozzle is identical to a standard SSME.
-
+//
 //	This config is technically deprecated, but will still be used by SSME-50 only parts (until someone can figure out MM wizardry to make the combined config work for that)
 //	==================================================
 @PART[*]:HAS[#engineType[SSME50]]:FOR[RealismOverhaulEngines]
@@ -124,8 +124,8 @@
 			name = RS-25-50
 			description = Phase I SSME
 			specLevel = prototype
-			minThrust = 1381
-			maxThrust = 2062
+			minThrust = 1384
+			maxThrust = 2066
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -139,8 +139,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 446
-				key = 1 389
+				key = 0 450
+				key = 1 391
 			}
 
 			%ullage = True
@@ -156,14 +156,22 @@
 			//	60 engines, 2 ignition failures, 1 other
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.966667
-				ignitionReliabilityEnd = 0.993333
-				cycleReliabilityStart = 0.983333
-				cycleReliabilityEnd = 0.996667
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954918
+				ignitionReliabilityEnd = 0.990984
+				cycleReliabilityStart = 0.971311
+				cycleReliabilityEnd = 0.994262
 				techTransfer = RS-25:50
 			}
 		}
@@ -172,8 +180,8 @@
 			name = RS-25A-50 //104% thrust
 			description = Phase II SSME. Rated for sustained operation at 104% thrust.
 			specLevel = concept
-			minThrust = 1381
-			maxThrust = 2145
+			minThrust = 1384
+			maxThrust = 2148.7
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -187,8 +195,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 446
-				key = 1 389
+				key = 0 448.3
+				key = 1 387.2
 			}
 
 			%ullage = True
@@ -204,14 +212,22 @@
 			//	189 engines, 3 ignition failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.984127
-				ignitionReliabilityEnd = 0.996825
-				cycleReliabilityStart = 0.994737
-				cycleReliabilityEnd = 0.998947
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.975000
+				ignitionReliabilityEnd = 0.996053
+				cycleReliabilityStart = 0.975000
+				cycleReliabilityEnd = 0.999211
 				techTransfer = RS-25A,RS-25-50,RS-25:50
 			}
 		}
@@ -220,8 +236,8 @@
 			name = RS-25C-50 //109% thrust
 			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
 			specLevel = concept
-			minThrust = 1381
-			maxThrust = 2248
+			minThrust = 1384
+			maxThrust = 2251.9
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -236,8 +252,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 446
-				key = 1 389
+				key = 0 447.1
+				key = 1 394.3
 			}
 
 			%ullage = True
@@ -253,14 +269,22 @@
 			//	48 engines, 1 failure.
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.979592
-				ignitionReliabilityEnd = 0.995918
-				cycleReliabilityStart = 0.979167
-				cycleReliabilityEnd = 0.995833
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.954762
+				ignitionReliabilityEnd = 0.996939
+				cycleReliabilityStart = 0.954762
+				cycleReliabilityEnd = 0.992857
 				techTransfer = RS-25C,RS-25A-50,RS-25A,RS-25-50,RS-25:50
 			}
 		}
@@ -269,8 +293,8 @@
 			name = RS-25D-50 //111% thrust
 			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
 			specLevel = concept
-			minThrust = 1381
-			maxThrust = 2289
+			minThrust = 1384
+			maxThrust = 2293.2
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -285,8 +309,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 446
-				key = 1 389
+				key = 0 447.1
+				key = 1 394.3
 			}
 
 			%ullage = True
@@ -302,14 +326,22 @@
 			//	93 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.989362
-				ignitionReliabilityEnd = 0.997872
-				cycleReliabilityStart = 0.989362
-				cycleReliabilityEnd = 0.997872
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.989894
+				ignitionReliabilityEnd = 0.998404
+				cycleReliabilityStart = 0.989894
+				cycleReliabilityEnd = 0.998404
 				techTransfer = RS-25D-E,RS-25C-50,RS-25C,RS-25A-50,RS-25A,RS-25-50,RS-25:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/SSME50_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME50_Config.cfg
@@ -75,7 +75,7 @@
 
 //	Notes:
 
-/	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME as reference.
+//	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME as reference.
 //	The performance of alternate nozzle configurations have been corrected to match the relative performance
 //	of their "base" configs.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.

--- a/GameData/RealismOverhaul/Engine_Configs/SSME650_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME650_Config.cfg
@@ -10,9 +10,9 @@
 //	Dry Mass: 3962 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 2093 kN
-//	ISP: 150 SL / 478 Vac
+//	ISP: 190 SL / 478 Vac	SL calculated with RPA
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa
+//	Chamber Pressure: ??? MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: N/A
@@ -88,7 +88,7 @@
 			atmosphereCurve
 			{
 				key = 0 478
-				key = 1 150
+				key = 1 190
 			}
 
 			%ullage = True
@@ -104,14 +104,22 @@
 			//	93 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 3600		//Rated to 55 missions, or 27000 seconds
+				testedBurnTime = 4615
 				ratedBurnTime = 480
 				overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
 				safeOverburn = true
-				ignitionReliabilityStart = 0.989362
-				ignitionReliabilityEnd = 0.997872
-				cycleReliabilityStart = 0.989362
-				cycleReliabilityEnd = 0.997872
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.989894
+				ignitionReliabilityEnd = 0.998404
+				cycleReliabilityStart = 0.989894
+				cycleReliabilityEnd = 0.998404
 				techTransfer = RS-25D-E,RS-25C,RS-25A,RS-25:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -5,29 +5,29 @@
 //
 //	=================================================================================
 //	SSME
-//	Block I Phase I
+//	Phase I
 //
 //	Dry Mass: 3527 kg (35 3372 kg, 50 3440 kg, 150 4400 kg)
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2090 kN (2151 35, 2062 50, 2124 150)
-//	ISP: 361 SL / 452 Vac (404/441 35, 389/446 50, ???/460 150)
+//	Thrust (Vac): 2090 kN (2043 35, 2066 50, 2130 150)
+//	ISP: 363.2 SL / 455.2 Vac (406/445 35, 391/450 50, 340?/464 150)
 //	Burn Time: 500
-//	Chamber Pressure: 22.88 MPa (22.3 MPa 35, 22.88 all others)
+//	Chamber Pressure: 20.48 MPa (@ 100% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 100% to 67%
-//	Nozzle Ratio: 68.8 (31.1 35, 44.4 50, 133.2 150)
+//	Nozzle Ratio: 77.5 (35 35, 50 50, 150 150)
 //	Ignitions: 1 (3 for 150)
 //	=================================================================================
 //	SSME
-//	Block I Phase II
+//	Phase II
 //
 //	Dry Mass: 3527 kg (35 3372 kg, 50 3440 kg, 150 4400 kg)
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2173.6 kN (2237 35, 2145 50, 2212 150)
-//	ISP: 361 SL / 452 Vac (404/441 35, 389/446 50, ???/460 150)
+//	Thrust (Vac): 2173.6 kN (2124.7 35, 2148.7 50, 2215.8 150)
+//	ISP: 361.5 SL / 453.5 Vac (404.1/443.3 35, 387.2/448.3 50, 340?/462.3 150)
 //	Burn Time: 500
-//	Chamber Pressure: 21.64 MPa (21.1 MPa 35, 22.88 all others)
+//	Chamber Pressure: 21.55 MPa (@ 104% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 104% to 67%
@@ -39,10 +39,10 @@
 //
 //	Dry Mass: 3753 kg (35 3589 kg, 50 3664 kg, 150 4686 kg)
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2278.1 kN (2345 35, 2248 50, 2318 150)
-//	ISP: 361 SL / 452 Vac (404/441 35, 389/446 50, ???/460 150)
+//	Thrust (Vac): 2278.1 kN (2227.2 35, 2251.9 50, 2321.9 150)
+//	ISP: 366.3 SL / 452.3 Vac (409.5/442.2 35, 394.3/447.1 50, 345?/461 150)
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa (18.5 MPa 35, 22.88 all others)
+//	Chamber Pressure: 20.74 MPa (@ 109% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 109% to 67%
@@ -54,10 +54,10 @@
 //
 //	Dry Mass: 3753 Kg (35 3589 kg, 50 3664 kg, 150 4686 kg)
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2319.9 kN (2388 35, 2289 50, 2361 150)
-//	ISP: 361 SL / 452 Vac (404/441 35, 389/446 50, ???/460 150)
+//	Thrust (Vac): 2319.9 kN (2268.1 35, 2293.2 50, 2364.5 150)
+//	ISP: 366.3 SL / 452.3 Vac (409.5/442.2 35, 394.3/447.1 50, 345?/461 150)
 //	Burn Time: 500
-//	Chamber Pressure: 18.93 MPa (18.5 MPa 35, 22.88 all others)
+//	Chamber Pressure: ??? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%
@@ -67,28 +67,31 @@
 
 //	Sources:
 
-//	https://web.archive.org/web/20120208191620/http://www.pw.utc.com/products/pwr/assets/pwr_SSME.pdf
-//	http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-//	http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
-//	http://www.b14643.de/Spacerockets_2/United_States_1/Space_Shuttle/Propulsion/engines.htm
-//	History of Liquid Propellant Rocket Engines, George P. Sutton
-//	https://space.nss.org/wp-content/uploads/NASA-CR3321-Transportation-Analysis.pdf
-//	doi:10.2514/6.1978-976
+//	[1] https://web.archive.org/web/20120208191620/http://www.pw.utc.com/products/pwr/assets/pwr_SSME.pdf
+//	[2] http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//	[3] http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
+//	[4] http://www.b14643.de/Spacerockets_2/United_States_1/Space_Shuttle/Propulsion/engines.htm
+//	[5] History of Liquid Propellant Rocket Engines, George P. Sutton
+//	[6] https://space.nss.org/wp-content/uploads/NASA-CR3321-Transportation-Analysis.pdf
+//	[7] doi:10.2514/6.1978-976
 
 //	Used by:
 
 //	Notes:
 
+//	Using source [4] as master reference, seems to be the most comprehensive and agrees with other sources
+//	pretty well.
 
-//	The paper used for reference is dated 1978-1980, and seems to use the preproduction SSME as reference.
-//	I have extrapolated the performance of this to the SSME upgrades.
-//	Since preproduction SSME got 456 s vac instead of 452, I have subtracted 4s from the vacuum performance of all engines
-//	SL ISP was 463 instead of 461, so 2 s has been subtracted from the SL performance.
+//	The paper used for reference is dated 1978-1980, and seems to use the Phase-I SSME as reference.
+//	The performance of alternate nozzle configurations have been corrected to match the relative performance
+//	of their "base" configs.
 //	Preproduction SSME was also much lighter, at 3008 kg. I have made this 17.3% heavier to match production SSME.
 //
 //	Regarding SSME-35:
-//	This engine has both a larger throat (as shown by the reduced chamber pressure), which results in increased thrust with the standard SSME pumps.
-//	Everything above the throat is identical to a standard SSME.
+//	This engine appears to have baseline performance defined as running at 109% throttle.
+//	Considering the difficulty experienced in achieving reliable operation at those power levels, I have 
+//	downrated it back to the same power level as it's "base" config.
+//	Everything above the nozzle is identical to a standard SSME.
 //
 //	Regarding SSME-50:
 //	This engine has a 50:1 nozzle ratio, and no further modifications.
@@ -110,7 +113,7 @@
 {
 	%title = #roSSMETitle	//RS-25 (SSME)
 	%manufacturer = #roMfrRocketdyne
-	%description = #roSSMEDesc	//The RS-25, also known as the Space Shuttle Main Engine (SSME), is a LH2/LOX fuel-rich staged combustion engine. Though complex and expensive, these engines provide very high performance and are extremely reliable. Three of these engines powered each Shuttle Orbiter and four will be used on the core stage of the SLS.
+	%description = #roSSMEDesc
 
 	@tags ^= :$: USA rocketdyne ssme rs25 liquid pump sustainer lqdhydrogen lqdoxygen
 
@@ -144,7 +147,7 @@
 		CONFIG
 		{
 			name = RS-25
-			description = Phase I SSME, with 68.8:1 nozzle.
+			description = Phase I SSME, with 77.5:1 nozzle.
 			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2090
@@ -161,8 +164,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 452
-				key = 1 361
+				key = 0 455.2
+				key = 1 363.2
 			}
 
 			%ullage = True
@@ -176,46 +179,46 @@
 			SUBCONFIG
 			{
 				name = 35AR
-				description = Phase-I SSME-35, fitted with larger throat and 31.1:1 nozzle for better sea level performance.
+				description = Phase-I SSME-35, fitted with 35:1 nozzle for better sea level performance.
 				specLevel = prototype
-				minThrust = 1441
-				maxThrust = 2151
+				minThrust = 1369
+				maxThrust = 2043
 				massMult = 0.9561
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 441
-					key = 1 404
+					key = 0 445
+					key = 1 406
 				}
 			}
 			SUBCONFIG
 			{
 				name = 50AR
-				description = Phase-I SSME-50, fitted with a 44.4:1 nozzle for better medium altitude performance.
+				description = Phase-I SSME-50, fitted with a 50:1 nozzle for better medium altitude performance.
 				specLevel = prototype
-				minThrust = 1381
-				maxThrust = 2062
+				minThrust = 1384
+				maxThrust = 2066
 				massMult = 0.9753
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 446
-					key = 1 389
+					key = 0 450
+					key = 1 391
 				}
 			}
 			SUBCONFIG
 			{
 				name = 150AR
-				description = Phase-I SSME-150, fitted with a 133.2:1 nozzle and restart kit for upper stage use.
+				description = Phase-I SSME-150, fitted with a 150:1 nozzle and restart kit for upper stage use.
 				specLevel = concept
-				minThrust = 1425
-				maxThrust = 2127
+				minThrust = 1427
+				maxThrust = 2130
 				massMult = 1.2475
 				costOffset = 1000
 				atmosphereCurve
 				{
-					key = 0 460
-					key = 1 200
+					key = 0 464
+					key = 1 340
 				}
 				ignitions = 3
 			}
@@ -245,7 +248,7 @@
 		CONFIG
 		{
 			name = RS-25A //104% thrust
-			description = Phase II SSME. Rated for sustained operation at 104% thrust.
+			description = Phase II SSME with 77.5:1 nozzle. Rated for sustained operation at 104% thrust.
 			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2173.6
@@ -262,8 +265,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 452
-				key = 1 361
+				key = 0 453.5
+				key = 1 361.5
 			}
 
 			%ullage = True
@@ -277,16 +280,16 @@
 			SUBCONFIG
 			{
 				name = 35AR
-				description = Phase-II SSME-35, fitted with larger throat and 35:1 nozzle for better sea level performance.
+				description = Phase-II SSME-35, fitted 35:1 nozzle for better sea level performance.
 				specLevel = concept
-				minThrust = 1441
-				maxThrust = 2237
+				minThrust = 1369
+				maxThrust = 2124.7
 				massMult = 0.9561
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 441
-					key = 1 404
+					key = 0 443.3
+					key = 1 404.1
 				}
 			}
 			SUBCONFIG
@@ -294,14 +297,14 @@
 				name = 50AR
 				description = Phase-II SSME-50, fitted with a 50:1 nozzle for better medium altitude performance.
 				specLevel = concept
-				minThrust = 1381
-				maxThrust = 2145
+				minThrust = 1384
+				maxThrust = 2148.7
 				massMult = 0.9753
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 446
-					key = 1 389
+					key = 0 448.3
+					key = 1 387.2
 				}
 			}
 			SUBCONFIG
@@ -309,14 +312,14 @@
 				name = 150AR
 				description = Phase-II SSME-150, fitted with a 150:1 nozzle and restart kit for upper stage use.
 				specLevel = speculative
-				minThrust = 1425
-				maxThrust = 2212
+				minThrust = 1427
+				maxThrust = 2215.8
 				massMult = 1.2475
 				costOffset = 1000
 				atmosphereCurve
 				{
-					key = 0 460
-					key = 1 200
+					key = 0 462.3
+					key = 1 340
 				}
 				ignitions = 3
 			}
@@ -347,7 +350,7 @@
 		CONFIG
 		{
 			name = RS-25C //109% thrust
-			description = Block IIA SSME. First major improvement to the engine, rated for sustained operation at 109% thrust.
+			description = Block IIA SSME with 69:1 nozzle. First major improvement to the engine, rated for sustained operation at 109% thrust. Sacrificed vacuum performance to finally meet target sea level performance.
 			specLevel = operational
 			minThrust = 1400.4
 			maxThrust = 2278.1
@@ -365,8 +368,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 452
-				key = 1 361
+				key = 0 452.3
+				key = 1 366.3
 			}
 
 			%ullage = True
@@ -380,46 +383,46 @@
 			SUBCONFIG
 			{
 				name = 35AR
-				description = Block IIA SSME-35, fitted with larger throat and 35:1 nozzle for better sea level performance.
+				description = Block IIA SSME-35, fitted with 31.2:1 nozzle for better sea level performance.
 				specLevel = concept
-				minThrust = 1441
-				maxThrust = 2345
+				minThrust = 1369
+				maxThrust = 2227.2
 				massMult = 1.0176
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 441
-					key = 1 404
+					key = 0 442.2
+					key = 1 409.5
 				}
 			}
 			SUBCONFIG
 			{
 				name = 50AR
-				description = Block IIA SSME-50, fitted with a 50:1 nozzle for better medium altitude performance.
+				description = Block IIA SSME-50, fitted with a 44.5:1 nozzle for better medium altitude performance.
 				specLevel = concept
-				minThrust = 1381
-				maxThrust = 2248
+				minThrust = 1384
+				maxThrust = 2251.9
 				massMult = 1.0388
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 446
-					key = 1 389
+					key = 0 447.1
+					key = 1 394.3
 				}
 			}
 			SUBCONFIG
 			{
 				name = 150AR
-				description = Block IIA SSME-150, fitted with a 150:1 nozzle and restart kit for upper stage use.
+				description = Block IIA SSME-150, fitted with a 133.5:1 nozzle and restart kit for upper stage use.
 				specLevel = speculative
-				minThrust = 1425
-				maxThrust = 2318
+				minThrust = 1427
+				maxThrust = 2321.9
 				massMult = 1.3286
 				costOffset = 1000
 				atmosphereCurve
 				{
-					key = 0 460
-					key = 1 200
+					key = 0 461
+					key = 1 345
 				}
 				ignitions = 3
 			}
@@ -450,10 +453,10 @@
 		CONFIG
 		{
 			name = RS-25D-E //111% thrust
-			description = Block II SSME. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E
+			description = Block II SSME with 69:1 nozzle. Rated up to 111% thrust in an emergency. To be used on SLS as the RS-25E.
 			specLevel = operational
 			minThrust = 1400.4
-			maxThrust = 2319.9
+			maxThrust = 2364.5
 			massMult = 1.065
 			PROPELLANT
 			{
@@ -468,8 +471,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 452
-				key = 1 361
+				key = 0 452.3
+				key = 1 366.3
 			}
 
 			%ullage = True
@@ -483,46 +486,46 @@
 			SUBCONFIG
 			{
 				name = 35AR
-				description = Block II SSME-35, fitted with larger throat and 35:1 nozzle for better sea level performance.
+				description = Block II SSME-35, 31.2:1 nozzle for better sea level performance.
 				specLevel = concept
-				minThrust = 1441
-				maxThrust = 2388
+				minThrust = 1369
+				maxThrust = 2268.1
 				massMult = 1.0176
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 441
-					key = 1 404
+					key = 0 442.2
+					key = 1 409.5
 				}
 			}
 			SUBCONFIG
 			{
 				name = 50AR
-				description = Block II SSME-50, fitted with a 50:1 nozzle for better medium altitude performance.
+				description = Block II SSME-50, fitted with a 44.5:1 nozzle for better medium altitude performance.
 				specLevel = concept
-				minThrust = 1381
-				maxThrust = 2289
+				minThrust = 1384
+				maxThrust = 2293.2
 				massMult = 1.0388
 				costOffset = 0
 				atmosphereCurve
 				{
-					key = 0 446
-					key = 1 389
+					key = 0 447.1
+					key = 1 394.3
 				}
 			}
 			SUBCONFIG
 			{
 				name = 150AR
-				description = Block II SSME-150, fitted with a 150:1 nozzle and restart kit for upper stage use.
+				description = Block II SSME-150, fitted with a 133.5:1 nozzle and restart kit for upper stage use.
 				specLevel = speculative
-				minThrust = 1425
-				maxThrust = 2361
+				minThrust = 1427
+				maxThrust = 2364.5
 				massMult = 1.3286
 				costOffset = 1000
 				atmosphereCurve
 				{
-					key = 0 460
-					key = 1 200
+					key = 0 461
+					key = 1 345
 				}
 				ignitions = 3
 			}


### PR DESCRIPTION
Improve SSME configs, properly defining the different performance levels between different versions instead of just varying thrust. These configs changes have also been propagated to all SSME-based engines.
These changes are not strictly save-breaking, but the changes in performance may result in some crafts with a narrow deltaV margin being unable to function.