### PR TITLE
Add ramjets

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar101_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Atar101_Config.cfg
@@ -25,6 +25,27 @@
 //	Exhaust Mixer: false
 //	Adjustable Nozzle: true
 //	=================================================================================
+//	Atar 101E-3
+//	1957, Griffon II, Vautour IIA/B/N, Etendard IV
+//
+//	Dry Mass: 940? kg
+//	Thrust (Dry): 34.3 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 1.079? lb/lbf-hr
+//	Area: 0.206 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 4.8		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 260 K		//Temp Design Point
+//	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 27000000 J	//Fuel heat of burning
+//	TIT: 1080 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 650 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
 
 //	Sources:
 
@@ -96,6 +117,45 @@
 			wetThrust = 0.0
 			maxThrust = 29.42	//Just to let MEC know thrust
 			drySFC = 1.089
+			throttleResponseMultiplier = 0.18
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = Atar101E-3
+			description = Atar 101, as used on the Vautour IIA/B/N, Etendard IV, and as the turbojet half of the Griffon combined cycle ramjet. Temperature Mach limit at 15 km: 2.57.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.206		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 4.8		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.8		//Mach Design Point
+			Tdes = 260		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 27000000	//Fuel heat of burning (joules?)
+			TIT = 1080		//Combustion peak temp
+			TAB = 0		//Afterburner temp?
+			maxT3 = 650		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 60
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 34.3
+			wetThrust = 0.0
+			maxThrust = 34.3	//Just to let MEC know thrust
+			drySFC = 1.079
 			throttleResponseMultiplier = 0.18
 
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Nord1500_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/Nord1500_Config.cfg
@@ -1,0 +1,184 @@
+//	==================================================
+//	Engine: RJ55/J67
+//
+//	Manufacturer: Nord Aviation
+//
+//	=================================================================================
+//	Atar 101E-3
+//	1957, Griffon II
+//
+//	Dry Mass: 1500? kg
+//	Thrust (Dry): 34.3 kN
+//	Thrust (Wet): 0.0 kN
+//	SFC (Dry): 1.079? lb/lbf-hr
+//	Area: 0.206 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 4.8		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.8 M		//Mach Design Point
+//	Tdes: 260 K		//Temp Design Point
+//	eta_n: 0.8		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 27000000 J	//Fuel heat of burning
+//	TIT: 1080 K		//Combustion peak temp
+//	TAB: 0 K		//Afterburner peak temp
+//	maxT3: 650 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	Nord 1500 Stato-Réacteur?
+//	1957, Griffon II
+//	Envelope 
+//
+//	Dry Mass: N/A kg
+//	Thrust: 67.8 kN
+//	Area: 0.45 m^2		//Compressor Area
+//	Mdes: 2.0 M			//Mach Design Point
+//	Tdes: 210 K			//Temp Design Point
+//	eta_n: 0.95			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 20000000 J		//Fuel heat of burning
+//	maxFar: 0.10		//Max fuel to air ratio
+//	maxEngineTemp: 2455 K	//Engine max temperature
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.avialogs.com/engines-w/wright/item/7733-yj67-w-3turbojetaircraftenginecharacteristicssummary-1april1953
+//	https://www.avialogs.com/engines-w/wright/item/7732-xrj55-w-1ramjetaircraftenginecharacteristicssummary-16july1956
+
+
+//	Used by:
+
+//	Notes:
+
+//	Concentric turbojet-ramjet, with ramjet duct surrounding Atar 101, acting as thrust augmentation.
+//	==================================================
+@PART[*]:HAS[#engineType[Nord1500]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roNord1500Title	//Nord 1500/Atar Combined Cycle Ramjet
+	%manufacturer = #roMfrNord
+	%description = #roNord1500Desc
+
+	@tags ^= :$: france snecma nord aviation atar 101E-3 nord stato-réacteur 1500 ramjet turbojet
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!MODULE[ModuleEngines*],*{}
+
+	MODULE
+	{
+		name = ModuleEnginesAJEJet
+		EngineType = Turbine
+		thrustVectorTransformName = thrustTransform
+		engineID = MainEngine
+	}
+	MODULE
+	{
+		name = ModuleEnginesAJERamjet
+		EngineType = Turbine
+		thrustVectorTransformName = thrustTransform
+		engineID = BackupEngine
+	}
+	
+	@MODULE[ModuleAlternator]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			%rate = 25.0
+		}
+	}
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = Atar101E-3
+		engineID = MainEngine
+		isMaster = True
+		origMass = 1.500
+
+		CONFIG
+		{
+			name = Atar101E-3
+			description = Temperature Mach limit at 15 km: 2.57.
+			specLevel = operational
+			massMult = 1.00
+			heatProduction = 10
+			
+			Area = 0.206	//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 4.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.7		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.8		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 27000000	//Fuel heat of burning (joules?)
+			TIT = 1080		//Combustion peak temp
+			TAB = 0			//Afterburner temp?
+			maxT3 = 650		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 70
+			
+			// Engine fitting params
+			defaultTPR = 0.95
+			dryThrust = 34.3
+			wetThrust = 0
+			maxThrust = 34.3	//Just to let MEC know thrust
+			drySFC = 1.079
+			throttleResponseMultiplier = 0.18
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			OtherModules
+			{
+				BackupEngine = Nord1500
+			}
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJERamjet
+		configuration = Nord1500
+		engineID = BackupEngine
+		isMaster = False
+
+		CONFIG
+		{
+			name = Nord1500
+			//description = 
+			specLevel = operational
+			massMult = 1.00
+			heatProduction = 10
+			
+			Area = 0.45		//Compressor Area
+			Mdes = 2.00		//Mach Design Point
+			Tdes = 210		//Temp Design Point
+			eta_n = 0.95		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 20000000	//Fuel heat of burning (joules?)
+			maxFar = 0.10
+			maxEngineTemp = 2455
+			thrustUpperLimit = 67.8
+			
+			// Engine fitting params
+			maxThrust = 67.8	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
@@ -100,10 +100,3 @@
 		}
 	}
 }
-
-+PART[aje_ramjet]:FOR[RealismOverhaul]
-{
-	@name = RO-RD012
-	@rescaleFactor = 1.36
-	%engineType = RD012
-}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
@@ -75,7 +75,7 @@
 		CONFIG
 		{
 			name = RD-012U
-			description = RD-012U, intended for La-350 Burya. Design speed M3.1@18 km.
+			description = RD-012U, used on La-350 Burya. Design speed M3.1@18 km.
 			specLevel = operational
 			massMult = 1.00
 			

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
@@ -13,8 +13,9 @@
 //	Area: 0.455 m^2		//Compressor Area (4/3rds Navaho?)
 //	Mdes: 3.1 M			//Mach Design Point
 //	Tdes: 220 K			//Temp Design Point
-//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	eta_n: 0.96			//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 25400000 J		//Fuel heat of burning		1500 s Isp
+//	maxFar: 0.06676		//Max fuel to air ratio
 //	maxEngineTemp: 2388 K	//Engine max temperature
 //	=================================================================================
 
@@ -78,12 +79,14 @@
 			description = RD-012U, used on La-350 Burya. Design speed M3.1@18 km.
 			specLevel = operational
 			massMult = 1.00
+			heatProduction = 10
 			
 			Area = 0.455		//Compressor Area
 			Mdes = 3.1		//Mach Design Point
 			Tdes = 220		//Temp Design Point
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			eta_n = 0.96	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 25400000	//Fuel heat of burning (joules?)
+			//maxFar = 0.1
 			maxEngineTemp = 2388
 			thrustUpperLimit = 76
 			

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RD012_Config.cfg
@@ -1,0 +1,109 @@
+//	==================================================
+//	Engine: RD-012
+//
+//	Manufacturer: OKB-670 Bondaryuk
+//
+//	=================================================================================
+//	RD-012U
+//	1958, La-350 Burya
+//	Envelope M2.7@16.5km to M3.3@25km?
+//
+//	Dry Mass: 1000? kg
+//	Thrust: 76? kN
+//	Area: 0.455 m^2		//Compressor Area (4/3rds Navaho?)
+//	Mdes: 3.1 M			//Mach Design Point
+//	Tdes: 220 K			//Temp Design Point
+//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 25400000 J		//Fuel heat of burning		1500 s Isp
+//	maxEngineTemp: 2388 K	//Engine max temperature
+//	=================================================================================
+
+//	Sources:
+
+//	http://www.astronautix.com/r/rd-012u.html
+//	https://www.b14643.de/Spacerockets/Specials/Ramjets_Burya-Buran/index.htm
+//	https://en.topwar.ru/9465-my-byli-pervye-sovetskiy-proekt-burya-pervyy-v-mire-mezhkontinentalnyy-ballisticheskiy-raketa-nositel.html
+//	https://testpilot.ru/review/shavrov/iii/4/350.php
+//	http://xn--d1abof0er.xn--p1ai/makaron.htm
+
+
+
+//	Used by:
+
+//	Notes:
+
+//	1.7 meters overall?
+//	La-350 design M3.1 @ 18 km?
+//	==================================================
+@PART[*]:HAS[#engineType[RD012]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roRD012Title	//RD-012 Ramjet
+	%manufacturer = #roMfrOKB670
+	%description = #roRD012Desc
+
+	@tags ^= :$: usa curtiss-wright curtiss wright rd012 rd-012 ramjet
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJERamjet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+	@MODULE[ModuleAlternator]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			%rate = 5.0		//ram-air turbine for power?
+		}
+	}
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJERamjet
+		configuration = RD-012U
+		modded = false
+		origMass = 1.0
+
+		CONFIG
+		{
+			name = RD-012U
+			description = RD-012U, intended for La-350 Burya. Design speed M3.1@18 km.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.455		//Compressor Area
+			Mdes = 3.1		//Mach Design Point
+			Tdes = 220		//Temp Design Point
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 25400000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 2388
+			thrustUpperLimit = 76
+			
+			// Engine fitting params
+			maxThrust = 76	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+
++PART[aje_ramjet]:FOR[RealismOverhaul]
+{
+	@name = RO-RD012
+	@rescaleFactor = 1.36
+	%engineType = RD012
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ43_Config.cfg
@@ -13,9 +13,10 @@
 //	Area: 0.231 m^2		//Compressor Area
 //	Mdes: 2.75 M		//Mach Design Point
 //	Tdes: 210 K			//Temp Design Point
-//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	eta_n: 0.95			//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 23600000 J		//Fuel heat of burning		scaled based on thrust
-//	maxEngineTemp: 2131 K	//Engine max temperature
+//	maxFar: 0.10		//Max fuel to air ratio
+//	maxEngineTemp: 2795 K	//Engine max temperature
 //	=================================================================================
 //	RJ43-MA-5
 //	1958, X-7, XQ-5, AQM-60A
@@ -26,9 +27,10 @@
 //	Area: 0.231 m^2		//Compressor Area
 //	Mdes: 2.00 M		//Mach Design Point
 //	Tdes: 290 K			//Temp Design Point
-//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 24500000 J		//Fuel heat of burning		matched to Navaho sfc @ M2.75, 23.5 km
-//	maxEngineTemp: 2149 K	//Engine max temperature
+//	eta_n: 0.95			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24500000 J		//Fuel heat of burning		matched to Navaho sfc of 2.52 @ M2.75, 16.764 km
+//	maxFar: 0.10		//Max fuel to air ratio
+//	maxEngineTemp: 2925 K	//Engine max temperature
 //	=================================================================================
 //	RJ43-MA-11
 //	1960, CIM-10B Bomarc B
@@ -39,9 +41,10 @@
 //	Area: 0.231 m^2		//Compressor Area
 //	Mdes: 3.00 M		//Mach Design Point
 //	Tdes: 230 K			//Temp Design Point
-//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 24500000 J		//Fuel heat of burning		matched to Navaho sfc @ M2.75, 23.5 km
-//	maxEngineTemp: 2234 K	//Engine max temperature
+//	eta_n: 0.95			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24500000 J		//Fuel heat of burning		matched to Navaho sfc of 2.52 @ M2.75, 16.764 km
+//	maxFar: 0.10		//Max fuel to air ratio
+//	maxEngineTemp: 3010 K	//Engine max temperature
 //	=================================================================================
 //	MA20S-4
 //	1966, D-21
@@ -52,9 +55,10 @@
 //	Area: 0.231 m^2		//Compressor Area
 //	Mdes: 3.30 M		//Mach Design Point
 //	Tdes: 230 K			//Temp Design Point
-//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	eta_n: 0.95			//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 25000000 J		//Fuel heat of burning		matched to D-21
-//	maxEngineTemp: 2397 K	//Engine max temperature
+//	maxFar: 0.10		//Max fuel to air ratio
+//	maxEngineTemp: 3170 K	//Engine max temperature
 //	=================================================================================
 
 //	Sources:
@@ -68,6 +72,8 @@
 //	https://doi.org/10.2514/6.2005-3538
 //	http://www.themilitarystandard.com/missile/bomarc/summary.php
 //	https://www.secretprojects.co.uk/threads/lockheed-m-12-and-d-21.8710/page-2
+//	https://www.joebaugher.com/usaf_fighters/f99.html
+//	https://web.archive.org/web/20120401094311/http://www.boeing.com/history/boeing/bomarc.html
 
 
 //	Used by:
@@ -117,12 +123,14 @@
 			description = RJ43-MA-3, as used on CIM-10 Bomarc A. Design speed M2.75@20 km.
 			specLevel = operational
 			massMult = 1.00
+			heatProduction = 10
 			
 			Area = 0.231		//Compressor Area
 			Mdes = 2.75		//Mach Design Point
 			Tdes = 210		//Temp Design Point
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			eta_n = 0.95	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 23600000	//Fuel heat of burning (joules?)
+			maxFar = 0.1
 			maxEngineTemp = 2131
 			thrustUpperLimit = 51
 			
@@ -143,12 +151,14 @@
 			description = RJ43-MA-5, as used on the X-7, XQ-5 and AQM-60A. Design speed M2.00@0 km.
 			specLevel = operational
 			massMult = 1.0848
+			heatProduction = 10
 			
 			Area = 0.231		//Compressor Area
 			Mdes = 2.00		//Mach Design Point
 			Tdes = 290		//Temp Design Point
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			eta_n = 0.95	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 24500000	//Fuel heat of burning (joules?)
+			maxFar = 0.1
 			maxEngineTemp = 2149
 			thrustUpperLimit = 53
 			
@@ -169,12 +179,14 @@
 			description = RJ43-MA-11, as used on CIM-10 Bomarc B. Design speed M3.00@21 km.
 			specLevel = operational
 			massMult = 1.0848
+			heatProduction = 10
 			
 			Area = 0.231		//Compressor Area
 			Mdes = 3.00		//Mach Design Point
 			Tdes = 230		//Temp Design Point
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			eta_n = 0.95	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 24500000	//Fuel heat of burning (joules?)
+			maxFar = 0.1
 			maxEngineTemp = 2234
 			thrustUpperLimit = 53
 			
@@ -195,12 +207,14 @@
 			description = Modified RJ43-MA-11, as used on D-21. Design speed M3.32@29 km.
 			specLevel = operational
 			massMult = 1.0848
+			heatProduction = 10
 			
 			Area = 0.231		//Compressor Area
 			Mdes = 3.30		//Mach Design Point
 			Tdes = 230		//Temp Design Point
-			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			eta_n = 0.95	//Efficiency at afterburner rear / nozzle entrance
 			FHV = 25000000	//Fuel heat of burning (joules?)
+			maxFar = 0.1
 			maxEngineTemp = 2397
 			thrustUpperLimit = 54
 			

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ43_Config.cfg
@@ -1,0 +1,226 @@
+//	==================================================
+//	Engine: RJ43
+//
+//	Manufacturer: Marquardt
+//
+//	=================================================================================
+//	RJ43-MA-3
+//	1952, CIM-10A Bomarc A
+//	Envelope M2.3@40kft to M2.85@64kft
+//
+//	Dry Mass: 224 kg
+//	Thrust: 51 kN
+//	Area: 0.231 m^2		//Compressor Area
+//	Mdes: 2.75 M		//Mach Design Point
+//	Tdes: 210 K			//Temp Design Point
+//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 23600000 J		//Fuel heat of burning		scaled based on thrust
+//	maxEngineTemp: 2131 K	//Engine max temperature
+//	=================================================================================
+//	RJ43-MA-5
+//	1958, X-7, XQ-5, AQM-60A
+//	Envelope M2.0@0kft to M2.4@40kft
+//
+//	Dry Mass: 243? kg
+//	Thrust: 53 kN
+//	Area: 0.231 m^2		//Compressor Area
+//	Mdes: 2.00 M		//Mach Design Point
+//	Tdes: 290 K			//Temp Design Point
+//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24500000 J		//Fuel heat of burning		matched to Navaho sfc @ M2.75, 23.5 km
+//	maxEngineTemp: 2149 K	//Engine max temperature
+//	=================================================================================
+//	RJ43-MA-11
+//	1960, CIM-10B Bomarc B
+//	Envelope M2.3@0kft to M3.0@70kft
+//
+//	Dry Mass: 243 kg
+//	Thrust: 53 kN
+//	Area: 0.231 m^2		//Compressor Area
+//	Mdes: 3.00 M		//Mach Design Point
+//	Tdes: 230 K			//Temp Design Point
+//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24500000 J		//Fuel heat of burning		matched to Navaho sfc @ M2.75, 23.5 km
+//	maxEngineTemp: 2234 K	//Engine max temperature
+//	=================================================================================
+//	MA20S-4
+//	1966, D-21
+//	Envelope M2.0@40kft to M3.32@95kft?
+//
+//	Dry Mass: 243? kg
+//	Thrust: 56? kN
+//	Area: 0.231 m^2		//Compressor Area
+//	Mdes: 3.30 M		//Mach Design Point
+//	Tdes: 230 K			//Temp Design Point
+//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 25000000 J		//Fuel heat of burning		matched to D-21
+//	maxEngineTemp: 2397 K	//Engine max temperature
+//	=================================================================================
+
+//	Sources:
+
+//	https://en.wikipedia.org/wiki/CIM-10_Bomarc
+//	https://en.wikipedia.org/wiki/Marquardt_RJ43
+//	https://en.wikipedia.org/wiki/Lockheed_D-21
+//	https://en.wikipedia.org/wiki/Wright_XRJ47
+//	https://web.archive.org/web/20130817173907/http://astronautix.com/lvs/bomarc.htm
+//	https://www1.grc.nasa.gov/historic-facilities/psl1-2/missiles-and-turbojets/
+//	https://doi.org/10.2514/6.2005-3538
+//	http://www.themilitarystandard.com/missile/bomarc/summary.php
+//	https://www.secretprojects.co.uk/threads/lockheed-m-12-and-d-21.8710/page-2
+
+
+//	Used by:
+
+//	Notes:
+
+//	28 inches dia
+//	Bomarc A design M2.75 @ 20 km
+//	Bomarc B design M3.00 @ 20 km (later 30 km?)
+//	D-21 design M3.32 @ 29 km
+//	==================================================
+@PART[*]:HAS[#engineType[RJ43]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roRJ43Title	//RJ43 Ramjet
+	%manufacturer = #roMfrMarquardt
+	%description = #roRJ43Desc
+
+	@tags ^= :$: usa marquardt rj43 rj-43 ramjet
+
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJERamjet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJERamjet
+		configuration = RJ43-MA-3
+		modded = false
+		origMass = 0.224
+
+		CONFIG
+		{
+			name = RJ43-MA-3
+			description = RJ43-MA-3, as used on CIM-10 Bomarc A. Design speed M2.75@20 km.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.231		//Compressor Area
+			Mdes = 2.75		//Mach Design Point
+			Tdes = 210		//Temp Design Point
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 23600000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 2131
+			thrustUpperLimit = 51
+			
+			// Engine fitting params
+			maxThrust = 51	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = RJ43-MA-5
+			description = RJ43-MA-5, as used on the X-7, XQ-5 and AQM-60A. Design speed M2.00@0 km.
+			specLevel = operational
+			massMult = 1.0848
+			
+			Area = 0.231		//Compressor Area
+			Mdes = 2.00		//Mach Design Point
+			Tdes = 290		//Temp Design Point
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24500000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 2149
+			thrustUpperLimit = 53
+			
+			// Engine fitting params
+			maxThrust = 53	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = RJ43-MA-11
+			description = RJ43-MA-11, as used on CIM-10 Bomarc B. Design speed M3.00@21 km.
+			specLevel = operational
+			massMult = 1.0848
+			
+			Area = 0.231		//Compressor Area
+			Mdes = 3.00		//Mach Design Point
+			Tdes = 230		//Temp Design Point
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24500000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 2234
+			thrustUpperLimit = 53
+			
+			// Engine fitting params
+			maxThrust = 53	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+		CONFIG
+		{
+			name = MA20S-4
+			description = Modified RJ43-MA-11, as used on D-21. Design speed M3.32@29 km.
+			specLevel = operational
+			massMult = 1.0848
+			
+			Area = 0.231		//Compressor Area
+			Mdes = 3.30		//Mach Design Point
+			Tdes = 230		//Temp Design Point
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 25000000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 2397
+			thrustUpperLimit = 54
+			
+			// Engine fitting params
+			maxThrust = 54	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+
++PART[aje_ramjet]:FOR[RealismOverhaul]
+{
+	@name = RO-RJ43
+	@rescaleFactor = 0.5688
+	%engineType = RJ43
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ43_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ43_Config.cfg
@@ -217,10 +217,3 @@
 		}
 	}
 }
-
-+PART[aje_ramjet]:FOR[RealismOverhaul]
-{
-	@name = RO-RJ43
-	@rescaleFactor = 0.5688
-	%engineType = RJ43
-}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
@@ -5,7 +5,7 @@
 //
 //	=================================================================================
 //	XRJ47-W-5
-//	1959, SM-64 Navaho
+//	1957, SM-64 Navaho
 //
 //	Dry Mass: 459 kg
 //	Thrust: 75? kN
@@ -14,7 +14,7 @@
 //	Tdes: 220 K			//Temp Design Point
 //	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 24500000 J		//Fuel heat of burning		scaled based on thrust
-//	maxEngineTemp: 2160 K	//Engine max temperature
+//	maxEngineTemp: 2175 K	//Engine max temperature
 //	=================================================================================
 
 //	Sources:
@@ -47,7 +47,7 @@
 
 	@tags ^= :$: usa curtiss-wright curtiss wright rj47 rj-47 ramjet
 
-	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
 	@MODULE[ModuleEngines*]
 	{
@@ -78,8 +78,8 @@
 		CONFIG
 		{
 			name = XRJ47-W-5
-			description = XRJ47-W-5, intended for SM-65 Navaho. Design speed M2.75@16.7 km.
-			specLevel = prototype
+			description = XRJ47-W-5, used on SM-65 Navaho. Design speed M2.75@16.7 km.
+			specLevel = operational
 			massMult = 1.00
 			
 			Area = 0.341		//Compressor Area
@@ -87,7 +87,7 @@
 			Tdes = 220		//Temp Design Point
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 24500000	//Fuel heat of burning (joules?)
-			maxEngineTemp = 2160
+			maxEngineTemp = 2175
 			thrustUpperLimit = 75
 			
 			// Engine fitting params

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
@@ -103,10 +103,3 @@
 		}
 	}
 }
-
-+PART[aje_ramjet]:FOR[RealismOverhaul]
-{
-	@name = RO-RJ47
-	//@rescaleFactor = 0.5688
-	%engineType = RJ47
-}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
@@ -1,0 +1,112 @@
+//	==================================================
+//	Engine: RJ47
+//
+//	Manufacturer: Wright
+//
+//	=================================================================================
+//	XRJ47-W-5
+//	1959, SM-64 Navaho
+//
+//	Dry Mass: 459 kg
+//	Thrust: 75? kN
+//	Area: 0.341 m^2		//Compressor Area
+//	Mdes: 2.75 M		//Mach Design Point
+//	Tdes: 220 K			//Temp Design Point
+//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24500000 J		//Fuel heat of burning		scaled based on thrust
+//	maxEngineTemp: 2160 K	//Engine max temperature
+//	=================================================================================
+
+//	Sources:
+
+//	https://en.wikipedia.org/wiki/CIM-10_Bomarc
+//	https://en.wikipedia.org/wiki/Marquardt_RJ43
+//	https://en.wikipedia.org/wiki/Lockheed_D-21
+//	https://en.wikipedia.org/wiki/Wright_XRJ47
+//	https://web.archive.org/web/20130817173907/http://astronautix.com/lvs/bomarc.htm
+//	https://www1.grc.nasa.gov/historic-facilities/psl1-2/missiles-and-turbojets/
+//	https://doi.org/10.2514/6.2005-3538
+//	http://www.themilitarystandard.com/missile/bomarc/summary.php
+//	https://www.secretprojects.co.uk/threads/lockheed-m-12-and-d-21.8710/page-2
+//	https://www.avialogs.com/engines-w/wright/item/7729-xrj47-w-5-ramjet-aircraft-engine-characteristics-summary-1-april-1957
+
+
+//	Used by:
+
+//	Notes:
+
+//	48 inches dia, 50.8 inches overall?
+//	SM-64 design M2.75 @ 16.8 km
+//	==================================================
+@PART[*]:HAS[#engineType[RJ47]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roRJ47Title	//RJ47 Ramjet
+	%manufacturer = #roMfrCW
+	%description = #roRJ47Desc
+
+	@tags ^= :$: usa curtiss-wright curtiss wright rj47 rj-47 ramjet
+
+	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJERamjet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+	@MODULE[ModuleAlternator]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			%rate = 5.0		//ram-air turbine for power?
+		}
+	}
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJERamjet
+		configuration = XRJ47-W-5
+		modded = false
+		origMass = 0.459
+
+		CONFIG
+		{
+			name = XRJ47-W-5
+			description = XRJ47-W-5, intended for SM-65 Navaho. Design speed M2.75@16.7 km.
+			specLevel = prototype
+			massMult = 1.00
+			
+			Area = 0.341		//Compressor Area
+			Mdes = 2.75		//Mach Design Point
+			Tdes = 220		//Temp Design Point
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 24500000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 2160
+			thrustUpperLimit = 75
+			
+			// Engine fitting params
+			maxThrust = 75	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+
++PART[aje_ramjet]:FOR[RealismOverhaul]
+{
+	@name = RO-RJ47
+	//@rescaleFactor = 0.5688
+	%engineType = RJ47
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ47_Config.cfg
@@ -8,13 +8,14 @@
 //	1957, SM-64 Navaho
 //
 //	Dry Mass: 459 kg
-//	Thrust: 75? kN
-//	Area: 0.341 m^2		//Compressor Area
+//	Thrust: 67? kN
+//	Area: 0.445 m^2		//Compressor Area
 //	Mdes: 2.75 M		//Mach Design Point
 //	Tdes: 220 K			//Temp Design Point
-//	eta_n: 0.9			//Efficiency at afterburner rear / nozzle entrance
-//	FHV: 24500000 J		//Fuel heat of burning		scaled based on thrust
-//	maxEngineTemp: 2175 K	//Engine max temperature
+//	eta_n: 0.96			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 24400000 J		//Fuel heat of burning		scaled based on thrust
+//	maxFar: 0.04		//Max fuel to air ratio
+//	maxEngineTemp: 1560 K	//Engine max temperature
 //	=================================================================================
 
 //	Sources:
@@ -36,7 +37,16 @@
 //	Notes:
 
 //	48 inches dia, 50.8 inches overall?
-//	SM-64 design M2.75 @ 16.8 km
+//	SM-64 design M2.75 @ 16.8 km, 36.25 kN thrust @ sfc 2.52 lb/hr/lb
+//	RJ47 thrust table
+//		55 kft:
+//	@M2.60 = 30.69
+//	@M2.65 = 32.47
+//	@M2.70 = 34.70
+//	@M2.75 = 36.25	(sfc 2.52)
+//	@M2.80 = 38.03
+//	@M2.85 = 39.37
+//	@M2.90 = 40.48
 //	==================================================
 @PART[*]:HAS[#engineType[RJ47]]:FOR[RealismOverhaulEngines]
 {
@@ -81,17 +91,19 @@
 			description = XRJ47-W-5, used on SM-65 Navaho. Design speed M2.75@16.7 km.
 			specLevel = operational
 			massMult = 1.00
+			heatProduction = 10
 			
-			Area = 0.341		//Compressor Area
+			Area = 0.445		//Compressor Area
 			Mdes = 2.75		//Mach Design Point
 			Tdes = 220		//Temp Design Point
 			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
-			FHV = 24500000	//Fuel heat of burning (joules?)
+			FHV = 24400000	//Fuel heat of burning (joules?)
+			maxFar = 0.04
 			maxEngineTemp = 2175
-			thrustUpperLimit = 75
+			thrustUpperLimit = 67
 			
 			// Engine fitting params
-			maxThrust = 75	//Just to let MEC know thrust
+			maxThrust = 67	//Just to let MEC know thrust
 			throttleResponseMultiplier = 1.0
 
 			PROPELLANT

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ55_Config.cfg
@@ -144,7 +144,7 @@
 			wetThrust = 99.42
 			maxThrust = 99.42	//Just to let MEC know thrust
 			drySFC = 0.795
-			throttleResponseMultiplier = 0.3	//60s double-spool, 0.3
+			throttleResponseMultiplier = 0.2
 
 			PROPELLANT
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ55_Config.cfg
@@ -1,0 +1,199 @@
+//	==================================================
+//	Engine: RJ55/J67
+//
+//	Manufacturer: Wright
+//
+//	=================================================================================
+//	J67-W-3
+//	1957, XF-103
+//
+//	Dry Mass: 3447 kg
+//	Thrust (Dry): 57.60 kN
+//	Thrust (Wet): 99.42 kN
+//	SFC (Dry): 0.795 lb/lbf-hr
+//	Area: 0.4 m^2	//Compressor Area
+//	BPR: 0.0		//Bypass Ratio
+//	CPR: 10.5		//Compressor Pressure Ratio
+//	FPR: 0.0		//Fan Ratio
+//	Mdes: 0.9 M		//Mach Design Point
+//	Tdes: 250 K		//Temp Design Point
+//	eta_n: 0.7		//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 29000000 J	//Fuel heat of burning
+//	TIT: 1089 K		//Combustion peak temp
+//	TAB: 2498* K		//Afterburner peak temp
+//	maxT3: 775 K	//Turbine max temperature
+//	Exhaust Mixer: false
+//	Adjustable Nozzle: true
+//	=================================================================================
+//	XRJ55-W-1
+//	1957, XF-103
+//	Envelope M2.24@35kft to M3.0@45kft
+//
+//	Dry Mass: N/A kg
+//	Thrust: 144.56 kN
+//	Area: 0.654 m^2		//Compressor Area
+//	Mdes: 3.0 M			//Mach Design Point
+//	Tdes: 215 K			//Temp Design Point
+//	eta_n: 0.97			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 17000000 J		//Fuel heat of burning		sfc 3.2 M3.0 @ 45kft
+//	maxEngineTemp: 2298 K	//Engine max temperature
+//	=================================================================================
+
+//	Sources:
+
+//	https://www.avialogs.com/engines-w/wright/item/7733-yj67-w-3turbojetaircraftenginecharacteristicssummary-1april1953
+//	https://www.avialogs.com/engines-w/wright/item/7732-xrj55-w-1ramjetaircraftenginecharacteristicssummary-16july1956
+
+
+//	Used by:
+
+//	Notes:
+
+//	56 inches dia
+//	J67 max speed M2.24 @ 35kft
+//	RJ55 design speed M3.0 @ 45kft, 144.56 kN thrust @ sfc 3.2 lb/hr/lb
+//	RJ55 thrust table
+//		35 kft:
+//	@M2.0 = 63.38
+//	@M2.20 = 91.19
+//	@M2.40 = 120.10
+//	@M2.45 = 133.45
+//		45kft:
+//	@M2.0 = 37.81
+//	@M2.20 = 55.60
+//	@M2.40 = 73.39
+//	@M2.60 = 93.41
+//	@M2.80 = 117.88
+//	@M3.00 = 144.56 (design sfc 3.2)
+//	==================================================
+@PART[*]:HAS[#engineType[RJ55]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roRJ55Title	//RJ55 Ramjet
+	%manufacturer = #roMfrCW
+	%description = #roRJ55Desc
+
+	@tags ^= :$: usa curtiss-wright curtiss wright j67 j-67 rj55 rj-55 ramjet turbojet
+
+	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
+
+	!MODULE[ModuleEngines*],*{}
+
+	MODULE
+	{
+		name = ModuleEnginesAJEJet
+		EngineType = Turbine
+		thrustVectorTransformName = thrustTransform
+		engineID = MainEngine
+	}
+	MODULE
+	{
+		name = ModuleEnginesAJERamjet
+		EngineType = Turbine
+		thrustVectorTransformName = thrustTransform
+		engineID = BackupEngine
+	}
+	
+	@MODULE[ModuleAlternator]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			%rate = 50.0
+		}
+	}
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJEJet
+		configuration = J67-W-3
+		engineID = MainEngine
+		isMaster = True
+		origMass = 3.447
+
+		CONFIG
+		{
+			name = J67-W-3
+			description = Temperature Mach limit at 15 km: 2.59.
+			specLevel = prototype
+			massMult = 1.00
+			heatProduction = 10
+			
+			Area = 0.4		//Compressor Area
+			BPR = 0.0		//Bypass Ratio
+			CPR = 10.5		//Compressor Pressure Ratio
+			FPR = 0.0		//Fan Ratio
+			Mdes = 0.7		//Mach Design Point
+			Tdes = 250		//Temp Design Point
+			eta_c = 0.95	//Efficiency at burner inlet
+			eta_t = 0.98	//Efficiency at burner exit
+			eta_n = 0.9		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 29000000	//Fuel heat of burning (joules?)
+			TIT = 1089		//Combustion peak temp
+			TAB = 2498		//Afterburner temp?
+			maxT3 = 775		//Turbine max temperature
+			exhaustMixer = False
+			adjustableNozzle = True
+			thrustUpperLimit = 200
+			
+			// Engine fitting params
+			defaultTPR = 0.85
+			dryThrust = 57.6
+			wetThrust = 99.42
+			maxThrust = 99.42	//Just to let MEC know thrust
+			drySFC = 0.795
+			throttleResponseMultiplier = 0.3	//60s double-spool, 0.3
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+			
+			OtherModules
+			{
+				BackupEngine = XRJ55-W-1
+			}
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJERamjet
+		configuration = XRJ55-W-1
+		engineID = BackupEngine
+		isMaster = False
+
+		CONFIG
+		{
+			name = XRJ55-W-1
+			//description = 
+			specLevel = prototype
+			massMult = 1.00
+			heatProduction = 10
+			
+			Area = 0.654		//Compressor Area
+			Mdes = 3.00		//Mach Design Point
+			Tdes = 215		//Temp Design Point
+			eta_n = 0.97		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 17000000	//Fuel heat of burning (joules?)
+			maxFar = 0.1
+			maxEngineTemp = 2298
+			thrustUpperLimit = 144.56
+			
+			// Engine fitting params
+			maxThrust = 144.56	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ55_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ55_Config.cfg
@@ -36,7 +36,8 @@
 //	Tdes: 215 K			//Temp Design Point
 //	eta_n: 0.97			//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 17000000 J		//Fuel heat of burning		sfc 3.2 M3.0 @ 45kft
-//	maxEngineTemp: 2298 K	//Engine max temperature
+//	maxFar: 0.10		//Max fuel to air ratio
+//	maxEngineTemp: 2300 K	//Engine max temperature
 //	=================================================================================
 
 //	Sources:
@@ -180,8 +181,8 @@
 			Tdes = 215		//Temp Design Point
 			eta_n = 0.97		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 17000000	//Fuel heat of burning (joules?)
-			maxFar = 0.1
-			maxEngineTemp = 2298
+			maxFar = 0.10
+			maxEngineTemp = 2300
 			thrustUpperLimit = 144.56
 			
 			// Engine fitting params

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
@@ -15,7 +15,8 @@
 //	Tdes: 225 K			//Temp Design Point
 //	eta_n: 0.98			//Efficiency at afterburner rear / nozzle entrance
 //	FHV: 32400000 J		//Fuel heat of burning
-//	maxEngineTemp: 3095 K	//Engine max temperature
+//	maxFar: 0.07		//Max fuel to air ratio
+//	maxEngineTemp: 3155 K	//Engine max temperature
 //	=================================================================================
 
 //	Sources:
@@ -79,13 +80,15 @@
 			description = XRJ59-MA-3, intended for the Convair Super Hustler, and tested on the X-7. Design speed M4.0@27.5 km.
 			specLevel = operational
 			massMult = 1.00
+			heatProduction = 10
 			
 			Area = 0.377		//Compressor Area
 			Mdes = 4.0		//Mach Design Point
 			Tdes = 225		//Temp Design Point
 			eta_n = 0.98		//Efficiency at afterburner rear / nozzle entrance
 			FHV = 32400000	//Fuel heat of burning (joules?)
-			maxEngineTemp = 3095
+			maxFar = 0.07
+			maxEngineTemp = 3155
 			thrustUpperLimit = 100
 			
 			// Engine fitting params

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
@@ -50,7 +50,7 @@
 
 	@tags ^= :$: usa marquardt rj59 rj-59 ramjet
 
-	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
+	%specLevel = operational	//operational, prototype, concept, speculative, altHist, sciFi
 
 	@MODULE[ModuleEngines*]
 	{

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
@@ -1,0 +1,110 @@
+//	==================================================
+//	Engine: RJ59
+//
+//	Manufacturer: Marquardt
+//
+//	=================================================================================
+//	XRJ59-MA-3
+//	1960, X-7, AQM-60?, Convair FISH/Super Hustler
+//	Envelope M2.0@40kft to M4.0@90.2kft?
+//
+//	Dry Mass: 345 kg
+//	Thrust: 100? kN
+//	Area: 0.377 m^2		//Compressor Area
+//	Mdes: 4.0 M			//Mach Design Point
+//	Tdes: 225 K			//Temp Design Point
+//	eta_n: 0.98			//Efficiency at afterburner rear / nozzle entrance
+//	FHV: 32400000 J		//Fuel heat of burning
+//	maxEngineTemp: 3095 K	//Engine max temperature
+//	=================================================================================
+
+//	Sources:
+
+//	https://en.wikipedia.org/wiki/CIM-10_Bomarc
+//	https://en.wikipedia.org/wiki/Marquardt_RJ43
+//	https://en.wikipedia.org/wiki/Lockheed_D-21
+//	https://en.wikipedia.org/wiki/Wright_XRJ47
+//	https://web.archive.org/web/20130817173907/http://astronautix.com/lvs/bomarc.htm
+//	https://www1.grc.nasa.gov/historic-facilities/psl1-2/missiles-and-turbojets/
+//	https://doi.org/10.2514/6.2005-3538
+//	http://www.themilitarystandard.com/missile/bomarc/summary.php
+//	https://www.secretprojects.co.uk/threads/lockheed-m-12-and-d-21.8710/page-2
+//	https://www.avialogs.com/engines-w/wright/item/7729-xrj47-w-5-ramjet-aircraft-engine-characteristics-summary-1-april-1957
+//	https://www.secretprojects.co.uk/threads/marquardt-rj59-ramjet-engines.1963/
+//	https://www.cia.gov/readingroom/document/05811775
+
+
+//	Used by:
+
+//	Notes:
+
+//	36 inches dia?
+//	design M4.0 @ 27.5 km, sfc 1.86
+//	==================================================
+@PART[*]:HAS[#engineType[RJ59]]:FOR[RealismOverhaulEngines]
+{
+
+	%title = #roRJ59Title	//RJ59 Ramjet
+	%manufacturer = #roMfrMarquardt
+	%description = #roRJ59Desc
+
+	@tags ^= :$: usa marquardt rj59 rj-59 ramjet
+
+	%specLevel = prototype	//operational, prototype, concept, speculative, altHist, sciFi
+
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesAJERamjet
+		%EngineType = Turbine
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+		}
+	}
+
+	!MODULE[ModuleAlternator]{}
+	!MODULE[ModuleGimbal]{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEnginesAJERamjet
+		configuration = XRJ59-MA-3
+		modded = false
+		origMass = 0.345
+
+		CONFIG
+		{
+			name = XRJ59-MA-3
+			description = XRJ59-MA-3, intended for the Convair Super Hustler, and tested on the X-7. Design speed M4.0@27.5 km.
+			specLevel = operational
+			massMult = 1.00
+			
+			Area = 0.377		//Compressor Area
+			Mdes = 4.0		//Mach Design Point
+			Tdes = 225		//Temp Design Point
+			eta_n = 0.98		//Efficiency at afterburner rear / nozzle entrance
+			FHV = 32400000	//Fuel heat of burning (joules?)
+			maxEngineTemp = 3095
+			thrustUpperLimit = 100
+			
+			// Engine fitting params
+			maxThrust = 100	//Just to let MEC know thrust
+			throttleResponseMultiplier = 1.0
+
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 1.0
+				DrawGauge = True
+			}
+		}
+	}
+}
+
++PART[aje_ramjet]:FOR[RealismOverhaul]
+{
+	@name = RO-RJ59
+	@rescaleFactor = 0.8
+	%engineType = RJ59
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Jet_Engine_Configs/RJ59_Config.cfg
@@ -101,10 +101,3 @@
 		}
 	}
 }
-
-+PART[aje_ramjet]:FOR[RealismOverhaul]
-{
-	@name = RO-RJ59
-	@rescaleFactor = 0.8
-	%engineType = RJ59
-}

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -1085,6 +1085,15 @@ Localization
 		//		RD-36
 		#roRD36Title = RD-36 Turbojet
 		#roRD36Desc = The RD-36 was a 1970s turbojet, developed to power the Tu-144. The RD-36 replaced the underperforming NK-144 engines, allowing the Tu-144 to achieve its intended range. Ultimately, the Tu-144 was taken out of service shortly after being upgraded due to costs. The RD-36 powered the Tu-144D and M-17.
+		//		RJ43
+		#roRJ43Title = RJ43 Ramjet
+		#roRJ43Desc = The RJ43 was a supersonic ramjet, designed to power the CIM-10 Bomarc surface to air missile at speeds up to Mach 3. It was also used on the X-7 and XQ-5/AQM-60 target drone, and was modified to power the D-21 up to speeds over Mach 3.3.
+		//		RJ47
+		#roRJ47Title = RJ47 Ramjet
+		#roRJ47Desc = The RJ47 was a supersonic ramjet, designed to power the SM-64 Navaho cruise missile up to Mach 2.75.
+		//		RJ59
+		#roRJ47Title = RJ59 Ramjet
+		#roRJ47Desc = The RJ59 was a supersonic ramjet, designed to power the Convair Super Hustler. Although the Super Hustler was cancelled, the RJ59 was fitted to the X-7 for testing, where it was able to achieve speeds over Mach 4.
 		//		Sapphire
 		#roSapphireTitle = Sapphire Turbojet
 		#roSapphireDesc = An early 1950s turbojet. Derived from the MetroVick F.2, the first axial-flow jet developed in Britain, the Sapphire powered the Hawker Hunter, Handley Page Victor, and Gloster Javelin.

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -1085,6 +1085,9 @@ Localization
 		//		RD-36
 		#roRD36Title = RD-36 Turbojet
 		#roRD36Desc = The RD-36 was a 1970s turbojet, developed to power the Tu-144. The RD-36 replaced the underperforming NK-144 engines, allowing the Tu-144 to achieve its intended range. Ultimately, the Tu-144 was taken out of service shortly after being upgraded due to costs. The RD-36 powered the Tu-144D and M-17.
+		//		RD-012
+		#roRD012Title = RD-012 Ramjet
+		#roRD012Desc = The RD-012 was a supersonic ramjet, designed to power the La-350 Burya cruise missile up to Mach 3.1.
 		//		RJ43
 		#roRJ43Title = RJ43 Ramjet
 		#roRJ43Desc = The RJ43 was a supersonic ramjet, designed to power the CIM-10 Bomarc surface to air missile at speeds up to Mach 3. It was also used on the X-7 and XQ-5/AQM-60 target drone, and was modified to power the D-21 up to speeds over Mach 3.3.
@@ -1092,8 +1095,8 @@ Localization
 		#roRJ47Title = RJ47 Ramjet
 		#roRJ47Desc = The RJ47 was a supersonic ramjet, designed to power the SM-64 Navaho cruise missile up to Mach 2.75.
 		//		RJ59
-		#roRJ47Title = RJ59 Ramjet
-		#roRJ47Desc = The RJ59 was a supersonic ramjet, designed to power the Convair Super Hustler. Although the Super Hustler was cancelled, the RJ59 was fitted to the X-7 for testing, where it was able to achieve speeds over Mach 4.
+		#roRJ59Title = RJ59 Ramjet
+		#roRJ59Desc = The RJ59 was a supersonic ramjet, designed to power the Convair Super Hustler. Although the Super Hustler was cancelled, the RJ59 was fitted to the X-7 for testing, where it was able to achieve speeds over Mach 4.
 		//		Sapphire
 		#roSapphireTitle = Sapphire Turbojet
 		#roSapphireDesc = An early 1950s turbojet. Derived from the MetroVick F.2, the first axial-flow jet developed in Britain, the Sapphire powered the Hawker Hunter, Handley Page Victor, and Gloster Javelin.

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -1067,6 +1067,9 @@ Localization
 		//		NK-25/32
 		#roNK25Title = NK-25/32 Low-Bypass Turbofan
 		#roNK25Desc = The NK-25 was a 1970s low-bypass turbofan, developed from the earlier NK-22. It is the most powerful supersonic jet engine ever flown, and was used to power the Tu-22M3, Tu-160, Tu-160M and Tu-144LL.
+		//		Nord 1500
+		#roNord1500Title = Nord 1500/Atar Combined Cycle Ramjet
+		#roNord1500Desc = The Nord 1500 ramjet was a combined cycle ramjet, mated to an Atar 101E. Used on the Griffon II experimental aircraft, the Atar 101 would accelerate the aircraft up to the speed of sound, at which point the ramjet could act as a thrust augmentor and accelerate aircraft up to speeds over Mach 2. Although the Griffon II performed well, it was cancelled in favor of more conventional aircraft.
 		//		Olympus 593
 		#roOlympus593Title = Olympus 593 Turbojet
 		#roOlympus593Desc = A late 1960s turbojet. The ultimate version of the Olympus turbojet, designed for sustained Mach 2 operation to power Concorde. Although thirsty at sea level, when mated to a well-optimized intake this engine can supercruise at Mach 2, achieving relatively good efficiency.

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -1094,6 +1094,9 @@ Localization
 		//		RJ47
 		#roRJ47Title = RJ47 Ramjet
 		#roRJ47Desc = The RJ47 was a supersonic ramjet, designed to power the SM-64 Navaho cruise missile up to Mach 2.75.
+		//		RJ55
+		#roRJ55Title = RJ55/J67 Combined Cycle Ramjet
+		#roRJ55Desc = The RJ55 was a combined cycle ramjet, mated to a J67. At low speeds, the RJ55 functioned as an afterburner for the J67 turbojet, but at mach 2.24 the turbojet would be shut down and the RJ55 would power the aircraft up to Mach 3. Designed for the XF-103, but difficuties with the J67 turbojet meant the prototype never flew under it's own power.
 		//		RJ59
 		#roRJ59Title = RJ59 Ramjet
 		#roRJ59Desc = The RJ59 was a supersonic ramjet, designed to power the Convair Super Hustler. Although the Super Hustler was cancelled, the RJ59 was fitted to the X-7 for testing, where it was able to achieve speeds over Mach 4.

--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -178,6 +178,8 @@ Localization
 		#roMfrYuzhnoye = Yuzhnoye Design Office	//(1991?-present)
 		//#roMfrUMZ = PA Yuzhmash	//(1966-2000) Yuzhny Machine-Building Plant? (Use design bureaus, not their factories)
 		//#roMfrPivdenmash = PA Pivdenmash	//(2000-present) State Factory Pivdenmash (Use design bureaus, not their factories)
+		//Bondaryuk (ОКБ-670)
+		#roMfrOKB670 = ОКБ-670 (Bondaryuk)
 		//ОКБ-692
 		#roMfrOKB692 = ОКБ-692	//(1959-1966?) renamed to KB Electropriborostroeniya
 		#roMfrKBElectro = Electrical Instrumentation Design Bureau	//(1966?-1976?) renamed to NPO Electropribor

--- a/GameData/RealismOverhaul/Localization/en-us-Squad.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Squad.cfg
@@ -14,6 +14,9 @@ Localization
 		//		RO-shockConeIntakeMig
 		#roRO-shockConeIntakeMigTitle = 0.86m Shock Cone Intake
 		#roRO-shockConeIntakeMigDesc = This shock cone intake works best between Mach 1.5 and Mach 3.0. This one is similar to the intake used on the MiG-21.
+		//		RO-shockConeIntakeBomarc
+		#roRO-shockConeIntakeBomarcTitle = 0.70m Shock Cone Intake
+		#roRO-shockConeIntakeBomarcDesc = This shock cone intake works best between Mach 1.5 and Mach 3.0. This one is similar to the intake used on the X-7.
 		//		shockConeIntake
 		#roshockConeIntakeDesc = This shock cone intake works best between Mach 1.5 and Mach 3.0.
 		//		airScoop

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -829,6 +829,84 @@
 	}
 }
 
+//Nord 1500 Stato-Réacteur
+//Clone RJ55 to create Nord 1500 (because I don't want to redo that work again)
++PART[RO-RJ55]:FOR[RealismOverhaul]
+{
+	@name = RO-Nord1500
+	%rescaleFactor = 1.2
+
+	%CoMOffset = 0, 3.1, 0
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 1.6, 2.4, 1.6
+	}
+
+	%engineType = Nord1500
+
+	@EFFECTS
+	{
+		@running_thrust
+		{
+			!AUDIO {}
+			!PREFAB_PARTICLE {}
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_deep
+				volume = 0.0 0.0
+				volume = 0.05 0.4
+				volume = 1.0 1.0
+				pitch = 0.0 0.6
+				pitch = 1.0 1.0
+				loop = true
+			}
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_smokeTrail_light
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+				localOffset = 0, 0, 1
+				localRotation = 1, 0, 0, -90
+			}
+		}
+		!power_wet {}
+		!shockDiamond {}
+	}
+}
+@PART[RO-Nord1500]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEnginesAJEJet]
+	{
+		//Jet dry
+		%spoolEffectName = running_turbine
+		//Jet wet
+		%powerEffectName = running_thrust
+		//%powerEffectName2 = power_wet
+		//%runningEffectName = shockDiamond
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
+	@MODULE[ModuleEnginesAJERamjet]
+	{
+		//Ramjet
+		%spoolEffectName = shockDiamond_rj
+		%spoolEffectName2 = running_thrust_rj
+		%powerEffectName = power_wet_rj
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
+}
+
 //RJ59
 //Clone J58 to be RJ59
 +PART[turboFanEngine]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -522,6 +522,74 @@
 	}
 }
 
+//RD-012
+//Clone J58 to be RD-012
++PART[turboFanEngine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-RD012
+	%rescaleFactor = 1.36
+
+	%CoMOffset = 0, 2.1, 0
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 1.6, 1.13, 1.6
+	}
+
+	%engineType = RD012
+}
+
+//RJ43
+//Clone J58 to be RJ43
++PART[turboFanEngine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-RJ43
+	%rescaleFactor = 0.5688
+
+	%CoMOffset = 0, 1.6, 0
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 1.6, 2.61, 1.6
+	}
+
+	%engineType = RJ43
+}
+
+//RJ47
+//Clone J58 to be RJ47
++PART[turboFanEngine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-RJ47
+	//%rescaleFactor = 0.5688
+
+	%CoMOffset = 0, 1.6, 0
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 1.6, 1.13, 1.6
+	}
+
+	%engineType = RJ47
+}
+
+//RJ59
+//Clone J58 to be RJ59
++PART[turboFanEngine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-RJ59
+	%rescaleFactor = 0.8
+
+	%CoMOffset = 0, 1.9, 0
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 1.6, 2.61, 1.6
+	}
+
+	%engineType = RJ59
+}
+
 //Sapphire ASSa.7 Mk.203
 //Clone avon to be Sapphire Mk.203
 //Source: https://www.jet-engine.net/miltfspec.htm

--- a/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
+++ b/GameData/RealismOverhaul/RO_DependentMods/RO_AJE.cfg
@@ -554,6 +554,20 @@
 	}
 
 	%engineType = RJ43
+	
+	//Fix effects to work properly with ramjet
+	@MODULE[ModuleEngines*]
+	{
+		//Ramjet
+		%runningEffectName = shockDiamond
+		%spoolEffectName = power_wet
+		%powerEffectName = running_thrust
+		
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
 }
 
 //RJ47
@@ -571,6 +585,248 @@
 	}
 
 	%engineType = RJ47
+	
+	//Fix effects to work properly with ramjet
+	@MODULE[ModuleEngines*]
+	{
+		//Ramjet
+		%runningEffectName = shockDiamond
+		%spoolEffectName = power_wet
+		%powerEffectName = running_thrust
+		
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
+}
+
+//RJ55
+//Clone J58 to be RJ55
++PART[turboFanEngine]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-RJ55
+	%rescaleFactor = 1.136
+
+	%CoMOffset = 0, 7.5, 0
+	@MODEL:HAS[#model[*EngineCore-Medium]]
+	{
+		@scale = 1.6, 7.1, 1.6
+	}
+
+	%engineType = RJ55
+	
+	//Just make completely new effects, stock effects do not like 2 engines in the same part
+	!EFFECTS,* {}
+	EFFECTS
+	{
+		//Jet dry
+		running_turbine
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.05 0.2
+				volume = 1.0 0.45
+				pitch = 0.0 0.3
+				pitch = 0.05 0.5
+				pitch = 1.0 0.65
+				loop = true
+			}
+		}
+		//Jet wet
+		running_thrust
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_spurts
+				volume = 0.0 0.0
+				volume = 0.5 1.0
+				volume = 1.0 1.5
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_smokeTrail_light
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+				localOffset = 0, 0, 1
+				localRotation = 1, 0, 0, -90
+			}
+		}
+		power_wet
+		{
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/afterburner_flame
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.16 0.0
+				emission = 0.3 0.5
+				emission = 0.5 1.0
+				emission = 1.0 1.0
+				speed = 0.1 0.05
+				speed = 0.3 1.0
+				speed = 0.5 1.15
+				speed = 1.0 1.15
+				localPosition = 0, 0, 0.08
+			}
+		}
+		shockDiamond
+		{
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/afterburner_shock
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.45 0.0
+				emission = 0.6 0.8
+				emission = 1 1.15
+				speed = 0.4 0.3
+				speed = 0.6 0.8
+				speed = 1.0 1.15
+			}
+		}
+		//Ramjet
+		running_thrust_rj
+		{
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_smokeTrail_light
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+				localOffset = 0, 0, 1
+				localRotation = 1, 0, 0, -90
+			}
+		}
+		power_wet_rj
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_spurts
+				volume = 0.0 0.0
+				volume = 0.5 1.0
+				volume = 1.0 1.5
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/afterburner_flame
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.16 0.0
+				emission = 0.3 0.5
+				emission = 0.5 1.0
+				emission = 1.0 1.0
+				speed = 0.1 0.05
+				speed = 0.3 1.0
+				speed = 0.5 1.15
+				speed = 1.0 1.15
+				localPosition = 0, 0, 0.08
+			}
+		}
+		shockDiamond_rj
+		{
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/afterburner_shock
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.45 0.0
+				emission = 0.6 0.8
+				emission = 1 1.15
+				speed = 0.4 0.3
+				speed = 0.6 0.8
+				speed = 1.0 1.15
+			}
+		}
+		//
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_exhaustSparks_flameout_2
+				transformName = smokePoint
+				oneShot = true
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}
+@PART[RO-RJ55]:AFTER[RealismOverhaulEngines]
+{
+	@MODULE[ModuleEnginesAJEJet]
+	{
+		//Jet dry
+		%spoolEffectName = running_turbine
+		//Jet wet
+		%powerEffectName = running_thrust
+		%powerEffectName2 = power_wet
+		%runningEffectName = shockDiamond
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
+	@MODULE[ModuleEnginesAJERamjet]
+	{
+		//Ramjet
+		%spoolEffectName = shockDiamond_rj
+		%spoolEffectName2 = running_thrust_rj
+		%powerEffectName = power_wet_rj
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
 }
 
 //RJ59
@@ -588,6 +844,20 @@
 	}
 
 	%engineType = RJ59
+
+	//Fix effects to work properly with ramjet
+	@MODULE[ModuleEngines*]
+	{
+		//Ramjet
+		%runningEffectName = shockDiamond
+		%spoolEffectName = power_wet
+		%powerEffectName = running_thrust
+		
+		//
+		%engageEffectName = engage
+		%disengageEffectName = disengage
+		%flameoutEffectName = flameout
+	}
 }
 
 //Sapphire ASSa.7 Mk.203

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Intakes.cfg
@@ -85,6 +85,29 @@
 	@description = #roRO-shockConeIntakeMigDesc
 }
 
+//create a Bomarc/X-7 sized intake
+//Required part diameter: 700 mm
++PART[shockConeIntake]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	@name = RO-shockConeIntakeBomarc
+	rescaleCube = 0.56
+	@DRAG_CUBE
+	{
+		rescaleX = 0.56
+		rescaleY = 0.56
+		rescaleZ = 0.56
+	}
+	
+	@mass = 0.045
+	//sure, inconel temps
+	%skinTempTag = Inconel
+	%internalTempTag = Inconel
+	
+	@title = #roRO-shockConeIntakeBomarcTitle	//0.70m Shock Cone Intake
+	@description = #roRO-shockConeIntakeBomarcDesc
+}
+
 @PART[shockConeIntake]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
@@ -120,6 +143,16 @@
 	@MODULE[AJEInlet]
 	{
 		@Area *= 0.4767
+	}
+}
+
+@PART[RO-shockConeIntakeBomarc]:FOR[RealismOverhaul]
+{
+	%rescaleFactor = 0.56
+	!MODULE[TweakScale] {}
+	@MODULE[AJEInlet]
+	{
+		@Area *= 0.3133
 	}
 }
 


### PR DESCRIPTION
Add several ramjet configs for AJE, and clone new parts for them.

This adds the following configs
Nord 1500/Atar101: Large French combined cycle turbojet/ramjet, designed for speeds between M0 and M2.2
RJ43: Small US ramjet, used for the CIM-10 Bomarc, X-7, AQM-60, and D-21, designed for speeds between M2 and M3
RJ47: Large US ramjet, used for SM-64 Navaho, designed for speeds of M2.75
RJ55/J67: Large US combined cycle turbojet/ramjet, designed for speeds between M0 and M3
RJ59: Small US ramjet, tested on X-7, designed for speeds between M3 and M4
RD-012: Large Soviet ramjet, used on La-350 Burya, designed for speeds of M3

it also creates a new spike inlet size, the 0.7m spike inlet, because the smaller ramjets (RJ43) are extremely sensitive to drag and need very closely matched intake sizes to maintain speed.

Although there are balance concerns around this, the higher-performance ramjets don't unlock until the late 50s/early 60s, which combined with the general difficulties of using ramjets, should keep things constrained.

resolves https://github.com/KSP-RO/RealismOverhaul/issues/2499 I guess