### PR TITLE
Add RD-0108, improve RD-0110 configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
@@ -9,13 +9,13 @@
 //
 //	Dry Mass: 410? Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 304 kN
+//	Thrust (Vac): 297.9 kN
 //	ISP: 194 SL / 326? Vac		SL calculated with RPA
 //	Burn Time: 165
 //	Chamber Pressure: 6.82? MPa
 //	Propellant: LOX / T-1
 //	Prop Ratio: 2.22?
-//	Throttle: N/A
+//	Throttle: ???
 //	Nozzle Ratio: 82.2
 //	Ignitions: 1
 //	=================================================================================
@@ -105,6 +105,7 @@
 		CONFIG
 		{
 			name = RD-0106
+			RODeprecated = True		//identical to 0107, just disable
 			description = Upper stage for the R-9.
 			specLevel = operational
 			maxThrust = 297.9
@@ -165,7 +166,7 @@
 		CONFIG
 		{
 			name = RD-0107
-			description = Upper stage for the R-7. Used on Vostok and Molniya rockets.
+			description = Upper stage for the R-7. Used on Vostok and Molniya rockets. Also used on the R-9 as the RD-0106.
 			specLevel = operational
 			maxThrust = 297.9
 			minThrust = 269.69 //90.5%

--- a/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0110_Config.cfg
@@ -7,7 +7,7 @@
 //	RD-0106 (8D715, RO-6)
 //	R-9
 //
-//	Dry Mass: 451? Kg
+//	Dry Mass: 410? Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 304 kN
 //	ISP: 194 SL / 326? Vac		SL calculated with RPA
@@ -19,10 +19,10 @@
 //	Nozzle Ratio: 82.2
 //	Ignitions: 1
 //	=================================================================================
-//	RD-0107
+//	RD-0107 (8D715K)
 //	Vostok, Molnyia
 //
-//	Dry Mass: 451 Kg
+//	Dry Mass: 410 Kg
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 297.9 kN
 //	ISP: 194 SL / 326 Vac		SL calculated with RPA
@@ -34,18 +34,33 @@
 //	Nozzle Ratio: 82.2
 //	Ignitions: 1
 //	=================================================================================
-//	RD-0110
+//	RD-0108 (8D715P)
+//	Voskhod, Molnyia-M
+//
+//	Dry Mass: 410 Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 297.9 kN
+//	ISP: 194 SL / 326 Vac		SL calculated with RPA
+//	Burn Time: 240
+//	Chamber Pressure: 6.82 MPa
+//	Propellant: LOX / T-1
+//	Prop Ratio: 2.22?
+//	Throttle: 100% to 90.5%
+//	Nozzle Ratio: 82.2
+//	Ignitions: 1
+//	=================================================================================
+//	RD-0110 (11D55)
 //	Molnyia-M, Soyuz
 //
-//	Dry Mass: 451 Kg
+//	Dry Mass: 408.5 Kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 298.2 kN
+//	Thrust (Vac): 318.78 kN		107% of 297.926
 //	ISP: 245 SL / 330.4 Vac		SL calculated with RPA
 //	Burn Time: 250
 //	Chamber Pressure: 15.53 MPa
 //	Propellant: LOX / T-1
 //	Prop Ratio: 2.22
-//	Throttle: 100% to 90.5%
+//	Throttle: 107% to 90.5%
 //	Nozzle Ratio: 82.2
 //	Ignitions: 1
 //	=================================================================================
@@ -57,11 +72,19 @@
 //	http://arc.aiaa.org/doi/book/10.2514/4.866371
 //	https://missilery.info/missile/r-9a
 //	https://rvsn.ruzhany.info/missile_ssystem_p01_16.html
+//	https://web.archive.org/web/20111014092851/http://www.kbkha.ru/?p=8&cat=8&prod=37
+//	http://forums.airbase.ru/2017/11/t93498_5--s-zemli-na-lunu-istoriya-lyudi-tekhnika-1958-1976.html
 
 //	Used by:
 
 //	Notes:
 
+//	RD-0106 and RD-0107 are functionally identical, differed only in mounting hardware I guess. Give same
+//	stats and reliability?
+//	RD-0108 was only used for Voskhod launches (unmanned and manned) and the first few Molniya-M launches.
+//	Mostly the same as the 0106/0107, but had "improved reliability" for manned launches. Give 0107 stats 
+//	with 0110 reliability?
+//	RD-0110 was a complete modernization, ran at higher pressures and had the option for 107% throttle.
 //	==================================================
 @PART[*]:HAS[#engineType[RD0110]]:FOR[RealismOverhaulEngines]
 {
@@ -76,71 +99,13 @@
 	MODULE
 	{
 		name = ModuleEngineConfigs
-		origMass = 0.451
+		origMass = 0.410
 		configuration = RD-0107
 		modded = false
 		CONFIG
 		{
 			name = RD-0106
 			description = Upper stage for the R-9.
-			specLevel = operational
-			maxThrust = 304
-			minThrust = 304
-			massMult = 1.0
-			PROPELLANT
-			{
-				name = Kerosene
-				ratio = 0.3981
-				DrawGauge = true
-			}
-			PROPELLANT
-			{
-				name = LqdOxygen
-				ratio = 0.6019
-			}
-			atmosphereCurve
-			{
-				key = 0 326
-				key = 1 194
-			}
-			
-			ullage = True
-			ignitions = 1
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.5
-			}
-			IGNITOR_RESOURCE
-			{
-				name = TEATEB
-				amount = 1
-			}
-
-			//R-9 Early R&D: 30 flights, 12 failures
-			//R-9 R&D: 65 flights, 10 failures
-			//Blaming 1/3rd of failures on upper stage
-			//no good data on these. Assuming 4:1 cycle to ignition failures based on RD0109, RD119
-			//80 ignitions, 2 failures
-			//78 cycles, 5 failures
-			TESTFLIGHT:NEEDS[TestLite|TestFlight]
-			{
-				testedBurnTime = 500		//Tested to 3 times rated burn time?
-				ratedBurnTime = 165
-				safeOverburn = true
-
-				ignitionReliabilityStart = 0.956996
-				ignitionReliabilityEnd = 0.993210
-				ignitionDynPresFailMultiplier = 0.1
-				cycleReliabilityStart = 0.907806
-				cycleReliabilityEnd = 0.985443
-				techTransfer = RD-0107:50
-			}
-		}
-		CONFIG
-		{
-			name = RD-0107
-			description = Upper stage for the R-7. Used on Vostok and early Molniya rockets.
 			specLevel = operational
 			maxThrust = 297.9
 			minThrust = 269.69 //90.5%
@@ -175,11 +140,75 @@
 				amount = 1
 			}
 
+			//Same as RD-0107
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 750		//Tested to 3 times rated burn time?
+				ratedBurnTime = 165
+				safeOverburn = true
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.983890
+				ignitionReliabilityEnd = 0.996778
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.944915
+				cycleReliabilityEnd = 0.988983
+				techTransfer = RD-0107:50
+			}
+		}
+		CONFIG
+		{
+			name = RD-0107
+			description = Upper stage for the R-7. Used on Vostok and Molniya rockets.
+			specLevel = operational
+			maxThrust = 297.9
+			minThrust = 269.69 //90.5%
+			massMult = 1.0
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3981
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6019
+			}
+			atmosphereCurve
+			{
+				key = 0 326
+				key = 1 194
+			}
+			
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			//R-9 Early R&D: 30 flights, 12 failures
+			//R-9 R&D: 65 flights, 10 failures
+			//Blaming 1/3rd of failures on upper stage
+			
 			//Molniya (8K78): 39 flights, 8 failures
 			//Voskhod (11A57): 299 flights, 13 failures
 			//no good data on these. Assuming 4:1 cycle to ignition failures based on RD0109, RD119
-			//338 ignitions, 4 failures
-			//334 cycles, 17 failures
+			//418 ignitions, 6 failures
+			//412 cycles, 22 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 750		//Tested to 3 times rated burn time?
@@ -193,12 +222,72 @@
 					key = 1.00 1.00 3 3
 				}
 
-				ignitionReliabilityStart = 0.982252
-				ignitionReliabilityEnd = 0.997198
+				ignitionReliabilityStart = 0.983890
+				ignitionReliabilityEnd = 0.996778
 				ignitionDynPresFailMultiplier = 0.1
-				cycleReliabilityStart = 0.932886
-				cycleReliabilityEnd = 0.989403
+				cycleReliabilityStart = 0.944915
+				cycleReliabilityEnd = 0.988983
 				techTransfer = RD-0106:50
+			}
+		}
+		CONFIG
+		{
+			name = RD-0108
+			description = Upper stage for the R-7. Used on Voskhod and early Molniya-M rockets.
+			specLevel = operational
+			maxThrust = 297.9
+			minThrust = 269.69 //90.5%
+			massMult = 1.0
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.3981
+				DrawGauge = true
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6019
+			}
+			atmosphereCurve
+			{
+				key = 0 326
+				key = 1 194
+			}
+			
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			IGNITOR_RESOURCE
+			{
+				name = TEATEB
+				amount = 1
+			}
+
+			//Same as RD-0110
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 750		//Tested to 3 times rated burn time?
+				ratedBurnTime = 240
+				safeOverburn = true
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.995052
+				ignitionReliabilityEnd = 0.999219
+				ignitionDynPresFailMultiplier = 0.1
+				cycleReliabilityStart = 0.983540
+				cycleReliabilityEnd = 0.997401
+				techTransfer = RD-0107,RD-0106:50
 			}
 		}
 		CONFIG
@@ -206,9 +295,9 @@
 			name = RD-0110
 			description = Developed for the upgraded Molniya-M, and later used on Soyuz.
 			specLevel = operational
-			maxThrust = 298.2
+			maxThrust = 318.78 //107%
 			minThrust = 269.69 //90.5%
-			massMult = 1.0
+			massMult = 0.9963
 			PROPELLANT
 			{
 				name = Kerosene
@@ -270,7 +359,7 @@
 				ignitionDynPresFailMultiplier = 0.1
 				cycleReliabilityStart = 0.983540
 				cycleReliabilityEnd = 0.997401
-				techTransfer = RD-0107,RD-0106:50
+				techTransfer = RD-0108,RD-0107,RD-0106:50
 			}
 		}
 	}


### PR DESCRIPTION
Add RD-0108 config, a more reliable, man-rated version of the RD-0107. Also adjust RD-0106 config to be the same as the RD-0107, give 107% throttle to RD-0110, and decrease mass of all RD-0110 variants