### PR TITLE
Add control to Zenith boosters for DECQ's Energia

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/EnergiaBuran/Energia.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/DECQ/EnergiaBuran/Energia.cfg
@@ -171,6 +171,12 @@
 			rate = 0.1
 		}
 	}
+ 	vesselType = Probe //Necessary for it not to be considered a debris on stage separation
+  	//Enable SAS on part as the boosters locked prograde for reentry
+  	MODULE
+   	{
+    		name = ModuleSAS
+      	}
 	MODULE
 	{
 		name = ModuleFuelTanks


### PR DESCRIPTION
Make the boosters actually controllable after staging, necessary for recovery