### PR TITLE
Add manufacturer loc tags and general improvements

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -3,6 +3,7 @@ Localization
 	RSSROConfig = True
 	en-us
 	{
+		#roMfrGeneric = Generic
 		//	============================================================================
 		//	Generic Manufacturer Localizations
 		//	============================================================================
@@ -29,15 +30,17 @@ Localization
 		#roMfrContinental = Continental Aircraft Engine Company	//(1929-1969) bought by Teledyne to become Teledyne Continental Motors in 1969
 		#roMrfConvair = Convair	//(1953-1996) sold off by General Dynamics 1994-1996
 		#roMfrCordant = Cordant Technologies	//(1998-2001) bought by ATK in 2001
+		#roMfrCRC = Communications Research Centre (CRC)	//(1970-present)
 		#roMfrCW = Curtiss-Wright	//(1929-present)
 		//D
 		#roMfrDHC = De Havilland Canada (DHC)	//(1928-1986, 2019-present) sold to Boeing in 1986. Reestablished as De Havilland Aircraft of Canada Limited in 2019
 		#roMfrDouglas = Douglas Aircraft	//(1921-1967) merged with McDonnell in 1967 to form McDonnell Douglas
+		#roMfrDTRE = Defence Research Telecommunications Establishment (DRTE)	//(1951-1969) renamed to Communications Research Centre in 1969.
+		#roMfrDynetics = Dynetics	//(1974-present)
 		//E
 		//F
 		//G
 		#roMfrGALCIT = GALCIT	//(1936-1943) Renamed to JPL in 1943
-		#roMfrGeneric = Generic
 		#roMfrGD = General Dynamics (GD)	//(1899-present)
 		#roMfrGE = General Electric (GE)	//(1892-present) Aerospace division sold to Martin Marietta 1993
 		#roMfrGCRC = Grand Central Rocket Company (GCRC)	//(1952-1960) bought by Lockheed in 1960
@@ -45,6 +48,7 @@ Localization
 		//H
 		#roMfrHercules = Hercules	//(1912-2008) sold to Ashland in 2008
 		#roMfrHoneywell = Honeywell	//(1906-1999) merged with Allied Signal to form Honeywell International in 1999. Spun off ATK in 1990
+		#roMfrHughes = Hughes Aircraft	//(1934-1997) sold to Raytheon in 1997
 		//I
 		#roMfrIBM = IBM	//(1911-present)
 		#roMfrISP = In-Space Propulsion (ISP)	//(1987-2012) bought by Moog to become Moog ISP
@@ -99,86 +103,90 @@ Localization
 		//	source: Challenge to Apollo: The Soviet Union and the Space Race, 1945-1974
 		//	https://www.secretprojects.co.uk/threads/okb-36-dobrynin-kolesov-rybinsk-jet-engines.12885/
 		//NII-88
-		#roMfrNII88 = Scientific Research Institute 88 (NII-88)	//(1946-1967) head of all Soviet space R&D. Most OKBs spun off from it's various departments in the early 1950s. Renamed to Central Scientific Research Institute (TsNIIMash)
-		#roMfrTsNIIMash = Central Research Institute of Machine Building (TsNIIMash)	//(1967-present)
-		//Korolev (OKB-1)
-		#roMfrOKB1 = OKB-1 (Korolev)	//(1946-1974) renamed to NPO Energia in 1974
+		#roMfrNII88 = Scientific Research Institute 88 (НИИ-88)	//(1946-1967) head of all Soviet space R&D. Most OKBs spun off from it's various departments in the early 1950s. Renamed to Central Scientific Research Institute (ЦНИИмаш)
+		#roMfrTsNIIMash = Central Research Institute of Machine Building (ЦНИИмаш)	//(1967-present)
+		//Korolev (ОКБ-1)
+		#roMfrOKB1 = ОКБ-1 (Korolev)	//(1946-1974) renamed to NPO Energia in 1974
 		#roMfrNPOEnergia = NPO Energia	//(1974-1994) privatized as RKK Energia in 1994
 		#roMfrRKKEnergia = RKK Energia	//(1994-present)
-		//Isayev (OKB-2)
-		#roMfrOKB2 = OKB-2 (Isayev)	//(1952-1966) Renamed to Design Bureau of Chemical Engineering (KB KhimMash)
-		#roMfrKBKhM = KB KhimMash (KBKhM)	//(1967-present)
-		//Bisnovat (OKB-4)
-		#roMfrOKB4 = OKB-4 (Bisnovat)	//(1946-1966) renamed to KB Molniya
-		#roMfrKBMolniya = KB Molniya	//(1966-1976) reorganized as NPO Molniya to develop Buran spaceplane
+		//Isayev (ОКБ-2)
+		#roMfrOKB2 = ОКБ-2 (Isayev)	//(1952-1966) Renamed to Design Bureau of Chemical Engineering (КБХМ)
+		#roMfrKBKhM = Chemical Engineering Design Bureau (КБХМ)	//(1967-present)
+		//Bisnovat (ОКБ-4)
+		#roMfrОКБ4 = ОКБ-4 (Bisnovat)	//(1946-1966) renamed to Molniya Design Bureau
+		#roMfrKBMolniya = Molniya Design Bureau	//(1966-1976) reorganized as NPO Molniya to develop Buran spaceplane
 		#roMfrNPOMolniya = NPO Molniya	//(1976-present)
-		//Shvetsov (OKB-19)
-		#roMfrOKB19 = OKB-19 (Shvetsov)	//(1934-1953) renamed to KB Soloviev
-		#roMfrSoloviev = KB Soloviev	//(1953-1989?) became OJSC Aviadvigatel
+		//Shvetsov (ОКБ-19)
+		#roMfrOKB19 = ОКБ-19 (Shvetsov)	//(1934-1953) renamed to Soloviev Design Bureau
+		#roMfrSoloviev = Soloviev Design Bureau	//(1953-1989?) became OJSC Aviadvigatel
 		#roMfrAviadvigatel = OJSC Aviadvigatel	//(1989-2003?) merged with Perm Engine Company, renamed to UEC-Aviadvigatel JSC
 		#roMfrUECAviadvigatel = UEC-Aviadvigatel JSC	//(2003?-present)
-		//Myasishchev (OKB-23)
-		#roMfrOKB23 = OKB-23 (Myasishchev)	//(1951-1988) renamed to Salyut design Bureau
-		#roMfrSalyut = KB Salyut	//(1988-1993) merged with Khrunichev Plant
-		#roMfrKhrunichev = Khrunichev State Research and Production Space Center	//(1993-present)
-		//Kolesov (OKB-36)
-		#roMfrOKB36 = OKB-36 (Kolesov)	//(1943-1966) renamed to Rybinsk Motor Design Bureau
-		#roMfrRKBM = KB Rybinsk Motor (RKBM)	//(1966-2001) merged with NPO Saturn to become UEC Saturn
-		//Chelomi (OKB-52)
-		#roMfrOKB52 = OKB-52 (Chelomi)	//(1955-1966) renamed to NPO Mashinostroyeniya in 1966
+		//Myasishchev (ОКБ-23)
+		#roMfrOKB23 = ОКБ-23 (Myasishchev)	//(1951-1988) renamed to Salyut Design Bureau
+		#roMfrSalyut = Salyut Design Bureau	//(1988-1993) merged with Khrunichev Plant
+		#roMfrKhrunichev = Khrunichev State Research and Production Space Center (ГКНПЦ)	//(1993-present)
+		//Kolesov (ОКБ-36)
+		#roMfrOKB36 = ОКБ-36 (Kolesov)	//(1943-1966) renamed to Rybinsk Motor Design Bureau
+		#roMfrRKBM = Rybinsk Motor Design Bureau (РКБМ)	//(1966-2001) merged with NPO Saturn to become UEC Saturn
+		//Chelomi (ОКБ-52)
+		#roMfrOKB52 = ОКБ-52 (Chelomi)	//(1955-1966) renamed to NPO Mashinostroyeniya in 1966
 		#roMfrNPOMash = NPO Mashinostroyeniya	//(1966-present)
-		//Kilmov/Izotov (OKB-117)
-		#roMfrOKB117 = OKB-117 (Kilmov/Izotov)	//(1946-1963) renamed in honor of Kilmov 1963
-		#roMfrOKBKilmov = Leningrad OKB Kilmov	//(1963-1975)
-		#roMfrNPOKilmov = Leningrad NPO Kilmov	//(1975-1992) reorganized as JSC Kilmov
-		#roMfrJSCKilmov = JSC Kilmov	//(1992-present)
-		//Kosberg (OKB-154)
-		#roMfrOKB154 = OKB-154 (Kosberg)	//(1946-1966) renamed to Design Bureau of Chemical Automation (KB Khimavtomatika)
-		#roMfrKBKhA = KB Khimavtomatika (KBKhA)	//(1966-present)
-		//Lyulka (OKB-165)
-		#roMfrOKB165 = OKB-165 (Lyulka)	//(1946-1966) renamed to NPO Saturn
+		//Klimov/Izotov (ОКБ-117)
+		#roMfrOKB117 = ОКБ-117 (Klimov/Izotov)	//(1946-1963) renamed in honor of Klimov 1963
+		#roMfrOKBKilmov = Leningrad OKB Klimov	//(1963-1975)
+		#roMfrNPOKilmov = Leningrad NPO Klimov	//(1975-1992) reorganized as JSC Klimov
+		#roMfrJSCKilmov = JSC Klimov	//(1992-present)
+		//Antonov (ОКБ-153)
+		#roMfrOKB153 = ОКБ-153 (Antonov)	//(1946-1983) renamed to Antonov Design Bureau
+		#roMfrAntonov = Antonov Design Bureau	//(1984-2008) renamed to Antonov State Enterprise
+		#roMfrSEA = Antonov State Enterprise	//(2009-present)
+		//Kosberg (ОКБ-154)
+		#roMfrOKB154 = ОКБ-154 (Kosberg)	//(1946-1966) renamed to Design Bureau of Chemical Automation (KB Khimavtomatika)
+		#roMfrKBKhA = Design Bureau of Chemical Automation (КБХА)	//(1966-present)
+		//Lyulka (ОКБ-165)
+		#roMfrOKB165 = ОКБ-165 (Lyulka)	//(1946-1966) renamed to NPO Saturn
 		#roMfrNPOSaturn = NPO Saturn	//(1966-2001) merged with Rybinsk Motors to become UEC Saturn
 		#roMfrUECSaturn = UEC NPO Saturn	//(2001-present)
-		//Kuznetsov (OKB-276)
-		#roMfrOKB276 = OKB-276 (Kuznetsov)	//(1946-1966) renamed to NPO Kuznetsov (NPO Trud)
+		//Kuznetsov (ОКБ-276)
+		#roMfrOKB276 = ОКБ-276 (Kuznetsov)	//(1946-1966) renamed to NPO Kuznetsov (NPO Trud)
 		#roMfrNPOKuznetstov = NPO Kuznetsov	//(1966-2009) merged into JSC Kuznetsov in 2009
 		#roMfrJSCKuznetstov = JSC Kuznettov	//(2009-present)
-		//Tumansky (OKB-300)
-		#roMfrOKB300 = OKB-300 (Tumansky)	//(1943-1966) renamed to MNZ Soyuz 1966
+		//Tumansky (ОКБ-300)
+		#roMfrOKB300 = ОКБ-300 (Tumansky)	//(1943-1966) renamed to MNZ Soyuz 1966
 		#roMfrMNZSoyuz = MNZ Soyuz	//(1966-1981) defunct?
-		//Lavochkin (OKB-301)
-		#roMfrOKB301 = OKB-301 (Lavochkin)	//(1945-1960) renamed to GSMZ Lavochkin
+		//Lavochkin (ОКБ-301)
+		#roMfrOKB301 = ОКБ-301 (Lavochkin)	//(1945-1960) renamed to GSMZ Lavochkin
 		#roMfrGSMZLavochkin = GSMZ Lavochkin	//(1960-1974) renamed to NPO Lavochkin
 		#roMfrNPOLavochkin = NPO Lavochkin	//(1974-present)
-		//Glushko (OKB-456)
-		#roMfrOKB456 = OKB-456 (Glushko)	//(1946-1967) merged with OKB-1, becoming sub-bureau KB EnergoMash
-		#roMfrKBEnergomash = KB EnergoMash	//(1967-1990) spun off from NPO Energia in 1990 to become NPO EnergoMash
+		//Glushko (ОКБ-456)
+		#roMfrOKB456 = ОКБ-456 (Glushko)	//(1946-1967) merged with OKB-1, becoming sub-bureau EnergoMash
+		#roMfrKBEnergomash = EnergoMash Design Bureau	//(1967-1990) spun off from NPO Energia in 1990 to become NPO EnergoMash
 		#roMfrEnergomash = NPO EnergoMash	//(1990-present)
-		//Ivchenko (OKB-478)
-		#roMfrOKB478 = OKB-478 (Ivchenko)	//(1945-????)
+		//Ivchenko (ОКБ-478)
+		#roMfrOKB478 = ОКБ-478 (Ivchenko)	//(1945-????)
 		#roMfrIvchenko = Ivchenko-Progress ZMKB	//(????-present)
-		//Yangel (OKB-586)
-		#roMfrOKB586 = OKB-586 (Yangel)	//(1951-1966) renamed to KB Yuzhnoye
-		#roMfrKBYuzhnoye = KB Yuzhnoye	//(1966-1986) renamed to NPO Yuzhnoye
+		//Yangel (ОКБ-586)
+		#roMfrOKB586 = ОКБ-586 (Yangel)	//(1951-1966) renamed to Yuzhnoye Design Bureau
+		#roMfrKBYuzhnoye = Yuzhnoye Design Bureau	//(1966-1986) renamed to NPO Yuzhnoye
 		#roMfrNPOYuzhnoye = NPO Yuzhnoye	//(1986-1991?) renamed after fall of USSR?
 		#roMfrYuzhnoye = Yuzhnoye Design Office	//(1991?-present)
 		//#roMfrUMZ = PA Yuzhmash	//(1966-2000) Yuzhny Machine-Building Plant? (Use design bureaus, not their factories)
 		//#roMfrPivdenmash = PA Pivdenmash	//(2000-present) State Factory Pivdenmash (Use design bureaus, not their factories)
-		//OKB-692
-		#roMfrOKB692 = OKB-692	//(1959-1966?) renamed to KB Electropriborostroeniya
-		#roMfrKBElectro = KB Electropriborostroeniya	//(1966?-1976?) renamed to NPO Electropribor
+		//ОКБ-692
+		#roMfrOKB692 = ОКБ-692	//(1959-1966?) renamed to KB Electropriborostroeniya
+		#roMfrKBElectro = Electrical Instrumentation Design Bureau	//(1966?-1976?) renamed to NPO Electropribor
 		#roMfrElectro = NPO Electropribor	//(1976?-1993) privatized as JSC Khartron
 		#roMfrKhartron = JSC Khartron	//(1993-present)
 		//Stechkin
 		#roMfrOKBFakel = OKB Fakel	//(1959-present)
 		//Keldysh/Dushkin
-		#roMfrNII3 = Scientific Research Institute 3 (NII-3)	//(1936-1942)
-		#roMfrNII1 = Scientific Research Institute 1 (NII-1)	//(1952-1965)
-		#roMfrNIITP = Scientific Research Institute of Thermal Processes (NIITP)	//(1965-1995) renamed to Keldysh Research Center
+		#roMfrNII3 = Scientific Research Institute 3 (НИИ-3)	//(1936-1942)
+		#roMfrNII1 = Scientific Research Institute 1 (НИИ-1)	//(1952-1965)
+		#roMfrNIITP = Scientific Research Institute of Thermal Processes (НИИТП)	//(1965-1995) renamed to Keldysh Research Center
 		#roMfrKeldysh = Keldysh Research Center	//(1995-present)
 		//Others
-		#roMfrKurchatov = Kurchatov Institute of Atomic Energy	//(1943-present)
-		#roMfrMPEI = Moscow Power Engineering Institute (MPEI)	//(1930-present)
+		#roMfrKurchatov = Kurchatov Institute of Atomic Energy (КИАЭ)	//(1943-present)
+		#roMfrMPEI = Moscow Power Engineering Institute (МЭИ)	//(1930-present)
 		
 		//	============================================================================
 		//	European Manufacturers
@@ -196,6 +204,7 @@ Localization
 		#roMfrBristol = Bristol Aeroplane	//(1910-1959) merged to form BAC, engine division merged to form Bristol Siddeley
 		#roMfrBristolSiddeley = Bristol Siddeley	//(1959-1966) bought by Rolls-Royce
 		#roMfrBAC = British Aircraft Corporation	//(1960-1977) bought by British Aerospace (BAe)
+		#roMfrBACAero = British Aircraft Corporation & Aérospatiale	//(1962-1979) Collaboration between BAC and Sud-Aviation/Aérospatiale to create the Concorde
 		//C
 		#roMfrCASA = Construcciones Aeronáuticas (CASA)	//(1923-1999) bought by EADS
 		#roMfrCassidian = Cassidian	//(2010-2014) reorganized into Airbus Defence and Space
@@ -212,9 +221,11 @@ Localization
 		//F
 		//G
 		//H
+		#roMfrHeinkel = Heinkel Flugzeugwerke	//(1922-1965)
 		//I
 		#roMfrDLR = Institute of Space Systems (DLR)	//(????-present)
 		//J
+		#roMfrJunkers = Junkers	//(1895-1969) absorbed by Messerschmitt-Bölkow-Blohm in 1969
 		//K
 		//L
 		#roMfrLRBA = Ballistic and Aerodynamic Research Laboratory (LRBA)	//(1946-1969) merged to form SEP
@@ -237,7 +248,7 @@ Localization
 		#roMfrSEREB = Company for the Study and Production of Ballistic Devices (SÉREB)	//(????-1970) merged with Nord Aviation
 		#roMfrSEP = European Propulsion Company (SEP)	//(1969-1997) merged with SNECMA 1997
 		#roMfrSEPR = Research Company for Jet Propulsion (SEPR)	//(1944-1969) merged to form SEP
-		#roMfrSNECMA = French National Aviation Engine Company (SNECMA)	//(1945-2016) renamed to Safran Aircraft Engines
+		#roMfrSNECMA = National Aviation Engine Company (SNECMA)	//(1945-2016) renamed to Safran Aircraft Engines
 		#roMfrSud = Sud-Aviation	//(1957-1970) merged with Nord Aviation to create SNIAS/Aérospatiale
 		//T
 		//U
@@ -252,8 +263,8 @@ Localization
 		#roMfrIHI = Ishikawajima-Harima Heavy Industries (IHI)	//(1960-present)
 		#roMfrISAS = Institute of Space and Astronautical Science (ISAS)	//(1955-present) became division of JAXA in 2003
 		#roMfrJAXA = Japan Aerospace Exploration Agency (JAXA)	//(2003-present)
-		#roMfrMHI = Mitsubishi Heavy Industries	//(1950-present)
-		#roMfrNAL = National Aerospace Laboratory of Japan (NAL)	//(1955-2003) merged to form JAXA
+		#roMfrMHI = Mitsubishi Heavy Industries (三菱重工)	//(1950-present)
+		#roMfrNAL = National Aerospace Laboratory of Japan (航技研)	//(1955-2003) merged to form JAXA
 		#roMfrNASDA = National Space Development Agency of Japan (NASDA)	//(1969-2003) merged to form JAXA
 		#roMfrNissan = Nissan	//(1930-present) sold aerospace division to IHI in 2000
 		
@@ -262,7 +273,7 @@ Localization
 		#roMfrAALPT = Academy of Aerospace Liquid Propulsion Technology (AALPT)	//(1970-present)
 		#roMfrARMT = Academy of Rocket Motors Technology (ARMT)	//(1962-present)
 		#roMfrCALT = China Academy of Launch Vehicle Technology (CALT)	//(1957-present) 
-		#roMfrCASC = China Aerospace Science and Technology Corporation (CASC)	//(1999-present)
+		#roMfrCASC = China Aerospace Science and Technology Corporation (中国航天)	//(1999-present)
 		#roMfrCapitalAerospace = Capital Aerospace Machinery	//(1983-present)
 		#roMfrCAST = China Academy of Space Technology (CAST)	//(1968-present)
 		#roMfrFactory211 = Factory 211	//(????-1983) privatized as Capital Aerospace Machinery co.?
@@ -274,7 +285,7 @@ Localization
 		#roMfrGB = Godrej & Boyce (G&B)	//(1897-present)
 		#roMfrLPSC = Liquid Propulsion Systems Center (LPSC)	//(1985-present)
 		#roMfrMTAR = MTAR Technologies	//(1969-present)
-		#roMfrHAL = Hindustan Aeronautics Limited (HAL)	//(1964-present)
+		#roMfrHAL = Hindustan Aeronautics Limited (हिऐलि)	//(1964-present)
 		#roMfrISRO = Indian Space Research Organisation (ISRO)	//(1969-present)
 		
 		//	============================================================================

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralParts.cfg
@@ -18,7 +18,7 @@
 
 @PART[proceduralBattery|proceduralStructural|proceduralStackDecoupler|proceduralTankKethane|proceduralTankTAC|proceduralTankOre|proceduralCrewTube]:FOR[RealismOverhaul]
 {
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
 }
@@ -104,7 +104,7 @@
 {
 	%RSSROConfig = True
 	@title = Nose Cone [Procedural]
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@attachRules = 1,1,1,1,0 // allow surface attachment
 }
 
@@ -114,7 +114,7 @@
 
 	%category = Thermal
 	@title = Heat Shield [Procedural]
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 
 	@maxTemp = 3673.15
 	%skinMaxTemp = 3773.15
@@ -125,7 +125,7 @@
 	%RSSROConfig = True
 
 	@title = Solid Rocket Motor [Procedural]
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 
 	@maxTemp = 673.15
 	%skinMaxTemp = 773.15
@@ -209,7 +209,7 @@
 	%RSSROConfig = True
 
 	@title = Tank [Procedural]
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = Switchable procedural tank. Comes in various levels of insulation, rigid/balloon, and pressurized/highly-pressurized forms. Defaults to type Default but can be switched to other types in the part popup menu.
 
 	@maxTemp = 773.15

--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_pFairings.cfg
@@ -5,7 +5,7 @@
 @PART[KzProcFairingSide*|KzInterstageAdapter2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 }
 
 +PART[KzInterstageAdapter2]:FOR[RealismOverhaul]
@@ -157,7 +157,7 @@
 	%RSSROConfig = True
 
 	@title = Thrust Plate [Procedural]
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 
 	// PF v6 integrated the resizers into the ProceduralFairingBase
 	@MODULE[ProceduralFairingBase]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Electrical.cfg
@@ -235,7 +235,7 @@
     @rescaleFactor = 1.5
 
     @title = Voyager MHW-RTG
-    @manufacturer = Department Of Energy (DOE)
+    @manufacturer = #roMfrGE
     @description = The Multihundred-Watt radioisotope thermoelectric generator (MHW-RTG) as found on the Voyager spacecraft.
 
     @mass = 0.107

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
@@ -2,6 +2,7 @@
 @PART[SXTRadialAirIntakeShockCone|SXTInlineAirIntakeTiny|SXTInlineAirIntake|LRadialAirIntake|SXTInlineAirIntakeTLarge]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@manufacturer = #roMfrGeneric
 	!RESOURCE[IntakeAtm] {}
 	!MODULE[ModuleResourceIntake] {}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Misc.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Misc.cfg
@@ -1,11 +1,13 @@
 @PART[SXTlaunchclamp1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@manufacturer = #roMfrGeneric
 }
 @PART[LMKIIIAircraftFusLong]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = true
 	@title = Boeing 737 Fuselage
+	@manufacturer = #roMfrBoeing
 	@description = Fuselage section of B737 airliner. Diameter is 3,75m
 
 	@mass = 5.0 // total guess
@@ -14,6 +16,7 @@
 {
 	%RSSROConfig = true
 	@title = Boeing 737 Fuselage (short)
+	@manufacturer = #roMfrBoeing
 	@description = Fuselage section of B737 airliner. Diameter is 3,75m
 
 	@mass = 2.5 // total guess	
@@ -21,5 +24,6 @@
 @PART[SXTradialWindow]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@manufacturer = #roMfrGeneric
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Aero.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Aero.cfg
@@ -20,7 +20,7 @@
     @rescaleFactor = 1.0
 
     @title = Conformal Rocket Cone Mk3
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = An elongated and slanted nose cone. Useful for solid rocket motors and other radially attached objects.
 
     @mass = 0.065

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Bonanza.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Bonanza.cfg
@@ -11,7 +11,7 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, -0.6, 0.0, 0.0, -1.0, 0.0, 1
 	@title = IO-550-B Piston Engine
-	@manufacturer = Continental
+	@manufacturer = #roMfrTCM
 	@description = Fuel-injected air-cooled horizontally-opposed six-cylinder aero engine. 300HP at 2700RPM at sea level.
 	
 	@mass = 0.26 // 65kg for housing and prop seems about right, prop is about 40-50kg?
@@ -80,7 +80,7 @@
 	@node_stack_bottom = 0.0, -2.97132, 0.0, 0.0, -1.0, 0.0, 1
 	@node_attach = 0.0, 0.0, 0.9984, 0.0, 0.0, -1.0, 1
 	@title = Bonanza Cabin
-	@manufacturer = Beechcraft
+	@manufacturer = #roMfrBeechcraft
 	@description = Cabin section for the Beechcraft Bonanza
 	@mass = 0.3
 	@crashTolerance = 5
@@ -162,7 +162,7 @@
 	@rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.77945, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Bonanza Tail
-	@manufacturer = Beechcraft
+	@manufacturer = #roMfrBeechcraft
 	@description = Tail section of the Beechcraft Bonanza.
 	@mass = 0.05
 	@crashTolerance = 5

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Command.cfg
@@ -11,7 +11,7 @@
 
 	// %rescaleFactor = 0.624
 	@title = Sputnik PS-1
-	@manufacturer = NPO Energomash
+	@manufacturer = #roMfrOKB1
 	@description = The first satellite to orbit the Earth.
 	@node_stack_bottom = 0.0, -0.515425, 0.0, 0.0, -1.0, 0.0, 0
 	@mass = 0.081
@@ -61,7 +61,7 @@
 	@maxTemp = 773.15
 	@skinMaxTemp = 873.15
 	@title = Sputnik PS-1 Antenna
-	@manufacturer = NPO Energomash
+	@manufacturer = #roMfrOKB1
 	@description = Small whip antenna for the Sputnik PS-1 satellite.
 
 	@MODULE[ModuleDataTransmitter]
@@ -109,7 +109,7 @@
 	%node_stack_bottom = 0.0, -0.494, 0.0, 0.0, -1.0, 0.0, 1
 	%node_stack_top = 0.0, 0, 0.0, 0.0, 1.0, 0.0, 1
 	@title = Mariner Core
-	@manufacturer = JPL
+	@manufacturer = #roMfrJPL
 	@description = Probe core used for the first Mariner missions and the early (Block I) Ranger missions.
 	!RESOURCE[ElectricCharge]
 	{
@@ -182,7 +182,7 @@
     @node_stack_bottom = 0, -0.38, 0.0, 0, -1.0, 0.0, 0
 
     @title = Alouette Core
-    @manufacturer = Defence Research Telecommunications Establishment (DRTE)
+    @manufacturer = #roMfrDTRE
     @description = Alouette 1 and 2 were the first Canadian satellites launched in 1962 and 1963 with the purpose of studying the upper ionospheric layers of the Earth. 
 
     @mass = 0.145
@@ -276,7 +276,7 @@
 	}
 	@mass = 2.0
 	@title = Saturn I Instrument Unit [3.9M]
-	@manufacturer = IBM
+	@manufacturer = #roMfrIBM
 	@description = Guidance ring used for early Saturn I launches.
 	@MODULE[ModuleCommand]
 	{
@@ -326,7 +326,7 @@
 {
 	%RSSROConfig = True
 	@title = Junkers Ju 87 cockpit
-	@manufacturer = Junkers
+	@manufacturer = #roMfrJunkers
 	@description = Cockpit for the Junkers Ju-87 also known as Stuka (from Sturzkampfflugzeug - dive bomber), two-man (pilot and rear gunner) German dive bomber and ground-attack aircraft.
 	@MODEL
 	{
@@ -391,7 +391,7 @@
 	%RSSROConfig = true
 	
 	@title = B-52 Stratofortress cockpit
-	@manufacturer = Boeing
+	@manufacturer = #roMfrBoeing
 	@description = Cockpit for the B-52 Stratofortress, long-range, subsonic, jet-powered strategic bomber.
 	// Rescale to 5.9m x 4.0m x 3.3m
 	@node_stack_bottom = 0.0, -1.3125, 0.0, 0, -1, 0, 3
@@ -423,7 +423,7 @@
 	%RSSROConfig = true
 	
 	@title = Concorde cockpit
-	@manufacturer = BAC / Sud-Aviation
+	@manufacturer = #roMfrBACAero
 	@description = Cockpit for the Aerospatiale-BAC Concorde, turbojet-powered, supersonic, passenger jet airliner.
 	// Rescale to 15,0m x 3,1m x 3,1m
 	@node_stack_bottom = 0.0, -4.9, 0.0, 0, -1, 0, 2
@@ -461,7 +461,7 @@
 {
 	%RSSROConfig = true
 	@title = Heinkel He 111 cockpit
-	@manufacturer = Heinkel
+	@manufacturer = #roMfrHeinkel
 	@description = Constructed originally for the German Heinkel He 111 type bomber, this cockpit is useful for airdrop carrier planes, reconnaisance craft, and other vehicles where high visibility is paramount.
 	
 	@crashTolerance = 5
@@ -516,7 +516,7 @@
 	%RSSROConfig = true
 	
 	@title = Boeing 737 cockpit
-	@manufacturer = Boeing
+	@manufacturer = #roMfrBoeing
 	@description = Cockpit for the Boeing 737- short-to medium range twinjet airliner. First flight: April 9, 1967.
 
 	@mass = 2.8 // total guess
@@ -565,7 +565,7 @@
 {
 	%RSSROConfig = True
 	@title =  DHC-3 Otter cockpit
-	@manufacturer = de Havilland Canada
+	@manufacturer = #roMfrDHC
 	@description = Cockpit for the DHC-3 Otter - single-engined, high-wing, propeller-driven, short take-off and landing (STOL) aircraft developed by de Havilland Canada.
 	@MODEL
 	{
@@ -619,6 +619,7 @@
 {
 	%RSSROConfig = True
 	@title = An-124 Cockpit
+	@manufacturer = #roMfrOKB153
 	@description =  Cockpit of the Antonov An-124, diameter is 6.75m.
 	@mass = 9
 	@rescaleFactor = 1.8
@@ -634,6 +635,7 @@
 {
 	%RSSROConfig = True
 	@title = An-124 Cockpit Radial
+	@manufacturer = #roMfrOKB153
 	@description =  Radial Cockpit of the Antonov An-124
 	@mass = 5
 	@rescaleFactor = 1.8
@@ -676,7 +678,7 @@
     @node_stack_top = 0.0, 1.035, 0.0, 0.0, 1.0, 0.0, 3
     @node_stack_bottom = 0.0, -1.035, 0.0, 0.0, -1.0, 0.0 , 3
 
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = While similar to the Mk2 Lander Can internally, the PPD-8 offers a ruggedized casing and improved crash resistance, plus handy EVA hand grips. It can also be controlled remotely.
 
     @mass = 2.75

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Copernicus.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Copernicus.cfg
@@ -34,11 +34,9 @@
     @node_stack_bottom2 = 0.0, -7.49, 0.0, 0.0, 1.0, 0.0, 3
     @node_attach = 3.56, 0.0, 0.0, 1.0, 0.0, 0.0
 
-    %TechRequired = specializedConstruction
-    %entryCost = 0
     @category = Structural
     @title = Strongback Truss (Closed Long)
-    @manufacturer = NASA
+    @manufacturer = #roMfrGeneric
     @description = A long, structural strongback truss, perfect for landers.
 
     @mass = 6.39
@@ -77,11 +75,9 @@
     @node_stack_bottom2 = 0.0, -2.515, 0.0, 0.0, 1.0, 0.0, 3
     @node_attach = 3.56, 0.0, 0.0, 1.0, 0.0, 0.0
 
-    %TechRequired = specializedConstruction
-    %entryCost = 0
     @category = Structural
     @title = Strongback Truss (Closed Short)
-    @manufacturer = NASA
+    @manufacturer = #roMfrGeneric
     @description = A short, structural strongback truss.
 
     @mass = 0.53
@@ -122,11 +118,9 @@
     @node_stack_bottom2 = 0.0, -9.985, 0.0, 0.0, 1.0, 0.0, 3
     @node_attach = 3.56, 0.0, 0.0, 1.0, 0.0, 0.0
 
-    %TechRequired = specializedConstruction
-    %entryCost = 0
     @category = Structural
     @title = Strongback Truss (Open Long)
-    @manufacturer = NASA
+    @manufacturer = #roMfrGeneric
     @description = A long strongback truss for carrying cargo.
 
     @mass = 4.26
@@ -172,11 +166,9 @@
     @node_stack_bottom2 = 0.0, -4.99, 0.0, 0.0, 1.0, 0.0, 3
     @node_attach = 3.56, 0.0, 0.0, 1.0, 0.0, 0.0
 
-    %TechRequired = specializedConstruction
-    %entryCost = 0
     @category = Structural
     @title = Strongback Truss (Open Medium)
-    @manufacturer = NASA
+    @manufacturer = #roMfrGeneric
     @description = A medium length strongback truss for carrying cargo.
 
     @mass = 2.13
@@ -217,11 +209,9 @@
     @node_stack_bottom2 = 0.0, -2.5, 0.0, 0.0, 1.0, 0.0, 3
     @node_attach = 3.56, 0.0, 0.0, 1.0, 0.0, 0.0
 
-    %TechRequired = specializedConstruction
-    %entryCost = 0
     @category = Structural
     @title = Strongback Truss (Open Short)
-    @manufacturer = NASA
+    @manufacturer = #roMfrGeneric
     @description = A short strongback truss for carrying cargo.
 
     @mass = 1.065

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Electrical.cfg
@@ -18,7 +18,7 @@
     %RSSROConfig = True
 
     @title = GPHS-RTG
-    @manufacturer = U.S. Department Of Energy [DOE]
+    @manufacturer = #roMfrGE
     @description = The General Purpose Heat Source - Radioisotope Thermoelectric Generator as found on the Galileo spacecraft.
     %rescaleFactor = 1.765
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Engines.cfg
@@ -15,44 +15,7 @@
 	%node_attach = 0.0, 0, 0.0, 0.0, 1.0, 0.0, 2
 
 	%attachRules = 1,1,1,1,0
-	%mass = 0.342
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 256.395
-		%maxThrust = 256.395
-		%heatProduction = 100
 
-		ullage = True
-		pressureFed = False
-		ignitions = 1
-
-		!PROPELLANT,* {}
-		PROPELLANT
-		{
-			name = Kerosene
-			ratio = 0.1755
-			DrawGauge = True
-		}
-		PROPELLANT
-		{
-			name = HTP
-			ratio = 0.8245
-		}
-
-		!atmosphereCurve {}
-		atmosphereCurve
-		{
-			key = 0 251
-			key = 1 217
-		}
-
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-	}
 	engineType = Gamma8
 }
 
@@ -74,44 +37,7 @@
 	%node_attach = 0.0, -0.08, 0.0, 0.0, 1.0, 0.0, 1
 
 	%attachRules = 1,1,1,1,0
-	%mass = 0.173
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 68.236
-		%maxThrust = 68.236
-		%heatProduction = 100
 
-		ullage = True
-		pressureFed = False
-		ignitions = 1
-
-		!PROPELLANT,* {}
-		PROPELLANT
-		{
-			name = Kerosene
-			ratio = 0.1755
-			DrawGauge = True
-		}
-		PROPELLANT
-		{
-			name = HTP
-			ratio = 0.8245
-		}
-
-		!atmosphereCurve {}
-		atmosphereCurve
-		{
-			key = 0 267
-			key = 1 189
-		}
-
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.25
-		}
-	}
 	engineType = Gamma2
 }
 
@@ -127,20 +53,6 @@
 	%rescaleFactor = 1.0
 	@node_stack_top = 0.0, 0.3484893, 0.0, 0.0, 1.0, 0.0, 0
 	node_stack_bottom = 0.0, -0.95355485, 0.0, 0.0, -1.0, 0.0, 1
-
-	@maxTemp = 800
-	@MODULE[ModuleEngines*]
-	{
-		@maxThrust = 34.35
-		@heatProduction = 100
-		@useEngineResponseTime = False
-		!engineAccelerationSpeed = DELETE
-		@atmosphereCurve
-		{
-			@key,0 = 0 278
-			@key,1 = 0 245
-		}
-	}
 
 	engineType = Waxwing
 }
@@ -161,37 +73,10 @@
 	@node_stack_bottom = 0.0, -3.12, 0.0, 0.0, -1.0, 0.0, 2
 	@node_attach = 0.0, 0.12, 0.0, 0.0, 1.0, 0.0 , 2
 
-	@mass = 1.578501
-	@maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 778.4388
-		@maxThrust = 1023.091
-		@heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 0.745
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.255
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 424
-			@key,1 = 1 200
-		}
-		!IGNITOR_RESOURCE,* {}
-	}
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = gimbal
-		gimbalRange = 7.5
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
 	}
 	engineType = J2
 }
@@ -207,37 +92,10 @@
 	@node_stack_bottom = 0.0, -3.12, 0.0, 0.0, -1.0, 0.0, 2
 	@node_attach = 0.0, 0.12, 0.0, 0.0, 1.0, 0.0 , 2
 	
-	%mass = 1.578501
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 938.469
-		%maxThrust = 1400.70
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 0.745
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.255
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 451
-			@key,1 = 1 280
-		}
-		!IGNITOR_RESOURCE,* {}
-	}
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = gimbal
-		gimbalRange = 7.5
-		useGimbalResponseSpeed = true
-		gimbalResponseSpeed = 16
 	}
 	engineType = HG3
 }
@@ -253,34 +111,10 @@
 	}
 	%scale = 1.0
 	%rescaleFactor = 1.0
-	%category = Propulsion
 
 	%node_stack_top = 0.0,0.997444,0.0 , 0.0, 1.0, 0.0, 3
 	%node_stack_bottom = 0.0,-2.6106416,0.0 , 0, -1, 0, 3
-	%mass = 3.45
-	%maxTemp = 2073.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 882.45
-		%maxThrust = 1961
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 0.729
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.271
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 455
-			@key,1 = 1 359
-		}
-		!IGNITOR_RESOURCE,* {}
-	}
+
 	engineType = RD0120
 }
 
@@ -303,30 +137,6 @@
 	%node_stack_top = 0.0, 0.11705, 0.0, 0.0, 1.0, 0.0, 4
 	%node_stack_bottom = 0.0, -3.565, 0.0 , 0, -1, 0, 4
 
-	%mass = 9.5
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%maxThrust = 7903
-		%minThrust = 4425.68
-		%heatProduction = 100
-		@atmosphereCurve
-		{
-			@key,0 = 0 337
-			@key,1 = 1 309
-		}
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Kerosene
-			@ratio = 0.346
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.654
-		}
-		!IGNITOR_RESOURCE,* {}
-	}
 	engineType = RD170
 }
 
@@ -422,35 +232,11 @@
 	@node_stack_bottom = 0.0, -0.6756, 0.0, 0.0, -1.0, 0.0, 0
 
 	%attachRules = 1,0,1,0,0
-	%mass = 0.08
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 33.4
-		%maxThrust = 33.4
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = UDMH
-			@ratio = 0.406
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = IWFNA
-			@ratio = 0.594
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 270
-			@key,1 = 1 240
-		}
-		!IGNITOR_RESOURCE,* {}
-	}
+
 	@MODULE[ModuleJettison],*
 	{
 		@bottomNodeName = bottom
 	}
-	!MODULE[ModuleEngineConfigs] {}
 	engineType = AJ10_Early
 }
 
@@ -469,35 +255,12 @@
 	@node_stack_bottom = 0.0, -0.97944, 0.0, 0.0, -1.0, 0.0, 0
 
 	%attachRules = 1,0,1,0,0
-	%mass = 0.09
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 35.1
-		%maxThrust = 35.1
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = UDMH
-			@ratio = 0.406
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = IWFNA
-			@ratio = 0.594
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 278
-			@key,1 = 1 215
-		}
-		!IGNITOR_RESOURCE,* {}
-	}
+
 	@MODULE[ModuleJettison],*
 	{
 		@bottomNodeName = bottom
 	}
-	!MODULE[ModuleEngineConfigs] {}
+
 	engineType = AJ10_Mid
 }
 // AJ10 adv, i.e. 118F & 118K
@@ -516,34 +279,12 @@
 	@node_stack_bottom = 0.0, -0.97944, 0.0, 0.0, -1.0, 0.0, 0
 
 	%attachRules = 1,0,1,0,0
-	%mass = 0.1
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 42.3
-		%maxThrust = 42.3
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Aerozine50
-			@ratio = 0.502
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = NTO
-			@ratio = 0.498
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 315
-			@key,1 = 1 215
-		}
-	}
+
 	@MODULE[ModuleJettison],*
 	{
 		@bottomNodeName = bottom
 	}
-	!MODULE[ModuleEngineConfigs] {}
+
 	@engineType = AJ10_Adv
 }
 
@@ -576,24 +317,6 @@
 	%engineTypeMult = 1
 	%massOffset = 0
 	%ignoreMass = False
-
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		@minThrust = 0
-		@maxThrust = 10.943
-		@heatProduction = 100
-		@useEngineResponseTime = False
-		!engineAccelerationSpeed = NULL
-
-		@atmosphereCurve
-		{
-			@key,0 = 0 286.2
-			@key,1 = 1 140
-		}
-	}
-
-	!RESOURCE,*{}
 }
 
 +PART[SXTKD170]:FOR[RealismOverhaul]
@@ -608,37 +331,8 @@
 	}
 	@scale = 1.0
 	%rescaleFactor = 0.4993
-	@mass = 1.278
-	@maxTemp = 1973.15
-	@attachRules = 1,0,1,0,0
 
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 941.44
-		@maxThrust = 941.44
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Kerosene
-			@ratio = 3531
-			@DrawGauge = True
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 6274
-		}
-		PROPELLANT
-		{
-			name = HTP
-			ignoreForIsp = True
-			ratio = 0.0195
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 314.79
-			@key,1 = 1 247.79
-		}
-	}
+	@attachRules = 1,0,1,0,0
 }
 
 +PART[R7_Core_Engine]:FOR[RealismOverhaul]
@@ -648,38 +342,8 @@
 	%RSSROConfig = True
 
 	%rescaleFactor = 0.4993
-	@mass = 1.19
-	@maxTemp = 1973.15
 
 	@attachRules = 1,0,1,0,0
-
-	@MODULE[ModuleEngines*]
-	{
-		@minThrust = 1000.28
-		@maxThrust = 1000.28
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Kerosene
-			@ratio = 0.3531
-			@DrawGauge = True
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			@ratio = 0.6274
-		}
-        PROPELLANT
-        {
-            name = HTP
-            ignoreForIsp = True
-            ratio = 0.0195
-        }
-		@atmosphereCurve
-		{
-			@key,0 = 0 312.75
-			@key,1 = 1 255.74
-		}
-	}
 }
 
 //	==================================================
@@ -709,9 +373,6 @@
 	@node_stack_top = 0.0, 0.08, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -4.36, 0.0, 0.0, -1.0, 0.0, 2
 
-	@mass = 2.27
-	@maxTemp = 573.15
-	%skinMaxTemp = 673.15
 	%bulkheadProfiles = size2
 
 	%engineType = BNTR
@@ -719,42 +380,10 @@
 	%massOffset = 0
 	%ignoreMass = False
 
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		@minThrust = 66.72
-		@maxThrust = 66.72
-		@heatProduction = 100
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 60
-
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 1.0
-		}
-
-		PROPELLANT
-		{
-			name = EnrichedUranium
-			ratio = 1.0813e-15
-			DrawGauge = False
-			ignoreForIsp = True
-		}
-
-		@atmosphereCurve
-		{
-			@key,0 = 0 930
-			@key,1 = 1 380
-		}
-	}
-
 	MODULE
 	{
 		name = ModuleGimbal
 		gimbalTransformName = thrustTransform
-		gimbalRange = 3.0
 	}
 }
 
@@ -771,45 +400,10 @@
 
 	@category = Engine
 
-	@mass = 12.86
-	@maxTemp = 573.15
-	%skinMaxTemp = 673.15
-
 	%engineType = NERVAII
 	%engineTypeMult = 1
 	%massOffset = 0
 	%ignoreMass = False
-
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-		@minThrust = 750.0
-		@maxThrust = 867.0
-		@heatProduction = 100
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 60
-
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = LqdHydrogen
-			@ratio = 1.0
-		}
-
-		PROPELLANT
-		{
-			name = EnrichedUranium
-			ratio = 1.0813e-15
-			DrawGauge = False
-			ignoreForIsp = True
-		}
-
-		@atmosphereCurve
-		{
-			@key,0 = 0 850
-			@key,1 = 1 380
-		}
-	}
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_FuelTank.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_FuelTank.cfg
@@ -14,6 +14,7 @@
 
     @category = FuelTank
     @title = 0.625m Fuselage (Pressurized)
+    @manufacturer = #roMfrGeneric
     @description = Highly-pressurized propellant-tank fuselage, 0.625m diameter. Rated for suborbital reentries. X-15 class.
 
     @mass = 0.012
@@ -50,7 +51,7 @@
 
     @category = FuelTank
     @title = OX - 4 Propellant Tank
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = A small, general purpose, propellant tank.
 
     @mass = 0.02
@@ -85,7 +86,7 @@
     @rescaleFactor = 1.0
 
     @title = Fuselage (Long) [Pressurized]
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = A reinforced fuselage for larger space planes. Long version.
 
     @mass = 0.72
@@ -120,7 +121,7 @@
     @rescaleFactor = 1.0
 
     @title =  Fuselage (Short) [Pressurized]
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = A reinforced fuselage for larger space planes. Short version.
 
     @mass = 0.36
@@ -157,6 +158,7 @@
 
     @category = FuelTank
     @title = Kerbodyne KX200-16 Propellant Tank
+    @manufacturer = #roMfrGeneric
  
     @mass = 0.15
     @crashTolerance = 10
@@ -184,6 +186,7 @@
 
     @category = FuelTank
     @title = Kerbodyne KX200-32 Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 0.3
     @crashTolerance = 10
@@ -211,6 +214,7 @@
 
     @category = FuelTank
     @title = Kerbodyne KX200-64 Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 0.6
     @crashTolerance = 10
@@ -238,6 +242,7 @@
 
     @category = FuelTank
     @title = Kerbodyne S3-S2-2430 Adapter Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 0.4
     @crashTolerance,* = NULL
@@ -273,6 +278,7 @@
 
     @category = FuelTank
     @title = Kerbodyne S5 Nose Cone Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 1.4
     @crashTolerance = 10
@@ -307,6 +313,7 @@
 
     @category = FuelTank
     @title = Kerbodyne S5-08000 Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 0.9
     @crashTolerance = 10
@@ -334,6 +341,7 @@
 
     @category = FuelTank
     @title = Kerbodyne S5-16000 Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 1.8
     @crashTolerance = 10
@@ -361,6 +369,7 @@
 
     @category = FuelTank
     @title = Kerbodyne S5-32000 Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 3.5
     @crashTolerance = 10
@@ -388,6 +397,7 @@
 
     @category = FuelTank
     @title = Kerbodyne S5-64000 Propellant Tank
+    @manufacturer = #roMfrGeneric
 
     @mass = 7.0
     @crashTolerance = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_LEM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_LEM.cfg
@@ -9,7 +9,7 @@
 	@node_stack_top = 0.0, 1.5264, 0.0, 0.0, 1.0, 0.0, 1
 	@node_stack_bottom = 0.0, -1.04, 0.0, 0.0, -1.0, 0.0, 1
 	@title = Apollo Lunar Module Ascent Module
-	@manufacturer = Grumman
+	@manufacturer = #roMfrGrumman
 	@description = Apollo Ascent Module. Contains two astronauts.
 	@mass = 1.889
 	@MODULE[ModuleCommand]
@@ -281,7 +281,7 @@
 	%node_stack_top = 0.0, 0.48, 0.0, 0.0, 1.0, 0.0, 2
 	@node_stack_bottom = 0.0, -1.4448, 0.0, 0.0, -1.0, 0.0, 1
 	@title = Apollo Lunar Module Descent Module
-	@manufacturer = Grumman
+	@manufacturer = #roMfrGrumman
 	@description = This part contains fuel for landing, experiments, and importantly legs to set down softly.
 	@mass = 0.671
 	!RESOURCE[LiquidFuel]
@@ -290,7 +290,7 @@
 	!RESOURCE[Oxidizer]
 	{
 	}
-	!MODULE[ModuleFuelTanks] {	}
+	!MODULE[ModuleFuelTanks] {}
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_N1.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_N1.cfg
@@ -6,46 +6,7 @@
 	%scale = 0.59488
 	%node_stack_top    = 0.0,  0.0, 0.0, 0.0, 1.0, 0.0, 6
 	%category = Propulsion
-	%title = NK-15/33 x30
-	%manufacturer = SNTK Kuznetsov
-	%description = That thruster plate belongs to N1 and N1F rockets. Sometimes explodes, though.
-	%mass = 39.41
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 37731
-		%maxThrust = 50308
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			%name = Kerosene
-			%ratio = 0.385
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.615
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 331
-			@key,1 = 1 297
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 2
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 1.0
-		}
-	}
+
 	!MODULE[ModuleEngineConfigs]
 	{
 	}
@@ -80,6 +41,7 @@
 	%node_stack_top    = 0.0,  9.8763793, 0.0, 0.0, 1.0, 0.0, 5
 	
 	%title = N-1 Block A
+	@manufacturer = #roMfrOKB1
 	%description = Stores fuel for Block A
 	
 	!MODULE[TweakScale]
@@ -105,6 +67,7 @@
 	%node_stack_top    = 0.0,  1.2614224, 0.0, 0.0, 1.0, 0.0, 5
 	
 	%title = N-1 Block A/B Decoupler
+	@manufacturer = #roMfrOKB1
 	%description = Install between 1st ans 2nd stages.
 	
 	!MODULE[TweakScale]
@@ -121,47 +84,9 @@
 	%node_stack_bottom = 0.0, -0.871497, 0.0, 0.0, -1.0, 0.0, 5
 	%node_stack_top    = 0.0,  0.0, 0.0, 0.0, 1.0, 0.0, 5
 	%category = Propulsion
-	%title = NK-15V/43 x8
-	%manufacturer = SNTK Kuznetsov
-	%description = That thruster plate belongs to N1 and N1F Block B. Really big and scary!
+
 	%attachRules = 1,0,1,1,0
-	%mass = 11.69
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 13184
-		%maxThrust = 13184
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			%name = Kerosene
-			%ratio = 0.385
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.615
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 331
-			@key,1 = 1 297
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 3
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 1.0
-		}
-	}
+
 	!MODULE[ModuleEngineConfigs]
 	{
 	}
@@ -196,6 +121,7 @@
 	%node_stack_top    = 0.0,  8.1908406, 0.0, 0.0, 1.0, 0.0, 5
 	
 	%title = N-1 Block B
+	@manufacturer = #roMfrOKB1
 	%description = Stores fuel for Block B.
 	
 	!MODULE[TweakScale]
@@ -221,6 +147,7 @@
 	%node_stack_top    = 0.0,  0.06724, 0.0, 0.0, 1.0, 0.0, 5
 	
 	%title = N-1 Block B/V Interstage
+	@manufacturer = #roMfrOKB1
 	%description = Install between 2nd and 3rd stages
 	
 	!MODULE[TweakScale]
@@ -237,47 +164,9 @@
 	%node_stack_bottom = 0.0, -1.0411441, 0.0, 0.0, -1.0, 0.0, 5
 	%node_stack_top    = 0.0,  0.0, 0.0, 0.0, 1.0, 0.0, 5
 	%category = Propulsion
-	%title = NK-21/39 x4
-	%manufacturer = SNTK Kuznetsov
-	%description = That thruster plate belongs to N1 and N1F Block V. This looks really small in comparison to the other parts!
+
 	%attachRules = 1,0,1,1,0
-	%mass = 2.888
-	%maxTemp = 1973.15
-	@MODULE[ModuleEngines*]
-	{
-		%minThrust = 1628
-		%maxThrust = 1628
-		%heatProduction = 100
-		@PROPELLANT[LiquidFuel]
-		{
-			%name = Kerosene
-			%ratio = 0.385
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			%name = LqdOxygen
-			%ratio = 0.615
-		}
-		@atmosphereCurve
-		{
-			@key,0 = 0 353
-			@key,1 = 1 246
-		}
-		%ullage = True
-		%pressureFed = False
-		%ignitions = 12
-		!IGNITOR_RESOURCE,* {}
-		IGNITOR_RESOURCE
-		{
-			name = ElectricCharge
-			amount = 0.5
-		}
-		IGNITOR_RESOURCE
-		{
-			name = TEATEB
-			amount = 1.0
-		}
-	}
+
 	!MODULE[ModuleEngineConfigs]
 	{
 	}
@@ -312,6 +201,7 @@
 	%node_stack_top    = 0.0,  4.06673572, 0.0, 0.0, 1.0, 0.0, 5
 	
 	%title = N-1 Block V
+	@manufacturer = #roMfrOKB1
 	%description = Stores fuel and avionics for the N-1 Block V.
 	
 	!MODULE[TweakScale]
@@ -334,6 +224,6 @@
 	%scale = 0.59488
 	%mass = 0.75 //Fix me
 	%title = N-1 Grid Fins
-	%manufacturer = SNTK Kuznetsov
+	%manufacturer = #roMfrNPOKuznetstov
 	%description = Improves N-1 stability
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_RCS.cfg
@@ -8,7 +8,7 @@
 	}
 	@mass = 0.02
 	@title = RCS Quad, Extensible (138/223 N class)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A generic RCS quad on an extensible boom. Use this for attitude control or translation/ullage for small stages and spacecraft.
 	@MODULE[ModuleRCS*]
 	{
@@ -41,7 +41,7 @@
 	}
 	@mass = 0.021
 	@title = Attitude Jet 3x (1.24/2 kN class)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A generic RCS thruster array. Use this for attitude control or translation/ullage for very large stages. Note that the thrust per nozzle is only one-third the thrust class; three nozzles fire in the same direction giving the class rating.
 	@MODULE[ModuleRCS*]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -16,6 +16,7 @@
     @rescaleFactor = 1.655
 
     @title = SPKTR-10 Lacuga Storage Container
+	@manufacturer = #roMfrGeneric
     @description = Hold 2 people with 30 days of supplies. An extension adapter for the PPD-10 Hitchhiker storage container.
 
     @mass = 4.8
@@ -192,6 +193,7 @@
     @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
 
     @title = PPD-4 Crew Cabin
+	@manufacturer = #roMfrGeneric
     @description = Hold 2 people with 23 days of supplies. A slightly cramped early station module. Features usable handle bars around the side.
 
     @mass = 3.5
@@ -362,6 +364,7 @@
     @node_attach = 0.0, 0.0, 1.5, 0.0, -1.0, 0.0, 2
 
     @title = PPD-6 Crew Cabin
+	@manufacturer = #roMfrGeneric
     @description = Hold 4 people with 23 days of supplies. A slightly cramped early station module. Features usable handle bars around the side.
 	
     @mass = 6
@@ -528,7 +531,7 @@
     @node_attach = 0.0, 0.0, 3.1, 0.0, -1.0, 0.0, 2
 	
     @title = Skylab Orbital Workshop
-	@manufacturer = McDonnell Douglas
+	@manufacturer = #roMfrMD
     @description = Hold 8 people with 155 days (5 months) of supplies. A large crew compartment designed for larger, more permanent space stations. Designed and launched in 1973, the Skylab orbital station was the wider space station ever. Given the 270m3 pressurised volume, there is plenty of room for all your IVA activies. It even features a orbital laboratory!
 
     @mass = 28
@@ -739,6 +742,7 @@
     @node_stack_bottom = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = Ares LK-S3E Heavy Planetary Habitat
+	@manufacturer = #roMfrGeneric
     @description = Hold 8 people with 45 days of supplies. A top of the line habitat meant for long-term operations. Typically after the initial 'colonists' made their situation more 'permanent' with a bit of lithobreaking. Features cabins, food preparation areas, sofas, space loos, laboratory, and even a home gym.
 
     @mass = 12.0
@@ -903,6 +907,7 @@
     @node_stack_bottom = 0.0, -2.28, 0.0, 0.0, -1.0, 0.0, 2
 
     @title = PPD-H Crew Cabin
+	@manufacturer = #roMfrGeneric
     @description = Hold 6 people with 107 days of supplies. Probodobodyne Inc first and only foray into crew habitation modules. Bulky, but not uncomfortable. It even features a handy set of exterior handrails. 
 
     @mass = 9.5
@@ -1045,6 +1050,7 @@
 {
     %RSSROConfig = True
     
+	@manufacturer = #roMfrGeneric
     @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.
 
     //restore to original SXT settings
@@ -1057,6 +1063,7 @@
 {
     %RSSROConfig = True
     
+	@manufacturer = #roMfrGeneric
     @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.
 
     //restore to original SXT settings
@@ -1095,7 +1102,7 @@
 
     @category = Utility
     @title = PPD-SM400 Service Module
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = An innovative multi-purpose design. Allows the storage of multiple and various resources to suit most mission parameters easily accessible by the crew.
 
     @mass = 6.0
@@ -1147,7 +1154,7 @@
 
     @category = Utility
     @title = PPD-SM1600 Service Module
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = An innovative multi-purpose design. Allows the storage of multiple and various resources to suit most mission parameters.
 
     @mass = 6.0
@@ -1195,7 +1202,7 @@
 
     @category = Utility
     @title = PPD-SM555 Service Module
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = A smaller version of the PPD-SM1600. Can hold approximately one third of the resources.
 
     @mass = 2.0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_fuselage.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_fuselage.cfg
@@ -2,6 +2,7 @@
 {
 	%RSSROConfig = True
 	@title = Beechcraft King Air fuselage
+	@manufacturer = #roMfrBeechcraft
 	@description =  Fuselage section of the twin-turboprop aircraft produced by Beechcraft.
 	@mass = 1
 	@MODEL
@@ -25,6 +26,7 @@
 {
 	%RSSROConfig = True
 	@title = Beechcraft King Air tail
+	@manufacturer = #roMfrBeechcraft
 	@description =  Tail section of the twin-turboprop aircraft produced by Beechcraft.
 	@mass = 0.2
 	@rescaleFactor = 2
@@ -42,6 +44,7 @@
 {
 	%RSSROConfig = True
 	@title = An-124 Hull section
+	@manufacturer = #roMfrOKB153
 	@description =  Hull section of the Antonov An-124, diameter is 6.75m.
 	@mass = 5
 	@rescaleFactor = 1.8
@@ -59,6 +62,7 @@
 {
 	%RSSROConfig = True
 	@title = An-124 Hull section Radial
+	@manufacturer = #roMfrOKB153
 	@description =  Radial hull section of the Antonov An-124
 	@mass = 2
 	@rescaleFactor = 1.8
@@ -76,6 +80,7 @@
 {
 	%RSSROConfig = True
 	@title = An-124 Hull section Radial End
+	@manufacturer = #roMfrOKB153
 	@description =  Radial hull section of the Antonov An-124
 	@mass = 2
 	@rescaleFactor = 1.8
@@ -94,6 +99,7 @@
 	%RSSROConfig = True
 	@name = SXTOsaulTail
 	@title = An-124 Tail Section
+	@manufacturer = #roMfrOKB153
 	@description =  Tail Section of the Antonov An-124, diameter is 6.75m.
 	@mass = 5
 	@rescaleFactor = 2.7
@@ -112,6 +118,7 @@
 {
 	%RSSROConfig = True
 	@title = C-130 Cargobay
+	@manufacturer = #roMfrLockheed
 	@description =  Cargobay of the C-130 Hercules, diameter is 3.75m.
 	@rescaleFactor = 1.5
 	@mass = 2.5
@@ -130,6 +137,7 @@
 {
 	%RSSROConfig = True
 	@title = Narrow-body airliner fuselage
+	@manufacturer = #roMfrGeneric
 	@description =  Fuselage section of B737, A320 etc, diameter is 3.75m.
 	@rescaleFactor = 1.5
 	@mass = 1.5
@@ -147,6 +155,7 @@
 {
 	%RSSROConfig = True
 	@title = Narrow-body airliner fuselage (Long)
+	@manufacturer = #roMfrGeneric
 	@description =  Fuselage section of B737, A320 etc, diameter is 3.75m.
 	@rescaleFactor = 1.5
 	@mass = 3
@@ -164,6 +173,7 @@
 {
 	%RSSROConfig = True
 	@title = Narrow-body airliner Tail
+	@manufacturer = #roMfrGeneric
 	@description =  Fuselage section of B737, A320 etc, diameter is 3.75m.
 	@rescaleFactor = 1.5
 	@mass = 3

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Science.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Science.cfg
@@ -5,6 +5,7 @@
 	!MODULE[TweakScale] {}
 	%rescaleFactor = 0.583	// Default part sets its MODEL scale at 1.25
 	@mass = 0.01
+	@manufacturer = #roMfrGeneric
 }
 
 // Big science ring
@@ -15,7 +16,7 @@
 	%rescaleFactor = 1.2
 	
 	@title = Station Science Module (Early)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This module, designed for use on space stations, contains various planetary science and space science equipment designed for use in repeatable experiments. Space is included for one scientist to work in the module, but their sleeping quarters and life support supplies must be provided separately.
 	
 	@mass = 3.5
@@ -212,7 +213,7 @@
     %RSSROConfig = True
 
 	@title = GC-MS + Antenna
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = The Gas Chromatograph - Mass Spectrometer (GC-MS) is an analytical instrument used for identification of multiple different substances in a selected gas sample, capable of detecting even trace amounts of them. Ideal of analyzing the atmospheric composition of unknown environments.
 	@mass = 0.004
 	@crashTolerance = 12

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Solar.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Solar.cfg
@@ -2,6 +2,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.00196 // Level 4 solid @ 0.0012t/m^2 + 0.0011t/m^2
+	@manufacturer = #roMfrGeneric
 	@description = Static Level 3 panel. 0.85m^2
 	!MODULE[TweakScale]
 	{
@@ -26,6 +27,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.0305 // Level 4 extendable @ 0.0012t/m^2 + 0.0026t/m^2
+	@manufacturer = #roMfrGeneric
 	@description = Extendable Level 3 solar panel. 8.0m^2
 	!MODULE[TweakScale]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -15,7 +15,7 @@
 @PART[asasmodule1-2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = Using a powerful electric motor, this large reaction wheel allows for minor attitude adjustments even to larger spacecraft without expending propellant.
 
 	@MODULE[TweakScale]
@@ -52,7 +52,7 @@
 @PART[cupola]:FOR[RealismOverhaul]
 {
 	@title = Cupola Observatory Module
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = Sporting large panes of transparent aluminum ceramic composite, the Cupola gives an unmatched view of space. ESA pioneered the design for the ISS, where it was attached in 2010 after launching on STS-130.
 	@mass = 1.88
 	%rescaleFactor = 1.6
@@ -106,7 +106,7 @@
 	%RSSROConfig = True
 	
 	@title = Habitation Module
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This non-controllable module is designed for space stations and very large, long-range spacecraft. It can be stocked with ample consumables, and provides toilets, showers and living quarters for up to four crewmembers. There are no bunks in space, however – instead, sleeping bags are strapped to the internal walls of the module.
 	@mass = 6.1
 	%rescaleFactor = 1.6
@@ -128,7 +128,7 @@
 {
 	%RSSROConfig = True
 	
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This module uses an electric motor to spin its internal flywheels, producing torque, which allows for minor attitude adjustments without expending propellant.
 	
 	@MODULE[TweakScale]
@@ -143,7 +143,7 @@
 {
 	%RSSROConfig = True
 	
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = Using a small electric motor, this reaction wheel lets probes and satellites adjust their attitudes without expending propellant.
 	
 	@MODULE[TweakScale]
@@ -165,7 +165,7 @@
 @PART[mk1-3pod]:FOR[RealismOverhaul]
 {
 	@title = Mk1-3 Command Pod (4m)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A three-person pod. Comes with built-in RCS thrusters running off NTO/MMH and a small battery. Heat shield required for safe reentry. Center of mass can be offset to allow lifting reentry (toggle Descent Mode).
 
 	%RSSROConfig = True
@@ -261,7 +261,7 @@
 {
 	%RSSROConfig = True
 
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A small, single-person cabin for use on non-atmospheric landers and small spacecraft.
 	@mass = 1.2
 	%maxTemp = 800
@@ -300,7 +300,7 @@
 {
 	@name = landerCabinMedium
 	%title = Mk1 Lander Can Advanced
-	%manufacturer = Generic
+	%manufacturer = #roMfrGeneric
 	%description = This capsule was designed for lightweight non-atmospheric landers, and seats two occupants.
 
 	%RSSROConfig = true
@@ -337,7 +337,7 @@
 @PART[mk1pod_v2]:FOR[RealismOverhaul]
 {
 	@title = Mk1 Pod (2m)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A one-person pod. Comes with built-in RCS thrusters running off High-Test Peroxide (HTP) and a large battery. Heat shield rated for LEO reentries. Center of mass can be offset slightly to allow lifting reentry (toggle Descent Mode).
 	@mass = 0.7
 
@@ -492,7 +492,7 @@
 // 3 Person lander can
 @PART[mk2LanderCabin_v2]:FOR[RealismOverhaul]
 {
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = 3-person cockpit for landers and space taxis. Much roomier than earlier models.
 	%RSSROConfig = True
 
@@ -543,7 +543,7 @@
 	%RSSROConfig = True
 
 	@title = Small Modern Satellite Bus
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This satellite bus includes a small reaction wheel and a large omnidirectional antenna, and only the slightest power draw. Perfect for your geosynchronous communications satellites.
 	@mass = 0.512
 	%rescaleFactor = 3.0
@@ -593,7 +593,7 @@
 	%RSSROConfig = True
 	
 	@title = Ranger Block III Core
-	@manufacturer = JPL
+	@manufacturer = #roMfrJPL
 	@description = This automated control unit was originally developed for the NASA Ranger program. It is especially suited for lunar probes and flyby missions.
 	@mass = 0.0769
 	%rescaleFactor = 1.2
@@ -626,7 +626,7 @@
 	%RSSROConfig = True
 	@name = RO_earlyControllableCore
 	@title = Early Controllable Core
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This relatively lightweight probe core allows early probes to be controlled during flight. However, it draws a fair amount of electricity for its abilities. Includes data storage for returning data to Earth (use Ship Manifest to transfer the data from the experiment to this core).
 	@mass = 0.05
 
@@ -670,7 +670,7 @@
 	%RSSROConfig = True
 	
 	@title = 1t Satellite Bus
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This is a large probe core for your bigger satellites and deep space missions.
 	@mass = 0.15
 
@@ -704,7 +704,7 @@
 	%RSSROConfig = True
 	@name = RO_surveyorCore
 	@title = Surveyor Core
-	@manufacturer = Hughes
+	@manufacturer = #roMfrHughes
 	@description = Avionics and control unit for Surveyor landing probes. Includes data storage for returning data to Earth (use Ship Manifest to transfer the data from the experiment to this core).
 	@mass = 0.15
 
@@ -744,7 +744,7 @@
 	%RSSROConfig = True
 
 	@title = Early Cube Satellite Bus
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This satellite bus is an early version of the popular cube shaped Satellite Design.
 	@mass = 0.66
 	%rescaleFactor = 3.0
@@ -783,7 +783,7 @@
 	%RSSROConfig = True
 
 	@title = Medium Modern Satellite Bus
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = This satellite bus includes a small reaction wheel and a large omnidirectional antenna, and only the slightest power draw. Perfect for your medium sized geosynchronous satellites communications satellites.
 	@mass = 0.776
 	%rescaleFactor = 4.0
@@ -834,7 +834,7 @@
 	%RSSROConfig = True
 
 	@title = Boeing 702 Large Satellite Bus
-	@manufacturer = Boeing
+	@manufacturer = #roMfrBoeing
 	@description = This satellite bus is very large, but it comes with plenty of room for your Communications Satellite needs.
 	@mass = 1.26
 
@@ -946,7 +946,7 @@
 	%RSSROConfig = True
 
 	@title = Sputnik PS-1
-	@manufacturer = NPO Energomash
+	@manufacturer = #roMfrOKB1
 	@description = The first satellite to orbit the Earth.
 	@mass = 0.081
 	%skinMaxTemp = 773.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Communication.cfg
@@ -16,7 +16,7 @@
     @maxTemp = 673.15
     %skinMaxTemp = 773.15
     !MODULE[ModuleDataTransmitter],*:NEEDS[RealAntennas|RemoteTech] {}
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
 }
 
 //  ==================================================
@@ -421,7 +421,6 @@
     %rescaleFactor:NEEDS[VenStockRevamp/Squad] = 0.8333
 
     @title = RA-15 Parabolic Antenna (2m)
-    @manufacturer = Generic
     @description = A fixed Gregorian - style parabolic antenna for deep space telecommunications.
 
     @mass = 0.06

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
@@ -204,7 +204,7 @@
     %rescaleFactor = 0.777228
 
     @title = Multi-Hundred Watt RTG
-    @manufacturer = NASA JPL & DOE
+    @manufacturer = #roMfrGE
     @description = The Multihundred-Watt radioisotope thermoelectric generators (MHW-RTG) as found on the Voyager spacecraft and two Lincoln Experimental Satellites.
 
     @mass = 0.0332

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
@@ -1,6 +1,8 @@
 //Remove stock intake module and resources (because AJE doesn't)
 @PART[IntakeRadialLong|shockConeIntake|airScoop|CircularIntake|miniIntake|ramAirIntake|MK1IntakeFuselage]:FOR[RealismOverhaul]
 {
+	@manufacturer = #roMfrGeneric
+	
 	!RESOURCE[IntakeAtm] {}
 	//keep IntakeAir though because it throws a NRE without it
 	!MODULE[ModuleResourceIntake] {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_NASA.cfg
@@ -10,6 +10,7 @@
 	!MODULE[TweakScale] {}
 	%rescaleFactor = 1.722222
 	@title = Launch Escape System (Apollo)
+	@manufacturer = #roMfrGeneric
 	@description = Stock LES with the performance of the Apollo LES built by Lockheed for use with the stock Mk1-2 pod. 
 	@mass = 2.574
 	@maxTemp = 1973.15
@@ -46,6 +47,7 @@
 	@name = RO_mk1_LES
 	%rescaleFactor = 0.8605
 	@title = Launch Escape System (Mercury)
+	@manufacturer = #roMfrGeneric
 	@description = Stock LES with the performance of the Mercury LES for use with the stock Mk1 pod.
 	@mass = 0.4679
 	@MODULE[ModuleEngines*]
@@ -230,7 +232,7 @@
 @PART[Size2LFB]:AFTER[RealismOverhaulEnginesPost] 
 {
 	@title = Pyrios Booster
-	%manufacturer = Dynetics
+	%manufacturer = #roMfrDynetics
 	@description = An 18-foot diameter liquid fuel booster employing two F-1B engines built for cost efficiency. Dynetics teaming with Pratt & Whitney Rocketdyne. [5.5 m]
 }
 
@@ -290,6 +292,7 @@
 	@node_stack_bottom = 0.0, -21.517229, 0.0, 0.0, -1.0, 0.0, 8
 	!node_attach = DELETE
 	@title = Space Launch System Main Fuel Tank
+	@manufacturer = #roMfrBoeing
 	@description = Taking the stock large tank, adding some more tanks to it and presto, the main tank for the Space Launch System.
 	@attachRules = 1,0,1,1,0
 	@mass = 70.338

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
@@ -2,6 +2,7 @@
 {
     %RSSROConfig = True
     @title = 1.25m Crew Carrier
+    @manufacturer = #roMfrGeneric
     @description = One-person inline crew hab section for spaceplanes. Rated for suborbital reentries. X-15 class.
     %maxTemp = 1000
     %skinMaxTemp = 1800
@@ -81,6 +82,7 @@
 @PART[InflatableHAB]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @manufacturer = #roMfrGeneric
     %rescaleFactor = 2.5
     @mass = 25
     @crashTolerance = 12

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Control.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Control.cfg
@@ -17,7 +17,7 @@
     %RSSROConfig = True
 
     @title = RW8 Radial Reaction Wheel
-    @manufacturer = Blue Canyon Tech
+    @manufacturer = #roMfrGeneric
 
     @mass = 0.0036
     @maxTemp = 673.15
@@ -41,7 +41,7 @@
     @rescaleFactor = 1.0
 
     @title = CH-R1 Avionics Module [Radial]
-    @manufacturer = Generic
+    @manufacturer = #roMfrGeneric
     @description = The CH-R1 Avionics Module includes all the required communications and control circuitry for remote control of a craft, be it crewed or uncrewed. Radially mounted for easier placement.
 
     @mass = 0.001

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Electrical.cfg
@@ -5,6 +5,7 @@
 @PART[SmallStripLight]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @manufacturer = #roMfrGeneric
     @mass = 0.0012
     @maxTemp = 1073.15
     // @MODULE[ModuleLight] { @resourceAmount = 0.002 }
@@ -12,6 +13,7 @@
 @PART[SmallSpotLight]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @manufacturer = #roMfrGeneric
     @mass = 0.0016
     @maxTemp = 1073.15
     @MODULE[ModuleLight] { @resourceAmount = 0.005 }
@@ -19,6 +21,7 @@
 @PART[SmallPointLight]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @manufacturer = #roMfrGeneric
     @mass = 0.001
     @maxTemp = 1073.15
     @MODULE[ModuleLight] { @resourceAmount = 0.001 }
@@ -47,7 +50,7 @@
     @rescaleFactor = 0.35
 
     @title = SNAP-3 Series RTG
-    @manufacturer = DOE (Department Of Energy)
+    @manufacturer = #roMfrMM
     @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency and power generation.
 
     @mass = 0.0022
@@ -92,7 +95,7 @@
     @rescaleFactor = 0.645
 
     @title = SNAP-9 Series RTG
-    @manufacturer = DOE (Department Of Energy)
+    @manufacturer = #roMfrMM
     @description = The SNAP-9 series were evolved designs of the experimental SNAP-3 series, again as part of the Transit system (precursor to the current GPS system), but now featuring over 10 times higher power generation.
 
     @mass = 0.011
@@ -137,7 +140,7 @@
     @rescaleFactor = 0.645
 
     @title = SNAP-19 Series RTG
-    @manufacturer = Teledyne Isotopes (Teledyne Technologies Inc.)
+    @manufacturer = #roMfrMM
     @description = The SNAP-19 series were originally developed for the Nimbus weather satellite program, complementing the regular solar arrays and countering their degradation due to radiation. Later, they were also used by the Pioneer 10 and 11 spacecrafts, along with the Viking Mars landers. Similar to the SNAP-9 series but with over 40% better conversion efficiency.
 
     @mass = 0.014
@@ -181,7 +184,7 @@
     @rescaleFactor = 1.019
 
     @title = Multi-Mission RTG
-    @manufacturer = DOE (Department Of Energy)
+    @manufacturer = #roMfrRocketdyne
     @description = The Multi-Mission RTG or MMRTG was designed for the Mars Science Laboratory and the Curiosity Rover for use on Mars.
 
     @mass = 0.0882

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
@@ -13,7 +13,7 @@
 	%RSSROConfig = True
 	!MODULE[TweakScale] {}
 	@title = Separation Motor (Small)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others. Smaller and less advanced than the radial separation motor.
 	@mass = 0.008
 	@maxTemp = 1973.15

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_RCS.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_RCS.cfg
@@ -13,7 +13,7 @@
 {
 	%RSSROConfig = True
 	@title = RCS Quad (550/890 N class)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A generic RCS quad. Use this for attitude control or translation/ullage for large stages and spacecraft. Note that the thrust per nozzle is only half the thrust class, but two nozzles fire in each direction.
 	%rescaleFactor = 1.4
 
@@ -26,7 +26,7 @@
 {
 	%RSSROConfig = True
 	@title = RCS Quad, 45deg (275/445 N class)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A generic RCS quad with 45degree side-thruster orientation. Use this for attitude control or translation/ullage for medium stages and spacecraft (when using NTO/MMH, same performance as the Apollo SM quads).
 	%rescaleFactor = 1.4
 
@@ -38,7 +38,7 @@
 {
 	%RSSROConfig = True
 	@title = Inline RCS block (138/223 N class)
-	@manufacturer = Generic
+	@manufacturer = #roMfrGeneric
 	@description = A generic inline RCS block. Use this for orientation on small capsules and probes.
 
 	// Default is 1.25, 1.07, 1.25.  Desired scale is 2,2,2

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Solar.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Solar.cfg
@@ -2,7 +2,9 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor *= 0.73 // for 1.9.5
+	@manufacturer = #roMfrGeneric
 	@description = Extendable Level 1 solar panel. 0.63m^2.
+
 	!MODULE[TweakScale] {}
 	@MODULE[ModuleDeployableSolarPanel]
 	{
@@ -22,6 +24,7 @@
 {
 	%RSSROConfig = True
 	@rescaleFactor *= 0.9 // for 1.9.5
+	@manufacturer = #roMfrGeneric
 	@description = Extendable Level 2 solar panel. 2.28m^2.
 	!MODULE[TweakScale] {}
 	@MODULE[ModuleDeployableSolarPanel]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Structural.cfg
@@ -1,5 +1,6 @@
 @PART[structCube*|OCTOs0Adapter|Angledpanel|largeTrussMount|microIbeam|stationHubLarge|shortDecoupler1-2|smallRadialDecoupler]:FOR[RealismOverhaul]
 {
+    @manufacturer = #roMfrGeneric
     %breakingForce = 250
     %breakingTorque = 250
     @maxTemp = 1073.15
@@ -56,6 +57,7 @@
     %RSSROConfig = True
 
     @title = Service Bay (OCTO)
+    @manufacturer = #roMfrGeneric
     @description = A smaller version of the normal service bays, this one has an octagonal format and it is ideal for small probes.
 
     @mass = 0.0075
@@ -102,6 +104,7 @@
 }
 @PART[MedLadder|LongLadder|MedLadderUtility|SMLadderUtility|LGLadderUtility]:FOR[RealismOverhaul]
 {
+    @manufacturer = #roMfrGeneric
     @description = #The $title$, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
     @maxTemp = 773.15
     %skinMaxTemp = 773.15
@@ -136,6 +139,7 @@
 {
     %RSSROConfig = True
     @title = Mk2 Pod Protective Cover
+    @manufacturer = #roMfrGeneric
     @description = Aerodynamic cover for the Mk2 Command Module. Provides protection from the aerodynamic forces inside the dense parts of the atmosphere and from the LES exhaust in the case of an emergency.
     @rescaleFactor = 1.61
     @mass = 0.12
@@ -152,6 +156,7 @@
 @PART[smallRadialDecoupler]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @manufacturer = #roMfrGeneric
     @description = A small radial decoupler.
     @mass = 0.0037
     !MODULE[ModuleTestSubject] {}
@@ -163,6 +168,7 @@
     %RSSROConfig = true
 
     @title = 1.25m Cargo Bay
+    @manufacturer = #roMfrGeneric
     @mass = 0.070 // comparable with other similar in size cargo bays (from B9)
     @maxTemp = 1000 // same as for the other mk1 parts
     %skinMaxTemp = 1800 // same as for the other mk1 parts

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Utility.cfg
@@ -1,6 +1,7 @@
 @PART[largeLandingLeg]:FOR[RealismOverhaul]
 {
 	//%RSSROConfig = True
+	@manufacturer = #roMfrGeneric
 	@mass = 0.25
 	@crashTolerance = 80
 }


### PR DESCRIPTION
Add manufacturer loc tags and general improvements to stock RO and SXT configs. This includes cleaning up pre-RealismOverhaulEngines configs, and moving some SXT configs from the REWORK folder to the SXT folder.