### PR TITLE
Added Waterfall support for jet engines J-58 and CR2 Ramjet

### DIFF
--- a/GameData/RealismOverhaul/Waterfall_Configs/AJE/aje.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/AJE/aje.cfg
@@ -1,0 +1,24 @@
+@PART[turboFanEngine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-turbojet-afterburner
+        audio = turbojet-afterburner
+        transform = thrustTransform
+        position = 0, 0, 0
+        rotation = 0, 0, 0
+        scale = 1.0, 1.0, 1.0
+    }
+}
+@PART[aje_ramjet]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-ramjet
+        audio = ramjet
+        transform = thrustTransform
+        position = 0, 0, 0
+        rotation = 0, 0, 0
+        scale = 1.0, 1.0, 1.0
+    }
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/_Audio/ramjet.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/_Audio/ramjet.cfg
@@ -1,0 +1,106 @@
+@PART[*]:HAS[@ROWaterfall:HAS[#audio[ramjet]]]:FOR[zROWaterfall_30_Audio]:NEEDS[Waterfall]
+{
+    // Same sound as without waterfall
+    @EFFECTS
+    {
+        &running_dry
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_jet_low
+                volume = 0.0 0.0
+                volume = 0.05 0.2
+                volume = 1.0 0.4
+                pitch = 0.0 0.2
+                pitch = 0.05 0.4
+                pitch = 1.0 0.5
+                loop = true
+            }
+        }
+        &power_dry
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_jet_deep
+                volume = 0.0 0.0
+                volume = 0.05 0.6
+                volume = 1.0 1.3
+                pitch = 0.0 0.3
+                pitch = 1.0 0.6
+                loop = true
+            }
+        }
+        &power_wet
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_rocket_spurts
+                volume = 0.0 0.0
+                volume = 0.1 0.4
+                volume = 1.0 1.0
+                pitch = 0.0 0.5
+                pitch = 0.33 0.8
+                pitch = 1.0 1.5
+                loop = true
+            }
+        }
+        &engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_medium
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+        &disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+        &flameout
+        {
+            PREFAB_PARTICLE
+            {
+                prefabName = fx_exhaustSparks_flameout_2
+                transformName = smokePoint
+                oneShot = true
+            }
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 1.0
+                pitch = 2.0
+                loop = false
+            }
+        }
+        &smoke
+        {
+            PREFAB_PARTICLE
+            {
+                prefabName = fx_smokeTrail_light
+                transformName = smokePoint
+                emission = 0.0 0.0
+                emission = 0.05 0.0
+                emission = 0.075 0.25
+                emission = 1.0 1.25
+                speed = 0.0 0.25
+                speed = 1.0 1.0
+                localOffset = 0, 0, 1
+                localRotation = 1, 0, 0, -90
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/_Audio/turbojet-afterburner.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/_Audio/turbojet-afterburner.cfg
@@ -1,0 +1,90 @@
+@PART[*]:HAS[@ROWaterfall:HAS[#audio[turbojet-afterburner]]]:FOR[zROWaterfall_30_Audio]:NEEDS[Waterfall]
+{
+    // Same sound as without waterfall
+	@EFFECTS
+	{
+		&running_thrust
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_spurts
+				volume = 0.0 0.0
+				volume = 0.5 1.0
+				volume = 1.0 1.5
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_smokeTrail_light
+				transformName = smokePoint
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+				localOffset = 0, 0, 1
+				localRotation = 1, 0, 0, -90
+			}
+		}
+		&running_turbine
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.02 0.0
+				volume = 0.1 0.6
+				volume = 0.2 0.8
+				volume = 0.5 0.8
+				pitch = 0.0 0.5
+				pitch = 0.2 0.8
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		&engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		&disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		&flameout
+		{
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_exhaustSparks_flameout_2
+				transformName = smokePoint
+				oneShot = true
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/_Processor/90_controllers.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/_Processor/90_controllers.cfg
@@ -6,6 +6,8 @@
     @ROWaterfall:HAS[#template[waterfall-ntr-lh2-1]] { &controllerSet = atmo-thrust }
     @ROWaterfall:HAS[#template[waterfall-rcs-jet-1]] { &controllerSet = rcs }
     @ROWaterfall:HAS[#template[rowaterfall-rcs-*]] { &controllerSet = rcs }
+    @ROWaterfall:HAS[#template[rowaterfall-turbojet*]] { &controllerSet = atmo-aje-1 }
+    @ROWaterfall:HAS[#template[rowaterfall-ramjet*]] { &controllerSet = atmo-aje-2 }
 
     // Generic fallback controller set.
     @ROWaterfall:HAS[~controllerSet] { controllerSet = atmo-thrust-basicRand }
@@ -69,6 +71,113 @@
             name = random
             linkedTo = random
             range = 0,1
+        }
+    }
+}
+ // AJE config with nozzle area from 0.6 to 1.9 (values taken from AJE's ModuleAJEJetAnimateNozzleArea for J-58)
+@PART:HAS[@ROWaterfall:HAS[#controllerSet[atmo-aje-1]]]:FOR[zROWaterfall_90_Controllers]:NEEDS[Waterfall] 
+{
+    @MODULE[ModuleWaterfallFX]:HAS[#__rowaterfall]
+    {
+        ATMOSPHEREDENSITYCONTROLLER { name = atmosphereDepth }
+        THRUSTCONTROLLER
+        {
+            engineID = basicEngine
+            name = throttle
+        }
+        RANDOMNESSCONTROLLER
+        {
+            range = 0,1
+            noiseType = random
+            scale = 1
+            minimum = 0
+            speed = 1
+            name = random
+        }
+        MACHCONTROLLER { name = mach }
+        CUSTOMPULLCONTROLLER
+        {
+            engineID = Engine
+            memberName = GetABThrottle
+            minInputValue = 0
+            maxInputValue = 1
+            responseRateUp = 100
+            responseRateDown = 100
+            name = afterburnerThrottle
+        }
+        CUSTOMPULLCONTROLLER
+        {
+            engineID = Engine
+            memberName = GetCoreThrottle
+            minInputValue = 0
+            maxInputValue = 1
+            responseRateUp = 100
+            responseRateDown = 100
+            name = coreThrottle
+        }
+        CUSTOMPULLCONTROLLER
+        {
+            engineID = Engine
+            memberName = GetNozzleArea
+            minInputValue = 0.6
+            maxInputValue = 1.9
+            responseRateUp = 100
+            responseRateDown = 100
+            name = nozzleArea
+        }
+    }
+}
+
+// AJE config with nozzle area from 0.4 to 0.7 (ModuleAJEJetAnimateNozzleArea has values 0.25..1.25 but actual range in-game for me seemed like 0.4..0.7 for some reason)
+@PART:HAS[@ROWaterfall:HAS[#controllerSet[atmo-aje-2]]]:FOR[zROWaterfall_90_Controllers]:NEEDS[Waterfall] 
+{
+    @MODULE[ModuleWaterfallFX]:HAS[#__rowaterfall]
+    {
+        ATMOSPHEREDENSITYCONTROLLER { name = atmosphereDepth }
+        THRUSTCONTROLLER
+        {
+            engineID = basicEngine
+            name = throttle
+        }
+        RANDOMNESSCONTROLLER
+        {
+            range = 0,1
+            noiseType = random
+            scale = 1
+            minimum = 0
+            speed = 1
+            name = random
+        }
+        MACHCONTROLLER { name = mach }
+        CUSTOMPULLCONTROLLER
+        {
+            engineID = Engine
+            memberName = GetABThrottle
+            minInputValue = 0
+            maxInputValue = 1
+            responseRateUp = 100
+            responseRateDown = 100
+            name = afterburnerThrottle
+        }
+        CUSTOMPULLCONTROLLER
+        {
+            engineID = Engine
+            memberName = GetCoreThrottle
+            minInputValue = 0
+            maxInputValue = 1
+            responseRateUp = 100
+            responseRateDown = 100
+            name = coreThrottle
+        }
+        CUSTOMPULLCONTROLLER
+        {
+            engineID = Engine
+            memberName = GetNozzleArea
+            minInputValue = 0.4
+            maxInputValue = 0.7
+            responseRateUp = 100
+            responseRateDown = 100
+            name = nozzleArea
         }
     }
 }

--- a/GameData/RealismOverhaul/Waterfall_Configs/_Templates/rowaterfall-ramjet.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/_Templates/rowaterfall-ramjet.cfg
@@ -1,0 +1,3840 @@
+EFFECTTEMPLATE
+{
+	templateName = rowaterfall-ramjet
+	EFFECT
+	{
+		name = refraction
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.449999988
+			rotationOffset = -90,0,0
+			scaleOffset = 0.600000024,25,0.600000024
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Distortion (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _DistortionTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _Highlight
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 10
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = -3
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.229222342
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Strength
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Swirl
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.800000012
+				}
+				FLOAT
+				{
+					floatName = _Blur
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.78 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.6 0 0
+				key = 1 1.3 0 0
+			}
+			zCurve
+			{
+				key = 0 0.78 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.33
+				key = 3 2 0.33 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TileY
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTileY
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 8 0 4
+				key = 1 12 4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tStrength
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 3
+				key = 0.1 0.15 0.4 0.4
+				key = 1 0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aStrength
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0.5
+				key = 0.7 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = plume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.200000003
+			rotationOffset = -90,0,0
+			scaleOffset = 0.25,11,0.25
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.697040319,0.360429794,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.335799754,0.393269867,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.0255777389
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.00666572154
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.712125182
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.047369
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.29999995
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 160
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1.5
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 25
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.805554867
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.0199999996
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.2
+				key = 3 1.6 0.2 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.01 0 0 10
+				key = 0.1 0.55 1 0.6
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 -9
+				key = 1 1.3 -9 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.1 0 0 10
+				key = 0.4 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _FadeOut
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFadeout
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 1 0 -0.6
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aFalloff
+			combinationType = ADD
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.8 0 -3 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.5
+				key = 3 0.5 -0.4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Noise
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tNoise
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.5 0 2
+				key = 1 4 2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = edgePlume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.150000006
+			rotationOffset = -90,0,0
+			scaleOffset = 0.25999999,11,0.25999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.762720346,0.52463001,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.32758972,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.0205221903
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.5
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.764611185
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.29999995
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.5474968
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.150000006
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.173611313
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.2
+				key = 3 1.6 0.2 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.01 0 0 30
+				key = 0.1 1.5 4 4
+				key = 1 3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 -8
+				key = 1 2.2 -8 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.1 0 0 10
+				key = 0.4 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _FadeOut
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFadeout
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 1 0 -0.2
+				key = 1 0.9 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aFalloff
+			combinationType = ADD
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.8 0 -3 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.5
+				key = 3 0.4 -0.4 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.300000012
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0500000007,0.5,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.15
+				key = 3 -0.5 -0.15 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,1.10000002
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0500000007,0.5,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.2
+				key = 3 -1.225 -0.2 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.05 0 0 0
+				key = 1 0.75 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.05 10 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock3
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,1.89999998
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0480000004,0.479999989,0.0480000004
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.65
+				key = 3 -1.95 -0.65 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.15 0 0 0
+				key = 1 0.6 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.15 10 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock4
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2.70000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0450000018,0.449999988,0.0450000018
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 6.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.9
+				key = 3 -2.8 -0.9 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.3 0 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.3 10 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock5
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,3.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0419999994,0.419999987,0.0419999994
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.15
+				key = 3 -3.65 -1.15 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.475 0 0 0
+				key = 1 0.4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.475 10 0 0
+				key = 1 3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock6
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,4.30000019
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0399999991,0.400000006,0.0399999991
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7.48221111
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.4
+				key = 3 -4.5 -1.4 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.55 0 0 0
+				key = 1 0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.55 10 0 0
+				key = 1 4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock7
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,5.0999999
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0399999991,0.400000006,0.0399999991
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7.48221111
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.66
+				key = 3 -5.35 -1.66 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.6 0 0 0
+				key = 1 0.2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.6 10 0 0
+				key = 1 5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock8
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,5.9000001
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0350000001,0.349999994,0.0350000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7.48221111
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -1.9
+				key = 3 -6.2 -1.9 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.65 0 0 0
+				key = 1 0.15 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.65 10 0 0
+				key = 1 6 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock9
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,6.69999981
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0350000001,0.349999994,0.0350000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7.48221111
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -2.1
+				key = 3 -7.05 -2.1 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.7 0 0 0
+				key = 1 0.1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.7 10 0 0
+				key = 1 7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock10
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,7.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0350000001,0.349999994,0.0350000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7.48221111
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -2.5
+				key = 3 -7.9 -2.5 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.75 0 0 0
+				key = 1 0.06 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.75 10 0 0
+				key = 1 7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock11
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,8.30000019
+			rotationOffset = -90,0,0
+			scaleOffset = 0.0350000001,0.349999994,0.0350000001
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.803770423,0.516420007,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.508210003,0.417899847,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 7.48221111
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.197166339
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.505555034
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.505554795
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.46916747
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.60666573
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 900
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -2.4
+				key = 3 -8.75 -2.4 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.8 0 0 0
+				key = 1 0.06 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.8 10 0 0
+				key = 1 5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 1 1 0 0
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = core
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.870000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.200000003,0.802999973,0.200000003
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.54926002,0.393269867,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.688830256,0.393269897,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.222000003
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.00300000003
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 140
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.705554783
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.5
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 10
+				key = 0.1 0.42 1 1
+				key = 1 0.92 0.5 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.09 0 0 7
+				key = 0.45 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.1 0 0 5
+				key = 1 20 20 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.7
+				key = 3 0.5 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = edgeCore
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.870000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.159999996,0.800000012,0.159999996
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.467159986,0.4014799,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.614940226,0.393269867,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.222000003
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.53383249
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.50999856
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 30
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 140
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2.9322176
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.207776681
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.5
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.701666415
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 30
+				key = 0.1 2.5 20 20
+				key = 1 17 50 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.1 0 0 5
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.1 0 0 5
+				key = 1 20 20 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.7
+				key = 3 0.4 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = exitSmoke
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.5
+			rotationOffset = 90,0,-180
+			scaleOffset = 0.200000003,20,0.200000003
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Alpha (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.219607845,0.180392161,0.156862751,1
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.282352954,0.235294119,0.200000003,0.985185206
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 3.6572206
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 3.38166213
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.443889707
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Intensity
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 60
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.200000003
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _Symmetry
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1.5 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Intensity
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tIntensity
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0.15
+				key = 1 0.05 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _SpeedY
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mSpeedY
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 40 0 20
+				key = 2 65 0 0
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Waterfall_Configs/_Templates/rowaterfall-turbojet-afterburner.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/_Templates/rowaterfall-turbojet-afterburner.cfg
@@ -1,0 +1,3692 @@
+EFFECTTEMPLATE
+{
+	templateName = rowaterfall-turbojet-afterburner
+	EFFECT
+	{
+		name = refraction
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-2
+			rotationOffset = -90,0,0
+			scaleOffset = 0.629999995,30,0.629999995
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Distortion (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _DistortionTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _Highlight
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 8.50555515
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = -3
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.266277611
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.800000012
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Strength
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Swirl
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 10
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 20
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.343777239
+				}
+				FLOAT
+				{
+					floatName = _Blur
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = coreThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.6 0 0
+				key = 1 1.3 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.2
+				key = 4 2 0.2 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TileY
+			controllerName = coreThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTileY
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 7 0 4
+				key = 1 11 4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = coreThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tStrength
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 3
+				key = 0.1 0.2 0.4 0.4
+				key = 1 0.35 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aStrength
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0.5
+				key = 0.7 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = plume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-2.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.300000012,11,0.300000012
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.655990243,0.32758975,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.335799754,0.393269867,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.25
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.396667123
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.520222187
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.26388681
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 55.5111847
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 49.2666283
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.454999298
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 1.10000002
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.77 0 0.65
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.1
+				key = 3 1.4 0.1 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 4
+				key = 0.1 0.25 0.25 0.25
+				key = 1 0.35 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 5 0 -5
+				key = 1 1 -5 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.05 0 0 10
+				key = 0.3 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aFalloff
+			combinationType = ADD
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.8 0 -3 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0.95 0 0.2
+				key = 4 1.2 0 0
+				key = 7 0.5 -0.6 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Noise
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tNoise
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 1 0 9
+				key = 1 12 9 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Noise
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aNoise
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Noise
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mNoise
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.5 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = edgePlume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.100000001
+			rotationOffset = -90,0,0
+			scaleOffset = 0.529999971,12,0.529999971
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.664200187,0.42610988,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.442529887,0.582100153,1,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.601110935
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.49111247
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.150000006
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.200000003
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.8 0 0.5
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.8 0 0.5
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.1
+				key = 4 1.5 0.1 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 10
+				key = 0.1 0.7 1 1
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 -8
+				key = 1 2.5 -8 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.05 0 0 10
+				key = 0.3 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aFalloff
+			combinationType = ADD
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.7 0 0 0
+				key = 1 2 10 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.4
+				key = 4 1.5 0 0
+				key = 7 0.8 -0.4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _ExpandBounded
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBounded
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.4 0 0
+				key = 0.7 0 -1 -1
+				key = 1 -0.4 -2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = bluePlume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.200000003
+			rotationOffset = -90,0,0
+			scaleOffset = 0.5,13,0.5
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.532840014,0.30295971,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0,0.319379747,1,1
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.247222617
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.0399999991
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 4.46733332
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.55944312
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.0583322
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 80
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.150000006
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.8 0 0.5
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 1
+				key = 1 1 0.3 0
+			}
+			zCurve
+			{
+				key = 0 0.8 0 0.5
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = newModifier
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0.1
+				key = 4 1.5 0.1 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 5
+				key = 0.1 0.3 0.5 0.5
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 7 0 -4
+				key = 1 2 -4 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.1 0 0 10
+				key = 0.4 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Falloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aFalloff
+			combinationType = ADD
+			floatCurve
+			{
+				key = 0.1 2 0 -3
+				key = 0.8 0 -3 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.8 -0.4 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 700
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.1
+				key = 4 -0.5 -0.1 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.100000001
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 705
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.2
+				key = 4 -0.9 -0.2 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.05 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock3
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0.699999988
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 710
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.25
+				key = 4 -1.3 -0.25 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.1 0 0 0
+				key = 1 0.9 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock4
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,1.29999995
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 695
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.3
+				key = 4 -1.7 -0.3 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.15 0 0 0
+				key = 1 0.75 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock5
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,1.89999998
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 690
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.4
+				key = 4 -2.1 -0.4 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 1 0.55 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock6
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 685
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.4
+				key = 4 -2.5 -0.4 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.3 0 0 0
+				key = 1 0.4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock7
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,3.0999999
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 707
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.45
+				key = 4 -2.9 -0.45 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.45 0 0 0
+				key = 1 0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock8
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,3.70000005
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 712
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.5
+				key = 4 -3.3 -0.5 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.6 0 0 0
+				key = 1 0.2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock9
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,4.30000019
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 697
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.6
+				key = 4 -3.7 -0.6 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.8 0 0 0
+				key = 1 0.1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock10
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,4.9000001
+			rotationOffset = -90,0,0
+			scaleOffset = 0.109999999,0.600000024,0.109999999
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.688830256,0.442529887,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,0.385059834,0.360429764,1
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.566221356
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 2.62888503
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -0.357776254
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.611721277
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0.101111233
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 7
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 608
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.100000001
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos
+			combinationType = REPLACE
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 0 0 -0.6
+				key = 4 -4.1 -0.6 0
+			}
+			zCurve
+			{
+			}
+		}
+		POSITIONMODIFIER
+		{
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mPos2
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 4 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.9 0 0 0
+				key = 1 0.05 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = afterburnerThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 10 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.2 0 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0.8
+				key = 4 2 0 0
+				key = 7 0.35 -0.2 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = exitSmoke
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.779999971
+			rotationOffset = 90,0,-180
+			scaleOffset = 0.300000012,40,0.300000012
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Alpha (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.237279594,0.220859602,0.220859572,1
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.220859587,0.179809526,0.155179486,1
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 6.7866683
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 3.05055523
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.699999988
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.696667135
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Intensity
+					value = 0.349999994
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 60
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = -0.200000003
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 3
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = nozzleArea
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = nozzleArea
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 0.8 -0.5 0
+			}
+			zCurve
+			{
+				key = 0 0.95 0 0.25
+				key = 1 1.2 0.25 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Intensity
+			controllerName = coreThrottle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tIntensity
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0.1
+				key = 1 0.03 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _SpeedY
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = mSpeedY
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 40 0 20
+				key = 2 65 0 0
+			}
+		}
+	}
+}


### PR DESCRIPTION
Main changes:

1. Added two new templates, `rowaterfall-turbojet-afterburner` (inspired by SR-71 photos it would seem) and `rowaterfall-ramjet` (J-404 Panther in stock KSP)

2. Templates from Stock Waterfall Effects were used as starting point (do I need to put attribution somewhere, like in `Credits.txt`?)
Throttle values usage was replaced with appropriate "core throttle" and "afterburner throttle" values from AJE, some other changes and adjustments were made to exhaust/shock diamond effects, added barely visible smoke trail effect for non-afterburner thrust

3. The main challenge was adapting plume sizes to AJE's variable nozzle area feature
Currently it is still a bit messy - I had to resort to adding two controller sets which differ only in expected range of value received from `GetNozzleArea()` since it isn't normalized by default
I have currently only implemented two engines, so can't say for sure how portable nozzle area->scale curves will turn out to be later when more configs will be added

4. The audio I simply copied over from `ModuleManager` cache from unmodified RO install, so it should be exactly as it was without waterfall

At min and max nozzle area:
![image](https://github.com/KSP-RO/RealismOverhaul/assets/10744285/7d2c492f-7e4d-4505-a92e-15b2e8b6700d)
![image](https://github.com/KSP-RO/RealismOverhaul/assets/10744285/65d43cf5-f3e3-4d87-bf44-374ca4cfddfa)

Current exhaust for comparison:
![image](https://github.com/KSP-RO/RealismOverhaul/assets/10744285/69e0ae05-e7c6-4961-bfd7-4591575c5084)

TODO:

1. Add configs for the rest of the jet engines
2. Maybe find more elegant solution to difference in how `nozzleArea` changes between different engines (if it actually will, haven't tested this thoroughly yet)