### PR TITLE
Hide too speculative engine upgrades from the RnD tree

### DIFF
--- a/Source/DynamicPartHider/DeprecatedHider.cs
+++ b/Source/DynamicPartHider/DeprecatedHider.cs
@@ -36,5 +36,10 @@ namespace RealismOverhaul
             }
             return true;
         }
+
+        public bool IsUpgradeAvaliable(PartUpgradeHandler.Upgrade upgrade)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Source/DynamicPartHider/DeprecatedHider.cs
+++ b/Source/DynamicPartHider/DeprecatedHider.cs
@@ -39,7 +39,7 @@ namespace RealismOverhaul
 
         public bool IsUpgradeAvaliable(PartUpgradeHandler.Upgrade upgrade)
         {
-            throw new NotImplementedException();
+            return true;
         }
     }
 }

--- a/Source/DynamicPartHider/DynamicPartHider.cs
+++ b/Source/DynamicPartHider/DynamicPartHider.cs
@@ -14,6 +14,8 @@ namespace RealismOverhaul
             public bool IsPartAvailable(AvailablePart ap);
 
             public bool IsRFConfigAvailable(ConfigNode cfg);
+
+            public bool IsUpgradeAvaliable(PartUpgradeHandler.Upgrade upgrade);
         }
 
         private static IFilter[] _filters;

--- a/Source/DynamicPartHider/PartUpgradeFiltering.cs
+++ b/Source/DynamicPartHider/PartUpgradeFiltering.cs
@@ -1,0 +1,20 @@
+using HarmonyLib;
+using KSP.UI.Screens;
+
+namespace RealismOverhaul.Harmony
+{
+	[HarmonyPatch(typeof(RDPartList))]
+	internal class PatchRDPartList
+	{
+		[HarmonyPrefix]
+		[HarmonyPatch("AddUpgradeListItem")]
+		private void Prefix_AddUpgradeListItem(PartUpgradeHandler.Upgrade upgrade, bool purchased)
+		{
+			foreach (var filter in Filters.Instance)
+			{
+				if (!filter.IsUpgradeAvaliable(upgrade))
+					return;
+			}
+		}
+	}
+}

--- a/Source/DynamicPartHider/PartUpgradeFiltering.cs
+++ b/Source/DynamicPartHider/PartUpgradeFiltering.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using KSP.UI.Screens;
+using UnityEngine;
 
 namespace RealismOverhaul.Harmony
 {
@@ -8,13 +9,14 @@ namespace RealismOverhaul.Harmony
 	{
 		[HarmonyPrefix]
 		[HarmonyPatch("AddUpgradeListItem")]
-		private void Prefix_AddUpgradeListItem(PartUpgradeHandler.Upgrade upgrade, bool purchased)
+		internal static bool Prefix_AddUpgradeListItem(PartUpgradeHandler.Upgrade upgrade, bool purchased)
 		{
-			foreach (var filter in Filters.Instance)
+			foreach (Filters.IFilter filter in Filters.Instance)
 			{
 				if (!filter.IsUpgradeAvaliable(upgrade))
-					return;
+					return false;
 			}
+			return true;
 		}
 	}
 }

--- a/Source/DynamicPartHider/SciFiHider.cs
+++ b/Source/DynamicPartHider/SciFiHider.cs
@@ -50,6 +50,11 @@ namespace RealismOverhaul
             if (tagsString.IndexOf("ro_specleveltag_scifi", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.SciFi; }
             return SpeculativeLevel.Operational;
         }
+
+        public bool IsUpgradeAvaliable(PartUpgradeHandler.Upgrade upgrade)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public enum SpeculativeLevel

--- a/Source/DynamicPartHider/SciFiHider.cs
+++ b/Source/DynamicPartHider/SciFiHider.cs
@@ -53,7 +53,26 @@ namespace RealismOverhaul
 
         public bool IsUpgradeAvaliable(PartUpgradeHandler.Upgrade upgrade)
         {
-            throw new NotImplementedException();
+            if (upgrade == null)
+            {
+                return false;
+            }
+            SpeculativeLevel setting = HighLogic.CurrentGame.Parameters.CustomParams<RealismOverhaulSettings>().speculativeLevel;
+            SpeculativeLevel level = GetSpeculativeLevelFromUpgradeDescription(upgrade);
+
+            return level <= setting;
+        }
+
+        public static SpeculativeLevel GetSpeculativeLevelFromUpgradeDescription(PartUpgradeHandler.Upgrade upgrade)
+        {
+            string description = upgrade.description;
+            if (description.IndexOf("available at specLevel operational", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.Operational; }
+            if (description.IndexOf("available at specLevel prototype", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.Prototype; }
+            if (description.IndexOf("available at specLevel concept", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.Concept; }
+            if (description.IndexOf("available at specLevel speculative", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.Speculative; }
+            if (description.IndexOf("available at specLevel althist", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.AltHist; }
+            if (description.IndexOf("available at specLevel scifi", StringComparison.OrdinalIgnoreCase) >= 0) { return SpeculativeLevel.SciFi; }
+            return SpeculativeLevel.Operational;
         }
     }
 

--- a/Source/RealismOverhaul.csproj
+++ b/Source/RealismOverhaul.csproj
@@ -56,6 +56,7 @@
     <Compile Include="DynamicPartHider\SciFiHider.cs" />
     <Compile Include="DynamicPartHider\RDTechFilter.cs" />
     <Compile Include="DynamicPartHider\RDTechFixer.cs" />
+    <Compile Include="DynamicPartHider\PartUpgradeFiltering.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
Currently, engine configs are only hidden in the VAB, while the part upgrade icons in the RnD tree are still present.
This fixes that, using the text in the description.