### PR TITLE
Configure FFT fission engines

### DIFF
--- a/GameData/RealismOverhaul/RO_Materials.cfg
+++ b/GameData/RealismOverhaul/RO_Materials.cfg
@@ -176,6 +176,17 @@
 	%skinInternalConductionMult = 2.44	//no idea what units this is in. Use Duraluminum (164 W/m-K) as reference
 	%skinSkinConductionMult = 2.44
 }
+//AZ-93 over aluminum (Heat-repellent coating, high emissivity in longwave IR, low emissivity in visual light)
+@PART:HAS[#skinTempTag[AZ93]]:FOR[RealismOverhaul_Materials]
+{
+	%skinMaxTemp = 588	//~50% strength
+	%emissiveConstant = 0.98	//Assuming we reject heat at ~300-400 K
+	%absorptiveConstant = 0.25	//Assuming we mostly absorb heat at ~5700K (sun)
+	//%skinMassPerArea = 1.0
+	%skinThermalMassModifier = 1.1375	//multiplier, 0.80 kJ/kg-K as basis
+	%skinInternalConductionMult = 1.0	//no idea what units this is in. Use Duraluminum (164 W/m-K) as reference
+	%skinSkinConductionMult = 1.0
+}
 
 //	=================================================================================
 //	Apply physics properties for internal materials
@@ -284,12 +295,16 @@
 }
 
 //	=================================================================================
-//	Override emissivity (if applicable)
+//	Override emissivity/absorptivity (if applicable)
 //	=================================================================================
 //	Allow overriding default material emissivity if it's painted
 @PART:HAS[#paintEmissivityTag]:AFTER[RealismOverhaul_Materials]
 {
 	@emissiveConstant = #$paintEmissivityTag$
+}
+@PART:HAS[#paintAbsorptivityTag]:AFTER[RealismOverhaul_Materials]
+{
+	@absorptiveConstant = #$paintAbsorptivityTag$
 }
 
 //	=================================================================================

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FarFutureTechnologies/FFT_RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FarFutureTechnologies/FFT_RO.cfg
@@ -238,14 +238,14 @@
 		systemPower = 40
 
 		// Nominal system output temperature
-		systemOutletTemperature = 120
-		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		systemOutletTemperature = 140
+		shutdownTemperature = 150		//Superconductors really don't like getting hot
 		// Valid system temperature range
 		temperatureCurve
 		{
 			key = 0 1.0
-			key = 120 1.0
-			key = 130 0.0
+			key = 140 1.0
+			key = 150 0.0
 		}
 	}
 	MODULE
@@ -260,14 +260,14 @@
 		systemPower = 40
 
 		// Nominal system output temperature
-		systemOutletTemperature = 120
-		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		systemOutletTemperature = 140
+		shutdownTemperature = 150		//Superconductors really don't like getting hot
 		// Valid system temperature range
 		temperatureCurve
 		{
 			key = 0 1.0
-			key = 120 1.0
-			key = 130 0.0
+			key = 140 1.0
+			key = 150 0.0
 		}
 	}
 	
@@ -314,48 +314,15 @@
 	@MODULE[ModuleSystemHeatEngine]
 	{
 		@systemPower = 2576		//2576 kW waste heat
-		@systemOutletTemperature = 373		//The paper doesn't seem to state what the outlet temperature is, but based on the considerable radiator mass and the fact the waste heat is all from cryocoolers and high-voltage electronics, it's probably not very high-grade heat
-		%shutdownTemperature = 423		//Capacitors don't like getting hot
+		@systemOutletTemperature = 423		//The paper doesn't seem to state what the outlet temperature is, but based on the considerable radiator mass and the fact the waste heat is all from cryocoolers and high-voltage electronics, it's probably not very high-grade heat
+		%shutdownTemperature = 473		//Capacitors don't like getting hot
 		
 		//I don't think this actually does anything
 		@temperatureCurve
 		{
 			@key,0 = 0, 1.0
-			@key,1 = 373, 1.0
-			@key,2 = 423, 0.0
-		}
-	}
-
-	//Add another loop for the magnozzle cooling system
-	//Stolen from 2011 Werka FFRE paper
-	MODULE
-	{
-		name = ModuleSystemHeat
-		// Cubic metres
-		volume = 5.0
-		moduleID = magnozzle
-		iconName = Icon_Gears
-	}
-	MODULE
-	{
-		name = ModuleSystemHeatEngine
-		// must be unique
-		moduleID = magnozzle
-		// ModuleSystemHeat to link to
-		systemHeatModuleID = magnozzle
-		engineModuleID = FissionPulse
-		// in KW at peak output
-		systemPower = 50
-
-		// Nominal system output temperature
-		systemOutletTemperature = 120
-		shutdownTemperature = 130		//Superconductors really don't like getting hot
-		// Valid system temperature range
-		temperatureCurve
-		{
-			key = 0 1.0
-			key = 120 1.0
-			key = 130 0.0
+			@key,1 = 423, 1.0
+			@key,2 = 473, 0.0
 		}
 	}
 	
@@ -422,11 +389,6 @@
 	}
 	
 	//everything else should be the same?
-	//Nozzle is bigger so make that have more waste heat I guess
-	@MODULE[ModuleSystemHeatEngine]:HAS[#moduleID[magnozzle]]
-	{
-		@systemPower = 100
-	}
 	
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -526,14 +488,14 @@
 		systemPower = 50
 
 		// Nominal system output temperature
-		systemOutletTemperature = 120
-		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		systemOutletTemperature = 140
+		shutdownTemperature = 150		//Superconductors really don't like getting hot
 		// Valid system temperature range
 		temperatureCurve
 		{
 			key = 0 1.0
-			key = 120 1.0
-			key = 130 0.0
+			key = 140 1.0
+			key = 150 0.0
 		}
 	}
 	@MODULE[ModuleWaterfallFX]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/FarFutureTechnologies/FFT_RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FarFutureTechnologies/FFT_RO.cfg
@@ -1,0 +1,546 @@
+//Fission particles are just straight Americium
+//~$1500/gram 2008, $219.5/gram 1965, 0.2195 funds/gram
+//Density 1.44
+//316 funds/liter?
+@RESOURCE_DEFINITION[FissionParticles]
+{
+	@unitCost = 316
+}
+//Cm-245 ~$2000/gram 2000, $365/gram 1965, 0.365 funds/gram
+//Density 1.0
+//pulse unit ~2 kg, of which 42.8g is Cm-245
+//~7.8 funds per liter, round up to 10 to account for transmission lines and magnets and stuff
+@RESOURCE_DEFINITION[FissionPellets]
+{
+	@unitCost = 10
+}
+//We're assuming weapons grade plutonium, enriched U-235 is expensive
+//~$5240/gram 2007, $796/gram 1965, 0.796 funds/gram
+//Density 1.05
+//~2% fissiles in water (water free), ~16 funds/liter
+@RESOURCE_DEFINITION[NuclearSaltWater]
+{
+	@unitCost = 16
+}
+
+//	=================================================================================
+//Fission fragment rocket
+//Source: https://www.projectrho.com/public_html/rocket/enginelist2.php
+//Although fft-ffre-solid-1 is clearly meant to be a Chapline solid platter engine, this design doesn't
+//really work. 1 km/s tip velocity required for platters is a little absurd without huge platters.
+//We're just gonna pretend this is a dusty plasma core...
+//Use NSWR model because it looks closer to the dusty plasma core
++PART[fft-nswr-2]:FOR[RealismOverhaul]
+{
+	@name = RO-fftdustyplasmaffre
+	%RSSROConfig = True
+	
+	@title = Dusty Plasma Fission Fragment Rocket Engine
+	@description = It's bad, folks
+	
+	//There's still some serious unresolved issues with FFREs...
+	%specLevel = speculative	//operational, prototype, concept, speculative, altHist, sciFi
+	
+	@rescaleFactor = 1.14	//~5.7 meters diameter
+	@mass = 113.4
+	
+	@MODULE[ModuleEngines*]
+	{
+		@minThrust = 0.0043		//idk, 10% min thrust
+		@maxThrust = 0.043
+		@engineID = FissionFragment
+		!PROPELLANT[NuclearSaltWater] {}
+		!PROPELLANT[ElectricCharge] {}
+		PROPELLANT
+		{
+			name = FissionParticles
+			ratio = 1.0
+			resourceFlowMode = STAGE_PRIORITY_FLOW
+			DrawGauge = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 527000
+			@key,1 = 1 1
+			@key,2 = 4 1
+			@key,3 = 12 1
+		}
+	}
+	//300 kWe MHD generator?
+	MODULE
+	{
+		name = ModuleAlternator
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 300
+		}
+	}
+	
+	//increase this since we are dealing with some serious heat...
+	@MODULE[ModuleSystemHeat]
+	{
+		@volume = 1000
+	}
+	//Combine high temp and medium temp cooling loops
+	//Medium temp cooling loop mass/power negligible...
+	@MODULE[ModuleSystemHeatEngine]
+	{
+		@engineModuleID = FissionFragment
+		@systemPower = 705000		//699 MW High temp loop + 6 MW meduim temp loop
+		@systemOutletTemperature = 1350
+		%shutdownTemperature = 1500
+		
+		//I don't think this actually does anything
+		@temperatureCurve
+		{
+			@key,0 = 0, 1.0
+			@key,1 = 1350, 1.0
+			@key,2 = 2000, 0.0
+		}
+	}
+	//Add another loop for the magnozzle cooling system
+	MODULE
+	{
+		name = ModuleSystemHeat
+		// Cubic metres
+		volume = 5.0
+		moduleID = magnozzle
+		iconName = Icon_Gears
+	}
+	MODULE
+	{
+		name = ModuleSystemHeatEngine
+		// must be unique
+		moduleID = magnozzle
+		// ModuleSystemHeat to link to
+		systemHeatModuleID = magnozzle
+		engineModuleID = FissionFragment
+		// in KW at peak output
+		systemPower = 50
+
+		// Nominal system output temperature
+		systemOutletTemperature = 120
+		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		// Valid system temperature range
+		temperatureCurve
+		{
+			key = 0 1.0
+			key = 120 1.0
+			key = 130 0.0
+		}
+	}
+	
+	@MODULE[ModuleWaterfallFX]
+	{
+		@engineID = FissionFragment
+		@TEMPLATE,*
+		{
+			@templateName = fft-ffre-rxn-1
+			@position = 0,0,-6
+			@scale = 1.0, 1.0, 4.56
+		}
+	}
+}
+//afterburning fission fragment rocket
+@PART[fft-ffre-plasma-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	@title = Dusty Plasma Afterburning Fission Fragment Rocket Engine
+	@rescaleFactor = 2.125	//~8.5 meters diameter
+	@mass = 268.961		//107000 kg dry, 268961 kg wet with moderator. I don't want to figure out how to make that work, so it's just wet mass for now
+	
+	//There's still some serious unresolved issues with FFREs...
+	%specLevel = speculative	//operational, prototype, concept, speculative, altHist, sciFi
+	
+	@MODULE[ModuleEngines*]:HAS[#engineID[FissionFragment]]
+	{
+		@minThrust = 0.0043		//idk, 10% min thrust
+		@maxThrust = 0.043
+		@atmosphereCurve
+		{
+			@key,0 = 0 527000
+		}
+	}
+	@MODULE[ModuleEngines*]:HAS[#engineID[Afterburning]]
+	{
+		@minThrust = 0.4651		//idk, 10% min thrust
+		@maxThrust = 4.651
+		@atmosphereCurve
+		{
+			@key,0 = 0 32000
+		}
+	}
+	//500 kWe Brayton generator?
+	MODULE
+	{
+		name = ModuleAlternator
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 500
+		}
+	}
+	//The entire engine is filled with transformer oil I guess?
+	@MODULE[ModuleSystemHeat]
+	{
+		@volume = 50000
+	}
+	//Combine high temp and medium temp cooling loops
+	//Medium temp cooling loop mass/power negligible...
+	@MODULE[ModuleSystemHeatEngine]:HAS[#engineModuleID[FissionFragment]]
+	{
+		@systemPower = 450000		//302 MW High temp loop + 147 MW meduim temp loop
+		@systemOutletTemperature = 1200
+		%shutdownTemperature = 1400
+		
+		//I don't think this actually does anything
+		@temperatureCurve
+		{
+			@key,0 = 0, 1.0
+			@key,1 = 1200, 1.0
+			@key,2 = 2000, 0.0
+		}
+	}
+	@MODULE[ModuleSystemHeatEngine]:HAS[#engineModuleID[Afterburning]]
+	{
+		@systemPower = 450000		//302 MW High temp loop + 147 MW meduim temp loop
+		@systemOutletTemperature = 1200
+		%shutdownTemperature = 1400
+		
+		//I don't think this actually does anything
+		@temperatureCurve
+		{
+			@key,0 = 0, 1.0
+			@key,1 = 1200, 1.0
+			@key,2 = 2000, 0.0
+		}
+	}
+	//Add another loop for the magnozzle cooling system
+	MODULE
+	{
+		name = ModuleSystemHeat
+		// Cubic metres
+		volume = 5.0
+		moduleID = magnozzle
+		iconName = Icon_Gears
+	}
+	MODULE
+	{
+		name = ModuleSystemHeatEngine
+		// must be unique
+		moduleID = magnozzle
+		// ModuleSystemHeat to link to
+		systemHeatModuleID = magnozzle
+		engineModuleID = FissionFragment
+		// in KW at peak output
+		systemPower = 40
+
+		// Nominal system output temperature
+		systemOutletTemperature = 120
+		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		// Valid system temperature range
+		temperatureCurve
+		{
+			key = 0 1.0
+			key = 120 1.0
+			key = 130 0.0
+		}
+	}
+	MODULE
+	{
+		name = ModuleSystemHeatEngine
+		// must be unique
+		moduleID = magnozzle2
+		// ModuleSystemHeat to link to
+		systemHeatModuleID = magnozzle
+		engineModuleID = Afterburning
+		// in KW at peak output
+		systemPower = 40
+
+		// Nominal system output temperature
+		systemOutletTemperature = 120
+		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		// Valid system temperature range
+		temperatureCurve
+		{
+			key = 0 1.0
+			key = 120 1.0
+			key = 130 0.0
+		}
+	}
+	
+	@MODULE[ModuleWaterfallFX]:HAS[#moduleID[ffreEffect]]
+	{
+		@TEMPLATE,*
+		{
+			@scale = 0.2125, 0.31875, 17
+		}
+	}
+	@MODULE[ModuleWaterfallFX]:HAS[#moduleID[ffreABEffect]]
+	{
+		@TEMPLATE,*
+		{
+			@scale = 2.125, 2.125, 2.125
+		}
+	}
+}
+
+//	=================================================================================
+//Mini-Mag Orion
+//Source: https://web.archive.org/web/20110727150819/http://ralph.open-aerospace.org/PDF/2003.01.23%20-%20MMO%20Final%20Report%20Summary.pdf
+//10 meter(?) Crewed Mars Mission design, 120 GJ pulse unit
+@PART[fft-fission-zpinch-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	@rescaleFactor = 2.0	//~10 meters diameter?
+	@title = 10 m "Mini-Mag" Orion
+	%skinTempTag = Steel
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	//Orion is well understood, Z-machine should achieve desired performance...
+	%specLevel = concept	//operational, prototype, concept, speculative, altHist, sciFi
+	
+	@mass = 110.010	//7115 kg pulsed power system + 102895 kg mag-nozzle
+					//Steady state power and radiators left as excercise to user
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 642
+		@minThrust = 64.2
+	}
+	@MODULE[ModuleSystemHeatEngine]
+	{
+		@systemPower = 2576		//2576 kW waste heat
+		@systemOutletTemperature = 373		//The paper doesn't seem to state what the outlet temperature is, but based on the considerable radiator mass and the fact the waste heat is all from cryocoolers and high-voltage electronics, it's probably not very high-grade heat
+		%shutdownTemperature = 423		//Capacitors don't like getting hot
+		
+		//I don't think this actually does anything
+		@temperatureCurve
+		{
+			@key,0 = 0, 1.0
+			@key,1 = 373, 1.0
+			@key,2 = 423, 0.0
+		}
+	}
+
+	//Add another loop for the magnozzle cooling system
+	//Stolen from 2011 Werka FFRE paper
+	MODULE
+	{
+		name = ModuleSystemHeat
+		// Cubic metres
+		volume = 5.0
+		moduleID = magnozzle
+		iconName = Icon_Gears
+	}
+	MODULE
+	{
+		name = ModuleSystemHeatEngine
+		// must be unique
+		moduleID = magnozzle
+		// ModuleSystemHeat to link to
+		systemHeatModuleID = magnozzle
+		engineModuleID = FissionPulse
+		// in KW at peak output
+		systemPower = 50
+
+		// Nominal system output temperature
+		systemOutletTemperature = 120
+		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		// Valid system temperature range
+		temperatureCurve
+		{
+			key = 0 1.0
+			key = 120 1.0
+			key = 130 0.0
+		}
+	}
+	
+	@MODULE[ModuleChargeableEngine]
+	{
+		@ChargeGoal = 192000	//192 MJ charge
+		//We're just gonna assume the magnozzle is already charged I guess
+	}
+	
+	@MODULE[ModulePulseEngineAnimator]
+	{
+		//Speed up animation from 4 seconds to 1 for 1 Hz pulse rate
+		@PulseSpeed
+		{
+			@key,0 = 0 0.24
+			@key,1 = 1 0.24
+		}
+	}
+	
+	@MODULE[ModuleWaterfallFX]
+	{
+		@EFFECT[glow]
+		{
+			@MODEL
+			{
+				@scaleOffset = 2, 2, 2
+			}
+		}
+		@EFFECT[flare]
+		{
+			@MODEL
+			{
+				@scaleOffset = 2, 2, 2
+			}
+		}
+	}
+}
+
+//Full size 20 meter design, 340 GJ pulse unit
++PART[fft-fission-zpinch-1]:FOR[RealismOverhaul]
+{
+	@name = RO-fft20mMMO
+	%RSSROConfig = True
+	
+	@rescaleFactor = 4.0	//~20 meters diameter?
+	@title = 20 m "Mini-Mag" Orion
+	
+	//Orion is well understood, Z-machine should achieve desired performance...
+	%specLevel = concept	//operational, prototype, concept, speculative, altHist, sciFi
+	
+	//pulsed power system same mass? Larger pellets are easier to ignite
+	//according to table I, power requirement decreases as pellet size increases
+	@mass = 206.715	//7115 kg pulsed power system + 199600 kg mag-nozzle
+					//Steady state power and radiators left as excercise to user
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 1870
+		@minThrust = 187
+		@atmosphereCurve
+		{
+			@key,0 = 0 16000
+			@key,1 = 1 100
+		}
+	}
+	
+	//everything else should be the same?
+	//Nozzle is bigger so make that have more waste heat I guess
+	@MODULE[ModuleSystemHeatEngine]:HAS[#moduleID[magnozzle]]
+	{
+		@systemPower = 100
+	}
+	
+	@MODULE[ModuleWaterfallFX]
+	{
+		@EFFECT[glow]
+		{
+			@MODEL
+			{
+				@scaleOffset = 2, 2, 2
+			}
+		}
+		@EFFECT[flare]
+		{
+			@MODEL
+			{
+				@scaleOffset = 2, 2, 2
+			}
+		}
+	}
+}
+
+@PART[fft-fueltank-targets-5-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	@rescaleFactor = 2.0	//~10 meters diameter?
+	%skinTempTag = Steel
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	//481625 kg propellant over ~4 tanks?
+	@RESOURCE[FissionPellets]
+	{
+		@amount = 120406
+		@maxAmount = 120406
+	}
+}
+
+//	=================================================================================
+//NSWR
+//source: https://www.projectrho.com/public_html/rocket/enginelist2.php
+//We're not even going to configure the low-enriched model, it wouldn't work (source Gerrit Bruhaug)
+@PART[fft-nswr-2]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	@title = 20 m Nuclear Salt Water Rocket
+	@mass = 495.467
+	@rescaleFactor = 4.0	//~20 meters diameter?
+	%skinTempTag = Inconel
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
+	
+	//Assuming we use high-enriched fuel, and build it big, NSWR should work...
+	%specLevel = concept	//operational, prototype, concept, speculative, altHist, sciFi
+	
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 8696.9
+		@minThrust = 869.69
+		
+		!PROPELLANT[ElectricCharge] {}	//it should be easy enough to power this with MHD tap-off
+		@atmosphereCurve
+		{
+			@key,0 = 0 8000
+			@key,1 = 1 6000
+		}
+	}
+	
+	@MODULE[ModuleSystemHeat]
+	{
+		@volume = 50
+	}
+	@MODULE[ModuleSystemHeatEngine]
+	{
+		@systemPower = 536000	//600 MW - 64 MW from integral radiators?
+		shutdownTemperature = 2500
+	}
+	//Add another loop for the magnozzle cooling system
+	//Stolen from 2011 Werka FFRE paper
+	MODULE
+	{
+		name = ModuleSystemHeat
+		// Cubic metres
+		volume = 5.0
+		moduleID = magnozzle
+		iconName = Icon_Gears
+	}
+	MODULE
+	{
+		name = ModuleSystemHeatEngine
+		// must be unique
+		moduleID = magnozzle
+		// ModuleSystemHeat to link to
+		systemHeatModuleID = magnozzle
+		engineModuleID = FissionPulse
+		// in KW at peak output
+		systemPower = 50
+
+		// Nominal system output temperature
+		systemOutletTemperature = 120
+		shutdownTemperature = 130		//Superconductors really don't like getting hot
+		// Valid system temperature range
+		temperatureCurve
+		{
+			key = 0 1.0
+			key = 120 1.0
+			key = 130 0.0
+		}
+	}
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE,*
+		{
+			@scale = 8.0, 8.0, 16.0
+		}
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Orion/StockishOrionDrive.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Orion/StockishOrionDrive.cfg
@@ -4,7 +4,7 @@
 @RESOURCE_DEFINITION[VYPulseUnit]
 {
 	@density = 0.079
-	@unitCost = 40
+	@unitCost = 100
 }
 //	============================================================================
 //	Propulsion Module Config

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -923,9 +923,8 @@
     %breakingTorque = 250
 
     //Aluminum with high emissivity coating
-    %skinTempTag = Aluminum
+    %skinTempTag = AZ93
     %internalTempTag = Aluminum
-    %paintEmissivityTag = 0.8
 
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.25
@@ -976,9 +975,8 @@
     %breakingTorque = 250
 
     //Aluminum with high emissivity coating
-    %skinTempTag = Aluminum
+    %skinTempTag = AZ93
     %internalTempTag = Aluminum
-    %paintEmissivityTag = 0.8
 
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.25
@@ -1029,9 +1027,8 @@
     %breakingTorque = 250
 
     //Aluminum with high emissivity coating
-    %skinTempTag = Aluminum
+    %skinTempTag = AZ93
     %internalTempTag = Aluminum
-    %paintEmissivityTag = 0.8
 
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.28 // 0.2702 sets the limit to 17C, or 290K
@@ -1078,9 +1075,8 @@
     %breakingTorque = 250
 
     //Aluminum with high emissivity coating
-    %skinTempTag = Aluminum
+    %skinTempTag = AZ93
     %internalTempTag = Aluminum
-    %paintEmissivityTag = 0.8
 
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.28
@@ -1130,9 +1126,8 @@
     %breakingTorque = 250
 
     //Aluminum with high emissivity coating
-    %skinTempTag = Aluminum
+    %skinTempTag = AZ93
     %internalTempTag = Aluminum
-    %paintEmissivityTag = 0.8
 
     %fuelCrossFeed = False
     @radiatorHeadroom = 0.28 // just a test value
@@ -1181,9 +1176,8 @@
     %breakingTorque = 250
 
     //Aluminum with high emissivity coating
-    %skinTempTag = Aluminum
+    %skinTempTag = AZ93
     %internalTempTag = Aluminum
-    %paintEmissivityTag = 0.8
 
     %fuelCrossFeed = False
 	%radiatorHeadroom = 0.29 // 0.2702 sets the limit to 17C, or 290K

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SystemHeat/HeatControlHighTempRadiators.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SystemHeat/HeatControlHighTempRadiators.cfg
@@ -1,8 +1,17 @@
 // High temperature radiators - ie. 1000 K 
-
-@PART[radiator-conformal-?|radiator-universal-?|radiator-fixed-?|radiator-surface-*-1]:AFTER[SystemHeat]
+@PART[radiator-conformal-?|radiator-universal-?|radiator-fixed-?|radiator-surface-*-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%skinTempTag = Molybdenum		//I guess?
+	%internalTempTag = Inconel
+	//Assuming these have a multi-spectral coating like AZ-93, but optimized for higher temperatures
+	%paintEmissivityTag = 0.95
+	%paintAbsorptivityTag = 0.5
+}
+
+//Hit ModuleSystemHeatRadiator later because SystemHeat patches them in a dumb way
+@PART[radiator-conformal-?|radiator-universal-?|radiator-fixed-?|radiator-surface-*-1]:AFTER[SystemHeat]
+{
 	@MODULE[ModuleSystemHeatRadiator]
 	{
 		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
@@ -11,5 +20,268 @@
 		
 		//Since this radiator is passive, it can only cool things hotter than it is
 		@overcoolFactor = 1
+	}
+}
+
+//  DEPLOYABLE double-sided
+// A little heavier than existing radiators
+// 15 kg/m^2
+// ==================
+@PART[radiator-conformal-1]:AFTER[SystemHeat]
+{
+	@mass = 0.0104
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~0.696 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.06		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 0.98		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 5.01		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 15.36		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 36.31		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-conformal-2]:AFTER[SystemHeat]
+{
+	@mass = 0.023
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~1.536 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.13		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 2.16		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 11.06		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 33.89		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 80.13		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-conformal-3]:AFTER[SystemHeat]
+{
+	@mass = 0.376
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~25.08 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 2.16		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 35.31		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 180.6		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 553.4		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 1308		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+
+@PART[radiator-universal-1]:AFTER[SystemHeat]
+{
+	@mass = 0.0397
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~2.645 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.23		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 3.72		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 19.05		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 58.36		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 138		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-universal-2]:AFTER[SystemHeat]
+{
+	@mass = 0.2577
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~17.182 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 1.48		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 24.19		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 123.7		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 379.1		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 896.3		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-universal-3]:AFTER[SystemHeat]
+{
+	@mass = 0.2898
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~19.32 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 1.67		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 27.2		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 139.1		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 426.3		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 1008		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+
+//  STATIC double-sided
+// A little heavier than existing radiators
+// 5 kg/m^2
+// ==================
+@PART[radiator-fixed-1]:AFTER[SystemHeat]
+{
+	@mass = 0.0089
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~1.785 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.15		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 2.51		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 12.86		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 39.39		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 93.1		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-fixed-2]:AFTER[SystemHeat]
+{
+	@mass = 0.0014
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~0.28 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.02		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 0.39		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 2.02		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 6.18		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 14.61		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-fixed-3]:AFTER[SystemHeat]
+{
+	@mass = 0.0576
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~11.52 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.99		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 16.22		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 82.96		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 254.2		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 601		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-fixed-4]:AFTER[SystemHeat]
+{
+	@mass = 0.2015
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~40.30 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 3.47		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 56.75		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 290.2		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 889.2		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 2102		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+
+//  STATIC single-sided
+// A little heavier than existing radiators
+// 10 kg/m^2
+// ==================
+@PART[radiator-surface-125-1]:AFTER[SystemHeat]
+{
+	@mass = 0.01
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~1.0 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.09		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 1.41		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 7.20		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 22.06		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 52.2		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-surface-25-1]:AFTER[SystemHeat]
+{
+	@mass = 0.018
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~1.8 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.16		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 2.53		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 12.96		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 39.72		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 93.9		//peak emission 2.90 microns, emissivity 0.92
+		}
+	}
+}
+@PART[radiator-surface-375-1]:AFTER[SystemHeat]
+{
+	@mass = 0.027
+
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		!temperatureCurve {}
+		//Area: ~2.7 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 200 0.23		//peak emission 14.5 microns, emissivity 0.95
+			key = 400 3.80		//peak emission 7.24 microns, emissivity 0.97
+			key = 600 19.44		//peak emission 4.83 microns, emissivity 0.98
+			key = 800 59.57		//peak emission 3.62 microns, emissivity 0.95
+			key = 1000 140.9		//peak emission 2.90 microns, emissivity 0.92
+		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SystemHeat/HeatControlMicrochannelRadiators.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SystemHeat/HeatControlMicrochannelRadiators.cfg
@@ -1,10 +1,21 @@
 // Graphene microchannel radiators - ie. 1300 K 
-//  DEPLOYABLE
-// ==================
-
-@PART[radiator-microchannel-?]:AFTER[SystemHeat]
+@PART[radiator-microchannel-*]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%skinTempTag = RCC	//close enough
+	%internalTempTag = Inconel
+}
+
+//Hit ModuleSystemHeatRadiator later because SystemHeat patches them in a dumb way
+//  DEPLOYABLE double-sided
+// Near future tech? A little lighter than existing radiators
+// 9 kg/m^2
+// ==================
+
+@PART[radiator-microchannel-1]:AFTER[SystemHeat]
+{
+	@mass = 0.4977
+
 	@MODULE[ModuleSystemHeatRadiator]
 	{
 		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
@@ -13,16 +24,57 @@
 		
 		//Since this radiator is passive, it can only cool things hotter than it is
 		@overcoolFactor = 1
+		
+		!temperatureCurve {}
+		//Area: ~55.3 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 250 11.02		//peak emission 11.59 microns, emissivity 0.90
+			key = 500 180.3		//peak emission 5.80 microns, emissivity 0.92
+			key = 750 942.5		//peak emission 3.86 microns, emissivity 0.95
+			key = 1000 3073		//peak emission 2.90 microns, emissivity 0.98
+			key = 1250 8956		//peak emission 2.23 microns, emissivity 0.98
+		}
 	}
 }
 
-// STATIC
+@PART[radiator-microchannel-2]:AFTER[SystemHeat]
+{
+	@mass = 0.9385
+	
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
+		//Remove electric power drain
+		!RESOURCE {}
+		
+		//Since this radiator is passive, it can only cool things hotter than it is
+		@overcoolFactor = 1
+		
+		!temperatureCurve {}
+		//Area: ~104.28 m^2
+		temperatureCurve
+		{
+			key = 0 0
+			key = 250 20.8		//peak emission 11.59 microns, emissivity 0.90
+			key = 500 340		//peak emission 5.80 microns, emissivity 0.92
+			key = 750 1777		//peak emission 3.86 microns, emissivity 0.95
+			key = 1000 5795		//peak emission 2.90 microns, emissivity 0.98
+			key = 1250 16551		//peak emission 2.23 microns, emissivity 0.98
+		}
+	}
+}
+
+// STATIC double-sided
+// 4 kg/m^2
 // ============
 
 // Rectangular
 @PART[radiator-microchannel-fixed-1]:AFTER[SystemHeat]
 {
-	%RSSROConfig = True
+	@mass = 0.1037
+	
 	@MODULE[ModuleSystemHeatRadiator]
 	{
 		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
@@ -47,7 +99,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_double_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_double_summary
 			transform = SQUAREPANELDOUBLE
-			addedMass = 0.675
+			addedMass = 0.1037
 			MODULE
 			{
 				IDENTIFIER
@@ -56,10 +108,15 @@
 				}
 				DATA
 				{
+					//Area: ~51.84 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 4250
+						key = 250 10.34		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 169		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 884		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 2880		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 8228		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -81,10 +138,15 @@
 				}
 				DATA
 				{
+					//Area: ~25.92 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 2125
+						key = 250 5.17		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 84.5		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 442		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 1440		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 4114		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -96,7 +158,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_twothirds_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_twothirds_summary
 			transform = SQUAREPANELTWOTHIRD
-			addedMass = -0.225
+			addedMass = -0.035
 			MODULE
 			{
 				IDENTIFIER
@@ -105,10 +167,15 @@
 				}
 				DATA
 				{
+					//Area: ~17.28 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 1420
+						key = 250 3.45		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 56.33		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 294.7		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 960		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 2743		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -120,7 +187,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_half_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_half_summary
 			transform = SQUAREPANELHALF
-			addedMass = -0.3375
+			addedMass = -0.052
 			MODULE
 			{
 				IDENTIFIER
@@ -129,10 +196,15 @@
 				}
 				DATA
 				{
+					//Area: ~12.96 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 1075
+						key = 250 2.59		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 42.3		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 221		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 720		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 2057		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -144,7 +216,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_third_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_third_summary
 			transform = SQUAREPANELTHIRD
-			addedMass = -0.4455
+			addedMass = -0.069
 			MODULE
 			{
 				IDENTIFIER
@@ -153,10 +225,15 @@
 				}
 				DATA
 				{
+					//Area: ~8.64 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 710
+						key = 250 1.72		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 28.2		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 147.3		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 480		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 1371		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -167,7 +244,8 @@
 // Nonrectangular
 @PART[radiator-microchannel-fixed-2]:AFTER[SystemHeat]
 {
-	%RSSROConfig = True
+	@mass = 0.0518
+	
 	@MODULE[ModuleSystemHeatRadiator]
 	{
 		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
@@ -200,10 +278,15 @@
 				}
 				DATA
 				{
+					//Area: ~12.96 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 1075
+						key = 250 2.59		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 42.3		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 221		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 720		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 2057		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -215,7 +298,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_30_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_30_summary
 			transform = TRIPANEL30
-			addedMass = -0.11253
+			addedMass = -0.0187
 			MODULE
 			{
 				IDENTIFIER
@@ -224,10 +307,15 @@
 				}
 				DATA
 				{
+					//Area: ~8.28 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 710
+						key = 250 1.65		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 27		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 141.2		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 460		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 1314		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -239,7 +327,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_22_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_22_summary
 			transform = TRIPANEL22
-			addedMass = -0.1705
+			addedMass = -0.0273
 			MODULE
 			{
 				IDENTIFIER
@@ -248,10 +336,15 @@
 				}
 				DATA
 				{
+					//Area: ~6.12 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 540
+						key = 250 1.22		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 19.9		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 104.4		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 340		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 971		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}
@@ -263,7 +356,7 @@
 			descriptionDetail = #LOC_SystemHeat_switcher_size_15_detail
 			descriptionSummary  = #LOC_HeatControl_switcher_size_15_summary
 			transform = TRIPANEL15
-			addedMass = -0.225
+			addedMass = -0.0379
 			MODULE
 			{
 				IDENTIFIER
@@ -272,10 +365,342 @@
 				}
 				DATA
 				{
+					//Area: ~3.47 m^2
 					temperatureCurve
 					{
 						key = 0 0
-						key = 1300 350
+						key = 250 0.69		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 11.3		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 59.2		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 193		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 551		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+	}
+}
+
+// create new double-sized statics (because having a bunch of radiators seems to cause lag...)
+// 4 kg/m^2
+// ============
+
+// Rectangular
++PART[radiator-microchannel-fixed-1]:AFTER[SystemHeat]
+{
+	//name needs to start the same so other mods (Kerbalism system heat) can patch it
+	@name = radiator-microchannel-fixed-10-RO
+	@rescaleFactor *= 2
+	@title = EF-8K Microchannel Graphene Heat Radiator Panel
+	@mass *= 4
+	
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@maxEnergyTransfer *= 4
+		@convectiveArea *= 4
+		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
+		//Remove electric power drain
+		!RESOURCE {}
+		
+		//Since this radiator is passive, it can only cool things hotter than it is
+		@overcoolFactor = 1
+	}
+
+	!MODULE[ModuleB9PartSwitch] {}
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = sizeSwitch
+		switcherDescription = #LOC_HeatControl_switcher_size_title
+		SUBTYPE
+		{
+			name = Double
+			title = #LOC_HeatControl_switcher_size_double_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_double_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_double_summary
+			transform = SQUAREPANELDOUBLE
+			addedMass = 0.4148
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~207.36 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 41.36		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 676		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 3536		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 11520		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 32912		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Square
+			title = #LOC_HeatControl_switcher_size_square_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_square_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_square_summary
+			transform = SQUAREPANELFULL
+			defaultSubtypePriority = 50
+			addedMass = 0
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~103.68 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 20.68		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 338		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 1768		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 5760		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 16456		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = TwoThirds
+			title = #LOC_HeatControl_switcher_size_twothirds_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_twothirds_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_twothirds_summary
+			transform = SQUAREPANELTWOTHIRD
+			addedMass = -0.140
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~69.12 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 13.8		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 225.3		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 1179		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 3840		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 10972		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Half
+			title = #LOC_HeatControl_switcher_size_half_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_half_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_half_summary
+			transform = SQUAREPANELHALF
+			addedMass = -0.208
+			MODULE
+			{
+				IDENTIFIER
+				{
+				name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~51.84 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 10.36		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 169.2		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 884		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 2880		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 8228		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Third
+			title = #LOC_HeatControl_switcher_size_third_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_third_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_third_summary
+			transform = SQUAREPANELTHIRD
+			addedMass = -0.276
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~34.56 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 6.88		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 112.8		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 589.2		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 1920		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 5484		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+	}
+}
+
+// Nonrectangular
++PART[radiator-microchannel-fixed-2]:AFTER[SystemHeat]
+{
+	//name needs to start the same so other mods (Kerbalism system heat) can patch it
+	@name = radiator-microchannel-fixed-20-RO
+	@rescaleFactor *= 2
+	@title = EF-4K Microchannel Graphene Heat Radiator Panel
+	@mass *= 4
+	
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@maxEnergyTransfer *= 4
+		@convectiveArea *= 4
+		//This is just a passive radiator. Coolant pumping should be negligable and/or already included in the reactor/converter power
+		//Remove electric power drain
+		!RESOURCE {}
+		
+		//Since this radiator is passive, it can only cool things hotter than it is
+		@overcoolFactor = 1
+	}
+	!MODULE[ModuleB9PartSwitch] {}
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = sizeSwitch
+		switcherDescription = #LOC_HeatControl_switcher_size_title
+		SUBTYPE
+		{
+			name = 45
+			title = #LOC_HeatControl_switcher_size_45_title
+			//descriptionDetail = #LOC_SystemHeat_switcher_size_45_detail
+			//descriptionSummary  = #LOC_HeatControl_switcher_size_45_summary
+			transform = TRIPANEL
+			addedMass = 0
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~51.84 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 10.36		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 169.2		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 884		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 2880		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 8228		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = 30
+			title = #LOC_HeatControl_switcher_size_30_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_30_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_30_summary
+			transform = TRIPANEL30
+			addedMass = -0.0748
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~33.12 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 6.6		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 108		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 564.8		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 1840		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 5256		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = 22
+			title = #LOC_HeatControl_switcher_size_22_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_22_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_22_summary
+			transform = TRIPANEL22
+			addedMass = -0.1092
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~24.48 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 4.88		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 79.6		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 417.6		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 1360		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 3884		//peak emission 2.23 microns, emissivity 0.98
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = 15
+			title = #LOC_HeatControl_switcher_size_15_title
+			descriptionDetail = #LOC_SystemHeat_switcher_size_15_detail
+			descriptionSummary  = #LOC_HeatControl_switcher_size_15_summary
+			transform = TRIPANEL15
+			addedMass = -0.1516
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleSystemHeatRadiator
+				}
+				DATA
+				{
+					//Area: ~13.88 m^2
+					temperatureCurve
+					{
+						key = 0 0
+						key = 250 2.76		//peak emission 11.59 microns, emissivity 0.90
+						key = 500 45.2		//peak emission 5.80 microns, emissivity 0.92
+						key = 750 236.8		//peak emission 3.86 microns, emissivity 0.95
+						key = 1000 772		//peak emission 2.90 microns, emissivity 0.98
+						key = 1250 2204		//peak emission 2.23 microns, emissivity 0.98
 					}
 				}
 			}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SystemHeat/SquadRadiators.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SystemHeat/SquadRadiators.cfg
@@ -1,8 +1,8 @@
 // Squad radiators
-
+//Source for ISS: https://www.nasa.gov/pdf/473486main_iss_atcs_overview.pdf
 @PART[radPanel*|foldingRad*]:AFTER[SystemHeat]
 {
-	@description = Cryocooler, for keeping cryogenic propellants cool. Install HeatControl for high temperature radiators.
+//	@description = Cryocooler, for keeping cryogenic propellants cool. Install HeatControl for high temperature radiators.
 	
 	@MODULE[ModuleSystemHeatRadiator]
 	{
@@ -10,36 +10,135 @@
 	}
 }
 
+//Hit ModuleSystemHeatRadiator later because SystemHeat patches them in a dumb way
+//~3.1 kg/m^2 (fixed double-sided)
 @PART[radPanelEdge]:AFTER[SystemHeat]
 {
-	@title = Cryocooler Radiator Panel (Fin)
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@convectiveArea = 6.24
+		
+		!temperatureCurve {}
+		//Area: ~6.24 m^2
+		//Z-93 coating
+		temperatureCurve
+		{
+			key = 0 0
+			key = 100 0.034		//peak emission 28.9 microns, emissivity 0.95
+			key = 200 0.549		//peak emission 14.5 microns, emissivity 0.97
+			key = 300 2.81		//peak emission 9.46 microns, emissivity 0.98
+			key = 400 8.61		//peak emission 7.24 microns, emissivity 0.95
+			key = 500 20.3		//peak emission 5.80 microns, emissivity 0.92
+		}
+	}
 }
 
-
+//~9.6 kg/m^2 (fixed single-sided)
 @PART[radPanelSm]:AFTER[SystemHeat]
 {
-	@title = Cryocooler Radiator Panel (Short)
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@convectiveArea = 2.4
+		
+		!temperatureCurve {}
+		//Area: ~2.4 m^2
+		//Z-93 coating
+		temperatureCurve
+		{
+			key = 0 0
+			key = 100 0.013		//peak emission 28.9 microns, emissivity 0.95
+			key = 200 0.211		//peak emission 14.5 microns, emissivity 0.97
+			key = 300 1.08		//peak emission 9.46 microns, emissivity 0.98
+			key = 400 3.31		//peak emission 7.24 microns, emissivity 0.95
+			key = 500 7.81		//peak emission 5.80 microns, emissivity 0.92
+		}
+	}
 }
 
-
+//~6.2 kg/m^2 (fixed single-sided)
 @PART[radPanelLg]:AFTER[SystemHeat]
 {
-	@title = Cryocooler Radiator Panel (Long)
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@convectiveArea = 4.68
+		
+		!temperatureCurve {}
+		//Area: ~4.68 m^2
+		//Z-93 coating
+		temperatureCurve
+		{
+			key = 0 0
+			key = 100 0.026		//peak emission 28.9 microns, emissivity 0.95
+			key = 200 0.412		//peak emission 14.5 microns, emissivity 0.97
+			key = 300 2.11		//peak emission 9.46 microns, emissivity 0.98
+			key = 400 6.46		//peak emission 7.24 microns, emissivity 0.95
+			key = 500 15.3		//peak emission 5.80 microns, emissivity 0.92
+		}
+	}
 }
 
-
+//~14 kg/m^2 (tracking double-sided)
 @PART[foldingRadSmall]:AFTER[SystemHeat]
 {
-	@title = Cryocooler Retractable Radiator (Small)
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@convectiveArea = 79.36
+		
+		!temperatureCurve {}
+		//Area: ~79.36 m^2
+		//Z-93 coating
+		temperatureCurve
+		{
+			key = 0 0
+			key = 100 0.428		//peak emission 28.9 microns, emissivity 0.95
+			key = 200 6.98		//peak emission 14.5 microns, emissivity 0.97
+			key = 300 35.7		//peak emission 9.46 microns, emissivity 0.98
+			key = 400 109.4		//peak emission 7.24 microns, emissivity 0.95
+			key = 500 258.8		//peak emission 5.80 microns, emissivity 0.92
+		}
+	}
 }
 
-
+//~8.9 kg/m^2 (tracking double-sided)
 @PART[foldingRadMed]:AFTER[SystemHeat]
 {
-	@title = Cryocooler Retractable Radiator (Medium)
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@convectiveArea = 141.9
+		
+		!temperatureCurve {}
+		//Area: ~141.9 m^2
+		//Z-93 coating
+		temperatureCurve
+		{
+			key = 0 0
+			key = 100 0.766		//peak emission 28.9 microns, emissivity 0.95
+			key = 200 12.5		//peak emission 14.5 microns, emissivity 0.97
+			key = 300 63.8		//peak emission 9.46 microns, emissivity 0.98
+			key = 400 195.6		//peak emission 7.24 microns, emissivity 0.95
+			key = 500 462.7		//peak emission 5.80 microns, emissivity 0.92
+		}
+	}
 }
 
+//~9.5 kg/m^2 (tracking double-sided)
 @PART[foldingRadLarge]:AFTER[SystemHeat]
 {
-	@title = Cryocooler Retractable Radiator (Large)
+	@MODULE[ModuleSystemHeatRadiator]
+	{
+		@convectiveArea = 398
+		
+		!temperatureCurve {}
+		//Area: ~398 m^2
+		//Z-93 coating
+		temperatureCurve
+		{
+			key = 0 0
+			key = 100 2.15		//peak emission 28.9 microns, emissivity 0.95
+			key = 200 35.0		//peak emission 14.5 microns, emissivity 0.97
+			key = 300 179		//peak emission 9.46 microns, emissivity 0.98
+			key = 400 549		//peak emission 7.24 microns, emissivity 0.95
+			key = 500 1298		//peak emission 5.80 microns, emissivity 0.92
+		}
+	}
 }


### PR DESCRIPTION
Configure FFT fission engines, including
-Dusty Plasma Fission Fragment Rocket Engine
-Dusty Plasma Afterburning Fission Fragment Rocket Engine
-10 m "Mini-Mag" Orion
-20 m "Mini-Mag" Orion
-20 m Nuclear Salt Water Rocket

Also configure radiators for more realistic properties, and change System Heat so it obeys the Stefan-Boltzmann law.