### PR TITLE
Update RO_FASA_ApolloCSM.cfg

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -176,12 +176,7 @@
 @PART[FASAApollo_CM_parachutes]:AFTER[RealismOverhaul]:NEEDS[DeadlyReentry]
 {
 	@maxTemp = 3000 // is in aero flow during re-entry somehow
-
-	MODULE
-	{
-		name = ModuleAeroReentry
-		%skinMaxTemp = 2500 // as suggested. this does not appear to be working
-	}
+	%skinMaxTemp = 3000
 }
 @PART[FASAApollo_CM]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
Implementation of skin thermals was moved from Deadly Reentry to stock maybe 9 years ago. Won't do anything to have it in ModuleAeroReentry.