### PR TITLE
Update LR91_Config.cfg

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -251,8 +251,6 @@
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-3:30
 			}
@@ -307,8 +305,6 @@
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-3:50
 			}
@@ -366,8 +362,6 @@
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5:50&LR91-AJ-3:30
 			}
@@ -423,10 +417,8 @@
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
-				
-				ignitionDynPresFailMultiplier = 0.1
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5-Kero,LR91-AJ-3:50
+    				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5-Kero,LR91-AJ-3:50
 			}
 		}
 		CONFIG
@@ -482,8 +474,6 @@
 				ignitionReliabilityEnd = 0.996250
 				cycleReliabilityStart = 0.944583
 				cycleReliabilityEnd = 0.991250
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
 			}
@@ -538,8 +528,6 @@
 				ignitionReliabilityEnd = 0.996250
 				cycleReliabilityStart = 0.944583
 				cycleReliabilityEnd = 0.991250
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-7-Kero,LR91-AJ-5-Kero,LR91-AJ-3:50
 			}
@@ -605,8 +593,6 @@
 				ignitionReliabilityEnd = 0.998649
 				cycleReliabilityStart = 0.980030
 				cycleReliabilityEnd = 0.996847
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
 			}
@@ -676,8 +662,6 @@
 				ignitionReliabilityEnd = 0.996341
 				cycleReliabilityStart = 0.976829
 				cycleReliabilityEnd = 0.996341
-				
-				ignitionDynPresFailMultiplier = 0.1
 
 				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-11,LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
 			}


### PR DESCRIPTION
Remove increased dynamic pressure penalty modifiers to ensure the LR91 can ignite without penalties on typical Titan II ascent profiles.

Fixes https://github.com/KSP-RO/RealismOverhaul/issues/2959