### PR TITLE
Reduce RD-200 mass

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD200_Config.cfg
@@ -7,7 +7,7 @@
 //	RD-200
 //	Short description
 //
-//	Dry Mass: 218 Kg
+//	Dry Mass: 169 kg	//218 kg wet. Based on ratio of other similar engines, 169 kg dry.
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 98.51 kN
 //	ISP: 210 SL / 234 Vac
@@ -16,7 +16,7 @@
 //	Propellant: Nitric Acid (AK20?) / TM-114 (gasoline?)
 //	Prop Ratio: 3.76
 //	Throttle: N/A
-//	Nozzle Ratio: ???
+//	Nozzle Ratio: 4?
 //	Ignitions: 1
 //	=================================================================================
 
@@ -25,6 +25,7 @@
 //	Astronautix - RD-200:															http://www.astronautix.com/r/rd-200.html
 //	Rocket Engines from the Glushko Design Bureau:									https://static1.squarespace.com/static/5ef8124031cfcf448b11db32/t/5f1c45ba0e1af3503c9843a2/1595688386290/Siddiqi+Rocket+Engines+from+the+Glushko+Design+Bureau+2001.pdf
 //	http://www.raketenspezialisten.de/pdf/jbisdruckvorlage.pdf
+//	http://www.lpre.de/energomash/index.htm
 
 //	Used by:
 
@@ -64,7 +65,7 @@
 		type = ModuleEngines
 		configuration = RD-200
 		modded = false
-		origMass = 0.218
+		origMass = 0.169
 		literalZeroIgnitions = true
 
 		CONFIG


### PR DESCRIPTION
After investigating why RD-200 fares so poorly in cost calculations, I discovered that it uses wet mass values, not dry mass values. Estimate dry mass, and also add a source that isn't astronautix