### PR TITLE
Config cleanup and some more improvements

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/18KS7800_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/18KS7800_Config.cfg
@@ -10,7 +10,7 @@
 //	Dry Mass: 27.21 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 34.09 kN
-//	ISP: ??? SL / 238.8 Vac
+//	ISP: 200? SL / 238.8 Vac
 //	Burn Time: 1.8
 //	Chamber Pressure: 6.89 MPa
 //	Propellant: NGNC

--- a/GameData/RealismOverhaul/Engine_Configs/25KS18000_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/25KS18000_Config.cfg
@@ -10,7 +10,7 @@
 //	Dry Mass: 117.9 Kg
 //	Thrust (SL): 82.7 kN
 //	Thrust (Vac): ??? kN
-//	ISP: 178 SL / ??? Vac
+//	ISP: 178 SL / 198.8? Vac
 //	Burn Time: 2.5
 //	Chamber Pressure: 9.24 MPa
 //	Propellant: NGNC

--- a/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A-4_Config.cfg
@@ -27,7 +27,7 @@
 //	Thrust (Vac): 288.68 kN
 //	ISP: 220 SL / 255 Vac
 //	Burn Time: 115
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.7? MPa	estimated with RPA
 //	Propellant: LOX / Hydyne
 //	Prop Ratio: 1.3253, same as A-6H?
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ10_Early_Config.cfg
@@ -9,7 +9,7 @@
 //
 //	Dry Mass: 84 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 35.585 kN
+//	Thrust (Vac): 33.8 kN
 //	ISP: 122 SL / 271 Vac		SL calculated with RPA
 //	Burn Time: 115
 //	Chamber Pressure: 1.4 MPa

--- a/GameData/RealismOverhaul/Engine_Configs/AJ260FL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ260FL_Config.cfg
@@ -1,29 +1,41 @@
+//	==================================================
 //	AJ-260 FL
-//	Bluedog_DB
 //
 //	Manufacturer: Aerojet
+//
 //	=================================================================================
 //	AJ-260 FL
-//	30.48 x 6.63448 m
+
 //	Dry Mass: 156,126 kg
-//	Thrust: 35,391 kN Vac
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 35,391 kN
 //	ISP: 238 SL / 263 Vac
 //	Web Burn Time: 114 s
 //	Total Burn Time: 130 s
+//	Chamber Pressure: 4.15 MPa
 //	Propellant: PBAN
-//	Propellant Weight: 1,492,229 kg
-//	Nozzle Diameter: 181 in
-//	Nozzle Expansion Ratio: 3.8:1
-//	Nozzle Exit Area:
+//	Throttle: N/A
+//	Nozzle Ratio: 3.8:1
+//	Ignitions: 1
 //	=================================================================================
 
-//	SOURCES
+//	Sources:
+
 //	#1: NASA CR-72127 - 260-in. Diameter Motor Deasibility Demonstration Program: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19670005578.pdf
 //	#2: NASA TM X-1906 - Thrust Vector Control Requirements for Launch Vehicles using a 260-inch Solid Rocket First Stage (1969): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700003019.pdf
 //	#3: Test of 260-Inch Diameter Motor SL-3: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680025253.pdf
-//
-//	=================================================================================
 
+//	Used by:
+
+//	* BDB
+//	* ROEngines
+
+//	Notes:
+
+//	30.48 x 6.63448 m
+//	Propellant Weight: 1,492,229 kg
+//	Nozzle Diameter: 181 in
+//	==================================================
 @PART[*]:HAS[#engineType[AJ260FL]]:FOR[RealismOverhaulEngines]
 {
 	%title = #roAJ260FLTitle	//AJ-260 FL

--- a/GameData/RealismOverhaul/Engine_Configs/AJ260SL_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AJ260SL_Config.cfg
@@ -1,38 +1,57 @@
+//	==================================================
 //	AJ-260 SL
-//	Bluedog_DB
 //
 //	Manufacturer: Aerojet
+//
 //	=================================================================================
 //	AJ-260 SL-1/2 (Short Length)
-//	80 ft, 9 in x 261.2 in = 21.6126 x 6.63448 m
+
 //	Dry Mass: 181,935 lb = 82,524.26 kg
 //	Liquid Injection Thrust Vector = 6650 kg added
 //	Total Dry Mass: 89,174.26 kg
-//	Thrust: 3,567,000 lbf = 15,866.8 kN
-//	Total Impulse: 371,900,000 lb s
+//	Thrust (SL): 3,567,000 lbf = 15,866.8 kN
+//	Thrust (Vac): ??? kN
 //	Web Burn Time: 114 s
 //	Total Burn Time: 130 s
-//	Chamber Pressure: 602 psia (max)
+//	Chamber Pressure: 4.15 MPa (max)
 //	Propellant: PBAN
-//	Propellant Weight: 1,676,366 lb = 760,386 kg
-//	Nozzle Diameter: 181 in
+//	Throttle: N/A
 //	Nozzle Expansion Ratio: 3.8:1
-//	Nozzle Exit Area:
+//	Ignitions: 1
 //	=================================================================================
 //	AJ-260 SL-3
-//	Thrust: 5,370,000 lbf = 23,886.941 kN
+
+//	Dry Mass: 181,935 lb = 82,524.26 kg
+//	Liquid Injection Thrust Vector = 6650 kg added
+//	Total Dry Mass: 89,174.26 kg
+//	Thrust (SL): 5,370,000 lbf = 23,886.941 kN
+//	Thrust (Vac): ??? kN
 //	Web Burn Time: 75.2 s
-//	Total Burn Time: 
+//	Total Burn Time: ???
+//	Chamber Pressure: 4.14 MPa (max)
+//	Propellant: PBAN
+//	Throttle: N/A
 //	Nozzle Area Ratio: 3.78
+//	Ignitions: 1
 //	=================================================================================
-//
-//	SOURCES
+
+//	Sources:
+
 //	#1: NASA CR-72127 - 260-in. Diameter Motor Deasibility Demonstration Program: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19670005578.pdf
 //	#2: NASA TM X-1906 - Thrust Vector Control Requirements for Launch Vehicles using a 260-inch Solid Rocket First Stage (1969): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19700003019.pdf
 //	#3: Test of 260-Inch Diameter Motor SL-3: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680025253.pdf
-//
-//	=================================================================================
 
+//	Used by:
+
+//	* BDB
+//	* ROEngines
+
+//	Notes:
+
+//	80 ft, 9 in x 261.2 in = 21.6126 x 6.63448 m
+//	Propellant Weight: 1,676,366 lb = 760,386 kg
+//	Nozzle Diameter: 181 in
+//	==================================================
 @PART[*]:HAS[#engineType[AJ260SL]]:FOR[RealismOverhaulEngines]
 {
 	%title = #roAJ260SLTitle	//AJ-260 SL

--- a/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AR1_Config.cfg
@@ -12,13 +12,11 @@
 //	Thrust (Vac): 2487 kN
 //	ISP: 305 SL / 337 Vac
 //	Burn Time: 450
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 26.66 MPa		same as RD-180???
 //	Propellant: LOX / RP-1
-//	Prop Ratio: 2.72 from the RD-180???
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
+//	Prop Ratio: 2.72		same as RD-180???
 //	Throttle: 100% to 50%
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 36.87		same as RD-180???
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Aestus_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 27.8 kN
 //	ISP: 113 SL / 306 Vac
 //	Burn Time: 1110
-//	Chamber Pressure: 1.1
+//	Chamber Pressure: 1.1 MPa
 //	Propellant: MON3 / MMH	designed in the 90s, probably MON3
 //	Prop Ratio: 1.9
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -7,7 +7,7 @@
 //	Model 117
 //	B-58 Hustler rocket pod
 //
-//	Dry Mass: 127 Kg
+//	Dry Mass: 114.3 Kg	a little lighter, because no Gimbal
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 67 kN
 //	ISP: 207 SL / 265.5 Vac		SL calculated with RPA
@@ -247,6 +247,7 @@
 			minThrust = 67
 			heatProduction = 100
 			gimbalRange = 0
+			massMult = 0.9
 			PROPELLANT
 			{
 				name = Kerosene

--- a/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Algol_III_Config.cfg
@@ -4,7 +4,7 @@
 //	Manufacturer: Aerojet
 //
 //	=================================================================================
-//	Algol III
+//	Algol IIIA
 //	Scout
 //
 //	Dry Mass: 1391.121 kg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 530.25896 kN
 //	ISP: 238 SL / 260.289 Vac
 //	Burn Time: 70
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.69 MPa
 //	Propellant: PBAN
 //	Prop Ratio: N/A
 //	Throttle: N/A
@@ -23,6 +23,7 @@
 //	Sources:
 
 //	NASA CR-165950 Scout Launch Vehicle Final Report.PDF
+//	https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770010201.pdf
 
 //	Used by:
 

--- a/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AltairIII_Config.cfg
@@ -1,25 +1,39 @@
-//	===============================================================
-//
-//	Altair III (FW4S) SRM
-//	Squad, Bluedog_DB
+//	==================================================
+//	Altair III (FW4S)
 //
 //	Manufacturer: United Aircraft
-//	Dimensions: 1.484122 x 0.508 m
-//	First Launch: 1965
-//	
-//	Dry Mass: 23.16585 kg
-//	Average Thrust: 25.227 kN
-//	ISP: 284.5 s
-//	Burn Time: 31.5 s
-//	Propellant Mass: 274.4232 kg
 //
+//	=================================================================================
+//	Altair III
+//	FW-4S
+//
+//	Dry Mass: 23.16585 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 25.227 kN
+//	ISP: ??? SL / 284.5 Vac
+//	Burn Time: 31.5
+//	Chamber Pressure: 5.92 MPa
+//	Propellant: CTPB
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+
+//	Sources:
+
 //	Source: NASA CR-145136 Scout Nozzle Data Book: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770010201.pdf
 //	Source 1: NASA CR-165950 Scout Launch Vehicle Final Report.PDF)
 //	Source 2: Performance of a UTC FW-4S Solid-Propellant Rocket Motor
 //	  https://apps.dtic.mil/dtic/tr/fulltext/u2/a002149.pdf
-//
-//	===============================================================
 
+//	Used by:
+
+//	Notes:
+
+//	Dimensions: 1.484122 x 0.508 m
+//	Propellant Mass: 274.4232 kg
+//	===============================================================
 @PART[*]:HAS[#engineType[Altair-III]]:FOR[RealismOverhaulEngines]
 {
 	@title = #roAltair-IIITitle	//Altair III FW-4S

--- a/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Altair_Config.cfg
@@ -1,6 +1,34 @@
-//Altair (X-248)
-//Squad
+//	==================================================
+//	Altair I
 //
+//	Manufacturer: Allegany Ballistics Laboratory
+//
+//	=================================================================================
+//	Altair I
+//	X-248
+//
+//	Dry Mass: 76.74777 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 16.35 kN
+//	ISP: ??? SL / 255.04 Vac
+//	Burn Time: 38.1
+//	Chamber Pressure: 1.49 MPa
+//	Propellant: PBAA
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 25.8
+//	Ignitions: 1
+//	=================================================================================
+
+//	Sources:
+
+//	NASA CR-165950 Scout Launch Vehicle Final Report.PDF
+//	The Vanguard Satellite Launching Vehicle: An Engineering Summary.PDF (1960)
+//	https://i0.wp.com/www.drewexmachina.com/wp-content/uploads/2017/12/ABL_3rd_stage_motor.jpg?ssl=1
+
+//	Used by:
+
+//	Notes:
 //
 // 1974072500-The-Vanguard-Satellite-Launching-Vehicle-an-Engineering-Summary.pdf
 // dimensions p.63 & p.65
@@ -15,27 +43,8 @@
 // 50 + 420 lb	-- 23 + 190 kg	109.1 l
 // 42 + 463 lb	-- 19 + 210 kg	120.65 l
 //
-//	===============================================================
-//
-//	Altair (X-248) SRM
-//	Squad, Bluedog_DB
-//
-//	Manufacturer: Allegany Ballistics Laboratory
-//	Dimensions: 1.47828 x 0.4572 m
-//	First Launch: Vanguard TV-4BU (1959)
-//	
-//	Dry Mass: 22.49816 kg
-//	Average Thrust: 13.34466 kN
-//	ISP: 255.04 s
-//	Burn Time: 39 s
 //	Propellant Mass: 206.2029 kg
-//
-//	Source 1: The Vanguard Satellite Launching Vehicle: An Engineering Summary.PDF (1960)
-//	Source 2: https://i0.wp.com/www.drewexmachina.com/wp-content/uploads/2017/12/ABL_3rd_stage_motor.jpg?ssl=1
-//
 //	===============================================================
-
-
 @PART[*]:HAS[#engineType[Altair]]:FOR[RealismOverhaulEngines]
 {
 	%title = #roAltairTitle	//Altair X-248

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 62.27508 kN
 //	ISP: ??? SL / 256 Vac
 //	Burn Time: 38.1
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 2.03 MPa
 //	Propellant: PBAA
 //	Prop Ratio: N/A
 //	Throttle: N/A
-//	Nozzle Ratio: 27
+//	Nozzle Ratio: 25.15
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Antares_II_Config.cfg
@@ -12,11 +12,26 @@
 //	Thrust (Vac): 93.074555 kN
 //	ISP: ??? SL / 281.15 Vac
 //	Burn Time: 33.7
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 2.87 MPa
 //	Propellant: PBAA
 //	Prop Ratio: N/A
 //	Throttle: N/A
 //	Nozzle Ratio: 17.5
+//	Ignitions: 1
+//	=================================================================================
+//	Antares IIB
+//	X-259
+//
+//	Dry Mass: 99? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 126.8 kN
+//	ISP: ??? SL / 284.95 Vac
+//	Burn Time: 28.9
+//	Chamber Pressure: 4.76 MPa
+//	Propellant: PBAA
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/BE-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-3_Config.cfg
@@ -9,14 +9,14 @@
 //
 //	Dry Mass: 480 Kg
 //	Thrust (SL): 490 kN
-//	Thrust (Vac): ??? kN
-//	ISP: 310 SL / 360 Vac
+//	Thrust (Vac): 511.3? kN
+//	ISP: 345 SL / 360 Vac	estimated with RPA
 //	Burn Time: 660
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 8.0? MPa	guess
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0?
 //	Throttle: 490 kN to 89 kN
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 5?	guess
 //	Ignitions: 5
 //	=================================================================================
 
@@ -64,7 +64,7 @@
 		{
 			name = BE3
 			specLevel = operational
-			maxThrust = 569	//490 kN SL
+			maxThrust = 511.3	//490 kN SL
 			minThrust = 89
 			PROPELLANT
 			{
@@ -80,7 +80,7 @@
 			atmosphereCurve
 			{
 				key = 0 360
-				key = 1 310 //approx
+				key = 1 345 //approx
 			}
 			ullage = True
 			ignitions = 5

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_1_Config.cfg
@@ -15,6 +15,7 @@
 //	Dry Mass: 669.9554 kg
 //	Propellant Mass: 3311.222 kg
 //	Nozzle Exit Area: 0.819912 m^2
+//	Chamber pressure: 398.7 psi
 //	ISP: 220.137
 //
 //	VACUUM VARIANT
@@ -26,6 +27,7 @@
 //	Propellant Mass: 3323.015
 //	ISP: 273.21 vac
 //	Total Impulse: 2,000,097 lb
+//	Chamber pressure: 398.7 psi
 //	Nozzle Expansion Ratio: 15.61
 //	Nozzle Exit Area: 2.4637 m^2
 //

--- a/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Castor_2_Config.cfg
@@ -1,20 +1,42 @@
-//  ===============================================================
-//  Castor 2 Solid Rocket Motor
-//  Bluedog_DB, Ven Stock Revamp
+//	==================================================
+//	Castor II
 //
-//  Manufacturer: Thiokol
-//  Diameter: 0.79 m
-//  Dry Mass: 677.2129 kg
+//	Manufacturer: Thiokol
 //
-//  Thrust: 270.29164 vac (that is the average, 318.1 is the maxThrust with the thrustCurve)
-//  ISP: 282.2 vac
-//  Burn Time: ~39.1 s
-//  Propellant Mass: 3723.99 kg
-//  
-//  Nozzle Expansion Ratio: 21.2
-//  Nozzle Exit Area: 2.471928 m^2
+//	=================================================================================
+//	Castor II SL
+//	Thor/Delta
 //
-//  Sources:
+//	Dry Mass: 677 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 369.23 kN
+//	ISP: 235 SL / 260.7 Vac
+//	Burn Time: 39.1
+//	Chamber Pressure: ??? MPa
+//	Propellant: CTPB
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
+//	Castor II Vac
+//	Scout
+//
+//	Dry Mass: 677 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 318.1 kN
+//	ISP: 220? SL / 282.2 Vac
+//	Burn Time: 39.1
+//	Chamber Pressure: 5.51 MPa
+//	Propellant: CTPB
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 21.2
+//	Ignitions: 1
+//	=================================================================================
+
+//	Sources:
+
 //    NASA CR-165950 Scout Launch Vehicle Final Report.PDF
 //    NASA CR-145136 Scout Nozzle Data Book (1976): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770010201.pdf
 //    Thrust Misalignments of Fixed Solid Rocket Motors: http://rsandt.com/media/Thrust%20Misalignments%20of%20Fixed-Nozzle%20Solid%20Rocket%20Motors.pdf
@@ -22,9 +44,13 @@
 //    NASA CR-146805 Post flight analyses for Delta mission 113: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19760014174.pdf
 //    NASA CR-66259 Desitgn and development of the Castor IIA rocket motor: https://www.ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19670004241.pdf
 //    The Development of Propulsion Technology for U.S. Space-Launch Vehicles (SL Isp of the SL version)
-//
-//  ===============================================================
 
+//	Used by:
+
+//	Notes:
+
+//	Propellant Mass: 3723.99 kg
+//	===============================================================
 @PART[*]:HAS[#engineType[Castor-2]]:FOR[RealismOverhaulEngines]
 {
 	%category = Engine

--- a/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Dropt_Config.cfg
@@ -1,21 +1,36 @@
-//	P 0.68 Dropt SRM (Diamant B/BP4)
-//	BDB
+//	==================================================
+//	P 0.68 Dropt SRM
 //
 //	Manufacturer: Aerospatiale
-//	===============================================================
 //
-//	Dimensions: 1.6 x 1.1 m
-//	Mass: 67 kg
-//	Propellant Mass: 685 kg
-//	Thrust: 50 kN
-//	ISP: 275s
-//	Burn Time: 45s
-//	Propellant: Isolane
+//	=================================================================================
+//	P 0.68 Dropt SRM
+//	Diamant B/BP4
 //
-//	Source 1: AIAA-98-3980 Large Space Solid Rocket Motors in Europe - Uhrig & Boury (1998)
-//	  http://majdalani.eng.auburn.edu/courses/09_propulsion_1/Papers/AIAA983980_Uhrig.pdf
-//	===============================================================
+//	Dry Mass: 67 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 50 kN
+//	ISP: ??? SL / 275 Vac
+//	Burn Time: 45
+//	Chamber Pressure: 5.8 MPa
+//	Propellant: PBAN
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	=================================================================================
 
+//	Sources:
+
+//	Source 1: AIAA-98-3980 Large Space Solid Rocket Motors in Europe - Uhrig & Boury (1998)
+//		http://majdalani.eng.auburn.edu/courses/09_propulsion_1/Papers/AIAA983980_Uhrig.pdf
+
+//	Used by:
+
+//	Notes:
+
+//	685 kg propellant
+//	==================================================
 @PART[*]:HAS[#engineType[Dropt]]:FOR[RealismOverhaulEngines]
 {
 	%title = #roDroptTitle	//P 0.68 Dropt

--- a/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/E1_Config.cfg
@@ -4,41 +4,117 @@
 //	Manufacturer: Rocketdyne
 //
 //	=================================================================================
-//	E-1
-//	
+//	E-1 (-380klbf)
+//	MA-4, 1963?
 //
-//	Dry Mass: ??? Kg
-//	Thrust (SL): 1690 kN
-//	Thrust (Vac): 1884 kN (Sutton claims 400klbf, but period documents say only 380klbf was tested).
-//	ISP: 260 SL / 290 Vac
-//	Burn Time: 165
-//	Chamber Pressure: ??? MPa
+//	Dry Mass: 1800? kg		Assuming a similar TWR to the H-1-188k
+//	Thrust (SL): 1690.32 kN	(Sutton claims 400klbf, but period documents say only 380klbf was tested).
+//	Thrust (Vac): 1947.53 kN
+//	ISP: 251.7 SL / 290 Vac		estimated with RPA
+//	Burn Time: 165?
+//	Chamber Pressure: 5.0 MPa		a little more than H-1?
 //	Propellant: LOX / RP-1
-//	Prop Ratio: 2.15
+//	Prop Ratio: 2.15?
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 12?
 //	Ignitions: 1
 //	=================================================================================
-//	E-1 Dynasoar
-//	
+//	E-1 Upgrade
+//	Deprecated
 //
-//	Dry Mass: ??? Kg
-//	Thrust (SL): 2081 kN
-//	Thrust (Vac): 2335 kN
-//	ISP: 256 SL / 290 Vac
+//	Dry Mass: 1814.4 Kg
+//	Thrust (SL): 2081.7 kN
+//	Thrust (Vac): 2366.3 kN
+//	ISP: 256 SL / 291 Vac
 //	Burn Time: 210
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.45 MPa
 //	Propellant: LOX / RP-1
 //	Prop Ratio: 2.25
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 12
+//	Ignitions: 1
+//	=================================================================================
+//	E-1 Upgrade2
+//	Deprecated
+//
+//	Dry Mass: 1814.4? Kg
+//	Thrust (SL): ??? kN		//525klbf sea level
+//	Thrust (Vac): 2662.6 kN
+//	ISP: 264 SL / 301 Vac
+//	Burn Time: 210?
+//	Chamber Pressure: 5.45? MPa
+//	Propellant: LOX / RP-1
+//	Prop Ratio: 2.25?
+//	Throttle: N/A
+//	Nozzle Ratio: 12?
+//	Ignitions: 1
+//	=================================================================================
+//	E-1-468k
+//	Dynasoar RBS version, 1966?
+//
+//	Dry Mass: 1814.4 Kg
+//	Thrust (SL): 2081.77 kN		468klbf sl
+//	Thrust (Vac): 2366.39 kN
+//	ISP: 256 SL / 291 Vac
+//	Burn Time: 210
+//	Chamber Pressure: 5.45 MPa
+//	Propellant: LOX / RP-1
+//	Prop Ratio: 2.25
+//	Throttle: N/A
+//	Nozzle Ratio: 12
+//	Ignitions: 1
+//	=================================================================================
+//	E-1-500k
+//	Original target thrust? 1969?
+//
+//	Dry Mass: 1814.4 Kg
+//	Thrust (SL): 2224.11 kN		500klbf sl
+//	Thrust (Vac): 2505.97 kN
+//	ISP: 258.27 SL / 291 Vac
+//	Burn Time: 210
+//	Chamber Pressure: 5.77? MPa
+//	Propellant: LOX / RP-1
+//	Prop Ratio: 2.25?
+//	Throttle: N/A
+//	Nozzle Ratio: 12?
+//	Ignitions: 1
+//	=================================================================================
+//	E-1-575k
+//	Speculative. Same thrust increase from standard E-1 as H-1-165k to H-1-250k, 1976?
+//
+//	Dry Mass: 1814.4? Kg
+//	Thrust (SL): 2557.73 kN		//575klbf sea level
+//	Thrust (Vac): 2828.57 kN
+//	ISP: 264.04 SL / 292 Vac
+//	Burn Time: 210?
+//	Chamber Pressure: 6.45? MPa
+//	Propellant: LOX / RP-1
+//	Prop Ratio: 2.35?		assuming slightly leaner to help increase thrust, like late H-1
+//	Throttle: N/A
+//	Nozzle Ratio: 12?
+//	Ignitions: 1
+//	=================================================================================
+//	E-1A_KS
+//	From Kolyma's Shadow
+//
+//	Dry Mass: 1835? Kg		a little heavier for nozzle extension?
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 2250 kN
+//	ISP: 369 SL / 310 Vac
+//	Burn Time: 240?
+//	Chamber Pressure: 6.0? MPa	estimated with RPA
+//	Propellant: LOX / RP-1
+//	Prop Ratio: 2.35?
+//	Throttle: N/A
+//	Nozzle Ratio: 15?	estimated with RPA
 //	Ignitions: 1
 //	=================================================================================
 
 //	Sources:
 
-//	Operation Dyna Soar Recoverable Booster Study: Selected Booster.PDF:						http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-//	alternatewars - Rocketdyne engines:															http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//	[1]Operation Dyna Soar Recoverable Booster Study: Selected Booster.PDF:						http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//	[2]alternatewars - Rocketdyne engines:															http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//	[3]https://www.drewexmachina.com/download-pdf/SV_1998_09.pdf
 //  [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 430
 
 //	Used by:
@@ -79,14 +155,14 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		configuration = E-1
-		origMass = 1.264 // Assuming a similar TWR to the H-1
+		origMass = 1.800
 
 		CONFIG
 		{
 			name = E-1
 			specLevel = prototype
-			minThrust = 1884.59 // 380klbf sea level
-			maxThrust = 1884.59
+			minThrust = 1947.53
+			maxThrust = 1947.53
 			heatProduction = 100
 			massMult = 1.0
 
@@ -122,20 +198,199 @@
 			atmosphereCurve
 			{
 				key = 0 290
-				key = 1 260
+				key = 1 251.7
 			}
 
 			//Never flown, all configs speculative
 			// Copied from H-1, slightly decreased
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 900	//Assume halfway between F-1 and H-1 (15 minutes)
+				testedBurnTime = 775	//Same as H-1-188k
 				ratedBurnTime = 165
 				safeOverburn = true
 				ignitionReliabilityStart = 0.95
 				ignitionReliabilityEnd = 0.995
 				cycleReliabilityStart = 0.96
 				cycleReliabilityEnd = 0.993
+				techTransfer = S-3D,S-3:25
+			}
+		}
+
+		CONFIG
+		{
+			name = E-1-468k
+			description = Uprated E-1 intended for use with the Dyna Soar project. This version is without boostback hardware.
+			specLevel = concept
+			minThrust = 2366.3
+			maxThrust = 2366.3
+			heatProduction = 100
+			massMult = 1.008
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3859
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6141
+			}
+
+			atmosphereCurve
+			{
+				key = 0 291
+				key = 1 256
+			}
+
+			//Never flown, all configs speculative
+			// Copied from H-1-188k
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 2025		//same as H-1
+				ratedBurnTime = 165
+				safeOverburn = true
+				ignitionReliabilityStart = 0.980612
+				ignitionReliabilityEnd = 0.996939
+				cycleReliabilityStart = 0.980612
+				cycleReliabilityEnd = 0.996939
+				techTransfer = S-3D,S-3:25&E-1:50
+			}
+		}
+		CONFIG
+		{
+			name = E-1-500k
+			description = Speculative E-1 upgrade, uprated to target thrust level of original E-1 study.
+			specLevel = speculative
+			minThrust = 2505.97
+			maxThrust = 2505.97
+			heatProduction = 100
+			massMult = 1.008
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3859
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6141
+			}
+
+			atmosphereCurve
+			{
+				key = 0 291
+				key = 1 258.27
+			}
+
+			//Never flown, all configs speculative
+			// Copied from H-1-200k
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 2025		//same as H-1
+				ratedBurnTime = 165
+				safeOverburn = true
+				ignitionReliabilityStart = 0.976829
+				ignitionReliabilityEnd = 0.996341
+				cycleReliabilityStart = 0.976829
+				cycleReliabilityEnd = 0.996341
+				techTransfer = S-3D,S-3:25&E-1-468k,E-1:50
+			}
+		}
+		CONFIG
+		{
+			name = E-1-575k
+			description = Speculative E-1 upgrade, uprated to maximum possible thrust.
+			specLevel = speculative
+			minThrust = 2828.57
+			maxThrust = 2828.57
+			heatProduction = 100
+			massMult = 1.008
+
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3756
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6244
+			}
+
+			atmosphereCurve
+			{
+				key = 0 292
+				key = 1 264.04
+			}
+
+			//Never flown, all configs speculative
+			// Copied from H-1-200k
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 2025		//same as H-1
+				ratedBurnTime = 165
+				safeOverburn = true
+				ignitionReliabilityStart = 0.976829
+				ignitionReliabilityEnd = 0.996341
+				cycleReliabilityStart = 0.976829
+				cycleReliabilityEnd = 0.996341
+				techTransfer = S-3D,S-3:25&E-1-500k,E-1-468k,E-1:50
 			}
 		}
 
@@ -144,10 +399,11 @@
 			name = E-1-Upgrade
 			description = Speculative upgrade configuration for the E-1 intended for use with the Dyna Soar project. This version is without boostback hardware.
 			specLevel = speculative
+			RODeprecated = true
 			minThrust = 2358.25 // 468klbf sea level
 			maxThrust = 2358.25
 			heatProduction = 100
-			massMult = 1.04 // 1.435 = 4000lb for boostback booster
+			massMult = 1.0
 
 			ullage = True
 			pressureFed = False
@@ -203,10 +459,11 @@
 			name = E-1-Upgrade2
 			description = Speculative upgrade configuration using late 1960s technology.
 			specLevel = speculative
+			RODeprecated = true
 			minThrust = 2662.6 //525klbf sea level
 			maxThrust = 2662.6
 			heatProduction = 100
-			massMult = 1.2
+			massMult = 1.0
 
 			ullage = True
 			pressureFed = False
@@ -265,7 +522,7 @@
 			minThrust = 2250
 			maxThrust = 2250
 			heatProduction = 100
-			massMult = 1.0
+			massMult = 1.0194
 
 			ullage = True
 			pressureFed = False
@@ -286,14 +543,14 @@
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.3859
+				ratio = 0.3756
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.6141
+				ratio = 0.6244
 			}
 
 			atmosphereCurve
@@ -302,17 +559,17 @@
 				key = 1 269
 			}
 
-			// RS-27 / F-1A level
+			// RS-27A / F-1A level
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 900
+				testedBurnTime = 2025		//same as H-1
 				ratedBurnTime = 240
 				safeOverburn = true
-				ignitionReliabilityStart = 0.99
-				ignitionReliabilityEnd = 0.998
-				cycleReliabilityStart = 0.99
-				cycleReliabilityEnd = 0.998
-				techTransfer = E-1-Upgrade2,E-1-Upgrade,E-1:50
+				ignitionReliabilityStart = 0.993310
+				ignitionReliabilityEnd = 0.998944
+				cycleReliabilityStart = 0.993310
+				cycleReliabilityEnd = 0.998944
+				techTransfer = S-3D,S-3:25&E-1-500k,E-1-468k,E-1:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F-1A_ETS_Config.cfg
@@ -1,14 +1,26 @@
+//	==================================================
 //	Throttlable F-1A series engine as found in 'Eyes Turned Skyward'
+//
+//	Manufacturer: Rocketdyne
+//
+//	=================================================================================
+//	F-1A-ETS
 //	
 //
-//	==================================================
-//	Rocketdyne F-1A engine.
+//	Dry Mass: 8390 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 9189.6 kN
+//	ISP: 268.8 SL / 306.2 Vac
+//	Burn Time: 315
+//	Chamber Pressure: 8.0 MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.27
+//	Throttle: 60% - 100%
+//	Nozzle Ratio: 16
+//	Ignitions: 1
+//	=================================================================================
 
-//	Dimensions: 3.8 m x 5.7 m
-//	Gross Mass: 8390 Kg
-//	Throttle Range: 60% - 100% // Estimation, if this value is canon please correct.
-//	Burn Time: 150 s
-//	O/F Ratio: 2.27
+//	Sources:
 
 //	Source 1: http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
 //	Source 2: http://history.msfc.nasa.gov/saturn_apollo/documents/F-1_Engine.pdf
@@ -72,8 +84,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 310
-				key = 1 270
+				key = 0 306.2
+				key = 1 268.8
 			}
 			
 			ullage = True
@@ -109,7 +121,7 @@
 				ignitionReliabilityEnd = 0.998
 				cycleReliabilityStart = 0.985
 				cycleReliabilityEnd = 0.998
-				techTransfer = F-1-1.5M, F-1-1.52M:50
+				techTransfer = F-1-1.5M,F-1-1.52M:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/H1_Config.cfg
@@ -5,16 +5,16 @@
 //
 //	=================================================================================
 //	H-1 165K
-//	1961, SA-1 through SA-4
+//	1961, SA-1 through SA-4. Actually downrated H-1-188k.
 //
-//	Dry Mass: 911 Kg
-//	Thrust (SL): 733.9563 kN
-//	Thrust (Vac): 823.25 kN
-//	ISP: 258 SL / 295 Vac		SL calculated with RPA
+//	Dry Mass: 911? Kg
+//	Thrust (SL): 733.9563 kN	[3/10] 165klbf sl
+//	Thrust (Vac): 846.76 kN
+//	ISP: 255.7 SL / 295? Vac		SL calculated with RPA
 //	Burn Time: 155
-//	Chamber Pressure: 4.05 MPa
+//	Chamber Pressure: 4.05? MPa
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.23
+//	Prop Ratio: 2.23?
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -23,14 +23,14 @@
 //	H-1 188K
 //	1964, SA-5 through SA-10
 //
-//	Dry Mass: 911 Kg
-//	Thrust (SL): 836.26536 kN
-//	Thrust (Vac): 939.02 kN
-//	ISP: 263 SL / 295 Vac
+//	Dry Mass: 911? Kg
+//	Thrust (SL): 836.26536 kN	[3/10] 188klbf sl
+//	Thrust (Vac): 950.19 kN
+//	ISP: 259.63 SL / 295 Vac		SL calculated with RPA
 //	Burn Time: 155
-//	Chamber Pressure: 4.52 MPa
+//	Chamber Pressure: 4.52 MPa		[8]
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.23
+//	Prop Ratio: 2.23		[8]
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -40,13 +40,13 @@
 //	1966, SA-201 through SA-205
 //
 //	Dry Mass: 911 Kg
-//	Thrust (SL): 889.644 kN
-//	Thrust (Vac): 997.889 kN
-//	ISP: 261 SL / 295 Vac		SL calculated with RPA
+//	Thrust (SL): 886.530 kN		[9] 199,300 klbf sl
+//	Thrust (Vac): 997.93 kN
+//	ISP: 262.07 SL / 295 Vac		SL calculated with RPA
 //	Burn Time: 155
-//	Chamber Pressure: 4.36 MPa
+//	Chamber Pressure: 4.75 MPa		[9]
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.23
+//	Prop Ratio: 2.338		[9]
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -56,29 +56,29 @@
 //	1973, SA-206 through SA-210
 //
 //	Dry Mass: 911 Kg
-//	Thrust (SL): 911.8851 kN
-//	Thrust (Vac): 1054.22 kN
-//	ISP: 263 SL / 295 Vac
+//	Thrust (SL): 908.771 kN		[9] 204,300 klbf sl
+//	Thrust (Vac): 1021.01 kN
+//	ISP: 262.57 SL / 295 Vac	[1]
 //	Burn Time: 155
-//	Chamber Pressure: 4.82 MPa
+//	Chamber Pressure: 4.82 MPa		[9]
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.23
+//	Prop Ratio: 2.341		[1/9]
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //  Gimbal: 10.5
 //	=================================================================================
 //	H-1 250K
-//	1975? Uprated S-IB concept
+//	1976? Uprated S-IB concept
 //
 //	Dry Mass: 911 Kg
-//	Thrust (SL): 1112.1 kN
-//	Thrust (Vac): 1247.4 kN
-//	ISP: 267 SL / 295 Vac		SL calculated with RPA
+//	Thrust (SL): 1112.1 kN		250,000 klbf sl
+//	Thrust (Vac): 1224.46 kN
+//	ISP: 267.93 SL / 295 Vac		SL calculated with RPA
 //	Burn Time: 155
-//	Chamber Pressure: 5.45? MPa
+//	Chamber Pressure: 5.78? MPa
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.23
+//	Prop Ratio: 2.34?
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -94,7 +94,7 @@
 //	Burn Time: 240
 //	Chamber Pressure: 4.85 MPa
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.23
+//	Prop Ratio: 2.245	[3/6]
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
@@ -105,29 +105,32 @@
 //
 //	Dry Mass: 1147 Kg
 //	Thrust (SL): 890.1 kN
-//	Thrust (Vac): 1054 kN
-//	ISP: 255 SL / 302 Vac
+//	Thrust (Vac): 1054.23 kN
+//	ISP: 255 SL / 302 Vac		[2]
 //	Burn Time: 265   // [A] Nominal Flight Duration: 265s
-//	Chamber Pressure: 4.85 MPa
+//	Chamber Pressure: 4.82 MPa		[2]
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.24
+//	Prop Ratio: 2.245		[3]
 //	Throttle: N/A
-//	Nozzle Ratio: 12
+//	Nozzle Ratio: 12		[2]
 //	Ignitions: 1
 //  Gimbal: 8.5
 //	=================================================================================
 
 //	Sources:
 
-//	#1: MSFC-MAN-206 Skylab Saturn IB Flight Manual (1972): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740021163.pdf
+//	[1] MSFC-MAN-206 Skylab Saturn IB Flight Manual (1972): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740021163.pdf
 
-//		http://www.rocket.com/rs-27a-engine
-//		http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
-//		http://www.apollosaturn.com/sibnews/sec4.htm
-//		https://web.archive.org/web/20041022144943/http://history.nasa.gov/SP-4206/ch4.htm
-//		http://www.astronautix.com/engines/rs27a.htm
-//		RS-27: https://www.history.nasa.gov/SP-4012/vol3/table1.31.htm
-//		http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
+//	[2] https://web.archive.org/web/20190307173028/https://www.rocket.com/rs-27a-engine
+//	[3] https://web.archive.org/web/20211229003426/http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//	[4] https://web.archive.org/web/20160520063133/http://www.apollosaturn.com/sibnews/sec4.htm
+//	[5] https://web.archive.org/web/20041022144943/http://history.nasa.gov/SP-4206/ch4.htm
+//	[6] http://www.astronautix.com/engines/rs27a.htm
+//	[7] https://web.archive.org/web/20190714132700/https://www.history.nasa.gov/SP-4012/vol3/table1.31.htm
+//	[8] http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
+//	[9] https://web.archive.org/web/20211229003426/http://www.alternatewars.com/BBOW/Space_Engines/H-1C-D_Manual.pdf
+//	[10] https://web.archive.org/web/20220531043804/https://www.alternatewars.com/BBOW/Space_Engines/Saturn_H-1_Design_Features.pdf
+//	[11] https://web.archive.org/web/20211229003426/http://www.alternatewars.com/BBOW/Space_Engines/Launch_Vehicles_Engines_PDP_1-JAN-1967.pdf
 //      [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 409 Table 7.8-1
 //      [A] History of Liquid Propelland Rocket Engines, George P. Sutton, Page 424
 
@@ -175,8 +178,8 @@
 			name = H-1-165K
 			description = Earliest prototype version of the H-1 Engine that flew on the Saturn I, Block I. It is rated at 165k lbf sea level thrust.
 			specLevel = operational
-			minThrust = 823.25
-			maxThrust = 823.25
+			minThrust = 846.76
+			maxThrust = 846.76
 			heatProduction = 100
 			massMult = 1.0
 
@@ -213,7 +216,7 @@
 			atmosphereCurve
 			{
 				key = 0 295
-				key = 1 258
+				key = 1 255.7
 			}
 
 			//Saturn 1 Block I: 4 flights, 0 failures
@@ -236,8 +239,8 @@
 			name = H-1-188K
 			description = Improved version of the H-1 Engine for the Saturn I, Block II. It is rated at 188k lbf sea level thrust.
 			specLevel = operational
-			minThrust = 938.02
-			maxThrust = 938.02
+			minThrust = 950.19
+			maxThrust = 950.19
 			heatProduction = 100
 			massMult = 1.0
 
@@ -274,14 +277,14 @@
 			atmosphereCurve
 			{
 				key = 0 295
-				key = 1 263
+				key = 1 259.63
 			}
 
 			//Saturn 1 Block II: 6 flights, 0 failures
 			//48 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 775	//Engine pulled from stage and tested in 1971 for Skylab missions. Subjected to 3 full burns and passed with no degradation. 775 seconds (1x acceptance burn, 3x shakedown burn, 1x flight burn)
+				testedBurnTime = 775
 				ratedBurnTime = 155
 				safeOverburn = true
 				ignitionReliabilityStart = 0.980612
@@ -297,8 +300,8 @@
 			name = H-1-200K
 			description = H-1 Engine that flew on the first 5 Saturn IB launches. It is rated at 200k lbf sea level thrust.
 			specLevel = operational
-			minThrust = 997.889
-			maxThrust = 997.889
+			minThrust = 997.93
+			maxThrust = 997.93
 			heatProduction = 100
 			massMult = 1.0
 
@@ -335,14 +338,14 @@
 			atmosphereCurve
 			{
 				key = 0 295
-				key = 1 261
+				key = 1 262.07
 			}
 
 			//Saturn 1B: 5 flights, 0 failures
 			//40 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 775	//Engine pulled from stage and tested in 1971 for Skylab missions. Subjected to 3 full burns and passed with no degradation. 775 seconds (1x acceptance burn, 3x shakedown burn, 1x flight burn)
+				testedBurnTime = 2025	//[11] target lifetime 2025 seconds
 				ratedBurnTime = 155
 				safeOverburn = true
 				ignitionReliabilityStart = 0.976829
@@ -358,8 +361,8 @@
 			name = H-1-205K
 			description = Final version of the H-1 Engine for the Saturn IB that flew on the 4 flights of Skylab and ASTP. It is rated at 205k lbf sea level thrust.
 			specLevel = operational
-			minThrust = 1054.22
-			maxThrust = 1054.22
+			minThrust = 1021.01
+			maxThrust = 1021.01
 			heatProduction = 100
 			massMult = 1.0
 
@@ -396,14 +399,14 @@
 			atmosphereCurve
 			{
 				key = 0 295
-				key = 1 263
+				key = 1 262.57
 			}
 
 			//Saturn 1B (Skylab): 4 flights, 0 failures
 			//32 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 775	//Engine pulled from stage and tested in 1971 for Skylab missions. Subjected to 3 full burns and passed with no degradation. 775 seconds (1x acceptance burn, 3x shakedown burn, 1x flight burn)
+				testedBurnTime = 2025	//[11] target lifetime 2025 seconds
 				ratedBurnTime = 155
 				safeOverburn = true
 				ignitionReliabilityStart = 0.976829
@@ -419,8 +422,8 @@
 			name = H-1-250K
 			description = Maximum possible thrust for H-1 design, proposed for a post-Apollo uprated Saturn IB. Although engines were tested at increased thrust levels, the end of Apollo and selection of Titan III over Saturn IB meant this was never developed further.
 			specLevel = concept
-			minThrust = 1247.4
-			maxThrust = 1247.4
+			minThrust = 1224.46
+			maxThrust = 1224.46
 			heatProduction = 100
 			massMult = 1.0
 
@@ -457,13 +460,13 @@
 			atmosphereCurve
 			{
 				key = 0 295
-				key = 1 267
+				key = 1 267.93
 			}
 
 			//No data, same as 205K
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 775	//Engine pulled from stage and tested in 1971 for Skylab missions. Subjected to 3 full burns and passed with no degradation. 775 seconds (1x acceptance burn, 3x shakedown burn, 1x flight burn)
+				testedBurnTime = 2025	//[11] target lifetime 2025 seconds
 				ratedBurnTime = 155
 				safeOverburn = true
 				ignitionReliabilityStart = 0.976829
@@ -539,7 +542,7 @@
 			//100 engines, 1 failure
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 1200	//Assume also good for 5x burn time, mildly upgraded over H-1
+				testedBurnTime = 2025	//[11] target lifetime 2025 seconds
 				ratedBurnTime = 240
 				safeOverburn = true
 				ignitionReliabilityStart = 0.978053
@@ -555,8 +558,8 @@
 			name = RS-27A
 			description = RS-27 with a higher expansion nozzle for Delta II
 			specLevel = operational
-			maxThrust = 1054
-			minThrust = 1054
+			maxThrust = 1054.23
+			minThrust = 1054.23
 			heatProduction = 100
 			massMult = 1.10425
 
@@ -610,7 +613,7 @@
 			//141 engines, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 1200	//Assume also good for 5x burn time, mildly upgraded over H-1
+				testedBurnTime = 2025	//[11] target lifetime 2025 seconds
 				ratedBurnTime = 265
 				safeOverburn = true
 				ignitionReliabilityStart = 0.993310

--- a/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HG-3_Config.cfg
@@ -1,19 +1,144 @@
-//	HG-3 series engine
-//	SXT, SHIP
 //	==================================================
-//	Rocketdyne HG-3 engine.
+//	HG-3
+//
+//	Manufacturer: Rocketdyne
+//
+//	=================================================================================
+//	HG-3
+//	
+//
+//	Dry Mass: 1780? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1400.70 kN
+//	ISP: 270 SL / 451 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 11.50? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 75?
+//	Ignitions: 2
+//	=================================================================================
+//	HG-3-SL
+//	
+//
+//	Dry Mass: 1733? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1382.07 kN
+//	ISP: 340 SL / 445 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 11.50? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 50?
+//	Ignitions: 1
+//	=================================================================================
+//	HG-3A
+//	
+//
+//	Dry Mass: 1780? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1400.70 kN
+//	ISP: 270 SL / 451 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 11.50? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 75?
+//	Ignitions: 5
+//	=================================================================================
+//	HG-3A-SL
+//	
+//
+//	Dry Mass: 1733? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1382.07 kN
+//	ISP: 340 SL / 445 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 11.50? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 50?
+//	Ignitions: 2
+//	=================================================================================
+//	HG-3B
+//	
+//
+//	Dry Mass: 1780? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1400.70 kN
+//	ISP: 340 SL / 458 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 16.00? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 100?
+//	Ignitions: 5
+//	=================================================================================
+//	HG-3B-SL
+//	
+//
+//	Dry Mass: 1733? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1382.07 kN
+//	ISP: 352 SL / 452 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 16.00? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 67?
+//	Ignitions: 2
+//	=================================================================================
+//	HG-3B-2
+//	
+//
+//	Dry Mass: 1780? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1422.44 kN
+//	ISP: 340 SL / 458 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 16.00? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 100?
+//	Ignitions: 5
+//	=================================================================================
+//	HG-3B-SL-2
+//	
+//
+//	Dry Mass: 1733? kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1403.81 kN
+//	ISP: 352 SL / 452 Vac	estimated with RPA
+//	Burn Time: 500
+//	Chamber Pressure: 16.00? MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Throttle: 100% to 67%
+//	Nozzle Ratio: 67?
+//	Ignitions: 2
+//	=================================================================================
 
-//	Dimensions: 2.1 m x 3.5 m
-//	Gross Mass: ?? (Assumed 1780 kg as rough estimate)
-//	Throttle Range: ?? (67% to 100% as rough estimation and to serve as stepping stone to RS-25)
-//	Burn Time: 600 s
-//	O/F Ratio: ?? (Assumed 5.5 ala J-2)
-
-// Upgrades (HG-3A, etc.) are purely speculative.
+//	Sources:
 
 //	Source 1: http://www.astronautix.com/h/hg-3.html
 //	Source 2: http://www.astronautix.com/h/hg-3-sl.html
 //	Source 3: https://history.msfc.nasa.gov/saturn_apollo/propulsion_center.html
+
+//	Used by:
+
+//	SXT
+//	ROEngines
+
+//	Notes:
+
+//	Upgrades (HG-3A, etc.) are purely speculative.
 //	==================================================
 @PART[*]:HAS[#engineType[HG3]]:FOR[RealismOverhaulEngines]
 {
@@ -64,7 +189,7 @@
 			atmosphereCurve
 			{
 				key = 0 451
-				key = 1 280
+				key = 1 270
 			}
 			
 			%ullage = True
@@ -172,7 +297,7 @@
 			atmosphereCurve
 			{
 				key = 0 451
-				key = 1 280
+				key = 1 270
 			}
 			
 			%ullage = True
@@ -283,7 +408,7 @@
 			atmosphereCurve
 			{
 				key = 0 458
-				key = 1 285
+				key = 1 340
 			}
 			
 			%ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR105_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 240.2 kN
 //	ISP: 210 SL / 301 Vac
 //	Burn Time: 330
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.52 MPa	estimated with RPA
 //	Propellant: LOX / RP-1
 //	Prop Ratio: 2.25
 //	Throttle: N/A
@@ -57,7 +57,7 @@
 //	Thrust (Vac): 373.2 kN
 //	ISP: 217 SL / 313 vac
 //	Burn Time: 350
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.71 MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: 2.25
 //	Throttle: N/A
@@ -72,7 +72,7 @@
 //	Thrust (Vac): 385.2 kN
 //	ISP: 220 SL / 316 vac
 //	Burn Time: 350
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.80 MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: 2.25
 //	Throttle: N/A
@@ -87,7 +87,7 @@
 //	Thrust (Vac): 386.4 kN
 //	ISP: 220 SL / 316 vac
 //	Burn Time: 350
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.80 MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: 2.25
 //	Throttle: N/A
@@ -102,7 +102,7 @@
 //	Thrust (Vac): 386.4 kN
 //	ISP: 220.4 SL / 316 vac
 //	Burn Time: 350
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.07 MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: 2.25
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR129_Config.cfg
@@ -16,8 +16,6 @@
 //	Chamber Pressure: 18.89 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
 //	Throttle: 100% to 20%
 //	Nozzle Ratio: 35:1/75:1
 //	Ignitions: 1
@@ -34,8 +32,6 @@
 //	Chamber Pressure: 20.68 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
 //	Throttle: 100% to 20%
 //	Nozzle Ratio: 35:1/75:1
 //	Ignitions: 1
@@ -52,8 +48,22 @@
 //	Chamber Pressure: 22.75 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
-//	Engine Nozzle: ???
-//	Nozzle Exit Area: ???
+//	Throttle: 100% to 50%
+//	Nozzle Ratio: 35:1/75:1
+//	Ignitions: 1
+//	=================================================================================
+//	LR129-P-3
+//	Speculative Space Shuttle main engine Block II
+//
+//	Dry Mass: 1632.9 kg		//~3600 lbs + 200 lbs gimbal hardware estimated mass for 350klbf engine
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1619.2 kN
+//	ISP: 393 SL / 440 Vac (retracted)	SL calculated with RPA
+//	ISP: 374 SL / 463 Vac (extended)	SL calculated with RPA
+//	Burn Time:	500
+//	Chamber Pressure: 22.75 MPa
+//	Propellant: LOX / LH2
+//	Prop Ratio: 6.0
 //	Throttle: 100% to 50%
 //	Nozzle Ratio: 35:1/75:1
 //	Ignitions: 1

--- a/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR79_Config.cfg
@@ -13,14 +13,14 @@
 //	Thrust (vac): Calculated by (766.34 S-3D value * 90%) = 696.6 kN
 //	ISP: 247.62 SL (all sources) / 288 vac
 //	Burn Time: 182 (burn time for Jupiter)
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 3.61? MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: 2.4
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	=================================================================================
-//	S-3D
+//	S-3D (LR79-NA-1?)
 //
 //	Dry Mass: 945.3 kg (Source #4)
 //	Thrust (SL): 150,000 lbf (all sources) = 667.233 kN
@@ -39,7 +39,7 @@
 //	Thor MB-3 Block I
 //	Data from Source #5
 //
-//	Dry Mass: ???
+//	Dry Mass: 933.66? kg		interpolated between S-3D and LR79-NA-13
 //	Thrust (SL): 150,000 lbf = 667.233 kN
 //	Thrust (Vac): 176,000 lbf = 782.886 kN
 //	ISP: 245 SL / 284 vac
@@ -57,7 +57,7 @@
 //	Thor MB-3 Block II
 //	Data from Source #5
 //
-//	Dry Mass: ???
+//	Dry Mass: 923.56? kg		interpolated between S-3D and LR79-NA-13
 //	Thrust (SL): 165,453 lbf = 735.9713437 kN
 //	Thrust (Vac): 190,998 lbf = 849.6011236 kN
 //	ISP: 248.3 SL / 286.2 vac
@@ -78,7 +78,7 @@
 //	Lower performance than orignal Hydrazine proposal, but much easier to build due to the properties of 
 //	UDMH being much closer to Kerosene.
 //
-//	Dry Mass: ???
+//	Dry Mass: 923.56? kg		same as LR79-NA-11
 //	Thrust (SL): 165,453 lbf = 735.9713437 kN
 //	Thrust (Vac): 190,998 lbf = 849.6011236 kN
 //	ISP: 266.1 SL / 305.5 vac		Calculated with RPA, using estimate with straight hydrazine as correction factor

--- a/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
@@ -7,16 +7,16 @@
 //	XLR83
 //	Navaho G-38
 //
-//	Dry Mass: 90 Kg
+//	Dry Mass: 1670 kg		TWR 110, roughly match LR43-NA-3
 //	Thrust (SL): 1801.5 kN
 //	Thrust (Vac): ??? kN
-//	ISP: 245 SL / ??? Vac
+//	ISP: 245 SL / 282 Vac
 //	Burn Time: 100
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 3.92? MPa		same as LR43-NA-3?
 //	Propellant: LOX / RP-1
-//	Prop Ratio: 2.25	//assumed to be the same as LR43
+//	Prop Ratio: 2.25?		same as LR43-NA-3?
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 8?		same as LR43-NA-3?
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR83_Config.cfg
@@ -64,7 +64,7 @@
 		type = ModuleEngines
 		modded = false
 		configuration = XLR83-NA-1
-		origMass = 0.415
+		origMass = 1.670
 		CONFIG
 		{
 			name = XLR83-NA-1

--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
@@ -1,12 +1,82 @@
-//References
-// http://www.astronautix.com/t/titanc.html
-// Note: TitanC config is as of published numbers on engine performance
-// for the Titan C application (simmed at 780psi, 12Ae/At). Speculative
-// alternates and upgrades simmed by doubling area ratio and (for the upgrades)
-// increasing efficiency and chamber pressure to later LR87 levels (5.7MPa).
-// The VacuumUpgrade config uses the LR91 nozzle AR (49.2)
-// Large increase in weight is from reignition equipment.
+//	==================================================
+//	LR-87 LH2
+//
+//	Manufacturer: Aerojet
+//
+//	=================================================================================
+//	LR87-LH2-TitanC
+//	Titan C
+//
+//	Dry Mass: 839? kg		same mass as a normal AJ-3 I guess
+//	Thrust (SL): ??? Kn
+//	Thrust (Vac): 667 kN
+//	ISP: 350 SL / 403 Vac		sl calculated with RPA
+//	Burn Time: 300?
+//	Chamber Pressure: 5.0 MPa		A little higher to get advertised sl performance
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Nozzle Ratio: 12?
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-LH2-Vacuum
+//	Upgrade with nozzle extension and uprated for Saturn
+//
+//	Dry Mass: 1050? kg		vac nozzle, restart equipment, and general uprating should add mass. Slightly lower TWR than TitanC
+//	Thrust (SL): ??? Kn
+//	Thrust (Vac): 778 kN
+//	ISP: 315 SL / 421 Vac		calculated with RPA
+//	Burn Time: 500?
+//	Chamber Pressure: 5.48 MPa		same as AJ-5
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Nozzle Ratio: 24?
+//	Ignitions: 2?
+//	=================================================================================
+//	LR87-LH2-SustainerUpgrade
+//	Speculative upgrade with sl nozzle
+//
+//	Dry Mass: 939? kg		keep TWR below 90
+//	Thrust (SL): ??? Kn
+//	Thrust (Vac): 801 kN
+//	ISP: 358 SL / 409 Vac		calculated with RPA
+//	Burn Time: 500?
+//	Chamber Pressure: 5.67 MPa		same as AJ-9
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Nozzle Ratio: 24?
+//	Ignitions: 2?
+//	=================================================================================
+//	LR87-LH2-VacuumUpgrade
+//	Speculative upgrade for use on later Saturn V missions
+//
+//	Dry Mass: 1050? kg		same as vacuum
+//	Thrust (SL): ??? Kn
+//	Thrust (Vac): 889 kN
+//	ISP: 289 SL / 434 Vac		calculated with RPA
+//	Burn Time: 500?
+//	Chamber Pressure: 5.67 MPa		same as AJ-9
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5?
+//	Nozzle Ratio: 34?
+//	Ignitions: 3?
+//	=================================================================================
 
+//	Sources:
+
+// http://www.astronautix.com/t/titanc.html
+
+//	Used by:
+
+//	Notes:
+// TitanC config is as of published numbers on engine performance
+// for the Titan C application (simmed at 5 MPa, 12Ae/At). Astronautix
+// mass figures are obviously wrong (suggesting 90+ TWR) so AJ-3 mass is
+// used instead.
+// Speculative alternates and upgrades simmed by increasing area ratio and
+// increasing chamber pressure to match the most similar standard LR87
+// version.
+
+//	==================================================
 @PART[*]:HAS[#engineType[LR87LH2]]:FOR[RealismOverhaulEngines]
 {
 	%title = #roLR87LH2Title	//LR87-LH2
@@ -38,7 +108,7 @@
 		type = ModuleEngines
 		configuration = LR87-LH2-TitanC
 		modded = false
-		origMass = 0.74
+		origMass = 0.839
 		CONFIG
 		{
 			name = LR87-LH2-TitanC
@@ -51,13 +121,13 @@
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.745
+				ratio = 0.7454
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.255
+				ratio = 0.2546
 			}
 			atmosphereCurve
 			{
@@ -87,22 +157,22 @@
 			maxThrust = 778.0
 			heatProduction = 175
 			ignitions = 2
-			massMult = 1.14865
+			massMult = 1.25149
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.745
+				ratio = 0.7454
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.255
+				ratio = 0.2546
 			}
 			atmosphereCurve
 			{
-				key = 0 419
-				key = 1 312
+				key = 0 421
+				key = 1 315
 			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -126,18 +196,18 @@
 			minThrust = 801 // 180 klbf
 			maxThrust = 801
 			heatProduction = 175
-			massMult = 1.08109
+			massMult = 1.11919
 			ignitions = 2
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.745
+				ratio = 0.7454
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.255
+				ratio = 0.2546
 			}
 			atmosphereCurve
 			{
@@ -165,23 +235,23 @@
 			minThrust = 889.0
 			maxThrust = 889.0
 			heatProduction = 175
-			massMult = 1.18
+			massMult = 1.25149
 			ignitions = 3
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.745
+				ratio = 0.7454
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.255
+				ratio = 0.2546
 			}
 			atmosphereCurve
 			{
 				key = 0 434
-				key = 1 233
+				key = 1 289
 			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
@@ -25,7 +25,7 @@
 //
 //	Dry Mass: 739 kg
 //	Thrust (SL): 215 klbf
-//	Thrust (Vac): 236.9 klbf
+//	Thrust (Vac): 236.9 klbf = 1053.8 kN
 //	ISP: 258.8 SL / 285.2 Vac
 //	Burn Time: 149.26
 //	Chamber Pressure: 5.48 MPa
@@ -54,7 +54,7 @@
 //	LR87-AJ-9
 //	Titan III
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 713 Kg
 //	Thrust (SL): 1023.1 kN
 //	Thrust (Vac): 1172.1 kN
 //	ISP: 258 SL / 296 Vac

--- a/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR89_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 617.4 kN
 //	ISP: 230 SL / 265 Vac
 //	Burn Time: 65
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 3.61 MPa	estimated with RPA
 //	Propellant: LOX / Ethanol90
 //	Prop Ratio: 1.375
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 8?
 //	Ignitions: 1
 //	=================================================================================
 //	LR43-NA-3
@@ -27,7 +27,7 @@
 //	Thrust (Vac): 756.8 kN
 //	ISP: 245 SL / 278 Vac
 //	Burn Time: ???
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 3.92? MPa
 //	Propellant: LOX / RP-1
 //	Prop Ratio: 2.25
 //	Throttle: N/A
@@ -37,7 +37,7 @@
 //	LR89-NA-3
 //	MA-1
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 640.8 Kg
 //	Thrust (SL): 658.8 kN
 //	Thrust (Vac): 758.7 kN
 //	ISP: 248 SL / 282 Vac
@@ -52,7 +52,7 @@
 //	LR89-NA-5
 //	MA-2
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 828 Kg
 //	Thrust (SL): 710.9 kN
 //	Thrust (Vac): 831.4 kN
 //	ISP: 251 SL / 290 Vac
@@ -67,7 +67,7 @@
 //	LR89-NA-6
 //	MA-3 Upgrade
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 883 Kg
 //	Thrust (SL): 747.3 kN
 //	Thrust (Vac): 846.6 kN
 //	ISP: 256 SL / 290 Vac
@@ -82,7 +82,7 @@
 //	LR89-NA-7.1
 //	MA-5.1 Atlas-Agena
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 1018 Kg
 //	Thrust (SL): 822.7 kN
 //	Thrust (Vac): 931.7 kN
 //	ISP: 258 SL / 292.2 Vac
@@ -97,7 +97,7 @@
 //	LR89-NA-7.2
 //	MA-5.2 Atlas-Centaur
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 1018 Kg
 //	Thrust (SL): 839.6 kN
 //	Thrust (Vac): 950.8 kN
 //	ISP: 259.1 SL / 293.4 Vac

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -6,7 +6,7 @@
 //	LR91-AJ-3
 //	Titan A / Titan I
 //
-//	Dry Mass: ???
+//	Dry Mass: 590 kg
 //	Thrust (SL): ???
 //	Thrust (vac): 80,603 + 975 (turbine) lbf = 362.88 - Verniers = 360.5 kN
 //	ISP: ??? SL / 310 Vac
@@ -21,7 +21,7 @@
 //	LR91-AJ-5
 //	Titan B / Titan II
 //
-//	Dry Mass: ???
+//	Dry Mass: 500 kg
 //	Thrust (SL): ???
 //	Thrust (vac): 100,000 + 865 (turbine) lbf = 448.67 - Verniers = 446.3 kN
 //	ISP: ??? SL / 315 Vac
@@ -36,7 +36,7 @@
 //	LR91-AJ-7
 //	Titan II GLV
 //
-//	Dry Mass: ???
+//	Dry Mass: 565 kg
 //	Thrust (SL): ???
 //	Thrust (vac): 100,000 + 865 (turbine) lbf = 448.67 - Verniers = 446.3 kN
 //	ISP: ??? SL / 315 Vac
@@ -51,7 +51,7 @@
 //	LR91-AJ-9
 //	Titan 3A/B/C
 //
-//	Dry Mass: ???
+//	Dry Mass: 590 kg
 //	Thrust (SL): ???
 //	Thrust (vac): 456.1
 //	ISP: ??? SL / 316 Vac
@@ -66,7 +66,7 @@
 //	LR91-AJ-11
 //	Titan 3D/E
 //
-//	Dry Mass: ???
+//	Dry Mass: 589 kg
 //	Thrust (SL): ???
 //	Thrust (vac): 456.1
 //	ISP: ??? SL / 318 Vac
@@ -81,7 +81,7 @@
 //	LR91-AJ-11A
 //	Titan IV
 //
-//	Dry Mass: ???
+//	Dry Mass: 589 kg
 //	Thrust (SL): ???
 //	Thrust (vac): 474.6
 //	ISP: ??? SL / 325.5 Vac

--- a/GameData/RealismOverhaul/Engine_Configs/LRBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LRBE_Config.cfg
@@ -27,7 +27,7 @@
 //	Thrust (Vac): 2473.5 kN
 //	ISP: 327.7 SL / 352.7 Vac
 //	Burn Time: 500
-//	Chamber Pressure: ??? MPa (@ 111% throttle)
+//	Chamber Pressure: 21.02? MPa (@ 111% throttle)
 //	Propellant: LOX / CH4
 //	Prop Ratio: 3.5
 //	Throttle: 100% to 67%

--- a/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/MR-80B_Config.cfg
@@ -10,13 +10,13 @@
 //	Dry Mass: 8.5 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 3.603 kN
-//	ISP: 204 SL / 223 Vac
+//	ISP: 79 SL / 223 Vac		204 is in Mars atmo, sl calculated with RPA
 //	Burn Time: 350
 //	Chamber Pressure: 2.4 MPa
 //	Propellant: Hydrazine
 //	Prop Ratio: N/A
 //	Throttle: 100% to ~8%
-//	Nozzle Ratio: 16.7
+//	Nozzle Ratio: 27.2
 //	Ignitions: Infinite
 //	=================================================================================
 
@@ -24,6 +24,7 @@
 
 //	http://matthewwturner.com/uah/IPT2008_summer/baselines/LOW%20Files/Payload/Downloads/AIAA-2007-5481-979.pdf
 //	https://www.rocket.com/sites/default/files/documents/Capabilities/PDFs/Monopropellant%20Data%20Sheets.pdf
+//	https://www.rocket.com/sites/default/files/documents/In-Space%20Data%20Sheets%204.8.20.pdf
 
 //	Used by:
 
@@ -82,7 +83,7 @@
 			atmosphereCurve
 			{
 				key = 0 223
-				key = 1 204
+				key = 1 79
 			}
 			ullage = False
 			pressureFed = True
@@ -99,6 +100,14 @@
 				//Extremely simple and reliable monopropellant engines
 				ratedBurnTime = 1000		//tested over 800 seconds, round up to 1000
 				ratedContinuousBurnTime = 215		//longest single burn
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
 				ignitionReliabilityStart = 0.99
 				ignitionReliabilityEnd = 0.999
 				cycleReliabilityStart = 0.99

--- a/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Merlin1_Config.cfg
@@ -37,7 +37,7 @@
 //	Merlin 1BVac
 //	
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 912? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 421.6 kN
 //	ISP: 161 SL / 332.1 Vac		SL calculated with RPA

--- a/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NAA75_110_Config.cfg
@@ -16,7 +16,7 @@
 //	Propellant: LOX / Ethanol75
 //	Prop Ratio: 1.354
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 3.61?
 //	Ignitions: 1
 //	=================================================================================
 //	A-6
@@ -34,20 +34,19 @@
 //	Nozzle Ratio: 3.61
 //	Ignitions: 1
 //	=================================================================================
-//  A-7
-//  Redstone, Mercury-Redstone
-//  
-//  Dry Mass: 740 Kg
-//  Thrust (SL): 346.6 kN (78klbf)
-//  Thrust (Vac): 395.5 kN
-//  ISP: 218 SL / 249 Vac
-//  Burn Time: 143 for MRLV
-//  Chamber Pressure: 2.19 MPa
-//  Propellant: LOX / Ethanol75
-//  Prop Ratio: 1.354
-//  Nozzle Ratio: 3.61
-//  Ignitions: 1
-//  
+//	A-7
+//	Redstone, Mercury-Redstone
+//	
+//	Dry Mass: 740 Kg
+//	Thrust (SL): 346.6 kN (78klbf)
+//	Thrust (Vac): 395.5 kN
+//	ISP: 218 SL / 249 Vac
+//	Burn Time: 143 for MRLV
+//	Chamber Pressure: 2.19 MPa
+//	Propellant: LOX / Ethanol75
+//	Prop Ratio: 1.354
+//	Nozzle Ratio: 3.61
+//	Ignitions: 1
 //	=================================================================================
 //	A-6H
 //	Jupiter-C / Juno I

--- a/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK33_Config.cfg
@@ -4,50 +4,80 @@
 //	Manufacturer: SNTK Kuznetsov
 //
 //	=================================================================================
-//	NK-15
+//	NK-15 (11D51)
 //	N-1
 //
-//	Dry Mass: 1247 Kg
+//	Dry Mass: 1247 Kg	[11]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 1681 kN
-//	ISP: 284 SL / 318 Vac
-//	Burn Time: 180
-//	Chamber Pressure: ??? MPa
+//	Thrust (Vac): 1543.6 kN		[3/11]
+//	ISP: 284 SL / 318 Vac	[3/4]
+//	Burn Time: 180?
+//	Chamber Pressure: 14.5 MPa	[11]
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.5
-//	Throttle: 100% to 50%
-//	Nozzle Ratio: ???
+//	Prop Ratio: 2.5		[3/4]
+//	Throttle: 100% to 50%?
+//	Nozzle Ratio: 27.7	[3/8/10]
 //	Ignitions: 1
 //	=================================================================================
-//	NK-33
+//	NK-33 (11D111)
 //	N-1F, Soyuz 2.1v
 //
-//	Dry Mass: 1222 Kg
+//	Dry Mass: 1240 Kg	[6]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 1766 kN
-//	ISP: 297 SL / 331 Vac
-//	Burn Time: 240
-//	Chamber Pressure: ??? MPa
+//	Thrust (Vac): 1765.7 kN		[6] (1681.6 kN @100%)
+//	ISP: 297.23 SL / 331 Vac	[6/11]
+//	Burn Time: 365	[6]
+//	Chamber Pressure: 14.83 MPa		[6/11] (14.54 MPa @100% [5/8/10])
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.6
-//	Throttle: 105% to 50%
-//	Nozzle Ratio: ???
-//	Ignitions: 2
+//	Prop Ratio: 2.62	[6]	2.59
+//	Throttle: 105% to 50%	[6]
+//	Nozzle Ratio: 27.7	[3/8/10]
+//	Ignitions: 1
+//	=================================================================================
+//	AJ26-58
+//	Kistler K-1
+//
+//	Dry Mass: 1407.9 Kg		[10]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1753.3 kN		[6] (1685.9 kN @100%)
+//	ISP: 297.23 SL / 331 Vac	[6/11]
+//	Burn Time: 365	[6]
+//	Chamber Pressure: 14.83 MPa		[6/11] (14.54 MPa @100% [5/8/10])
+//	Propellant: CooledLOX / CooledRG-1
+//	Prop Ratio: 2.59	[8]
+//	Throttle: 104% to 55%	[5]
+//	Nozzle Ratio: 27.7	[3/8/10]
+//	Ignitions: 1	[10]
+//	=================================================================================
+//	AJ26-59
+//	Kistler K-1, restartable
+//
+//	Dry Mass: 1458.8 Kg		[10]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1753.3 kN		[6] (1685.9 kN @100%)
+//	ISP: 297.23 SL / 331 Vac	[6/11]
+//	Burn Time: 365	[6]
+//	Chamber Pressure: 14.83 MPa		[6/11] (14.54 MPa @100% [5/8/10])
+//	Propellant: CooledLOX / CooledRP-1
+//	Prop Ratio: 2.59	[8]
+//	Throttle: 104% to 55%	[5]
+//	Nozzle Ratio: 27.7	[3/8/10]
+//	Ignitions: 2	[10]
 //	=================================================================================
 //	AJ26-62
 //	Antares
 //
-//	Dry Mass: 1459 Kg
+//	Dry Mass: 1459? kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 1815 kN
-//	ISP: 301.6 SL / 331.9 Vac
+//	ISP: 301.6 SL / 331.9 Vac	[9]
 //	Burn Time: 240
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 16.42 MPa		[9]
 //	Propellant: CooledLOX / CooledRP-1
-//	Prop Ratio: 2.7
-//	Throttle: 100% to 50%
-//	Nozzle Ratio: ???
-//	Ignitions: 2
+//	Prop Ratio: 2.7		[9]
+//	Throttle: 108% to 58%	[9]
+//	Nozzle Ratio: 27.7?
+//	Ignitions: 1
 //	=================================================================================
 
 //	Sources:
@@ -55,13 +85,16 @@
 // [1]	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000088626.pdf
 // [2]	http://www.scribd.com/doc/46957813/Aviadvigatel
 // [3]	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm - dubious
-// [4]	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
-// [5]	http://www.lpre.de/sntk/NK-33/index.htm
-// [6]	http://history.nasa.gov/SP-4408pt1.pdf
-// [7]	http://lpre.de/resources/articles/AIAA-1998-3361.pdf - good on data
-// [8]	https://web.archive.org/web/20140115161002/http://www.orbital.com/NewsInfo/Publications/Antares%20UG.pdf
-// [9]	http://sites.nationalacademies.org/cs/groups/depssite/documents/webpage/deps_068011.pdf		- AJ26-62 reliability
-// [10]	Anisimov: "EVOLUTION OF THE NK-33 AND NK-43 REUSABLE LOX/KEROSENE ENGINES"
+// [4]	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+// [5]	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
+// [6]	http://www.lpre.de/sntk/NK-33/index.htm
+// [7]	http://history.nasa.gov/SP-4408pt1.pdf
+// [8]	http://lpre.de/resources/articles/AIAA-1998-3361.pdf - good on data
+// [9]	https://web.archive.org/web/20140115161002/http://www.orbital.com/NewsInfo/Publications/Antares%20UG.pdf
+// [10]	http://sites.nationalacademies.org/cs/groups/depssite/documents/webpage/deps_068011.pdf		- AJ26-62 reliability
+// [11]	http://www.lpre.de/sntk/index.htm
+// [12]	Anisimov: "EVOLUTION OF THE NK-33 AND NK-43 REUSABLE LOX/KEROSENE ENGINES"
+// [13]	http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf
 
 //	Used by:
 
@@ -72,9 +105,9 @@
 {
 	%title = #roNK33Title	//NK-15/33
 	%manufacturer = #roMfrNPOKuznetstov
-	%description = #roNK33Desc	//The NK-15 and NK-33 were originally built in the 1960s/early 1970s for the Soviet N1 and then N1F rocket, respectively. Though the N1F was scrapped, the engines survived. Aerojet acquired several NK-33 engines in the 1990s and refurbished them as AJ26-62 engines for Orbital Science's Antares launch vehicle. Modifications made by Aerojet included increasing rated thrust and equipping the engines to support gimballing.
+	%description = #roNK33Desc
 
-	@tags ^= :$: USSR okb-276 kuznetsov aerojet nk-15 nk-33 aj26-62 liquid pump booster kerosene lqdoxygen
+	@tags ^= :$: USSR okb-276 kuznetsov aerojet nk-15 nk-33 aj26-58 aj26-59 aj26-62 liquid pump booster kerosene lqdoxygen
 
 	%specLevel = operational
 
@@ -99,16 +132,18 @@
 		name = ModuleEngineConfigs
 		configuration = NK-15
 		modded = false
-		origMass = 1.222
+		origMass = 1.240
 		CONFIG
 		{
 			name = NK-15
 			description = Developed as the first stage engine of the N-1 moon rocket. Gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 1681 // 378,000 Ibf 
-			minThrust = 841
+			maxThrust = 1543.6
+			minThrust = 771.8
 			heatProduction = 100
-			massMult = 1.21812 // 1.020458 (NK-15, no gimbal) * 1.1937 (increase % for gimbal)
+			massMult = 1.1418 // 1.0056 (NK-15, no gimbal) * 1.1354 (increase % for gimbal)
+			ullage = True
+			ignitions = 1
 			gimbalRange = 6
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -124,12 +159,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 331
-				key = 1 297
+				key = 0 318
+				key = 1 284
 			}
 			
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -175,10 +208,12 @@
 			name = NK-15-Original-NoGimbal
 			description = Developed as the first stage engine of the N-1 moon rocket. No gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 1681
-			minThrust = 841
+			maxThrust = 1543.6
+			minThrust = 771.8
 			heatProduction = 100
-			massMult = 1.020458
+			massMult = 1.0056
+			ullage = True
+			ignitions = 1
 			gimbalRange = 0
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -194,12 +229,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 331
-				key = 1 297
+				key = 0 318
+				key = 1 284
 			}
 			
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -237,31 +270,31 @@
 			name = NK-33
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. Gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 1766 //105% rated thrust
-			minThrust = 841
+			maxThrust = 1765.7
+			minThrust = 840.8
 			heatProduction = 100
-			massMult = 1.1937 // 1.459t, mass value from AJ26-59
+			massMult = 1.1354 	//(increase % for gimbal)
+			ullage = True
+			ignitions = 1
 			gimbalRange = 6
-			// 2.6 O/F mass ratio (b14643.de)
+			// 2.62 O/F mass ratio
 			PROPELLANT
 			{
 				name = CooledRG-1
-				ratio = 0.3576
+				ratio = 0.3558
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.6424
+				ratio = 0.6442
 			}
 			atmosphereCurve
 			{
 				key = 0 331
-				key = 1 297
-			}	
+				key = 1 297.23
+			}
 			
-			ullage = True
-			ignitions = 2
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -270,7 +303,7 @@
 			IGNITOR_RESOURCE
 			{
 				name = TEATEB
-				amount = 1
+				amount = 2
 			}
 
 			//due to limited data, data from both the NK-33 and AJ26-62 is used
@@ -282,7 +315,7 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 450		//Tested to 450 seconds
-				ratedBurnTime = 240 //based on Antares and Soyuz 2-1v burn times.
+				ratedBurnTime = 365
 				safeOverburn = true
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
@@ -304,31 +337,31 @@
 			name = NK-33-Original-NoGimbal
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. Revived following the fall of the USSR, now used on Soyuz 2.1v. No gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 1766
-			minThrust = 841
+			maxThrust = 1765.7
+			minThrust = 840.8
 			heatProduction = 100
-			massMult = 1
+			massMult = 1.0000
+			ullage = True
+			ignitions = 1
 			gimbalRange = 0
-			// 2.6 O/F mass ratio (b14643.de)
+			// 2.62 O/F mass ratio
 			PROPELLANT
 			{
 				name = CooledRG-1
-				ratio = 0.3576
+				ratio = 0.3558
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.6424
+				ratio = 0.6442
 			}
 			atmosphereCurve
 			{
 				key = 0 331
-				key = 1 297
+				key = 1 297.23
 			}
 			
-			ullage = True
-			ignitions = 2
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -337,13 +370,13 @@
 			IGNITOR_RESOURCE
 			{
 				name = TEATEB
-				amount = 1
+				amount = 2
 			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 450		//Tested to 450 seconds
-				ratedBurnTime = 240
+				ratedBurnTime = 365
 				safeOverburn = true
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
@@ -362,14 +395,138 @@
 		}
 		CONFIG
 		{
+			name = AJ26-58
+			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. This is a single start reusable version, intended for the K-1 first stage.
+			specLevel = prototype
+			maxThrust = 1753.3
+			minThrust = 927.2
+			heatProduction = 100
+			massMult = 1.1354
+			ignitions = 1
+			ullage = True
+			gimbalRange = 6
+			PROPELLANT
+			{
+				name = CooledRP-1
+				ratio = 0.3659
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = CooledLqdOxygen
+				ratio = 0.6341
+			}
+			atmosphereCurve
+			{
+				key = 0 331
+				key = 1 297.23
+			}
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 2
+			}
+
+			//0.997 target reliability
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 5870	//5870 seconds between overhauls
+				ratedBurnTime = 365
+				safeOverburn = true
+				overburnPenalty = 1.5		//rated for reuse, but wasn't terribly reliable
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.997
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.997
+				techTransfer = AJ26-59,NK-33,NK-33-Original-NoGimbal,NK-15,NK-15-Original-NoGimbal:50
+			}
+		}
+		CONFIG
+		{
+			name = AJ26-59
+			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. This is a two start reusable version, intended for the K-1 first stage.
+			specLevel = prototype
+			maxThrust = 1753.3
+			minThrust = 927.2
+			heatProduction = 100
+			massMult = 1.1765
+			ignitions = 2
+			ullage = True
+			gimbalRange = 6
+			PROPELLANT
+			{
+				name = CooledRP-1
+				ratio = 0.3659
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = CooledLqdOxygen
+				ratio = 0.6341
+			}
+			atmosphereCurve
+			{
+				key = 0 331
+				key = 1 297.23
+			}
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 5870	//5870 seconds between overhauls
+				ratedBurnTime = 365
+				safeOverburn = true
+				overburnPenalty = 1.5		//rated for reuse, but wasn't terribly reliable
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.997
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.997
+				techTransfer = AJ26-58,NK-33,NK-33-Original-NoGimbal,NK-15,NK-15-Original-NoGimbal:50
+			}
+		}
+		CONFIG
+		{
 			name = AJ26-62
-			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. Formerly used for the Antares-100 series
+			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. Non-reusable version for Antares.
 			specLevel = operational
 			maxThrust = 1815
-			minThrust = 941.92
+			minThrust = 977.82
 			heatProduction = 100
-			massMult = 1.1937
-			ignitions = 2
+			massMult = 1.1766
+			ignitions = 1
+			ullage = True
 			gimbalRange = 6
 			// 2.7 O/F mass ratio (Antares UG)
 			PROPELLANT
@@ -389,8 +546,6 @@
 				key = 1 301.6 // Antares UG
 			}
 			
-			ullage = True
-			ignitions = 2
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -399,12 +554,14 @@
 			IGNITOR_RESOURCE
 			{
 				name = TEATEB
-				amount = 1
+				amount = 2
 			}
 
+			//0.988 target reliability
+			//pretty close to actual reliability
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 2400		//Tested to 450 seconds. Upgraded for reuse in K-1, with many modifications to increase reliability. Rate for 10 flights?
+				testedBurnTime = 450
 				ratedBurnTime = 240
 				safeOverburn = true
 				overburnPenalty = 1.5		//rated for reuse, but wasn't terribly reliable
@@ -420,7 +577,7 @@
 				ignitionReliabilityEnd = 0.980556
 				cycleReliabilityStart = 0.876852
 				cycleReliabilityEnd = 0.980556
-				techTransfer = NK-15,NK-15-Original-NoGimbal,NK-33,NK-33-Original-NoGimbal:50
+				techTransfer = AJ26-59,AJ26-58,NK-33,NK-33-Original-NoGimbal,NK-15,NK-15-Original-NoGimbal:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK43_Config.cfg
@@ -4,44 +4,67 @@
 //	Manufacturer: SNTK Kuznetsov 
 //
 //	=================================================================================
-//	NK-15V
+//	NK-15V (11D52)
 //	N-1
 //
-//	Dry Mass: 1345 Kg
+//	Dry Mass: 1396 Kg	[11]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 1755 kN
-//	ISP: 255 SL / 346 Vac		SL calculated with RPA
+//	Thrust (Vac): 1647.5 kN		[3/4]
+//	ISP: 259 SL / 325 Vac		[3/4] SL calculated with RPA
 //	Burn Time: 240
-//	Chamber Pressure: 14.57? MPa
+//	Chamber Pressure: 14.5 MPa	[11]
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.5
-//	Throttle: 100% to 50%
-//	Nozzle Ratio: 80?
+//	Prop Ratio: 2.5		[3/4]
+//	Throttle: 100% to 50%?
+//	Nozzle Ratio: 51?	NK-15V was smaller and had worse ISP. Assume lower area ratio based on diameter ratio (2/2.5 m)
 //	Ignitions: 1
 //	=================================================================================
-//	NK-43
+//	NK-43 (11D112)
 //	N-1
 //
-//	Dry Mass: 1396 Kg
+//	Dry Mass: 1396 Kg	[11/13]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 1755 kN
-//	ISP: 254 SL / 346 Vac		SL calculated with RPA
-//	Burn Time: 360
-//	Chamber Pressure: 14.57 MPa
+//	Thrust (Vac): 1757.4 kN		[3/4/6/11]
+//	ISP: 251 SL / 346 Vac		SL calculated with RPA
+//	Burn Time: 346
+//	Chamber Pressure: 14.57 MPa		[3/4/6/11]
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.8
-//	Throttle: 100% to 50%
-//	Nozzle Ratio: 80?
-//	Ignitions: 3
+//	Prop Ratio: 2.8		[3/4/6]
+//	Throttle: 100% to 50%?
+//	Nozzle Ratio: 79.7	[10]
+//	Ignitions: 3???
+//	=================================================================================
+//	AJ26-60
+//	Kistler K-1
+//
+//	Dry Mass: 1473 Kg	[5]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 1823.9 kN		[5] (1753.8 kN @100%?)
+//	ISP: 251 SL / 346 Vac		SL calculated with RPA
+//	Burn Time: 346
+//	Chamber Pressure: 14.54 MPa		[5]
+//	Propellant: CooledLOX / CooledRP-1
+//	Prop Ratio: 2.8		[3/4]
+//	Throttle: 104% to 55%?	[5]
+//	Nozzle Ratio: 79.7	[10]
+//	Ignitions: 1	[5]
 //	=================================================================================
 
 //	Sources:
 
-//	FIXME: NK15 stats from http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/Propulsion/engines.htm, may be unreliable
-//	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm (more reliable)
-//	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
-//	http://www.lpre.de/sntk/NK-33/index.htm
-//	Assume NK-15V has same performance stats as NK-43(as stated in multiple sources) when no other references are found.
+// [1]	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000088626.pdf
+// [2]	http://www.scribd.com/doc/46957813/Aviadvigatel
+// [3]	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm - dubious
+// [4]	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+// [5]	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
+// [6]	http://www.lpre.de/sntk/NK-33/index.htm
+// [7]	http://history.nasa.gov/SP-4408pt1.pdf
+// [8]	http://lpre.de/resources/articles/AIAA-1998-3361.pdf - good on data
+// [9]	https://web.archive.org/web/20140115161002/http://www.orbital.com/NewsInfo/Publications/Antares%20UG.pdf
+// [10]	http://sites.nationalacademies.org/cs/groups/depssite/documents/webpage/deps_068011.pdf		- AJ26-62 reliability
+// [11]	http://www.lpre.de/sntk/index.htm
+// [12]	Anisimov: "EVOLUTION OF THE NK-33 AND NK-43 REUSABLE LOX/KEROSENE ENGINES"
+// [13]	http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf
 
 //	Used by:
 
@@ -52,7 +75,7 @@
 {
 	%title = #roNK43Title	//NK-15V/43
 	%manufacturer = #roMfrNPOKuznetstov
-	%description = #roNK43Desc	//Originally designed and built for the N1F, the NK-43 is a derivative of the NK-33 with longer bell and restart capability for upper stages.
+	%description = #roNK43Desc
 
 	@tags ^= :$: USSR okb-276 kuznetsov nk-15v nk-43 liquid pump upper kerosene lqdoxygen
 
@@ -85,10 +108,12 @@
 			name = NK-15V
 			description = Developed as the second stage engine of the N-1 moon rocket. Gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 1755
-			minThrust = 877.5
+			maxThrust = 1647.5
+			minThrust = 823.75
 			heatProduction = 100
-			massMult = 1.15009 // 0.963467 (NK-15V, no gimbal) * 1.1937 (increase % for gimbal)
+			massMult = 1.0552 //1.0552 (increase % for gimbal)
+			ullage = True
+			ignitions = 1
 			gimbalRange = 6
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -104,12 +129,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 346
-				key = 1 255
+				key = 0 325
+				key = 1 259
 			}
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -148,10 +171,12 @@
 			name = NK-15V-Original-NoGimbal
 			description = Developed as the second stage engine of the N-1 moon rocket. No gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 1755
-			minThrust = 877.5
+			maxThrust = 1647.5
+			minThrust = 823.75
 			heatProduction = 100
-			massMult = 0.963467
+			massMult = 1.00
+			ullage = True
+			ignitions = 1
 			gimbalRange = 0
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -167,12 +192,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 346
-				key = 1 255
+				key = 0 325
+				key = 1 259
 			}
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -211,10 +234,12 @@
 			name = NK-43
 			description =  Developed as an upgrade to the NK-15V, and then abandoned with the cancellation of the N-1. Gimbal, differential throttle.
 			specLevel = prototype
-			minThrust = 877.5
-			maxThrust = 1755
+			minThrust = 878.7
+			maxThrust = 1757.4
 			heatProduction = 100
-			massMult = 1.1937 // 1 (NK-43, no gimbal) * 1.1937 (increase % for gimbal)
+			massMult = 1.0552 //1.0552 (increase % for gimbal)
+			ullage = True
+			ignitions = 3
 			gimbalRange = 6
 			// 2.8 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -231,11 +256,9 @@
 			atmosphereCurve
 			{
 				key = 0 346
-				key = 1 254
+				key = 1 251
 			}
 
-			ullage = True
-			ignitions = 3
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -250,7 +273,7 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 450		//Tested to 450 seconds, same as NK-33
-				ratedBurnTime = 360
+				ratedBurnTime = 346
 				safeOverburn = true
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
@@ -272,10 +295,12 @@
 			name = NK-43-Original-NoGimbal
 			description = Developed as an upgrade to the NK-15, and then abandoned with the cancellation of the N-1. No gimbal, differential throttle.
 			specLevel = prototype
-			maxThrust = 1755
-			minThrust = 877.5
+			minThrust = 878.7
+			maxThrust = 1757.4
 			heatProduction = 100
 			massMult = 1
+			ullage = True
+			ignitions = 3
 			gimbalRange = 0
 			// 2.8 O/F mass ratio (b14643.de)
 			PROPELLANT
@@ -292,11 +317,9 @@
 			atmosphereCurve
 			{
 				key = 0 346
-				key = 1 254
+				key = 1 251
 			}
 
-			ullage = True
-			ignitions = 3
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -311,7 +334,7 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 450		//Tested to 450 seconds, same as NK-33
-				ratedBurnTime = 360
+				ratedBurnTime = 346
 				safeOverburn = true
 
 				// assume roughly exponential relationship between chamber pressure and lifespan
@@ -326,6 +349,67 @@
 				cycleReliabilityStart = 0.92
 				cycleReliabilityEnd = 0.996
 				techTransfer = NK-43,NK-33,NK-33-Original-NoGimbal:100&NK-15V,NK-15V-Original-NoGimbal:50
+			}
+		}
+		CONFIG
+		{
+			name = AJ26-60
+			description = The NK-33 design was sold to Aerojet in the mid 1990s. Aerojet modified it to create the AJ26. This is a single start reusable version, intended for the K-1 second stage.
+			specLevel = prototype
+			minThrust = 964.59
+			maxThrust = 1823.9
+			heatProduction = 100
+			massMult = 1.0552 //1.0552 (increase % for gimbal)
+			ullage = True
+			ignitions = 1
+			gimbalRange = 6
+			// 2.8 O/F mass ratio (b14643.de)
+			PROPELLANT
+			{
+				name = CooledRG-1
+				ratio = 0.3408
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = CooledLqdOxygen
+				ratio = 0.6592
+			}
+			atmosphereCurve
+			{
+				key = 0 346
+				key = 1 251
+			}
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 3
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 5870	//5870 seconds between overhauls
+				ratedBurnTime = 346
+				safeOverburn = true
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.997
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.997
+				techTransfer = NK-43,NK-43-Original-NoGimbal,NK-33,NK-33-Original-NoGimbal:100&NK-15V,NK-15V-Original-NoGimbal:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/NK9V_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V_Config.cfg
@@ -4,89 +4,97 @@
 //	Manufacturer: SNTK Kuznetsov
 //
 //	=================================================================================
-//	NK-9V
-//	
+//	NK-9V (8D517V?)
+//	GR-1, N1
 //
-//	Dry Mass: 640 Kg
+//	Dry Mass: 640? Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 451.1 kN
-//	ISP: 219 SL / 345 Vac		SL calculated with RPA
+//	Thrust (Vac): 451.1 kN		[3/4/11]
+//	ISP: 237 SL / 345 Vac		[3/4/11], SL calculated with RPA
 //	Burn Time: 240
-//	Chamber Pressure: 7.85 MPa
+//	Chamber Pressure: 10.34 MPa		[3/13]
 //	Propellant: LOX / RG-1
-//	Prop Ratio: 2.5
+//	Prop Ratio: 2.5		[3/4]
 //	Throttle: N/A
-//	Nozzle Ratio: 80?
+//	Nozzle Ratio: 79.7?
 //	Ignitions: 1
 //	=================================================================================
-//	NK-21
+//	NK-21 (11D59)
 //	N1
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 584? Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 400 kN
-//	ISP: ??? SL / 340 Vac
-//	Burn Time: 240
-//	Chamber Pressure: ??? MPa
+//	Thrust (Vac): 402.1 kN		[3/4]
+//	ISP: 225 SL / 340 Vac		[3/4], SL calculated with RPA
+//	Burn Time: 450?
+//	Chamber Pressure: 9.20 MPa		[4]
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.5
-//	Throttle: 100% to 60%
-//	Nozzle Ratio: ???
+//	Prop Ratio: 2.5		[3/4]
+//	Throttle: 100% to 60%?
+//	Nozzle Ratio: 79.7?
 //	Ignitions: 1
 //	=================================================================================
-//	NK-19
+//	NK-19 (11D53)
 //	N1
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 721.6? Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 400 kN
-//	ISP: ??? SL / 353 Vac
-//	Burn Time: 240
-//	Chamber Pressure: ??? MPa
+//	Thrust (Vac): 451.1 kN		[3/4/11]
+//	ISP: 230 SL / 345 Vac		[3/4], SL calculated with RPA
+//	Burn Time: 450?
+//	Chamber Pressure: 9.20 MPa		[4]
 //	Propellant: CooledLOX / CooledRG-1
 //	Prop Ratio: 2.5
-//	Throttle: 100% to 60%
-//	Nozzle Ratio: ???
+//	Throttle: 100% to 60%?
+//	Nozzle Ratio: 79.7?
 //	Ignitions: 1
 //	=================================================================================
-//	NK-39
+//	NK-39 (11D113)
 //	N1F
 //
-//	Dry Mass: 700 Kg
+//	Dry Mass: 584 Kg		[11]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 400 kN
-//	ISP: 235 SL / 352 Vac		SL calculated with RPA
-//	Burn Time: 240
-//	Chamber Pressure: 9.20 MPa
+//	Thrust (Vac): 407 kN		[3/4/11]
+//	ISP: 213 SL / 352 Vac		[3/4/11] SL calculated with RPA
+//	Burn Time: 600?
+//	Chamber Pressure: 9.20 MPa	[3/4/13]
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.6
+//	Prop Ratio: 2.62		same as NK-33?
 //	Throttle: 100% to 60%
-//	Nozzle Ratio: 80?
+//	Nozzle Ratio: 114	[10]
 //	Ignitions: 1
 //	=================================================================================
-//	NK-31
+//	NK-31 (11D114)
 //	N1F
 //
-//	Dry Mass: 722 Kg
+//	Dry Mass: 721.6 Kg		[13]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 402 kN
-//	ISP: 236 SL / 353 Vac		SL calculated with RPA
-//	Burn Time: 240
-//	Chamber Pressure: 9.20 MPa
+//	Thrust (Vac): 402.1 kN		[3/4/13]
+//	ISP: 214 SL / 353 Vac		[3/4/11/13] SL calculated with RPA
+//	Burn Time: 600?
+//	Chamber Pressure: 9.20 MPa	[3/4/13]
 //	Propellant: CooledLOX / CooledRG-1
-//	Prop Ratio: 2.6
+//	Prop Ratio: 2.62		same as NK-33?
 //	Throttle: 100% to 60%
-//	Nozzle Ratio: 80?
-//	Ignitions: 2
+//	Nozzle Ratio: 114	[10]
+//	Ignitions: 2?
 //	=================================================================================
 
 //	Sources:
 
-
-//	http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
-//	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm
-//	http://www.k204.ru/books/Aviadvigatel2.pdf
-//	http://www.lpre.de/sntk/
+// [1]	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000088626.pdf
+// [2]	http://www.scribd.com/doc/46957813/Aviadvigatel
+// [3]	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm - dubious
+// [4]	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+// [5]	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
+// [6]	http://www.lpre.de/sntk/NK-33/index.htm
+// [7]	http://history.nasa.gov/SP-4408pt1.pdf
+// [8]	http://lpre.de/resources/articles/AIAA-1998-3361.pdf - good on data
+// [9]	https://web.archive.org/web/20140115161002/http://www.orbital.com/NewsInfo/Publications/Antares%20UG.pdf
+// [10]	http://sites.nationalacademies.org/cs/groups/depssite/documents/webpage/deps_068011.pdf		- AJ26-62 reliability
+// [11]	http://www.lpre.de/sntk/index.htm
+// [12]	Anisimov: "EVOLUTION OF THE NK-33 AND NK-43 REUSABLE LOX/KEROSENE ENGINES"
+// [13]	http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf
 
 //	Used by:
 //		Bobcat
@@ -131,11 +139,12 @@
 			name = NK-9V
 			description = Original vacuum version of NK-9 for the GR-1 rocket.
 			specLevel = prototype
-			maxThrust = 451.1 // b14643
+			maxThrust = 451.1
 			minThrust = 451.1
 			heatProduction = 205
-			massMult = 1
-			// 2.5 O/F mass ratio (b14643.de)
+			massMult = 1.0
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = RG-1
@@ -150,11 +159,9 @@
 			atmosphereCurve
 			{
 				key = 0 345
-				key = 1 219
+				key = 1 237
 			}
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -186,9 +193,12 @@
 			name = NK-21
 			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
 			specLevel = operational
-			maxThrust = 400 // b14643
-			minThrust = 240 // assume 60% throttle.
+			maxThrust = 402.1
+			minThrust = 241 // assume 60% throttle.
 			heatProduction = 205
+			massMult = 0.9125
+			ullage = True
+			ignitions = 1
 			// 2.5 O/F mass ratio (b14643.de)
 			PROPELLANT
 			{
@@ -203,13 +213,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 340 // b14643.de
-				key = 1 219 // guess
+				key = 0 340
+				key = 1 225
 			}
-			massMult = 0.9 // I...guess?
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -249,11 +256,12 @@
 			name = NK-19
 			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
 			specLevel = operational
-			maxThrust = 400
-			minThrust = 240
+			maxThrust = 451.1
+			minThrust = 270.7
 			heatProduction = 205
-			massMult = 1 // I...guess?
-			// 2.5 O/F mass ratio (b14643.de)
+			massMult = 1.1275
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = CooledRG-1
@@ -267,12 +275,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 353 //assuming same as NK-31
-				key = 1 219 // guess
+				key = 0 345
+				key = 1 230
 			}
-
-			ullage = True
-			ignitions = 1
+			
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -312,30 +318,29 @@
 			name = NK-39
 			description = Improved for N1F Block V. No gimbal, differential throttle.
 			specLevel = prototype
-			maxThrust = 400
-			minThrust = 240 //FIXME guessing 60% min throttle
+			maxThrust = 407
+			minThrust = 244.2 //FIXME guessing 60% min throttle
 			heatProduction = 205
-			massMult = 1.09375 // 700kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
-			// 2.6 O/F mass ratio (b14643.de)
+			massMult = 0.9125
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = CooledRG-1
-				ratio = 0.3576
+				ratio = 0.3558
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.6424
+				ratio = 0.6442
 			}
 			atmosphereCurve
 			{
 				key = 0 352
-				key = 1 235
+				key = 1 213
 			}
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -373,26 +378,25 @@
 			name = NK-31
 			description = Improved for N1F Block G. Relightable. Gimbal, throttle.
 			specLevel = prototype
-			maxThrust = 402 // b14643
-			minThrust = 240 // assume some level of throttle, engine design was capable, and LH2 replacement engine for this stage had throttle.
+			maxThrust = 402.1
+			minThrust = 241.3 // assume some level of throttle, engine design was capable, and LH2 replacement engine for this stage had throttle.
 			heatProduction = 205
-			massMult = 1.128125 // 722kg http://www.scribd.com/doc/7362263/Russian-Liquid-Propellant-Engines#scribd
-			// 2.6 O/F mass ratio (b14643.de)
+			massMult = 1.1275
 			PROPELLANT
 			{
 				name = CooledRG-1
-				ratio = 0.3576
+				ratio = 0.3558
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.6424
+				ratio = 0.6442
 			}
 			atmosphereCurve
 			{
 				key = 0 353
-				key = 1 236
+				key = 1 214
 			}
 
 			ullage = True

--- a/GameData/RealismOverhaul/Engine_Configs/NK9_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9_Config.cfg
@@ -4,27 +4,83 @@
 //	Manufacturer: SNTK Kuznetsov
 //
 //	=================================================================================
-//	NK-9
-//	R-9
+//	NK-9 (8D517)
+//	R-9/GR-1
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 491.55 Kg		[13]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 421 kN
-//	ISP: 286.5 SL / 328 Vac
-//	Burn Time: 300
-//	Chamber Pressure: 7.85 MPa
+//	Thrust (Vac): 426.6 kN		[3/4/13]
+//	ISP: 286.5 SL / 328 Vac		[3/4/11/13]
+//	Burn Time: 150	[14]
+//	Chamber Pressure: 10.34 MPa		[3/13]
 //	Propellant: LOX / RG-1
+//	Prop Ratio: 2.5		[3/4]
+//	Throttle: N/A
+//	Nozzle Ratio: 25?		estimated with RPA
+//	Ignitions: 1
+//	=================================================================================
+//	NK-9-1969
+//	speculative upgrade with NK-15 tech
+//
+//	Dry Mass: 491.55 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 482 kN	TWR 100?
+//	ISP: 283.5 SL / 330 Vac
+//	Burn Time: 190?
+//	Chamber Pressure: 10.34 MPa
+//	Propellant: CooledLOX / CooledRG-1
 //	Prop Ratio: 2.5
 //	Throttle: N/A
-//	Nozzle Ratio: 40
+//	Nozzle Ratio: 27.7
+//	Ignitions: 1
+//	=================================================================================
+//	NK-9-1972
+//	speculative upgrade with NK-33 tech
+//
+//	Dry Mass: 491.55 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 555 kN	TWR 115?
+//	ISP: 286 SL / 331 Vac
+//	Burn Time: 240?
+//	Chamber Pressure: 10.58 MPa
+//	Propellant: CooledLOX / CooledRG-1
+//	Prop Ratio: 2.62
+//	Throttle: N/A
+//	Nozzle Ratio: 27.7
+//	Ignitions: 1
+//	=================================================================================
+//	NK-9-2009
+//	speculative upgrade with NK-33 tech
+//
+//	Dry Mass: 491.55 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 603 kN	TWR 125?
+//	ISP: 291.3 SL / 331.6 Vac
+//	Burn Time: 240?
+//	Chamber Pressure: 11.71 MPa
+//	Propellant: CooledLOX / CooledRP-1
+//	Prop Ratio: 2.7
+//	Throttle: N/A
+//	Nozzle Ratio: 27.7
 //	Ignitions: 1
 //	=================================================================================
 
 //	Sources:
 
-//	http://www.astronautix.com/engines/nk9.htm
-//	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm
-//	http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf
+// [1]	http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20000088626.pdf
+// [2]	http://www.scribd.com/doc/46957813/Aviadvigatel
+// [3]	http://www.b14643.de/Spacerockets_1/East_Europe_2/N-1/NK/index.htm - dubious
+// [4]	http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
+// [5]	https://web.archive.org/web/20130703154050/http://www.spaceandtech.com/spacedata/engines/nk33_specs.shtml
+// [6]	http://www.lpre.de/sntk/NK-33/index.htm
+// [7]	http://history.nasa.gov/SP-4408pt1.pdf
+// [8]	http://lpre.de/resources/articles/AIAA-1998-3361.pdf - good on data
+// [9]	https://web.archive.org/web/20140115161002/http://www.orbital.com/NewsInfo/Publications/Antares%20UG.pdf
+// [10]	http://sites.nationalacademies.org/cs/groups/depssite/documents/webpage/deps_068011.pdf		- AJ26-62 reliability
+// [11]	http://www.lpre.de/sntk/index.htm
+// [12]	Anisimov: "EVOLUTION OF THE NK-33 AND NK-43 REUSABLE LOX/KEROSENE ENGINES"
+// [13]	http://lpre.de/resources/articles/LPRE%20DESIGNED%20BY%20KUZNETSOV%20COMPANY.pdf
+// [14]	https://rocketengines.ru/historical-digest/events/february-21-29-2.html
 
 //	Used by:
 //		Bobcat
@@ -62,7 +118,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 0.36 // Guess a TWR of 120
+		origMass = 0.49155
 		engineType = L
 		configuration = NK-9
 		modded = false
@@ -71,9 +127,12 @@
 			name = NK-9
 			description = Developed for R-9 ICBM, and later used as the first stage engine for GR-1, the N-1 predecessor.
 			specLevel = prototype
-			maxThrust = 421 // sources differ. Nautix says 441kN for the engine, but 421kN for the GR-1's stage. lpre.de also says 421 kn, so go with this
-			minThrust = 421
+			maxThrust = 426.6
+			minThrust = 426.6
 			heatProduction = 205
+			massMult = 1.0
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = RG-1
@@ -88,12 +147,9 @@
 			atmosphereCurve
 			{
 				key = 0 328
-				key = 1 286.5	//calculated from sl and vac thrust
+				key = 1 286.5
 			}
-			massMult = 1.0
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -125,9 +181,12 @@
 			name = NK-9-1969
 			description = Speculative upgrade, assuming technologies from the NK-15 were integrated back into the NK-9
 			specLevel = speculative
-			maxThrust = 421
-			minThrust = 421
+			maxThrust = 482
+			minThrust = 482
 			heatProduction = 205
+			massMult = 1.0
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = CooledRG-1
@@ -141,13 +200,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 331
-				key = 1 297
+				key = 0 330
+				key = 1 283.5
 			}
-			massMult = 1.0
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -160,15 +216,16 @@
 			}
 
 			//no data, never flown
+			//same as NK-15
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 450		//Assume same as NK-33
 				ratedBurnTime = 190
 				safeOverburn = true
-				ignitionReliabilityStart = 0.925824
-				ignitionReliabilityEnd = 0.985165
-				cycleReliabilityStart = 0.925824
-				cycleReliabilityEnd = 0.985165
+				ignitionReliabilityStart = 0.876852
+				ignitionReliabilityEnd = 0.980556
+				cycleReliabilityStart = 0.876852
+				cycleReliabilityEnd = 0.980556
 				techTransfer = NK-9,NK-9V:50
 			}
 		}
@@ -177,29 +234,29 @@
 			name = NK-9-1972
 			description = Speculative upgrade, assuming technologies from the NK-33 were integrated back into the NK-9
 			specLevel = speculative
-			maxThrust = 436 // (for same TWR as NK-33 - (1766 / 1459) * 360)
-			minThrust = 436
+			maxThrust = 555
+			minThrust = 555
 			heatProduction = 205
+			massMult = 1.0
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = CooledRG-1
-				ratio = 0.3667
+				ratio = 0.3558
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.6333
+				ratio = 0.6442
 			}
 			atmosphereCurve
 			{
 				key = 0 331
-				key = 1 297
+				key = 1 286
 			}
-			massMult = 1.0
 
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -212,15 +269,16 @@
 			}
 
 			//no data, never flown
+			//same as NK-33
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 450		//Assume same as NK-33
 				ratedBurnTime = 240
 				safeOverburn = true
-				ignitionReliabilityStart = 0.93
-				ignitionReliabilityEnd = 0.996
-				cycleReliabilityStart = 0.92
-				cycleReliabilityEnd = 0.996
+				ignitionReliabilityStart = 0.876852
+				ignitionReliabilityEnd = 0.980556
+				cycleReliabilityStart = 0.876852
+				cycleReliabilityEnd = 0.980556
 				techTransfer = NK-9-1969,NK-9,NK-9V:50
 			}
 		}
@@ -229,10 +287,12 @@
 			name = NK-9-2009
 			description = Speculative upgrade, assuming Aerojet purchased and upgraded NK-9s for their own use.
 			specLevel = speculative
-			maxThrust = 448 // (for same TWR as AJ26-62 - (1815 / (1222 * 1.1937)) * 360)
-			minThrust = 448
+			maxThrust = 603
+			minThrust = 603
 			heatProduction = 205
-			// 2.7 O/F mass ratio (Antares UG)
+			massMult = 1.0
+			ullage = True
+			ignitions = 1
 			PROPELLANT
 			{
 				name = CooledRP-1
@@ -246,13 +306,10 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 331.9 // Antares UG
-				key = 1 301.6 // Antares UG
+				key = 0 331.6
+				key = 1 291.3
 			}
-			massMult = 1.0
 			
-			ullage = True
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -265,15 +322,17 @@
 			}
 
 			//no data, never flown
+			//NK-33 really did not enjoy 108+% throttle, poor reliability
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 450		//Assume same as NK-33
+				testedBurnTime = 450
 				ratedBurnTime = 240
 				safeOverburn = true
-				ignitionReliabilityStart = 0.95
-				ignitionReliabilityEnd = 0.996
-				cycleReliabilityStart = 0.96
-				cycleReliabilityEnd = 0.996
+
+				ignitionReliabilityStart = 0.876852
+				ignitionReliabilityEnd = 0.980556
+				cycleReliabilityStart = 0.876852
+				cycleReliabilityEnd = 0.980556
 				techTransfer = NK-9-1972,NK-9-1969,NK-9,NK-9V:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -9,7 +9,7 @@
 //
 //	Dry Mass: 90 Kg
 //	Thrust (SL): 1.750 kN
-//	Thrust (Vac): ??? kN
+//	Thrust (Vac): 1.785 kN
 //	ISP: 210 SL / 215 Vac
 //	Burn Time: 80
 //	Chamber Pressure: 2.53 MPa
@@ -24,7 +24,22 @@
 //
 //	Dry Mass: 90 Kg
 //	Thrust (SL): 1.431 kN
-//	Thrust (Vac): ??? kN
+//	Thrust (Vac): 1.460 kN
+//	ISP: 210 SL / 215 Vac
+//	Burn Time: 200
+//	Chamber Pressure: 2.53 MPa
+//	Propellant: AK20 / Kerosene
+//	Prop Ratio: 4.0
+//	Throttle: 100% to 34%
+//	Nozzle Ratio: ???
+//	Ignitions: 2
+//	=================================================================================
+//	RDA-1-150
+//	planned upgrade for RP-318 rocket plane
+//
+//	Dry Mass: 90 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 2.942 kN
 //	ISP: 210 SL / 215 Vac
 //	Burn Time: 200
 //	Chamber Pressure: 2.53 MPa

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110R_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 68.3 kN
 //	ISP: 259 SL / 298 Vac
 //	Burn Time: 250
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 15.53 MPa
 //	Propellant: LOX / RG-1
 //	Prop Ratio: 2.22
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0164_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 3831 kN
 //	ISP: 311.5 SL / 358 Vac
 //	Burn Time: 360
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 16.6? MPa
 //	Propellant: LOX / CH4
-//	Prop Ratio: ???
+//	Prop Ratio: 3.5?
 //	Throttle: 100% to 45%
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 40?
 //	Ignitions: 4
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0169_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 716 kN
 //	ISP: ??? SL / 372 Vac
 //	Burn Time: 720
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 16.6? MPa
 //	Propellant: LOX / CH4
-//	Prop Ratio: ???
+//	Prop Ratio: 3.5?
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 90?
 //	Ignitions: 8
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -10,13 +10,13 @@
 //	Dry Mass: 90 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 30.98 kN
-//	ISP: ??? SL / 297 Vac
+//	ISP: 152 SL / 297 Vac		sl calculated with RPA
 //	Burn Time: 150
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.3 MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 1.8?
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 43.3
 //	Ignitions: 1
 //	=================================================================================
 //	RD-0214
@@ -25,13 +25,13 @@
 //	Dry Mass: 90 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 30.98 kN
-//	ISP: ??? SL / 293 Vac
+//	ISP: 189 SL / 293 Vac
 //	Burn Time: 300
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.3? MPa
 //	Propellant: NTO / UDMH
-//	Prop Ratio: ???
+//	Prop Ratio: 1.8?
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 31?		estimated with RPA
 //	Ignitions: 1
 //	=================================================================================
 
@@ -96,7 +96,7 @@
 			atmosphereCurve
 			{
 				key = 0 297
-				key = 1 215
+				key = 1 152
 			}
 
 			//UR-200 (8K81) (R&D): 7 flights, 0 failures
@@ -144,7 +144,7 @@
 			atmosphereCurve
 			{
 				key = 0 293
-				key = 1 215
+				key = 1 189
 			}
 
 			//Proton-K (8K82K): 27 flights, 0 failures

--- a/GameData/RealismOverhaul/Engine_Configs/RD0228_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0228_Config.cfg
@@ -8,7 +8,7 @@
 //	RD-0228
 //	R-36M, R-36MU
 //
-//	Dry Mass: ??? kg
+//	Dry Mass: 770? kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 760 kN	(1)main + verniers total?
 //	ISP: 234 SL / 340 Vac	(1)main + verniers total?		SL calculated with RPA

--- a/GameData/RealismOverhaul/Engine_Configs/RD0229_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0229_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 729.02 kN	Guess
 //	ISP: 235 SL / 341.4 Vac	Guess
 //	Burn Time: 153	(5)
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 16.32? MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.60	Guess
 //	Throttle: N/A
@@ -22,7 +22,7 @@
 //	RD-0256
 //	R-36M2, Dnepr
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 680? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 805.52 kN	Guess
 //	ISP: 235 SL / 341.3 Vac	Guess

--- a/GameData/RealismOverhaul/Engine_Configs/RD0230_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0230_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 30.98 kN	Guess
 //	ISP: ??? SL / 307 Vac	Guess
 //	Burn Time: 175	(5)
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.3? MPa		same as RD-0214
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.6 (Guess)
 //	Throttle: N/A
@@ -22,12 +22,12 @@
 //	RD-0257
 //	R-36M2, Dnepr
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 90? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 30.98 kN	Guess
 //	ISP: ??? SL / 307 Vac	Guess
 //	Burn Time: 190
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.3? MPa		same as RD-0214
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.6 (Guess)
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD0236_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0236_Config.cfg
@@ -4,10 +4,10 @@
 //	Manufacturer: KB Khimavtomatika
 //
 //	=================================================================================
-//	RD-0230
+//	RD-0236
 //	UR-100N, UR-100NUTTKh, Strela, Rokot
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 60? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 15.76 kN	(1)
 //	ISP: 232 SL / 293 Vac	(1)		SL calculated with RPA
@@ -50,7 +50,7 @@
 		type = ModuleEngines
 		configuration = RD-0236
 		modded = false
-		origMass = 0.090
+		origMass = 0.060
 		
 		CONFIG
 		{

--- a/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0242M2_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 50.0 kN
 //	ISP: ??? SL / 280 Vac
 //	Burn Time: 380 s
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 15.3 MPa
 //	Propellant: NTO / MMH
 //	Prop Ratio: 1.65
 //	Throttle: 60% to 100%

--- a/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD100_Config.cfg
@@ -42,7 +42,7 @@
 //	Thrust (Vac): 428 kN
 //	ISP: 214 SL / 235 Vac
 //	Burn Time: 83
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 2.28? MPa		halfway between 101 and 103?
 //	Propellant: LOX / Ethanol90
 //	Prop Ratio: ???
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD107_RD117_Config.cfg
@@ -135,7 +135,7 @@
 //	Thrust (Vac): 1033.3 kN
 //	ISP: 261 SL / 317.6 Vac
 //	Burn Time: 130
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.86? MPa
 //	Propellant: Cooled LOX / Cooled Syntin
 //	Prop Ratio: ???
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD108_RD118_Config.cfg
@@ -133,7 +133,7 @@
 //	Thrust (Vac): 1011 kN
 //	ISP: 257 SL / 319 Vac
 //	Burn Time: 310	core ~108 tons wet?
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.86? MPa
 //	Propellant: Cooled LOX / Cooled Syntin
 //	Prop Ratio: ???
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD120_Config.cfg
@@ -37,7 +37,7 @@
 //	RD-120K
 //	
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 1080? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 853.18 kN
 //	ISP: 304.4 SL / 330 Vac

--- a/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD1_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): ??? kN
 //	ISP: 200 SL / ??? Vac
 //	Burn Time: 300	//guess, based on planned 10 minute flight times, assumed half under power, and half gliding
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 2.0 MPa
 //	Propellant: AK20 / Kerosene
 //	Prop Ratio: 4.05 // ??? Copy from S2.253
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD253_Config.cfg
@@ -72,7 +72,7 @@
 //	Thrust (Vac): 1698 kN
 //	ISP: 285 SL / 316 Vac
 //	Burn Time: 148
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 14.71? MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.69
 //	Throttle: N/A
@@ -87,7 +87,7 @@
 //	Thrust (Vac): 1748 kN
 //	ISP: 285 SL / 316 Vac
 //	Burn Time: 148
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 14.71? MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.69
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD254_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD254_Config.cfg
@@ -72,7 +72,7 @@
 //	Thrust (Vac): 1782 kN
 //	ISP: 240 SL / 327.8 Vac		SL calculated with RPA
 //	Burn Time: 225
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 14.71? MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.69
 //	Throttle: N/A
@@ -87,7 +87,7 @@
 //	Thrust (Vac): 1834 kN
 //	ISP: 240 SL / 327.8 Vac		SL calculated with RPA
 //	Burn Time: 225
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 14.71? MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.69
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD57_Config.cfg
@@ -42,7 +42,7 @@
 //	Thrust (Vac): 395.0 kN
 //	ISP: 292 SL / 460 Vac		SL calculated with RPA
 //	Burn Time: ???
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 11.5? MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.80
 //	Throttle: 303 kN minimum?

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -275,48 +275,48 @@
 //	Ignitions: 15
 //	=================================================================================
 //	CECE-Base
-//	Technology demonstrator
+//	Technology demonstrator (RL10A-4-2 based?)
 //
 //	Dry Mass: 210 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 67 kN
-//	ISP: ??? SL / 460 Vac
+//	ISP: 249 SL / 460 Vac
 //	Burn Time: 10000
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.20 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.80
 //	Throttle: 100% to 6.66%
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 61?	no nozzle extension?
 //	Ignitions: 50
 //	=================================================================================
 //	CECE-High
-//	Technology demonstrator
+//	Technology demonstrator (RL10B-2 based?)
 //
 //	Dry Mass: 256 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 110 kN
-//	ISP: ??? SL / 465 Vac
+//	ISP: 1 @0.915 atm SL / 465 Vac
 //	Burn Time: 10000
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.44 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.88
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 285?	probably used B-2 nozzle
 //	Ignitions: 50
 //	=================================================================================
 //	CECE-Methane
-//	Technology demonstrator
+//	Technology demonstrator (RL10A-4-2 based?)
 //
 //	Dry Mass: 210 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 67 kN
-//	ISP: ??? SL / 360 Vac
+//	ISP: 88 SL / 360 Vac
 //	Burn Time: 10000
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.20 MPa
 //	Propellant: LOX / CH4
 //	Prop Ratio: 3.6
 //	Throttle: 100% to 25%
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 61?	no nozzle extension?
 //	Ignitions: 50
 //	=================================================================================
 
@@ -1366,7 +1366,7 @@
 			atmosphereCurve
 			{
 				key = 0 460 //target was >445 s
-				key = 1 100
+				key = 1 249
 			}
 			massMult = 1.257
 
@@ -1421,7 +1421,7 @@
 			atmosphereCurve
 			{
 				key = 0 465
-				key = 1 100
+				key = 0.915 1
 			}
 			massMult = 1.533
 
@@ -1469,7 +1469,7 @@
 			atmosphereCurve
 			{
 				key = 0 360 //target >350 s
-				key = 1 100
+				key = 1 88
 			}
 			massMult = 1.257
 

--- a/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS2100_Config.cfg
@@ -7,14 +7,14 @@
 //	RS-2100
 //	
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 2948 Kg		Target TWR 83
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 2399.5 kN
 //	ISP: 384 SL / 450 Vac
 //	Burn Time: ???
-//	Chamber Pressure: ??? MPa
-//	Propellant: LOX / LH2
-//	Prop Ratio: ???
+//	Chamber Pressure: 22.4 MPa
+//	Propellant: Subcooled LOX / Subcooled LH2
+//	Prop Ratio: 6.0?
 //	Throttle: 100% to 55%
 //	Nozzle Ratio: ???
 //	Ignitions: 4
@@ -62,7 +62,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 2.950 // originally was 6.8 tons but config said it should be this... no idea
+		origMass = 2.948
 		configuration = RS-2100
 
 		CONFIG
@@ -85,14 +85,14 @@
 			PROPELLANT
 			{
 				name = LqdHydrogen
-				ratio = 0.72
+				ratio = 0.7441
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name = LqdOxygen
-				ratio = 0.28
+				name = CooledLqdOxygen
+				ratio = 0.2559
 				DrawGauge = False
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -40,7 +40,7 @@
 //	Dry Mass: 6665 Kg	150 lbs heavier
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 3570 kN	same as RS-68A?
-//	ISP: 362 SL / 412 Vac	same as RS-68A?
+//	ISP: 364 SL / 414.2 Vac		[4] sl estimated with RPA
 //	Burn Time: 330
 //	Chamber Pressure: 9.90 MPa
 //	Propellant: LOX / LH2
@@ -72,21 +72,22 @@
 //	Thrust (Vac): 4110 kN
 //	ISP: 364 SL / 435 Vac
 //	Burn Time: 450
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 13? MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 55% to 102%
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 40?
 //	Ignitions: 1
 //	=================================================================================
 
 //	Sources:
 
 
-//	ULA - Delta IV launch vehicle summary:			http://www.ulalaunch.com/products_deltaiv.aspx
-//	ULA - Delta IV launch services user's guide:	http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
-//	Norbert Brügge - Delta IV propulsion:			http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Propulsion/engines.htm
-//	NTRS - Ares V and RS-68B:						http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf
+//	[1]ULA - Delta IV launch vehicle summary:			http://www.ulalaunch.com/products_deltaiv.aspx
+//	[2]ULA - Delta IV launch services user's guide:	http://www.ulalaunch.com/uploads/docs/Launch_Vehicles/Delta_IV_Users_Guide_June_2013.pdf
+//	[3]Norbert Brügge - Delta IV propulsion:			http://www.b14643.de/Spacerockets_2/United_States_5/Delta_IV/Propulsion/engines.htm
+//	[4]NTRS - Ares V and RS-68B:						http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20090014109.pdf
+//	[5]https://forum.nasaspaceflight.com/index.php?topic=56171.0
 //  History of Liquid Propellant Rocket Engines, George P. Sutton
 
 //	Used by:

--- a/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS68_Config.cfg
@@ -293,8 +293,8 @@
 
 			atmosphereCurve
 			{
-				key = 0 412
-				key = 1 362
+				key = 0 414.2
+				key = 1 364
 			}
 
 			//Man-rated, fudge to late-model SSME levels

--- a/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS76_Config.cfg
@@ -19,6 +19,21 @@
 //	Nozzle Ratio: ???
 //	Ignitions: 3	//Intended for flyback boosters
 //	=================================================================================
+//	RS-76A
+//	Speculative upgrade with RD-180 parts
+//
+//	Dry Mass: 6732 kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 4621.29 kN
+//	ISP: 308 SL / 337 Vac
+//	Burn Time: 480
+//	Chamber Pressure: 19.31 MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.7
+//	Throttle: 100% to 65%
+//	Nozzle Ratio: ???
+//	Ignitions: 3	//Intended for flyback boosters
+//	=================================================================================
 
 //	Sources:
 

--- a/GameData/RealismOverhaul/Engine_Configs/RS88_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RS88_Config.cfg
@@ -8,37 +8,40 @@
 //	prototype
 //
 //	Dry Mass: 250 Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 220 kN
-//	ISP: 273 SL / 324 Vac
+//	Thrust (SL): 230.86 kN
+//	Thrust (Vac): 255.77 kN	[4]
+//	ISP: 222 SL / 244 Vac	[4]
 //	Burn Time: ???
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.45 MPa	[4]
 //	Propellant: LOX / Ethanol75
-//	Prop Ratio: 1.29
+//	Prop Ratio: 1.49	[4]
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 7.04	[4]
 //	Ignitions: 1
 //	=================================================================================
 //	LAE
 //	CST-100
 //
 //	Dry Mass: 250 Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 258 kN
-//	ISP: 220 SL / 290 Vac
+//	Thrust (SL): 176.6 kN	[5],[6] assuming SL
+//	Thrust (Vac): 193.49 kN
+//	ISP: 230 SL / 252 Vac	estimated with RPA
 //	Burn Time: ???
-//	Chamber Pressure: ??? MPa
-//	Propellant: NTO / MMH
-//	Prop Ratio: 1.65
-//	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Chamber Pressure: 4.45? MPa		same as RS-88?
+//	Propellant: MON3 / MMH
+//	Prop Ratio: 1.65?
+//	Throttle: 100-75%?		"precise throttle control"
+//	Nozzle Ratio: 7.04?		it looks the same as RS-88?
 //	Ignitions: 1
 //	=================================================================================
 
 //	Sources:
-//		NTRS - RS-88 Pad Abort Demonstrator Thrust Chamber Assembly:					http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
-//		Encyclopedia Astronautica - RS-88 engine:										http://astronautix.com/r/rs-88.html
-//		Boeing - Design Considerations for a Commercial Crew Transportation System:		http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//		[1]NTRS - RS-88 Pad Abort Demonstrator Thrust Chamber Assembly:					http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050237017.pdf
+//		[2]Encyclopedia Astronautica - RS-88 engine:										http://astronautix.com/r/rs-88.html
+//		[3]Boeing - Design Considerations for a Commercial Crew Transportation System:		http://www.boeing.com/assets/pdf/defense-space/space/ccts/docs/Space_2011_Boeing.pdf
+//		[4]https://arc.aiaa.org/doi/epdf/10.2514/6.2005-4422
+//		[5]https://www.spaceflightinsider.com/organizations/boeing/launch-abort-engines-boeing-cst-100-starliner-undergo-testing/
+//		[6]https://www.americaspace.com/2014/08/08/aerojet-rocketdyne-completes-ccicap-work-with-boeings-cst-100-spacecraft/
 
 //	Used by:
 //		CST-100 pack
@@ -82,8 +85,8 @@
 		{
 			name = RS-88
 			specLevel = operational
-			maxThrust = 220
-			minThrust = 220
+			maxThrust = 255.77
+			minThrust = 191.83
 			ullage = True
 			pressureFed = True
 			ignitions = 1
@@ -97,21 +100,21 @@
 			PROPELLANT
 			{
 				name = Ethanol75
-				ratio = 0.5285
+				ratio = 0.5236
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.4715
+				ratio = 0.4764
 				DrawGauge = False
 			}
 
 			atmosphereCurve
 			{
-				key = 0 324
-				key = 1 273
+				key = 0 244
+				key = 1 222
 			}
 		}
 
@@ -119,8 +122,8 @@
 		{
 			name = LAE
 			specLevel = operational
-			minThrust = 258
-			maxThrust = 258
+			minThrust = 145.12
+			maxThrust = 193.49
 			heatProduction = 0.88 //0.220
 			ullage = True
 			pressureFed = True
@@ -149,8 +152,8 @@
 
 			atmosphereCurve
 			{
-				key = 0 290
-				key = 1 220
+				key = 0 252
+				key = 1 230
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRMV_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 15800 kN
 //	ISP: 242 SL / 266 Vac
 //	Burn Time: 126
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.24? MPa
 //	Propellant: PBAN
 //	Prop Ratio: N/A
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 7.2
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RSRM_Config.cfg
@@ -13,11 +13,11 @@
 //	Thrust (Vac): 14819 kN
 //	ISP: 243 SL / 268 Vac
 //	Burn Time: 123
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.24 MPa
 //	Propellant: PBAN
 //	Prop Ratio: N/A
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 7.72
 //	Ignitions: 1
 //	=================================================================================
 //	FWC-SRM
@@ -27,11 +27,11 @@
 //	Thrust (Vac): 14819 kN
 //	ISP: 243 SL / 268 Vac
 //	Burn Time: 123
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.24 MPa
 //	Propellant: PBAN
 //	Prop Ratio: N/A
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 7.72
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ.20_Config.cfg
@@ -7,7 +7,7 @@
 //	RZ.20-Mk1
 //	Rolls-Royce prototype
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 131? Kg		same as RL10?
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 70 kN
 //	ISP: 171 SL / 410 Vac		SL calculated with RPA
@@ -22,16 +22,16 @@
 //	RZ.20-Mk2
 //	Increased expansion ratio proposal
 //
-//	Dry Mass: ??? Kg
+//	Dry Mass: 131? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): ??? kN
 //	ISP: 185 SL / 425? Vac		SL calculated with RPA
 //	Burn Time: ???
-//	Chamber Pressure: 2.07 MPa
+//	Chamber Pressure: 2.72 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.0
 //	Throttle: N/A
-//	Nozzle Ratio: 40?	same as RL10
+//	Nozzle Ratio: 61?	same as RL10
 //	Ignitions: ???	//Used electric ignitor system
 //	=================================================================================
 
@@ -79,7 +79,7 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		origMass = 0.167	//Assumed same as RL10
+		origMass = 0.131
 		modded = false
 		configuration = RZ20-Mk1
 
@@ -107,7 +107,7 @@
 				key = 0 410
 				key = 1 171
 			}
-			massMult = 0.87
+			massMult = 1.0
 			%ullage = True
 			%ignitions = 10	//assumed same as RL10, used similar spark ignitor system
 			%IGNITOR_RESOURCE
@@ -154,7 +154,7 @@
 				key = 0 425
 				key = 1 185
 			}
-			massMult = 0.95
+			massMult = 1.0
 			%ullage = True
 			%ignitions = 10	//assumed same as RL10, used similar spark ignitor system
 			%IGNITOR_RESOURCE

--- a/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RZ_Config.cfg
@@ -13,7 +13,7 @@
 //	Thrust (Vac): 696.6 kN
 //	ISP: 247.62 SL / 288 Vac
 //	Burn Time: 182
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 3.61 MPa
 //	Propellant: LOX / RP1
 //	Prop Ratio: 2.4
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RangerRetro_Config.cfg
@@ -7,7 +7,7 @@
 //	MC-4-610
 //	Ranger/Mariner Propulsion System
 //
-//	Dry Mass: 16.8 Kg	//Including tankage and fuel
+//	Dry Mass: 9.8? kg	16.8 kg Including tankage and fuel
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 225 N		//50 lbf
 //	ISP: 49 SL / 234.97 Vac

--- a/GameData/RealismOverhaul/Engine_Configs/Rita_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rita_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 180 kN
 //	ISP: ??? SL / 274 Vac
 //	Burn Time: 62
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.0 MPa
 //	Propellant: PBAN
 //	Prop Ratio: N/A
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rubis_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 53 kN
 //	ISP: ??? SL / 274 Vac
 //	Burn Time: 45
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.1 MPa
 //	Propellant: PUPE
 //	Prop Ratio: N/A
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 26.19 kN
 //	ISP: 311 SL / 317 Vac
 //	Burn Time: 150
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 12? MPa
 //	Propellant: LOX / RP-1
 //	Prop Ratio: 2.5
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 10.5?
 //	Ignitions: 5
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Rutherford_Vac_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 25.79 kN
 //	ISP: ??? SL / 343 Vac
 //	Burn Time: 288
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 12? MPa
 //	Propellant: LOX / RP-1
 //	Prop Ratio: 2.5
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 35?
 //	Ignitions: 5
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/S155_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S155_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 19.5 kN
 //	ISP: 248.5 SL / 255 Vac
 //	Burn Time: 1200
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.5? MPa
 //	Propellant: AK20 / Tonka-250
 //	Prop Ratio: 3.6 (copied from S5.3M)
 //	Throttle: 100% to 50%
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 5.6?
 //	Ignitions: ???
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S2_253_Config.cfg
@@ -26,10 +26,10 @@
 //	Thrust (Vac): 127.5 kN	[1]
 //	ISP: 233 SL / 258 Vac	assuming same as S5.2
 //	Burn Time: 65	[1]
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.8 MPa	assuming same as S5.2
 //	Propellant: AK27 / TM-185
 //	Prop Ratio: 3.43	assuming same as S5.2
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 10.4	assuming same as S5.2
 //	Ignitions: 1
 //	=================================================================================
 //	S5.2 (9D21)
@@ -54,7 +54,7 @@
 //	Thrust (Vac): 165.5 kN	[1]
 //	ISP: 240 SL / 265 Vac	[1]
 //	Burn Time: 90	[1]
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 6.8? MPa
 //	Propellant: AK27 / UDMH	[1]
 //	Prop Ratio: 2.32	[1] 8.5 m2 UDMH, 10.46 m2 AK27, 1.23 volume
 //	Nozzle Ratio: 10.4?

--- a/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_92_Config.cfg
@@ -22,7 +22,7 @@
 //	S5.92-l.n.
 //	Fregat-M
 //
-//	Dry Mass: 75 Kg
+//	Dry Mass: 80 Kg		5 kg for nozzle extension?
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 20.01 kN
 //	ISP: 170 SL / 333.4 Vac		SL calculated with RPA
@@ -171,7 +171,7 @@
 			minThrust = 13.96
 			maxThrust = 20.01
 			gimbalRange = 5.0
-			massMult = 1.0
+			massMult = 1.0667
 			ullage = True
 			pressureFed = False
 			ignitions = 50

--- a/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S5_98M_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 19.61 kN
 //	ISP: 216 SL / 328 Vac		SL calculated with RPA
 //	Burn Time: 3200
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 9.8 MPa
 //	Propellant: NTO / UDMH
 //	Prop Ratio: 2.0
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SRMU_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 8233.777 kN
 //	ISP: 251 SL / 281 Vac
 //	Burn Time: 145
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 5.93 MPa
 //	Propellant: HTPB
 //	Prop Ratio: N/A
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 15.7
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/SSBE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSBE_Config.cfg
@@ -27,7 +27,7 @@
 //	Thrust (Vac): 2306 kN
 //	ISP: 333.8 SL / 358.7 Vac
 //	Burn Time: 500
-//	Chamber Pressure: ??? MPa (@ 111% throttle)
+//	Chamber Pressure: 21.04? MPa (@ 111% throttle)
 //	Propellant: LOX / RP-1 / LH2
 //	Prop Ratio: 2.8
 //	Throttle: 111% to 67%

--- a/GameData/RealismOverhaul/Engine_Configs/SSME50X_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME50X_config.cfg
@@ -29,7 +29,7 @@
 //	ISP: 394.3 SL / 447.1 Vac (retracted)
 //	ISP: 345 SL / 461 Vac (extended)
 //	Burn Time: 500
-//	Chamber Pressure: ??? MPa (@ 111% throttle)
+//	Chamber Pressure: 21.02? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%

--- a/GameData/RealismOverhaul/Engine_Configs/SSME650_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME650_Config.cfg
@@ -12,7 +12,7 @@
 //	Thrust (Vac): 2093 kN
 //	ISP: 190 SL / 478 Vac	SL calculated with RPA
 //	Burn Time: 500
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 21.04 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/SSME_Config.cfg
@@ -57,7 +57,7 @@
 //	Thrust (Vac): 2319.9 kN (2268.1 35, 2293.2 50, 2364.5 150)
 //	ISP: 366.3 SL / 452.3 Vac (409.5/442.2 35, 394.3/447.1 50, 345?/461 150)
 //	Burn Time: 500
-//	Chamber Pressure: ??? MPa (@ 111% throttle)
+//	Chamber Pressure: 21.02? MPa (@ 111% throttle)
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0
 //	Throttle: 111% to 67%

--- a/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Stentor_Config.cfg
@@ -10,13 +10,13 @@
 //	Dry Mass: 339 Kg
 //	Thrust (SL): 110 kN
 //	Thrust (Vac): ??? kN
-//	ISP: ??? SL / 220 Vac
-//	Burn Time: ???
-//	Chamber Pressure: ??? MPa
+//	ISP: 200 SL / 220 Vac	sl estimated with RPA
+//	Burn Time: 29 s
+//	Chamber Pressure: 3.28? MPa		same as early gamma?
 //	Propellant: HTP / RP-1
 //	Prop Ratio: 8.2
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 5?	estimated with RPA
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TDE_Config.cfg
@@ -10,9 +10,9 @@
 //	Dry Mass: 8.9 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 2.811 kN
-//	ISP: 179 SL / 210 Vac
+//	ISP: 122 SL / 210 Vac		179 is in Mars atmo?, sl calculated with RPA
 //	Burn Time: ???
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 2.4 MPa
 //	Propellant: Hydrazine
 //	Prop Ratio: N/A
 //	Throttle: 100% to 9%
@@ -21,6 +21,7 @@
 //	=================================================================================
 
 //	Sources:
+//	http://matthewwturner.com/uah/IPT2008_summer/baselines/LOW%20Files/Payload/Downloads/AIAA-2007-5481-979.pdf
 
 //	Used by:
 
@@ -85,7 +86,7 @@
 			atmosphereCurve
 			{
 				key = 0 210
-				key = 1 179
+				key = 1 122
 			}
 			ullage = False
 			pressureFed = True

--- a/GameData/RealismOverhaul/Engine_Configs/Topaze_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Topaze_Config.cfg
@@ -5,14 +5,14 @@
 //
 //	=================================================================================
 //	P2.2 Topaze
-//	Ablestar
+//	Diamant A and B
 //
 //	Dry Mass: 456 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 156 kN
 //	ISP: ??? SL / 259 Vac
 //	Burn Time: 44
-//	Chamber Pressure: 0.7 MPa
+//	Chamber Pressure: 3.5 MPa
 //	Propellant: PBAN
 //	Prop Ratio: N/A
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -42,7 +42,7 @@
 //	Thrust (Vac): 156.3 kN
 //	ISP: ??? SL / 311.9 Vac
 //	Burn Time: 245
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 4.2? MPa
 //	Propellant: LOX / RP-1
 //	Prop Ratio: 2.40
 //	Throttle: N/A

--- a/GameData/RealismOverhaul/Engine_Configs/XLR10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR10_Config.cfg
@@ -4,7 +4,7 @@
 //	Manufacturer: RMI
 //
 //	=================================================================================
-//	XLR-10-RM-2
+//	XLR10-RM-2
 //	Viking
 //
 //	Dry Mass: 192 Kg	//same as X-405?
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 110.5 kN		// 24,800 lbf
 //	ISP: 179.6 SL / 214.5 Vac
 //	Burn Time: 103
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.5? MPa
 //	Propellant: LOX / 95% Ethanol
 //	Prop Ratio: 1.127	//based on Viking propellant load
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 3.5?		estimated with RPA
 //	Ignitions: 1
 //	=================================================================================
 

--- a/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
@@ -10,30 +10,30 @@
 //	Dry Mass: 150 Kg
 //	Thrust (SL): 24.6 kN
 //	Thrust (Vac): 26.68 kN
-//	ISP: 207 SL / 226.6 Vac (Sutton says 209s SL, but scaling based off 228 on -5)
+//	ISP: 207 SL / 226.6 Vac (Sutton says 209s SL, but scaling based off 228 on -5)(RPA agrees with 192s SL)
 //	Burn Time: 360 // Reverting from [A] change to allow for low-throttle cruise, as was origina;
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.52? MPa
 //	Propellant: LOX / Ethanol75
 //	Prop Ratio: 1.439 (calculated based on X-1 fuel load of 311 Gal LOX 293 Gal Ethanol)
 //	Throttle: 100% to 25%, in 25% increments
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 3.3?
 //	Ignitions: 4
 //	=================================================================================
-//  XLR35-RM-1 // [A] [B] MX-774 proposed rocket engine. Project cancelled, only 3 test flights - Large amount of data is appropriated from other XLR11 variants, data in [B] missing.
-//  RTV-A-2 Hiroc Long-Range Ballistic Missile
+//	XLR35-RM-1 // [A] [B] MX-774 proposed rocket engine. Project cancelled, only 3 test flights - Large amount of data is appropriated from other XLR11 variants, data in [B] missing.
+//	RTV-A-2 Hiroc Long-Range Ballistic Missile
 //
-//  Dry Mass: 185 kg // Guessed based off the removal of separate ignition capabilities and addition of gimbaL
-//  Thrust (SL): 33.8 kN // 7.6 klbf
-//  Thrust (VAC): 37.56 kN // 8.4 klbf
-//  ISP: 211 SL / 234.4 VAC
-//  Burn Time: ???
-//  Chamber Pressure: 2.86 MPa
-//  Propellant: LOX / Ethanol75
-//  Prop Ratio: 1.2
-//  Throttle: 100% to 25%
-//  Nozzle Ratio: ???
-//  Ignitions: 1
-//  Gimbal: 5 Degrees // Guessed
+//	Dry Mass: 185 kg // Guessed based off the removal of separate ignition capabilities and addition of gimbaL
+//	Thrust (SL): 33.8 kN // 7.6 klbf
+//	Thrust (VAC): 37.56 kN // 8.4 klbf
+//	ISP: 211 SL / 234.4 VAC
+//	Burn Time: ???
+//	Chamber Pressure: 2.86 MPa
+//	Propellant: LOX / Ethanol75
+//	Prop Ratio: 1.2
+//	Throttle: 100% to 25%
+//	Nozzle Ratio: ???
+//	Ignitions: 1
+//	Gimbal: 5 Degrees // Guessed
 //	=================================================================================
 //	XLR11-RM-5
 //	X-1
@@ -176,7 +176,7 @@
 			PROPELLANT
 			{
 				name = Nitrogen
-				ratio = 11.25
+				ratio = 11.25		//FIXME: too low, also should probably be Helium
 				ignoreForIsp = True
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -9,15 +9,15 @@
 //
 //	Dry Mass: 157 Kg
 //	Thrust (SL): 66.72 kN
-//	Thrust (Vac): ??? kN
-//	ISP: ??? SL / ??? Vac
+//	Thrust (Vac): 73.75 kN
+//	ISP: 208 SL / 230 Vac		estimated with RPA
 //	Burn Time: 650
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.52 MPa		same as pumpfed XLR11?
 //	Propellant: LOX / Ethanol75
 //	Prop Ratio: 1.6
-//	Throttle: 66.72 kN to 11.12 kN
-//	Nozzle Ratio: ???
-//	Ignitions: 6	//electrical ignitors and compressed nitrogen was used to start the engine. Going with the same 6 ignitions as XLR99 due to lack of data
+//	Throttle: 66.72 kN to 11.12 kN (sl)
+//	Nozzle Ratio: 2.5?		estimated with RPA
+//	Ignitions: 6		electrical ignitors and compressed nitrogen was used to start the engine. Going with the same 6 ignitions as XLR99 due to lack of data
 //	=================================================================================
 
 //	Sources:
@@ -63,8 +63,8 @@
 		{
 			name = XLR25-CW-1
 			specLevel = operational
-			minThrust = 12.02
-			maxThrust = 72.17
+			minThrust = 12.29
+			maxThrust = 73.75
 			massMult = 1.0
 
 			%ullage = False
@@ -91,7 +91,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 225
+				key = 0 230
 				key = 1 208
 			}
 

--- a/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR41_Config.cfg
@@ -12,11 +12,11 @@
 //	Thrust (Vac): 333 kN
 //	ISP: 203 SL / 239 Vac
 //	Burn Time: 70
-//	Chamber Pressure: ??? MPa
+//	Chamber Pressure: 1.5 MPa	same as A-4?
 //	Propellant: LOX / Ethanol75
 //	Prop Ratio: 1.24
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 3.4	same as A-4?
 //	Ignitions: 1
 //	=================================================================================
 


### PR DESCRIPTION
Continue to work on cleaning up engine configs, adding sources, etc. 
Also make improvements to a few of the more neglected configs. Changes include:

- Make Bell Model 117 a little lighter since it has no gimbal
- Use RPA to try to estimate BE-3 performance a little better
- Complete overhaul of E-1 configs. Using the E-1 Dynasoar RBS version, the only config for which comprehensive data exists, create configs of 380, 468, 500 and 575 klbf SL thrust, using RPA and the H-1 to estimate performance data. Old E-1 configs have been deprecated, and the Kolyma's Shadow E-1A is kept mostly the same
- Improve H-1 SL ISP using data from Skylab 2 and the H-1 users manual
- Revise HG-3 SL performance using RPA
- Reduce XLR83 T/W to a sane value by increasing dry mass
- Reduce LR87-LH2 T/W to a sane value by increasing dry mass. Also revise performance a little using RPA
- Correct MR-80/MR-80B SL ISP (it was previously using ISP values from Mars "sea level")
- Completely revise NK-9 engine configs based on better sources
- Completely revise NK-9V engine configs based on better sources
- Completely revise NK-15/33 engine configs based on better sources. Also add AJ26-58 and AJ26-59 configs.
- Completely revise NK-15V/43 engine configs based on better sources. Also add AJ26-60 config.
- Reduce mass of RD-0236
- Use RPA to better estimate SL performance of RL10-CECE configs
- Configure RS-2100 to use subcooled propellants
- Correct RS-68B ISP
- Completely revise RS-88/LAE configs based on better sources

Although many changes are made, this should not be save-breaking. Many changes were made, but most were minor. The only significant performance reductions were to the NK-15, NK-15V, RS-88, and LAE.