### PR TITLE
Remove stock part tags that aren't relevant in RO context

### DIFF
--- a/Source/Harmony/BasePartCategorizer.cs
+++ b/Source/Harmony/BasePartCategorizer.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using KSP.UI.Screens;
+
+namespace RealismOverhaul.Harmony
+{
+    [HarmonyPatch(typeof(BasePartCategorizer))]
+    internal class PatchBasePartCategorizer
+    {
+        /// <summary>
+        /// Called through GameEvents.onLanguageSwitched
+        /// </summary>
+        [HarmonyPostfix]
+        [HarmonyPatch("LoadAutoTags")]
+        internal static void LoadAutoTags()
+        {
+            PartTagNuker.NukeTags();
+        }
+    }
+}

--- a/Source/PartTagNuker.cs
+++ b/Source/PartTagNuker.cs
@@ -1,0 +1,25 @@
+﻿using KSP.UI.Screens;
+using UnityEngine;
+
+namespace RealismOverhaul
+{
+    /// <summary>
+    /// Removes stock part tags that aren't relevant in RO context.
+    /// Cannot be done in a Harmony patch because the relevant code runs before plugins are initialized.
+    /// </summary>
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    internal class PartTagNuker : MonoBehaviour
+    {
+        internal void Start()
+        {
+            NukeTags();
+        }
+
+        internal static void NukeTags()
+        {
+            BasePartCategorizer.size0Tags = BasePartCategorizer.size1Tags = BasePartCategorizer.size1p5Tags =
+                BasePartCategorizer.size2Tags = BasePartCategorizer.size3Tags = BasePartCategorizer.size4Tags =
+                BasePartCategorizer.srfTags = BasePartCategorizer.radialTag = new string[0];
+        }
+    }
+}

--- a/Source/RealismOverhaul.csproj
+++ b/Source/RealismOverhaul.csproj
@@ -37,6 +37,8 @@
     <Compile Include="AdjustableCoMShifter.cs" />
     <Compile Include="DebugTools\DebugDrawer.cs" />
     <Compile Include="DebugTools\DrawTools.cs" />
+    <Compile Include="PartTagNuker.cs" />
+    <Compile Include="Harmony\BasePartCategorizer.cs" />
     <Compile Include="Harmony\ModuleEngines.cs" />
     <Compile Include="Harmony\KSPUtil.cs" />
     <Compile Include="Harmony\KSPWheel.cs" />


### PR DESCRIPTION
Ever been annoyed by term `Gemini` giving you half of the part 🐱alog? Well, no longer!