### PR TITLE
Fix Stock/SXT IVAs

### DIFF
--- a/GameData/RealismOverhaul/REWORK/RO_SXT_fuselage.cfg
+++ b/GameData/RealismOverhaul/REWORK/RO_SXT_fuselage.cfg
@@ -55,26 +55,6 @@
     }
 }
 
-@PART[SXTOsaulNoseCockpitAn225]:AFTER[RealFuels]
-{
-	%RSSROConfig = True
-	@title = An-124 Cockpit
-	@description =  Cockpit of the Antonov An-124, diameter is 6.75m.
-	@mass = 9
-	@rescaleFactor = 1.8
-	%vesselType = Plane
-}
-
-@PART[SXTOsualRadCockpit]:AFTER[RealFuels]
-{
-	%RSSROConfig = True
-	@title = An-124 Cockpit Radial
-	@description =  Radial Cockpit of the Antonov An-124
-	@mass = 5
-	@rescaleFactor = 1.8
-	%vesselType = Plane
-}
-
 @PART[SXTOsualRadHull]:AFTER[RealFuels]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -447,6 +447,15 @@
 		@maxAmount = 43200
 	}
 }
+@INTERNAL[ententecockpit]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.24, 1.40, 1.24
+
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.1, 1.1, 1.1
+	}
+}
 
 @PART[SXTke111]:FOR[RealismOverhaul]
 {
@@ -532,6 +541,17 @@
 		@maxAmount = 43200
 	}
 }
+@INTERNAL[kossakint]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.504, 1.625, 1.504
+	//%offset = 0, 0, 0.025
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.1, 1.1, 1.1
+		%kerbalOffset = 0.0, 0.1, 0.0
+		//%kerbalEyeOffset = 0.0, 0.1, 0.0
+	}
+}
 
 //  ==================================================
 //  DHC-3 Otter cockpit
@@ -578,6 +598,50 @@
 		name = Oxygen
 		amount = 225
 		maxAmount = 225
+	}
+}
+@INTERNAL[clydeInternal]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.33, 1.33, 1.33
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.1, 1.1, 1.1
+		%kerbalEyeOffset = 0.0, 0.1, 0.0
+	}
+}
+
+//  ==================================================
+//  An-124 cockpit
+
+//  Realism Overhaul configuration.
+//  ==================================================
+@PART[SXTOsaulNoseCockpitAn225]:AFTER[RealFuels]
+{
+	%RSSROConfig = True
+	@title = An-124 Cockpit
+	@description =  Cockpit of the Antonov An-124, diameter is 6.75m.
+	@mass = 9
+	@rescaleFactor = 1.8
+	%vesselType = Plane
+	
+	@INTERNAL[kossakint]
+	{
+		%offset = 0 , 2.0 , -1.75
+	}
+}
+
+@PART[SXTOsualRadCockpit]:AFTER[RealFuels]
+{
+	%RSSROConfig = True
+	@title = An-124 Cockpit Radial
+	@description =  Radial Cockpit of the Antonov An-124
+	@mass = 5
+	@rescaleFactor = 1.8
+	%vesselType = Plane
+	
+	@INTERNAL[kossakint]
+	{
+		%offset = 0 , -0.1 , -1.15
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -1137,10 +1137,10 @@
 
 @INTERNAL[landerCabinSmallInternal|landerCabinSmallInternalRPM]:BEFORE[RealismOverhaul]
 {
-	%scaleAll = 1, 1, 1
+	%scaleAll = 1.6, 1.6, 1.6
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1, 1, 1
+		%kerbalScale = 1.2, 1.2, 1.2
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
@@ -1149,7 +1149,7 @@
 +INTERNAL[landerCabinSmallInternal]:BEFORE[RealismOverhaul]
 {
 	@name = landerCabinMediumInternal
-	%scaleAll = 1.4, 1.4, 1.4
+	%scaleAll = 1.6, 1.6, 1.6
 
 	@MODULE[InternalSeat]
 	{
@@ -1203,8 +1203,21 @@
 	@MODULE[InternalSeat],*
 	{
 		%kerbalScale = 1.3, 1.3, 1.3
-		%kerbalOffset = 0.0, 0.0, 0.0
+		//%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+//add third seat
+@INTERNAL[mk2LanderCanInternal]
+{
+	MODULE
+	{
+		name = InternalSeat
+		seatTransformName = pilotSeat_01
+		allowCrewHelmet = false
+		kerbalScale = 1.3, 1.3, 1.3
+		kerbalOffset = -0.3, 0, -1.5
+		kerbalEyeOffset = 0, 0, 0.0
 	}
 }
 
@@ -1224,7 +1237,7 @@
 	%scaleAll = 1.722222, 1.722222, 1.722222
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalScale = 1.25, 1.25, 1.25
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -591,7 +591,7 @@
 	@INTERNAL
 	{
 		@name = RO-Mk1CockpitInternal-1.25
-		%offset = 0.0, -0.1, 0.0
+		%offset = 0.0, 0.1, 0.0
 	}
 
 	@MODULE[ModuleAnimateGeneric]
@@ -897,13 +897,13 @@
 +INTERNAL[mk1CockpitInternal]:FOR[RealismOverhaul]
 {
 	@name = RO-Mk1CockpitInternal-1.25
-	%scaleAll = 1.25, 1.25, 1.25
+	%scaleAll = 1.0, 1.0, 1.0
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1.25, 1.25, 1.25
+		%kerbalScale = 1.0, 1.0, 1.0
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset:NEEDS[VenStockRevamp] = 0.0, -0.13, 0.0
-		%kerbalEyeOffset:NEEDS[ReStock] = 0.0, -0.04, 0.0
+		%kerbalEyeOffset:NEEDS[ReStock] = 0.0, 0.04, 0.0
 	}
 }
 
@@ -912,7 +912,7 @@
 	%scaleAll = 1.722222, 1.722222, 1.722222
 	@MODULE[InternalSeat],*
 	{
-		%kerbalScale = 1.722222, 1.722222, 1.722222
+		%kerbalScale = 1.25, 1.25, 1.25
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
 	}
@@ -926,5 +926,15 @@
 		%kerbalScale = 1.25, 1.25, 1.25
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+@INTERNAL[mk2InlineInternal]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.722222, 1.722222, 1.722222
+	@MODULE[InternalSeat],*
+	{
+		%kerbalScale = 1.35, 1.35, 1.35
+		%kerbalOffset = 0.0, 0.0, 0.0
+		%kerbalEyeOffset = 0.0, 0.05, 0.0
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Command.cfg
@@ -203,6 +203,10 @@
 	%resetHeatShieldAblator = true
 	%heatShieldDiameter = 3.0
 }
+@INTERNAL[KV1_IVA|KV3_IVA]:FOR[RealismOverhaul]
+{
+	%scaleAll = 1.3043478, 1.3043478, 1.3043478
+}
 
 @PART[kv1Pod]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Fix Stock/SXT IVAs, rescaling to fit parts, adjusting kerbal positions so they can see over the dashboard, and adding a third seat to the Mk2 lander can.
Partially resolves https://github.com/KSP-RO/RealismOverhaul/issues/2308, the cause of kerbal scale changing on EVA/crew transfer is still unknown.