### PR TITLE
Fix mass of an XLR11 Config (XLR35-RM-1) for using incorrect massMult

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR11_Config.cfg
@@ -409,7 +409,7 @@
 			specLevel = operational
 			maxThrust = 37.56
 			minThrust = 37.56
-			massMult = 1.233
+			massMult = 0.8726
 			heatProduction = 100
 			pressureFed = False
 			ignitions = 1


### PR DESCRIPTION
It was base on the wrong origMass. In config description, the XLR35-RM-1 weighs 185kg, and origMass is 212kg, but in the original version massMult was 1.233, which is definitely incorrect since it was greater than 1. Considering that this is the ratio of the mass between XLR35-RM-1 & XLR11-RM-3 (first config), obviously someone thought origMass was the mass of the first config (-RM-3, 150kg), which it was not.