### PR TITLE
Improve mfr naming

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -3,6 +3,7 @@ Localization
 	RSSROConfig = True
 	en-us
 	{
+		#roMfrGeneric = Generic
 		//	============================================================================
 		//	Generic Manufacturer Localizations
 		//	============================================================================
@@ -29,15 +30,17 @@ Localization
 		#roMfrContinental = Continental Aircraft Engine Company	//(1929-1969) bought by Teledyne to become Teledyne Continental Motors in 1969
 		#roMrfConvair = Convair	//(1953-1996) sold off by General Dynamics 1994-1996
 		#roMfrCordant = Cordant Technologies	//(1998-2001) bought by ATK in 2001
+		#roMfrCRC = Communications Research Centre (CRC)	//(1970-present)
 		#roMfrCW = Curtiss-Wright	//(1929-present)
 		//D
 		#roMfrDHC = De Havilland Canada (DHC)	//(1928-1986, 2019-present) sold to Boeing in 1986. Reestablished as De Havilland Aircraft of Canada Limited in 2019
 		#roMfrDouglas = Douglas Aircraft	//(1921-1967) merged with McDonnell in 1967 to form McDonnell Douglas
+		#roMfrDTRE = Defence Research Telecommunications Establishment (DRTE)	//(1951-1969) renamed to Communications Research Centre in 1969.
+		#roMfrDynetics = Dynetics	//(1974-present)
 		//E
 		//F
 		//G
 		#roMfrGALCIT = GALCIT	//(1936-1943) Renamed to JPL in 1943
-		#roMfrGeneric = Generic
 		#roMfrGD = General Dynamics (GD)	//(1899-present)
 		#roMfrGE = General Electric (GE)	//(1892-present) Aerospace division sold to Martin Marietta 1993
 		#roMfrGCRC = Grand Central Rocket Company (GCRC)	//(1952-1960) bought by Lockheed in 1960
@@ -45,6 +48,7 @@ Localization
 		//H
 		#roMfrHercules = Hercules	//(1912-2008) sold to Ashland in 2008
 		#roMfrHoneywell = Honeywell	//(1906-1999) merged with Allied Signal to form Honeywell International in 1999. Spun off ATK in 1990
+		#roMfrHughes = Hughes Aircraft	//(1934-1997) sold to Raytheon in 1997
 		//I
 		#roMfrIBM = IBM	//(1911-present)
 		#roMfrISP = In-Space Propulsion (ISP)	//(1987-2012) bought by Moog to become Moog ISP
@@ -99,86 +103,90 @@ Localization
 		//	source: Challenge to Apollo: The Soviet Union and the Space Race, 1945-1974
 		//	https://www.secretprojects.co.uk/threads/okb-36-dobrynin-kolesov-rybinsk-jet-engines.12885/
 		//NII-88
-		#roMfrNII88 = Scientific Research Institute 88 (NII-88)	//(1946-1967) head of all Soviet space R&D. Most OKBs spun off from it's various departments in the early 1950s. Renamed to Central Scientific Research Institute (TsNIIMash)
-		#roMfrTsNIIMash = Central Research Institute of Machine Building (TsNIIMash)	//(1967-present)
-		//Korolev (OKB-1)
-		#roMfrOKB1 = OKB-1 (Korolev)	//(1946-1974) renamed to NPO Energia in 1974
+		#roMfrNII88 = Scientific Research Institute 88 (НИИ-88)	//(1946-1967) head of all Soviet space R&D. Most OKBs spun off from it's various departments in the early 1950s. Renamed to Central Scientific Research Institute (ЦНИИмаш)
+		#roMfrTsNIIMash = Central Research Institute of Machine Building (ЦНИИмаш)	//(1967-present)
+		//Korolev (ОКБ-1)
+		#roMfrOKB1 = ОКБ-1 (Korolev)	//(1946-1974) renamed to NPO Energia in 1974
 		#roMfrNPOEnergia = NPO Energia	//(1974-1994) privatized as RKK Energia in 1994
 		#roMfrRKKEnergia = RKK Energia	//(1994-present)
-		//Isayev (OKB-2)
-		#roMfrOKB2 = OKB-2 (Isayev)	//(1952-1966) Renamed to Design Bureau of Chemical Engineering (KB KhimMash)
-		#roMfrKBKhM = KB KhimMash (KBKhM)	//(1967-present)
-		//Bisnovat (OKB-4)
-		#roMfrOKB4 = OKB-4 (Bisnovat)	//(1946-1966) renamed to KB Molniya
-		#roMfrKBMolniya = KB Molniya	//(1966-1976) reorganized as NPO Molniya to develop Buran spaceplane
+		//Isayev (ОКБ-2)
+		#roMfrOKB2 = ОКБ-2 (Isayev)	//(1952-1966) Renamed to Design Bureau of Chemical Engineering (КБХМ)
+		#roMfrKBKhM = Chemical Engineering Design Bureau (КБХМ)	//(1967-present)
+		//Bisnovat (ОКБ-4)
+		#roMfrОКБ4 = ОКБ-4 (Bisnovat)	//(1946-1966) renamed to Molniya Design Bureau
+		#roMfrKBMolniya = Molniya Design Bureau	//(1966-1976) reorganized as NPO Molniya to develop Buran spaceplane
 		#roMfrNPOMolniya = NPO Molniya	//(1976-present)
-		//Shvetsov (OKB-19)
-		#roMfrOKB19 = OKB-19 (Shvetsov)	//(1934-1953) renamed to KB Soloviev
-		#roMfrSoloviev = KB Soloviev	//(1953-1989?) became OJSC Aviadvigatel
+		//Shvetsov (ОКБ-19)
+		#roMfrOKB19 = ОКБ-19 (Shvetsov)	//(1934-1953) renamed to Soloviev Design Bureau
+		#roMfrSoloviev = Soloviev Design Bureau	//(1953-1989?) became OJSC Aviadvigatel
 		#roMfrAviadvigatel = OJSC Aviadvigatel	//(1989-2003?) merged with Perm Engine Company, renamed to UEC-Aviadvigatel JSC
 		#roMfrUECAviadvigatel = UEC-Aviadvigatel JSC	//(2003?-present)
-		//Myasishchev (OKB-23)
-		#roMfrOKB23 = OKB-23 (Myasishchev)	//(1951-1988) renamed to Salyut design Bureau
-		#roMfrSalyut = KB Salyut	//(1988-1993) merged with Khrunichev Plant
-		#roMfrKhrunichev = Khrunichev State Research and Production Space Center	//(1993-present)
-		//Kolesov (OKB-36)
-		#roMfrOKB36 = OKB-36 (Kolesov)	//(1943-1966) renamed to Rybinsk Motor Design Bureau
-		#roMfrRKBM = KB Rybinsk Motor (RKBM)	//(1966-2001) merged with NPO Saturn to become UEC Saturn
-		//Chelomi (OKB-52)
-		#roMfrOKB52 = OKB-52 (Chelomi)	//(1955-1966) renamed to NPO Mashinostroyeniya in 1966
+		//Myasishchev (ОКБ-23)
+		#roMfrOKB23 = ОКБ-23 (Myasishchev)	//(1951-1988) renamed to Salyut Design Bureau
+		#roMfrSalyut = Salyut Design Bureau	//(1988-1993) merged with Khrunichev Plant
+		#roMfrKhrunichev = Khrunichev State Research and Production Space Center (ГКНПЦ)	//(1993-present)
+		//Kolesov (ОКБ-36)
+		#roMfrOKB36 = ОКБ-36 (Kolesov)	//(1943-1966) renamed to Rybinsk Motor Design Bureau
+		#roMfrRKBM = Rybinsk Motor Design Bureau (РКБМ)	//(1966-2001) merged with NPO Saturn to become UEC Saturn
+		//Chelomi (ОКБ-52)
+		#roMfrOKB52 = ОКБ-52 (Chelomi)	//(1955-1966) renamed to NPO Mashinostroyeniya in 1966
 		#roMfrNPOMash = NPO Mashinostroyeniya	//(1966-present)
-		//Kilmov/Izotov (OKB-117)
-		#roMfrOKB117 = OKB-117 (Kilmov/Izotov)	//(1946-1963) renamed in honor of Kilmov 1963
-		#roMfrOKBKilmov = Leningrad OKB Kilmov	//(1963-1975)
-		#roMfrNPOKilmov = Leningrad NPO Kilmov	//(1975-1992) reorganized as JSC Kilmov
-		#roMfrJSCKilmov = JSC Kilmov	//(1992-present)
-		//Kosberg (OKB-154)
-		#roMfrOKB154 = OKB-154 (Kosberg)	//(1946-1966) renamed to Design Bureau of Chemical Automation (KB Khimavtomatika)
-		#roMfrKBKhA = KB Khimavtomatika (KBKhA)	//(1966-present)
-		//Lyulka (OKB-165)
-		#roMfrOKB165 = OKB-165 (Lyulka)	//(1946-1966) renamed to NPO Saturn
+		//Klimov/Izotov (ОКБ-117)
+		#roMfrOKB117 = ОКБ-117 (Klimov/Izotov)	//(1946-1963) renamed in honor of Klimov 1963
+		#roMfrOKBKilmov = Leningrad OKB Klimov	//(1963-1975)
+		#roMfrNPOKilmov = Leningrad NPO Klimov	//(1975-1992) reorganized as JSC Klimov
+		#roMfrJSCKilmov = JSC Klimov	//(1992-present)
+		//Antonov (ОКБ-153)
+		#roMfrOKB153 = ОКБ-153 (Antonov)	//(1946-1983) renamed to Antonov Design Bureau
+		#roMfrAntonov = Antonov Design Bureau	//(1984-2008) renamed to Antonov State Enterprise
+		#roMfrSEA = Antonov State Enterprise	//(2009-present)
+		//Kosberg (ОКБ-154)
+		#roMfrOKB154 = ОКБ-154 (Kosberg)	//(1946-1966) renamed to Design Bureau of Chemical Automation (KB Khimavtomatika)
+		#roMfrKBKhA = Design Bureau of Chemical Automation (КБХА)	//(1966-present)
+		//Lyulka (ОКБ-165)
+		#roMfrOKB165 = ОКБ-165 (Lyulka)	//(1946-1966) renamed to NPO Saturn
 		#roMfrNPOSaturn = NPO Saturn	//(1966-2001) merged with Rybinsk Motors to become UEC Saturn
 		#roMfrUECSaturn = UEC NPO Saturn	//(2001-present)
-		//Kuznetsov (OKB-276)
-		#roMfrOKB276 = OKB-276 (Kuznetsov)	//(1946-1966) renamed to NPO Kuznetsov (NPO Trud)
+		//Kuznetsov (ОКБ-276)
+		#roMfrOKB276 = ОКБ-276 (Kuznetsov)	//(1946-1966) renamed to NPO Kuznetsov (NPO Trud)
 		#roMfrNPOKuznetstov = NPO Kuznetsov	//(1966-2009) merged into JSC Kuznetsov in 2009
 		#roMfrJSCKuznetstov = JSC Kuznettov	//(2009-present)
-		//Tumansky (OKB-300)
-		#roMfrOKB300 = OKB-300 (Tumansky)	//(1943-1966) renamed to MNZ Soyuz 1966
+		//Tumansky (ОКБ-300)
+		#roMfrOKB300 = ОКБ-300 (Tumansky)	//(1943-1966) renamed to MNZ Soyuz 1966
 		#roMfrMNZSoyuz = MNZ Soyuz	//(1966-1981) defunct?
-		//Lavochkin (OKB-301)
-		#roMfrOKB301 = OKB-301 (Lavochkin)	//(1945-1960) renamed to GSMZ Lavochkin
+		//Lavochkin (ОКБ-301)
+		#roMfrOKB301 = ОКБ-301 (Lavochkin)	//(1945-1960) renamed to GSMZ Lavochkin
 		#roMfrGSMZLavochkin = GSMZ Lavochkin	//(1960-1974) renamed to NPO Lavochkin
 		#roMfrNPOLavochkin = NPO Lavochkin	//(1974-present)
-		//Glushko (OKB-456)
-		#roMfrOKB456 = OKB-456 (Glushko)	//(1946-1967) merged with OKB-1, becoming sub-bureau KB EnergoMash
-		#roMfrKBEnergomash = KB EnergoMash	//(1967-1990) spun off from NPO Energia in 1990 to become NPO EnergoMash
+		//Glushko (ОКБ-456)
+		#roMfrOKB456 = ОКБ-456 (Glushko)	//(1946-1967) merged with OKB-1, becoming sub-bureau EnergoMash
+		#roMfrKBEnergomash = EnergoMash Design Bureau	//(1967-1990) spun off from NPO Energia in 1990 to become NPO EnergoMash
 		#roMfrEnergomash = NPO EnergoMash	//(1990-present)
-		//Ivchenko (OKB-478)
-		#roMfrOKB478 = OKB-478 (Ivchenko)	//(1945-????)
+		//Ivchenko (ОКБ-478)
+		#roMfrOKB478 = ОКБ-478 (Ivchenko)	//(1945-????)
 		#roMfrIvchenko = Ivchenko-Progress ZMKB	//(????-present)
-		//Yangel (OKB-586)
-		#roMfrOKB586 = OKB-586 (Yangel)	//(1951-1966) renamed to KB Yuzhnoye
-		#roMfrKBYuzhnoye = KB Yuzhnoye	//(1966-1986) renamed to NPO Yuzhnoye
+		//Yangel (ОКБ-586)
+		#roMfrOKB586 = ОКБ-586 (Yangel)	//(1951-1966) renamed to Yuzhnoye Design Bureau
+		#roMfrKBYuzhnoye = Yuzhnoye Design Bureau	//(1966-1986) renamed to NPO Yuzhnoye
 		#roMfrNPOYuzhnoye = NPO Yuzhnoye	//(1986-1991?) renamed after fall of USSR?
 		#roMfrYuzhnoye = Yuzhnoye Design Office	//(1991?-present)
 		//#roMfrUMZ = PA Yuzhmash	//(1966-2000) Yuzhny Machine-Building Plant? (Use design bureaus, not their factories)
 		//#roMfrPivdenmash = PA Pivdenmash	//(2000-present) State Factory Pivdenmash (Use design bureaus, not their factories)
-		//OKB-692
-		#roMfrOKB692 = OKB-692	//(1959-1966?) renamed to KB Electropriborostroeniya
-		#roMfrKBElectro = KB Electropriborostroeniya	//(1966?-1976?) renamed to NPO Electropribor
+		//ОКБ-692
+		#roMfrOKB692 = ОКБ-692	//(1959-1966?) renamed to KB Electropriborostroeniya
+		#roMfrKBElectro = Electrical Instrumentation Design Bureau	//(1966?-1976?) renamed to NPO Electropribor
 		#roMfrElectro = NPO Electropribor	//(1976?-1993) privatized as JSC Khartron
 		#roMfrKhartron = JSC Khartron	//(1993-present)
 		//Stechkin
 		#roMfrOKBFakel = OKB Fakel	//(1959-present)
 		//Keldysh/Dushkin
-		#roMfrNII3 = Scientific Research Institute 3 (NII-3)	//(1936-1942)
-		#roMfrNII1 = Scientific Research Institute 1 (NII-1)	//(1952-1965)
-		#roMfrNIITP = Scientific Research Institute of Thermal Processes (NIITP)	//(1965-1995) renamed to Keldysh Research Center
+		#roMfrNII3 = Scientific Research Institute 3 (НИИ-3)	//(1936-1942)
+		#roMfrNII1 = Scientific Research Institute 1 (НИИ-1)	//(1952-1965)
+		#roMfrNIITP = Scientific Research Institute of Thermal Processes (НИИТП)	//(1965-1995) renamed to Keldysh Research Center
 		#roMfrKeldysh = Keldysh Research Center	//(1995-present)
 		//Others
-		#roMfrKurchatov = Kurchatov Institute of Atomic Energy	//(1943-present)
-		#roMfrMPEI = Moscow Power Engineering Institute (MPEI)	//(1930-present)
+		#roMfrKurchatov = Kurchatov Institute of Atomic Energy (КИАЭ)	//(1943-present)
+		#roMfrMPEI = Moscow Power Engineering Institute (МЭИ)	//(1930-present)
 		
 		//	============================================================================
 		//	European Manufacturers
@@ -196,6 +204,7 @@ Localization
 		#roMfrBristol = Bristol Aeroplane	//(1910-1959) merged to form BAC, engine division merged to form Bristol Siddeley
 		#roMfrBristolSiddeley = Bristol Siddeley	//(1959-1966) bought by Rolls-Royce
 		#roMfrBAC = British Aircraft Corporation	//(1960-1977) bought by British Aerospace (BAe)
+		#roMfrBACAero = British Aircraft Corporation & Aérospatiale	//(1962-1979) Collaboration between BAC and Sud-Aviation/Aérospatiale to create the Concorde
 		//C
 		#roMfrCASA = Construcciones Aeronáuticas (CASA)	//(1923-1999) bought by EADS
 		#roMfrCassidian = Cassidian	//(2010-2014) reorganized into Airbus Defence and Space
@@ -212,9 +221,11 @@ Localization
 		//F
 		//G
 		//H
+		#roMfrHeinkel = Heinkel Flugzeugwerke	//(1922-1965)
 		//I
 		#roMfrDLR = Institute of Space Systems (DLR)	//(????-present)
 		//J
+		#roMfrJunkers = Junkers	//(1895-1969) absorbed by Messerschmitt-Bölkow-Blohm in 1969
 		//K
 		//L
 		#roMfrLRBA = Ballistic and Aerodynamic Research Laboratory (LRBA)	//(1946-1969) merged to form SEP
@@ -237,7 +248,7 @@ Localization
 		#roMfrSEREB = Company for the Study and Production of Ballistic Devices (SÉREB)	//(????-1970) merged with Nord Aviation
 		#roMfrSEP = European Propulsion Company (SEP)	//(1969-1997) merged with SNECMA 1997
 		#roMfrSEPR = Research Company for Jet Propulsion (SEPR)	//(1944-1969) merged to form SEP
-		#roMfrSNECMA = French National Aviation Engine Company (SNECMA)	//(1945-2016) renamed to Safran Aircraft Engines
+		#roMfrSNECMA = National Aviation Engine Company (SNECMA)	//(1945-2016) renamed to Safran Aircraft Engines
 		#roMfrSud = Sud-Aviation	//(1957-1970) merged with Nord Aviation to create SNIAS/Aérospatiale
 		//T
 		//U
@@ -252,8 +263,8 @@ Localization
 		#roMfrIHI = Ishikawajima-Harima Heavy Industries (IHI)	//(1960-present)
 		#roMfrISAS = Institute of Space and Astronautical Science (ISAS)	//(1955-present) became division of JAXA in 2003
 		#roMfrJAXA = Japan Aerospace Exploration Agency (JAXA)	//(2003-present)
-		#roMfrMHI = Mitsubishi Heavy Industries	//(1950-present)
-		#roMfrNAL = National Aerospace Laboratory of Japan (NAL)	//(1955-2003) merged to form JAXA
+		#roMfrMHI = Mitsubishi Heavy Industries (三菱重工)	//(1950-present)
+		#roMfrNAL = National Aerospace Laboratory of Japan (航技研)	//(1955-2003) merged to form JAXA
 		#roMfrNASDA = National Space Development Agency of Japan (NASDA)	//(1969-2003) merged to form JAXA
 		#roMfrNissan = Nissan	//(1930-present) sold aerospace division to IHI in 2000
 		
@@ -262,7 +273,7 @@ Localization
 		#roMfrAALPT = Academy of Aerospace Liquid Propulsion Technology (AALPT)	//(1970-present)
 		#roMfrARMT = Academy of Rocket Motors Technology (ARMT)	//(1962-present)
 		#roMfrCALT = China Academy of Launch Vehicle Technology (CALT)	//(1957-present) 
-		#roMfrCASC = China Aerospace Science and Technology Corporation (CASC)	//(1999-present)
+		#roMfrCASC = China Aerospace Science and Technology Corporation (中国航天)	//(1999-present)
 		#roMfrCapitalAerospace = Capital Aerospace Machinery	//(1983-present)
 		#roMfrCAST = China Academy of Space Technology (CAST)	//(1968-present)
 		#roMfrFactory211 = Factory 211	//(????-1983) privatized as Capital Aerospace Machinery co.?
@@ -274,7 +285,7 @@ Localization
 		#roMfrGB = Godrej & Boyce (G&B)	//(1897-present)
 		#roMfrLPSC = Liquid Propulsion Systems Center (LPSC)	//(1985-present)
 		#roMfrMTAR = MTAR Technologies	//(1969-present)
-		#roMfrHAL = Hindustan Aeronautics Limited (HAL)	//(1964-present)
+		#roMfrHAL = Hindustan Aeronautics Limited (हिऐलि)	//(1964-present)
 		#roMfrISRO = Indian Space Research Organisation (ISRO)	//(1969-present)
 		
 		//	============================================================================


### PR DESCRIPTION
Try to improve mfr naming and localization consistency by fully translating improper nouns while simply transliterating proper nouns, and providing abbreviations in their native language where applicable (latin characters are used for foreign names if the company branding uses latin characters).