### PR TITLE
Fix and greatly expand resistojet RCS configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/Electric_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Electric_Engine_Configs/Electric_RCS_Config.cfg
@@ -1,4 +1,21 @@
 // RCS generic config
+// sources:
+// http://www.astronautix.com/graphics/m/mr501b.jpg
+// https://arc.aiaa.org/doi/abs/10.2514/6.1985-1159
+// http://electricrocket.org/IEPC/7vc5f5xg.pdf
+// https://seitzman.gatech.edu/classes/ae6450/electrothermal_thrusters.pdf
+// https://ntrs.nasa.gov/api/citations/19920022098/downloads/19920022098.pdf
+
+// Hard data a little hard to find. Anything other than MR-501/502 seems to be one-off systems or cubesat
+// stuff designed for pulsed operation.
+// Mostly from RPA.
+// For basic cold gas propellants, heat is applied until the chamber temp reaches the target temp
+// (decomposing propellants until they reach equilibrium if necessary). RPA enthalpy change used to
+// determine power draw.
+// For hydrazine, hydrazine is decomposed, and then heated further. Using real performance data because
+// this is thermodynamically complex and the MR-501 is well-documented.
+// Chamber pressure 0.75 MPA, expansion ratio 200, mass basis set based on MR-501B
+// Config sizing set to ~1450 Watts at 1.0 scale (heating element is largest part)
 @PART[*]:HAS[#engineType[ElectricRCSGeneric]]:FOR[RealismOverhaulEngines]
 {	
 	MODULE
@@ -10,47 +27,322 @@
 		minTechLevel = 2
 		origTechLevel = 2
 		engineType = L
-		configuration = Hydrazine-Electrothermal
+		configuration = Nitrogen-1000K
 		modded = false
 		
-		origMass = 0.137
+		origMass = 0.00511	//based on MR-501B
 		
+		//nitrogen resistojet: Vela-III, 1965						lvl2
+		//Ammonia resistojet: ATS-4, 1968							lvl3
+		//Hydrazine resistojet: Intelsat-V, 1980? GE Comsats 1980	lvl4
+		//MR-501: first mass-produced resistojet, Satcom 1R, 1983
+		//Wastejet: MOL, Freedom
+		//SERT II/SEPS (Solar Electric Propulsion System) mercury ion: 1970s
+		//Hydrazine Arcjet: Telstar 4, 1993
+		//N2O resistojet: UoSAT-12, 1999
+		//Butane resistojet: UK-DMC, 2003
+		//Water resistojet: UK-DMC, 2003
 		CONFIG
 		{
-			name = Hydrazine-Electrothermal
+			name = Nitrogen-1000K
 			specLevel = operational
-			thrusterPower = 0.045
+			thrusterPower = 0.0017
 			PROPELLANT
 			{
 				ratio = 1.0
-				name = Hydrazine
+				name = Nitrogen
 				DrawGauge = True
 			}
 
 			PROPELLANT
 			{
-				name = Helium
-				ratio = 15.0
-				ignoreForIsp = True
-			}
-			
-			PROPELLANT
-			{
 				name = ElectricCharge
-				ratio = 3257
+				ratio = 1.2207		//Heating nitrogen from 273 to 1073K at 90% eff. RPA enthalpy calcs
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
 
-			IspSL = 0.30
-			IspV = 0.9006
+			IspSL = 0.0
+			IspV = 0.4065
 		}
-
 		CONFIG
 		{
-			name = Hydrazine-Arcjet
+			name = Nitrogen-2000K
 			specLevel = operational
-			thrusterPower = 0.0045
+			thrusterPower = 0.0011
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Nitrogen
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 2.8779		//Heating nitrogen from 273 to 2073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.6276
+		}
+		CONFIG
+		{
+			name = CarbonDioxide-1000K
+			specLevel = operational
+			thrusterPower = 0.0021
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = CarbonDioxide
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1.6840		//Heating co2 from 273 to 1073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.4347
+		}
+		CONFIG
+		{
+			name = CarbonDioxide-2000K
+			specLevel = operational
+			thrusterPower = 0.0011
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = CarbonDioxide
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4.7006		//Heating co2 from 273 to 2073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.6067
+		}
+		CONFIG
+		{
+			name = Hydrogen-1000K
+			specLevel = operational
+			thrusterPower = 0.0005
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Hydrogen
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1.1597		//Heating hydrogen from 273 to 1073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 1.6198
+		}
+		CONFIG
+		{
+			name = Hydrogen-2000K
+			specLevel = operational
+			thrusterPower = 0.0003
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Hydrogen
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 2.6771		//Heating hydrogen from 273 to 2073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 2.3391
+		}
+		CONFIG
+		{
+			name = Ammonia-1000K
+			specLevel = operational
+			thrusterPower = 0.0006
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = LqdAmmonia	//autogenous pressurization
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4211		//Heating ammonia from 273 to 1073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.8568
+		}
+		CONFIG
+		{
+			name = Ammonia-2000K
+			specLevel = operational
+			thrusterPower = 0.0005
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = LqdAmmonia	//autogenous pressurization
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 7256		//Heating ammonia from 273 to 2073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 1.1508
+		}
+		CONFIG
+		{
+			name = Water-1000K
+			specLevel = operational
+			thrusterPower = 0.0018
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Water
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Nitrogen
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1354		//Heating water from 273 to 1073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.5785
+		}
+		CONFIG
+		{
+			name = Water-2000K
+			specLevel = operational
+			thrusterPower = 0.0009
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = Water
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Nitrogen
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4354		//Heating water from 273 to 2073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.8881
+		}
+		CONFIG
+		{
+			name = WasteWater-1000K
+			specLevel = operational
+			thrusterPower = 0.0014
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = WasteWater
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = CarbonDioxide
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 1618		//Heating water from 273 to 1073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.5410
+		}
+		CONFIG
+		{
+			name = WasteWater-2000K
+			specLevel = operational
+			thrusterPower = 0.0008
+			PROPELLANT
+			{
+				ratio = 1.0
+				name = WasteWater
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = CarbonDioxide
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+			PROPELLANT
+			{
+				name = ElectricCharge
+				ratio = 4599		//Heating water from 273 to 2073K at 90% eff. RPA enthalpy calcs
+				DrawGauge = True
+				minResToLeave = 10.0
+			}
+
+			IspSL = 0.0
+			IspV = 0.8693
+		}
+		CONFIG
+		{
+			name = Hydrazine-2000K
+			specLevel = operational
+			thrusterPower = 0.001
 			PROPELLANT
 			{
 				ratio = 1.0
@@ -60,21 +352,21 @@
 
 			PROPELLANT
 			{
-				name = Helium
-				ratio = 15.0
+				name = Nitrogen
+				ratio = 11.25
 				ignoreForIsp = True
 			}
 			
 			PROPELLANT
 			{
 				name = ElectricCharge
-				ratio = 24559
+				ratio = 3878
 				DrawGauge = True
 				minResToLeave = 10.0
 			}
 
-			IspSL = 0.5
-			IspV = 1.76205
+			IspSL = 0.0
+			IspV = 0.9225
 		}
 	}
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ROMods/ROEngines.cfg
@@ -234,3 +234,4 @@
 @PART[ROE-Agena_EquipmentRack]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-AgenaSPS]:FOR[RealismOverhaul] { %RSSROConfig = true }
 @PART[ROE-ModularRCS]:FOR[RealismOverhaul] { %RSSROConfig = true }
+@PART[ROE-ModularResistojetRCS]:FOR[RealismOverhaul] { %RSSROConfig = true }


### PR DESCRIPTION
Improve generic resistojet RCS configs to an actually usable state. 

Add and balance various inert and monopropellant resistojet configs at two different temperature setpoints, including hydrazine, ammonia, and wastewater.