### PR TITLE
CI using CKAN

### DIFF
--- a/.github/workflows/attachReleaseArtifacts.yml
+++ b/.github/workflows/attachReleaseArtifacts.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
     
+env:
+  KSP_ROOT: /tmp/ksp
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   attach-release-artifacts:
@@ -28,14 +31,18 @@ jobs:
 
       - name: Download required assemblies
         id: download-assemblies
-        uses: KSP-RO/BuildTools/download-assemblies@master
+        uses: KSP-RO/BuildTools/download-assemblies-v2@master
         with:
           KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
+          dependency-identifiers: |
+            Harmony2
+            ROUtils
+            RealFuels
 
       - name: Update AssemblyInfo
         uses: KSP-RO/BuildTools/update-assembly-info@master
         with:
-          path: ${GITHUB_WORKSPACE}/Source/Properties/AssemblyInfo.cs
+          path: ${{ github.workspace }}/Source/Properties/AssemblyInfo.cs
           tag: ${{ github.event.release.tag_name }}
 
       - name: Build mod solution
@@ -43,28 +50,28 @@ jobs:
         env:
           TAG_STRING: ${{ github.event.release.tag_name }}
         run: |
-          msbuild /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/RealismOverhaul.sln
-          msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/KerbalPlugins.EngineGroupController.sln
-          cp -v ${GITHUB_WORKSPACE}/Source/obj/Release/RealismOverhaul.dll ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/Plugins/RealismOverhaul.dll
-          cp -v ${GITHUB_WORKSPACE}/Source/InstallChecker/obj/Release/ROInstallChecker.dll ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/Plugins/ROInstallChecker.dll
-          cp -v ${GITHUB_WORKSPACE}/Source/EngineGroupController/obj/Release/EngineGroupController.dll ${GITHUB_WORKSPACE}/GameData/EngineGroupController/Plugins/EngineGroupController.dll
-          cp -v ${GITHUB_WORKSPACE}/Source/UnityGUIFramework/obj/Release/UnityGUIFramework.dll ${GITHUB_WORKSPACE}/GameData/EngineGroupController/Plugins/UnityGUIFramework.dll
+          msbuild /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${{ github.workspace }}/Source/RealismOverhaul.sln /p:KSPRoot="${{ env.KSP_ROOT }}"
+          msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${{ github.workspace }}/Source/KerbalPlugins.EngineGroupController.sln /p:KSPRoot="${{ env.KSP_ROOT }}"
+          cp -v ${{ github.workspace }}/Source/obj/Release/RealismOverhaul.dll ${{ github.workspace }}/GameData/RealismOverhaul/Plugins/RealismOverhaul.dll
+          cp -v ${{ github.workspace }}/Source/InstallChecker/obj/Release/ROInstallChecker.dll ${{ github.workspace }}/GameData/RealismOverhaul/Plugins/ROInstallChecker.dll
+          cp -v ${{ github.workspace }}/Source/EngineGroupController/obj/Release/EngineGroupController.dll ${{ github.workspace }}/GameData/EngineGroupController/Plugins/EngineGroupController.dll
+          cp -v ${{ github.workspace }}/Source/UnityGUIFramework/obj/Release/UnityGUIFramework.dll ${{ github.workspace }}/GameData/EngineGroupController/Plugins/UnityGUIFramework.dll
 
       - name: Remove excess DLLs
         uses: KSP-RO/BuildTools/remove-excess-dlls@master
         with:
-          path: ${GITHUB_WORKSPACE}/GameData/
+          path: ${{ github.workspace }}/GameData/
 
       - name: Update version file
         uses: KSP-RO/BuildTools/update-version-file@master
         with:
           tag: ${{ github.event.release.tag_name }}
-          path: ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/RO.version
+          path: ${{ github.workspace }}/GameData/RealismOverhaul/RO.version
 
       - name: Update Readme
         uses: KSP-RO/BuildTools/update-version-in-readme@master
         with:
-          path: ${GITHUB_WORKSPACE}/README.md
+          path: ${{ github.workspace }}/README.md
           tag: ${{ github.event.release.tag_name }}
 
       - name: Update changelog file
@@ -72,7 +79,7 @@ jobs:
         with:
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}
-          path: ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/changelog.cfg
+          path: ${{ github.workspace }}/GameData/RealismOverhaul/changelog.cfg
 
       - name: Assemble release
         id: assemble-release
@@ -82,9 +89,9 @@ jobs:
           echo "Release zip: ${RELEASE_DIR}/RealismOverhaul-${{ github.event.release.tag_name }}.zip"
           mkdir -v "${RELEASE_DIR}"
           echo "::set-output name=release-dir::${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/Ships" "${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/GameData" "${RELEASE_DIR}"
-          cp -v "${GITHUB_WORKSPACE}/README.md" "${RELEASE_DIR}/README.md"
+          cp -v -R "${{ github.workspace }}/Ships" "${RELEASE_DIR}"
+          cp -v -R "${{ github.workspace }}/GameData" "${RELEASE_DIR}"
+          cp -v "${{ github.workspace }}/README.md" "${RELEASE_DIR}/README.md"
           cd ${RELEASE_DIR}
           zip -r RealismOverhaul-${{ github.event.release.tag_name }}.zip GameData Ships README.md
         
@@ -109,9 +116,9 @@ jobs:
           TAG_STRING: ${{ github.event.release.tag_name }}
         run: |
           RELEASEBRANCH=${{ env.tagged_branch }}
-          git add "${GITHUB_WORKSPACE}/GameData/RealismOverhaul/RO.version"
-          git add "${GITHUB_WORKSPACE}/README.md"
-          git add "${GITHUB_WORKSPACE}/GameData/RealismOverhaul/changelog.cfg"
+          git add "${{ github.workspace }}/GameData/RealismOverhaul/RO.version"
+          git add "${{ github.workspace }}/README.md"
+          git add "${{ github.workspace }}/GameData/RealismOverhaul/changelog.cfg"
           git commit -m "Update version to $TAG_STRING"
           git push origin $RELEASEBRANCH
           git tag $TAG_STRING $RELEASEBRANCH --force

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  KSP_ROOT: /tmp/ksp
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-secret:
@@ -37,25 +40,29 @@ jobs:
           
       - name: Download required assemblies
         id: download-assemblies
-        uses: KSP-RO/BuildTools/download-assemblies@master
+        uses: KSP-RO/BuildTools/download-assemblies-v2@master
         with:
           KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
+          dependency-identifiers: |
+            Harmony2
+            ROUtils
+            RealFuels
 
       - name: Build mod solution
         run: |
-          rm -f ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/Plugins/*.dll
-          rm -f ${GITHUB_WORKSPACE}/GameData/EngineGroupController/Plugins/*.dll
-          msbuild /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/RealismOverhaul.sln
-          msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/KerbalPlugins.EngineGroupController.sln
-          cp -v ${GITHUB_WORKSPACE}/Source/obj/Release/RealismOverhaul.dll ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/Plugins/RealismOverhaul.dll
-          cp -v ${GITHUB_WORKSPACE}/Source/InstallChecker/obj/Release/ROInstallChecker.dll ${GITHUB_WORKSPACE}/GameData/RealismOverhaul/Plugins/ROInstallChecker.dll
-          cp -v ${GITHUB_WORKSPACE}/Source/EngineGroupController/obj/Release/EngineGroupController.dll ${GITHUB_WORKSPACE}/GameData/EngineGroupController/Plugins/EngineGroupController.dll
-          cp -v ${GITHUB_WORKSPACE}/Source/UnityGUIFramework/obj/Release/UnityGUIFramework.dll ${GITHUB_WORKSPACE}/GameData/EngineGroupController/Plugins/UnityGUIFramework.dll
+          rm -f ${{ github.workspace }}/GameData/RealismOverhaul/Plugins/*.dll
+          rm -f ${{ github.workspace }}/GameData/EngineGroupController/Plugins/*.dll
+          msbuild /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${{ github.workspace }}/Source/RealismOverhaul.sln /p:KSPRoot="${{ env.KSP_ROOT }}"
+          msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${{ github.workspace }}/Source/KerbalPlugins.EngineGroupController.sln /p:KSPRoot="${{ env.KSP_ROOT }}"
+          cp -v ${{ github.workspace }}/Source/obj/Release/RealismOverhaul.dll ${{ github.workspace }}/GameData/RealismOverhaul/Plugins/RealismOverhaul.dll
+          cp -v ${{ github.workspace }}/Source/InstallChecker/obj/Release/ROInstallChecker.dll ${{ github.workspace }}/GameData/RealismOverhaul/Plugins/ROInstallChecker.dll
+          cp -v ${{ github.workspace }}/Source/EngineGroupController/obj/Release/EngineGroupController.dll ${{ github.workspace }}/GameData/EngineGroupController/Plugins/EngineGroupController.dll
+          cp -v ${{ github.workspace }}/Source/UnityGUIFramework/obj/Release/UnityGUIFramework.dll ${{ github.workspace }}/GameData/EngineGroupController/Plugins/UnityGUIFramework.dll
 
       - name: Remove excess DLLs
         uses: KSP-RO/BuildTools/remove-excess-dlls@master
         with:
-          path: ${GITHUB_WORKSPACE}/GameData/
+          path: ${{ github.workspace }}/GameData/
 
       - name: Assemble release
         id: assemble-release
@@ -64,9 +71,9 @@ jobs:
           echo "Release dir: ${RELEASE_DIR}"
           mkdir -v "${RELEASE_DIR}"
           echo "::set-output name=release-dir::${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/GameData" "${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/Ships" "${RELEASE_DIR}"
-          cp -v "${GITHUB_WORKSPACE}/README.md" "${RELEASE_DIR}"
+          cp -v -R "${{ github.workspace }}/GameData" "${RELEASE_DIR}"
+          cp -v -R "${{ github.workspace }}/Ships" "${RELEASE_DIR}"
+          cp -v "${{ github.workspace }}/README.md" "${RELEASE_DIR}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/Source/EngineGroupController/EngineGroupController.csproj
+++ b/Source/EngineGroupController/EngineGroupController.csproj
@@ -32,32 +32,52 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>d:\Games\Kerbal_1.0.4_RSS\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>d:\Games\Kerbal_1.0.4_RSS\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp-firstpass.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>d:\Games\Kerbal_1.0.4_RSS\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Core.dll">
+      <HintPath>$(ReferencePath)/System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Xml.Linq.dll">
+      <HintPath>$(ReferencePath)/System.Xml.Linq.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>d:\Games\Kerbal_1.0.4_RSS\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Data.DataSetExtensions.dll">
+      <HintPath>$(ReferencePath)/System.Data.DataSetExtensions.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Data.dll">
+      <HintPath>$(ReferencePath)/System.Data.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Xml.dll">
+      <HintPath>$(ReferencePath)/System.Xml.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.AnimationModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.AnimationModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UI.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/EngineGroupController/EngineGroupController.csproj
+++ b/Source/EngineGroupController/EngineGroupController.csproj
@@ -31,6 +31,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
       <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>

--- a/Source/InstallChecker/ROInstallChecker.csproj
+++ b/Source/InstallChecker/ROInstallChecker.csproj
@@ -33,12 +33,21 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="UnityEngine.CoreModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/RealismOverhaul.csproj
+++ b/Source/RealismOverhaul.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AdjustableCoMShifter.cs" />
     <Compile Include="DebugTools\DebugDrawer.cs" />
@@ -74,38 +78,44 @@
     <Compile Include="DynamicPartHider\PartUpgradeFiltering.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/GameData/000_Harmony/0Harmony.dll">
+      <HintPath>$(ReferencePath)/0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ROUtils">
-      <HintPath>..\..\..\..\..\..\Games\R112\GameData\ROUtils\Plugins\ROUtils.dll</HintPath>
+    <Reference Include="$(KSPRoot)/GameData/ROUtils/Plugins/ROUtils.dll">
+      <HintPath>$(ReferencePath)/ROUtils.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.PhysicsModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UI.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RealFuels">
+    <Reference Include="$(KSPRoot)/GameData/RealFuels/Plugins/RealFuels.dll">
+      <HintPath>$(ReferencePath)/RealFuels.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UIModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/UnityGUIFramework/UnityGUIFramework.csproj
+++ b/Source/UnityGUIFramework/UnityGUIFramework.csproj
@@ -30,36 +30,61 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>d:\Games\Kerbal_1.0.4_RSS\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>d:\Games\Kerbal_1.0.4_RSS\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Core.dll">
+      <HintPath>$(ReferencePath)/System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Xml.Linq.dll">
+      <HintPath>$(ReferencePath)/System.Xml.Linq.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Data.DataSetExtensions.dll">
+      <HintPath>$(ReferencePath)/System.Data.DataSetExtensions.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Data.dll">
+      <HintPath>$(ReferencePath)/System.Data.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.Xml.dll">
+      <HintPath>$(ReferencePath)/System.Xml.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.ImageConversionModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.IMGUIModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.TextRenderingModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UnityWebRequestWWWModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
This PR changes the csproj to use paths relative to `KSPRoot` and also updates the workflows for CI to use CKAN to install dependencies.
Custom dlls can still be provided by adding them to this repo: https://github.com/KSP-RO/BuildLibs

If `KSPRoot` is not set, `ReferencePath` will be used instead. With this behaviour `ReferencePath` can be set to either a folder with all references, or to a KSP install for local development
