### PR TITLE
Making generic solid rocket motors more consistent and realistic

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1143,6 +1143,9 @@
 //  Spin Motor (small)
 //  ==================================================
 
+//Source for separation motors: https://www.northropgrumman.com/wp-content/uploads/NG-Propulsion-Products-Catalog.pdf (Page 49)
+//For dry mass:propellant mass, using a ratio of 1:0.9, a little better than the BSM
+
 @PART[ROSmallSpinMotor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1183,7 +1183,7 @@
 			PROPELLANT
 			{
 				name = PSPC
-				ratio = 1.0
+				ratio = 2.069 //dry mass * 0.9 = propellant mass
 				DrawGauge = True
 			}
 		}
@@ -1200,7 +1200,7 @@
 	@title = Radial Separation Motor (Medium)
 	@description = Small solid motor use to help separate one stage from another or perform ullage. Best used with others.
 
-	@mass = 0.044
+	@mass = 0.032
 
 	@MODULE[ModuleEngines*]
 	{
@@ -1210,7 +1210,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 20.34
+		volume = 16.552 //dry mass * 0.9 = propellant mass
 		type = PSPC
 		basemass = -1
 	}
@@ -1248,7 +1248,7 @@
 	@description = Larger solid motor use to help separate one stage from another or perform ullage. Best used with others.
 
 	%rescaleFactor = 2.0
-	@mass = 0.25
+	@mass = 0.256
 
 	@MODULE[ModuleFuelTanks]
 	{
@@ -1280,7 +1280,7 @@
 
 	@MODULE[ModuleFuelTanks]
 	{
-		@volume *= 0.25		// Should be *.125, but balancing vs snubOtron, which has volume=5.
+		@volume *= 0.25	//same mass and volume as SnubOTron
 	}
 
 	@MODULE[ModuleEngineConfigs]
@@ -1304,8 +1304,8 @@
 	{
 		%atmosphereCurve
 		{
-			@key,0 = 0 220
-			@key,1 = 0 200
+			@key,0 = 0 225
+			@key,1 = 0 190
 		}
 	}
 	@MODULE[ModuleEngineConfigs]
@@ -1314,8 +1314,8 @@
 		{
 			%atmosphereCurve
 			{
-				key = 0 220
-				key = 1 200
+				key = 0 225
+				key = 1 190
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1153,7 +1153,7 @@
 	@title = Spin Motor (Small)
 	@description = Very small solid motor used to spin stabilize stages.
 
-	@mass = 0.004
+	@mass = 0.00381
 
 	MODULE
 	{
@@ -1165,7 +1165,7 @@
 		TANK
 		{
 		  name = PSPC
-		  amount = 1
+		  amount = 1.11
 		  maxAmount = 1
 		}
 	}
@@ -1186,7 +1186,7 @@
 			PROPELLANT
 			{
 				name = PSPC
-				ratio = 2.069 //dry mass * 0.9 = propellant mass
+				ratio = 1
 				DrawGauge = True
 			}
 		}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1304,8 +1304,8 @@
 	{
 		%atmosphereCurve
 		{
-			@key,0 = 0 250
-			@key,1 = 0 220
+			@key,0 = 0 220
+			@key,1 = 0 200
 		}
 	}
 	@MODULE[ModuleEngineConfigs]
@@ -1314,8 +1314,8 @@
 		{
 			%atmosphereCurve
 			{
-				key = 0 250
-				key = 1 220
+				key = 0 220
+				key = 1 200
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1143,9 +1143,6 @@
 //  Spin Motor (small)
 //  ==================================================
 
-//Source for separation motors: https://www.northropgrumman.com/wp-content/uploads/NG-Propulsion-Products-Catalog.pdf (Page 49)
-//For dry mass:propellant mass, using a ratio of 1:0.9, a little better than the BSM
-
 @PART[ROSmallSpinMotor]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -1158,7 +1155,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1
+		volume = 1.11
 		type = PSPC
 		basemass = -1
 
@@ -1192,6 +1189,9 @@
 		}
 	}
 }
+
+//Source for separation motors: https://www.northropgrumman.com/wp-content/uploads/NG-Propulsion-Products-Catalog.pdf (Page 49)
+//For dry mass:propellant mass, using a ratio of 1:0.9, a little better than the BSM
 
 //  ==================================================
 //  Radial Separation motor (medium).

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg
@@ -1293,7 +1293,7 @@
 }
 
 // sepMotorSmall and sepMotorLarge get this through the copy not directly
-@PART[sepMotor1|ROSmallSpinMotor|SnubOtron]:FOR[RealismOverhaul]
+@PART[sepMotor1|ROSmallSpinMotor]:FOR[RealismOverhaul]
 {
 	@manufacturer = Generic
 	@crashTolerance = 10

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
@@ -33,15 +33,15 @@
 		%thrustVectorTransformName = newThrustTransform
 		@atmosphereCurve
 		{
-			@key,0 = 0 220
-			@key,1 = 0 200
+			@key,0 = 0 225
+			@key,1 = 0 190
 		}
 	}
 	!RESOURCE[SolidFuel] {}
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 5.0
+		volume = 7.2 //dry mass * 0.9
 		type = PSPC
 		basemass = -1
 	}
@@ -64,8 +64,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 220
-				key = 1 200
+				key = 0 225
+				key = 1 190
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
@@ -8,6 +8,9 @@
 // Any parts in here are created by Vens New Parts.
 // If they exist, assume VNP exists if we need to reference its models.
 
+//Source for separation motors: https://www.northropgrumman.com/wp-content/uploads/NG-Propulsion-Products-Catalog.pdf (Page 49)
+//For dry mass:propellant mass, using a ratio of 1:0.9, a little better than the BSM
+
 @PART[SnubOtron]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
@@ -41,7 +41,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 7.2 //dry mass * 0.9
+		volume = 4.138 //dry mass * 0.9 = propellant mass
 		type = PSPC
 		basemass = -1
 	}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Engines.cfg
@@ -33,8 +33,8 @@
 		%thrustVectorTransformName = newThrustTransform
 		@atmosphereCurve
 		{
-			@key,0 = 0 230
-			@key,1 = 0 220
+			@key,0 = 0 220
+			@key,1 = 0 200
 		}
 	}
 	!RESOURCE[SolidFuel] {}
@@ -64,8 +64,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 230
-				key = 1 220
+				key = 0 220
+				key = 1 200
 			}
 		}
 	}


### PR DESCRIPTION
This reduces the specific impulse of all of the generic solid rocket motors (spin motor, radial separation motor (small/medium/large), separation motor (small)) to 220 in a vacuum and 200 in the atmosphere. I'm unsure if these values are balanced, so I'm open to discussion for them. The purpose of this is to at least make them all consistent with each other.