### PR TITLE
Add oxygen gas to HP tanks for the new RCS configs

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -566,6 +566,19 @@ PARTUPGRADE
 	description = You can now add Water, Food and Oxygen to Service Module Tanks
 }
 
+PARTUPGRADE
+{
+	name = RFTech-AddOxygenGas
+	partIcon = RO-RFTank-Seperate
+	techRequired = standardDockingPorts
+	entryCost = 0
+	cost = 0
+	title = Oxygen Gas RCS Tank Upgrade
+	basicInfo = You can now add Oxygen to High Pressure Tanks as RCS fuel
+	manufacturer = Generic
+	description = You can now add Oxygen to High Pressure Tanks as RCS fuel
+}
+
 // Isogrid and Conventional Tanks
 PARTUPGRADE
 {
@@ -907,6 +920,7 @@ PARTUPGRADE
 	!TANK[Methane] {}
 	!TANK[Nitrogen] {}
 	!TANK[NitrousOxide] {}
+	!TANK[Oxygen] {}
 	!TANK[XenonGas] {}
 }
 // pressure increases bp of liquids. Assuming 15 bar vapor over liquids
@@ -945,7 +959,6 @@ PARTUPGRADE
 	!TANK[Food] {}
 	!TANK[LithiumPeroxide] {}
 	!TANK[LithiumHydroxide] {}
-	!TANK[Oxygen] {}
 	!TANK[PotassiumSuperoxide] {}
 	!TANK[Waste] {}
 	!TANK[WasteWater] {}


### PR DESCRIPTION
#2754 added several RCS configs that use oxygen gas as the oxidizer, which can only be added to SM tanks. This pull request will allow adding oxygen gas to HP tanks after the tech node `standardDockingPorts`, which unlocks such RCS configs. 

Needs https://github.com/KSP-RO/RP-0/pull/1939. 