### PR TITLE
Adjust lander can masses based on correct LM mass

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Command.cfg
@@ -327,7 +327,7 @@
 
 	@manufacturer = #roMfrGeneric
 	@description = A small, single-person cabin for use on non-atmospheric landers and small spacecraft.
-	@mass = 0.62
+	@mass = 1.00	//guess. Slightly heavier than Mk1 Pod, but it has more room, more resources, can EVA, etc.
 	%rescaleFactor = 1.6
 	
 	@MODULE[ModuleScienceContainer]
@@ -348,7 +348,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 180
+		volume = 250	//twice Mk1 Pod
 		basemass = -1
 		type = ServiceModule
 	}
@@ -375,7 +375,7 @@
 		%volume = 1200
 	}
 
-	%mass = 1.0
+	%mass = 1.53	//roughly the same as dry LM w/o fuel tanks. Will need to be changed if massless tanks are removed.
 
 	@MODULE[ModuleCommand]
 	{
@@ -459,7 +459,7 @@
 	!RESOURCE[CharredAblator] {}
 	
 	%skinTempTag = Inconel
-	%skinMassPerArea = 3.38				//Rene 41 8.24 ton/m^3. 0.41 mm Rene 41, 3.38 kg/m^2?
+	%skinMassPerArea = 5.24 // equivalent to ROCapsules Mercury
 
 	@MODULE[ModuleCommand]
 	{
@@ -568,7 +568,6 @@
 @PART[mk1pod_v2]:AFTER[RealismOverhaul_Materials]
 {
 	@skinMaxTemp = 2200		//Raising this until we can find a better way to deal with excess heat flux
-	%skinMassPerArea = 5.24 // equivalent to ROCapsules Mercury
 }
 
 // 3 Person lander can
@@ -579,7 +578,7 @@
 	%RSSROConfig = True
 
 	%rescaleFactor = 1.6
-	%mass = 2.1
+	%mass = 1.9	//~sqrt(1.5) times LM dry mass
 	%CrewCapacity = 3
 
 	@MODULE[ModuleScienceContainer]


### PR DESCRIPTION
Adjust 1, 2 and 3-crew lander can mass to be balanced with corrected LM dry mass.