### PR TITLE
Update RD-270 default configuration

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD270_Config.cfg
@@ -99,7 +99,7 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		origMass = 4.47
-		configuration = RD-270-11D420
+		configuration = RD-270-8D420
 		modded = false
 		CONFIG
 		{


### PR DESCRIPTION
With a non-existent config in the `configuration` field, it appears to default to the first config, the deprecated `RD-270` instead of the `RD-270-8D420`, the `RD-270-11D420` config is missing due to the 11D420 → 8D420 switch in [this commit](https://github.com/KSP-RO/RealismOverhaul/commit/dfb1bde0ade9c983e762ef299f79d181e9e02932)

Don't know how much harm the current behaviour actually causes but it is a little confusing to open the configs window and see zero selected, then select one with identical stats