### PR TITLE
Shorten really long engine descriptions

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -60,12 +60,12 @@ Localization
 		//		AJ260FL
 		#roAJ260FLTitle = AJ-260 FL
 		#roAJ260FLDesc = The AJ-260 was the largest rocket motor ever tested. This is the full length version of the engine. With a gross mass of 1,648 tons, it provides a thrust of 35,391 kN for more than 2 minutes. This version was designed as an alternative to the Saturn IB and as a booster for Apollo Applications launch vehicles.
-		#roAJ260FLSideTitle = AJ-260 FL
+		#roAJ260FLSideTitle = AJ-260 FL Radial Solid Rocket Booster
 		#roAJ260FLSideDesc = The AJ-260 was the largest rocket motor ever tested. This is the full length version of the engine. With a gross mass of 1,648 tons, it provides a thrust of 35,391 kN for more than 2 minutes. This version was designed as an alternative to the Saturn IB and as a booster for Apollo Applications launch vehicles. This is the radially attached version to be used as a strap-on booster. [Diameter: 6.6 m]
 		//		AJ260SL
 		#roAJ260SLTitle = AJ-260 SL
 		#roAJ260SLDesc = The AJ-260 was the largest rocket motor ever tested. This is the short length version, a 21.6 x 6.6 meter behemoth that weighed more than 842 tons fully loaded. It was capable of providing over 15 MN of thrust for 120 seconds. The program was ultimately cancelled, but not before three test firings where the engines performed exactly to specifications.
-		#roAJ260SLSideTitle = AJ-260 SL
+		#roAJ260SLSideTitle = AJ-260 SL Radial Solid Rocket Booster
 		#roAJ260SLSideDesc = The AJ-260 was the largest rocket motor ever tested. This is the short length version, a 21.6 x 6.6 meter behemoth that weighed more than 842 tons fully loaded. It was capable of providing over 15 MN of thrust for 120 seconds. The program was ultimately cancelled, but not before three test firings where the engines performed exactly to specifications. This is the radially attached version to be used as a strap-on booster. [Diameter: 6.6 m]
 		//		Alcyone
 		#roAlcyoneTitle = Alcyone 1A BE-3A
@@ -348,7 +348,7 @@ Localization
 		#roLR87LH2Desc = Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. Aerojet also proposed this engine for Saturn upper stage duties, but NASA selected the J-2 over the LR87-LH2 and it was canceled in 1961.
 		//		LR89
 		#roLR89Title = LR43/LR89
-		#roLR89Desc = Beginning its life as the etholox-powered XLR43-NA-3, this was the first US engine to use tubular-wall construction for its combustion chamber. It served as the basis for US early orbital engines, with its lineage stretching to the 21st century. The LR43 was converted to run on kerosene for Atlas and was later renamed LR89, and the LR79 derivative powered Thor. Later LR89s were upgraded with RS-27 components for higher efficiency, whereas the RS-27 itself was used on Delta by that point. LR89 configs are comparable to similar-era -79 configs, since they were the same engine underneath.
+		#roLR89Desc = Beginning its life as the etholox-powered XLR43-NA-3, this was the first US engine to use tubular-wall construction for its combustion chamber. It served as the basis for early orbital US engines, with its lineage stretching to the 21st century. The LR43 was converted to run on kerosene for Atlas and was later renamed LR89, and the LR79 derivative powered Thor. Later LR89s used RS-27 components for higher efficiency, whereas the RS-27 itself was used on Delta by that point. LR89 configs are comparable to similar-era -79 configs, since they were the same engine underneath.
 		//		LR91
 		#roLR91Title = LR91
 		#roLR91Desc = The LR91 powered the second stage of Titan launchers. Exhaust from the gas generator provided roll control.
@@ -398,7 +398,7 @@ Localization
 		//N
 		//		NAA75_110
 		#roNAA75_110Title = NAA-75-110 A-Series
-		#roNAA75_110Desc = The power plant of the Redstone missile. Originally designed for ethanol/LOX (A-6) it was later adapted to use Hydyne/LOX for 6% more performance in Jupiter-C / Juno I. When adapted for crewed use under Mercury, the A-7 was used with the original ethalox mixture, accepting slightly lower performance for the lack of toxicity. TVC was provided by carbon thrust vanes and additional attitude control was provided by actuating fins in the guidance section.
+		#roNAA75_110Desc = The power plant of the Redstone missile. Originally designed for ethanol/LOX it was later adapted to use Hydyne/LOX for 6% more performance in Jupiter-C / Juno I. When adapted for crewed use under Mercury, the A-7 was used with the original ethalox mixture, accepting slightly lower performance for the lack of toxicity. TVC was provided by carbon thrust vanes and additional attitude control was provided by actuating fins in the guidance section.
 		//		NERVA
 		#roNERVATitle = NERVA I
 		#roNERVADesc = A 1970s low-TWR vacuum engine, the NERVA (Nuclear Engine for Rocket Vehicle Applications) is designed for orbital tugs and large rocket upper stages.
@@ -488,7 +488,7 @@ Localization
 		#roRD57Desc = A 1970s low TWR staged combustion hydrolox upper stage engine intended for use on the N-1/N-1M. A later version designated RD-57M had am extendable nozzle and was intended for the Vulkan and Energia-M rockets. The engine was marketed by Aerojet in the 1990s under the designation D-57 for use on an SSTO demonstrator.
 		//		RD58
 		#roRD58Title = S1.5400/RD-58 Series
-		#roRD58Desc = The world's first closed-cycle engine. The S1.5400 was used as the final stage for the R-7 in Molniya configuration to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (apogee kicks are needed for Molniya orbits). It was given the industry designation 11D33. The 11D33M brought upgrades and was the basis for the RD-58 with higher performance still (designated 11D58). The RD-58 was used on many Russian launchers, including N1 and Buran and is still in use on Proton and Zenit.
+		#roRD58Desc = The world's first closed-cycle engine. The S1.5400 was used as the final stage for the R-7's Molniya configuration to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (apogee kicks are needed for Molniya orbits). It was given the industry designation 11D33. The 11D33M brought upgrades and was the basis for the RD-58 with higher performance still (designated 11D58). The RD-58 was used on many Russian launchers, including N1 and Buran and is still in use on Proton and Zenit.
 		//		RD100
 		#roRD100Title = RD-100
 		#roRD100Desc = RD-100 series engines were the first large scale ethalox Russian engines ever developed and fired. The original RD-100 engine was a 1:1 copy of the German Model 39 engine (used on the A-4 ballistic missile), with later variants (RD-101 and RD-103/M) featuring ever increasing performance to satisfy the needs of the larger R-2 and R-5 IRBMs.
@@ -620,7 +620,7 @@ Localization
 		#roRD263Desc = A staged combustion hypergolic booster engine designed to replace the RD-250 engines used on the R-36. Also used for the MR-UR-100.
 		//		RD270
 		#roRD270Title = RD-270
-		#roRD270Desc = The largest single-chamber engine ever built in the USSR, and the first full-flow staged combustion engine, the RD-270 was fueled by NTO and UDMH combined under some of the highest pressures ever encountered in an ignition chamber. Extensively tested to power the first and second stages of the UR-700, it was cancelled with the rest of the UR-700 project and never flew, despite efforts to convert it to kerosene for the N-1.								
+		#roRD270Desc = The largest single-chamber engine ever built in the USSR, and the first full-flow staged combustion engine, the RD-270 was fueled by NTO and UDMH combined under some of the highest pressures ever encountered in an ignition chamber. Extensively tested to power the first and second stages of the UR-700, it was cancelled with the rest of the UR-700 project and never flew, despite efforts to convert it to kerosene for the N-1.
 		//		RD270M
 		#roRD270MTitle = RD-270M
 		#roRD270MDesc = Modification of the RD-270 to use highly toxic pentaborane as fuel. Although the M variant boasts higher thrust and isp, the fuel mixture is much, much more toxic than even UDMH. Pentaborane has a flash point of 30 degrees Celsius, a tendency to form shock-sensitive explosive compounds, and is classified as "immediately dangerous to life or health" with concentrations at or above one part per million. 
@@ -661,7 +661,7 @@ Localization
 		#roRitaDesc = A French solid rocket engine used on the Diamant BP4 launch vehicle, replacing the Topaz Second Stage.
 		//		RL10
 		#roRL10Title = RL10
-		#roRL10Desc = A restartable expander-cycle hydrolox engine used in multiple upper stages, including Centaur, the Saturn I S-IV, and the Delta Cryogenic Second Stage. It has low thrust, but very high isp and low mass.
+		#roRL10Desc = A restartable expander-cycle hydrolox engine used in multiple upper stages, including Centaur, the Saturn I S-IV, and the Delta Cryogenic Second Stage. It has low thrust, but very high ISP and low mass.
 		//		RL60
 		#roRL60Title = RL60/Vinci
 		#roRL60Desc = A next generation cryogenic upper stage engine designed to replace the RL10, providing higher performance while maintaining the same installation envelope. Also available in a lower 180kN thrust Vinci-180 model.

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -32,7 +32,7 @@ Localization
 		#roAestusDesc = A hypergolic upper stage engine. The baseline Aestus engine is pressure fed and is used on the Ariane 5 G, GS and ES series, while the Aestus II (also known as RS-72) variant is pump-fed with better overall performance.
 		//		Agena
 		#roAgenaTitle = XLR81 (Agena) Vacuum Engine
-		#roAgenaDesc = A missile-derived gas-generator engine used on Agena. Early engines were nearly identical to the military version, while later variants improved capabilities and performance. Engine restart was added on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D had propellant sumps to handle ullage. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
+		#roAgenaDesc = Originally developed for a standoff weapon for the B-58 Hustler, the XLR81 is a gas-generator engine with storable propellants. Later space variants improved performance and capability. Engine restart was added on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D used propellant sumps to handle ullage. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
 		//		AgenaSPS
 		#roAgenaSPSTitle = Agena-D Secondary Propulsion System
 		#roAgenaSPSDesc = A secondary propulsion system developed for the Gemini program on the Agena Target Vehicle. It allowed for fine control and orbital maneuvers without igniting the main engine. It was later offered to commercial customers as an upgrade for Agena. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -32,10 +32,10 @@ Localization
 		#roAestusDesc = A hypergolic upper stage engine. The baseline Aestus engine is pressure fed and is used on the Ariane 5 G, GS and ES series, while the Aestus II (also known as RS-72) variant is pump-fed with better overall performance.
 		//		Agena
 		#roAgenaTitle = XLR81 (Agena) Vacuum Engine
-		#roAgenaDesc = A gas-generator nitric acid/UDMH vacuum engine used on Agena. The XLR81 family was derived from the Bell Hustler Rocket Engine, originally developed for use on an air-to-surface missile. Early engines were nearly identical to the Hustler engine, while later variants offered new capabilities and improved performance. Engine restart was introduced on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D used propellant sumps to eliminate the need for ullage thrust. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
+		#roAgenaDesc = A missile-derived gas-generator engine used on Agena. Early engines were nearly identical to the military version, while later variants improved capabilities and performance. Engine restart was added on the Agena B's XLR81-BA-7 (Model 8081). The XLR81-BA-11 (Model 8096) used on Agena D had propellant sumps to handle ullage. The XLR81-BA-13 (Model 8247) powered the Gemini Agena Target Vehicle (a modified Agena D) and was rated for up to 14 restarts.
 		//		AgenaSPS
 		#roAgenaSPSTitle = Agena-D Secondary Propulsion System
-		#roAgenaSPSDesc = A secondary propulsion system developed for use in the Gemini program on the Agena Target Vehicle, allowing for fine control and orbital maneuvers without igniting the main engine. It was later made available to commercial customers as an optional upgrade for Agena. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
+		#roAgenaSPSDesc = A secondary propulsion system developed for the Gemini program on the Agena Target Vehicle. It allowed for fine control and orbital maneuvers without igniting the main engine. It was later offered to commercial customers as an upgrade for Agena. The system is a completely contained unit including propellant tanks, one 16-lb thrust chamber, and one 200-lb thrust chamber.
 		//		AJ10_137
 		#roAJ10_137Title = AJ10-137 (Service Propulsion System)
 		#roAJ10_137Desc = The Aerojet AJ10-137 was used as the Service Propulsion System on the Apollo CSM. It was designed to operate for up to 750 seconds and could restart 50 times.
@@ -44,13 +44,13 @@ Localization
 		#roAJ10_190Desc = A low thrust pressure-fed hypergolic engine used on the Space Shuttle for orbital insertion, maneuvering, and deorbiting. Currently used by the Orion MPCV.
 		//		AJ10_Adv
 		#roAJ10_AdvTitle = AJ10 Series (Advanced)
-		#roAJ10_AdvDesc = A small pressure-fed hypergolic engine. A derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents advanced era AJ10s with a nozzle extension and restart capability. Used on Transtage as AJ10-138; similar models but back with the -118 designation were used on the Delta F and Delta K upper stages.
+		#roAJ10_AdvDesc = A small pressure-fed hypergolic engine. A derivative of the first US liquid engine, the AJ10 is the longest-lived of any engine family, from the US's first satellite launch vehicle, Vanguard, through the Apollo CSM, and even planned for an Orion service module. This represents advanced AJ10s with a nozzle extension and restart capability. Used on Transtage and the Delta F and Delta K upper stages.
 		//		AJ10_Early
 		#roAJ10_EarlyTitle = AJ10 Series (Early)
-		#roAJ10_EarlyDesc = A small pressure-fed hypergolic engine. A derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This is the original Vanguard second stage / Able / Delta configuration, without restart capability.
+		#roAJ10_EarlyDesc = A small pressure-fed hypergolic engine. A derivative of the first US liquid engine, the AJ10 is the longest-lived of any engine family, from the US's first satellite launch vehicle, Vanguard, through the Apollo CSM, and even planned for an Orion service module. This is the original Vanguard second stage / Able / Delta configuration, without restart capability.
 		//		AJ10_Mid
 		#roAJ10_MidTitle = AJ10 Series (Mid)
-		#roAJ10_MidDesc = A small pressure-fed hypergolic engine. A derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This represents mid-period AJ10s with a nozzle extension and restart capability. Used on Thor-Ablestar and Delta E through Delta N.
+		#roAJ10_MidDesc = A small pressure-fed hypergolic engine. A derivative of the first US liquid engine, the AJ10 is the longest-lived of any engine family, from the US's first satellite launch vehicle, Vanguard, through the Apollo CSM, and even planned for an Orion service module. This represents mid-period AJ10s with a nozzle extension and restart capability. Used on Thor-Ablestar and Delta E through Delta N.
 		//		AJ10_Transtar
 		#roAJ10_TranstarTitle = AJ23 Transtar
 		#roAJ10_TranstarDesc = A pump-fed upgrade for the AJ10 developed in the 1980s as a high performance upper stage and tug. It was based heavily on the Shuttle OMS, with the same nozzle and combustion chamber, but had turbomachinery installed in place of a pressure-fed system. The program was cancelled after the Challenger disaster, but Transtar 1 flew as the Titan Launch Dispenser on Titan IV.
@@ -59,10 +59,14 @@ Localization
 		#roAJ60ADesc = The AJ-60A is an SRB produced by Aerojet Rocketdyne. They are currently used as strap-on boosters on United Launch Alliance's Atlas V rocket.
 		//		AJ260FL
 		#roAJ260FLTitle = AJ-260 FL
-		#roAJ260FLDesc = The AJ-260 was the largest rocket motor ever tested. This is the full length version of the engine. With a gross mass of 1,648 tons, it provides a thrust of 35,391 kN for more than 2 minutes. This version was designed as an alternative to the Saturn IB and as a booster motor for Apollo Applications launch vehicles.
+		#roAJ260FLDesc = The AJ-260 was the largest rocket motor ever tested. This is the full length version of the engine. With a gross mass of 1,648 tons, it provides a thrust of 35,391 kN for more than 2 minutes. This version was designed as an alternative to the Saturn IB and as a booster for Apollo Applications launch vehicles.
+		#roAJ260FLSideTitle = AJ-260 FL
+		#roAJ260FLSideDesc = The AJ-260 was the largest rocket motor ever tested. This is the full length version of the engine. With a gross mass of 1,648 tons, it provides a thrust of 35,391 kN for more than 2 minutes. This version was designed as an alternative to the Saturn IB and as a booster for Apollo Applications launch vehicles. This is the radially attached version to be used as a strap-on booster. [Diameter: 6.6 m]
 		//		AJ260SL
 		#roAJ260SLTitle = AJ-260 SL
-		#roAJ260SLDesc = The AJ-260 was the largest rocket motor ever tested. This is the short length version, a 21.6 x 6.6 meter behemoth that weighed more than 842 tons fully loaded. It was capable of providing over 15,000 kN of thrust for 120 seconds. The program was ultimately cancelled, but not before three test firings where the engines performed exactly to specifications.
+		#roAJ260SLDesc = The AJ-260 was the largest rocket motor ever tested. This is the short length version, a 21.6 x 6.6 meter behemoth that weighed more than 842 tons fully loaded. It was capable of providing over 15 MN of thrust for 120 seconds. The program was ultimately cancelled, but not before three test firings where the engines performed exactly to specifications.
+		#roAJ260SLSideTitle = AJ-260 SL
+		#roAJ260SLSideDesc = The AJ-260 was the largest rocket motor ever tested. This is the short length version, a 21.6 x 6.6 meter behemoth that weighed more than 842 tons fully loaded. It was capable of providing over 15 MN of thrust for 120 seconds. The program was ultimately cancelled, but not before three test firings where the engines performed exactly to specifications. This is the radially attached version to be used as a strap-on booster. [Diameter: 6.6 m]
 		//		Alcyone
 		#roAlcyoneTitle = Alcyone 1A BE-3A
 		#roAlcyoneDesc = A very small solid kick motor developed for use as the 5th stage on the Scout launch vehicles. It was only ever launched once, on the Scout E-1 used for Explorer 52. Maximum thrust 27.5kN, burn time 9 seconds.
@@ -133,7 +137,7 @@ Localization
 		#roCastor-2Desc = A derivative of the Castor 1 motor, the Castor 2 featured higher specific impulse and propellant load, a lower dry mass fraction, and a longer burn time. It was used as strap-on booster starting with Delta E and in all but the early Scouts. Burn time 39s.
 		//		Castor-4
 		#roCastor-4Title = Castor 4
-		#roCastor-4Desc = The Castor 4 was developed as the second stage of the Athena H missile and first flew in 1971. It was later adapted to replace Delta's Castor 2 boosters, increasing GTO capacity from 723 kg to nearly 900 kg. The resulting Delta 3000-series launched in 1975 and was the first to adopt a staggered booster staging sequence. Previous Delta vehicles burned their motors in a 6-3 sequence and then jettisoned all SRMs at once. The heavier and longer-burning Castor 4 required that the ground-lit motors be jettisoned immediately after depletion to reduce dead weight. Early launches used a less efficient 5-4 sequence to reduce acceleration but returned to a 6-3 sequence after Delta was strengthened in the early 80s.
+		#roCastor-4Desc = The Castor 4 was developed as the second stage of the Athena H missile and first flew in 1971. It was later adapted to replace Delta's Castor 2 boosters, increasing GTO capacity from 723 kg to nearly 900 kg. The Delta 3000-series launched in 1975 with a staggered booster staging sequence. Previous Deltas burned their motors in a 6-3 sequence and then jettisoned all SRMs at once. The heavier and longer-burning Castor 4 required that the motors be jettisoned as soon as they ran out to reduce dead weight. A less efficient 5-4 sequence was used until Delta was strengthened in the early 80s to handle the acceleration of a 6-3 sequence.
 		//		Castor-4A
 		#roCastor-4ATitle = Castor 4A
 		#roCastor-4ADesc = The Castor 4A was introduced on the first generation of Delta II launchers, the 6000-series, and offered improved thrust and specific impulse by replacing PBAA with higher energy HTPB. This, combined with a stretched first stage (the Extra-Extended Long Tank Thor), and a return to the more efficient 6-3 SRM ignition sequence, improved Delta's performance by 11% over the 3000-series. The Castor 4A was flown on the Delta II from 1989 until 1993, when it was replaced by the GEM 40. The boosters were also used on the Atlas IIAS from 1993 until 2004. Burn time 53 seconds.
@@ -148,7 +152,7 @@ Localization
 		#roCastor-30BDesc = The CASTOR 30B is a low cost, robust, state-of-the-art upper stage motor. This production motor incorporates a few modifications from the CASTOR 30, primarily a change in propellant and a longer nozzle. It is 169.9 inches long and nominally designed as an upper stage that can function as a second or third stage depending on the vehicle configuration.
 		//		Castor-30XL
 		#roCastor-30XLTitle = Castor 30XL
-		#roCastor-30XLDesc = The CASTOR 30XL is more than a stretched version of the CASTOR 30. The motor is 235.8 inches long and designed to function as a second or third stage depending on the vehicle configuration. The nozzle is 8 feet long, with a submerged design, a high-performance expansion ratio (55.9:1), and a dual density exit cone for high altitude operation. It features an electro-mechanical TVA system with actuators, thermal battery, and electronic controller.
+		#roCastor-30XLDesc = The CASTOR 30XL is more than a stretched version of the CASTOR 30. The motor is 235.8 inches long and designed to function as a second or third stage depending on vehicle configuration. The nozzle is 8 feet long and submerged, with a high expansion ratio (55.9:1), a dual density exit cone for high altitude operation, and an electro-mechanical TVA system.
 		//		Castor-120
 		#roCastor-120Title = Castor 120
 		#roCastor-120Desc = The Castor 120 is a medium solid booster used on the Minotaur and Athena launch vehicles. Its design was based on the TU-903, which serves as the first stage of the Peacekeeper ICBM. The standard thrust curve can be modified to produce a regressive burn that reduces maximum acceleration or a saddle-shaped profile that limits aerodynamic forces. Burn time 79 seconds.
@@ -212,20 +216,20 @@ Localization
 		#roGEM-40Desc = The Graphite-Epoxy Motor (GEM) replaced the steel case used on earlier Castor-series boosters with a lighter composite case. The 40-inch (1-meter) diameter GEM 40 was used on the Delta II 7000-series in sets of three, four, or nine. When nine boosters were used, six were ignited at liftoff and the remaining three were ignited after burnout and jettison of the first six. Burn time: 58 seconds.
 		//		GEM-46
 		#roGEM-46Title = GEM 46
-		#roGEM-46Desc = The 46-inch (1.2-meter) diameter GEM 46 was used on the Delta III and Delta II Heavy. On both vehicles they were used in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with TVC while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC. Burn time 75 seconds.
+		#roGEM-46Desc = The 46-inch (1.2-m) diameter GEM 46 was used on the Delta III and Delta II Heavy in sets of nine, with six ignited at liftoff and three ignited after burnout of the first six. On the Delta III, three ground-lit boosters were equipped with TVC while all the remaining boosters used fixed nozzles. The Delta II Heavy used no boosters with TVC. Burn time 75 seconds.
 		//		GEM-60
 		#roGEM-60Title = GEM 60
 		#roGEM-60Desc = The 60-inch (1.5-meter) diameter GEM 60 is used on the Delta IV in sets of two or four. When two boosters are used, both are equipped with thrust vector control (TVC). When four are used, two boosters use TVC while the other two use fixed nozzles to reduce weight. Burn time 90 seconds.
 		//		GEM-63
 		#roGEM-63Title = GEM 63
-		#roGEM-63Desc = In 2015, ULA announced that Orbital ATK would develop the GEM 63 as a drop-in replacement for the AJ-60A, and would replace Aerojet Rocketdyne as their Atlas V SRM supplier by the end of 2018. The GEM 63 will be larger than the GEM 60 used on the Delta IV and will not be equipped with thrust vectoring. As with the AJ-60A, launches using the four-meter fairing will be able to be equipped with up to three boosters while up to five boosters can be used with the five-meter fairing.
+		#roGEM-63Desc = In 2015, ULA announced that Orbital ATK would develop the GEM 63 as a drop-in replacement for the AJ-60A, and replace Aerojet-Rocketdyne for Atlas V SRMs. The GEM 63 is larger than the GEM 60 used on the Delta IV and cannot thrust vector. As with the AJ-60A, launches using the 4 m fairing will be able to use up to three boosters while up to five can be used with the 5 m fairing.
 		//		GEM-63XL
 		#roGEM-63XLTitle = GEM 63XL
 		#roGEM-63XLDesc = In addition to the GEM 63 for Atlas V, Orbital ATK will develop a larger variant, the GEM 63XL, for Vulcan. The boosters will be approximately 1.5 m longer than the GEM 63 and Vulcan will be able to use up to four boosters with a four-meter fairing or six boosters with a five-meter fairing.
 		//H
 		//		H1
 		#roH1Title = H-1/RS-27
-		#roH1Desc = The H-1 is an upgrade to the original LR79 engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1/RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio optimized for performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters.
+		#roH1Desc = The H-1 is an upgrade to the original LR79 engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The RS-27A has a higher expansion ratio optimized for performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters.
 		//		HERMeS
 		#roHERMESTitle = HERMeS Hall Effect Thruster
 		#roHERMESDesc = HERMeS (Hall Effect Rocket with Magnetic Shielding) is a an experimental Hall effect ion thruster. It was later developed into AEPS, the planned propulsion system for the Lunar Gateway.
@@ -301,7 +305,7 @@ Localization
 		#roKTDU425ADesc = A Soviet gas generator hypergolic vacuum engine. Designed for use in the propulsion systems of the Mars and Venera 3MV, 4MV and 5MV spacecraft buses.
 		//		KVD1
 		#roKVD1Title = RD-56/KVD-1/CE-7.5
-		#roKVD1Desc = A staged combustion hydrolox upper stage engine intended for the N-1M and considered for Proton and Angara, and eventually licensed to India for its GSLV. Later versions were developed by India for domestic use as the CE-7.5. The main engine bell is fixed in place and two verniers are used to provide combined pitch-yaw-roll control. This engine runs with a somewhat higher than average O/F ratio, resulting in a denser than average hydrolox stage.
+		#roKVD1Desc = A staged combustion hydrolox engine intended for the N-1M, considered for Proton and Angara, and eventually licensed to India for its GSLV. Later versions were developed by India for domestic use as the CE-7.5. The main engine bell is fixed in place and two verniers provide combined pitch-yaw-roll control. This engine runs with a somewhat higher than average O/F ratio, resulting in a denser than average hydrolox stage.
 		//L
 		//		LE3
 		#roLE3Title = LE-3
@@ -326,7 +330,7 @@ Localization
 		#roLMAEDesc = A pressure-fed engine used for the ascent module of the Apollo lunar lander.
 		//		LMDE
 		#roLMDETitle = Lunar Module Descent Engine (LMDE)
-		#roLMDEDesc = A deeply-throttleable pressure-fed engine used for the descent module of the Apollo lunar lander. The version used on J-class missions had slightly higher specific impulse, which helped enough payload capacity for the rover and other equipment. A later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts and slightly higher thrust but lower efficiency and no throttling capability.
+		#roLMDEDesc = A deeply-throttleable pressure-fed engine used for the descent module of the Apollo lunar lander. The version on J-class missions had slightly higher isp, which helped give payload capacity for the rover and other equipment. A later variant (TR-201) was used on Delta P series as an upper stage engine; this was a low-cost model with more restarts and slightly higher thrust but with lower efficiency and no throttling.
 		//		LPNTR
 		#roLPNTRTitle = Low-Pressure NTR
 		#roLPNTRDesc = The low-pressure NTR is a proposal for a higher performance NTR, relying on hydrogen dissociation. By decreasing the chamber pressure of an NTR to near atmospheric pressure, it is possible to trigger dissociation of diatomic hydrogen into monatomic hydrogen, greatly increasing specific impulse. This low pressure also allows for extremely lightweight construction, allowing for an acceptable TWR despite the low mass flow. The LPNTR is also extremely simple, requiring no pumps, and self-regulating using hydrogen as a moderator, although it also lacks a gimbal.
@@ -344,7 +348,7 @@ Localization
 		#roLR87LH2Desc = Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. Aerojet also proposed this engine for Saturn upper stage duties, but NASA selected the J-2 over the LR87-LH2 and it was canceled in 1961.
 		//		LR89
 		#roLR89Title = LR43/LR89
-		#roLR89Desc = Beginning its life as the etholox-powered XLR43-NA-3, this was the first US engine to use tubular-wall construction for its combustion chamber. It served as the basis for the early orbital engines of the US, with its lineage carrying on all the way to the 21st century. The LR43 was converted to run on kerosene for Atlas and was later renamed LR89, and the LR79 derivative powered Thor. Late model LR89s were upgraded with RS-27 components for higher efficiency, whereas the RS-27 itself was used on Delta by that point. LR89 configs are comparable to similar-era -79 configs, since they were the same engine underneath.
+		#roLR89Desc = Beginning its life as the etholox-powered XLR43-NA-3, this was the first US engine to use tubular-wall construction for its combustion chamber. It served as the basis for US early orbital engines, with its lineage stretching to the 21st century. The LR43 was converted to run on kerosene for Atlas and was later renamed LR89, and the LR79 derivative powered Thor. Later LR89s were upgraded with RS-27 components for higher efficiency, whereas the RS-27 itself was used on Delta by that point. LR89 configs are comparable to similar-era -79 configs, since they were the same engine underneath.
 		//		LR91
 		#roLR91Title = LR91
 		#roLR91Desc = The LR91 powered the second stage of Titan launchers. Exhaust from the gas generator provided roll control.
@@ -353,7 +357,7 @@ Localization
 		#roLR101Desc = A pump or pressure-fed kerolox vernier engine. Used for attitude control and final velocity adjustment in the MA-x system (2x LR89 + LR105 + 2x LR101) on Atlas, and MB-x system (LR79 or RS-27 + 2xLR101) on Thor-Able, Thor-Agena, Thor-Delta, and Delta.
 		//		LR105
 		#roLR105Title = LR105
-		#roLR105Desc = Kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s), is lit on the ground, but a bit over 2 minutes into flight the boosters are dropped and the Atlas core continues to orbit under the power of the sustainer engine (and the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for increased performance. As a sustainer engine, the LR105 has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine.
+		#roLR105Desc = A kerolox gas-generator sustainer engine used in the Atlas launch vehicle. It, like the Atlas's booster engines (LR89s), is lit on the ground, but after a bit over 2 minutes the boosters are dropped and Atlas continues to orbit under the power of the LR105 (with the verniers for roll control and final adjustment). The final configuration of the LR105 (like the LR89) uses RS-27 components for better performance. As a sustainer, the LR105 has sea level and vacuum efficiencies somewhere between a booster and an upper stage engine.
 		//		LR129
 		#roLR129Title = LR129
 		#roLR129Desc = Staged combustion sustainer engine developed for the USAF ISINGLASS spaceplane. After the ISINGLASS project was cancelled, it was adapted by P&W for their SSME proposal. It utilized staged combustion, mixture control, and extendable nozzles to allow for versatility and high performance.
@@ -394,7 +398,7 @@ Localization
 		//N
 		//		NAA75_110
 		#roNAA75_110Title = NAA-75-110 A-Series
-		#roNAA75_110Desc = The power plant of the PGM-11 Redstone Short Range Ballistic Missile (SRBM). Originally designed for ethanol/LOX (A-6) it was later adapted to use Hydyne/LOX for approximately 6% more performance in Jupiter-C / Juno I. When the Redstone was adapted from the Jupiter-C for manned use under the Project Mercury (Mercury-Redstone Launch Vehicle - MRLV), the A-7 was used with the original ethalox mixture, accepting a slightly lower performance for the lack of toxicity. Thrust vector control was provided by carbon thrust vanes and additional attitude control was provided by actuating fins placed in the guidance section.
+		#roNAA75_110Desc = The power plant of the Redstone missile. Originally designed for ethanol/LOX (A-6) it was later adapted to use Hydyne/LOX for 6% more performance in Jupiter-C / Juno I. When adapted for crewed use under Mercury, the A-7 was used with the original ethalox mixture, accepting slightly lower performance for the lack of toxicity. TVC was provided by carbon thrust vanes and additional attitude control was provided by actuating fins in the guidance section.
 		//		NERVA
 		#roNERVATitle = NERVA I
 		#roNERVADesc = A 1970s low-TWR vacuum engine, the NERVA (Nuclear Engine for Rocket Vehicle Applications) is designed for orbital tugs and large rocket upper stages.
@@ -420,7 +424,7 @@ Localization
 		#roNK9VDesc = A staged combustion kerolox upper/vacuum engine designed by Kuznetsov for the Korolev GR-1 project. Reused (as NK-19) on the N1, upgraded for the N1F with restart capability as NK-31.
 		//		NK33
 		#roNK33Title = NK-15/33
-		#roNK33Desc =A soviet staged combustion booster engine developed as part of a Soviet initiative to build a 150 ton thrust booster engine for the N-1. The NK-15 was ultimately chosen to power the N-1, and the NK-33 developed to power the upgraded N-1F. Though the N-1F was scrapped, the engines survived. Aerojet acquired several NK-33 engines in the 1990s and refurbished them as AJ26-62 engines for the Antares launch vehicle. Modifications made by Aerojet included increasing rated thrust and equipping the engines to support gimballing.
+		#roNK33Desc =A staged combustion engine developed as part of an initiative to build a 150-ton-thrust booster engine for the N-1. The NK-15 powered the N-1, and the NK-33 was developed to power the upgraded N-1F. Though the N-1F was scrapped, the engines survived and were sold to Aerojet in the 1990s. Refurbished as AJ26-62 engines, they powered Antares. Modifications made by Aerojet included increasing thrust and adding gimbals.
 		//		NK43
 		#roNK43Title = NK-15V/43
 		#roNK43Desc = Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
@@ -457,7 +461,7 @@ Localization
 		//R
 		//		R4D11
 		#roR4D11Title = R-4D
-		#roR4D11Desc = A 490 N bipropellant thruster as found in the propulsion system of the ESA ATV and the Orion MPCV Service Module. The R-4D high performance liquid apogee thruster performs orbit-raising maneuvers for many communication satellite platforms, including the Astrium Eurostar 3000, Boeing Space Systems 702HP, MELCO DS-2000, and the Loral LS-1300. The R-4D has also played a role in NASA missions such as Cassini's orbital insertion around Saturn.
+		#roR4D11Desc = A 490 N bipropellant thruster found in the propulsion system of the ESA ATV and the Orion MPCV Service Module. It performs orbit-raising maneuvers for many communication satellite platforms, including the Astrium Eurostar 3000, Boeing Space Systems 702HP, MELCO DS-2000, and the Loral LS-1300. The R-4D has also played a role in NASA missions such as Cassini's orbital insertion around Saturn.
 		//		R40
 		#roR40Title = R-40
 		#roR40Desc = A pressure-fed vacuum hypergolic engine used for attitude control on the Space Shuttle.
@@ -484,7 +488,7 @@ Localization
 		#roRD57Desc = A 1970s low TWR staged combustion hydrolox upper stage engine intended for use on the N-1/N-1M. A later version designated RD-57M had am extendable nozzle and was intended for the Vulkan and Energia-M rockets. The engine was marketed by Aerojet in the 1990s under the designation D-57 for use on an SSTO demonstrator.
 		//		RD58
 		#roRD58Title = S1.5400/RD-58 Series
-		#roRD58Desc = World's first closed-cycle kerolox vacuum engine. The S1.5400 served as an R-7 upper stage and the RD-58 upgrade was used as an upper stage / OMS for many Soviet and Russian vehicles, such as Proton, N1, Zenit, and Buran. The S1.5400 was used as the Blok L stage, the final stage for the Molniya configuration of the R-7, to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (apogee kicks were needed to place Molniya satellites in their final orbits). It was given the industry designation 11D33. An upgraded version, termed 11D33M, had slightly improved performance. The RD-58 is a derivative of the 11D33M engine with higher performance (industry designation 11D58); it has been used on many Russian launchers and is still in use today on Proton and Zenit.
+		#roRD58Desc = The world's first closed-cycle engine. The S1.5400 was used as the final stage for the R-7 in Molniya configuration to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (apogee kicks are needed for Molniya orbits). It was given the industry designation 11D33. The 11D33M brought upgrades and was the basis for the RD-58 with higher performance still (designated 11D58). The RD-58 was used on many Russian launchers, including N1 and Buran and is still in use on Proton and Zenit.
 		//		RD100
 		#roRD100Title = RD-100
 		#roRD100Desc = RD-100 series engines were the first large scale ethalox Russian engines ever developed and fired. The original RD-100 engine was a 1:1 copy of the German Model 39 engine (used on the A-4 ballistic missile), with later variants (RD-101 and RD-103/M) featuring ever increasing performance to satisfy the needs of the larger R-2 and R-5 IRBMs.
@@ -607,19 +611,19 @@ Localization
 		#roRD0243Desc = Staged combustion booster engine module. Developed as the first stage engine of the R-29RM Submarine-Launched Ballistic Missile, the RD-0243 consists of an RD-0244 main engine and RD-0245 vernier engine. In order to save space, the engine is submerged within the fuel tank of the R-29RM, with the rear bulkhead of the missile welded to the engine nozzle. Also used on the Shtil' launch vehicle, a unique smallsat launcher capable of being deployed from Delta IV submarines.
 		//		RD253
 		#roRD253Title = RD-253/RD-275
-		#roRD253Desc = Soviet hypergolic staged combustion booster engine. Developed as part of a Soviet initiative to build a 150 ton thrust booster engine for the N-1, versions were created burning nitric acid, nitrogen tetroxide, or liquid oxygen with UDMH. Although the NK-15 was ultimately selected to power the N-1, the RD-253, using nitrogen tetroxide, was chosen to power the UR-500/Proton, becoming the workhorse of the Soviet space program.
+		#roRD253Desc = A Soviet hypergolic staged combustion engine. Developed as part of an initiative to build a 150-ton-thrust booster engine for the N-1, versions were created burning nitric acid, NTO, or LOX with UDMH. Although the NK-15 was ultimately selected to power the N-1, the RD-253, using NTO, was chosen to power the UR-500/Proton, becoming the workhorse of the Soviet space program.
 		//		RD254
 		#roRD254Title = RD-254
-		#roRD254Desc = Soviet hypergolic staged combustion vacuum engine. Developed as part of a Soviet initiative to build a 150 ton thrust vacuum engine for the N-1, versions were created burning nitric acid, nitrogen tetroxide, or liquid oxygen with UDMH. Although the NK-15V was ultimately selected to power the N-1, the RD-254, using nitrogen tetroxide, was chosen to power the upper stages of the UR-700. Unlike it's sibling, the RD-253, the RD-254 was cancelled with the rest of the UR-700 project and never flew.
+		#roRD254Desc = A Soviet hypergolic staged combustion engine. Developed as part of an initiative to build a 150-ton-thrust vacuum engine for the N-1, versions were created burning nitric acid, NTO, or LOX with UDMH. Although the NK-15V was ultimately selected to power the N-1, the RD-254, using NTO, was chosen to power the upper stages of the UR-700. The RD-254 was cancelled with the rest of the UR-700 project and never flew.
 		//		RD263
 		#roRD263Title = RD-263/RD-268
 		#roRD263Desc = A staged combustion hypergolic booster engine designed to replace the RD-250 engines used on the R-36. Also used for the MR-UR-100.
 		//		RD270
 		#roRD270Title = RD-270
-		#roRD270Desc = The largest single-chamber engine ever built in the Soviet Union, and the first engine to ever use full-flow staged combustion, the RD-270 was fueled by an NTO/UDMH mixture combined under some of the highest pressures ever encountered in an ignition chamber. Intended to power the first and second stages of the UR-700, it was cancelled with the rest of the UR-700 project, despite efforts to convert it to kerosene for use on the N-1 instead. Never flown but extensively tested.
+		#roRD270Desc = The largest single-chamber engine ever built in the USSR, and the first full-flow staged combustion engine, the RD-270 was fueled by NTO and UDMH combined under some of the highest pressures ever encountered in an ignition chamber. Extensively tested to power the first and second stages of the UR-700, it was cancelled with the rest of the UR-700 project and never flew, despite efforts to convert it to kerosene for the N-1.								
 		//		RD270M
 		#roRD270MTitle = RD-270M
-		#roRD270MDesc = Modification of the RD-270 to use highly toxic pentaborane as fuel. Although the M variant boasts higher thrust and isp, the fuel mixture is much, much more toxic than even UDMH. Pentaborane has a flash point of 30 degrees Celsius, a tendency to form shock-sensitive explosive compounds, and is classified as "immediately dangerous to life and health" with concentrations at or above one part per million. 
+		#roRD270MDesc = Modification of the RD-270 to use highly toxic pentaborane as fuel. Although the M variant boasts higher thrust and isp, the fuel mixture is much, much more toxic than even UDMH. Pentaborane has a flash point of 30 degrees Celsius, a tendency to form shock-sensitive explosive compounds, and is classified as "immediately dangerous to life or health" with concentrations at or above one part per million. 
 		//		RD301
 		#roRD301Title = RD-301
 		#roRD301Desc = An exotic fuel-rich staged combustion vacuum engine. Developed as a high-energy upper stage for Proton by Glushko, the RD-301 burned liquid fluorine and ammonia, which gave very high performance and density. It was tested extensively, but never flew due to toxicity concerns.
@@ -657,7 +661,7 @@ Localization
 		#roRitaDesc = A French solid rocket engine used on the Diamant BP4 launch vehicle, replacing the Topaz Second Stage.
 		//		RL10
 		#roRL10Title = RL10
-		#roRL10Desc = A restartable expander-cycle hydrolox engine used in multiple upper stages, including Centaur, the Saturn I S-IV, and the Delta Cryogenic Second Stage. It has low thrust, but very high specific impulse and low mass, making it ideal for high energy applications beyond LEO, like launching satellites to geostationary transfer orbits or to the Moon or the planets beyond.
+		#roRL10Desc = A restartable expander-cycle hydrolox engine used in multiple upper stages, including Centaur, the Saturn I S-IV, and the Delta Cryogenic Second Stage. It has low thrust, but very high isp and low mass.
 		//		RL60
 		#roRL60Title = RL60/Vinci
 		#roRL60Desc = A next generation cryogenic upper stage engine designed to replace the RL10, providing higher performance while maintaining the same installation envelope. Also available in a lower 180kN thrust Vinci-180 model.
@@ -744,7 +748,7 @@ Localization
 		#roSPT140Desc = The SPT-140 is an enlarged SPT-100 created to power large, modern communications satellites.
 		//		SRMU
 		#roSRMUTitle = SRMU
-		#roSRMUDesc = The Titan IVB Solid Rocket Motor Upgrade (SRMU, also know as the Upgraded Solid Rocket Motor or USRM), was developed with the goal of achieving a 25% increase in capacity over the Titan IVA with the UA1207 SRM. It achieved this through the use of a more energetic propellant and a 3-segment composite case that carried more fuel and weighed less than the UA1207's 7-segment steel case. Burn time 150 seconds.
+		#roSRMUDesc = The Titan IVB Solid Rocket Motor Upgrade (also known as the Upgraded Solid Rocket Motor or USRM), was developed with the goal of 25% more capacity than the Titan IVA with the UA1207 SRM. It achieved this through a more energetic propellant and a 3-segment composite case that carried more fuel and weighed less than the UA1207's 7-segment steel case. Burn time 150 seconds.
 		//		SSBE
 		#roSSBETitle = SSBE
 		#roSSBEDesc = Developed from the RS-25 SSME, the Space Shuttle Booster Engine (SSBE) was a concept for a kerolox fueled Space Shuttle booster. The engine used three fuel-rich preburners, burning a mixture of LH2 and RP-1 to minimize coking. The LH2 was also used to cool the combustion chamber, allowing unmodified SSME components to be used.
@@ -891,7 +895,10 @@ Localization
 		#roVikasDesc = A high thrust hypergolic vacuum engine. Derived from the European Viking engines that were used on the early Ariane launch vehicles for booster or sustainer roles. ISRO adapted them as a vacuum engine for the second stage of the Polar Satellite Launch Vehicle (PSLV) and the Geosynchronous Satellite Launch Vehicle (GSLV) families.
 		//		Viking
 		#roVikingTitle = Viking
-		#roVikingDesc = A hypergolic booster engine developed for the European Ariane launch vehicle. Used as both a first stage engine and second stage engine when equipped with an extended nozzle. A version was also created for the Ariane 4 strap-on liquid boosters. Average performance compared to its contemporaries, but reliable.
+		#roVikingDesc = A hypergolic booster engine developed for the European Ariane launch vehicle. Used as both a first stage engine and second stage engine when equipped with an extended nozzle. A version was also created for the Ariane 4 strap-on liquid boosters. Unremarkable performance, but good reliability.
+		//		Viking (5/6)
+		#roViking56Title = Viking (5/6)
+		#roViking56Desc = Operational Viking variants with bell nozzle. Includes those used on the first stage of Ariane 1-4, and on the Ariane 4 strap-on liquid boosters. The Viking is a hypergolic booster engine developed for Ariane and used as both a first and second stage engine (when equipped with an extended nozzle). Unremarkable performance, but good reliability.
 		//		Vulcain
 		#roVulcainTitle = Vulcain
 		#roVulcainDesc = Vulcain is a gas-generator sustainer engine used on Ariane 5 and planned for Ariane 6.

--- a/GameData/RealismOverhaul/Waterfall_Configs/_Processor/99_finalize.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/_Processor/99_finalize.cfg
@@ -4,10 +4,10 @@
 @PART[*]:HAS[@ROWaterfall]:FOR[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
 {
     @description ^= : Plume configured by RealPlume.$::
-    @description ^= :$: <i>Plume and sound provided by Waterfall.</i>:
+    @description ^= :$: <i>Plume and sound from Waterfall.</i>:
 }
 
 @PART[*]:HAS[@ROWaterfall:HAS[#useHybrid]]:FOR[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
 {
-    @description ^= :provided by Waterfall:provided by Waterfall and SmokeScreen:
+    @description ^= :from Waterfall:from Waterfall and SmokeScreen:
 }


### PR DESCRIPTION
Also added localisations for some of the longer engines that needed it.
Hopefully it's fine to switch to plume and sound from Waterfall, as it's a bit shorter.
Viking (5/6) and the AJ260 radial will need scroll bars until I finish localizing ROE
Currently, only the NAA75, LR89, LR105, Agena, RD58, Castor 4 and AJ260 SL radial have scroll bars, and those descriptions have all been shortened significantly.
Removed advice on how to use an RL10 as that should be clear from its stats.
In general, some review would be nice. I've tested it, but I have had to elide some information and want to make sure I'm not removing too much