### PR TITLE
Add full names and abbreviations to resources

### DIFF
--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -18,7 +18,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = ANFA22
-  displayName = Aniline-Furfuryl Alcohol 22%
+  displayName = Aniline-Furfuryl 22%
   abbreviation = ANFA22
   density = 0.001042
   unitCost = 0.0001 //placeholder
@@ -33,7 +33,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = ANFA37
-  displayName = Aniline-Furfuryl Alcohol 37%
+  displayName = Aniline-Furfuryl 37%
   abbreviation = ANFA37
   density = 0.0010585
   unitCost = 0.0001 //placeholder
@@ -105,7 +105,6 @@ RESOURCE_DEFINITION
 // Create new Kerosenes, change old Kerosene to JP-4 or the like.
 @RESOURCE_DEFINITION[Kerosene]:FOR[RealismOverhaul]
 {
-  %displayName = Commercial Kerosene
   %abbreviation = Kerosene
   //We're letting this represent commercial jet fuels (Jet-A, JP-4, JP-5, T-1, etc.).
   //JP-4 specced between 0.751-0.802 @ 15 C. Assuming average of 0.777
@@ -166,7 +165,7 @@ RESOURCE_DEFINITION
 	//Cooled to -7 C (Falcon 9)
 	//In a kerolox stage, the LOX will keep the kerosene cool, so we're not worrying about it heating up
 	name = CooledKerosene
-	displayName = Subcooled Commercial Kerosene
+	displayName = Subcooled Kerosene
 	abbreviation = CooledKero
 	density = 0.000796
 	unitCost = 0.000145
@@ -244,7 +243,7 @@ RESOURCE_DEFINITION
 {
 	//Cooled to 70 K (Falcon 9)
 	name = CooledLqdOxygen
-	displayName = Subcooled Liquid Oxygen
+	displayName = Subcooled LqdOxygen
 	abbreviation = CooledLOX
 	density = 0.001236
 	unitCost = 0.00002815

--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -18,6 +18,8 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = ANFA22
+  displayName = Aniline-Furfuryl Alcohol 22%
+  abbreviation = ANFA22
   density = 0.001042
   unitCost = 0.0001 //placeholder
   hsp = 2163 // specific heat capacity (kJ/tonne-K as units)
@@ -31,6 +33,8 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = ANFA37
+  displayName = Aniline-Furfuryl Alcohol 37%
+  abbreviation = ANFA37
   density = 0.0010585
   unitCost = 0.0001 //placeholder
   hsp = 2150 // specific heat capacity (kJ/tonne-K as units)
@@ -101,6 +105,8 @@ RESOURCE_DEFINITION
 // Create new Kerosenes, change old Kerosene to JP-4 or the like.
 @RESOURCE_DEFINITION[Kerosene]:FOR[RealismOverhaul]
 {
+  %displayName = Commercial Kerosene
+  %abbreviation = Kerosene
   //We're letting this represent commercial jet fuels (Jet-A, JP-4, JP-5, T-1, etc.).
   //JP-4 specced between 0.751-0.802 @ 15 C. Assuming average of 0.777
   //TS-1 is specced for a minimum of 0.775. Close enough?
@@ -111,6 +117,7 @@ RESOURCE_DEFINITION
 {
 	name = RP-1
 	displayName = RP-1
+	abbreviation = RP-1
 	density = 0.000807	//specced between 0.799-0.815, assuming average 0.807
 	//source: https://ntrs.nasa.gov/citations/20040140275
 	unitCost = 0.0007160	//2.71/gallon, 1965$
@@ -126,6 +133,7 @@ RESOURCE_DEFINITION
 {
 	name = RG-1
 	displayName = RG-1
+	abbreviation = RG-1
 	density = 0.000833	//specced between 0.830-0.836 @ 20 C, assuming average of 0.833
 	//source: https://ntrs.nasa.gov/citations/20040140275
 	unitCost = 0.0007160	//Probably about the same as RP-1
@@ -142,7 +150,8 @@ RESOURCE_DEFINITION
 {
 	//Cooled to 0 C
 	name = CooledAerozine50
-	displayName = CooledA50
+	displayName = Subcooled Aerozine50
+	abbreviation = CooledA50
 	density = 0.000920 //from https://rocketprops.readthedocs.io/en/latest/_static/Aerojet_Propellant_Properties.pdf
 	unitCost = 0.002284
 	hsp = 2970.1 // specific heat capacity (kJ/tonne-K as units).
@@ -157,7 +166,8 @@ RESOURCE_DEFINITION
 	//Cooled to -7 C (Falcon 9)
 	//In a kerolox stage, the LOX will keep the kerosene cool, so we're not worrying about it heating up
 	name = CooledKerosene
-	displayName = CooledKero
+	displayName = Subcooled Commercial Kerosene
+	abbreviation = CooledKero
 	density = 0.000796
 	unitCost = 0.000145
 	hsp = 1882 // specific heat capacity (kJ/tonne-K as units).
@@ -172,7 +182,8 @@ RESOURCE_DEFINITION
 	//Cooled to -7 C (Falcon 9)
 	//In a kerolox stage, the LOX will keep the kerosene cool, so we're not worrying about it heating up
 	name = CooledRP-1
-	displayName = CooledRP-1
+	displayName = Subcooled RP-1
+	abbreviation = CooledRP-1
 	density = 0.000827	//According to https://kinetics.nist.gov/RealFuels/macccr/macccr2008/Bruno2.pdf
 	unitCost = 0.0007160	//2.71/gallon, 1965$
 	hsp = 1882 // specific heat capacity (kJ/tonne-K as units).
@@ -188,7 +199,8 @@ RESOURCE_DEFINITION
 	//In a kerolox stage, the LOX will keep the kerosene cool, so we're not worrying about it heating up
 	//RG-1, also known as naftil/napthelene
 	name = CooledRG-1
-	displayName = CooledRG-1
+	displayName = Subcooled RG-1
+	abbreviation = CooledRG-1
 	density = 0.000854	//According to https://kinetics.nist.gov/RealFuels/macccr/macccr2008/Bruno2.pdf
 	unitCost = 0.0007160	//2.71/gallon, 1965$
 	hsp = 1882 // specific heat capacity (kJ/tonne-K as units).
@@ -203,7 +215,8 @@ RESOURCE_DEFINITION
 	//Cooled to -7 C (Falcon 9)
 	//In a kerolox stage, the LOX will keep the kerosene cool, so we're not worrying about it heating up
 	name = CooledSyntin
-	displayName = CooledSyntin
+	displayName = Subcooled Syntin
+	abbreviation = CooledSyntin
 	density = 0.000872
 	unitCost = 0.01117
 	flowMode = STACK_PRIORITY_SEARCH
@@ -216,7 +229,8 @@ RESOURCE_DEFINITION
 {
 	//Cooled to 0 C
 	name = CooledNTO
-	displayName = CooledNTO
+	displayName = Subcooled NTO
+	abbreviation = CooledNTO
 	density = 0.001505 //from https://rocketprops.readthedocs.io/en/latest/_static/Aerojet_Propellant_Properties.pdf
 	unitCost = 0.004172
 	hsp = 1521.6 // specific heat capacity (kJ/tonne-K as units).
@@ -230,7 +244,8 @@ RESOURCE_DEFINITION
 {
 	//Cooled to 70 K (Falcon 9)
 	name = CooledLqdOxygen
-	displayName = CooledLOX
+	displayName = Subcooled Liquid Oxygen
+	abbreviation = CooledLOX
 	density = 0.001236
 	unitCost = 0.00002815
 	hsp = 918 // specific heat capacity (kJ/tonne-K as units) // recalc, mols are for O2 on wiki


### PR DESCRIPTION
Since you can apparently specify separate abbreviations and display names for resources, give our resources more verbose display names.