### PR TITLE
Rename SNTP config to fix name conflict in RP-0

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/SNTPPFE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/SNTPPFE_Config.cfg
@@ -127,7 +127,7 @@
 		}
 		CONFIG
 		{
-			name = SNTPPFE100
+			name = SNTPPFE100-Hydrogen
 			description = Production engine predicted performance. Increased core temperature to 3000K and Carbon-Carbon turbopumps to handle higher flow rates and inlet temperatures
 			specLevel = concept
 			minThrust = 49

--- a/GameData/RealismOverhaul/UpgradeData.cfg
+++ b/GameData/RealismOverhaul/UpgradeData.cfg
@@ -11,4 +11,8 @@ ROMECCONFIGUPGRADES
 	{
 		XLR81-BA-13 = XLR81-BA-11$StartTanks
 	}
+	14.24.0
+	{
+		SNTPPFE100 = SNTPPFE100-Hydrogen
+	}
 }


### PR DESCRIPTION
And use config upgrades to avoid breaking anything. You should probably make sure the version listed in the upgrade config matches what the next RO version will be.

For https://github.com/KSP-RO/RP-0/pull/1917