### PR TITLE
Add Helium/Nitrogen to stock HP tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -171,6 +171,26 @@ RESOURCE_DEFINITION
 		maxAmount = 0.0
 		note = (pressurized)
 	}
+	TANK
+	{
+		name = Nitrogen
+		mass = 0.000081
+		utilization = 200
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = Helium
+		mass = 0.000081
+		utilization = 200
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
 }
 
 // New Solids:


### PR DESCRIPTION
Apparently stock RF HP tank types (Service Module/Fuselage) lost the ability to hold Helium and Nitrogen at some point? This results in many parts that use stock tank definitions still being unusable with HP engines and RCS. Add these resource definitions back in so stuff works again.