### PR TITLE
Correct R-36 reliability data

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD215_Config.cfg
@@ -387,19 +387,21 @@
 				amount = 1.0
 			}
 
+			//R-36 (8K67): 106 flights, 11 failures (16 total, giving 5 to upper stage)
+			//R-36 (8K67P): 20 flights, 0 failures
 			//R-36-O (8K69): 23 flights, 3 failures
 			//Tsiklon-2A (11K67): 8 flights, 0 failures
 			//Tsiklon-2 (11K69): 106 flights, 0 failures
-			//411 engines, 3 failures
+			//789 engines, 14 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 400
 				ratedBurnTime = 120
 				safeOverburn = true
-				ignitionReliabilityStart = 0.988471
-				ignitionReliabilityEnd = 0.998180
-				cycleReliabilityStart = 0.988471
-				cycleReliabilityEnd = 0.998180
+				ignitionReliabilityStart = 0.976350
+				ignitionReliabilityEnd = 0.996266
+				cycleReliabilityStart = 0.976350
+				cycleReliabilityEnd = 0.996266
 				techTransfer = RD-214-8D59:25&RD-215M-8D613,RD-225-8D721,RD-217-8D515,RD-215-8D513:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD219_Config.cfg
@@ -185,20 +185,22 @@
 				amount = 1.0
 			}
 
+			//R-36 (8K67): 95 flights, 5 failures (16 total, giving 5 to upper stage)
+			//R-36 (8K67P): 20 flights, 0 failures
 			//R-36-O (8K69): 23 flights, 2 failures. (2 cycle) (engine stuck on)
 			//Tsiklon-2A (11K67): 8 flights, 0 failures
 			//Tsiklon-2 (11K69): 106 flights, 1 failure. (1 cycle?)
-			//137 ignitions, 0 failures
-			//137 cycles, 3 failures
+			//252 ignitions, 1 failures?
+			//251 cycles, 7 failures?
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 400
 				ratedBurnTime = 160
 				safeOverburn = true
-				ignitionReliabilityStart = 0.993116
-				ignitionReliabilityEnd = 0.998913
-				cycleReliabilityStart = 0.965580
-				cycleReliabilityEnd = 0.994565
+				ignitionReliabilityStart = 0.991238
+				ignitionReliabilityEnd = 0.998617
+				cycleReliabilityStart = 0.961045
+				cycleReliabilityEnd = 0.993849
 				techTransfer = RD-219-8D713:50
 			}
 		}
@@ -236,7 +238,7 @@
 			{
 				name = ElectricCharge
 				amount = 1.0
-      }
+			}
 
 			//Tsiklon-3 (11K68): 121 flights, 0 failures
 			//121 ignitions, 0 failures


### PR DESCRIPTION
Include early R-36 versions in reliability data for RD-250/252.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/2780