### PR TITLE
Increase Juno Block II thrust

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno45k_Config.cfg
@@ -24,7 +24,7 @@
 //
 //	Dry Mass: 113 kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 200.1699 kN
+//	Thrust (Vac): 253.3688 kN		thrust increased for constant volumetric flow
 //	ISP: 127 SL / 305 Vac		SL calculated with RPA
 //	Burn Time: 135 s
 //	Chamber Pressure: 1.38 MPa
@@ -148,8 +148,8 @@
 			name = Juno45k-BII
 			description = Juno IV Block II second stage, converted to use ClF3 to increase performance.
 			specLevel = concept
-			minThrust = 200.17
-			maxThrust = 200.17
+			minThrust = 253.3688
+			maxThrust = 253.3688
 			heatProduction = 100
 			
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Juno6k_Config.cfg
@@ -24,7 +24,7 @@
 //
 //	Dry Mass: 83.9 kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 26.68932 kN
+//	Thrust (Vac): 34.176 kN		thrust increased for constant volumetric flow
 //	ISP: 110 SL / 302 vac		SL calculated with RPA
 //	Burn Time: 450 s
 //	Chamber Pressure: 1.03 MPa
@@ -148,8 +148,8 @@
 			name = Juno6k-BII
 			description = Juno IV Block II second stage, converted to use ClF3 to increase performance.
 			specLevel = concept
-			minThrust = 26.68932
-			maxThrust = 26.68932
+			minThrust = 34.176
+			maxThrust = 34.176
 			heatProduction = 100
 			PROPELLANT
 			{


### PR DESCRIPTION
Increase thrust of Juno 45k and 6k engines to maintain roughly the same volumetric fuel flow when using denser ClF3 fuel mix.