### PR TITLE
Fix MM issue in RO_RealFuels.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -29,7 +29,6 @@ TANK_DEFINITION
 	defaultMass = 0.00006
 }
 
-
 TANK_DEFINITION
 {
 	name = Tank-Sep-Steel-HP
@@ -430,7 +429,7 @@ TANK_DEFINITION
 	addSoundingPayload = true
 	maxUtilization = 50
 	defaultMass = 0.00028
-	
+
 	TANK
 	{
 		name = ElectricCharge
@@ -454,7 +453,7 @@ TANK_DEFINITION
 	addSoundingPayload = true
 	maxUtilization = 50
 	defaultMass = 0.000216
-	
+
 	TANK
 	{
 		name = ElectricCharge
@@ -478,7 +477,7 @@ TANK_DEFINITION
 	addSoundingPayload = true
 	maxUtilization = 60
 	defaultMass = 0.00016
-	
+
 	TANK
 	{
 		name = ElectricCharge
@@ -502,7 +501,7 @@ TANK_DEFINITION
 	addSoundingPayload = true
 	maxUtilization = 75
 	defaultMass = 0.000096
-	
+
 	TANK
 	{
 		name = ElectricCharge
@@ -669,7 +668,7 @@ disabledPARTUPGRADE
 	title = Isogrid Tank Upgrade
 	basicInfo = You can now use Aluminum gridded tanks
 	manufacturer = Generic
-	description = You can now use Aluminum gridded tanks. Isogrids and orthogrids are advanced hollowed-out structures milled out of a single block of material that have very high rigidity yet exceptional material and mass savings. The delicate & complex lattices on the panel require very high precision machining and thus such a construction is much more expensive to produce than more standard tanks. Nevertheless, gridded tanks have been utilized by nearly every NASA orbital vehicle since the very first to use gridded aluminum construction: the Thor/Delta and Titan rockets as well as the Agena upper stage. 
+	description = You can now use Aluminum gridded tanks. Isogrids and orthogrids are advanced hollowed-out structures milled out of a single block of material that have very high rigidity yet exceptional material and mass savings. The delicate & complex lattices on the panel require very high precision machining and thus such a construction is much more expensive to produce than more standard tanks. Nevertheless, gridded tanks have been utilized by nearly every NASA orbital vehicle since the very first to use gridded aluminum construction: the Thor/Delta and Titan rockets as well as the Agena upper stage.
 }
 
 PARTUPGRADE
@@ -792,7 +791,7 @@ PARTUPGRADE
 	%TANK[PotassiumSuperoxide] {}
 	%TANK[Waste] { %fillable = False }
 	%TANK[WasteWater] { %fillable = False }
-	
+
 	//everything else down here
 	%TANK[Aerozine50] {}
 	%TANK[CooledAerozine50] {}	//273 K, but we're gonna ignore that for now
@@ -995,93 +994,115 @@ PARTUPGRADE
 // and the gas can be captured (if applicable)
 @TANK_DEFINITION:HAS[#addResourcesSM[true],~preserveResources[true]]:FIRST
 {
-	@TANK[LqdAmmonia] {
+	@TANK[LqdAmmonia]
+	{
 		@temperature = 283.2	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Ammonia
 	}
-	@TANK[ClF3] {
+	@TANK[ClF3]
+	{
 		@temperature = 358.2	//calculated with peng-robinson. high thermal expansion, hits 90% of 1 atm density before boiling. decomposes above 473.2 K
 	}
-	@TANK[ClF5] {
+	@TANK[ClF5]
+	{
 		@temperature = 314.2	//calculated with peng-robinson. high thermal expansion, hits 90% of 1 atm density before boiling.
 		%isDewar = True
 	}
-	@TANK[Diborane] {
+	@TANK[Diborane]
+	{
 		@temperature = 358.1	//FIXME: Using liquid parameters, but supercritical at 100 bar
 	}
-	@TANK[Ethane] {
+	@TANK[Ethane]
+	{
 		@temperature = 349	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
 		%isDewar = True
 	}
-	@TANK[Ethylene] {
+	@TANK[Ethylene]
+	{
 		@temperature = 221.2	//high thermal expansion, hits 90% of 1 atm density before boiling
-		%isDewar = True 
+		%isDewar = True
 	}
-	@TANK[LqdFluorine] {
+	@TANK[LqdFluorine]
+	{
 		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Fluorine
 	}
-	@TANK[FLOX30] {
+	@TANK[FLOX30]
+	{
 		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
-		%isDewar = True 
+		%isDewar = True
 	}
-	@TANK[FLOX70] {
+	@TANK[FLOX70]
+	{
 		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
-		%isDewar = True 
+		%isDewar = True
 	}
-	@TANK[FLOX88] {
+	@TANK[FLOX88]
+	{
 		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
-		%isDewar = True 
+		%isDewar = True
 	}
-	@TANK[LqdHelium] {
+	@TANK[LqdHelium]
+	{
 		@temperature = 43.8	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
 		%isDewar = True
 		%boiloffProduct = Helium
 	}
-	@TANK[LqdHydrogen] {
+	@TANK[LqdHydrogen]
+	{
 		@temperature = 39.6	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
 		%isDewar = True
 		%boiloffProduct = Hydrogen
 	}
-	@TANK[LqdMethane] {
+	@TANK[LqdMethane]
+	{
 		@temperature = 150.0	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Methane
 	}
-	@TANK[MON10] {
+	@TANK[MON10]
+	{
 		@temperature = 361.0	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
 	}
-	@TANK[MON15] {
+	@TANK[MON15]
+	{
 		@temperature = 356.6	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
 	}
-	@TANK[MON20] {
+	@TANK[MON20]
+	{
 		@temperature = 352.1	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
 	}
-	@TANK[MON25] {
+	@TANK[MON25]
+	{
 		@temperature = 347.8	//Probably supercritical, and Peng-Robinsion doesn't work for mixtures. Guess
 		%isDewar = True
 	}
-	@TANK[N2F4] {
+	@TANK[N2F4]
+	{
 		@temperature = 340	//FIXME: Guess, similar to Ethane?
 		%isDewar = True
 	}
-	@TANK[LqdNitrogen] {
+	@TANK[LqdNitrogen]
+	{
 		@temperature = 101.7	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Nitrogen
 	}
-	@TANK[OF2] {
+	@TANK[OF2]
+	{
 		@temperature = 168.0	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 	}
-	@TANK[LqdOxygen] {
+	@TANK[LqdOxygen]
+	{
 		@temperature = 117.9	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True
 		%boiloffProduct = Oxygen
 	}
-	@TANK[CooledLqdOxygen] {
+	@TANK[CooledLqdOxygen]
+	{
 		@temperature = 93
 		%isDewar = True
 		%boiloffProduct = Oxygen
@@ -1119,7 +1140,10 @@ PARTUPGRADE
 {
 	@TANK,* { &mass = #$../defaultMass$ }
 }
-@TANK_DEFINITION:HAS[#defaultMass]:FOR[zzzTagCleanup] { -defaultMass = DEL }
+@TANK_DEFINITION:HAS[#defaultMass]:FOR[zzzTagCleanup]
+{
+	-defaultMass = DEL
+}
 
 // LH2 tank mass correction
 @TANK_DEFINITION:HAS[~balloonTemps[true],~preserveResources[true]] // not FIRST anymore.

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -1023,7 +1023,15 @@ PARTUPGRADE
 		%isDewar = True
 		%boiloffProduct = Fluorine
 	}
-	@TANK[FLOX30|FLOX70|FLOX88] {
+	@TANK[FLOX30] {
+		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
+		%isDewar = True 
+	}
+	@TANK[FLOX70] {
+		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
+		%isDewar = True 
+	}
+	@TANK[FLOX88] {
 		@temperature = 109.6	//high thermal expansion, hits 90% of 1 atm density before boiling
 		%isDewar = True 
 	}

--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -955,7 +955,10 @@ PARTUPGRADE
 	@TANK[Diborane] { @temperature = 215.2 }	//calculated with Peng-Robinson. high thermal expansion, hits 90% of 1 atm density before boiling
 	@TANK[Ethane] { @temperature = 255.1 }	//No significant thermal expansion
 	@TANK[Ethylene] { @temperature = 207.1 }	//high thermal expansion, hits 90% of 1 atm density before boiling
-	@TANK[LqdFluorine|FLOX30|FLOX70|FLOX88] { @temperature = 118.5 }	//No significant thermal expansion
+	@TANK[LqdFluorine] { @temperature = 118.5 }	//No significant thermal expansion
+	@TANK[FLOX30] { @temperature = 118.5 }	//No significant thermal expansion
+	@TANK[FLOX70] { @temperature = 118.5 }	//No significant thermal expansion
+	@TANK[FLOX88] { @temperature = 118.5 }	//No significant thermal expansion
 	@TANK[LqdHelium] { @temperature = 8.39 }	//supercritical, set bp to point where density is 90% of liquid phase at 1 atm
 	@TANK[LqdHydrogen] { @temperature = 27.2 }	//high thermal expansion, hits 90% of 1 atm density before boiling
 	@TANK[LqdMethane] { @temperature = 137.4 }	//high thermal expansion, hits 90% of 1 atm density before boiling

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Salyut_Mir.cfg
@@ -16,7 +16,7 @@
 	!MODULE[TweakScale]
 	{
 	}
-	%MODULE[ModuleRTAntenna]:FOR[zzzRealismOverhaul]
+	%MODULE[ModuleRTAntenna]
 	{
 		@Mode0OmniRange = 0
 		@Mode1OmniRange = 40000000

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Tantares/RO_Tantares_Soyuz_LOK.cfg
@@ -1431,7 +1431,7 @@
 	}
   !MODULE[ModuleDataTransmitter]
   {}
-  %MODULE[ModuleRTAntennaPassive]:FOR[zzzRealismOverhaul]
+  %MODULE[ModuleRTAntennaPassive]
   {
     %OmniRange = 1500000
 
@@ -1467,7 +1467,7 @@
 	}
   !MODULE[ModuleDataTransmitter]
   {}
-  %MODULE[ModuleRTAntennaPassive]:FOR[zzzRealismOverhaul]
+  %MODULE[ModuleRTAntennaPassive]
   {
     %OmniRange = 1500000
 


### PR DESCRIPTION
Combining names with OR only works in top-level nodes. This currently looks for a node with the exact name `LqdFluorine|FLOX30|FLOX70|FLOX88`