### PR TITLE
Restore TF configs for generic thrusters

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -415,56 +415,68 @@
 	//FIXME: This should probably be shown in PAW, similar to MERF
 	@description ^= :$: <b><color=red> RCS requires High-Pressure tanks to function.</color></b>
 }
-@PART[*]:HAS[~useRcsMass[True],#engineType[RCSGeneric]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[RCSGeneric],@MODULE[ModuleEngines*]]:FOR[RealismOverhaulEngines]
+{
+	//just tag generic thrusters, since TF doesn't apply to RCS
+	%useRCSTestFlightConfig = true
+}
+@PART[*]:HAS[~useRcsMass[?rue],#engineType[RCSGeneric]]:FOR[RealismOverhaulEngines]
 {
 	@MODULE[ModuleEngineConfigs]:HAS[#type[ModuleRCS]]
 	{
 		-origMass = NULL
 	}
 }
-@PART[*]:HAS[#useRCSTestFlightConfig[True],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]:NEEDS[TestLite|TestFlight]
+//these have to cover an incredibly wide range of thrusters over a wide era, so be pretty generous
+@PART[*]:HAS[#useRCSTestFlightConfig[?rue],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]:NEEDS[TestLite|TestFlight]
 {
 	!useRCSTestFlightConfig = NULL
 
+	//cold gas thrusters completely inert, only failures likely from valves during start/shutdown
 	TESTFLIGHT
 	{
 		name = ColdGasRCS
 		mainConfiguration = engineConfig = Helium,engineConfig = Nitrogen:ColdGasRCS
-		ratedBurnTime = 1200
+		ratedBurnTime = 36000	//10 hours
 		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.999
+		ignitionReliabilityEnd = 0.9999
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.999
-		reliabilityDataRateMultiplier = 0.1
-		techTransfer = NitrousOxide,HTP,Hydrazine,Cavea-B,MMH+NTO,MMH+MON3,MMH+MON10,UDMH+NTO,Aerozine50+NTO:50
+		cycleReliabilityStart = 0.99
+		cycleReliabilityEnd = 1.0
+		reliabilityDataRateMultiplier = 7.8	//100 minutes to max du?
+		techTransfer = NitrousOxide,HTP,Hydrazine,ASCENT,Cavea-B,MMH+NTO,MMH+MON3,MMH+MON10,UDMH+NTO,Aerozine50+NTO,Kerosene+O2,Syntin+O2,Ethanol+O2,CH4+O2,H2+O2:20
 	}
 
+	//catalyst erosion and burnthroughs can occur, but are rare
+	//Once again, most failures due to valves during ignition
 	TESTFLIGHT
 	{
 		name = MonopropellantRCS
-		mainConfiguration = engineConfig = NitrousOxide,engineConfig = HTP,engineConfig = Hydrazine,engineConfig = Cavea-B:MonopropellantRCS
-		ratedBurnTime = 1200
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.999
+		mainConfiguration = engineConfig = NitrousOxide,engineConfig = HTP,engineConfig = Hydrazine,engineConfig = Cavea-B:MonopropellantRCS,engineConfig = ASCENT:MonopropellantRCS
+		ratedBurnTime = 36000	//10 hours
+		ignitionReliabilityStart = 0.96
+		ignitionReliabilityEnd = 0.9995
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.999
-		reliabilityDataRateMultiplier = 0.1
-		techTransfer = Helium,Nitrogen,MMH+NTO,MMH+MON3,MMH+MON10,UDMH+NTO,Aerozine50+NTO:50
+		cycleReliabilityStart = 0.975
+		cycleReliabilityEnd = 0.9995
+		reliabilityDataRateMultiplier = 7.8	//100 minutes to max du?
+		techTransfer = Helium,Nitrogen,MMH+NTO,MMH+MON3,MMH+MON10,UDMH+NTO,Aerozine50+NTO,Kerosene+O2,Syntin+O2,Ethanol+O2,CH4+O2,H2+O2:20
 	}
 
+	//more valves, potential for hard start, more failure modes
+	//burnthrough failures can occur, but are unlikely
+	//Reference AJ10-Mid (first AJ10 with restarts) for start data, AJ10-190 (modern AJ10) for end data
 	TESTFLIGHT
 	{
 		name = BipropellantRCS
-		mainConfiguration = engineConfig = MMH+NTO,engineConfig = MMH+MON3,engineConfig = MMH+MON10,engineConfig = UDMH+NTO,engineConfig = Aerozine50+NTO:BipropellantRCS
-		ratedBurnTime = 1200
-		ignitionReliabilityStart = 0.98
-		ignitionReliabilityEnd = 0.999
+		mainConfiguration = engineConfig = MMH+NTO,engineConfig = MMH+MON3,engineConfig = MMH+MON10,engineConfig = UDMH+NTO,engineConfig = Aerozine50+NTO:BipropellantRCS,engineConfig = Kerosene+O2:BipropellantRCS,engineConfig = Syntin+O2:BipropellantRCS,engineConfig = Ethanol+O2:BipropellantRCS,engineConfig = CH4+O2:BipropellantRCS,engineConfig = H2+O2:BipropellantRCS
+		ratedBurnTime = 36000	//10 hours
+		ignitionReliabilityStart = 0.90
+		ignitionReliabilityEnd = 0.9994
 		ignitionDynPresFailMultiplier = 0.1
-		cycleReliabilityStart = 0.98
-		cycleReliabilityEnd = 0.999
-		reliabilityDataRateMultiplier = 0.1
-		techTransfer = Helium,Nitrogen,NitrousOxide,HTP,Hydrazine,Cavea-B:50
+		cycleReliabilityStart = 0.95
+		cycleReliabilityEnd = 0.9994
+		reliabilityDataRateMultiplier = 7.8	//100 minutes to max du?
+		techTransfer = Helium,Nitrogen,NitrousOxide,HTP,Hydrazine,ASCENT,Cavea-B:20
 	}
 }


### PR DESCRIPTION
Restore TF configs for generic thrusters (only, since TF apparently does not support RCS failures). Configs are fairly generous, since they have to support a very wide range of thrusters and eras.

All configs get a 10 hour burn time (this should be enough for almost everything). Data rates are tuned so 10,000 du should be reached after ~100 minutes of operation (shorter in the event of a failure rewarding extra du).
Thruster types have been given the following stats

Cold Gas Thrusters (inert, only likely possible failure modes from valves)
ignition 0.98 -> 0.9999
cycle 0.99 -> 1.0

Monopropellant Thrusters (simple, but bed erosion and burn-through possible along with valve failure)
ignition 0.96 -> 0.9995
cycle 0.975 -> 0.9995

Bipropellant Thrusters (more complex, reliability based on AJ10)
ignition 0.90 -> 0.9994
cycle 0.95 -> 0.9994

This should give some incentive to choose something other than bipropellant thrusters the second they become available, and encourage installing backup engines, similar to many real space probes like Cassini-Huygens.