### PR TITLE
Add more reactors, improve existing configs

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -62,6 +62,7 @@ Localization
 		#roMfrLRC = Lewis Research Center	//(1958-1999) Renamed to Glenn Research Center in 1999
 		#roMfrLockheed = Lockheed	//(1926-1995) merged with Martin Marietta to form Lockheed Martin in 1995
 		#roMfrLM = Lockheed Martin	//(1995-present)
+		#roMfrLANL = Los Alamos National Laboratory	//(1943-present)
 		//M
 		#roMfrMartin = Martin	//(1917-1961) merged with American-Marietta to form Martin Marietta in 1961
 		#roMfrMarquardt = Marquardt	//(1944-1991) bought by CCI in 1968. Rocket-Propulsion division sold to Kaiser Aerospace in 1991.
@@ -191,6 +192,7 @@ Localization
 		//Others
 		#roMfrKurchatov = Kurchatov Institute of Atomic Energy (КИАЭ)	//(1943-present)
 		#roMfrMPEI = Moscow Power Engineering Institute (МЭИ)	//(1930-present)
+		#roMfrRedStar = Krasnaya Zvezda State Enterprise (ГПКЗ)	//(1971-2023) Absorbed by NIKIET JSC
 		
 		//	============================================================================
 		//	European Manufacturers

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -77,6 +77,7 @@
 	@rescaleFactor = 0.803949
 
 	@title = NASA & DOE Advanced Sterling RG
+	@manufacturer = #roMfrLM
 	@description = A much lighter and more efficient radioisotope generator by using the sterling cycle.
 	@mass = 0.032
 	@MODULE[ModuleGenerator]
@@ -111,13 +112,16 @@
 //	=================================================================================
 //	RAPID-L reactor
 //	=================================================================================
+// source: https://inis.iaea.org/search/search.aspx?orig_q=RN:37002589
 @PART[reactor-25]:FOR[RealismOverhaul]
 {
-	@title = USDOE RAPID-L Nuclear Reactor
+	@title = RAPID-L Nuclear Reactor
 	@manufacturer = Japan Atomic Energy Research Institute
 	@description = Japanese design based for lunar bases. Design lifetime 8 years at full power. <b>Meant to be buried underground.</b>
-	@mass = 7.1
+	@mass = 6.6		//including power conversion equipment and radiators? -500 kg fuel
+	%specLevel = concept
 
+	//~2 meters dia, 7 meters length
 	@MODEL
 	{
 		@scale = 0.41928, 1, 0.41928
@@ -137,7 +141,7 @@
 	{
 		name = UraniumNitride
 		amount = 35
-		maxAmount = 35
+		maxAmount = 35		//~500 kg
 	}
 }
 
@@ -195,6 +199,8 @@
 }
 @PART[reactor-25]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 2.50	//subtract 2.5 tons radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -234,9 +240,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 1373
+		NominalTemperature = 850		//reactor outlet temp 1373 K, but heat rejected to radiator at only 950 K after thermoelectric system
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1513
+		CriticalTemperature = 950
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -284,22 +290,568 @@
 }
 
 //	=================================================================================
-//	SNAP-50 - main source: https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-50/ and references
+//	Prometheus reactor
+//	=================================================================================
+// source: http://everyspec.com/NASA/NASA-JPL/JPL_Prometheus_Final_Report_3673/
+// https://web.archive.org/web/20160327150008/http://navalreactorshistorydb.info:8080/xtf/data/pdf/002/002.pdf
++PART[reactor-25]:FOR[RealismOverhaul]
+{
+	@name = RO-reactor-prometheus
+	@title = Prometheus 200 KWe Nuclear Reactor
+	@manufacturer = #roMfrJPL
+	@description = NASA reactor design intended for large deep space nuclear-electric probes, including Jupiter Icy Moons Explorer (JIMO). Advanced gas-cooled fast reactor design with redundant Brayton-cycle generators. Design lifetime 10 years at full power, plus 10 years at reduced power.
+	@mass = 4.362		//reactor assembly 3309 kg, radiators 1553 kg, -500 kg fuel?
+	%specLevel = concept
+
+	//by pixel counting, ~2.1x7.8 meters
+	@MODEL
+	{
+		@scale = 0.41928, 1, 0.41928
+	}
+	@rescaleFactor = 2.0034
+
+	// resources
+	!RESOURCE,* {}
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 45.6
+	}
+	//Uranium Oxide
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 45.6
+		maxAmount = 45.6		//500 kg?
+	}
+}
+
+@PART[RO-reactor-prometheus]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
+{
+	// reactor parameters
+	@MODULE[FissionGenerator]
+	{
+		@PowerGeneration = 200
+		@HeatUsed = 1000
+	}
+	@MODULE[FissionReactor]
+	{
+		// Heat to generate (kW*50 - no clue why, hardcoded)
+		@HeatGeneration = #$../MODULE[FissionGenerator]/HeatUsed$
+		@HeatGeneration *= 50
+		@NominalTemperature = 1150		// Above this temp more power output but risky
+		@CriticalTemperature = 1350		// Above this temp, reactor takes damage
+
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		@CoreDamageRate = 0.02
+
+		// Base lifetime calculations off this resource
+		@FuelName = EnrichedUranium
+
+		!INPUT_RESOURCE {}
+		!OUTPUT_RESOURCE {}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000121322 // 10 years of operation at full power, 10 years at reduced power. 12 years?
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.000000121322
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[RadioactiveStorageContainer]
+	{
+		@DangerousFuel = DepletedFuel
+		@SafeFuel = EnrichedUranium
+	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 1150				//Internal temp goal - we don't transfer till we hit this point
+		@HeatRadiantMultiplier = 0.1		//If the core is hotter, how much heat radiates?
+		@CoreShutdownTemp = 1350			//At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 5000					//Maximum amount of radiator capacity we can consume
+	}
+
+}
+@PART[RO-reactor-prometheus]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
+{
+	@mass -= 1.553		//subtract radiator mass since system heat actually needs rads
+	!MODULE[ModuleUpdateOverride] {}
+	!MODULE[FissionReactor] {}
+	!MODULE[FissionGenerator] {}
+	!MODULE[ModuleCoreHeatNoCatchup] {}
+	!MODULE[RadioactiveStorageContainer] {}
+	
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
+	{
+		name = ModuleSystemHeat
+		volume = 10
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+	
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
+		{
+			key = 0 0 0 0
+			key = 100 1000 0 0
+		}
+
+		// Above this temp, risky
+		NominalTemperature = 505		//reactor outlet temp 1150 K, but heat rejected to radiator at only 505 K after recuperator
+		// Above this temp, reactor takes damage
+		CriticalTemperature = 605
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
+
+		// -- Electrical stuff
+		// Power generated
+		ElectricalGeneration
+		{
+			key = 0 0
+			key = 100 200
+		}
+
+		// --- Fuel stuff
+		// Base lifetime calculations off this resource
+		FuelName = EnrichedUranium
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000121322 // 12 years of operation
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.000000121322
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedFuel
+	}
+}
+
+//	=================================================================================
+//	SNAP-8 35 kWe - main source: https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-50/
+//	https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-8/
+//	=================================================================================
++PART[reactor-25]:FOR[RealismOverhaul]
+{
+	@name = RO-reactor-snap8
+	%RSSROConfig = True
+	@title = NASA SNAP-8 Nuclear Reactor
+	@manufacturer = #roMfrAtomicsInt
+	@description = The SNAP 8 program was an evolution of the SNAP 2/10A design. Much larger and more powerful than it's predecessors, it was heavily shielded for use on manned space stations, with an output of 35 kWe. Reverted to thermoelectric power converters due to development cost and reliability concerns around the mercury vapor turbines of SNAP-2. Design lifetime 5 years at full power.
+	@mass = 13.657	//including radiator mass and heat conversion equipment? -82 kg fuel
+	%specLevel = prototype	//reactor and power conversion equipment tested extensively
+
+	//6.6 meters diameter, 8.2 meters tall
+	@MODEL
+	{
+		@scale = 1.114, 1, 1.114
+	}
+	@rescaleFactor = 2.340
+
+	%node_attach = #$node_stack_bottom$
+	@attachRules = 1,0,1,1,1
+
+	// resources
+	!RESOURCE,* {}
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 7.47
+	}
+	//Uranium-Zirconium-Hydride, unknown enrichment
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 7.47
+		maxAmount = 7.47		//~82 kg fuel
+	}
+}
+@PART[RO-reactor-snap8]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
+{
+	// reactor parameters
+	@MODULE[FissionGenerator]
+	{
+		@PowerGeneration = 35
+		@HeatUsed = 600
+	}
+	@MODULE[FissionReactor]
+	{
+		@HeatGeneration = #$../MODULE[FissionGenerator]/HeatUsed$
+		@HeatGeneration *= 50
+		@NominalTemperature = 978		// Above this temp more power output but risky
+		@CriticalTemperature = 1078		// Above this temp, reactor takes damage
+
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		@CoreDamageRate = 0.05
+
+		// Base lifetime calculations off this resource
+		@FuelName = EnrichedUranium
+
+		!INPUT_RESOURCE {}
+		!OUTPUT_RESOURCE {}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.0000000473565 // 5 years of operation
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.0000000473565
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[RadioactiveStorageContainer]
+	{
+		@DangerousFuel = DepletedFuel
+		@SafeFuel = EnrichedUranium
+	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 1366				//Internal temp goal - we don't transfer till we hit this point
+		@HeatRadiantMultiplier = 0.05		//If the core is hotter, how much heat radiates?
+		@CoreShutdownTemp = 2000			//At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 2200					//Maximum amount of radiator capacity we can consume
+	}
+}
+@PART[RO-reactor-snap8]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
+{
+	@mass -= 0.315	//subtract 315 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
+	!MODULE[ModuleUpdateOverride] {}
+	!MODULE[FissionReactor] {}
+	!MODULE[FissionGenerator] {}
+	!MODULE[ModuleCoreHeatNoCatchup] {}
+	!MODULE[RadioactiveStorageContainer] {}
+	
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
+	{
+		name = ModuleSystemHeat
+		volume = 10
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
+		{
+			key = 0 0 0 0
+			key = 100 600 0 0
+		}
+
+		// Above this temp, risky
+		NominalTemperature = 766		//reactor outlet temp 978 K, but heat rejected to radiator at only 766 K after thermoelectric system
+		// Above this temp, reactor takes damage
+		CriticalTemperature = 866
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
+
+		// -- Electrical stuff
+		// Power generated
+		ElectricalGeneration
+		{
+			key = 0 0
+			key = 100 35
+		}
+
+		// --- Fuel stuff
+		// Base lifetime calculations off this resource
+		FuelName = EnrichedUranium
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.0000000473565 // 5 years of operation
+			FlowMode = NO_FLOW
+		}
+		@OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.0000000473565
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedFuel
+	}
+}
+//	=================================================================================
+//	SNAP-50 35 kWe - main source: https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-50/ and references
 //	=================================================================================
 +PART[reactor-25]:FOR[RealismOverhaul]
 {
 	@name = RO-reactor-snap50
 	%RSSROConfig = True
-	@title = NASA SNAP-50 Nuclear Reactor
-	@manufacturer = Pratt & Whitney
-	@description = The SNAP 50 was a developmental reactor program separate from the main program. The SNAP 50 was advantageous in that it would operate a high conversion efficiencies and high power levels. But, because of the Rankine cycle conversion, it had a higher probability of single point failure and increased weight. Design lifetime 2 years at full power. <b>Meant to be buried underground for use in crewed bases.</b>
-	@mass = 9.382
+	@title = NASA SNAP-50 35 kWe Nuclear Reactor
+	@manufacturer = #roMfrPW
+	@description = The SNAP 50 was a developmental reactor program separate from the main program. Developed for the ANP under the infamous Project PLUTO, Pratt & Whitney offered the reactor to NASA after the end of the ANP program. The SNAP 50 was advantageous in that it would operate a high conversion efficiencies and high power levels. But, because of the Rankine cycle conversion, it had a higher probability of single point failure and increased weight. This is a scaled-down design, intended for space stations or nuclear-electric tugs. Design lifetime 2 years at full power.
+	@mass = 7.6505	//including radiator mass and heat conversion equipment? -187.5 kg fuel
+	%specLevel = prototype	//reactor core tested as part of ANP/Project PLUTO, power conversion system tested as part of SNAP?
 
+	//35 kWe: 1.5 meters dia, 1.8 meters long
+	//300 kWe: ~6.5 meters dia, 10.5 meters long
 	@MODEL
 	{
 		@scale = 1.68224, 1, 1.68224
 	}
 	@rescaleFactor = 0.428
+
+	%node_attach = #$node_stack_bottom$
+	@attachRules = 1,0,1,1,1
+
+	// resources
+	!RESOURCE,* {}
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 17.0938
+	}
+	//Uranium Nitride, enrichment unknown?
+	RESOURCE
+	{
+		name = UraniumNitride
+		amount = 13.125
+		maxAmount = 13.125		//~187.5 kg fuel
+	}
+}
+@PART[RO-reactor-snap50]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
+{
+	// reactor parameters
+	@MODULE[FissionGenerator]
+	{
+		@PowerGeneration = 35
+		@HeatUsed = 385
+	}
+	@MODULE[FissionReactor]
+	{
+		@HeatGeneration = #$../MODULE[FissionGenerator]/HeatUsed$
+		@HeatGeneration *= 50
+		@NominalTemperature = 1366		// Above this temp more power output but risky
+		@CriticalTemperature = 1400		// Above this temp, reactor takes damage
+
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		@CoreDamageRate = 0.05
+
+		// Base lifetime calculations off this resource
+		@FuelName = UraniumNitride
+
+		!INPUT_RESOURCE {}
+		!OUTPUT_RESOURCE {}
+		INPUT_RESOURCE
+		{
+			ResourceName = UraniumNitride
+			Ratio = 0.000000207837 // 2 years of operation
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.0000002709266
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[RadioactiveStorageContainer]
+	{
+		@DangerousFuel = DepletedFuel
+		@SafeFuel = UraniumNitride
+	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 1366				//Internal temp goal - we don't transfer till we hit this point
+		@HeatRadiantMultiplier = 0.05		//If the core is hotter, how much heat radiates?
+		@CoreShutdownTemp = 2000			//At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 2200					//Maximum amount of radiator capacity we can consume
+	}
+}
+@PART[RO-reactor-snap50]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
+{
+	@mass -= 0.170	//subtract 170 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
+	!MODULE[ModuleUpdateOverride] {}
+	!MODULE[FissionReactor] {}
+	!MODULE[FissionGenerator] {}
+	!MODULE[ModuleCoreHeatNoCatchup] {}
+	!MODULE[RadioactiveStorageContainer] {}
+	
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
+	{
+		name = ModuleSystemHeat
+		volume = 10
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
+		{
+			key = 0 0 0 0
+			key = 100 385 0 0
+		}
+
+		// Above this temp, risky
+		NominalTemperature = 865		//reactor outlet temp 1366 K, but heat rejected to radiator at only 865 K after condensor
+		// Above this temp, reactor takes damage
+		CriticalTemperature = 965
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
+
+		// -- Electrical stuff
+		// Power generated
+		ElectricalGeneration
+		{
+			key = 0 0
+			key = 100 35
+		}
+
+		// --- Fuel stuff
+		// Base lifetime calculations off this resource
+		FuelName = UraniumNitride
+
+		INPUT_RESOURCE
+		{
+			ResourceName = UraniumNitride
+			Ratio = 0.000000207837 // 2 years of operation
+			FlowMode = NO_FLOW
+		}
+		@OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.0000002709266
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = UraniumNitride, DepletedFuel
+	}
+}
+//	=================================================================================
+//	SNAP-50 300 kWe - main source: https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-50/ and references
+//	=================================================================================
++PART[reactor-25]:FOR[RealismOverhaul]
+{
+	@name = RO-reactor-snap50-300
+	%RSSROConfig = True
+	@title = NASA SNAP-50 300 kWe Nuclear Reactor
+	@manufacturer = #roMfrPW
+	@description = The SNAP 50 was a developmental reactor program separate from the main program. Developed for ANP under the infamous Project PLUTO, Pratt & Whitney offered the reactor to NASA after the end of the ANP program. The SNAP 50 was advantageous in that it would operate a high conversion efficiencies and high power levels. But, because of the Rankine cycle conversion, it had a higher probability of single point failure and increased weight. This is the full-size design, intended for large space stations or lunar bases. Design lifetime 2 years at full power.
+	@mass = 19.431	//including radiator mass and heat conversion equipment? -300 kg fuel
+	%specLevel = prototype	//reactor core tested as part of ANP/Project PLUTO, power conversion system tested as part of SNAP?
+
+	//35 kWe: 1.5 meters dia, 1.8 meters long
+	//300 kWe: ~6.5 meters dia, 10.5 meters long
+	@MODEL
+	{
+		@scale = 0.8679, 1, 0.8679
+	}
+	@rescaleFactor = 2.996
 
 	%node_attach = #$node_stack_bottom$
 	@attachRules = 1,0,1,1,1
@@ -317,10 +869,10 @@
 	{
 		name = UraniumNitride
 		amount = 21
-		maxAmount = 21
+		maxAmount = 21		//~300 kg fuel
 	}
 }
-@PART[RO-reactor-snap50]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
+@PART[RO-reactor-snap50-300]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
 {
 	// reactor parameters
 	@MODULE[FissionGenerator]
@@ -370,8 +922,10 @@
 		@MaxCoolant = 2200					//Maximum amount of radiator capacity we can consume
 	}
 }
-@PART[RO-reactor-snap50]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
+@PART[RO-reactor-snap50-300]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.91	//subtract 910 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -411,9 +965,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 1366
+		NominalTemperature = 865		//reactor outlet temp 1366 K, but heat rejected to radiator at only 865 K after condensor
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1400
+		CriticalTemperature = 965
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -468,10 +1022,12 @@
 {
 	%RSSROConfig = True
 	@title = TOPAZ-II Nuclear Reactor
-	@manufacturer = Kurchatov Institute of Atomic Energy
-	@description = I. V. Kurchatov Institute of Atomic Energy. Only loosely related to TOPAZ-I, which was flown in the last 2 Soviet RORSAT satellites, it was part of an alternate thermionic reactor program to TOPAZ-I. Planned to be flown in the late 90s. Design lifetime 4 years at full power.
-	@mass = 1.037	//seems heavy compared to TOPAZ-I
+	@manufacturer = #roMfrKurchatov
+	@description = Thermionic reactor ENISY. Only loosely related to TOPAZ-I, which was flown in the last 2 Soviet RORSAT satellites, it was part of an alternate thermionic reactor program to TOPAZ-I. Planned to be flown in the late 90s. Design lifetime 4 years at full power.
+	@mass = 1.010		//including radiator mass and heat conversion equipment? -27 kg fuel
+	%specLevel = prototype
 	
+	//1.4 meters dia, 4 meters length
 	@MODEL
 	{
 		@scale = 0.60345, 1, 0.60345
@@ -491,7 +1047,7 @@
 	{
 		name = EnrichedUranium
 		amount = 2.461
-		maxAmount = 2.461
+		maxAmount = 2.461		//~27 kg fuel
 	}
 }
 
@@ -547,6 +1103,7 @@
 }
 @PART[reactor-125]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.075	//subtract 75 kg radiator mass, since system heat actually needs rads
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -586,9 +1143,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 823
+		NominalTemperature = 600		//reactor outlet temp 2100 K, but heat rejected to radiator at only 600 K after electrode
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1073
+		CriticalTemperature = 700
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -643,10 +1200,12 @@
 	@name = RO-reactor-TOPAZI
 	%RSSROConfig = True
 	@title = TOPAZ-I Nuclear Reactor
-	@manufacturer = Kurchatov Institute of Atomic Energy
-	@description = Thermionic reactor, used in the last 2 Soviet RORSAT satellites. Design lifetime of 1 year.
-	@mass = 0.320	//including shielding, not including power and radiator systems? 930 kg fully assembled?
+	@manufacturer = #roMfrRedStar
+	@description = Thermionic reactor TEU-5 TOPOL, used in the last 2 Soviet RORSAT satellites. Design lifetime of 1 year.
+	@mass = 0.905	//including shielding, not including power and radiator systems? 930 kg fully assembled? -25 kg fuel
+	%specLevel = operational
 	
+	//1.4 meters dia, 4 meters length
 	@MODEL
 	{
 		@scale = 0.60345, 1, 0.60345
@@ -666,7 +1225,7 @@
 	{
 		name = EnrichedUranium
 		amount = 2.2789
-		maxAmount = 2.2789
+		maxAmount = 2.2789		//~25 kg fuel
 	}
 }
 @PART[RO-reactor-TOPAZI]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
@@ -721,6 +1280,8 @@
 }
 @PART[RO-reactor-TOPAZI]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.050	//subtract 50 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -760,9 +1321,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 970
+		NominalTemperature = 873		//reactor outlet temp 1773 K, but heat rejected to radiator at only 873 K after electrode
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1073
+		CriticalTemperature = 973
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -817,9 +1378,13 @@
 	@name = RO-reactor-BES5
 	%RSSROConfig = True
 	@title = BES-5 Nuclear Reactor
+	@manufacturer = #roMfrRedStar
 	@description = Soviet nuclear reactor, used in the first 31 RORSAT satellites. Intended lifetime of 4 months at full power.
-	@mass = 0.385	//385 kg including shielding, not including power and radiator systems?
+	@mass = 1.107	//Assumed the same as TOPAZ-I (Satellites equipped with BES-5 had roughly the same gross mass as satellites with TOPAZ-I). -30 kg fuel
+	//385 kg including shielding, not including power and radiator systems?
+	%specLevel = operational
 	
+	//1.4 meters dia, 4 meters length
 	@MODEL
 	{
 		@scale = 0.60345, 1, 0.60345
@@ -839,7 +1404,7 @@
 	{
 		name = EnrichedUranium
 		amount = 2.7347
-		maxAmount = 2.7347
+		maxAmount = 2.7347		//~30 kg fuel
 	}
 }
 
@@ -895,6 +1460,8 @@
 }
 @PART[RO-reactor-BES5]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.050	//subtract 50 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -934,9 +1501,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 823
+		NominalTemperature = 970		//reactor outlet temp ??? K, but heat rejected to radiator at only 970 K after thermoelectric system
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1073
+		CriticalTemperature = 1070
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -990,16 +1557,19 @@
 {
 	@name = RO-reactor-kilopower
 	%RSSROConfig = True
-	@title = NASA Kilopower Reactor
-	@manufacturer = NASA & DoE
+	@title = NASA Kilopower 10kWe Reactor
+	@manufacturer = #roMfrLANL
 	@description = Simple and extremely reliable 10 kW stirling reactor. Developed by NASA for long-term manned expeditions to the Moon and Mars and advanced outer solar system probes. Design lifetime 100 years at full power. <b>Meant to be buried underground for use in crewed bases.</b>
-	@mass = 0.757  // low shielding variant
+	@mass = 0.714  // low shielding variant, -43 kg fuel
+	//including radiator mass and heat conversion equipment?
+	%specLevel = prototype
 
+	//0.6 meters dia, 1.5 meters length
 	@MODEL
 	{
-		@scale = 0.6666667, 1, 0.6666667
+		@scale = 0.7556, 1, 0.7556
 	}
-	@rescaleFactor = 0.75
+	@rescaleFactor = 0.6618
 
 	%node_attach = #$node_stack_bottom$
 	@attachRules = 1,1,1,1,1
@@ -1017,7 +1587,7 @@
 	{
 		name = EnrichedUranium
 		amount = 3.92
-		maxAmount = 3.92
+		maxAmount = 3.92		//~43 kg fuel
 	}
 }
 @PART[RO-reactor-kilopower]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
@@ -1073,6 +1643,8 @@
 }
 @PART[RO-reactor-kilopower]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.027	//subtract 27 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -1112,9 +1684,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 1073
+		NominalTemperature = 640		//reactor outlet temp 1073 K, but heat rejected to radiator at only 640? K after stirling engine
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1273
+		CriticalTemperature = 740
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -1170,15 +1742,19 @@
 {
 	%RSSROConfig = True
 	@title = NASA SAFE-400 Nuclear Reactor
-	@manufacturer = NASA & DoE
-	@description = Safe Affordable Fission Engine. Small and lightweight but powerful reactor enabled by new technology. Design lifetime of 15 years at full power. <b><color=red>Warning: unshielded!</color></b>
-	@mass = 0.516  // no shielding
+	@manufacturer = #roMfrLANL
+	@description = Safe Affordable Fission Engine. Small and lightweight but powerful reactor enabled by new technology. Design lifetime of 15 years at full power.
+	@mass = 2.048  // -140 kg fuel
+	//541 kg, not including shielding, radiator mass or heat conversion equipment
+	//Guess 1646 kg for controls, power conversion equipment, shielding, radiators (half of Prometheus)
+	%specLevel = concept
 
+	//2/3rds the size of Prometheus? 1.4x5.3 meters
 	@MODEL
 	{
-		@scale = 1.18034, 1, 1.18034
+		@scale = 0.5196, 1, 0.5196
 	}
-	@rescaleFactor = 1.270815
+	@rescaleFactor = 4.4902
 
 	// resources
 	!RESOURCE,* {}
@@ -1193,7 +1769,7 @@
 	{
 		name = UraniumNitride
 		amount = 9.79
-		maxAmount = 9.79
+		maxAmount = 9.79	//~140 kg fuel
 	}
 }
 @PART[reactor-0625]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
@@ -1250,6 +1826,8 @@
 }
 @PART[reactor-0625]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.400	//subtract 400 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -1288,9 +1866,9 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 1240
+		NominalTemperature = 505		//reactor outlet temp 1240 K, but heat rejected to radiator at only 505? K after recuperator
 		// Above this temp, reactor takes damage
-		CriticalTemperature = 1400
+		CriticalTemperature = 605
 		// Amount of damage taken by core when over critical temp
 		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
 		CoreDamageRate = 0.008
@@ -1345,9 +1923,11 @@
 	@name = RO-reactor-snap10a
 	%RSSROConfig = True
 	@title = NASA SNAP-10A Nuclear Reactor
-	@manufacturer = Atomics International
-	@description = Only design from the SNAPSHOT (Space Nuclear Auxiliary Power Shot) program to ever be launched, and the first nuclear reactor to ever be operated in-orbit. Design lifetime 1 year. <b><color=red>Warning: unshielded!</color></b>
-	@mass = 0.336  // no shielding
+	@manufacturer = #roMfrAtomicsInt
+	@description = Only design from the SNAPSHOT (Space Nuclear Auxiliary Power Shot) program to ever be launched, and the first nuclear reactor to ever be operated in-orbit. Design lifetime 1 year.
+	@mass = 0.433  //-3 kg fuel
+	//including radiator mass and heat conversion equipment
+	%specLevel = operational
 
 	@MODEL
 	{
@@ -1368,7 +1948,7 @@
 	{
 		name = EnrichedUranium
 		amount = 0.271
-		maxAmount = 0.271
+		maxAmount = 0.271		//~3 kg fuel
 	}
 }
 @PART[RO-reactor-snap10a]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
@@ -1424,6 +2004,8 @@
 }
 @PART[RO-reactor-snap10a]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
 {
+	@mass -= 0.024	//subtract 24 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
 	!MODULE[ModuleUpdateOverride] {}
 	!MODULE[FissionReactor] {}
 	!MODULE[FissionGenerator] {}
@@ -1463,7 +2045,7 @@
 		}
 
 		// Above this temp, risky
-		NominalTemperature = 846
+		NominalTemperature = 766		//reactor outlet temp 846 K, but heat rejected to radiator at only 766 K after thermoelectric system
 		// Above this temp, reactor takes damage
 		CriticalTemperature = 866
 		// Amount of damage taken by core when over critical temp
@@ -1483,6 +2065,186 @@
 		{
 			key = 0 0
 			key = 100 0.59
+		}
+
+		// --- Fuel stuff
+		// Base lifetime calculations off this resource
+		FuelName = EnrichedUranium
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000008592 // 1 year
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.000000008592
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatFissionFuelContainer
+		EngineerLevelForTransfer = 1
+		ResourceNames = EnrichedUranium, DepletedFuel
+	}
+}
+//	=================================================================================
+//	SNAP-2 - main source: https://www.osti.gov/biblio/4430852
+//	https://beyondnerva.com/fission-power-systems/systems-for-nuclear-auxiliary-power-snap/snap-2/
+//	=================================================================================
++PART[reactor-0625]:FOR[RealismOverhaul]
+{
+	@name = RO-reactor-snap2
+	%RSSROConfig = True
+	@title = NASA SNAP-2 Nuclear Reactor
+	@manufacturer = #roMfrAtomicsInt
+	@description = Sister program to SNAP-10A, SNAP-2 used the same reactor design, but mated to a much more efficient (and complex) Mercury vapor turbine. Design lifetime 1 year.
+	@mass = 1.178 //-3 kg fuel
+	//including radiator mass and heat conversion equipment?
+	%specLevel = prototype	//same reactor as SNAP-10, CRU system tested independently
+
+	//Twice SNAP-10 based on drawings?
+	@MODEL
+	{
+		@scale = 1.57379, 1, 1.57379	// 3.16m long, 1.2m wide
+	}
+	@rescaleFactor = 2.5
+
+	// resources
+	!RESOURCE,* {}
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 0.271
+	}
+	//Uranium-Zirconium-Hydride, unknown enrichment
+	RESOURCE
+	{
+		name = EnrichedUranium
+		amount = 0.271
+		maxAmount = 0.271		//~3 kg fuel
+	}
+}
+@PART[RO-reactor-snap2]:FOR[RealismOverhaul]:NEEDS[!SystemHeat]
+{
+	// reactor parameters
+	@MODULE[FissionGenerator]
+	{
+		@PowerGeneration = 10
+		@HeatUsed = 55		//reactor run at higher power level than SNAP-10
+	}
+	@MODULE[FissionReactor]
+	{
+		@HeatGeneration = #$../MODULE[FissionGenerator]/HeatUsed$
+		@HeatGeneration *= 50
+		@NominalTemperature = 846		// Above this temp more power output but risky
+		@CriticalTemperature = 866		// Above this temp, reactor takes damage
+
+
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		@CoreDamageRate = 0.01
+
+		// Base lifetime calculations off this resource
+		@FuelName = EnrichedUranium
+
+		!INPUT_RESOURCE {}
+		!OUTPUT_RESOURCE {}
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 0.000000008592 // 1 year
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 0.000000008592
+			FlowMode = NO_FLOW
+		}
+	}
+	@MODULE[RadioactiveStorageContainer]
+	{
+		@DangerousFuel = DepletedFuel
+		@SafeFuel = EnrichedUranium
+	}
+	@MODULE[ModuleCoreHeatNoCatchup]
+	{
+		@CoreTempGoal = 846					//Internal temp goal - we don't transfer till we hit this point
+		@HeatRadiantMultiplier = 0.05		//If the core is hotter, how much heat radiates?
+		@CoreShutdownTemp = 2000			//At what core temperature do we shut down all generators on this part?
+		@MaxCoolant = 30					//Maximum amount of radiator capacity we can consume
+	}
+}
+@PART[RO-reactor-snap2]:FOR[zzzRealismOverhaul]:NEEDS[SystemHeat]
+{
+	@mass -= 0.036	//subtract 36 kg radiator mass, since system heat actually needs rads
+	//Radiator mass just determined with Heat Control Radiators...
+	!MODULE[ModuleUpdateOverride] {}
+	!MODULE[FissionReactor] {}
+	!MODULE[FissionGenerator] {}
+	!MODULE[ModuleCoreHeatNoCatchup] {}
+	!MODULE[RadioactiveStorageContainer] {}
+	
+	//if the user has installed SystemHeat reactor configs, this will already be configured with SystemHeat modules
+	//if they have not, then the reactor will not be configured
+	//to make things easier for me, just preemptively delete any SystemHeat modules that might exist and make new ones
+	//patch must be run in zzzRealismOverhaul to make sure we patch *after* SystemHeat does
+	
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+	!MODULE[ModuleSystemHeatFissionFuelContainer] {}
+	
+	MODULE
+	{
+		name = ModuleSystemHeat
+		volume = 1
+		moduleID = reactor
+		iconName = Icon_Nuclear
+	}
+	
+	MODULE
+	{
+		name = ModuleSystemHeatFissionReactor
+		moduleID = reactor
+
+		// -- Heat stuff
+		// ModuleSystemHeat instance to link to
+		systemHeatModuleID = reactor
+		// Heat kW
+		HeatGeneration
+		{
+			key = 0 0 0 0
+			key = 100 55 0 0		//reactor run at higher power than SNAP-10
+		}
+
+		// Above this temp, risky
+		NominalTemperature = 588		//reactor outlet temp 922 K, but heat rejected to radiator at only 588 K after mercury vapor turbine
+		// Above this temp, reactor takes damage
+		CriticalTemperature = 688
+		// Amount of damage taken by core when over critical temp
+		// %/s/K, so with value 0.001, at 200 K over CriticalTemp, reactor takes 0.2% damage/s
+		CoreDamageRate = 0.008
+
+		// When repairing, amount of core damage to heal (%)
+		RepairAmountPerKit  = 20
+
+		CurrentPowerPercent = 100
+		ThrottleIncreaseRate = 5
+		MinimumThrottle = 5
+
+		// -- Electrical stuff
+		// Power generated
+		ElectricalGeneration
+		{
+			key = 0 0
+			key = 100 10
 		}
 
 		// --- Fuel stuff


### PR DESCRIPTION
Add SNAP-50 300 KWe, SNAP-2, SNAP-8, and Prometheus.

SNAP-2 is the more advanced sister program to SNAP-10A, using the same reactor core mated to a mercury vapor turbine. 10 KWe output, ~1.2 tons.

SNAP-8 is a enlarged derivative of SNAP-10A, using more advanced thermoelectric converters. 35 KWe output, ~14 tons.

SNAP-50 has been adjusted to match the 35 kWe, as the ingame version had the size and mass of the 35 kWe model, but had the output of the 300 kWe model. 35 kWe output, ~8 tons.

SNAP-50 300 kWe is the full-size SNAP-50 model. 300 kWe, ~20 tons.

Prometheus 200 kWe is the baseline Prometheus design, intended for JIMO. 200 kWe, ~5 tons.

SAFE-400 has had power conversion equipment and shielding mass added based on Prometheus. 100 kWe, ~2 tons.

Also improve scale of existing reactors, and subtract fuel/radiator mass where applicable.