### PR TITLE
Improve J-2T config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -7,12 +7,12 @@
 //	J-2T-200K
 //	drop-in replacement for J-2
 //
-//	Dry Mass: 1400 Kg
+//	Dry Mass: 1511? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 889.3 kN
-//	ISP: 360 SL / 450 Vac	//estimated with RPA
+//	ISP: 362 SL / 442 Vac	//estimated with RPA
 //	Burn Time: 600
-//	Chamber Pressure: 8.58? MPa
+//	Chamber Pressure: 6.89? MPa	//1000 psi @ MR5.5 should be 78 inches, same as 250k at MR6.0?
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.5		//could run from 5 to 7. Give 5.5 so it matches J-2 at least.
 //	Throttle: 20% to 100%
@@ -22,12 +22,12 @@
 //	J-2T-250K
 //	
 //
-//	Dry Mass: 1400 Kg
+//	Dry Mass: 1511 Kg	//3332 lbs as installed (alone). Clusters are actually heavier because they need shielding
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1111.6 kN
-//	ISP: 371 SL / 450.1 Vac
+//	ISP: 373 SL / 440 Vac	//based on table 56 (p. 384) and 58
 //	Burn Time: 600	//rated to 600 seconds single burn
-//	Chamber Pressure: 10.34 MPa
+//	Chamber Pressure: 8.96 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0		//6.0 nominal
 //	Throttle: 20% to 100%
@@ -76,14 +76,14 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 1.4
+		origMass = 1.511
 		configuration = J-2T-200K
 		modded = false
 		CONFIG
 		{
 			name = J-2T-200K
 			description = Five minutes minimum between restarts.
-			specLevel = prototype	//test models at least sorta got near 200k (vacuum, but were tested in SL conditions)
+			specLevel = prototype
 			maxThrust = 889.3
 			minThrust = 177.8
 			PROPELLANT
@@ -99,8 +99,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 450
-				key = 1 360
+				key = 0 442
+				key = 1 362
 			}
 			ullage = True
 			ignitions = 3
@@ -141,7 +141,7 @@
 		{
 			name = J-2T-250K
 			description = Five minutes minimum between restarts.
-			specLevel = concept	//test models never actually got near 250k?
+			specLevel = prototype
 			maxThrust = 1111.6
 			minThrust = 222.32
 			PROPELLANT
@@ -157,8 +157,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 450.1
-				key = 1 371
+				key = 0 440
+				key = 1 373
 			}
 			ullage = True
 			ignitions = 3

--- a/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2T_Config.cfg
@@ -10,14 +10,14 @@
 //	Dry Mass: 1400 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 889.3 kN
-//	ISP: 300 SL / 435 Vac
-//	Burn Time: 500
-//	Chamber Pressure: ??? MPa
+//	ISP: 360 SL / 450 Vac	//estimated with RPA
+//	Burn Time: 600
+//	Chamber Pressure: 8.58? MPa
 //	Propellant: LOX / LH2
-//	Prop Ratio: 6.0
+//	Prop Ratio: 5.5		//could run from 5 to 7. Give 5.5 so it matches J-2 at least.
 //	Throttle: 20% to 100%
 //	Nozzle Ratio: ???
-//	Ignitions: 3
+//	Ignitions: 3?
 //	=================================================================================
 //	J-2T-250K
 //	
@@ -25,11 +25,11 @@
 //	Dry Mass: 1400 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1111.6 kN
-//	ISP: 290 SL / 441 Vac
-//	Burn Time: 500
-//	Chamber Pressure: ??? MPa
+//	ISP: 371 SL / 450.1 Vac
+//	Burn Time: 600	//rated to 600 seconds single burn
+//	Chamber Pressure: 10.34 MPa
 //	Propellant: LOX / LH2
-//	Prop Ratio: 6.0
+//	Prop Ratio: 6.0		//6.0 nominal
 //	Throttle: 20% to 100%
 //	Nozzle Ratio: ???
 //	Ignitions: 3
@@ -50,7 +50,7 @@
 {
 	@title = #roJ2TTitle	//J-2T
 	@manufacturer = #roMfrRocketdyne
-	@description = #roJ2TDesc	//A aerospike engine using proven technology from the J-2 and introducing an aerospike nozzle to the developing J-2S machinery.
+	@description = #roJ2TDesc
 
 	@tags ^= :$: USA rocketdyne j-2t liquid pump upper sustainer lqdhydrogen lqdoxygen
 
@@ -83,24 +83,24 @@
 		{
 			name = J-2T-200K
 			description = Five minutes minimum between restarts.
-			specLevel = prototype
+			specLevel = prototype	//test models at least sorta got near 200k (vacuum, but were tested in SL conditions)
 			maxThrust = 889.3
 			minThrust = 177.8
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.7286
+				ratio = 0.7454
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.2714
+				ratio = 0.2546
 			}
 			atmosphereCurve
 			{
-				key = 0 435
-				key = 1 300
+				key = 0 450
+				key = 1 360
 			}
 			ullage = True
 			ignitions = 3
@@ -114,7 +114,7 @@
 			{
 				// Copied from J-2S, used J-2S turbomachinery
 				testedBurnTime = 12000		//Engine design lifetime 12000 seconds. One engine ran 6.5 hours?
-				ratedBurnTime = 500
+				ratedBurnTime = 600
 				safeOverburn = true
 				
 				restartWindowPenalty		//Solid starter cartidges allow restart anytime. Just 5 minutes for quick cooldown at tank head idle?
@@ -134,14 +134,14 @@
 				ignitionReliabilityEnd = 0.9999
 				cycleReliabilityStart = 0.9665
 				cycleReliabilityEnd = 0.9999
-				techTransfer = J-2-230K,J-2-225K,J-2-200K:30
+				techTransfer = J-2S,J-2-230K,J-2-225K,J-2-200K:30
 			}
 		}
 		CONFIG
 		{
 			name = J-2T-250K
 			description = Five minutes minimum between restarts.
-			specLevel = prototype
+			specLevel = concept	//test models never actually got near 250k?
 			maxThrust = 1111.6
 			minThrust = 222.32
 			PROPELLANT
@@ -157,8 +157,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 441
-				key = 1 290
+				key = 0 450.1
+				key = 1 371
 			}
 			ullage = True
 			ignitions = 3
@@ -172,7 +172,7 @@
 			{
 				// Copied from J-2S, used J-2S turbomachinery
 				testedBurnTime = 12000		//Engine design lifetime 12000 seconds. One engine ran 6.5 hours?
-				ratedBurnTime = 500
+				ratedBurnTime = 600
 				safeOverburn = true
 				
 				restartWindowPenalty		//Solid starter cartidges allow restart anytime. Just 5 minutes for quick cooldown at tank head idle?
@@ -192,7 +192,7 @@
 				ignitionReliabilityEnd = 0.9999
 				cycleReliabilityStart = 0.9665
 				cycleReliabilityEnd = 0.9999
-				techTransfer = J-2T-200K,J-2-230K,J-2-225K,J-2-200K:30
+				techTransfer = J-2T-200K,J-2S,J-2-230K,J-2-225K,J-2-200K:30
 			}
 		}
 	}


### PR DESCRIPTION
The Isp numbers previously used by the J-2T didn't really make any sense, coming in worse even than the numbers achieved by the ground tests. Give J-2T-250k it's estimated performance numbers from the optimized common module, and derive 200k numbers from that. Also change 200k MR to 5.5, so it can actually be a drop-in J-2 replacement.

Resolves https://github.com/KSP-RO/RealismOverhaul/issues/2878