### PR TITLE
Delay tag removals so other mods can access them

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -966,7 +966,7 @@ PARTUPGRADE
 	@TANK[LqdOxygen] { @temperature = 112.1 }	//high thermal expansion, hits 90% of 1 atm density before boiling
 	@TANK[CooledLqdOxygen] { @temperature = 88 } // FIXME
 }
-@TANK_DEFINITION:HAS[#addResourcesHP[true],~preserveResources[true]]:FOR[zzzTagCleanup]
+@TANK_DEFINITION:HAS[#addResourcesHP[true]]:FOR[zzzTagCleanup]
 {
 	-addResourcesHP = DEL
 }
@@ -1073,7 +1073,7 @@ PARTUPGRADE
 		%boiloffProduct = Oxygen
 	}
 }
-@TANK_DEFINITION:HAS[#addResourcesSM[true],~preserveResources[true]]:FOR[zzzTagCleanup]
+@TANK_DEFINITION:HAS[#addResourcesSM[true]]:FOR[zzzTagCleanup]
 {
 	-addResourcesSM = DEL
 }

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -779,7 +779,6 @@ PARTUPGRADE
 // Create everything first here in the order we want.
 @TANK_DEFINITION:HAS[#addResources[true]]:FIRST
 {
-	-addResources = DEL
 	//put life support stuff first
 	%TANK[CarbonDioxide]
 	{
@@ -918,6 +917,10 @@ PARTUPGRADE
 	%TANK[Water] { %temperature = 388.2 }	//from NIST webbook
 	%TANK[XenonGas] { %utilization = 100 }
 }
+@TANK_DEFINITION:HAS[#addResources[true]]:FOR[zzzTagCleanup]
+{
+	-addResources = DEL
+}
 
 // HP resources
 // Remove HP resources from tanks not tagged
@@ -943,7 +946,6 @@ PARTUPGRADE
 // assume a vapor recirculation system is present, so overflowed fluids still boil and provide cooling.
 @TANK_DEFINITION:HAS[#addResourcesHP[true],~preserveResources[true]]:FIRST
 {
-	-addResourcesHP = DEL
 	@TANK[LqdAmmonia] { @temperature = 278.6 }	//high thermal expansion, hits 90% of 1 atm density before boiling
 	@TANK[ClF3] { @temperature = 343.2 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
 	@TANK[ClF5] { @temperature = 308.2 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
@@ -964,6 +966,10 @@ PARTUPGRADE
 	@TANK[LqdOxygen] { @temperature = 112.1 }	//high thermal expansion, hits 90% of 1 atm density before boiling
 	@TANK[CooledLqdOxygen] { @temperature = 88 } // FIXME
 }
+@TANK_DEFINITION:HAS[#addResourcesHP[true],~preserveResources[true]]:FOR[zzzTagCleanup]
+{
+	-addResourcesHP = DEL
+}
 
 // SM resources
 // Remove SM resources from tanks not tagged
@@ -983,7 +989,6 @@ PARTUPGRADE
 // and the gas can be captured (if applicable)
 @TANK_DEFINITION:HAS[#addResourcesSM[true],~preserveResources[true]]:FIRST
 {
-	-addResourcesSM = DEL
 	@TANK[LqdAmmonia] {
 		@temperature = 283.2	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
@@ -1068,13 +1073,20 @@ PARTUPGRADE
 		%boiloffProduct = Oxygen
 	}
 }
+@TANK_DEFINITION:HAS[#addResourcesSM[true],~preserveResources[true]]:FOR[zzzTagCleanup]
+{
+	-addResourcesSM = DEL
+}
 
 // Add lead and Beryllium
 @TANK_DEFINITION:HAS[#addLead[true]]:FIRST
 {
-	-addLead = DEL
 	%TANK[LeadBallast] {}
 	%TANK[Beryllium] {}
+}
+@TANK_DEFINITION:HAS[#addLead[true]]:FOR[zzzTagCleanup]
+{
+	-addLead = DEL
 }
 
 // Add default values to all subtanks
@@ -1093,7 +1105,7 @@ PARTUPGRADE
 {
 	@TANK,* { &mass = #$../defaultMass$ }
 }
-@TANK_DEFINITION:HAS[#defaultMass] { !defaultMass = DEL }
+@TANK_DEFINITION:HAS[#defaultMass]:FOR[zzzTagCleanup] { -defaultMass = DEL }
 
 // LH2 tank mass correction
 @TANK_DEFINITION:HAS[~balloonTemps[true],~preserveResources[true]] // not FIRST anymore.
@@ -1111,7 +1123,6 @@ PARTUPGRADE
 // Balloon insulation fixes
 @TANK_DEFINITION:HAS[#balloonTemps[true]] // not FIRST anymore.
 {
-	-balloonTemps = DEL
 	@TANK[LqdOxygen]
 	{
 		%wallThickness = 0.0012
@@ -1142,4 +1153,8 @@ PARTUPGRADE
 		%insulationThickness = 0.01
 		%insulationConduction = 0.02
 	}
+}
+@TANK_DEFINITION:HAS[#balloonTemps[true]]:FOR[zzzTagCleanup]
+{
+	-balloonTemps = DEL
 }


### PR DESCRIPTION
Move tag removals to `FOR[zzzTagCleanup]` a la https://github.com/KSP-RO/RealismOverhaul/blob/3de3a8cb47c64b14540b342e3c58502845f6458e/GameData/RealismOverhaul/RO_Deprecation.cfg#L11-L14. 
Thank @arrowmaster for the idea. 