### PR TITLE
Add HIAD heat shield tag

### DIFF
--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -152,6 +152,37 @@
 	//}
 }
 
+// Apply physics properties for Inflatable shield
+@PART:HAS[#heatShieldTag[Inflatable]]:FOR[RealismOverhaul_HeatShield]
+{
+	// Nextel 440 satin yarn skin over kevlar inflatable structure
+	%maxTemp = 673
+	%skinMaxTemp = 1573
+	@maxTemp:NEEDS[DeadlyReentry] = 923
+	@skinMaxTemp:NEEDS[DeadlyReentry] = 1823
+	//IRVE-3 was 281 kg total
+	//1/2" Nextel 440 satin is 0.88 kg/m^2, (two layers 1/4" used on IRVE-3). 277 kg on 10-meter HIAD
+	//1 mm kevlar is 1.15 kg/m^2, about 722 kg on 10-meter HIAD
+	%heatShieldDensity = 0.01
+	%thermalMassModifier = 1.363
+	%skinThermalMassModifier = 1.413
+	%skinMassPerArea = 10.5 // 10.5kg/m^2, so 1/2 of the mass is skin mass
+	//	Since skin conduction mults are multiplied by heatConductivity, set them relative to heatConductivity
+	%skinInternalConductionMult = 1.286
+	%skinSkinConductionMult = 1.286
+	%emissiveConstant = 0.87
+	%absorptiveConstant = 0.15
+	
+	%heatConductivity = 0.0007 // default is 0.12
+	
+	%heatShieldNoAblator = true
+
+
+	!MODULE[ModuleAblator] {}
+	!RESOURCE[Ablator] {}
+	!RESOURCE[CharredAblator] {}
+}
+
 // Apply physics properties for LEO-rated shield
 // Same as Gemini for now. Best to use Mercury or Apollo directly instead of this.
 @PART:HAS[#heatShieldTag[LEO]]:FOR[RealismOverhaul_HeatShield]

--- a/GameData/RealismOverhaul/RO_Materials.cfg
+++ b/GameData/RealismOverhaul/RO_Materials.cfg
@@ -122,12 +122,24 @@
 //Nomex/FRSI (Felt Reusable Surface Insulation)
 @PART:HAS[#skinTempTag[Nomex]]:FOR[RealismOverhaul_Materials]
 {
-	%skinMaxTemp = 644
+	%skinMaxTemp = 670	//reusable up to 670 K
 	%emissiveConstant = 0.2	//"Optimized for low emissivity"
 	//%skinMassPerArea = 1.0
 	%skinThermalMassModifier = 1.575	//multiplier, 0.80 kJ/kg-K as basis
 	%skinInternalConductionMult = 0.00152	//no idea what units this is in. Use Duraluminum (164 W/m-K) as reference
 	%skinSkinConductionMult = 0.00152
+}
+
+//Nextel 440
+@PART:HAS[#skinTempTag[Nextel]]:FOR[RealismOverhaul_Materials]
+{
+	%skinMaxTemp = 1573
+	%emissiveConstant = 0.87	//Assuming we reject heat at ~300-400 K
+	%absorptiveConstant = 0.15	//Assuming we mostly absorb heat at ~5700K (sun)
+	//%skinMassPerArea = 1.0
+	%skinThermalMassModifier = 1.413	//multiplier, 0.80 kJ/kg-K as basis
+	%skinInternalConductionMult = 0.0009	//no idea what units this is in. Use Duraluminum (164 W/m-K) as reference
+	%skinSkinConductionMult = 0.0009
 }
 
 //	Ceramics


### PR DESCRIPTION
Add heatshield tag for inflatable heat shields. The HIAD does not use ablator and relies on it's size to manage heat load. It is inferior to a conventional heat shield for Earth orbital returns, but is useful for suborbital returns, or reentry on planets with very thin atmosphere (Mars).