### PR TITLE
Update Kerbal Atomics and add LPNTR

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LPNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LPNTR_Config.cfg
@@ -85,7 +85,7 @@
 	%category = Engine
 	%title = #roLPNTRTitle	//Low-Pressure NTR
 	%manufacturer = #roMfrJPL
-	%description = #roPrincetonLPNTRDesc
+	%description = #roLPNTRDesc
 
 	@tags ^= :$: USA jpl lpntr low pressure ntr nuclear pump upper lqdhydrogen
 
@@ -111,8 +111,8 @@
 		modded = False
 		origMass = 2.227	//2277 kg - 50 kg uranium
 		
-		primaryDescription = High-Pressure Mode
-		secondaryDescription = Low-Pressure Mode
+		primaryDescription = High-Pressure
+		secondaryDescription = Low-Pressure
 		toPrimaryText = Engage High-Pressure Mode
 		toSecondaryText = Engage Low-Pressure Mode
 

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LPNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LPNTR_Config.cfg
@@ -1,0 +1,320 @@
+//	==================================================
+//	LPNTR
+//
+//	Manufacturer: Idaho National Engineering Laboratory
+//
+//	=================================================================================
+//	LPNTR-3200 High Pressure
+//	Full thrust mode
+//
+//	Dry Mass: 2277 Kg	//835 kg engine + 1442 kg shield
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 47.596 kN
+//	ISP: ??? SL / 1037 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 0.103 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 40?
+//	Ignitions: ???
+//	=================================================================================
+//	LPNTR-3200 Low Pressure
+//	20% thrust mode for maximum dissociation
+//
+//	Dry Mass: 2277 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 9.532 kN
+//	ISP: ??? SL / 1072 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 0.021 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 40?
+//	Ignitions: ???
+//	=================================================================================
+//	LPNTR-3600 High Pressure
+//	Full thrust mode
+//
+//	Dry Mass: 2277 Kg	//835 kg engine + 1442 kg shield
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 47.596 kN
+//	ISP: ??? SL / 1183 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 0.103 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 40?
+//	Ignitions: ???
+//	=================================================================================
+//	LPNTR-3600 Low Pressure
+//	20% thrust mode for maximum dissociation
+//
+//	Dry Mass: 2277 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 9.532 kN
+//	ISP: ??? SL / 1223 Vac
+//	Burn Time: 3600
+//	Chamber Pressure: 0.021 MPa
+//	Propellant: LH2
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 40?
+//	Ignitions: ???
+//	=================================================================================
+
+//	Sources:
+
+//	[1] https://ntrs.nasa.gov/citations/19920001876
+//	[2] https://www.osti.gov/biblio/6189106
+//	[3] https://arc.aiaa.org/doi/10.2514/3.23799
+
+
+//	Used by:
+
+//	Notes:
+//	Thermodynamic calculations at 1 atm fairly accurate,
+//	However, calculations at 0.1 atm diverge significantly when a more accurate thermodynamic model is used.
+//	Using ISP numbers from [3]
+//	==================================================
+
+@PART[*]:HAS[#engineType[LPNTR]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roLPNTRTitle	//Low-Pressure NTR
+	%manufacturer = #roMfrJPL
+	%description = #roPrincetonLPNTRDesc
+
+	@tags ^= :$: USA jpl lpntr low pressure ntr nuclear pump upper lqdhydrogen
+
+	%specLevel = concept
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[Module*EngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!MODULE[ModuleResourceConverter],*{}
+	!MODULE[ModuleHybridEngine],*{}
+	!MODULE[ModuleGimbal],*{}
+	!RESOURCE,*{}
+
+	MODULE
+	{
+		name = ModuleBimodalEngineConfigs
+		type = ModuleEngines
+		configuration = LPNTR-3200HP
+		modded = False
+		origMass = 2.227	//2277 kg - 50 kg uranium
+		
+		primaryDescription = High-Pressure Mode
+		secondaryDescription = Low-Pressure Mode
+		toPrimaryText = Engage High-Pressure Mode
+		toSecondaryText = Engage Low-Pressure Mode
+
+		CONFIG
+		{
+			name = LPNTR-3200HP
+			description = Low pressure NTR baseline, operating with a core temperature of 3200 K and thrust of 11klbf.
+			specLevel = concept
+			minThrust = 9.832	//ISP should vary continuously with thrust, but we can't do that
+			maxThrust = 47.596
+			massMult = 1.0
+			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
+			ullage = True
+			pressureFed = False	//pressurefed, but at 0.1 MPa tank head is more than enough to feed
+			ignitions = 100	//Completely self-regulated by LH2 flow, very low pressure, very low stresses on startup
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 1.0
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = EnrichedUranium
+				ratio = 1.0813e-15
+				DrawGauge = False
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1037
+				key = 0.12 1
+			}
+			SUBCONFIG
+			{
+				name = LPNTR-3200LP
+				minThrust = 4.760
+				maxThrust = 9.532
+				
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 1.0
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = EnrichedUranium
+					ratio = 1.0813e-15
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+
+				atmosphereCurve
+				{
+					key = 0 1072
+					key = 0.025 1
+				}
+			}
+			
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 72000 // 20 hours
+				ratedContinuousBurnTime = 3600		//1 hour
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+			}
+		}
+		CONFIG
+		{
+			name = LPNTR-3600HP
+			description = Low pressure NTR upgrade, operating with a core temperature of 3600 K and thrust of 15klbf.
+			specLevel = concept
+			minThrust = 9.532	//ISP should vary continuously with thrust, but we can't do that
+			maxThrust = 47.596
+			massMult = 1.0
+			throttleResponseRate = 0.055 // Should be around 30 seconds to ramp up from 0% thrust to 100% thrust.
+
+			ullage = True
+			pressureFed = False	//pressurefed, but at 0.1 MPa tank head is more than enough to feed
+			ignitions = 100	//Completely self-regulated by LH2 flow, very low pressure, very low stresses on startup
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 1.0
+			}
+
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = EnrichedUranium
+				ratio = 1.0813e-15
+				DrawGauge = False
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1183
+				key = 0.12 1
+			}
+			SUBCONFIG
+			{
+				name = LPNTR-3600LP
+				minThrust = 4.760
+				maxThrust = 9.532
+				
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 1.0
+					DrawGauge = True
+				}
+
+				PROPELLANT
+				{
+					name = EnrichedUranium
+					ratio = 1.0813e-15
+					DrawGauge = False
+					ignoreForIsp = True
+				}
+
+				atmosphereCurve
+				{
+					key = 0 1350
+					key = 0.025 1
+				}
+			}
+			
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 72000 // 20 hours
+				ratedContinuousBurnTime = 3600		//1 hour
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				explicitDataRate = True
+				ignitionReliabilityStart = 0.99
+				ignitionReliabilityEnd = 0.999997
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.999
+				cycleReliabilityEnd = 0.999997
+				reliabilityMidV = 0.8
+				reliabilityMidH = 0.1
+				reliabilityMidTangentWeight = 0
+				
+				techTransfer = LPNTR-3200HP:50
+			}
+		}
+	}
+
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 4.558		//~50 kg
+		maxAmount = 4.558
+		isTweakable = False
+	}
+
+	RESOURCE
+	{
+		name = DepletedUranium
+		amount = 0
+		maxAmount = 4.558
+		isTweakable = False
+	}
+}

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -298,6 +298,9 @@ Localization
 		//		LMDE
 		#roLMDETitle = Lunar Module Descent Engine (LMDE)
 		#roLMDEDesc = A deeply throttleable pressure-fed engine used for the descent module of the Apollo lunar lander using storable propellants. The version used on J-class missions had slightly higher specific impulse, which, along with other changes, gave enough payload capacity for the rover and other equipment. A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability.
+		//		LPNTR
+		#roLPNTRTitle = Low-Pressure NTR
+		#roLPNTRDesc = The low pressure NTR is a proposal for a higher performance NTR, relying on hydrogen dissociation. By decreasing the chamber pressure of an NTR to near atmospheric pressure, it is possible to trigger dissociation of diatomic hydrogen into monatomic hydrogen, greatly increasing specific impulse. This low pressure also allows for extremely lightweight construction, allowing for an acceptable TWR despite the low mass flow. The LPNTR is also extremely simple, requiring no pumps, and self-regulating using hydrogen as a moderator, although it also lacks a gimbal.
 		//		LR79
 		#roLR79Title = LR79
 		#roLR79Desc = A long-lasting US kerolox gas-generator booster engine. The same components and broadly the same performance as the LR89, the LR79 (also known as S-3D in Jupiter / Juno II) powered the Jupiter, Thor, and Thor-Delta (Delta) rockets.

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalAtomics/KerbalAtomics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalAtomics/KerbalAtomics.cfg
@@ -2,55 +2,23 @@
 {
 	%engineType = BNTR
 	%RSSROConfig = True
-	%category = Propulsion
-	@mass = 2.27
-	@maxTemp = 573.15
 
 	// https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20040182399.pdf ;  2004 presentation, with a 1.56m diameter BNTR
 
 	@MODEL,0
 	{
-		@scale = 0.6,0.6,0.6
+		@scale = 1.0,1.0,1.0
 	}
-	rescaleFactor =  1.0
-	@node_stack_top = 0.0, 1.394, 0.0, 0.0, 1.0, 0.0, 2
-	@node_stack_bottom = 0.0, -1.21848, 0.0, 0.0, -1.0, 0.0, 2
-	@node_attach = 0.0, 0, 0.0, 0.0, 1.0, 0.0, 2
+	%rescaleFactor = 0.6807
 	@attachRules = 1,1,1,1,0
 
 
-	!MODULE[ModuleEngines*]
-	{
-		%heatProduction = 100
-		%minThrust = 66.72
-		%maxThrust = 66.72
-		%ullage = True
-		%ignitions = 60
-		@PROPELLANT[LiquidFuel]
-		{
-	                name = LqdHydrogen
-	                ratio = 1.0
-	                DrawGauge = True
-		}
-	
-	            @PROPELLANT
-		{
-	                name = EnrichedUranium
-	                ratio = 1.0813e-15
-	                DrawGauge = False
-	                ignoreForIsp = True
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 930
-			@key,1 = 1 380
-		}
-
-	}
-		!MODULE[MultiModeEngine] {}
-		!MODULE[ModuleActiveRadiator] {}
-		!MODULE[ModuleAlternator] {}
-		!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleEngines*],1 {}
+	!MODULE[MultiModeEngine] {}
+	!MODULE[ModuleActiveRadiator] {}
+	!MODULE[ModuleGenerator] {}
+	!MODULE[Emitter] {}
+	!MODULE[ModuleColorChanger]:HAS[#moduleID[heatColor]] {}
 }
 
 
@@ -58,98 +26,84 @@
 {
 	%engineType = NERVA
 	%RSSROConfig = True
-	%category = Propulsion
-	@mass = 2.27
-	@maxTemp = 573.15
 
 	@MODEL,0
 	{
-		@scale = 2.57,2.35,2.57
+		@scale = 1.0936,1.0,1.0936
 	}
-	rescaleFactor =  1.0
-	@node_stack_top = 0.0, 3.948, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -6.23, 0.0, 0.0, -1.0, 0.0, 1
-	@node_attach = 0.0, 0, 0.0, 0.0, 1.0, 0.0, 2
+	%rescaleFactor = 2.35
 	@attachRules = 1,1,1,1,0
 
 
-	!MODULE[ModuleEngines*]
-	{
-		%heatProduction = 100
-		%minThrust = 0
-		%maxThrust = 334
-		%ullage = True
-		%ignitions = 60
-		@PROPELLANT[LiquidFuel]
-		{
-	                name = LqdHydrogen
-	                ratio = 1.0
-	                DrawGauge = True
-		}
-		@PROPELLANT
-		{
-			name = EnrichedUranium
-			ratio = 0.00000000001
-		}
-		@atmosphereCurve
-		{
-			key = 0 825
-			key = 1 380
-		}
-
-	}
-		!MODULE[MultiModeEngine] {}
-		!MODULE[ModuleActiveRadiator] {}
-		!MODULE[ModuleAlternator] {}
-		!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleEngines*],1 {}
+	!MODULE[MultiModeEngine] {}
+	!MODULE[ModuleActiveRadiator] {}
+	!MODULE[ModuleGenerator] {}
+	!MODULE[Emitter] {}
+	!MODULE[ModuleColorChanger]:HAS[#moduleID[heatColor]] {}
 }
 
 @PART[ntr-sc-125-2]:FOR[RealismOverhaul]
 {
 	%engineType =  NERVAII
 	%RSSROConfig = True
-	%category = Propulsion
-	@mass = 2.27
-	@maxTemp = 573.15
 
-	@MODEL,0    	// arbitrary rescale; feels like it should be slightly 'fatter', even if smaller than nerva
+	@MODEL,0	// arbitrary rescale; feels like it should be slightly 'fatter', even if smaller than nerva
 	{
-	 	@scale = 3.9,4.7125,3.9
+		@scale = 0.8276,1.0,0.8276
 	}
-	rescaleFactor =  1.0
-	@node_stack_top = 0.0, 5.4194, 0.0, 0.0, 1.0, 0.0, 1
-	@node_stack_bottom = 0.0, -6.888, 0.0, 0.0, -1.0, 0.0, 1
-	@node_attach = 0.0, 0, 0.0, 0.0, 1.0, 0.0, 2
+	%rescaleFactor = 4.7125
 	@attachRules = 1,1,1,1,0
 
 
-	!MODULE[ModuleEngines*]
-	{
-		%heatProduction = 100
-		%minThrust = 750
-		%maxThrust = 867
-		%ullage = True
-		%ignitions = 60
-			@PROPELLANT
-			{
-				name = LqdHydrogen
-				ratio = 1.0
-				DrawGauge = True
-			}
-			@PROPELLANT
-			{
-				name = EnrichedUranium
-				ratio = 0.00000000001
-			}
-			@atmosphereCurve
-			{
-				key = 0 850
-				key = 1 380
-			}
+	!MODULE[ModuleEngines*],1 {}
+	!MODULE[MultiModeEngine] {}
+	!MODULE[ModuleActiveRadiator] {}
+	!MODULE[ModuleGenerator] {}
+	!MODULE[Emitter] {}
+	!MODULE[ModuleColorChanger]:HAS[#moduleID[heatColor]] {}
+}
 
+@PART[ntr-gc-25-1]:FOR[RealismOverhaul]
+{
+	%engineType =  LPNTR
+	%RSSROConfig = True
+
+	@MODEL,0
+	{
+		@scale = 1.0,1.0,1.0
 	}
-		!MODULE[MultiModeEngine] {}
-		!MODULE[ModuleActiveRadiator] {}
-		!MODULE[ModuleAlternator] {}
-		!MODULE[ModuleGenerator] {}
+	%rescaleFactor = 1.4348
+	@attachRules = 1,1,1,1,0
+
+	!MODULE[MultiModeEngine] {}
+	!MODULE[ModuleActiveRadiator] {}
+	!MODULE[ModuleGenerator] {}
+	!MODULE[Emitter] {}
+	!MODULE[ModuleColorChanger]:HAS[#moduleID[heatColor]] {}
+}
+
++PART[ntr-sc-125-2]:FOR[RealismOverhaul]
+{
+	@name = RO-KA-PrincetonLNTR
+	%engineType =  PrincetonLNTR
+	
+	@MODEL,0
+	{
+		@scale = 1.0,1.0,1.0
+	}
+	%rescaleFactor = 2.1
+}
+
+//Similar mass to NERVA I, similar size?
++PART[ntr-sc-125-2]:FOR[RealismOverhaul]
+{
+	@name = RO-KA-LRCNTR
+	%engineType =  LRCLNTR
+	
+	@MODEL,0
+	{
+		@scale = 1.0,1.0,1.0
+	}
+	%rescaleFactor = 3.0
 }

--- a/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-1.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-1.cfg
@@ -1,4 +1,4 @@
-@PART[ntr-sc-125-1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[ntr-sc-125-1]:BEFORE[RealPlume]:NEEDS[!ROWaterfall]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-2.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-125-2.cfg
@@ -1,4 +1,4 @@
-@PART[ntr-sc-125-2]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[ntr-sc-125-2]:BEFORE[RealPlume]:NEEDS[!ROWaterfall]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-25-1_BNTR.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/KerbalAtomics/KA-ntr-sc-25-1_BNTR.cfg
@@ -1,4 +1,4 @@
-@PART[ntr-sc-25-1]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[ntr-sc-25-1]:BEFORE[RealPlume]:NEEDS[!ROWaterfall]
 {
     PLUME
     {

--- a/GameData/RealismOverhaul/Waterfall_Configs/KerbalAtomics/KerbalAtomicsWF.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/KerbalAtomics/KerbalAtomicsWF.cfg
@@ -1,0 +1,37 @@
+//=============
+//	Waterfall
+//=============
+@PART[ntr-sc-25-1|ntr-sc-125-1|ntr-sc-125-2|RO-KA-PrincetonLNTR|RO-KA-LRCNTR|ntr-gc-25-1]:BEFORE[ROWaterfall]
+{
+	@MODULE[ModuleWaterfallFX]:HAS[#moduleID[*FX]]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= #$/rescaleFactor$
+		}
+	}
+	!MODULE[ModuleWaterfallFX]:HAS[#moduleID[*FXLOX]] {}
+}
+
+//manually compensate for any model stretching we did
+//also remove the LANTR plume from stuff that doesn't need it
+@PART[ntr-sc-125-1]:BEFORE[ROWaterfall]
+{
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= 1.0936
+		} 
+	}
+}
+@PART[ntr-sc-125-2]:BEFORE[ROWaterfall]
+{
+	@MODULE[ModuleWaterfallFX],*
+	{
+		@TEMPLATE
+		{
+			@scale[*] *= 0.8276
+		} 
+	}
+}


### PR DESCRIPTION
Update Kerbal Atomics configs, and add config for LPNTR.
Changes include:

- Clean up KerbalAtomics configs to remove unneeded patches
- Patch KerbalAtomics Waterfall configs to work properly in RO (and disable RealPlume configs if Waterfall is installed)
- Configure KerbalAtomics parts for the LRCLNTR, Princeton LNTR, and LPNTR
- Add Low Pressure NTR engine config.