### PR TITLE
Add configs for Stockish Project Orion

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -42,6 +42,7 @@ Localization
 		//F
 		//G
 		#roMfrGALCIT = GALCIT	//(1936-1943) Renamed to JPL in 1943
+		#roMfrGA = General Atomics
 		#roMfrGD = General Dynamics (GD)	//(1899-present)
 		#roMfrGE = General Electric (GE)	//(1892-present) Aerospace division sold to Martin Marietta 1993
 		#roMfrGCRC = Grand Central Rocket Company (GCRC)	//(1952-1960) bought by Lockheed in 1960

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Orion/StockishOrionDrive.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Orion/StockishOrionDrive.cfg
@@ -8,19 +8,22 @@
 }
 //	============================================================================
 //	Propulsion Module Config
+//USAF Orion seems kinda optimistic, but it's still the best-studied design, and this mod seems hardcoded to match it's performance
 @PART[SPO_Orion5Meter]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@rescaleFactor = 2.0
 	@title = USAF 10 Meter Orion Drive
 	@manufacturer = #roMfrGA
-	@description = Kaboom
+	@description = The legendary Orion Nuclear Pulse drive, utilizing nuclear shaped charges fired at a heavy pusher plate to achieve incredibly high thrust and performance. This is one of the later proposals, presented to the air force in the mid-1960s as a downscaled, lower performance version of the original 4000 ton Orion space battleship proposal. This would allow it to be carried to a suborbital trajectory by a Saturn V or other large rocket before starting its engines, reducing the risks involved. It was also offered to NASA to carry an 8-man crew to Mars and back in a matter of months. Although subscale tests were performed using conventional explosives, and full-size nuclear pulse units were allegedly testing, the political implications of developing such a drive and the Nuclear Test Ban treaty resulted in it's cancellation around 1965. Atmospheric use inadvisable.
 	
 	%skinTempTag = Inconel
 	%internalTempTag = Instruments
 	%skinInsulationTag = True
 	
 	@mass = 107.9
+	
+	%specLevel = prototype		//I mean, sorta?
 	
 	//This module is kinda bad
 	//Half the config values don't actually do anything, and performance is just determined by relative charge size
@@ -41,6 +44,37 @@
 		@maxAmount = 138
 	}
 }
+//source: https://www.projectrho.com/public_html/rocket/enginelist3.php#medusa
+//sorta, this isn't configurable enough to match thrust and Isp. Just match thrust I guess, 33 ks Isp is still pretty good.
+@PART[SPO_Medusa50Meter]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@title = 100 Meter Medusa Drive
+	@manufacturer = #roMfrGA
+	@description = The legendary Medusa Nuclear Pulse drive, utilizing nuclear shaped charges fired at a lightweight sail to achieve incredibly high thrust and performance. Using a sail suspended by cables in front of the craft allows for a much simpler structure and shock absorption mechanism. The lightweight nature of the sail also allows it to be much larger, extracting more performance from the nuclear pulse units, and a greater standoff to be utilized, allowing the use of larger pulse units. Atmospheric use inadvisable.
+	
+	%skinTempTag = Inconel
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	@mass = 150		//about 1.5 times Orion I guess
+	
+	%specLevel = altHist		//since this mod can't match the performance of any actual Medusa proposal
+	
+	//This module is kinda bad
+	//Half the config values don't actually do anything, and performance is just determined by relative charge size
+	//(The largest charge will always perform the same, regardless of if it's 1 kt or 10 kt, and smaller charges will be fractions of that)
+	//However, it can be coerced into matching USAF Orion well enough
+	@MODULE[ModuleNuclearPulseEngine]
+	{
+		@CollimationFactor = 2.20	//To match 26 MN thrust
+		@MinYield = 0.5
+		@MaxYield = 2.5
+		@YieldIncrement = 0.5
+		%PlateDiameter = 100	//This is broken and doesn't appear to do anything
+	}
+}
 //	============================================================================
 //	Orion Spine configs
 //12-meter spine 6170 kg. Since this is 4 meters, 1/3rd mass
@@ -55,6 +89,7 @@
 	%skinTempTag = Aluminum
 	%internalTempTag = Instruments
 	%skinInsulationTag = True
+	%specLevel = prototype
 	
 	!MODULE[ModuleResourceConverter] {}
 	!RESOURCE[Metals] {}
@@ -71,6 +106,7 @@
 	%skinTempTag = Aluminum
 	%internalTempTag = Instruments
 	%skinInsulationTag = True
+	%specLevel = prototype
 	
 	!MODULE[ModuleResourceConverter] {}
 	!RESOURCE[Metals] {}
@@ -85,6 +121,7 @@
 	
 	%skinTempTag = Aluminum
 	%internalTempTag = Aluminum
+	%specLevel = prototype
 }
 @PART[SPO_Adapter375]:FOR[RealismOverhaul]
 {
@@ -96,6 +133,7 @@
 	
 	%skinTempTag = Aluminum
 	%internalTempTag = Aluminum
+	%specLevel = prototype
 }
 @PART[SPO_Adapter25]:FOR[RealismOverhaul]
 {
@@ -107,6 +145,7 @@
 	
 	%skinTempTag = Aluminum
 	%internalTempTag = Aluminum
+	%specLevel = prototype
 }
 @PART[SPO_Adapter125]:FOR[RealismOverhaul]
 {
@@ -118,6 +157,7 @@
 	
 	%skinTempTag = Aluminum
 	%internalTempTag = Aluminum
+	%specLevel = prototype
 }
 //	============================================================================
 //	Orion magazine configs
@@ -133,6 +173,7 @@
 	%skinTempTag = Aluminum
 	%internalTempTag = Instruments
 	%skinInsulationTag = True
+	%specLevel = prototype
 	
 	@RESOURCE[VYPulseUnit]
 	{
@@ -152,6 +193,7 @@
 	%skinTempTag = Aluminum
 	%internalTempTag = Instruments
 	%skinInsulationTag = True
+	%specLevel = prototype
 	
 	@RESOURCE[VYPulseUnit]
 	{
@@ -171,6 +213,7 @@
 	%skinTempTag = Aluminum
 	%internalTempTag = Instruments
 	%skinInsulationTag = True
+	%specLevel = prototype
 	
 	@RESOURCE[VYPulseUnit]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Orion/StockishOrionDrive.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Orion/StockishOrionDrive.cfg
@@ -1,0 +1,180 @@
+﻿//source: https://www.projectrho.com/public_html/rocket/realdesigns2.php#id--Project_Orion--USAF_10_Meter_Orion
+//	============================================================================
+//	Pulse Unit Resource config
+@RESOURCE_DEFINITION[VYPulseUnit]
+{
+	@density = 0.079
+	@unitCost = 40
+}
+//	============================================================================
+//	Propulsion Module Config
+@PART[SPO_Orion5Meter]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@title = USAF 10 Meter Orion Drive
+	@manufacturer = #roMfrGA
+	@description = Kaboom
+	
+	%skinTempTag = Inconel
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	@mass = 107.9
+	
+	//This module is kinda bad
+	//Half the config values don't actually do anything, and performance is just determined by relative charge size
+	//(The largest charge will always perform the same, regardless of if it's 1 kt or 10 kt, and smaller charges will be fractions of that)
+	//However, it can be coerced into matching USAF Orion well enough
+	@MODULE[ModuleNuclearPulseEngine]
+	{
+		@CollimationFactor = 0.22	//Roughly match performance of USAF Orion
+		@MinYield = 0.5		//Half-size starting units
+		@MaxYield = 1.0		//USAF Orion used 1 kt units
+		@YieldIncrement = 0.5
+		%PlateDiameter = 5	//This is broken and doesn't appear to do anything
+	}
+	
+	@RESOURCE[VYPulseUnit]
+	{
+		@amount = 138		//138 starting units stored in drive module
+		@maxAmount = 138
+	}
+}
+//	============================================================================
+//	Orion Spine configs
+//12-meter spine 6170 kg. Since this is 4 meters, 1/3rd mass
+@PART[SPO_SpineS]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 2.057
+	@manufacturer = #roMfrGA
+	@description = 4-meter spinal truss, containing pulse unit magazine bays and pulse unit feed mechanisms.
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	!MODULE[ModuleResourceConverter] {}
+	!RESOURCE[Metals] {}
+}
+//12-meter spine 6170 kg. Since this is 8 meters, 2/3rd mass
+@PART[SPO_SpineL]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 4.109
+	@manufacturer = #roMfrGA
+	@description = 8-meter spinal truss, containing pulse unit magazine bays and pulse unit feed mechanisms.
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	!MODULE[ModuleResourceConverter] {}
+	!RESOURCE[Metals] {}
+}
+@PART[SPO_Adapter5]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 0.400	//guess
+	@title = 10m Orion Spine Adapter
+	@manufacturer = #roMfrGA
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[SPO_Adapter375]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 0.400	//guess
+	@title = 7.5m Orion Spine Adapter
+	@manufacturer = #roMfrGA
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[SPO_Adapter25]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 0.400	//guess
+	@title = 5m Orion Spine Adapter
+	@manufacturer = #roMfrGA
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[SPO_Adapter125]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 0.400	//guess
+	@title = 2.5m Orion Spine Adapter
+	@manufacturer = #roMfrGA
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+//	============================================================================
+//	Orion magazine configs
+//1 Magazine deck 181 kg, ~1 meter tall, 60 charges. Since this is double that, double mass and capacity
+@PART[SPO_SmallMag]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 0.362
+	@manufacturer = #roMfrGA
+	@description = Small Orion Magazine, equivalent to two pulse unit stacks. Holds 120 pulse units.
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	@RESOURCE[VYPulseUnit]
+	{
+		@amount = 120
+		@maxAmount = 120
+	}
+}
+//1 Magazine deck 181 kg, ~1 meter tall, 60 charges. Since this is 4x that, 4x mass and capacity
+@PART[SPO_MedMag]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 0.724
+	@manufacturer = #roMfrGA
+	@description = Medium Orion Magazine, equivalent to four pulse unit stacks. Holds 240 pulse units.
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	@RESOURCE[VYPulseUnit]
+	{
+		@amount = 240
+		@maxAmount = 240
+	}
+}
+//1 Magazine deck 181 kg, ~1 meter tall, 60 charges. Since this is 8x that, 8x mass and capacity
+@PART[SPO_LargeMag]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@rescaleFactor = 2.0
+	@mass = 1.448
+	@manufacturer = #roMfrGA
+	@description = Large Orion Magazine, equivalent to eight pulse unit stacks. Holds 480 pulse units.
+	
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	@RESOURCE[VYPulseUnit]
+	{
+		@amount = 480
+		@maxAmount = 480
+	}
+}


### PR DESCRIPTION
Add some configs for [Stockish Project Orion](https://forum.kerbalspaceprogram.com/topic/192855-18x-111x-stockish-project-orion-v182-update-12292020/), which seems to be the most functional KSP Orion drive mod.

The Orion drive and associated parts are configured to match the 10-meter USAF Orion, 2600 kN thrust, 3360 s Isp, with 2 pulse unit sizes.

Due to the limitations of the mod (lots of hardcoded variables), the Medusa drive doesn't really match the Medusa drive proposal performance or scale, but still provides significantly higher performance. 26,000 kN thrust, 33,650 s Isp, with 5 pulse unit sizes.