### PR TITLE
Rebalance later tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -200,7 +200,7 @@ TANK_DEFINITION
 	description = This is the all-new 1950's technology that will be used by SpaceX's Starship vehicle & Superheavy booster.
 	highlyPressurized = False
 	basemass = 0.000018 * volume
-	baseCost = 0.0025 * volume
+	baseCost = 0.0018 * volume
 	addResources = true
 	addLead = true
 	maxUtilization = 97
@@ -214,7 +214,7 @@ TANK_DEFINITION
 	description = This is a highly-pressurized tank, capable of storing propellants at pressures upwards of 100 MPa. However, substantial additional mass is required to safely maintain this high pressure.
 	highlyPressurized = true
 	basemass = 0.00005938 * volume
-	baseCost = 0.0025 * volume
+	baseCost = 0.0018 * volume
 	addResources = true
 	addResourcesHP = true
 	addLead = true
@@ -350,7 +350,7 @@ TANK_DEFINITION
 	baseCost = 0.01 * volume
 	addResources = true
 	addLead = true
-	maxUtilization = 96
+	maxUtilization = 97
 	defaultMass = 0.0000065
 }
 
@@ -407,7 +407,7 @@ TANK_DEFINITION
 	description = Balloon tanks do not have an internal framework, but instead rely on internal pressurization to keep its shape. If the pressurization fails, the balloon tank collapses. They are constructed of very thin sheets of stainless steel and have very good mass fractions, but the logistics involved in maintaining pressurization make them quite expensive. These modern balloon tanks were first used by Centaur III.
 	highlyPressurized = False
 	basemass = 0.000010 * volume
-	baseCost = 0.009 * volume
+	baseCost = 0.007 * volume
 	addResources = true
 	balloonTemps = true
 	addLead = true
@@ -655,7 +655,7 @@ PARTUPGRADE
 	title = Conventional Structure Tank Upgrade
 	basicInfo = You can now use stir-welded Steel Alloy Stringer tanks
 	manufacturer = Generic
-	description = You can now use stir-welded Steel Alloy Stringer tanks. This is the all-new 1950's technology that will be used by SpaceX's Starship vehicle & Superheavy booster. These are 24% (standard) or 70% (HP) heavier than refined Al-Li stringer tanks while costing the same amount to tool and 15% less once tooled.
+	description = You can now use stir-welded Steel Alloy Stringer tanks. This is the all-new 1950's technology that will be used by SpaceX's Starship vehicle & Superheavy booster. These are 24% (standard) or 70% (HP) heavier than refined Al-Li stringer tanks while costing 20% less to tool and once tooled.
 }
 
 //Isogrid
@@ -721,7 +721,7 @@ PARTUPGRADE
 	title = Isogrid Tank Upgrade
 	basicInfo = You can now use Advanced Carbon Composite tanks
 	manufacturer = Generic
-	description = You can now use Advanced Carbon Composite tanks. Ceramic-metal alloys and insulating complex composite structures are still speculative, but if they ever come to fruitition, they'd probably be something like this. These are 40% lighter than composite tanks while costing 33% more to tool and 18% more once tooled.
+	description = You can now use Advanced Carbon Composite tanks. Ceramic-metal alloys and insulating complex composite structures are still speculative, but if they ever come to fruition, they'd probably be something like this. These are 40% lighter than composite tanks while costing 33% more to tool and 18% more once tooled.
 }
 
 //Balloon tanks
@@ -761,7 +761,7 @@ PARTUPGRADE
 	title = Balloon Tank Upgrade
 	basicInfo = You can now use Steel & Aluminum-Lithium Alloy balloon tanks
 	manufacturer = Generic
-	description = You can now use Steel & Aluminum-Lithium Alloy balloon tanks. These modern balloon tanks were first used by Centaur III. These are 5% lighter than refined balloon tanks while costing the same amount to tool and 40% more once tooled.
+	description = You can now use Steel & Aluminum-Lithium Alloy balloon tanks. These modern balloon tanks were first used by Centaur III. These are 5% lighter than refined balloon tanks while costing 7% more to tool and 25% more once tooled.
 }
 
 // These patches mangle stock RF tank types because stock RF tank types just have stuff manually added 


### PR DESCRIPTION
Increase the max utilization of advanced composite tanks to match standard composite tanks
Make Starship tanks cheaper to balance their high weight
Change modern balloon tanks to only a bit more expensive than their refined counterparts (25% instead of 40%) and increase their tooling cost to 7% more than refined balloon tanks.

Please merge at same time as RP-1 counterpart