### PR TITLE
Soviet Lunar Lander engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/15D13_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/15D13_Config.cfg
@@ -95,7 +95,7 @@
 	!MODULE[ModuleAlternator],*{}
 	!RESOURCE,*{}
 
-	!MODULE[ModuleGimbal],*	//no gimbal
+	!MODULE[ModuleGimbal],* {}	//no gimbal
 
 	MODULE
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/15D13_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/15D13_Config.cfg
@@ -1,0 +1,267 @@
+//	==================================================
+//	15D13
+//
+//	Designer: Izotov/Klimov
+//
+//	=================================================================================
+//	15D13
+//	UR-100 (used with 15D14 verniers)
+//
+//	Dry Mass: 107 kg		No idea. Soviet hypergolic gas generator, assume 125 TWR?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 131.41 kN		[3],[8],[9],[10],[11]
+//	ISP: 220 SL / 326 Vac	[4],[5]. [10] says 320, we're assuming that is including verniers.
+//	Burn Time: 184	[5]
+//	Chamber Pressure: 8.92 MPa		same as RD-252?
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.6		same as every other Soviet Hypergolic engine I guess
+//	Throttle: N/A
+//	Nozzle Ratio: 73?	calculated with RPA
+//	Ignitions: 1
+//	=================================================================================
+//	11D423
+//	LK-700S
+//	15D13 with minor modifications
+//
+//	Dry Mass: 117.7 kg	10% heavier for redundancy and restart capability?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 131.41 kN		[12]
+//	ISP: 220 SL / 326 Vac	[7]
+//	Burn Time: 184?
+//	Chamber Pressure: 8.92 MPa		same as RD-252?
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.6		same as every other Soviet Hypergolic engine I guess
+//	Throttle: N/A
+//	Nozzle Ratio: 73?	calculated with RPA
+//	Ignitions: 5	ascent/return engine for LK-700, give it some margins
+//	=================================================================================
+//	5D22
+//	A-350Zh (used with 5D18 verniers)
+//
+//	Dry Mass: 117.7 kg	10% heavier for redundancy and restart capability?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 131.41 kN		[12]
+//	ISP: 227 SL / 335 Vac	[7]
+//	Burn Time: 40	[5]
+//	Chamber Pressure: 10 MPa	higher?
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.6		same as every other Soviet Hypergolic engine I guess
+//	Throttle: N/A		was supposed to have throttle, but feature seems to have been eliminated to increase commonality with 15D13
+//	Nozzle Ratio: 85?	calculated with RPA
+//	Ignitions: 2	[12]engine ignited for boost phase, then coasted, and reignited for terminal guidance
+//	=================================================================================
+
+
+//	Sources:
+
+//	[1]http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//	[2]https://www.russianspaceweb.com/ur100.html
+//	[3]http://www.astronautix.com/1/15d13.html
+//	[4]http://www.astronautix.com/1/11d423.html
+//	[5]http://www.astronautix.com/8/8d423.html
+//	[6]http://militaryrussia.ru/blog/topic-343.html
+//	[7]http://militaryrussia.ru/blog/topic-344.html
+//	[8]http://mass-destruction-weapon.blogspot.com/2019/06/100.html
+//	[9]https://www.arms-expo.ru/articles/armed-forces/rvsn-ur-100-8k84-mezhkontinentalnaya-ballisticheskaya-raketa-shakhtnogo-bazirovaniya/
+//	[10]https://missilery.info/missile/8k84
+//	[11]http://war-russia.info/index.php/nomenklatura-vooruzhenij/374-raketnye-vojska-strategicheskogo-naznachekiya-rvsn/mezhkontinentalnye-ballisticheskie-rakety-mbr/2094-r-16-8k64-ss-7-saddler-1961g-2]
+//	[12]http://www.famhist.ru/famhist/sprn/00089523.htm
+//	[13]https://forum.novosti-kosmonavtiki.ru/index.php?topic=9898.100
+//	[14]https://forum.novosti-kosmonavtiki.ru/index.php?topic=12754.0
+
+//	Used by:
+
+//	Notes:
+
+//	15D13 main engine and 15D14 vernier engine made a 8D419/8D423/DU-419 propulsion unit
+//	5D22 main engine and 5D18 vernier engine made a R5-117 propulsion unit?
+//	==================================================
+@PART[*]:HAS[#engineType[15D13]]:FOR[RealismOverhaulEngines]
+{
+	%title = #ro15D13Title	//15D13
+	%manufacturer = #roMfrOKBKilmov
+	%description = #ro15D13Desc
+
+	@tags ^= :$: USSR okb117 leningrad klimov izotov 15d13 15d14 8d419 8d423 11d423 du-419 5d22 5d18 r5-117 liquid pump lander upper udmh nto
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*	//no gimbal
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 15D13
+		origMass = 0.107
+		
+		CONFIG
+		{
+			name = 15D13
+			description = Used on the UR-100 second stage. One 15D13 and one 15D14 make up a DU-419/8D419 propulsion unit.
+			specLevel = operational
+			minThrust = 131.41
+			maxThrust = 131.41
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			massMult = 1.00
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4106
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5894
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 326
+				key = 1 220
+			}
+
+			//UR-100 (8K84) (R&D): 336 flights, 19 failures
+			//Blame 1/4 of failures on upper stage (more engines on lower stage, but upper stages tend to
+			//be less reliable)
+			//say 1 ignition failure, 4 cycle failure (roughly same ratio as RD-252
+			//322 ignitions, 1 failures
+			//321 cycles, 4 failures
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 550	//late 60s, triple time?
+				ratedBurnTime = 184
+				safeOverburn = true
+				ignitionReliabilityStart = 0.994582
+				ignitionReliabilityEnd = 0.998916
+				cycleReliabilityStart = 0.985248
+				cycleReliabilityEnd = 0.997050
+			}
+		}
+		CONFIG
+		{
+			name = 11D423
+			description = Modified 15D13, intended for use as the ascent/return engine on the LK-700S. More reliable, with restart capability.
+			specLevel = prototype
+			minThrust = 131.41
+			maxThrust = 131.41
+			ullage = True
+			pressureFed = False
+			ignitions = 5
+			massMult = 1.10
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4106
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5894
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 326
+				key = 1 220
+			}
+
+			//It's already flight-proven to be really reliable
+			//Just bump it up a little I guess
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 550	//late 60s, triple time?
+				ratedBurnTime = 184
+				safeOverburn = true
+				ignitionReliabilityStart = 0.994582
+				ignitionReliabilityEnd = 0.999
+				cycleReliabilityStart = 0.985248
+				cycleReliabilityEnd = 0.998
+				techTransfer = 15D13:50
+			}
+		}
+		CONFIG
+		{
+			name = 5D22
+			description = Sustainer engine of A-350Zh Anti-Ballistic Missile. Capable of rapid restart under high dynamic pressure for rapid upper atmosphere manuevers.
+			specLevel = operational
+			minThrust = 131.41
+			maxThrust = 131.41
+			ullage = False	//Fuel tanks spun to stabilize rocket and centrifugally ullage fuel during high-G maneuvers?
+			pressureFed = False
+			ignitions = 2
+			throttleResponseRate = 100	//make it start faster
+			massMult = 1.10
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4106
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5894
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 335
+				key = 1 227
+			}
+
+			//Same as 15D13 I guess
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 550
+				ratedBurnTime = 40
+				safeOverburn = true
+				ignitionReliabilityStart = 0.994582
+				ignitionReliabilityEnd = 0.998916
+				ignitionDynPresFailMultiplier = 0.05	//able to ignite in high-Q scenarios
+				cycleReliabilityStart = 0.985248
+				cycleReliabilityEnd = 0.997050
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU416_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU416_Config.cfg
@@ -1,0 +1,134 @@
+//	==================================================
+//	KTDU-416
+//
+//	Manufacturer: Isayev Design Bureau (KhimMash)
+//
+//	=================================================================================
+//	KTDU-416
+//	11D416
+//	LK-700 landing engine
+//
+//	Dry Mass: 40 kg?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 16.37 kN
+//	ISP: 88 SL / 314 Vac
+//	Burn Time: ???
+//	Chamber Pressure: 8.3 MPa?
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 1.93 (to 1.73 at minimum throttle?)
+//	Throttle: Throttle down to 6.37 kN?
+//	Nozzle Ratio: 65?
+//	Ignitions: 11?
+//	=================================================================================
+
+//	Sources:
+
+//	[1]http://www.astronautix.com/1/11d416.html
+//	[2]http://epizodsspace.airbase.ru/bibl/molodtsov/01/05-2.html
+//	[3]http://www.lpre.de/kbhm/index.htm
+//	[4]http://www.astronautix.com/l/lk-700.html
+
+//	Used by:
+
+//
+
+//	Notes:
+
+//	There's pretty much no info on this. Just assume it's a smaller 11D417.
+//	==================================================
+@PART[*]:HAS[#engineType[KTDU416]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roKTDU416Title	//KTDU-416
+	%manufacturer = #roMfrKBKhM
+	%description = #roKTDU416Desc
+
+	@tags ^= :$: USSR kbkhm isayev ktdu-416 11d416 lk-700 liquid pump lander udmh nto
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal],*	//They were also used as verniers to control the braking stages (maybe?), so almost certainly gimbaled
+	{
+		@gimbalRange = 5.0
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = 11D416
+		origMass = 0.04
+
+		CONFIG
+		{
+			name = 11D416
+			specLevel = operational
+			minThrust = 6.37
+			maxThrust = 16.37
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = False
+			pressureFed = False
+			ignitions = 11
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.01
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4842
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5158
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 314
+				key = 1 215
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 1950	//Late 60s, assume 3x burn time
+				ratedBurnTime = 650
+				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+				
+				//same as RD-858?
+				ignitionReliabilityStart = 0.977964
+				ignitionReliabilityEnd = 0.996521
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.988455
+				cycleReliabilityEnd = 0.998177
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU416_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU416_Config.cfg
@@ -11,7 +11,7 @@
 //	Dry Mass: 40 kg?
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 16.37 kN
-//	ISP: 88 SL / 314 Vac
+//	ISP: 215 SL / 314 Vac
 //	Burn Time: ???
 //	Chamber Pressure: 8.3 MPa?
 //	Propellant: NTO / UDMH
@@ -45,7 +45,7 @@
 
 	@tags ^= :$: USSR kbkhm isayev ktdu-416 11d416 lk-700 liquid pump lander udmh nto
 
-	%specLevel = operational
+	%specLevel = concept	//I can find no evidence anyone actually built one
 
 	@MODULE[ModuleEngines*]
 	{
@@ -73,7 +73,7 @@
 		CONFIG
 		{
 			name = 11D416
-			specLevel = operational
+			specLevel = concept
 			minThrust = 6.37
 			maxThrust = 16.37
 			heatProduction = 100

--- a/GameData/RealismOverhaul/Engine_Configs/KTDU417_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU417_Config.cfg
@@ -11,13 +11,13 @@
 //	Dry Mass: 81 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 18.89 kN	//1929 kgf?
-//	ISP: 88 SL / 314 Vac
+//	ISP: 215 SL / 314 Vac
 //	Burn Time: 650
 //	Chamber Pressure: 8.3 MPa
-//	Propellant: AK27I / UDMH
-//	Prop Ratio: 1.8
+//	Propellant: NTO / UDMH	drew pressurized AK27/UDMH from 417B tanks to start
+//	Prop Ratio: 1.93 (to 1.73 at minimum throttle?)
 //	Throttle: Throttle down to 7.35 kN
-//	Nozzle Ratio: 300?
+//	Nozzle Ratio: 65?
 //	Ignitions: 11
 //	=================================================================================
 //	KTDU-417B
@@ -31,7 +31,7 @@
 //	Burn Time: 30
 //	Chamber Pressure: 0.89 MPa
 //	Propellant: AK27I / UDMH
-//	Prop Ratio: 2.4
+//	Prop Ratio: 2.64 (to 2.16 at minimum throttle?)
 //	Throttle: Throttle down to 2.06 kN
 //	Nozzle Ratio: 7?
 //	Ignitions: 11
@@ -39,7 +39,10 @@
 
 //	Sources:
 
-//	Encyclopedia Astronautica - KTDU-417 engine:		http://www.astronautix.com/k/ktdu-417.html
+//	https://www.laspace.ru/upload/iblock/6e0/6e0b967d62d9184dd3b25f24b6ae1418.pdf
+//	https://forum.raumfahrer.net/index.php?topic=12187.75
+//	https://web.archive.org/web/20111020161711/http://www.b14643.de/Spacerockets_1/Diverse/KB-Isayev_KDUs/
+//	http://www.astronautix.com/k/ktdu-417.html
 //	https://www.mediafire.com/file/5b3cy43y76ywnd8/ychebnikiav597.pdf/file
 //  https://disk.yandex.com/i/dxgEavo9_yTUVA, Page 234
 //  [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 666
@@ -57,7 +60,7 @@
 	%category = Engine
 	%title = #roKTDU417Title	//KTDU-417
 	%manufacturer = #roMfrKBKhM
-	%description = #roKTDU417Desc	//The landing engine for Luna 15-24. The main gas generator engine was used for orbital manuevering and descent, and then switched over to a secondary pressurefed engine for terminal descent. Use an action group to toggle between the main and secondary engines quickly to make landing easier.
+	%description = #roKTDU417Desc
 
 	@tags ^= :$: USSR kbkhm isayev ktdu-417 11d417 11d417b liquid pump lander udmh nitric acid
 
@@ -72,7 +75,7 @@
 	!MODULE[ModuleAlternator],*{}
 	!RESOURCE,*{}
 
-	@MODULE[ModuleGimbal],*		//Secondary "verniers" could probably gimbal, based on pictures of KTDU-417 and Ye-8 bus
+	@MODULE[ModuleGimbal],*		//Main engine (11D417) had (valved, RCS-style) verniers fed by gas generator exhaust. Secondary engine (11D417B) may have had gimbal.
 	{
 		@gimbalRange = 5.0
 		%useGimbalResponseSpeed = True
@@ -115,21 +118,21 @@
 			PROPELLANT
 			{
 				name = UDMH
-				ratio = 0.5185
+				ratio = 0.4842
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name = AK27
-				ratio = 0.4815
+				name = NTO
+				ratio = 0.5158
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
 				key = 0 314
-				key = 1 88
+				key = 1 215
 			}
 
 			//Luna 15: 5 Burns completed before computer failure
@@ -195,17 +198,25 @@
 			PROPELLANT
 			{
 				name = UDMH
-				ratio = 0.4468
+				ratio = 0.4233
 				DrawGauge = True
 			}
 			
 			PROPELLANT
 			{
 				name = AK27
-				ratio = 0.5532
+				ratio = 0.5767
 				DrawGauge = False
 			}
-			//Used bleed pressure from main engine?
+			
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 13.35
+				DrawGauge = False
+				ignoreForIsp = True
+			}
+			
 			atmosphereCurve
 			{
 				key = 0 254

--- a/GameData/RealismOverhaul/Engine_Configs/RD0216_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0216_Config.cfg
@@ -20,6 +20,22 @@
 //	Nozzle Ratio: ???
 //	Ignitions: 1
 //	=================================================================================
+//	RD-???? (11D23)
+//	UR-700/LK-700?
+//	I have no real evidence that this was the 11D23, but it's the right thrust, made by the right manufacturer, in the right time period
+//
+//	Dry Mass: 199 Kg		Guess. Bigger nozzle, but no Gimbal.
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 230.5 kN		Not including 15.76 kN from RD-0236 vernier?
+//	ISP: 200 SL / 328.8 Vac		guess, based on thrust difference between 15D2 and 11D23
+//	Burn Time: 183?
+//	Chamber Pressure: 17.5 MPa?
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.6?
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1?
+//	=================================================================================
 //	RD-0235 (15D113)
 //	UR-100N
 //
@@ -44,6 +60,8 @@
 //	Encyclopedia Astronautica - RD-0216 engine:					http://www.astronautix.com/r/rd-0216.html
 //	Russian space-rocket and missile liquid-propellant engines:	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
 //	Upper Stage Liquid Propellant Rocket Engines:				https://www.scielo.br/j/jatm/a/jg5XF3Ls6mb98g9WXwVK3Zw/?format=pdf&lang=en
+//	http://www.astronautix.com/l/lk-700.html
+//	http://www.astronautix.com/1/11d23.html
 
 //	Used by:
 
@@ -51,6 +69,7 @@
 
 //	UR-100 first stage consisting of 3 RD-0216 and 1 RD-0217 (containing heat exchanger for tank pressurization)
 //	UR-100N second stage consisting of 1 RD-0253 (15D113), and 1 4-chamber RD-0236 (15D114) vernier engine.
+//	LK-700 Blok I used 3 11D23s, and Blok II used one. KTDU-416 engines on Blok II provided attitude control for both.
 //	==================================================
 @PART[*]:HAS[#engineType[RD0216]]:FOR[RealismOverhaulEngines]
 {
@@ -124,17 +143,73 @@
 			}
 
 			//UR-100 (8K84) (R&D): 336 flights, 19 failures
-			//1344 engines, 19 failures
+			//Blame 1/4 of failures on upper stage (more engines on lower stage, but upper stages tend to
+			//be less reliable)
+			//1344 engines, 14 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 300
 				ratedBurnTime = 140
 				safeOverburn = true
-				ignitionReliabilityStart = 0.985206
-				ignitionReliabilityEnd = 0.997041
+				ignitionReliabilityStart = 0.989033
+				ignitionReliabilityEnd = 0.997807
+				cycleReliabilityStart = 0.989033
+				cycleReliabilityEnd = 0.997807
+				reliabilityMidH = 0.7
+				reliabilityDataRateMultiplier = 0.5
+			}
+		}
+		CONFIG
+		{
+			name = 11D23
+			description = Used on Blok I and II of the LK-700, alongside KTDU-416 verniers.
+			specLevel = concept
+			minThrust = 230.5
+			maxThrust = 230.5
+			gimbalRange = 0
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			massMult = 1.30
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4106
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5894
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 328.8
+				key = 1 200
+			}
+
+			//same as RD-0235 I guess, it's already pretty reliable
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 550
+				ratedBurnTime = 183
+				safeOverburn = true
+				ignitionReliabilityStart = 0.989593
+				ignitionReliabilityEnd = 0.998357
 				ignitionDynPresFailMultiplier = 0.1
-				cycleReliabilityStart = 0.985206
-				cycleReliabilityEnd = 0.997041
+				cycleReliabilityStart = 0.989593
+				cycleReliabilityEnd = 0.998357
+				techTransfer = RD-0216:50
 				reliabilityMidH = 0.7
 				reliabilityDataRateMultiplier = 0.5
 			}
@@ -184,8 +259,8 @@
 			//212 engines, 2 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 300
-				ratedBurnTime = 140
+				testedBurnTime = 550
+				ratedBurnTime = 183
 				safeOverburn = true
 				ignitionReliabilityStart = 0.989593
 				ignitionReliabilityEnd = 0.998357

--- a/GameData/RealismOverhaul/Engine_Configs/RD510_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD510_Config.cfg
@@ -1,0 +1,134 @@
+//	==================================================
+//	RD-510
+//
+//	Manufacturer: Glushko
+//
+//	=================================================================================
+//	RD-510 (11D217)
+//	Lunar Lander prototype
+//
+//	Dry Mass: 222 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 117.68 kN
+//	ISP: 227 SL / 331 Vac		SL calculated with RPA
+//	Burn Time: "long service life"	[5]
+//	Chamber Pressure: 14.71 MPa
+//	Propellant: HTP / RG-1
+//	Prop Ratio: 7.31?	estimated with RPA
+//	Throttle: 10:1 throttling	[5]
+//	Nozzle Ratio: 132?		estimated with RPA
+//	Ignitions: "multiple"	[5]
+//	=================================================================================
+
+//	Sources:
+
+//	[1]http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+//	[2]http://www.lpre.de/energomash/index.htm
+//	[3]http://www.b14643.de/Spacerockets/Specials/R_and_UR-Missiles/Gallery/UR-700/UR-700.htm
+//	[4]http://forums.airbase.ru/2019/06/t108369--rd-510-rd-502-rd-161p.2340.html
+//	[5]http://www.lpre.de/resources/articles/H2O2.pdf
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+
+@PART[*]:HAS[#engineType[RD510]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roRD510Title	//RD-510
+	%manufacturer = #roMfrKBEnergomash
+	%description = #roRD510Desc
+
+	@tags ^= :$: USSR glushko energomash rd510 11d217 liquid pump upper lander htp kerosene
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	//I don't see any reason why it shouldn't have a gimbal
+	@MODULE[ModuleGimbal],*
+	{
+		%gimbalRange = 5.0
+		%useGimbalResponceSpeed = True
+		%gimbalResponceSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = RD-510-11D214
+		origMass = 0.222
+
+		CONFIG
+		{
+			name = RD-510-11D214
+			specLevel = prototype	//completed over 250 test firings?
+			minThrust = 11.77
+			maxThrust = 117.68
+			gimbalRange = 5.0
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 12	//same as RD-858?
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.01
+			}
+
+			PROPELLANT
+			{
+				name = RG-1
+				ratio = 0.1903
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.8097
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 331
+				key = 1 227
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 3600	//tested to several thousand seconds. Say 1 hour
+				ratedBurnTime = 910	//long life? Same as LMDE I guess
+				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+				
+				//Same as RD-58S
+				ignitionReliabilityStart = 0.977907
+				ignitionReliabilityEnd = 0.996512
+				cycleReliabilityStart = 0.976250
+				cycleReliabilityEnd = 0.996250
+				
+				techTransfer = RD-502-11D11:20	//Loosely related
+			}
+		}
+	}
+}
+

--- a/GameData/RealismOverhaul/Engine_Configs/RD858_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD858_Config.cfg
@@ -1,0 +1,146 @@
+//	==================================================
+//	RD-858
+//
+//	Manufacturer: KB Yuzhnoye
+//
+//	=================================================================================
+//	RD-858
+//	LK Lander main engine
+//
+//	Dry Mass: 53 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 20.104 kN full thrust, 8.414 kN low thrust
+//	ISP: 152 SL / 314.9 Vac		[3], SL calculated with RPA
+//	Burn Time: 470
+//	Chamber Pressure: 7.85 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.03	(down to 1.6 at low throttle)
+//	Throttle: 9.8% in high thrust mode, +- 35% in low thrust mode?
+//	Nozzle Ratio: 71	nozzle exit pressure 0.68 atm
+//	Ignitions: 12	designed for 2, but able to perform up to 12 [1]
+//	=================================================================================
+
+//	Sources:
+
+//	[1]https://old.yuzhnoye.com/en/company/history/liquid-propellant-rocket-engines.html
+//	[2]http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
+//	[3]http://www.astronautix.com/r/rd-858.html
+//	[4]https://www.russianspaceweb.com/lk-block-e.html
+//	[5]https://epizodyspace.ru/bibl/inostr-yazyki/sov-luna/sovets-luna.pdf
+
+//	Used by:
+
+//	Notes:
+
+//	These values presumably include verniers
+//	==================================================
+
+@PART[*]:HAS[#engineType[RD858]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roRD858Title	//RD-858
+	%manufacturer = #roMfrKBYuzhnoye
+	%description = #roRD858Desc
+
+	@tags ^= :$: USSR yangel yuzhnoye rd-858 11D411 liquid pump lander upper udmh nto
+
+	%specLevel = prototype
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal]
+	{
+		%gimbalRange = 10	//verniers. Actually appear to be fixed RCS-type, but oh well. Configure on part by part basis
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.053
+		configuration = RD-858
+
+		CONFIG
+		{
+			name = RD-858
+			description = A.K.A. 11D411. Main engine for LK lander.
+			specLevel = prototype
+			minThrust = 5.469
+			maxThrust = 20.104
+			heatProduction = 55
+			ullage = False	//heavily baffled fuel tanks
+			pressureFed = False
+			ignitions = 12
+			massMult = 1.0
+			
+			varyMixture = 0.03	//3.0% mixture variance [3]
+			varyFlow = 0.005	//Active flow control for throttling?
+			
+			//9.8% throttle in high thrust mode, +- 35% in low thrust mode
+			//27.2%? min throttle
+			throttleCurve
+			{
+				key = 0.000 0.272 0.00 0.391
+				key = 0.750 0.565 0.391 0.00
+				key = 0.751 0.902 0.00 0.392
+				key = 1.000 1.000 0.392 0.00
+			}
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4716
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5284
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 314.9
+				key = 1 152
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 3600	//tested to several thousand seconds. Say 1 hour
+				ratedBurnTime = 470
+				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+				
+				//Same as RD-58M. Not super reliable, but you have a backup.
+				ignitionReliabilityStart = 0.977964
+				ignitionReliabilityEnd = 0.996521
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.988455
+				cycleReliabilityEnd = 0.998177
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/RD859_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD859_Config.cfg
@@ -1,0 +1,129 @@
+//	==================================================
+//	RD-859
+//
+//	Manufacturer: KB Yuzhnoye
+//
+//	=================================================================================
+//	RD-859
+//	LK Lander backup engine
+//
+//	Dry Mass: 57 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 20.055 kN
+//	ISP: 150 SL / 311.9 Vac		[3], SL calculated with RPA
+//	Burn Time: 470
+//	Chamber Pressure: 7.85 MPa
+//	Propellant: NTO / UDMH
+//	Prop Ratio: 2.00
+//	Throttle: 9.8%
+//	Nozzle Ratio: 71	nozzle exit pressure 0.68 atm
+//	Ignitions: 2?
+//	=================================================================================
+
+//	Sources:
+
+//	[1]https://old.yuzhnoye.com/en/company/history/liquid-propellant-rocket-engines.html
+//	[2]http://www.b14643.de/Spacerockets/Specials/Ukrainian_Rocket_engines/engines.htm
+//	[3]http://www.astronautix.com/r/rd-858.html
+//	[4]https://www.russianspaceweb.com/lk-block-e.html
+//	[5]https://epizodyspace.ru/bibl/inostr-yazyki/sov-luna/sovets-luna.pdf
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+
+@PART[*]:HAS[#engineType[RD859]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = #roRD859Title	//RD-859
+	%manufacturer = #roMfrKBYuzhnoye
+	%description = #roRD859Desc
+
+	@tags ^= :$: USSR yangel yuzhnoye rd-859 11D412 liquid pump lander upper udmh nto
+
+	%specLevel = prototype
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}	//probably fixed?
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		origMass = 0.057
+		configuration = RD-859
+
+		CONFIG
+		{
+			name = RD-859
+			description = A.K.A. 11D412. Backup engine for LK Lander.
+			specLevel = prototype
+			minThrust = 18.090
+			maxThrust = 20.055
+			heatProduction = 55
+			ullage = False	//heavily baffled fuel tanks
+			pressureFed = False
+			ignitions = 2
+			massMult = 1.0
+			
+			varyMixture = 0.03	//3.0% mixture variance [3]
+
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.4753
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.5247
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 311.9
+				key = 1 150
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.25
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 3600	//tested to several thousand seconds. Say 1 hour
+				ratedBurnTime = 400
+				safeOverburn = true
+				
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+				
+				//Same as RD-58M. Not super reliable, but you have a backup.
+				ignitionReliabilityStart = 0.977964
+				ignitionReliabilityEnd = 0.996521
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.988455
+				cycleReliabilityEnd = 0.998177
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -6,13 +6,17 @@ Localization
 		//	============================================================================
 		//	Engine Config Localizations
 		//	============================================================================
-		//A
+		//#
+		//		15D13
+		#ro15D13Title = 15D13
+		#ro15D13Desc = Soviet hypergolic gas generator upper stage engine. Created for the upper stage of the UR-100, the 15D13 was one of the first rockets ever developed by OKB-117. In order to save time, it's development was combined with the 5D22 upper stage engine for the A-350Zh anti-ballistic missile. It was also proposed as the braking engine for the LK-700S lander as the 11D423.
 		//		18KS7800
 		#ro18KS7800Title = Aerojet 1.8KS-7800
 		#ro18KS7800Desc = A small solid fueled booster taken from the AIM-7 Sparrow missile. It was used as the third stage on the Aerobee 300 and 300A sounding rockets.
 		//		25KS18000
 		#ro25KS18000Title = Aerojet 2.5KS-18000
 		#ro25KS18000Desc = A small but powerful solid fueled booster used as the first stage for the Aerobee line of sounding rockets.
+		//A
 		//		A-4
 		#roA-4Title = A-4
 		#roA-4Desc = A Thiel alcolox engine used on the V-2 missile. Interim design, but went into production. Used 18 x 1.5 tonne thrust chambers that fed a common mixing chamber. Work began 1936, testing in 1939, and mass production from 1943-1945.
@@ -264,6 +268,9 @@ Localization
 		//		KTDU35
 		#roKTDU35Title = KTDU-35
 		#roKTDU35Desc = The KTDU-35 is a gas generator hypergolic engine capable of multiple ignitions, used on the first generation Soyuz and Progress spacecrafts (the 7K series). It consists of the single nozzle S5.60 main engine and the dual nozzle S5.35 backup engine. If the main engine fails, the backup one will assume its position.
+		//		KTDU416
+		#roKTDU416Title = KTDU-416
+		#roKTDU416Desc = The vernier and landing engine for the LK-700S. Three were to be used as verniers on the TLI and Lunar injection stages, while another three would enable a controlled final descent for the LK-700S.
 		//		KTDU417
 		#roKTDU417Title = KTDU-417
 		#roKTDU417Desc = The landing engine for Luna 15-24. The main gas generator engine was used for orbital manuevering and descent, and then switched over to a secondary pressurefed engine for terminal descent. Use an action group to toggle between the main and secondary engines quickly to make landing easier.
@@ -521,7 +528,7 @@ Localization
 		#roRD215Desc = A Soviet dual chamber gas generator engine. Designed in the late 1950s to use storable propellants for ICBMs because the cryogenic propellants in the current R-7 could not be stored for long periods, requiring lengthy fueling before launch. It was used in clusters of up to three in many Soviet ICBMs, and later in the Kosmos and Tsiklon launch vehicles.
 		//		RD0216
 		#roRD0216Title = RD-0216/0217
-		#roRD0216Desc = A staged combustion, hypergolic rocket engine. Used as a power plant on the first stage of the UR-100 rocket, with 3 RD-0216s and 1 RD-0217 forming a 15D2 engine module. Features a two-axis gimbal mechanism for attitude control.
+		#roRD0216Desc = A staged combustion, hypergolic rocket engine. Used as a power plant on the first stage of the UR-100 rocket, with 3 RD-0216s and 1 RD-0217 forming a 15D2 engine module. Features a two-axis gimbal mechanism for attitude control. It was later modified into an upper stage engine for the UR-100N, and proposed as an upper stage engine for the UR-700/LK-700 complex.
 		//		RD219
 		#roRD219Title = RD-219
 		#roRD219Desc = A Soviet dual chamber gas generator engine. Designed in the late 1950s to use storable propellants for ICBMs because the cryogenic propellants in the current R-7 could not be stored for long periods, requiring lengthy fuelling before launch. Used on the R-16 and R-36 ICBMs, and Tsiklon-2 and Tsiklon-3 LVs.
@@ -575,6 +582,9 @@ Localization
 		#roRD301Desc = An exotic fuel-rich staged combustion vacuum engine. Developed as a high-energy upper stage for Proton by Glushko, the RD-301 burned liquid flourine and ammonia, which gave very high performance and density. It was tested extensively, but never flew due to toxicity concerns.
 		//		RD0410MID
 		#roRD0410MIDTitle = RD-0410
+		//		RD510
+		#roRD510Title = RD-510
+		#roRD510Desc = A staged combustion kerosene and peroxide lander engine, developed for Soviet heavy manned moon landers. Derived from the earlier RD-502 project, the use of hydrogen peroxide with kerosene allowed for a very dense, storable, and non-toxic stage. Although tested extensively, and proposed for various lunar lander designs including the LK-700, it never flew.
 		//		RD701
 		#roRD701Title = RD-701
 		#roRD701Desc = A staged combustion tripropellant liquid fuel engine using Kerosene, liquid Hydrogen, and liquid Oxygen. Originally developed for the MAKS space plane. In the booster phase of the ascent it uses a mixture of Kerosene with liquid Hydrogen and it switches to pure Hydrogen for the sustainer phase.
@@ -588,8 +598,14 @@ Localization
 		#roRD855Title = RD-851/855
 		#roRD855Desc = A pump-fed hypergolic vernier thruster used on the first stage of the R-16, R-36 and Tsyklon rocket.
 		//		RD856
-    #roRD856Title = RD-852/856
+		#roRD856Title = RD-852/856
 		#roRD856Desc = A pump-fed hypergolic vernier thruster used on the second stage of the R-16 and R-36 ICBM, and the Tsyklon (Cyclone) launch vehicle series for attitude control.
+		//		RD858
+		#roRD858Title = RD-858
+		#roRD858Desc = A gas generator hypergolic engine for the LK lander. It serves as the main engine of the LK lander, used for final descent to the moon, and takeoff to lunar orbit.
+		//		RD859
+		#roRD859Title = RD-859
+		#roRD859Desc = A gas generator hypergolic engine for the LK lander. It serves as the backup engine of the LK lander. It has limited throttling capability, and is only to be used for takeoff or abort.
 		//		RD864
 		#roRD864Title = RD-864/869
 		#roRD864Desc = Pressure-fed upper stage engine developed for the 3rd stage of R-36MUTTKh. This represents 1/4th of an RD-864. The RD-864 was able to restart many times and had extremely high gimbal authority and limited throttle, to allow it to dodge American missile defenses while deploying multiple warheads. The R-36M2 used an upgraded version of the engine known as the RD-869.


### PR DESCRIPTION
Add every significant Soviet lander engine proposed, including the 11D23 for the LK-700 TLI stage, 15D13 for the LK-700 ascent stage, KTDU-416 for the LK-700 landing stage, RD-858/859 for the LK lander, and RD-510.

Also update the KTDU-417/417B