### PR TITLE
Recommendation suppression property for netkans

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -1,122 +1,121 @@
-{
-    "spec_version"   : "v1.26",
-    "$kref"          : "#/ckan/github/KSP-RO/RealismOverhaul",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "name"           : "Realism Overhaul",
-    "identifier"     : "RealismOverhaul",
-    "abstract"       : "Multipatch to KSP to give spacecraft components realistic stats and sizes, and performance based on real-world spacecraft.",
-    "license"        : "CC-BY-SA",
-    "release_status" : "stable",
-    "depends" : [
-        { "name" : "AdvancedJetEngine" },
-        { "name" : "FAR" },
-        { "name" : "KerbalJointReinforcementContinued" },
-        { "name" : "ModuleManager" },
-        { "name" : "RealChute" },
-        { "name" : "RealFuels" },
-        { "name" : "RealHeat" },
-        { "name" : "RealPlume" },
-        { "name" : "SmokeScreen" },
-        { "name" : "KSPCommunityFixes" },
-		{ "name" : "KerbalChangelog" }
-    ],
-    "recommends" : [
-        { "name" : "ROLoadingImages" },
-        { "name" : "B9-PWings-Fork" },
-        { "name" : "Waterfall" },
-        { "name" : "HangerExtenderExtended" },
-        { "name" : "KSCSwitcher" },
-        { "name" : "MechJeb2" },
-        { "name" : "ProceduralFairings" },
-        { "name" : "ProceduralParts" },
-        { "any_of": [
-            { "name" : "RCSBuildAid" },
-            { "name" : "RCSBuildAidCont" }
-        ] },
-        { "name" : "RealSolarSystem" },
-        { "any_of": [
-            { "name" : "RemoteTech" },
-            { "name" : "RealAntennas" }
-        ] },
-        { "any_of": [
-            { "name" : "Kerbalism-Config-RO" },
-            { "name" : "TACLS" }
-        ] },
-        { "name" : "TexturesUnlimited" },
-        { "name" : "RSSVE-Textures" }
-    ],
-    "suggests"   : [
-        { "name" : "RealismOverhaulCraftFiles" },
-        { "name" : "ALCOR" },
-        { "name" : "AntaresCygnus" },
-        { "name" : "ATKPropulsionPack" },
-        { "name" : "ConnectedLivingSpace" },
-        { "name" : "CryoEngines" },
-        { "name" : "DMagicOrbitalScience" },
-        { "name" : "FASA" },
-        { "name" : "FilterExtensions" },
-        { "name" : "KAS" },
-        { "name" : "KSP-AVC" },
-        { "name" : "KWRocketryRebalanced" },
-        { "name" : "NearFutureConstruction" },
-        { "name" : "NearFuturePropulsion" },
-        { "name" : "NearFutureSolar" },
-        { "name" : "NearFutureSpacecraft" },
-        { "name" : "NewTantares" },
-        { "name" : "NewTantaresLV" },
-        { "name" : "RealScaleBoosters" },
-        { "name" : "ROCapsules" },
-        { "name" : "ROEngines" },
-        { "name" : "ROEnginesExtended" },
-        { "name" : "ROSolar" },
-        { "name" : "ROTanks" },
-        { "name" : "ROHeatshields" },
-        { "name" : "RLAReborn" },
-        { "name" : "RN-SalyutStations" },
-        { "name" : "RN-Skylab" },
-        { "name" : "RN-SovietProbes" },
-        { "name" : "RN-SovietRockets" },
-        { "name" : "RN-SovietSpacecraft" },
-        { "name" : "RN-USProbesPack" },
-        { "name" : "RN-USRockets" },
-        { "name" : "SCANsat" },
-        { "name" : "SpaceXLaunchVehicles" },
-        { "name" : "SXTContinued" },
-        { "name" : "Taerobee" },
-        { "name" : "Toolbar" },
-        { "any_of": [
-            { "name" : "TestFlight" },
-            { "name" : "TestLite" }
-        ] },
-        { "any_of": [
-            { "name" : "VenStockRevamp" },
-            { "name" : "Restock" }
-        ] },
-        { "name" : "UniversalStorage" },
-        { "name" : "VenStockRevamp-NewParts" }
-    ],
-    "provides"  : [ "RealPlumeConfigs", "RealFuels-Engine-Configs", "TestFlightConfig" ],
-    "conflicts" :   [
-        { "name" : "TweakableEverythingCont" },
-        { "name" : "RealPlumeConfigs" },
-        { "name" : "TestFlightConfig" },
-        { "name" : "StockWaterfallEffects" },
-        { "name" : "WaterfallRestock" }
-    ],
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/155700-122-realism-overhaul-v1150-05262017/",
-        "manual" : "https://github.com/KSP-RO/RealismOverhaul/wiki"
-    },
-    "install" : [
-        {
-            "file"       : "GameData/RealismOverhaul",
-            "install_to" : "GameData"
-        },
-        {
-            "file"       : "GameData/EngineGroupController",
-            "install_to" : "GameData",
-            "comment"    : "Engine Group Controller, unique to RO."
-        }
-    ]
-}
+spec_version: v1.26
+$kref: '#/ckan/github/KSP-RO/RealismOverhaul'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+name: Realism Overhaul
+identifier: RealismOverhaul
+abstract: >-
+  Multipatch to KSP to give spacecraft components realistic stats and sizes, and
+  performance based on real-world spacecraft.
+license: CC-BY-SA
+release_status: stable
+depends:
+  - name: ModuleManager
+  - name: AdvancedJetEngine
+    suppress_recommendations: true
+  - name: FAR
+    suppress_recommendations: true
+  - name: KerbalJointReinforcementContinued
+    suppress_recommendations: true
+  - name: RealChute
+    suppress_recommendations: true
+  - name: RealFuels
+    suppress_recommendations: true
+  - name: RealHeat
+    suppress_recommendations: true
+  - name: RealPlume
+    suppress_recommendations: true
+  - name: SmokeScreen
+    suppress_recommendations: true
+  - name: KSPCommunityFixes
+    suppress_recommendations: true
+  - name: KerbalChangelog
+    suppress_recommendations: true
+recommends:
+  - name: ROLoadingImages
+  - name: B9-PWings-Fork
+  - name: Waterfall
+  - name: HangerExtenderExtended
+  - name: KSCSwitcher
+  - name: MechJeb2
+  - name: ProceduralFairings
+  - name: ProceduralParts
+  - any_of:
+      - name: RCSBuildAid
+      - name: RCSBuildAidCont
+  - name: RealSolarSystem
+  - any_of:
+      - name: RemoteTech
+      - name: RealAntennas
+  - any_of:
+      - name: Kerbalism-Config-RO
+      - name: TACLS
+  - name: TexturesUnlimited
+  - name: RSSVE-Textures
+suggests:
+  - name: RealismOverhaulCraftFiles
+  - name: ALCOR
+  - name: AntaresCygnus
+  - name: ATKPropulsionPack
+  - name: ConnectedLivingSpace
+  - name: CryoEngines
+  - name: DMagicOrbitalScience
+  - name: FASA
+  - name: FilterExtensions
+  - name: KAS
+  - name: KSP-AVC
+  - name: KWRocketryRebalanced
+  - name: NearFutureConstruction
+  - name: NearFuturePropulsion
+  - name: NearFutureSolar
+  - name: NearFutureSpacecraft
+  - name: NewTantares
+  - name: NewTantaresLV
+  - name: RealScaleBoosters
+  - name: ROCapsules
+  - name: ROEngines
+  - name: ROEnginesExtended
+  - name: ROSolar
+  - name: ROTanks
+  - name: ROHeatshields
+  - name: RLAReborn
+  - name: RN-SalyutStations
+  - name: RN-Skylab
+  - name: RN-SovietProbes
+  - name: RN-SovietRockets
+  - name: RN-SovietSpacecraft
+  - name: RN-USProbesPack
+  - name: RN-USRockets
+  - name: SCANsat
+  - name: SpaceXLaunchVehicles
+  - name: SXTContinued
+  - name: Taerobee
+  - name: Toolbar
+  - any_of:
+      - name: TestFlight
+      - name: TestLite
+  - any_of:
+      - name: VenStockRevamp
+      - name: Restock
+  - name: UniversalStorage
+  - name: VenStockRevamp-NewParts
+provides:
+  - RealPlumeConfigs
+  - RealFuels-Engine-Configs
+  - TestFlightConfig
+conflicts:
+  - name: TweakableEverythingCont
+  - name: RealPlumeConfigs
+  - name: TestFlightConfig
+  - name: StockWaterfallEffects
+  - name: WaterfallRestock
+resources:
+  homepage: >-
+    http://forum.kerbalspaceprogram.com/index.php?/topic/155700-122-realism-overhaul-v1150-05262017/
+  manual: https://github.com/KSP-RO/RealismOverhaul/wiki
+install:
+  - file: GameData/RealismOverhaul
+    install_to: GameData
+  - file: GameData/EngineGroupController
+    install_to: GameData
+    comment: Engine Group Controller, unique to RO.


### PR DESCRIPTION
Hi!

This is a pending follow-up item for KSP-CKAN/CKAN#3892.

Sometime in the next 3 months or so, there will most likely be a new CKAN client release featuring "deep recommendations", where all the dependencies in a changeset will contribute recommendations and suggestions, instead of just what the user clicks on.

This pull request applies the `suppress_recommendations` property to suppress this behavior for affected KSP-RO netkans.

Cheers!
