### PR TITLE
Configure new default shapes for B9 wings and control surfaces

### DIFF
--- a/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralWing.cfg
+++ b/GameData/RealismOverhaul/RO_RecommendedMods/Procedurals/RO_ProceduralWing.cfg
@@ -1,3 +1,19 @@
+@ProceduralWingDefaults:FOR[RealismOverhaul]
+{
+	@baseLength = 0.85, 0.85, 0.85, 0.85
+	@baseWidthRoot = 1.15, 0.085, 0, 0
+	@baseWidthTip = 0.15, 0.085, 0, 0
+	@baseOffsetRoot = 0, 0, 0, 0
+	@baseOffsetTip = 0.5, 0, 0, 0
+	@baseThicknessRoot = 0.075, 0.075, 0, 0
+	@baseThicknessTip = 0.075, 0.075, 0, 0
+	@edgeTypeLeading = 2, 1, 2, 1
+	@edgeWidthLeadingRoot = 0.15, 0, 0, 0
+	@edgeWidthLeadingTip = 0.15, 0, 0, 0
+	@edgeWidthTrailingRoot = 0.15, 0.235, 0, 0
+	@edgeWidthTrailingTip = 0.15, 0.235, 0, 0
+}
+
 @PART[B9_Aero_Wing_ControlSurface_SH_4mProcedural]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True


### PR DESCRIPTION
![image](https://github.com/KSP-RO/RealismOverhaul/assets/1120038/63069ebd-f986-42a5-ba46-086adfd32434)

Depends on B9 Procwings release v0.45.1.