### PR TITLE
J-2S mass, and J-2/F-1 residuals

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
@@ -100,6 +100,11 @@
 			minThrust = 7775.49
 			maxThrust = 7775.49
 			heatProduction = 100
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			residualsThresholdBase = 0.0119	//[1] 1.19%
+			
 			PROPELLANT
 			{
 				name = RP-1
@@ -117,9 +122,6 @@
 				key = 1 262.1
 			}
 			
-			ullage = True
-			pressureFed = False
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -153,6 +155,11 @@
 			minThrust = 7895.01
 			maxThrust = 7895.01
 			heatProduction = 100
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			residualsThresholdBase = 0.0119	//[1] 1.19%
+			
 			PROPELLANT
 			{
 				name = RP-1
@@ -170,9 +177,6 @@
 				key = 1 265
 			}
 			
-			ullage = True
-			pressureFed = False
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -208,6 +212,11 @@
 			maxThrust = 9189.6
 			massMult = 0.97673
 			heatProduction = 100
+			ullage = True
+			pressureFed = False
+			ignitions = 1
+			residualsThresholdBase = 0.0119	// 1.19%?
+			
 			PROPELLANT
 			{
 				name = RP-1
@@ -225,9 +234,6 @@
 				key = 1 268.8
 			}
 			
-			ullage = True
-			pressureFed = False
-			ignitions = 1
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge

--- a/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/J2_Config.cfg
@@ -35,9 +35,9 @@
 //	Dry Mass: 1566.708 kg
 //	Thrust (SL): ??? kN
 //	Thrust (vac): 1000.8495 kN
-//	ISP: 300 SL / 424.4 Vac		SL calculated with RPA
+//	ISP: 302 SL / 424.4 Vac		SL calculated with RPA
 //	Burn Time: 580
-//	Chamber Pressure: 4.94? MPa
+//	Chamber Pressure: 5.15? MPa		extrapolated from J-2-230K
 //	Propellant: LOX / LH2
 //	O/F Ratio: 5.5
 //	Throttle: 77% to 100%
@@ -50,9 +50,9 @@
 //	Dry Mass: 1566.708 kg
 //	Thrust (sl): 717.94271 kN	Source #6
 //	Thrust (vac): 1023.0906 kN
-//	ISP: 300 SL / 425 Vac		SL calculated with RPA
+//	ISP: 304 SL / 425 Vac		SL calculated with RPA
 //	Burn Time: 580 // [B] 390s on S-II, 580s on IVB, leaving as 580
-//	Chamber Pressure: 4.94 MPa
+//	Chamber Pressure: 5.26 MPa	[2]
 //	Propellant: LOX / LH2
 //	O/F Ratio: 5.5
 //	Throttle: 77% to 100%
@@ -62,7 +62,7 @@
 //	J-2S (1973)
 //	Designed as an upgraded and simplified J-2 engine for further development
 //
-//	Dry Mass: 1723.65 kg
+//	Dry Mass: 1467.37 kg	[4] mass w/o accessories? lighter than standard J-2 makes more sense anyway.
 //	Thrust (sl): 876.29934 kN	Source #6
 //	Thrust (vac): 1178.7783 kN
 //	ISP: 323 SL / 436 Vac		SL calculated with RPA
@@ -152,6 +152,8 @@
 			maxThrust = 889.644
 			heatProduction = 100
 			massMult = 1.00
+			residualsThresholdBase = 0.006	//[1] 0.6%
+			
 			PROPELLANT	// 5.0 Mixture Ratio
 			{
 				name = LqdHydrogen
@@ -185,6 +187,7 @@
 				massMult = 1.093
 				ignitions = 3
 				ullage = False	//CVS system kept tanks ullaged even at minimum setting
+				residualsThresholdBase = 0.01	//[1] 1.0%
 				costOffset = 150
 			}
 
@@ -226,6 +229,8 @@
 			maxThrust = 1000.850
 			heatProduction = 100
 			massMult = 1.00
+			residualsThresholdBase = 0.006	//[1] 0.6%
+			
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -240,7 +245,7 @@
 			atmosphereCurve
 			{
 				key = 0 424
-				key = 1 300	 // Flow separation caused damage to the bell
+				key = 1 302	 // Flow separation caused damage to the bell
 			}
 
 			ullage = True
@@ -259,6 +264,7 @@
 				massMult = 1.093
 				ignitions = 3
 				ullage = False	//CVS system kept tanks ullaged even at minimum setting
+				residualsThresholdBase = 0.01	//[1] 1.0%
 				costOffset = 150
 			}
 
@@ -304,6 +310,8 @@
 			maxThrust = 1023.091
 			heatProduction = 100
 			massMult = 1.00
+			residualsThresholdBase = 0.006	//[1] 0.6%
+			
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -318,7 +326,7 @@
 			atmosphereCurve
 			{
 				key = 0 424.5
-				key = 1 300	 // Flow separation caused damage to the bell
+				key = 1 304	 // Flow separation caused damage to the bell
 			}
 
 			ullage = True
@@ -337,6 +345,7 @@
 				massMult = 1.093
 				ignitions = 3
 				ullage = False	//CVS system kept tanks ullaged even at minimum setting
+				residualsThresholdBase = 0.01	//[1] 1.0%
 				costOffset = 150
 			}
 
@@ -380,8 +389,10 @@
 			specLevel = prototype
 			minThrust = 196.463	// 6:1 throttling thanks to redesigned pumps and injectors
 			maxThrust = 1178.778
-			massMult = 1.036835 // All sources state the J-2S was heavier than J-2
+			massMult = 0.9366
 			heatProduction = 100
+			residualsThresholdBase = 0.006	//0.6%? Starter cartridge system and fast cooldown eliminated most plumbing associated with restart
+			
 			PROPELLANT
 			{
 				name = LqdHydrogen


### PR DESCRIPTION
Revise J-2S mass to consider just the dry engine, not engine and accessories. Also add residual settings to F-1 and J-2.