### PR TITLE
Fix MH RD-107/108

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Engine.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Engine.cfg
@@ -195,7 +195,10 @@
 	@title = RD108 Series
 	
 	%engineType = RD108-118
-		
+	%useVerniers = True
+	%vernierThrust = 137.3
+	%massOffset = -0.16
+	
 	@MODULE[ModuleEngines*]
 	{
 		@minThrust = 801.44
@@ -263,6 +266,9 @@
 	@tiitle = RD107 Series
 	
 	%engineType = RD107-117
+	%useVerniers = True
+	%vernierThrust = 68.6
+	%massOffset = -0.08
 	
 	@MODULE[ModuleEngines*]
 	{
@@ -313,6 +319,7 @@
 	}
 }
 
+//source: http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 @PART[LiquidEngineRV-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -371,15 +378,17 @@
 		type = ModuleEngines
 		configuration = Core/booster Verniers
 		modded = false
+		literalZeroIgnitions = True
 		CONFIG
 		{
 			name = Core_Verniers
-			maxThrust = 35
-			minThrust = 35
+			description = A.K.A. S1.35800.
+			maxThrust = 34.3
+			minThrust = 34.3
 			heatProduction = 100
             ullage = True
             pressureFed = False
-            ignitions = 1
+            ignitions = 0
 
             PROPELLANT
             {
@@ -412,12 +421,13 @@
 		CONFIG
 		{
 			name = Booster_Verniers
-			maxThrust = 35
-			minThrust = 35
+			description = A.K.A. S1.35800.
+			maxThrust = 34.3
+			minThrust = 34.3
 			heatProduction = 100
             ullage = True
             pressureFed = False
-            ignitions = 1
+            ignitions = 0
 
 
             PROPELLANT


### PR DESCRIPTION
Subtract the vernier thrust and mass from the MH RD-107/108, and prevent the MH RD-107/108 verniers from being airstarted.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/2815