### PR TITLE
Give station parts control even without crew

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -567,9 +567,8 @@
 	}
 	
 	MODULE
- 	{ 
+	{
 		name = ModuleCommand
-		minimumCrew = 1 
 	}
 	
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_225m_Parts.cfg
@@ -34,7 +34,7 @@
 	!RESOURCE,* {}
 	
 	%MODULE[ModuleProbeControlPoint] {}
-	%MODULE[ModuleCommand] { %minimumCrew = 1 }
+	%MODULE[ModuleCommand] { !minimumCrew = DEL }
 	
 	// This is not the primary storage for resources in the station, but should be used in an emergency
 	!MODULE[ModuleFuelTanks],* {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_338m_Parts.cfg
@@ -40,7 +40,7 @@
 	%reactionWheelMode = CMG
 
 	%MODULE[ModuleProbeControlPoint] {}
-	%MODULE[ModuleCommand] { %minimumCrew = 1 }
+	%MODULE[ModuleCommand] { !minimumCrew = DEL }
 	
 	// This is not the primary storage for resources in the station, but should be used in an emergency
 	!MODULE[ModuleFuelTanks],* {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_450m_Parts.cfg
@@ -32,7 +32,7 @@
 	!RESOURCE,* {}
 	
 	%MODULE[ModuleProbeControlPoint] {}
-	%MODULE[ModuleCommand] { %minimumCrew = 1 }
+	%MODULE[ModuleCommand] { !minimumCrew = DEL }
 	
 	// This is not the primary storage for resources in the station, but should be used in an emergency
 	!MODULE[ModuleFuelTanks],* {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_675m_Parts.cfg
@@ -36,7 +36,7 @@
 	%reactionWheelMode = CMG
 	
 	%MODULE[ModuleProbeControlPoint] {}
-	%MODULE[ModuleCommand] { %minimumCrew = 1 }
+	%MODULE[ModuleCommand] { !minimumCrew = DEL }
 	
 	// This is not the primary storage for resources in the station, but should be used in an emergency
 	!MODULE[ModuleFuelTanks],* {}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/StationPartsExpansion/RO_SSPX_900m_Parts.cfg
@@ -28,7 +28,7 @@
 	%reactionWheelMode = CMG
 	
 	%MODULE[ModuleProbeControlPoint] {}
-	%MODULE[ModuleCommand] { %minimumCrew = 1 }
+	%MODULE[ModuleCommand] { !minimumCrew = DEL }
 	
 	// This is not the primary storage for resources in the station, but should be used in an emergency
 	!MODULE[ModuleFuelTanks],* {}


### PR DESCRIPTION
Previously station parts already had avionics BUT the avionics was only capable of doing anything when the vessel had crew.
![image](https://github.com/user-attachments/assets/ad5d663f-2875-448b-b8dd-211cfacb3013)
