### PR TITLE
Fix Liquid-Core NTR Mixture Ratios

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LRCLNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/LRCLNTR_Config.cfg
@@ -110,7 +110,7 @@
 			PROPELLANT
 			{
 				name = CoreModerator	//1:50 Core Material (including Uranium):Hydrogen flow
-				ratio = 0.00010333
+				ratio = 0.00020667
 				DrawGauge = False
 				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
 			}

--- a/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/PrincetonLNTR_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Nuclear_Engine_Configs/PrincetonLNTR_Config.cfg
@@ -123,7 +123,7 @@
 			PROPELLANT
 			{
 				name = CoreModerator	//1:50 Core Material (including Uranium):Hydrogen flow
-				ratio = 0.00010333
+				ratio = 0.00020667
 				DrawGauge = False
 				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
 			}
@@ -185,7 +185,7 @@
 			PROPELLANT
 			{
 				name = CoreModerator	//1:50 Core Material (including Uranium):Hydrogen flow
-				ratio = 0.00010333
+				ratio = 0.00020667
 				DrawGauge = False
 				//don't ignore for ISP, reactor material in exhaust is limiting factor of LNTR performance.
 			}


### PR DESCRIPTION
CoreModerator is assumed to have a density of half of uranium dioxide, so to achieve a mass flow rate four times that of uranium, the volume ratio should be eight times, not four times. 

Old ratios:
![old](https://github.com/KSP-RO/RealismOverhaul/assets/87010939/c9a999d5-9396-48e9-bdc7-4cf358f645d7)
New ratios:
![new](https://github.com/KSP-RO/RealismOverhaul/assets/87010939/59c51b1d-05b8-40c3-9ad2-901fa7511de3)
