### PR TITLE
Update Raptor description

### DIFF
--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -488,7 +488,7 @@ Localization
 		#roRangerRetroDesc = A 225 N hydrazine thruster, used on all Ranger and early Mariner spacecraft for midcourse corrections. Since reliable hydrazine catalysts had not yet been developed, the engines were only capable of two starts.
 		//		Raptor
 		#roRaptorTitle = Raptor
-		#roRaptorDesc = The Raptor is a methalox full-flow staged combustion engine designed for both Starship & the Super Heavy Launch Vehicle. The Super Heavy first stage uses 31 sea-level optimized engines, and Starship uses 3 sea-level engines and 3 vacuum engines.
+		#roRaptorDesc = The Raptor is a methalox full-flow staged combustion engine designed for both Starship & the Super Heavy Launch Vehicle. The Super Heavy first stage uses 33 sea-level optimized engines, and Starship uses 3 sea-level engines and 3 vacuum engines.
 		//		RD1
 		#roRD1Title = RD-1
 		#roRD1Desc = A four-chamber nitric acid and kerosene engine developed by Glushko during WW2. It was used in various rocket powered aircraft proposals, and tested extensively in the Pe-2RD, a Pe-2 bomber with an RD-1 installed in the fuselage, but abandoned after WW2, as jet engines proved to be more reliable for high performance aircraft.


### PR DESCRIPTION
Superheavy uses 33 engines now, 31 is the old number.

In conjunction with: https://github.com/KSP-RO/ROEngines/pull/229