### PR TITLE
Enable physics on KF2 landing gear

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
@@ -506,6 +506,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.19
+	@PhysicsSignificance = 0
 
 	@MODULE[KSPWheelBase]
 	{
@@ -521,6 +522,7 @@
 {
 	%RSSROConfig = True
 	@mass = 0.2
+	@PhysicsSignificance = 0
 
 	@MODULE[KSPWheelBase]
 	{
@@ -536,7 +538,8 @@
 {
 	%RSSROConfig = True
 	@mass = 0.46
-	
+	@PhysicsSignificance = 0
+
 	@MODULE[KSPWheelBase]
 	{
 		%wheelMass = 0.46
@@ -551,6 +554,7 @@
 {
 	%RSSROConfig = True
 	@mass = 1.5
+	@PhysicsSignificance = 0
 
 	@MODULE[KSPWheelBase]
 	{


### PR DESCRIPTION
Since there doesn't seem to be any reason not to, disable the physicless-ness of KF2 landing gear.

resolves https://github.com/KSP-RO/RealismOverhaul/issues/2958