### PR TITLE
Add KerbalFoundries 2 RO configs, attempt 2

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
@@ -4,7 +4,13 @@
 	@mass = 0.05
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.05 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.05
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 43.0
@@ -29,7 +35,13 @@
 	@mass = 0.055
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.055 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.055
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 43.0
@@ -54,7 +66,13 @@
 	@mass = 0.03
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.03 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.03
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 11.0
@@ -79,10 +97,18 @@
 	@mass = 0.02
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.02 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.02
+		%minScale = 0.5
+		%maxScale = 2
+		%maxSpeed = 22
+		%maxLoadRating = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
-		%wheelSpeedMax = 65.0
+		%wheelSpeedMax = 20
 		@idleDrain = 0
 
 		@RESOURCE[ElectricCharge] { @rate = 4 }
@@ -91,9 +117,9 @@
 		torqueCurve
 		{
 			key = 0.0  2.0 0.0 0.0
-			key = 21.6  1.5 0.0 0.0
-			key = 43.3 0.5 0.0 0.0
-			key = 65 0.0 0.0 0.0
+			key = 6.6  1.5 0.0 0.0
+			key = 13.3 0.5 0.0 0.0
+			key = 20 0.0 0.0 0.0
 		}
 	}
 }
@@ -104,10 +130,18 @@
 	@mass = 0.1
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.1 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.1
+		%minScale = 0.5
+		%maxScale = 2
+		%maxSpeed = 30
+		%maxLoadRating = 3
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
-		%wheelSpeedMax = 43.5
+		%wheelSpeedMax = 30
 		@idleDrain = 0
 
 		@RESOURCE[ElectricCharge] { @rate = 10 }
@@ -116,9 +150,9 @@
 		torqueCurve
 		{
 			key = 0.0  2.0 0.0 0.0
-			key = 14.3  1.5 0.0 0.0
-			key = 28.6 0.5 0.0 0.0
-			key = 43 0.0 0.0 0.0
+			key = 10  1.5 0.0 0.0
+			key = 20 0.5 0.0 0.0
+			key = 30 0.0 0.0 0.0
 		}
 	}
 }
@@ -129,10 +163,16 @@
 	@mass = 0.75
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.75 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.75
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
-		%wheelSpeedMax = 43.5
+		%wheelSpeedMax = 43
 		@idleDrain = 0
 
 		@RESOURCE[ElectricCharge] { @rate = 20 }
@@ -154,7 +194,13 @@
 	@mass = 0.08
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.08 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.08
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 11.5
@@ -179,7 +225,13 @@
 	@mass = 0.05
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.05 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.05
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -204,7 +256,13 @@
 	@mass = 0.1
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.1 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.1
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -226,10 +284,18 @@
 @PART[KF-Skid]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.5
+	@mass = 0.1
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.5 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.1
+		%minScale = 0.5
+		%maxScale = 2
+		%maxSpeed = 110
+		%maxLoadRating = 15
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 50.0
@@ -254,7 +320,13 @@
 	@mass = 0.75
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.75 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.75
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -279,7 +351,13 @@
 	@mass = 0.95
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.95 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.95
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -304,7 +382,13 @@
 	@mass = 0.2
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.2 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.2
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -329,13 +413,22 @@
 	@mass = 2
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 2 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 2
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
 		@idleDrain = 0
 
-		@RESOURCE[ElectricCharge] { @rate = 100 }
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 100
+		}
 
 		!torqueCurve,*{}
 		torqueCurve
@@ -354,7 +447,13 @@
 	@mass = 0.065
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 0.065 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.065
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -378,7 +477,13 @@
 	@mass = 1.0
 	@crashTolerance = 18
 
-	@MODULE[ModuleWheelBase] { @mass = 1.0 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 1.0
+		%minScale = 0.5
+		%maxScale = 2
+	}
+
 	@MODULE[ModuleWheelMotor]
 	{
 		%wheelSpeedMax = 23.5
@@ -400,17 +505,31 @@
 @PART[KF-ALG-Small]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.1
+	@mass = 0.19
 
-	@MODULE[ModuleWheelBase] { @mass = 0.1 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.19
+		%minScale = 0.35
+		%maxScale = 1.5
+		%maxSpeed = 120
+		%maxLoadRating = 20
+	}
 }
 
 @PART[KF-ALG-SmallSide]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.09
+	@mass = 0.2
 
-	@MODULE[ModuleWheelBase] { @mass = 0.09 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.2
+		%minScale = 0.35
+		%maxScale = 1.5
+		%maxSpeed = 120
+		%maxLoadRating = 20
+	}
 }
 
 @PART[KF-ALG-Medium]:FOR[RealismOverhaul]
@@ -418,7 +537,14 @@
 	%RSSROConfig = True
 	@mass = 0.46
 	
-	@MODULE[ModuleWheelBase] { @mass = 0.46 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 0.46
+		%minScale = 0.7
+		%maxScale = 1.5
+		%maxSpeed = 150
+		%maxLoadRating = 40
+	}
 }
 
 @PART[KF-ALG-Large]:FOR[RealismOverhaul]
@@ -426,5 +552,12 @@
 	%RSSROConfig = True
 	@mass = 1.5
 
-	@MODULE[ModuleWheelBase] { @mass = 1.5 }
+	@MODULE[KSPWheelBase]
+	{
+		%wheelMass = 1.5
+		%minScale = 0.7
+		%maxScale = 2
+		%maxSpeed = 150
+		%maxLoadRating = 130
+	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
@@ -1,0 +1,430 @@
+@PART[KF-WheelTruck-Single]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.05
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.05 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 43.0
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 1 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 14.3  1.5 0.0 0.0
+			key = 28.6 0.5 0.0 0.0
+			key = 43 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-WheelTruck-Dual]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.055
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.055 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 43.0
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 1.05 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 14.3  1.5 0.0 0.0
+			key = 28.6 0.5 0.0 0.0
+			key = 43 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-WheelTiny]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.03
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.03 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 11.0
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 0.2 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 3.6  1.5 0.0 0.0
+			key = 7.3 0.5 0.0 0.0
+			key = 11 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-WheelSmall]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.02
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.02 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 65.0
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 4 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 21.6  1.5 0.0 0.0
+			key = 43.3 0.5 0.0 0.0
+			key = 65 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-WheelMedium]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.1
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.1 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 43.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 10 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 14.3  1.5 0.0 0.0
+			key = 28.6 0.5 0.0 0.0
+			key = 43 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-WheelLarge]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.75
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.75 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 43.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 20 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 14.3  1.5 0.0 0.0
+			key = 28.6 0.5 0.0 0.0
+			key = 43 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackTiny]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.08
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.08 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 11.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 4 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 3.8  1.5 0.0 0.0
+			key = 7.6 0.5 0.0 0.0
+			key = 11.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackSurface]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.05
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.05 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 1 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackSmall]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.1
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.1 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 10 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-Skid]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.5
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.5 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 50.0
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 10 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 50 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackInverting]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.75
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.75 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 24 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackLong]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.95
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.95 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 30 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackMedium]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.2
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.2 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 15 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackMole]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 2
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 2 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 100 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-TrackSimple]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.065
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 0.065 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+		@RESOURCE[ElectricCharge] { @rate = 2 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-ScrewDrive]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 1.0
+	@crashTolerance = 18
+
+	@MODULE[ModuleWheelBase] { @mass = 1.0 }
+	@MODULE[ModuleWheelMotor]
+	{
+		%wheelSpeedMax = 23.5
+		@idleDrain = 0
+
+		@RESOURCE[ElectricCharge] { @rate = 25 }
+
+		!torqueCurve,*{}
+		torqueCurve
+		{
+			key = 0.0  2.0 0.0 0.0
+			key = 7.8  1.5 0.0 0.0
+			key = 15.6 0.5 0.0 0.0
+			key = 23.5 0.0 0.0 0.0
+		}
+	}
+}
+
+@PART[KF-ALG-Small]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.1
+
+	@MODULE[ModuleWheelBase] { @mass = 0.1 }
+}
+
+@PART[KF-ALG-SmallSide]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.09
+
+	@MODULE[ModuleWheelBase] { @mass = 0.09 }
+}
+
+@PART[KF-ALG-Medium]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 0.46
+	
+	@MODULE[ModuleWheelBase] { @mass = 0.46 }
+}
+
+@PART[KF-ALG-Large]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@mass = 1.5
+
+	@MODULE[ModuleWheelBase] { @mass = 1.5 }
+}


### PR DESCRIPTION
Continuation of #2763.

New in this PR:
* The correct partmodule is KSPWheelBase instead of ModuleWheelBase
* Greatly limit the min and max allowed scaling
* Rebalance most of the parts against what we already have configured