### PR TITLE
Add RealChuteForStock dependency

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -19,6 +19,8 @@ depends:
     suppress_recommendations: true
   - name: RealChute
     suppress_recommendations: true
+  - name: RealChuteForStock
+    suppress_recommendations: true
   - name: RealFuels
     suppress_recommendations: true
   - name: ROUtils


### PR DESCRIPTION
Version 1.4.9.2 of RealChute splits the patches for stock/restock parachutes off into a separate mod.