### PR TITLE
Fix Stock RF tank types

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -753,21 +753,10 @@ PARTUPGRADE
 
 // These patches mangle stock RF tank types because stock RF tank types just have stuff manually added 
 // to them, and lack the tags these patches expect.
-// Kill two birds with one stone, and just tag stock RF tank types (removing the need to manually add stuff,
-// and protecting them from these patches)
-@TANK_DEFINITION[Default|Cryogenic|Structural|Balloon|BalloonCryo]:FIRST
+// Tag stock tank types to avoid being touched by our patches
+@TANK_DEFINITION[Default|Cryogenic|Structural|Balloon|BalloonCryo|Fuselage|ServiceModule|ElectricPropulsion]:FIRST
 {
-	%addResources = true
-	%addLead = true
-}
-@TANK_DEFINITION[Fuselage|ServiceModule|ElectricPropulsion]:FIRST
-{
-	%addResources = true
-	%addResourcesHP = true
-	%addResourcesSM = true
-	%addLead = true
-	%addPayload = true
-	%addSoundingPayload = true
+	%preserveResources = true
 }
 
 // Regular resources
@@ -905,7 +894,7 @@ PARTUPGRADE
 
 // HP resources
 // Remove HP resources from tanks not tagged
-@TANK_DEFINITION:HAS[~addResourcesHP[true]]:FIRST
+@TANK_DEFINITION:HAS[~addResourcesHP[true],~preserveResources[true]]:FIRST
 {
 	!TANK[Ammonia] {}
 	!TANK[ArgonGas] {}
@@ -924,7 +913,7 @@ PARTUPGRADE
 // Some liquids expand significantly before they boil. We're gonna assume they can expand to 90% of
 // their defined density before overflowing their tanks and being vented. We will also be generous and 
 // assume a vapor recirculation system is present, so overflowed fluids still boil and provide cooling.
-@TANK_DEFINITION:HAS[#addResourcesHP[true]]:FIRST
+@TANK_DEFINITION:HAS[#addResourcesHP[true],~preserveResources[true]]:FIRST
 {
 	-addResourcesHP = DEL
 	@TANK[LqdAmmonia] { @temperature = 278.6 }	//high thermal expansion, hits 90% of 1 atm density before boiling
@@ -949,7 +938,7 @@ PARTUPGRADE
 
 // SM resources
 // Remove SM resources from tanks not tagged
-@TANK_DEFINITION:HAS[~addResourcesSM[true]]:FIRST
+@TANK_DEFINITION:HAS[~addResourcesSM[true],~preserveResources[true]]:FIRST
 {
 	!TANK[CarbonDioxide] {}
 	!TANK[CoreModerator] {}
@@ -964,7 +953,7 @@ PARTUPGRADE
 // set boiling points assuming tank pressure of 100 bar
 // Everything that still has a bp below ~350 k gets a dewar
 // and the gas can be captured (if applicable)
-@TANK_DEFINITION:HAS[#addResourcesSM[true]]:FIRST
+@TANK_DEFINITION:HAS[#addResourcesSM[true],~preserveResources[true]]:FIRST
 {
 	-addResourcesSM = DEL
 	@TANK[LqdAmmonia] {
@@ -1073,7 +1062,7 @@ PARTUPGRADE
 @TANK_DEFINITION:HAS[#defaultMass] { !defaultMass = DEL }
 
 // LH2 tank mass correction
-@TANK_DEFINITION:HAS[~balloonTemps[true]] // not FIRST anymore.
+@TANK_DEFINITION:HAS[~balloonTemps[true],~preserveResources[true]] // not FIRST anymore.
 {
 	@TANK[LqdHydrogen]
 	{

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -751,6 +751,25 @@ PARTUPGRADE
 	description = You can now use Steel & Aluminum-Lithium Alloy balloon tanks. Balloon tanks do not have an internal framework, but instead rely on internal pressurization to keep its shape. If the pressurization fails, the balloon tank collapses. They are constructed of very thin sheets of stainless steel and have very good mass fractions, but the logistics involved in maintaining pressurization make them quite expensive. These modern balloon tanks were first used by Centaur III.
 }
 
+// These patches mangle stock RF tank types because stock RF tank types just have stuff manually added 
+// to them, and lack the tags these patches expect.
+// Kill two birds with one stone, and just tag stock RF tank types (removing the need to manually add stuff,
+// and protecting them from these patches)
+@TANK_DEFINITION[Default|Cryogenic|Structural|Balloon|BalloonCryo]:FIRST
+{
+	%addResources = true
+	%addLead = true
+}
+@TANK_DEFINITION[Fuselage|ServiceModule|ElectricPropulsion]:FIRST
+{
+	%addResources = true
+	%addResourcesHP = true
+	%addResourcesSM = true
+	%addLead = true
+	%addPayload = true
+	%addSoundingPayload = true
+}
+
 // Regular resources
 // set boiling points assuming tank pressure of 1.5 bar
 // stuff with boiling points above 293 K gets left alone, except for water/ethanol because they're useful
@@ -780,11 +799,11 @@ PARTUPGRADE
 	%TANK[Ammonia] { %utilization = 100 }
 	%TANK[LqdAmmonia]
 	{
-		temperature = 248.23	//from NIST webbook
-		wallThickness = 0.0025
-		wallConduction = 8
-		insulationThickness = 0.01
-		insulationConduction = 0.02
+		%temperature = 248.23	//from NIST webbook
+		&wallThickness = 0.0025
+		&wallConduction = 8
+		&insulationThickness = 0.01
+		&insulationConduction = 0.02
 	}
 	%TANK[Aniline] {}
 	%TANK[Aniline22] {}
@@ -811,22 +830,22 @@ PARTUPGRADE
 	%TANK[Helium] { %utilization = 200 }
 	%TANK[LqdHelium]
 	{
-		temperature = 4.7	//from NIST webbook
-		wallThickness = 0.0025
-		wallConduction = 205
-		insulationThickness = 0.0381
-		insulationConduction = 0.014
+		%temperature = 4.7	//from NIST webbook
+		&wallThickness = 0.0025
+		&wallConduction = 205
+		&insulationThickness = 0.0381
+		&insulationConduction = 0.014
 	}
 	%TANK[HTP] {}
 	%TANK[Hydrazine] {}
 	%TANK[Hydrogen] { %utilization = 100 }
 	%TANK[LqdHydrogen]
 	{
-		temperature = 21.82	//from NIST webbook
-		wallThickness = 0.0025
-		wallConduction = 205
-		insulationThickness = 0.0381
-		insulationConduction = 0.014
+		%temperature = 21.82	//from NIST webbook
+		&wallThickness = 0.0025
+		&wallConduction = 205
+		&insulationThickness = 0.0381
+		&insulationConduction = 0.014
 	}
 	%TANK[Hydyne] {}
 	%TANK[IRFNA-III] {}
@@ -837,11 +856,11 @@ PARTUPGRADE
 	%TANK[Methane] { %utilization = 100 }
 	%TANK[LqdMethane]
 	{
-		temperature = 116.83	//from NIST webbook
-		wallThickness = 0.0025
-		wallConduction = 16
-		insulationThickness = 0.01
-		insulationConduction = 0.02
+		%temperature = 116.83	//from NIST webbook
+		&wallThickness = 0.0025
+		&wallConduction = 16
+		&insulationThickness = 0.01
+		&insulationConduction = 0.02
 	}
 	%TANK[Methanol] {}
 	%TANK[MMH] {}
@@ -856,22 +875,22 @@ PARTUPGRADE
 	%TANK[Nitrogen] { %utilization = 200 }
 	%TANK[LqdNitrogen]
 	{
-		wallThickness = 0.0025
-		wallConduction = 16
-		temperature = 81.2	//from NIST webbook
-		insulationThickness = 0.01
-		insulationConduction = 0.02
+		&wallThickness = 0.0025
+		&wallConduction = 16
+		%temperature = 81.2	//from NIST webbook
+		&insulationThickness = 0.01
+		&insulationConduction = 0.02
 	}
 	%TANK[NitrousOxide] { %utilization = 100 }
 	%TANK[NTO] {}
 	%TANK[OF2] { %temperature = 133.3 }	//from NIST webbook
 	%TANK[LqdOxygen]
 	{
-		wallThickness = 0.0025
-		wallConduction = 16
-		temperature = 94.25	//from NIST webbook
-		insulationThickness = 0.01
-		insulationConduction = 0.02
+		&wallThickness = 0.0025
+		&wallConduction = 16
+		%temperature = 94.25	//from NIST webbook
+		&insulationThickness = 0.01
+		&insulationConduction = 0.02
 	}
 	%TANK[Pentaborane] {}	//{ %temperature = 337.2 }	//from https://pubchem.ncbi.nlm.nih.gov/compound/Pentaborane
 	%TANK[Syntin] {}

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -110,6 +110,24 @@ RESOURCE_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 	}
+	TANK
+	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
 }
 
 @TANK_DEFINITION[Fuselage|ServiceModule]:FOR[RealismOverhaul]:NEEDS[RealFuels]
@@ -122,6 +140,36 @@ RESOURCE_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline22
+		mass = 0.000085
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.000085
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = ASCENT
+		mass = 0.000081
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -110,24 +110,6 @@ RESOURCE_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 	}
-	TANK
-	{
-		name = Aniline22
-		mass = 0.00002
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-	}
-	TANK
-	{
-		name = Aniline37
-		mass = 0.00002
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-	}
 }
 
 @TANK_DEFINITION[Fuselage|ServiceModule]:FOR[RealismOverhaul]:NEEDS[RealFuels]
@@ -140,56 +122,6 @@ RESOURCE_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-	}
-	TANK
-	{
-		name = Aniline22
-		mass = 0.000085
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		note = (pressurized)
-	}
-	TANK
-	{
-		name = Aniline37
-		mass = 0.000085
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		note = (pressurized)
-	}
-	TANK
-	{
-		name = ASCENT
-		mass = 0.000081
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		note = (pressurized)
-	}
-	TANK
-	{
-		name = Nitrogen
-		mass = 0.000081
-		utilization = 200
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		note = (pressurized)
-	}
-	TANK
-	{
-		name = Helium
-		mass = 0.000081
-		utilization = 200
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-		note = (pressurized)
 	}
 }
 


### PR DESCRIPTION
My recent patches to alphabetize stuff breaks the stock RF tank types, because the bulk patches remove resources from *all* tanks not tagged as HP, breaking stock RF tank types.

Tag stock RF tank types to avoid being touched by our patches.

resolves https://github.com/KSP-RO/RealismOverhaul/issues/2843