### PR TITLE
Lower part mass for SmartParts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SmartParts/RO_SmartParts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SmartParts/RO_SmartParts.cfg
@@ -26,27 +26,27 @@
 @PART[km_smart_alt_low]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.0002
+	@mass = 0.0001
 }
 @PART[km_smart_fuel]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.0002
+	@mass = 0.0001
 }
 @PART[km_prox_sensor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.0002
+	@mass = 0.0001
 }
 @PART[km_smart_radio]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.0002
+	@mass = 0.0001
 }
 @PART[km_smart_time]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.0002
+	@mass = 0.0001
 }
 @PART[km_valve]:FOR[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SmartParts/RO_SmartParts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SmartParts/RO_SmartParts.cfg
@@ -1,48 +1,60 @@
 @PART[kb-fuel-breaker1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.001
 }
 @PART[kb-fuel-breaker15]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.001
 }
 @PART[kb-fuel-breaker2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.001
 }
 @PART[kb-fuel-breaker3]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.001
 }
 @PART[FuelController]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.001
 }
 @PART[km_smart_alt_low]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }
 @PART[km_smart_fuel]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }
 @PART[km_prox_sensor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }
 @PART[km_smart_radio]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }
 @PART[km_smart_time]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }
 @PART[km_valve]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }
 @PART[km_valve2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@mass = 0.0002
 }


### PR DESCRIPTION
Currently SmartParts controllers like altitude / time activation triggers weigh 0.05T (50kg) each, which is far too heavy to use for any upper stage / payload, and is not realistic even for early technology. 

Surveyor's radar altimeter package, which fired the main retro-engine then jettisoned itself, is only 8.43 pounds or 3.8kg.

<img width="494" alt="image" src="https://user-images.githubusercontent.com/13956642/228317207-60a12934-23d1-4e1b-9588-da009c05efcf.png">
<img width="647" alt="image" src="https://user-images.githubusercontent.com/13956642/228317224-45da0e16-3711-440b-8018-db5046a50036.png">

This PR changes SmartParts fuel couplers to 1kg, fuel valves to 200g, and controller parts to 100g. This results in a fairly accurate mass when added to a decoupler. 

Currently the smart parts offer no more control ability than kOS / mechjeb, so lowering the mass of these control parts shouldn't pose a balance issue.