### PR TITLE
Resource temps again (and alphabetization)

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -753,40 +753,31 @@ PARTUPGRADE
 
 // Regular resources
 // set boiling points assuming tank pressure of 1.5 bar
-// stuff with boiling points above 293 K gets left alone, except for water/ethanol because they're useful for evaporative cooling
+// stuff with boiling points above 293 K gets left alone, except for water/ethanol because they're useful
+// for evaporative cooling.
+// Create everything first here in the order we want.
 @TANK_DEFINITION:HAS[#addResources[true]]:FIRST
 {
 	-addResources = DEL
-	%TANK[LqdOxygen]
+	//put life support stuff first
+	%TANK[CarbonDioxide]
 	{
-		wallThickness = 0.0025
-		wallConduction = 16
-		temperature = 94.25	//from NIST webbook
-		insulationThickness = 0.01
-		insulationConduction = 0.02
+		%utilization = 200
+		%fillable = False
 	}
-	%TANK[Kerosene] {}
-	%TANK[LqdHydrogen]
-	{
-		temperature = 21.82	//from NIST webbook
-		wallThickness = 0.0025
-		wallConduction = 205
-		insulationThickness = 0.0381
-		insulationConduction = 0.014
-	}
-	%TANK[NTO] {}
-	%TANK[UDMH] {}
+	%TANK[Food] {}
+	%TANK[LithiumPeroxide] {}
+	%TANK[LithiumHydroxide] {}
+	%TANK[Oxygen] { %utilization = 200 }
+	%TANK[PotassiumSuperoxide] {}
+	%TANK[Waste] { %fillable = False }
+	%TANK[WasteWater] { %fillable = False }
+	
+	//everything else down here
 	%TANK[Aerozine50] {}
-	%TANK[MMH] {}
-	%TANK[HTP] {}
-	%TANK[AvGas] {}
-	%TANK[IRFNA-III] {}
-	%TANK[Aniline] {}
-	%TANK[Aniline22] {}
-	%TANK[Aniline37] {}
-	%TANK[Ethanol75] { %temperature = 361.8 }	//from NIST webbook
-	%TANK[Ethanol90] { %temperature = 361.8 }	//from NIST webbook
-	%TANK[Ethanol] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[AK20] {}
+	%TANK[AK27] {}
+	%TANK[Ammonia] { %utilization = 100 }
 	%TANK[LqdAmmonia]
 	{
 		temperature = 248.23	//from NIST webbook
@@ -795,51 +786,29 @@ PARTUPGRADE
 		insulationThickness = 0.01
 		insulationConduction = 0.02
 	}
-	%TANK[LqdMethane]
-	{
-		temperature = 116.83	//from NIST webbook
-		wallThickness = 0.0025
-		wallConduction = 16
-		insulationThickness = 0.01
-		insulationConduction = 0.02
-	}
-	%TANK[ClF3] { %temperature = 296.2 }	//from NIST webbook
+	%TANK[Aniline] {}
+	%TANK[Aniline22] {}
+	%TANK[Aniline37] {}
+	%TANK[ArgonGas] { %utilization = 100 }
+	%TANK[ASCENT] {}
+	%TANK[AvGas] {}
+	%TANK[CaveaB] {}
+	%TANK[CoreModerator] {}
+	%TANK[ClF3] { %temperature = 294.5 }	//from NIST webbook
 	%TANK[ClF5] { %temperature = 269.4 }	//from NIST webbook
 	%TANK[Diborane] { %temperature = 188.1 }	//from NIST webbook
-	%TANK[Pentaborane] {}	//{ %temperature = 337.2 }	//from https://pubchem.ncbi.nlm.nih.gov/compound/Pentaborane
 	%TANK[Ethane] { %temperature = 192.2 }	//from NIST webbook
+	%TANK[Ethanol75] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Ethanol90] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Ethanol] { %temperature = 361.8 }	//from NIST webbook
 	%TANK[Ethylene] { %temperature = 176.4 }	//from NIST webbook
-	%TANK[OF2] { %temperature = 133.3 }	//from NIST webbook
-	%TANK[LqdFluorine] { %temperature = 88.4 }	//from NIST webbook
 	%TANK[FLOX30] { %temperature = 88.4 }
 	%TANK[FLOX70] { %temperature = 88.4 }
 	%TANK[FLOX88] { %temperature = 88.4 }
-	%TANK[N2F4] { %temperature = 200.15 }	//from NIST webbook FIXME: Can't find data for higher pressures
-	%TANK[Methanol] {}
+	%TANK[Fluorine] { %utilization = 100 }
+	%TANK[LqdFluorine] { %temperature = 88.4 }	//from NIST webbook
 	%TANK[Furfuryl] {}
-	%TANK[UH25] {}
-	%TANK[Tonka250] {}
-	%TANK[Tonka500] {}
-	%TANK[IWFNA] {}
-	%TANK[IRFNA-IV] {}
-	%TANK[AK20] {}
-	%TANK[AK27] {}
-	%TANK[MON1] {}
-	%TANK[MON3] {}
-	%TANK[MON10] { %temperature = 291.2 }	//from https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
-	%TANK[LqdMON25] { %temperature = 271.8 }	//from https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
-	%TANK[Hydyne] {}
-	%TANK[Syntin] {}
-	%TANK[Water] { %temperature = 388.2 }	//from NIST webbook
-	%TANK[Turpentine] {}
-	%TANK[LqdNitrogen]
-	{
-		wallThickness = 0.0025
-		wallConduction = 16
-		temperature = 81.2	//from NIST webbook
-		insulationThickness = 0.01
-		insulationConduction = 0.02
-	}
+	%TANK[Helium] { %utilization = 200 }
 	%TANK[LqdHelium]
 	{
 		temperature = 4.7	//from NIST webbook
@@ -848,96 +817,212 @@ PARTUPGRADE
 		insulationThickness = 0.0381
 		insulationConduction = 0.014
 	}
+	%TANK[HTP] {}
+	%TANK[Hydrazine] {}
+	%TANK[Hydrogen] { %utilization = 100 }
+	%TANK[LqdHydrogen]
+	{
+		temperature = 21.82	//from NIST webbook
+		wallThickness = 0.0025
+		wallConduction = 205
+		insulationThickness = 0.0381
+		insulationConduction = 0.014
+	}
+	%TANK[Hydyne] {}
+	%TANK[IRFNA-III] {}
+	%TANK[IRFNA-IV] {}
+	%TANK[IWFNA] {}
+	%TANK[Kerosene] {}
+	%TANK[KryptonGas] { %utilization = 100 }
+	%TANK[Methane] { %utilization = 100 }
+	%TANK[LqdMethane]
+	{
+		temperature = 116.83	//from NIST webbook
+		wallThickness = 0.0025
+		wallConduction = 16
+		insulationThickness = 0.01
+		insulationConduction = 0.02
+	}
+	%TANK[Methanol] {}
+	%TANK[MMH] {}
+	%TANK[MHF3] {}
+	%TANK[MON1] {}
+	%TANK[MON3] {}
+	%TANK[MON10] { %temperature = 291.2 }	//from https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
+	%TANK[MON15] { %temperature = 284.7 }	//interpolated
+	%TANK[MON20] { %temperature = 278.3 }	//interpolated
+	%TANK[MON25] { %temperature = 271.8 }	//from https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
+	%TANK[N2F4] { %temperature = 207.5 }	//from ChemCad 8 library
+	%TANK[Nitrogen] { %utilization = 200 }
+	%TANK[LqdNitrogen]
+	{
+		wallThickness = 0.0025
+		wallConduction = 16
+		temperature = 81.2	//from NIST webbook
+		insulationThickness = 0.01
+		insulationConduction = 0.02
+	}
+	%TANK[NitrousOxide] { %utilization = 100 }
+	%TANK[NTO] {}
+	%TANK[OF2] { %temperature = 133.3 }	//from NIST webbook
+	%TANK[LqdOxygen]
+	{
+		wallThickness = 0.0025
+		wallConduction = 16
+		temperature = 94.25	//from NIST webbook
+		insulationThickness = 0.01
+		insulationConduction = 0.02
+	}
+	%TANK[Pentaborane] {}	//{ %temperature = 337.2 }	//from https://pubchem.ncbi.nlm.nih.gov/compound/Pentaborane
+	%TANK[Syntin] {}
+	%TANK[Tonka250] {}
+	%TANK[Tonka500] {}
+	%TANK[Turpentine] {}
+	%TANK[UDMH] {}
+	%TANK[UH25] {}
+	%TANK[Water] { %temperature = 388.2 }	//from NIST webbook
+	%TANK[XenonGas] { %utilization = 100 }
 }
 
 // HP resources
+// Remove HP resources from tanks not tagged
+@TANK_DEFINITION:HAS[~addResourcesHP[true]]:FIRST
+{
+	!TANK[Ammonia] {}
+	!TANK[ArgonGas] {}
+	!TANK[ASCENT] {}
+	!TANK[CaveaB] {}
+	!TANK[Helium] {}
+	!TANK[Hydrazine] {}
+	!TANK[Hydrogen] {}
+	!TANK[KryptonGas] {}
+	!TANK[Methane] {}
+	!TANK[Nitrogen] {}
+	!TANK[NitrousOxide] {}
+	!TANK[XenonGas] {}
+}
+// pressure increases bp of liquids. Assuming 15 bar vapor over liquids
+// Some liquids expand significantly before they boil. We're gonna assume they can expand to 90% of
+// their defined density before overflowing their tanks and being vented. We will also be generous and 
+// assume a vapor recirculation system is present, so overflowed fluids still boil and provide cooling.
 @TANK_DEFINITION:HAS[#addResourcesHP[true]]:FIRST
 {
 	-addResourcesHP = DEL
-	%TANK[Hydrazine]    {}
-	%TANK[Nitrogen]     { %utilization = 200 }
-	%TANK[Helium]       { %utilization = 200 }
-	%TANK[CaveaB]       {}
-	%TANK[ASCENT]       {}
-	%TANK[ArgonGas]     { %utilization = 100 }
-	%TANK[KryptonGas]   { %utilization = 100 }
-	%TANK[XenonGas]     { %utilization = 100 }
-	%TANK[Ammonia]      { %utilization = 100 }
-	%TANK[NitrousOxide] { %utilization = 100 }
-	%TANK[Methane]      { %utilization = 100 }
-
-	//pressure increases bp of liquids. Assuming 15 bar vapor over liquids
-	@TANK[LqdAmmonia] { @temperature = 311.9 }
-	@TANK[ClF3] { @temperature = 387.3 }
-	@TANK[ClF5] { @temperature = 355.6 }
-	@TANK[Diborane] { @temperature = 251.8 }
-	@TANK[Ethane] { @temperature = 255.1 }
-	@TANK[Ethylene] { @temperature = 234.2 }
-	@TANK[LqdFluorine|FLOX30|FLOX70|FLOX88] { @temperature = 118.5 }
-	@TANK[LqdHelium] { @temperature = 6.69 }	//supercritical, set bp to point where density is 90% of liquid phase
-	@TANK[LqdHydrogen] { @temperature = 33.7 }	//supercritical, set bp to point where density is 90% of liquid phase
-	@TANK[LqdMethane]  { @temperature = 158.5 }
-	@TANK[MON10] { @temperature = 351.1 }
-	@TANK[LqdMON25] { @temperature = 326.7 }
-	@TANK[N2F4] { @temperature = 255 }	//FIXME: Guess
-	@TANK[LqdNitrogen] { @temperature = 110.4 }
-	@TANK[OF2] { @temperature = 169.7 }
-	@TANK[LqdOxygen]   { @temperature = 127.0 }
+	@TANK[LqdAmmonia] { @temperature = 278.6 }	//high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[ClF3] { @temperature = 343.2 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[ClF5] { @temperature = 308.2 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[Diborane] { @temperature = 215.2 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[Ethane] { @temperature = 255.1 }	//No significant thermal expansion
+	@TANK[Ethylene] { @temperature = 207.1 }	//high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[LqdFluorine|FLOX30|FLOX70|FLOX88] { @temperature = 118.5 }	//No significant thermal expansion
+	@TANK[LqdHelium] { @temperature = 8.39 }	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
+	@TANK[LqdHydrogen] { @temperature = 27.2 }	//high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[LqdMethane] { @temperature = 137.4 }	//high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[MON10] { @temperature = 338.0 }	//high thermal expansion, hits 90% of 1 atm density before boiling, based on https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
+	@TANK[MON15] { @temperature = 333.9 }	//interpolated
+	@TANK[MON20] { @temperature = 329.7 }	//interpolated
+	@TANK[MON25] { @temperature = 325.6 }	//high thermal expansion, hits 90% of 1 atm density before boiling, based on https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
+	@TANK[N2F4] { @temperature = 236.5 }	//From ChemCad 8 Library. high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[LqdNitrogen] { @temperature = 94.5 }	//high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[OF2] { @temperature = 155.0 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
+	@TANK[LqdOxygen] { @temperature = 112.1 }	//high thermal expansion, hits 90% of 1 atm density before boiling
 }
 
 // SM resources
+// Remove SM resources from tanks not tagged
+@TANK_DEFINITION:HAS[~addResourcesSM[true]]:FIRST
+{
+	!TANK[CarbonDioxide] {}
+	!TANK[CoreModerator] {}
+	!TANK[Food] {}
+	!TANK[LithiumPeroxide] {}
+	!TANK[LithiumHydroxide] {}
+	!TANK[Oxygen] {}
+	!TANK[PotassiumSuperoxide] {}
+	!TANK[Waste] {}
+	!TANK[WasteWater] {}
+}
+// set boiling points assuming tank pressure of 100 bar
+// Everything that still has a bp below ~350 k gets a dewar
+// and the gas can be captured (if applicable)
 @TANK_DEFINITION:HAS[#addResourcesSM[true]]:FIRST
 {
 	-addResourcesSM = DEL
-	%TANK[Oxygen] { %utilization = 200 }
-	%TANK[Food] {}
-	%TANK[CarbonDioxide]
-	{
-		%utilization = 200
-		%fillable = False
-	}
-	%TANK[Waste] { %fillable = False }
-	%TANK[WasteWater] { %fillable = False }
-	%TANK[LithiumPeroxide] {}
-	%TANK[LithiumHydroxide] {}
-	%TANK[PotassiumSuperoxide] {}
-	%TANK[CoreModerator] {}
-
-	// Everything that still has a bp below 293 k gets a dewar
-	// and the gas can be captured (if applicable)
 	@TANK[LqdAmmonia] {
+		@temperature = 283.2	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Ammonia
 	}
-	@TANK[Diborane] { %isDewar = True }
-	@TANK[Ethane] { %isDewar = True }
-	@TANK[Ethylene] { %isDewar = True }
+	@TANK[ClF3] {
+		@temperature = 358.2	//calculated with peng-robinson. high thermal expansion, hits 90% of 1 atm density before boiling. decomposes above 473.2 K
+	}
+	@TANK[ClF5] {
+		@temperature = 314.2	//calculated with peng-robinson. high thermal expansion, hits 90% of 1 atm density before boiling.
+		%isDewar = True
+	}
+	@TANK[Diborane] {
+		@temperature = 358.1	//FIXME: Using liquid parameters, but supercritical at 100 bar
+	}
+	@TANK[Ethane] {
+		@temperature = 349	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
+		%isDewar = True
+	}
+	@TANK[Ethylene] {
+		@temperature = 221.2	//high thermal expansion, hits 90% of 1 atm density before boiling
+		%isDewar = True 
+	}
 	@TANK[LqdFluorine] {
+		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Fluorine
 	}
-	@TANK[FLOX30] { %isDewar = True }
-	@TANK[FLOX70] { %isDewar = True }
-	@TANK[FLOX88] { %isDewar = True }
+	@TANK[FLOX30|FLOX70|FLOX88] {
+		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
+		%isDewar = True 
+	}
 	@TANK[LqdHelium] {
+		@temperature = 43.8	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
 		%isDewar = True
 		%boiloffProduct = Helium
 	}
 	@TANK[LqdHydrogen] {
+		@temperature = 39.6	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
 		%isDewar = True
 		%boiloffProduct = Hydrogen
 	}
 	@TANK[LqdMethane] {
+		@temperature = 150.0	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Methane
 	}
-	@TANK[N2F4] { %isDewar = True }
+	@TANK[MON10] {
+		@temperature = 361.0	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
+	}
+	@TANK[MON15] {
+		@temperature = 356.6	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
+	}
+	@TANK[MON20] {
+		@temperature = 352.1	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
+	}
+	@TANK[MON25] {
+		@temperature = 347.8	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
+		%isDewar = True
+	}
+	@TANK[N2F4] {
+		@temperature = 340	//FIXME: Guess, similar to Ethane?
+		%isDewar = True
+	}
 	@TANK[LqdNitrogen] {
+		@temperature = 101.7	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Nitrogen
 	}
-	@TANK[OF2] { %isDewar = True }
+	@TANK[OF2] {
+		@temperature = 168.0	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
+		%isDewar = True
+	}
 	@TANK[LqdOxygen] {
+		@temperature = 117.9	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Oxygen
 	}

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -752,6 +752,8 @@ PARTUPGRADE
 }
 
 // Regular resources
+// set boiling points assuming tank pressure of 1.5 bar
+// stuff with boiling points above 293 K gets left alone, except for water/ethanol because they're useful for evaporative cooling
 @TANK_DEFINITION:HAS[#addResources[true]]:FIRST
 {
 	-addResources = DEL
@@ -759,14 +761,14 @@ PARTUPGRADE
 	{
 		wallThickness = 0.0025
 		wallConduction = 16
-		temperature = 90.15
+		temperature = 94.25	//from NIST webbook
 		insulationThickness = 0.01
 		insulationConduction = 0.02
 	}
 	%TANK[Kerosene] {}
 	%TANK[LqdHydrogen]
 	{
-		temperature = 20.15
+		temperature = 21.82	//from NIST webbook
 		wallThickness = 0.0025
 		wallConduction = 205
 		insulationThickness = 0.0381
@@ -782,12 +784,12 @@ PARTUPGRADE
 	%TANK[Aniline] {}
 	%TANK[Aniline22] {}
 	%TANK[Aniline37] {}
-	%TANK[Ethanol75] { %temperature = 351.65 }
-	%TANK[Ethanol90] { %temperature = 351.65 }
-	%TANK[Ethanol] { %temperature = 351.65 }
+	%TANK[Ethanol75] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Ethanol90] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Ethanol] { %temperature = 361.8 }	//from NIST webbook
 	%TANK[LqdAmmonia]
 	{
-		temperature = 237.65
+		temperature = 248.23	//from NIST webbook
 		wallThickness = 0.0025
 		wallConduction = 8
 		insulationThickness = 0.01
@@ -795,24 +797,24 @@ PARTUPGRADE
 	}
 	%TANK[LqdMethane]
 	{
-		temperature = 111.45
+		temperature = 116.83	//from NIST webbook
 		wallThickness = 0.0025
 		wallConduction = 16
 		insulationThickness = 0.01
 		insulationConduction = 0.02
 	}
-	%TANK[ClF3] {}
-	%TANK[ClF5] {}
-	%TANK[Diborane] { %temperature = 180.65 }
-	%TANK[Pentaborane] {}
-	%TANK[Ethane] { %temperature = 184.65 }
-	%TANK[Ethylene] { %temperature = 169.45 }
-	%TANK[OF2] { %temperature = 128.4 }
-	%TANK[LqdFluorine] { %temperature = 85.04 }
-	%TANK[FLOX30] { %temperature = 85.04 }
-	%TANK[FLOX70] { %temperature = 85.04 }
-	%TANK[FLOX88] { %temperature = 85.04 }
-	%TANK[N2F4] { %temperature = 200.15 }
+	%TANK[ClF3] { %temperature = 296.2 }	//from NIST webbook
+	%TANK[ClF5] { %temperature = 269.4 }	//from NIST webbook
+	%TANK[Diborane] { %temperature = 188.1 }	//from NIST webbook
+	%TANK[Pentaborane] {}	//{ %temperature = 337.2 }	//from https://pubchem.ncbi.nlm.nih.gov/compound/Pentaborane
+	%TANK[Ethane] { %temperature = 192.2 }	//from NIST webbook
+	%TANK[Ethylene] { %temperature = 176.4 }	//from NIST webbook
+	%TANK[OF2] { %temperature = 133.3 }	//from NIST webbook
+	%TANK[LqdFluorine] { %temperature = 88.4 }	//from NIST webbook
+	%TANK[FLOX30] { %temperature = 88.4 }
+	%TANK[FLOX70] { %temperature = 88.4 }
+	%TANK[FLOX88] { %temperature = 88.4 }
+	%TANK[N2F4] { %temperature = 200.15 }	//from NIST webbook FIXME: Can't find data for higher pressures
 	%TANK[Methanol] {}
 	%TANK[Furfuryl] {}
 	%TANK[UH25] {}
@@ -824,22 +826,23 @@ PARTUPGRADE
 	%TANK[AK27] {}
 	%TANK[MON1] {}
 	%TANK[MON3] {}
-	%TANK[MON10] {}
+	%TANK[MON10] { %temperature = 291.2 }	//from https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
+	%TANK[LqdMON25] { %temperature = 271.8 }	//from https://rocketprops.readthedocs.io/en/latest/_static/AFRPL-TR_76-76_MON_propellants.pdf
 	%TANK[Hydyne] {}
 	%TANK[Syntin] {}
-	%TANK[Water] { %temperature = 373.17 }
+	%TANK[Water] { %temperature = 388.2 }	//from NIST webbook
 	%TANK[Turpentine] {}
 	%TANK[LqdNitrogen]
 	{
 		wallThickness = 0.0025
 		wallConduction = 16
-		temperature = 77.36
+		temperature = 81.2	//from NIST webbook
 		insulationThickness = 0.01
 		insulationConduction = 0.02
 	}
 	%TANK[LqdHelium]
 	{
-		temperature = 4.21
+		temperature = 4.7	//from NIST webbook
 		wallThickness = 0.0025
 		wallConduction = 205
 		insulationThickness = 0.0381
@@ -863,17 +866,23 @@ PARTUPGRADE
 	%TANK[NitrousOxide] { %utilization = 100 }
 	%TANK[Methane]      { %utilization = 100 }
 
-	//pressure increases bp of liquids. Assuming 10 bar vapor over liquids
-	@TANK[LqdAmmonia] { @temperature = 298.06 }
-	@TANK[OF2] { @temperature = 162.3 }
-	@TANK[LqdFluorine|FLOX30|FLOX70|FLOX88] { @temperature = 111.80 }
-	@TANK[LqdHydrogen] { @temperature = 31.393 }
-	@TANK[LqdMethane]  { @temperature = 149.14 }
-	@TANK[LqdOxygen]   { @temperature = 119.62 }
-	@TANK[LqdNitrogen] { @temperature = 103.75 }
-	@TANK[LqdHelium] { @temperature = 5.11 }
-	@TANK[Ethane] { @temperature = 241.1 }
-	@TANK[Ethylene] { @temperature = 221.3 }
+	//pressure increases bp of liquids. Assuming 15 bar vapor over liquids
+	@TANK[LqdAmmonia] { @temperature = 311.9 }
+	@TANK[ClF3] { @temperature = 387.3 }
+	@TANK[ClF5] { @temperature = 355.6 }
+	@TANK[Diborane] { @temperature = 251.8 }
+	@TANK[Ethane] { @temperature = 255.1 }
+	@TANK[Ethylene] { @temperature = 234.2 }
+	@TANK[LqdFluorine|FLOX30|FLOX70|FLOX88] { @temperature = 118.5 }
+	@TANK[LqdHelium] { @temperature = 6.69 }	//supercritical, set bp to point where density is 90% of liquid phase
+	@TANK[LqdHydrogen] { @temperature = 33.7 }	//supercritical, set bp to point where density is 90% of liquid phase
+	@TANK[LqdMethane]  { @temperature = 158.5 }
+	@TANK[MON10] { @temperature = 351.1 }
+	@TANK[LqdMON25] { @temperature = 326.7 }
+	@TANK[N2F4] { @temperature = 255 }	//FIXME: Guess
+	@TANK[LqdNitrogen] { @temperature = 110.4 }
+	@TANK[OF2] { @temperature = 169.7 }
+	@TANK[LqdOxygen]   { @temperature = 127.0 }
 }
 
 // SM resources
@@ -894,39 +903,44 @@ PARTUPGRADE
 	%TANK[PotassiumSuperoxide] {}
 	%TANK[CoreModerator] {}
 
-	// Cryo resources in SM tanks get a dewar flask
-	// and the gas can be captured
-	@TANK[LqdOxygen] {
+	// Everything that still has a bp below 293 k gets a dewar
+	// and the gas can be captured (if applicable)
+	@TANK[LqdAmmonia] {
 		%isDewar = True
-		%boiloffProduct = Oxygen
+		%boiloffProduct = Ammonia
+	}
+	@TANK[Diborane] { %isDewar = True }
+	@TANK[Ethane] { %isDewar = True }
+	@TANK[Ethylene] { %isDewar = True }
+	@TANK[LqdFluorine] {
+		%isDewar = True
+		%boiloffProduct = Fluorine
+	}
+	@TANK[FLOX30] { %isDewar = True }
+	@TANK[FLOX70] { %isDewar = True }
+	@TANK[FLOX88] { %isDewar = True }
+	@TANK[LqdHelium] {
+		%isDewar = True
+		%boiloffProduct = Helium
 	}
 	@TANK[LqdHydrogen] {
 		%isDewar = True
 		%boiloffProduct = Hydrogen
 	}
-	@TANK[LqdAmmonia] {
-		%isDewar = True
-		%boiloffProduct = Ammonia
-	}
 	@TANK[LqdMethane] {
 		%isDewar = True
 		%boiloffProduct = Methane
 	}
-	@TANK[LqdFluorine] {
-		%isDewar = True
-		%boiloffProduct = Fluorine
-	}
+	@TANK[N2F4] { %isDewar = True }
 	@TANK[LqdNitrogen] {
 		%isDewar = True
 		%boiloffProduct = Nitrogen
 	}
-	@TANK[LqdHelium] {
+	@TANK[OF2] { %isDewar = True }
+	@TANK[LqdOxygen] {
 		%isDewar = True
-		%boiloffProduct = Helium
+		%boiloffProduct = Oxygen
 	}
-	@TANK[FLOX30] { %isDewar = True }
-	@TANK[FLOX70] { %isDewar = True }
-	@TANK[FLOX88] { %isDewar = True }
 }
 
 // Add lead

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -56,6 +56,22 @@ RESOURCE_DEFINITION
   ksparpicon = RealFuels/Resources/ARPIcons/ASCENT
 }
 
+//Create MHF-3 (Mixed Hydrazine Fuel 3, J.D. Clark Eutectic)
+//MHF-3
+RESOURCE_DEFINITION
+{
+  name = MHF3
+  density = 0.0008948
+  unitCost = 0.0001 //placeholder
+  hsp = 3005
+  conductivity = 0.16074
+  flowMode = STACK_PRIORITY_SEARCH
+  transfer = PUMP
+  isTweakable = True
+  isVisible = true
+  ksparpicon = RealFuels/Resources/ARPIcons/ASCENT
+}
+
 //Create core material
 RESOURCE_DEFINITION
 {


### PR DESCRIPTION
Another pass over defined resources properties. Changes include:

- Set temperatures for everything with a bp below 20 oC
- Change unpressurized tank reference pressure to 1.5 bar (slightly increasing resource boiling points)
- Change SM tank reference pressure to 100 bar (increasing resource boiling point, or forcing them into the supercritical region)
- Pay attention to fluid densities: Since we cannot change densities on the fly, fluids are assumed to be subcooled when pressurized to maintain the same density. Since most fluids will expand significantly when heated, their "boiling point" will be set to the point where they expand 10% (from their defined density). After this point, excess is assumed to be vented, but not before being sent through a vapor recircularization system, allowing them to provide cooling from their heat of vaporization. Fluids in the supercritical region are assumed to be kept at a temperature where their density is 90% of their defined density, with excess once again being vented.
- Add MHF-3, A.K.A. Clark Eutectic, Eutectic MMH/Hydrazine mix created by John D. Clark.
- Alphabetize all resources: Alphabetize resource lists, except for life-support resources and electric charge, which are left at the top of the list for easy access (sadly, I cannot move RP-1 contract resources to the top of the list).