### PR TITLE
Improve RTGs, add SNAP-3A

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -79,13 +79,55 @@
 	@title = NASA & DOE Advanced Sterling RG
 	@manufacturer = #roMfrLM
 	@description = A much lighter and more efficient radioisotope generator by using the sterling cycle.
-	@mass = 0.032
-	@MODULE[ModuleGenerator]
+	@mass = 0.0308	//32 kg - 1.2 kg Pu238
+	//switch to ModuleResourceConverter so the RTG patch is able to apply
+	!MODULE[ModuleGenerator],* {}
+
+	MODULE
 	{
-		@OUTPUT_RESOURCE[ElectricCharge]
+		name = ModuleResourceConverter
+		ConverterName = RTG
+		StartActionName = Start
+		StopActionName = Stop
+		AlwaysActive = True
+		FillAmount = 1.0
+		AutoShutdown = false
+		GeneratesHeat = False
+		TemperatureModifier = 2.0
+		UseSpecializationBonus = False
+		DefaultShutoffTemp = 0.5
+
+		INPUT_RESOURCE
 		{
-			@rate = 0.130
+			ResourceName = Plutonium-238
+			Ratio = 1.6428e-10
 		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = DepletedFuel
+			Ratio = 1.6428e-10
+		}
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.13	// 130 w
+		}
+	}
+	
+	RESOURCE
+	{
+		name = Plutonium-238
+		amount = 0.060557
+		maxAmount = 0.060557
+	}
+
+	RESOURCE
+	{
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 0.060557
 	}
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Electrical.cfg
@@ -5,6 +5,7 @@
 
 //  Dimensions: 0.042 m x 4.114 m
 //  Gross Mass: 55.9 Kg
+//  Pu238 mass 7.8 kg
 //  Power Generation: 288.6 W
 
 //  Source 1: http://www.osti.gov/scitech/servlets/purl/1033366
@@ -22,7 +23,7 @@
     @description = The General Purpose Heat Source - Radioisotope Thermoelectric Generator as found on the Galileo spacecraft.
     %rescaleFactor = 1.765
 
-    @mass = 0.0483
+    @mass = 0.0481	//55.9 kg - 7.8 kg Pu238
     %breakingForce = 250
     %breakingTorque = 250
     %fuelCrossFeed = False
@@ -55,8 +56,8 @@
     RESOURCE
     {
         name = Plutonium-238
-        amount = 0.409
-        maxAmount = 0.409
+        amount = 0.3936
+        maxAmount = 0.3936
     }
 }
 
@@ -78,5 +79,5 @@
 {
     @title ^= :$: [Shielded]:
     @description ^= :$:  Includes a protective cover.:
-    @mass = 0.0541
+    @mass = 0.0541	//61.9 kg - 7.8 kg
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Electrical.cfg
@@ -187,11 +187,13 @@
 //  Multihundred-Watt Radioisotope Thermoelectric Generator (RTG).
 
 //  Dimensions: 0.406 m x 0.508 m
-//  Gross Mass: 33.19 Kg
+//  Gross Mass: 37.69 Kg
+//  2.2 kWt Pu-238 -> Pu-238 0.39 W/g -> 5.64 kg Pu238
 
 //  Source 1: http://fas.org/nuke/space/bennett0706.pdf
 //  Source 2: http://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1977-076A
 //  Source 3: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20120016365.pdf
+//  Source 4: https://web.archive.org/web/20130215003518/http://fti.neep.wisc.edu/neep602/SPRING00/lecture5.pdf
 //  ==================================================
 
 @PART[rtg]:FOR[RealismOverhaul]
@@ -214,7 +216,7 @@
     %internalTempTag = Inconel
     %paintEmissivityTag = 0.8
 
-    @mass = 0.0332
+    @mass = 0.03205		//37.69 kg - 5.64 kg Pu238
     %fuelCrossFeed = false
 
     !MODULE[TweakScale] {}
@@ -256,15 +258,15 @@
     RESOURCE
     {
         name = Plutonium-238
-        amount = 0.227
-        maxAmount = 0.227
+        amount = 0.28462
+        maxAmount = 0.28462
     }
 
     RESOURCE
     {
         name = DepletedFuel
         amount = 0
-        maxAmount = 0.227
+        maxAmount = 0.28462
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Electrical.cfg
@@ -49,11 +49,11 @@
     }
     @rescaleFactor = 0.35
 
-    @title = SNAP-3 Series RTG
+    @title = SNAP-3 Series RTG (Pu238)
     @manufacturer = #roMfrMM
-    @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency and power generation.
+    @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency, with target power generation of 2.4 watts. Plutonium-238 variant, with lower power but much longer life.
 
-    @mass = 0.0022
+    @mass = 0.0013
 
     !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
@@ -67,6 +67,42 @@
         {
             ResourceName = ElectricCharge
             Ratio = 0.0025
+        }
+    }
+}
+
+//  ==================================================
+//  SNAP-3 series RTG (Polonium-210)
+
+//  Dimensions: 0.12 m x 0.14 m
+//  Gross Mass: 2.3 Kg
+
+//  Sources:
+// https://www.osti.gov/servlets/purl/4034092
+// https://ntrs.nasa.gov/citations/19670002048
+// https://www.osti.gov/biblio/4496406
+// https://www.osti.gov/biblio/4220878
+//  ==================================================
+
++PART[rtgMini]:FOR[RealismOverhaul]
+{
+    @name = RO-SNAP-3-RTGPo210
+    @title = SNAP-3 Series RTG (Po210)
+    @manufacturer = #roMfrMM
+    @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency, with target power generation of 2.4 watts. Polonium-210 variant, with higher power, but a design life of only 90 days.
+
+    !MODULE[ModuleResourceConverter],*{}
+    !MODULE[ModuleGenerator],*{}
+
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = RTGPo210
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.0038		//Going with higher 3.8 watts number. 3.8 watts means power output drops to design output of 2.4 watts at 90 days.
         }
     }
 }
@@ -205,7 +241,7 @@
     }
 }
 
-@PART[rtgMini|RO-SNAP-9-RTG|RO-SNAP-19-RTG|RO-MMRTG]:FOR[RealismOverhaul]
+@PART[rtgMini|RO-SNAP-3-RTGPo210|RO-SNAP-9-RTG|RO-SNAP-19-RTG|RO-MMRTG]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
 
@@ -255,6 +291,52 @@
         name = DepletedFuel
         amount = 0
         maxAmount = 0.0505
+    }
+}
+
+// Reset fuel amounts for SNAP-3
+// sources: 
+// https://web.archive.org/web/20130215003518/http://fti.neep.wisc.edu/neep602/SPRING00/lecture5.pdf
+// Pu-238 fuel: https://www.osti.gov/biblio/4220878
+// Po-210 fuel: https://www.osti.gov/biblio/4496406
+@PART[rtgMini]:FOR[RealismOverhaul]
+{
+    !RESOURCE,*{}
+    //  52.52 Watts Pu-238 loaded -> 0.56 W/g Pu-238 -> 93.79 g Pu-238
+    //  Plutonium-238 mass approximately 0.09379 kg.
+
+    RESOURCE
+    {
+        name = Plutonium-238
+        amount = 0.004733
+        maxAmount = 0.004733
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
+        maxAmount = 0.004733
+    }
+}
+@PART[RO-SNAP-3-RTGPo210]:FOR[RealismOverhaul]
+{
+    !RESOURCE,*{}
+    //  1495 Ci Po-210 loaded -> 4500 Ci/g Po-210 -> 0.3322 g Po-210
+    //  Plutonium-238 mass approximately 0.0003322 kg.
+
+    RESOURCE
+    {
+        name = Plutonium-238
+        amount = 0.00001676
+        maxAmount = 0.00001676
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
+        maxAmount = 0.00001676
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Electrical.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Electrical.cfg
@@ -49,11 +49,11 @@
     }
     @rescaleFactor = 0.35
 
-    @title = SNAP-3 Series RTG (Pu238)
+    @title = SNAP-3B Series RTG (Pu238)
     @manufacturer = #roMfrMM
     @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency, with target power generation of 2.4 watts. Plutonium-238 variant, with lower power but much longer life.
 
-    @mass = 0.0013
+    @mass = 0.0022
 
     !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
@@ -87,7 +87,7 @@
 +PART[rtgMini]:FOR[RealismOverhaul]
 {
     @name = RO-SNAP-3-RTGPo210
-    @title = SNAP-3 Series RTG (Po210)
+    @title = SNAP-3A Series RTG (Po210)
     @manufacturer = #roMfrMM
     @description = The SNAP-3 series were the first radioisotope thermoelectric generators (RTGs) to ever operate in space, as part of the Transit system (precursor to the current GPS system). Very low overall efficiency, with target power generation of 2.4 watts. Polonium-210 variant, with higher power, but a design life of only 90 days.
 
@@ -134,7 +134,7 @@
     @manufacturer = #roMfrMM
     @description = The SNAP-9 series were evolved designs of the experimental SNAP-3 series, again as part of the Transit system (precursor to the current GPS system), but now featuring over 10 times higher power generation.
 
-    @mass = 0.011
+    @mass = 0.011	//12 kg - 1 kg Pu238
 
     !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
@@ -179,7 +179,7 @@
     @manufacturer = #roMfrMM
     @description = The SNAP-19 series were originally developed for the Nimbus weather satellite program, complementing the regular solar arrays and countering their degradation due to radiation. Later, they were also used by the Pioneer 10 and 11 spacecrafts, along with the Viking Mars landers. Similar to the SNAP-9 series but with over 40% better conversion efficiency.
 
-    @mass = 0.014
+    @mass = 0.0133	//15 kg - 1.654 kg Pu238
 
     !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
@@ -223,7 +223,7 @@
     @manufacturer = #roMfrRocketdyne
     @description = The Multi-Mission RTG or MMRTG was designed for the Mars Science Laboratory and the Curiosity Rover for use on Mars.
 
-    @mass = 0.0882
+    @mass = 0.040122	//43.6 kg - 3.478 kg Pu238
 
     !MODULE[ModuleResourceConverter],*{}
     !MODULE[ModuleGenerator],*{}
@@ -248,8 +248,10 @@
     @crashTolerance = 16
     %breakingForce = 250
     %breakingTorque = 250
-    @maxTemp = 1273.15
-    %skinMaxTemp = 1773.15
+    //Haynes 25 core, aluminum fins and fittings, high emissivity coating
+    %skinTempTag = Aluminum
+    %internalTempTag = Inconel
+    %paintEmissivityTag = 0.8
     %fuelCrossFeed = False
 
     @MODULE[ModuleResourceConverter]:HAS[#ConverterName[RTG]]
@@ -277,7 +279,7 @@
         }
     }
 
-    //  Plutonium-238 mass approximately 1 Kg.
+    //  Plutonium-238 mass approximately 1 kg (at least, for SNAP-9).
 
     !RESOURCE,*{}
     RESOURCE
@@ -337,6 +339,32 @@
         name = DepletedFuel
         amount = 0
         maxAmount = 0.00001676
+    }
+}
+
+// Reset fuel amounts for SNAP-19
+// sources: 
+// https://www.osti.gov/biblio/4269349
+// https://web.archive.org/web/20130215003518/http://fti.neep.wisc.edu/neep602/SPRING00/lecture5.pdf
+@PART[RO-SNAP-19-RTG]:FOR[RealismOverhaul]
+{
+    !RESOURCE,*{}
+    // 645 watts of Pu-238 per RTG
+    // Pu-238 specific power 0.39 W/g
+    //  Plutonium-238 mass approximately 1.654 kg.
+
+    RESOURCE
+    {
+        name = Plutonium-238
+        amount = 0.08346
+        maxAmount = 0.08346
+    }
+
+    RESOURCE
+    {
+        name = DepletedFuel
+        amount = 0
+        maxAmount = 0.08346
     }
 }
 


### PR DESCRIPTION
Adjust masses and fuel load of RTGs to be more accurate. Fix Near Future Electrical ASRG so it gets patched properly. Add SNAP-3A, the Polonium-fueled version of SNAP-3.

Needs: https://github.com/KSP-RO/ROKerbalism/pull/155