### PR TITLE
Add Soviet/Russian Hall Effect thrusters

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/PPS1350_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/PPS1350_Config.cfg
@@ -15,7 +15,7 @@
 //	Burn Time: ??? Hours
 //	Chamber Pressure: N/A MPa
 //	Propellant: Xenon
-//	Prop Ratio: N/A
+//	Efficiency: 55%
 //	Throttle: ???
 //	Nozzle Ratio: N/A
 //	Ignitions: Infinite

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT140_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT140_Config.cfg
@@ -1,0 +1,134 @@
+//	==================================================
+//	SPT-140
+//
+//	Manufacturer: OKB Fakel
+//
+//	=================================================================================
+//	SPT-140
+//	
+//
+//	Dry Mass: 8.4 kg
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.193 N
+//	Power: 3000 W
+//	ISP: ??? SL / 1680 Vac
+//	Burn Time: 9000 Hours
+//	Chamber Pressure: N/A MPa
+//	Propellant: Xenon
+//	Efficiency: 50%
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: Infinite
+//	=================================================================================
+//	SPT-140D
+//	
+//
+//	Dry Mass: 8.5 kg
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.290 N
+//	Power: 4500 W
+//	ISP: ??? SL / 1770 Vac
+//	Burn Time: 4500 Hours
+//	Chamber Pressure: N/A MPa
+//	Propellant: Xenon
+//	Efficiency: 55%
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: Infinite
+//	=================================================================================
+
+//	Sources:
+
+//	[1]https://web.archive.org/web/20190214002735/http://www.fakel-russia.com/images/gallery/produczia/fakel_spd_en_print.pdf
+//	[2]https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2531&context=smallsat
+//	[3]https://web.archive.org/web/20110606033558/http://www.novosti-kosmonavtiki.ru/content/numbers/198/35.shtml
+//	[4]https://www.nasa.gov/sites/default/files/atoms/files/table_4-10-_hall-effect_electric_propulsion_thrusters.pdf
+//	[5]https://ntrs.nasa.gov/api/citations/19980016322/downloads/19980016322.pdf
+//	[6]https://apps.dtic.mil/sti/citations/ADA410741
+
+//	Used by:
+
+//	==================================================
+
+@PART[*]:HAS[#engineType[SPT140]]:FOR[RealismOverhaulEngines]
+{
+	%title = SPT-140 Hall Effect Thruster
+	%manufacturer = #roMfrOKBFakel
+	%description = The SPT-140 is an enlarged SPT-100 created to power large, modern communications satellites. Mass/power ratio: 2.80 kg/kW.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = Electric
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = SPT-140
+		origMass = 0.0084
+		CONFIG
+		{
+			name = SPT-140
+			minThrust = 0.0000965
+			maxThrust = 0.000193
+			heatProduction = 1500 // efficiency 0.50
+
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1456.6
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1680
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			name = SPT-140D
+			minThrust = 0.000145
+			maxThrust = 0.000290
+			heatProduction = 2025 // efficiency 0.55
+
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1534.6
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1770
+				key = 1 1
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT140_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT140_Config.cfg
@@ -91,7 +91,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1456.6
+				ratio = 1509.4
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
@@ -119,7 +119,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1534.6
+				ratio = 1587.5
 				DrawGauge = True
 				minResToLeave = 10.0
 			}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT50_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT50_Config.cfg
@@ -91,7 +91,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1093.4
+				ratio = 781.3
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
@@ -120,7 +120,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1182.4
+				ratio = 1156.2
 				DrawGauge = True
 				minResToLeave = 10.0
 			}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT50_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT50_Config.cfg
@@ -25,9 +25,9 @@
 //
 //	Dry Mass: 1.32 kg	[4]
 //	Thrust (SL): ??? N
-//	Thrust (Vac): 0.0148 N	[4]
-//	Power: 220 W	[4]
-//	ISP: ??? SL / 930 Vac	[4]
+//	Thrust (Vac): 0.018 N	[6]
+//	Power: 300 W	[6]
+//	ISP: ??? SL / 1200 Vac	[6]
 //	Burn Time: 5000 Hours	[5]
 //	Chamber Pressure: N/A MPa
 //	Propellant: Xenon
@@ -44,6 +44,7 @@
 //	[3]https://web.archive.org/web/20110606033558/http://www.novosti-kosmonavtiki.ru/content/numbers/198/35.shtml
 //	[4]https://www.nasa.gov/sites/default/files/atoms/files/table_4-10-_hall-effect_electric_propulsion_thrusters.pdf
 //	[5]http://electricrocket.org/IEPC/IEPC_2017_38.pdf
+//	[6]https://spacesupplier.ir/equipments/stationary-plasma-thruster-spt-50m/?lang=en
 
 //	Used by:
 
@@ -104,8 +105,8 @@
 		CONFIG
 		{
 			name = SPT-50M
-			minThrust = 0.0000074
-			maxThrust = 0.0000148
+			minThrust = 0.000009
+			maxThrust = 0.000018
 			heatProduction = 130 // efficiency 0.41?
 			massMult = 1.0732
 
@@ -126,7 +127,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 930
+				key = 0 1200
 				key = 1 1
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT50_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT50_Config.cfg
@@ -1,0 +1,134 @@
+//	==================================================
+//	SPT-50
+//
+//	Manufacturer: OKB Fakel
+//
+//	=================================================================================
+//	SPT-50
+//	
+//
+//	Dry Mass: 1.23 kg	[4]
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.014 N	[4]
+//	Power: 220 W	[4]
+//	ISP: ??? SL / 860 Vac	[4]
+//	Burn Time: 2500 Hours	[5],[4]
+//	Chamber Pressure: N/A MPa
+//	Propellant: Xenon
+//	Efficiency: 26%
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: Infinite
+//	=================================================================================
+//	SPT-50M
+//	
+//
+//	Dry Mass: 1.32 kg	[4]
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.0148 N	[4]
+//	Power: 220 W	[4]
+//	ISP: ??? SL / 930 Vac	[4]
+//	Burn Time: 5000 Hours	[5]
+//	Chamber Pressure: N/A MPa
+//	Propellant: Xenon
+//	Efficiency: 41%
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: 3000
+//	=================================================================================
+
+//	Sources:
+
+//	[1]https://web.archive.org/web/20190214002735/http://www.fakel-russia.com/images/gallery/produczia/fakel_spd_en_print.pdf
+//	[2]https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2531&context=smallsat
+//	[3]https://web.archive.org/web/20110606033558/http://www.novosti-kosmonavtiki.ru/content/numbers/198/35.shtml
+//	[4]https://www.nasa.gov/sites/default/files/atoms/files/table_4-10-_hall-effect_electric_propulsion_thrusters.pdf
+//	[5]http://electricrocket.org/IEPC/IEPC_2017_38.pdf
+
+//	Used by:
+
+//	==================================================
+
+@PART[*]:HAS[#engineType[SPT50]]:FOR[RealismOverhaulEngines]
+{
+	%title = SPT-50 Hall Effect Thruster
+	%manufacturer = #roMfrOKBFakel
+	%description = An early Soviet Hall Effect thruster, used on Soviet and Russian weather satellites. Mass/power ratio: 5.45 kg/kW.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = Electric
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = SPT-50
+		origMass = 0.00123
+		CONFIG
+		{
+			name = SPT-50
+			minThrust = 0.000007
+			maxThrust = 0.000014
+			heatProduction = 163 // efficiency 0.26?
+
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1093.4
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			atmosphereCurve
+			{
+				key = 0 860
+				key = 1 1
+			}
+		}
+		CONFIG
+		{
+			name = SPT-50M
+			minThrust = 0.0000074
+			maxThrust = 0.0000148
+			heatProduction = 130 // efficiency 0.41?
+			massMult = 1.0732
+
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1182.4
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			atmosphereCurve
+			{
+				key = 0 930
+				key = 1 1
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT60_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT60_Config.cfg
@@ -1,0 +1,88 @@
+//	==================================================
+//	SPT-60
+//
+//	Manufacturer: OKB Fakel
+//
+//	=================================================================================
+//	SPT-60
+//	
+//
+//	Dry Mass: 1.2 kg	[3]
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.030 N	[3]
+//	Power: 575 W	[3] 517 W without cathode? Using SPT-70 as a correction factor (660/593) to get 575 W
+//	ISP: ??? SL / 1185 Vac	[3] 2500s without cathode? Using SPT-70 as a correction factor (1470/3100) to get 1185s
+//	Burn Time: ??? Hours
+//	Chamber Pressure: N/A MPa
+//	Propellant: Xenon
+//	Efficiency: 35%?
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: Infinite
+//	=================================================================================
+
+//	Sources:
+
+//	[1]https://web.archive.org/web/20190214002735/http://www.fakel-russia.com/images/gallery/produczia/fakel_spd_en_print.pdf
+//	[2]https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2531&context=smallsat
+//	[3]https://web.archive.org/web/20110606033558/http://www.novosti-kosmonavtiki.ru/content/numbers/198/35.shtml
+//	[4]https://www.nasa.gov/sites/default/files/atoms/files/table_4-10-_hall-effect_electric_propulsion_thrusters.pdf
+
+//	Used by:
+
+//	==================================================
+
+@PART[*]:HAS[#engineType[SPT60]]:FOR[RealismOverhaulEngines]
+{
+	%title = SPT-60 Hall Effect Thruster
+	%manufacturer = #roMfrOKBFakel
+	%description = The first ever operational ion thruster, the SPT-60 Hall Effect thruster was first used in 1971 on Soviet Meteor weather satellites. Mass/power ratio: 2.09 kg/kW.
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = Electric
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = SPT-60
+		origMass = 0.0012
+		CONFIG
+		{
+			name = SPT-60
+			minThrust = 0.000015
+			maxThrust = 0.000030
+			heatProduction = 374 // efficiency 0.35?
+
+			PROPELLANT
+			{
+				name = XenonGas
+				ratio = 1.0
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1312.9
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			atmosphereCurve
+			{
+				key = 0 1185
+				key = 1 1
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT70_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT70_Config.cfg
@@ -1,69 +1,53 @@
 //	==================================================
-//	SPT-100
+//	SPT-70
 //
 //	Manufacturer: OKB Fakel
 //
 //	=================================================================================
-//	SPT-100
+//	SPT-70
 //	
 //
-//	Dry Mass: 3.5 Kg
+//	Dry Mass: 1.5 kg	[1],[3]
 //	Thrust (SL): ??? N
-//	Thrust (Vac): 0.080 N
-//	Power: 1350 W
-//	ISP: ??? SL / 1600 Vac
-//	Burn Time: 4000 Hours
-//	Chamber Pressure: N/A MPa
-//	Propellant: Xenon
-//	Efficiency: 48%
-//	Throttle: 50%?
-//	Nozzle Ratio: N/A
-//	Ignitions: Infinite
-//	=================================================================================
-//	SPT-100B
-//	
-//
-//	Dry Mass: 3.5 Kg
-//	Thrust (SL): ??? N
-//	Thrust (Vac): 0.083 N
-//	Power: 1350 W
-//	ISP: ??? SL / 1600 Vac
-//	Burn Time: 9000 Hours
-//	Chamber Pressure: N/A MPa
-//	Propellant: Xenon
-//	Efficiency: 45%
-//	Throttle: 50%?
-//	Nozzle Ratio: N/A
-//	Ignitions: Infinite
-//	=================================================================================
-//	SPT-100M
-//	
-//
-//	Dry Mass: 4.5 Kg
-//	Thrust (SL): ??? N
-//	Thrust (Vac): 0.0902 N
-//	Power: 1350 W
-//	ISP: ??? SL / 1734 Vac
-//	Burn Time: ??? Hours
-//	Chamber Pressure: N/A MPa
-//	Propellant: Xenon
-//	Efficiency: 52%?
-//	Throttle: 50%?
-//	Nozzle Ratio: N/A
-//	Ignitions: Infinite
-//	=================================================================================
-//	SPT-100D
-//	
-//
-//	Dry Mass: 3.0 Kg
-//	Thrust (SL): ??? N
-//	Thrust (Vac): 0.0883 N
-//	Power: 1500 W
-//	ISP: ??? SL / 1740 Vac
-//	Burn Time: 7255 Hours
+//	Thrust (Vac): 0.039 N	[4]
+//	Power: 660 W
+//	ISP: ??? SL / 1470 Vac	[1],[4]
+//	Burn Time: 3100 Hours
 //	Chamber Pressure: N/A MPa
 //	Propellant: Xenon
 //	Efficiency: 43%
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: Infinite
+//	=================================================================================
+//	SPT-70M
+//	
+//
+//	Dry Mass: 1.5? kg
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.0413 N	[4]
+//	Power: 660 W
+//	ISP: ??? SL / 1580 Vac	[4]
+//	Burn Time: ??? Hours
+//	Chamber Pressure: N/A MPa
+//	Propellant: Xenon
+//	Efficiency: 50%?
+//	Throttle: 50%?
+//	Nozzle Ratio: N/A
+//	Ignitions: Infinite
+//	=================================================================================
+//	SPT-70MK
+//	
+//
+//	Dry Mass: 1.5? kg
+//	Thrust (SL): ??? N
+//	Thrust (Vac): 0.0313 N	[4]
+//	Power: 660 W
+//	ISP: ??? SL / 1460 Vac	[4]
+//	Burn Time: ??? Hours
+//	Chamber Pressure: N/A MPa
+//	Propellant: Krypton
+//	Efficiency: 37%?
 //	Throttle: 50%?
 //	Nozzle Ratio: N/A
 //	Ignitions: Infinite
@@ -75,17 +59,16 @@
 //	[2]https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2531&context=smallsat
 //	[3]https://web.archive.org/web/20110606033558/http://www.novosti-kosmonavtiki.ru/content/numbers/198/35.shtml
 //	[4]https://www.nasa.gov/sites/default/files/atoms/files/table_4-10-_hall-effect_electric_propulsion_thrusters.pdf
-//	[5]https://ntrs.nasa.gov/citations/19930016017
 
 //	Used by:
 
 //	==================================================
 
-@PART[*]:HAS[#engineType[SPT100]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[SPT70]]:FOR[RealismOverhaulEngines]
 {
-	%title = SPT-100 Hall Effect Thruster
+	%title = SPT-70 Hall Effect Thruster
 	%manufacturer = #roMfrOKBFakel
-	%description = A Hall effect ion thruster used on many commercial spacecraft for station keeping. Mass/power ratio: 2.96 kg/kW.
+	%description = A Hall effect ion thruster used on many commercial spacecraft for station keeping. Mass/power ratio: 2.27 kg/kW.
 
 	@MODULE[ModuleEngines*]
 	{
@@ -103,14 +86,14 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		configuration = SPT-100
-		origMass = 0.0035
+		configuration = SPT-70
+		origMass = 0.0015
 		CONFIG
 		{
-			name = SPT-100
-			minThrust = 0.000040
-			maxThrust = 0.000080
-			heatProduction = 702 // efficiency 0.48
+			name = SPT-70
+			minThrust = 0.000020
+			maxThrust = 0.000039
+			heatProduction = 376 // efficiency 0.43
 
 			PROPELLANT
 			{
@@ -122,23 +105,23 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1248.5
+				ratio = 1401.9
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
 
 			atmosphereCurve
 			{
-				key = 0 1600
+				key = 0 1470
 				key = 1 1
 			}
 		}
 		CONFIG
 		{
-			name = SPT-100B
-			minThrust = 0.0000415
-			maxThrust = 0.000083
-			heatProduction = 743 // efficiency 0.45
+			name = SPT-70M
+			minThrust = 0.0000206
+			maxThrust = 0.0000413
+			heatProduction = 330 // efficiency 0.5?
 
 			PROPELLANT
 			{
@@ -150,28 +133,27 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1248.5
+				ratio = 1507.0
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
 
 			atmosphereCurve
 			{
-				key = 0 1600
+				key = 0 1580
 				key = 1 1
 			}
 		}
 		CONFIG
 		{
-			name = SPT-100M
-			minThrust = 0.000045
-			maxThrust = 0.0000902
-			heatProduction = 648 // efficiency 0.52
-			massMult = 1.2857
+			name = SPT-70MK
+			minThrust = 0.0000156
+			maxThrust = 0.0000313
+			heatProduction = 415 // efficiency 0.37?
 
 			PROPELLANT
 			{
-				name = XenonGas
+				name = KryptonGas
 				ratio = 1.0
 				DrawGauge = True
 			}
@@ -179,43 +161,14 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1352.9
+				ratio = 1180.9
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
 
 			atmosphereCurve
 			{
-				key = 0 1734
-				key = 1 1
-			}
-		}
-		CONFIG
-		{
-			name = SPT-100D
-			minThrust = 0.0000442
-			maxThrust = 0.0000883
-			heatProduction = 855 // efficiency 0.43
-			massMult = 0.8571
-
-			PROPELLANT
-			{
-				name = XenonGas
-				ratio = 1.0
-				DrawGauge = True
-			}
-
-			PROPELLANT
-			{
-				name = ElectricCharge
-				ratio = 1508.5
-				DrawGauge = True
-				minResToLeave = 10.0
-			}
-
-			atmosphereCurve
-			{
-				key = 0 1740
+				key = 0 1460
 				key = 1 1
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT70_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT70_Config.cfg
@@ -31,7 +31,7 @@
 //	Burn Time: ??? Hours
 //	Chamber Pressure: N/A MPa
 //	Propellant: Xenon
-//	Efficiency: 50%?
+//	Efficiency: 49%
 //	Throttle: 50%?
 //	Nozzle Ratio: N/A
 //	Ignitions: Infinite
@@ -47,7 +47,7 @@
 //	Burn Time: ??? Hours
 //	Chamber Pressure: N/A MPa
 //	Propellant: Krypton
-//	Efficiency: 37%?
+//	Efficiency: 35%
 //	Throttle: 50%?
 //	Nozzle Ratio: N/A
 //	Ignitions: Infinite
@@ -59,6 +59,7 @@
 //	[2]https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2531&context=smallsat
 //	[3]https://web.archive.org/web/20110606033558/http://www.novosti-kosmonavtiki.ru/content/numbers/198/35.shtml
 //	[4]https://www.nasa.gov/sites/default/files/atoms/files/table_4-10-_hall-effect_electric_propulsion_thrusters.pdf
+//	[5]http://electricrocket.org/2019/336.pdf
 
 //	Used by:
 
@@ -121,7 +122,7 @@
 			name = SPT-70M
 			minThrust = 0.0000206
 			maxThrust = 0.0000413
-			heatProduction = 330 // efficiency 0.5?
+			heatProduction = 337 // efficiency 0.49
 
 			PROPELLANT
 			{
@@ -149,7 +150,7 @@
 			name = SPT-70MK
 			minThrust = 0.0000156
 			maxThrust = 0.0000313
-			heatProduction = 415 // efficiency 0.37?
+			heatProduction = 429 // efficiency 0.35
 
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT70_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/SPT70_Config.cfg
@@ -106,7 +106,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1401.9
+				ratio = 1437.8
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
@@ -134,7 +134,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1507.0
+				ratio = 1459.5
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
@@ -162,7 +162,7 @@
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 1180.9
+				ratio = 1131.9
 				DrawGauge = True
 				minResToLeave = 10.0
 			}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/NearFuturePropulsion/RO_NearFuture_Propulsion_Ion.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/NearFuturePropulsion/RO_NearFuture_Propulsion_Ion.cfg
@@ -42,6 +42,20 @@
 
 +PART[ionArgon-0625-2]:FOR[RealismOverhaul]
 {
+	// SPT-140 Hall Effect Thruster
+	// the 140 appears to stand for 140 mm
+	%RSSROConfig = True
+	@name = RO-SPT140
+	%engineType = SPT140
+
+	%rescaleFactor = 0.28
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+}
+
++PART[ionArgon-0625-2]:FOR[RealismOverhaul]
+{
 	// SPT-100 Hall Effect Thruster
 	// the 100 appears to stand for 100 mm
 	%RSSROConfig = True
@@ -49,6 +63,20 @@
 	%engineType = SPT100
 
 	%rescaleFactor = 0.2
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+}
+
++PART[ionArgon-0625-2]:FOR[RealismOverhaul]
+{
+	// SPT-70 Hall Effect Thruster
+	// the 70 appears to stand for 70 mm
+	%RSSROConfig = True
+	@name = RO-SPT70
+	%engineType = SPT70
+
+	%rescaleFactor = 0.14
 
 	!MODULE[TweakScale] {}
 	!EFFECTS[engage] {} // remove ignition sound effects
@@ -62,6 +90,32 @@
 	%engineType = PPS1350
 
 	%rescaleFactor = 0.5
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+}
+
++PART[ionArgon-0625]:FOR[RealismOverhaul]
+{
+	// SPT-60 Hall Effect Thruster
+	%RSSROConfig = True
+	@name = RO-SPT60
+	%engineType = SPT60
+
+	%rescaleFactor = 0.15
+
+	!MODULE[TweakScale] {}
+	!EFFECTS[engage] {} // remove ignition sound effects
+}
+
++PART[ionArgon-0625]:FOR[RealismOverhaul]
+{
+	// SPT-60 Hall Effect Thruster
+	%RSSROConfig = True
+	@name = RO-SPT50
+	%engineType = SPT50
+
+	%rescaleFactor = 0.125
 
 	!MODULE[TweakScale] {}
 	!EFFECTS[engage] {} // remove ignition sound effects

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -64,6 +64,8 @@
 +PART[liquidEngineMainsail_v2]:BEFORE[RealismOverhaul]:NEEDS[ReStock] { @name = RO-KTDU5A }
 +PART[liquidEngine3_v2]:BEFORE[RealismOverhaul]:NEEDS[!ReStock] { @name = RO-KTDU5A }
 
++PART[ionEngine]:BEFORE[RealismOverhaul] { @name = RO-ionSPT60 }	//restock doesn't rename the ion engine?
+
 // Phase 2: Model Patching
 
 // Typically use a :HAS[#mesh] pattern to detect original stock parts instead of ReStock/VSR patches.
@@ -626,7 +628,7 @@
 // Phase 3: Configuration
 
 // Commons
-@PART[RO-RD-253|engineLargeSkipper|ionEngine|RO-LR105|RO-LR79|RO-E1|RO-H1-RS27|RO-LR-89|RO-RD58|RO-RD-0210|RO-LMDE|RO-LMAE|RO-RD-0105|RO-SurveyorVernier|RO-KDU414]:FOR[RealismOverhaul]
+@PART[RO-RD-253|engineLargeSkipper|ionEngine|RO-ionSPT60|RO-LR105|RO-LR79|RO-E1|RO-H1-RS27|RO-LR-89|RO-RD58|RO-RD-0210|RO-LMDE|RO-LMAE|RO-RD-0105|RO-SurveyorVernier|RO-KDU414]:FOR[RealismOverhaul]
 {
 	@MODULE[ModuleEngines*]
 	{
@@ -699,6 +701,16 @@
 {
 	%RSSROConfig = True
 	%engineType = NSTAR
+	%rescaleFactor = 0.75
+	!MODULE[ElectricEngineThrustLimiter]{}
+}
+
+//  SPT-60 (ion engine).
+@PART[RO-ionSPT60]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	%engineType = SPT60
+	%rescaleFactor = 0.15
 	!MODULE[ElectricEngineThrustLimiter]{}
 }
 


### PR DESCRIPTION
Add Soviet/Russian Hall Effect thrusters, including SPT-60, the first ion engine ever used operationally in space.
Full list of changes include

- Add SPT-50, SPT-60, SPT-70, SPT-140
- Adjust SPT-100 configs based on new sources
- Clone NearFuturePropulsion parts to create parts for SPT-50/60/70/140