### PR TITLE
Improve intake titles/descriptions

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Squad.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Squad.cfg
@@ -26,6 +26,7 @@ Localization
 		#rominiIntakeTitle = Small Pitot Intake
 		#rominiIntakeDesc = This pitot intake works best between Mach 0 and Mach 1.5.
 		//		ramAirIntake
+		#roramAirIntakeTitle = Adjustable Ramp Intake
 		#roramAirIntakeDesc = This adjustable ramp intake works best between Mach 1.0 and Mach 3.0.
 		//		MK1IntakeFuselage
 		#roMK1IntakeFuselageTitle = 1.25m Fuselage (Diverterless Intake)

--- a/GameData/RealismOverhaul/Localization/en-us-Squad.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Squad.cfg
@@ -3,14 +3,32 @@ Localization
 	RSSROConfig = True
 	en-us
 	{
+		//		IntakeRadialLong
+		#roIntakeRadialLongDesc = This adjustable ramp intake works best between Mach 1.0 and Mach 3.0.
 		//		RO-IntakeRadialLongPitot
 		#roRO-IntakeRadialLongPitotTitle = Pitot Intake (Radial)
-		#roRO-IntakeRadialLongPitotDesc = This is a small, surface attached pitot tube intake, optimized for subsonic speeds.
+		#roRO-IntakeRadialLongPitotDesc = This pitot intake works best between Mach 0 and Mach 1.5.
 		//		RO-shockConeIntakeSmall
 		#roRO-shockConeIntake125Title = 1.25m Shock Cone Intake
-		#roRO-shockConeIntake125Desc = A moderately sized shock cone intake, optimized for supersonic speeds. This one is similar to the intake used on the English Electric Lightning.
+		#roRO-shockConeIntake125Desc = This shock cone intake works best between Mach 1.5 and Mach 3.0. This one is similar to the intake used on the English Electric Lightning.
 		//		RO-shockConeIntakeMig
 		#roRO-shockConeIntakeMigTitle = 0.86m Shock Cone Intake
-		#roRO-shockConeIntakeMigDesc = A small shock cone intake, optimized for supersonic speeds. This one is similar to the intake used on the MiG-21.
+		#roRO-shockConeIntakeMigDesc = This shock cone intake works best between Mach 1.5 and Mach 3.0. This one is similar to the intake used on the MiG-21.
+		//		shockConeIntake
+		#roshockConeIntakeDesc = This shock cone intake works best between Mach 1.5 and Mach 3.0.
+		//		airScoop
+		#roairScoopTitle = XM-G50 Radial Pitot Intake
+		#roairScoopDesc = This pitot intake works best between Mach 0 and Mach 1.5.
+		//		CircularIntake
+		#roCircularIntakeTitle = Pitot Intake
+		#roCircularIntakeDesc = This pitot intake works best between Mach 0 and Mach 1.5.
+		//		miniIntake
+		#rominiIntakeTitle = Small Pitot Intake
+		#rominiIntakeDesc = This pitot intake works best between Mach 0 and Mach 1.5.
+		//		ramAirIntake
+		#roramAirIntakeDesc = This adjustable ramp intake works best between Mach 1.0 and Mach 3.0.
+		//		MK1IntakeFuselage
+		#roMK1IntakeFuselageTitle = 1.25m Fuselage (Diverterless Intake)
+		#roMK1IntakeFuselageDesc = This diverterless supersonic intake works best between Mach 0 and Mach 2.0.
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
@@ -7,8 +7,29 @@
 	!MODULE[ModuleResourceIntake] {}
 }
 
+@PART[SXTRadialAirIntakeShockCone]:FOR[RealismOverhaul]
+{
+	@name = XF-104 Radial Shock Cone Intake
+	@description = This shock cone intake works best between Mach 1.5 and Mach 3.0.
+}
+
+@PART[SXTInlineAirIntake]:FOR[RealismOverhaul]
+{
+	@name = XM-600 1.25m Pitot Intake
+	@description = This pitot intake works best between Mach 0 and Mach 1.5.
+}
+
+@PART[LRadialAirIntake]:FOR[RealismOverhaul]
+{
+	@name = XM-C200 Radial Pitot Intake
+	@description = This pitot intake works best between Mach 0 and Mach 1.5.
+}
+
 @PART[SXTInlineAirIntakeTLarge]:FOR[RealismOverhaul]
 {
+	@name = XM-800 2.5m Pitot Intake
+	@description = This pitot intake works best between Mach 0 and Mach 1.5.
+	
 	@MODULE[AJEInlet]
 	{
 		@Area = 2.92

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/Intakes.cfg
@@ -9,25 +9,25 @@
 
 @PART[SXTRadialAirIntakeShockCone]:FOR[RealismOverhaul]
 {
-	@name = XF-104 Radial Shock Cone Intake
+	@title = XF-104 Radial Shock Cone Intake
 	@description = This shock cone intake works best between Mach 1.5 and Mach 3.0.
 }
 
 @PART[SXTInlineAirIntake]:FOR[RealismOverhaul]
 {
-	@name = XM-600 1.25m Pitot Intake
+	@title = XM-600 1.25m Pitot Intake
 	@description = This pitot intake works best between Mach 0 and Mach 1.5.
 }
 
 @PART[LRadialAirIntake]:FOR[RealismOverhaul]
 {
-	@name = XM-C200 Radial Pitot Intake
+	@title = XM-C200 Radial Pitot Intake
 	@description = This pitot intake works best between Mach 0 and Mach 1.5.
 }
 
 @PART[SXTInlineAirIntakeTLarge]:FOR[RealismOverhaul]
 {
-	@name = XM-800 2.5m Pitot Intake
+	@title = XM-800 2.5m Pitot Intake
 	@description = This pitot intake works best between Mach 0 and Mach 1.5.
 	
 	@MODULE[AJEInlet]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
@@ -133,7 +133,8 @@
 	%RSSROConfig = True
 	@mass = 0.045
 	%skinMaxTemp = 1144	//sure, inconel temps
-	@title = Ramp Intake
+	@title = #roramAirIntakeTitle
+	@description = #roramAirIntakeDesc
 }
 
 @PART[CircularIntake|miniIntake|ramAirIntake]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
@@ -11,6 +11,7 @@
 @PART[IntakeRadialLong]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@description = #roIntakeRadialLongDesc
 	@mass = 0.114
 }
 //Clone to create pitot tube version
@@ -75,6 +76,7 @@
 @PART[shockConeIntake]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@description = #roshockConeIntakeDesc
 	%skinMaxTemp = 1144	//sure, inconel temps
 	rescaleCube = 1
 	@DRAG_CUBE
@@ -108,16 +110,22 @@
 @PART[airScoop]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@title = #roairScoopTitle
+	@description = #roairScoopDesc
 	@mass = 0.02
 }
 @PART[CircularIntake]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@title = #roCircularIntakeTitle
+	@description = #roCircularIntakeDesc
 	@mass = 0.02
 }
 @PART[miniIntake]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	@title = #rominiIntakeTitle
+	@description = #rominiIntakeDesc
 	@mass = 0.005
 }
 @PART[ramAirIntake]:FOR[RealismOverhaul]
@@ -135,4 +143,12 @@
 		@type = free
 		!defaultScale = DELETE
 	}
+}
+
+@PART[MK1IntakeFuselage]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.045
+	%skinMaxTemp = 1144	//sure, inconel temps
+	@title = Ramp Intake
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Mk1.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Mk1.cfg
@@ -32,7 +32,8 @@
 @PART[MK1IntakeFuselage]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@title = 1.25m Fuselage (Intake)
+	@title = #roMK1IntakeFuselageTitle
+	@description = #roMK1IntakeFuselageDesc
 	!MODULE[TweakScale] {}
 	!MODULE[ModuleFuelTanks] {}
 	MODULE


### PR DESCRIPTION
Since intake type does actually matter quite a bit with AJE, label and describe intake type as clearly as possible. This just gets Stock and SXT intakes.