### PR TITLE
Patch basic support for new resources into old tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -328,6 +328,257 @@ RESOURCE_DEFINITION
 	@density = 0.0008511	//UH25 is 25% Hydrazine Hydrate, not Hydrazine. Hydrate density source: https://www.fishersci.com/shop/products/hydrazine-hydrate-100-hydrazine-64-thermo-scientific/AC196711000
 }
 
+//Add new resources to old tank types
+//mostly just for compatibility, new stuff should not use these
+@TANK_DEFINITION[Default|Structural|Balloon|BalloonCryo|Cryogenic]:FOR[RealismOverhaul]:NEEDS[RealFuels]
+{
+	TANK
+	{
+		name = Beryllium
+		mass = 0.000016
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledAerozine50
+		mass = 0.000016
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledNTO
+		mass = 0.000016
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = ANFA22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = ANFA37
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = RP-1
+		mass = 0.000012
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = RG-1
+		mass = 0.000012
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledKerosene
+		mass = 0.000012
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledRP-1
+		mass = 0.000012
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledRG-1
+		mass = 0.000012
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledSyntin
+		mass = 0.000012
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledLqdOxygen
+		mass = 0.000014
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		wallThickness = 0.0025
+		wallConduction = 16
+		temperature = 70.15
+		insulationThickness = 0.01
+		insulationConduction = 0.02
+		note = (lacks insulation)
+	}
+}
+@TANK_DEFINITION[Fuselage|ServiceModule]:FOR[RealismOverhaul]:NEEDS[RealFuels]
+{
+	TANK
+	{
+		name = Beryllium
+		mass = 0.000081
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledAerozine50
+		mass = 0.000081
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledNTO
+		mass = 0.000081
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = ANFA22
+		mass = 0.000085
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = ANFA37
+		mass = 0.000085
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = ASCENT
+		mass = 0.000081
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = RP-1
+		mass = 0.000077
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = RG-1
+		mass = 0.000077
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledKerosene
+		mass = 0.000077
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledRP-1
+		mass = 0.000077
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledRG-1
+		mass = 0.000077
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledSyntin
+		mass = 0.000077
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = CooledLqdOxygen
+		mass = 0.000079
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		temperature = 70.15
+		wallThickness = 0.001
+		wallConduction = 11.4
+		insulationThickness = 0.05
+		insulationConduction = 0.000017
+		note = (has insulation, pressurized)
+		boiloffProduct = Oxygen
+		isDewar = true
+	}
+}
+
 // New Solids:
 +RESOURCE_DEFINITION[HTPB]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Considering just how many things still use the old tank types, we really should have some sort of basic support for them still. This will allow the various new resources we have created to be added to old tank types. Since these should exclusively be premade tank parts with fixed mass and cost, only basic configs are required to restore functionality.