### PR TITLE
RL10 Updates

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -251,7 +251,7 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 106.0 kN		[16]
 //	ISP: 122 SL / 453.8 Vac		[16], SL calculated with RPA
-//	Burn Time: 1200
+//	Burn Time: 1200		Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
 //	Chamber Pressure: 4.34 MPa	[16]
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.5		[16]
@@ -265,8 +265,8 @@
 //	Dry Mass: 305 kg	[16]
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 110.1 kN		[16]
-//	ISP: 1 @0.915 atm / 465.5 Vac		[16], SL calculated with RPA
-//	Burn Time: 1130?
+//	ISP: 1 @0.915 atm / 465.6 Vac		calculated with RPA
+//	Burn Time: 1175?	set to allow full burning of 28.6 T of propellant (ICPS full fuel load)
 //	Chamber Pressure: 4.34 MPa	[16]
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.7		[16]
@@ -296,7 +296,7 @@
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 108.3 kN		[16]
 //	ISP: 45 SL / 460.1 Vac		[16], SL calculated with RPA
-//	Burn Time: 1350
+//	Burn Time: 1275?
 //	Chamber Pressure: 4.34 MPa	[16]
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.70		[16]
@@ -304,7 +304,7 @@
 //	Nozzle Ratio: 215
 //	Ignitions: 15
 //	=================================================================================
-//	RL10C-X
+//	RL10E-1 (RL10C-X)
 //	Centaur V
 //
 //	Dry Mass: 227 kg	[16]
@@ -317,7 +317,22 @@
 //	Prop Ratio: 5.5		[16]
 //	Throttle: N/A
 //	Nozzle Ratio: 230?
-//	Ignitions: 15
+//	Ignitions: 25		[16]
+//	=================================================================================
+//	RL10E-3EL (RL10CX-3EL)
+//	Commercial Passenger Transport
+//
+//	Dry Mass: 272 kg	[16]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 108.1 kN		[16]
+//	ISP: 24 SL / 470.5 Vac		[16]
+//	Burn Time: 1350, 180,000 seconds rated life
+//	Chamber Pressure: 4.34 MPa	[16]
+//	Propellant: LOX / LH2
+//	Prop Ratio: 4.7		[16]
+//	Throttle: N/A
+//	Nozzle Ratio: 285	[16]
+//	Ignitions: 260
 //	=================================================================================
 //	CECE-Base
 //	Technology demonstrator (RL10A-4-2 based?)
@@ -1165,20 +1180,20 @@
 			//Delta-4M+(5,4): 4 flights, 0 failures
 			//Delta-4M+(5,4) (upg.): 4 flights, 0 failures
 			//Delta-4H: 7 flights, 0 failures
-			//Delta-4H (upg.): 6 flights, 0 failures
-			//44 ignitions, 0 failures
-			//44 cycles, 0 failures
+			//Delta-4H (upg.): 9 flights, 0 failures
+			//47 ignitions, 0 failures
+			//47 cycles, 0 failures
 			//Assuming 2 ignitions per flight average
-			//44 restarts, 1 failures
+			//47 restarts, 1 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 3500		//According to Program Status of RL60 Engine
 				ratedBurnTime = 1130
 				safeOverburn = true
-				ignitionReliabilityStart = 0.975094
-				ignitionReliabilityEnd = 0.996067
-				cycleReliabilityStart = 0.978889
-				cycleReliabilityEnd = 0.996667
+				ignitionReliabilityStart = 0.976667
+				ignitionReliabilityEnd = 0.996316
+				cycleReliabilityStart = 0.980208
+				cycleReliabilityEnd = 0.996875
 				ignitionDynPresFailMultiplier = 0.05
 				techTransfer = RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
@@ -1217,28 +1232,32 @@
 				amount = 0.5
 			}
 
-			//Atlas-5(401): 21 flights, 0 failures
-			//Atlas-5(411): 3 flights, 0 failures
-			//Atlas-5(421): 5 flights, 0 failures
-			//Atlas-5(422): 1 flights, 0 failures
-			//Atlas-5(431): 1 flights, 0 failures
-			//Atlas-5(501): 2 flights, 0 failures
-			//Atlas-5(531): 1 flights, 0 failures
-			//Atlas-5(541): 6 flights, 0 failures
-			//Atlas-5(551): 7 flights, 0 failures
-			//48 ignitions, 0 failures
-			//48 cycles, 0 failures
+			//Counting all C-1, C-1A, and (for now) C-1-1 variants together until VC can fly more
+			//Atlas-5(401): 41 flights, 0 failures
+			//Atlas-5(411): 6 flights, 0 failures
+			//Atlas-5(421): 9 flights, 0 failures
+			//Atlas-5(431): 3 flights, 0 failures
+			//Atlas-5(501): 8 flights, 0 failures
+			//Atlas-5(511): 1 flights, 0 failures
+			//Atlas-5(521): 2 flights, 0 failures
+			//Atlas-5(531): 5 flights, 0 failures
+			//Atlas-5(541): 9 flights, 0 failures
+			//Atlas-5(551): 14 flights, 0 failures
+			//Atlas-5(N22): 3 flights, 0 failures
+			//17 launches remain
+			//101 ignitions, 0 failures
+			//101 cycles, 0 failures
 			//Assuming 2 ignitions per flight average
-			//48 restarts, 0 failed
+			//101 restarts, 0 failed
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
 				ratedBurnTime = 1130 //is modified RL10B-2
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
 				techTransfer = RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
@@ -1277,16 +1296,17 @@
 				amount = 0.5
 			}
 
-			//same as C-1
+			//Atlas V flew with C-1, C-1A, and C-1-1, unclear which flight had which
+			//same as C-1, use same data for both
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
 				ratedBurnTime = 1130 //is modified RL10B-2
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
 				techTransfer = RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
@@ -1294,7 +1314,7 @@
 		CONFIG
 		{
 			name = RL10C-1-1
-			specLevel = prototype
+			specLevel = operational
 			minThrust = 106.0
 			maxThrust = 106.0
 			heatProduction = 100
@@ -1325,17 +1345,18 @@
 				amount = 0.5
 			}
 
-			//no data, never flown
-			//using C-1 data
+			//Vulcan VC2: 1 flight, 0 failures
+			//Atlas V flew with C-1, C-1A, and C-1-1, unclear which flight had which
+			//same as C-1, use same data for both
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-				ratedBurnTime = 1200 //Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
+				ratedBurnTime = 1200		//Set to allow full burning of 54 T of propellant (Centaur V full load) with 2x engines
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
 				techTransfer = RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
@@ -1361,7 +1382,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 465.5
+				key = 0 465.6
 				key = 0.915 1
 			}
 			massMult = 1.8263
@@ -1374,19 +1395,19 @@
 				amount = 0.5
 			}
 
-			//no data, never flown
+			//SLS Block 1: 1 flight, 0 failures
 			//using C-1 data
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-				ratedBurnTime = 1130 //is modified RL10B-2
+				ratedBurnTime = 1175
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
-				techTransfer = RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+				techTransfer = RL10C-2-1,RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
 		}
 		CONFIG
@@ -1423,17 +1444,17 @@
 				%amount = 0.5
 			}
 
-			//no data, never flown
+			//This was flown at most 4 times before Delta IV was retired
 			//using C-1 data
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-				ratedBurnTime = 1130 //is modified RL10B-2
+				ratedBurnTime = 1130
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
 				techTransfer = RL10C-2,RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
@@ -1477,24 +1498,24 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
-				ratedBurnTime = 1350 //Set to allow full burning of 129 T of propellant (EUS full load) with 4x engines
+				ratedBurnTime = 1275
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
-				techTransfer = RL10C-2-1,RL10C-1-1,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+				techTransfer = RL10C-2-1,RL10C-2,RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
 		}
 		CONFIG
 		{
-			name = RL10C-X
+			name = RL10E-1
 			specLevel = prototype
 			minThrust = 107.3
 			maxThrust = 107.3
 			heatProduction = 100
-			description = Planned upgrade of RL10C-1-1 for use on Vulcan-Centaur and potentially the Exporation Upper Stage.
+			description = Extensive upgrade of the RL-10, with an additively manufactured Copper-Chrome combustion chamber and C-Sic nozzle extension.
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -1514,7 +1535,7 @@
 			massMult = 1.3593
 
 			ullage = True
-			ignitions = 15
+			ignitions = 25
 			IGNITOR_RESOURCE
 			{
 				name = ElectricCharge
@@ -1528,12 +1549,62 @@
 				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
 				ratedBurnTime = 1130
 				safeOverburn = true
-				ignitionReliabilityStart = 0.990206
-				ignitionReliabilityEnd = 0.998454
-				cycleReliabilityStart = 0.980612
-				cycleReliabilityEnd = 0.996939
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
 				ignitionDynPresFailMultiplier = 0.08
-				techTransfer = RL10C-1-1,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+				techTransfer = RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+			}
+		}
+		CONFIG
+		{
+			name = RL10E-3EL
+			specLevel = prototype
+			minThrust = 108.1
+			maxThrust = 108.1
+			heatProduction = 100
+			description = RL10E-1 modified for extremely long life to allow for 50 earth-moon trips on a commercial passenger transport vehicle.
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7741
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2259 //4.7
+			}
+			atmosphereCurve
+			{
+				key = 0 470.5
+				key = 1 24
+			}
+			massMult = 1.6287
+
+			ullage = True
+			ignitions = 260
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			//no data, never flown
+			//using C-1 data
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 180000		//50 hours life
+				ratedBurnTime = 1350		//idk, no more than 22 minute single burn? Same as C-3
+				safeOverburn = true
+				overburnPenalty = 1.1		//Nearly infinite fatigue life
+				ignitionReliabilityStart = 0.995320
+				ignitionReliabilityEnd = 0.999261
+				cycleReliabilityStart = 0.990686
+				cycleReliabilityEnd = 0.998529
+				ignitionDynPresFailMultiplier = 0.08
+				techTransfer = RL10E-1,RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
 		}
 		CONFIG

--- a/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RL10_Config.cfg
@@ -112,7 +112,7 @@
 //	RL10A-4
 //	Centaur D2A
 //
-//	Dry Mass: 143 Kg		(guess, nozzle extension weighs ~25 kg)
+//	Dry Mass: 149 kg		(guess, A-4-2 nozzle extension weighs ~19 kg [16])
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 91.2 kN
 //	ISP: 243 SL / 446.4 Vac		SL calculated with RPA
@@ -142,7 +142,7 @@
 //	RL10A-4-1 and RL10A-4-2 (represented as RL10A-4-1-2)
 //	Centaur D2A1/D3B-SEC
 //
-//	Dry Mass: 142 Kg		(guess, nozzle extension weighs ~25 kg)
+//	Dry Mass: 149 kg	[16] A-4-2N w/o nozzle extension
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 97.9 kN
 //	ISP: 249 SL / 446.4 Vac		SL calculated with RPA
@@ -172,14 +172,14 @@
 //	RL10A-4-2N
 //	Centaur D5/III
 //
-//	Dry Mass: 168 Kg
+//	Dry Mass: 168 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 99.2 kN
-//	ISP: 217 SL / 451.0 Vac		SL calculated with RPA
+//	Thrust (Vac): 99.2 kN	[16]
+//	ISP: 217 SL / 451.0 Vac		[16], SL calculated with RPA
 //	Burn Time: 894
-//	Chamber Pressure: 4.20 MPa
+//	Chamber Pressure: 4.20 MPa	[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.5
+//	Prop Ratio: 5.5		[16]
 //	Throttle: N/A
 //	Nozzle Ratio: 84
 //	Ignitions: 20
@@ -200,16 +200,16 @@
 //	Ignitions: 20
 //	=================================================================================
 //	RL10B-2
-//	DCSS
+//	DCUS/DCSS
 //
-//	Dry Mass: 277 Kg
+//	Dry Mass: 302 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 110.1 kN
-//	ISP: 1 @0.915 atm / 465.5 Vac		SL calculated with RPA
+//	Thrust (Vac): 110.1 kN	[16]
+//	ISP: 1 @0.915 atm / 465.5 Vac		[16], SL calculated with RPA
 //	Burn Time: 1130
-//	Chamber Pressure: 4.44 MPa
+//	Chamber Pressure: 4.36 MPa	[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.88
+//	Prop Ratio: 5.88	[16]
 //	Throttle: N/A
 //	Nozzle Ratio: 290
 //	Ignitions: 15
@@ -217,44 +217,74 @@
 //	RL10C-1
 //	Centaur D5/III
 //
-//	Dry Mass: 191 Kg
+//	Dry Mass: 186 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 101.85 kN
-//	ISP: 154 SL / 449.7 Vac		SL calculated with RPA
+//	Thrust (Vac): 101.85 kN		[16]
+//	ISP: 148 SL / 449.7 Vac		[16], SL calculated with RPA
 //	Burn Time: 1130
-//	Chamber Pressure: 4.36 MPa
+//	Chamber Pressure: 4.23 MPa	[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.5
+//	Prop Ratio: 5.5		[16]
 //	Throttle: N/A
 //	Nozzle Ratio: 130
 //	Ignitions: 20
 //	=================================================================================
-//	RL10C-1-1
-//	Centaur V
+//	RL10C-1A
+//	Centaur D5/III (2018? first appearance I can find of an apparently smooth NEX 33" instead of NEX with B-2 mounting lugs)
 //
-//	Dry Mass: 188 Kg
+//	Dry Mass: 192 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 105.9 kN
-//	ISP: 123 SL / 453.8 Vac		SL calculated with RPA
-//	Burn Time: 1200
-//	Chamber Pressure: 4.36 MPa
+//	Thrust (Vac): 102.78 kN		[16]
+//	ISP: 116 SL / 453.8 Vac		[16], SL calculated with RPA
+//	Burn Time: 1130
+//	Chamber Pressure: 4.23 MPa	[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.5
+//	Prop Ratio: 5.5		[16]
 //	Throttle: N/A
-//	Nozzle Ratio: 155
+//	Nozzle Ratio: 155?
 //	Ignitions: 20
+//	=================================================================================
+//	RL10C-1-1
+//	Centaur III/V (C-1-1A used on Centaur V but it's identical?)
+//
+//	Dry Mass: 188 kg	[16]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 106.0 kN		[16]
+//	ISP: 122 SL / 453.8 Vac		[16], SL calculated with RPA
+//	Burn Time: 1200
+//	Chamber Pressure: 4.34 MPa	[16]
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.5		[16]
+//	Throttle: N/A
+//	Nozzle Ratio: 155?
+//	Ignitions: 20?
+//	=================================================================================
+//	RL10C-2
+//	ICPS
+//
+//	Dry Mass: 305 kg	[16]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 110.1 kN		[16]
+//	ISP: 1 @0.915 atm / 465.5 Vac		[16], SL calculated with RPA
+//	Burn Time: 1130?
+//	Chamber Pressure: 4.34 MPa	[16]
+//	Propellant: LOX / LH2
+//	Prop Ratio: 5.7		[16]
+//	Throttle: N/A
+//	Nozzle Ratio: 285?
+//	Ignitions: 15?
 //	=================================================================================
 //	RL10C-2-1
 //	DCSS
 //
-//	Dry Mass: 277 Kg
+//	Dry Mass: 300 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 111.2 kN
-//	ISP: 1 @0.915 atm / 465.5 Vac		SL calculated with RPA
+//	Thrust (Vac): 110.1 kN		[16]
+//	ISP: 1 @0.915 atm / 465.5 Vac	[16], SL calculated with RPA
 //	Burn Time: 1130
-//	Chamber Pressure: 4.44 MPa
+//	Chamber Pressure: 4.36 MPa		[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.88
+//	Prop Ratio: 5.88		[16]
 //	Throttle: N/A
 //	Nozzle Ratio: 285
 //	Ignitions: 15
@@ -262,14 +292,14 @@
 //	RL10C-3
 //	EUS
 //
-//	Dry Mass: 230 Kg
+//	Dry Mass: 219 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 108.5 kN
-//	ISP: 52 SL / 460.1 Vac
+//	Thrust (Vac): 108.3 kN		[16]
+//	ISP: 45 SL / 460.1 Vac		[16], SL calculated with RPA
 //	Burn Time: 1350
-//	Chamber Pressure: 4.44 MPa
+//	Chamber Pressure: 4.34 MPa	[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.70
+//	Prop Ratio: 5.70		[16]
 //	Throttle: N/A
 //	Nozzle Ratio: 215
 //	Ignitions: 15
@@ -277,16 +307,16 @@
 //	RL10C-X
 //	Centaur V
 //
-//	Dry Mass: 231.3 Kg
+//	Dry Mass: 227 kg	[16]
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 107.2911 kN
-//	ISP: 52 SL / 460.9 Vac
+//	Thrust (Vac): 107.3 kN		[16]
+//	ISP: 24 SL / 460.9 Vac		[16]
 //	Burn Time: 1350
-//	Chamber Pressure: 4.44 MPa
+//	Chamber Pressure: 4.34 MPa	[16]
 //	Propellant: LOX / LH2
-//	Prop Ratio: 5.5
+//	Prop Ratio: 5.5		[16]
 //	Throttle: N/A
-//	Nozzle Ratio: 215
+//	Nozzle Ratio: 230?
 //	Ignitions: 15
 //	=================================================================================
 //	CECE-Base
@@ -312,7 +342,7 @@
 //	Thrust (Vac): 110 kN
 //	ISP: 1 @0.915 atm SL / 465 Vac
 //	Burn Time: 10000
-//	Chamber Pressure: 4.44 MPa
+//	Chamber Pressure: 4.36 MPa
 //	Propellant: LOX / LH2
 //	Prop Ratio: 5.88
 //	Throttle: N/A
@@ -337,21 +367,22 @@
 
 //	Sources:
 
-//	http://www.alternatewars.com/BBOW/Space_Engines/RL10B-2.pdf
-//	http://www.alternatewars.com/BBOW/Space_Engines/1966_RL10_Handbook.pdf
-//	http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4.pdf
-//	http://www.alternatewars.com/BBOW/Space_Engines/1984_Martin_Marietta_OTV_Excerpt.pdf
-//	http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf - Lunar Lander Designs for Crewed Surface Sortie Missions in a Cost-Constrained Environment
-//	http://www.islandone.org/SpaceAccessUpdates/930614-DCXN.html
-//	http://www.rocket.com/common-extensible-cryogenic-engine
-//	https://web.archive.org/web/20080921093712/http://www.spaceandtech.com/spacedata/engines/rl10_specs.shtml	has gimbal ranges!
-//	http://www.alternatewars.com/BBOW/Space_Engines/RL60.pdf has RL10B-2 ignition count
-//	http://www.rocket.com/rl10-engine - RL10 Engine, Aerojet Rocketdyne
-//	https://www.spacelaunchreport.com/vulcan.html - Vulcan Data Sheet
-//	https://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
-//	https://www.asme.org/wwwasmeorg/media/resourcefiles/aboutasme/who%20we%20are/engineering%20history/landmarks/36-rl-10-rocket-engine.pdf
-//	https://ntrs.nasa.gov/citations/19910004173
-//	https://ntrs.nasa.gov/citations/19710025908
+//	[1] http://www.alternatewars.com/BBOW/Space_Engines/RL10B-2.pdf
+//	[2] http://www.alternatewars.com/BBOW/Space_Engines/1966_RL10_Handbook.pdf
+//	[3] http://www.alternatewars.com/BBOW/Space_Engines/RL10A-4.pdf
+//	[4] http://www.alternatewars.com/BBOW/Space_Engines/1984_Martin_Marietta_OTV_Excerpt.pdf
+//	[5] http://www.sei.aero/eng/papers/uploads/archive/AIAA-2013-5479_Paper.pdf - Lunar Lander Designs for Crewed Surface Sortie Missions in a Cost-Constrained Environment
+//	[6] http://www.islandone.org/SpaceAccessUpdates/930614-DCXN.html
+//	[7] http://www.rocket.com/common-extensible-cryogenic-engine
+//	[8] https://web.archive.org/web/20080921093712/http://www.spaceandtech.com/spacedata/engines/rl10_specs.shtml	has gimbal ranges!
+//	[9] http://www.alternatewars.com/BBOW/Space_Engines/RL60.pdf has RL10B-2 ignition count
+//	[10] http://www.rocket.com/rl10-engine - RL10 Engine, Aerojet Rocketdyne
+//	[11] https://www.spacelaunchreport.com/vulcan.html - Vulcan Data Sheet
+//	[12] https://www.b14643.de/Spacerockets/Specials/P&W_RL10_engine/index.htm
+//	[13] https://www.asme.org/wwwasmeorg/media/resourcefiles/aboutasme/who%20we%20are/engineering%20history/landmarks/36-rl-10-rocket-engine.pdf
+//	[14] https://ntrs.nasa.gov/citations/19910004173
+//	[15] https://ntrs.nasa.gov/citations/19710025908
+//	[16] https://doi.org/10.2514/6.2022-4270
 //  History of Liquid Propellant Rocket Engines, George P. Sutton
 
 //	Used by:
@@ -797,11 +828,11 @@
 				key = 0 446.4
 				key = 1 243
 			}
-			massMult = 0.86
+			massMult = 0.8922
 
-			%ullage = True
-			%ignitions = 20
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 20
+			IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
 				%amount = 0.5
@@ -898,11 +929,11 @@
 				key = 0 446.4
 				key = 1 249
 			}
-			massMult = 0.85
+			massMult = 0.8922
 
-			%ullage = True
-			%ignitions = 20
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 20
+			IGNITOR_RESOURCE
 			{
 				%name = ElectricCharge
 				%amount = 0.5
@@ -1009,14 +1040,14 @@
 				key = 0 451.0
 				key = 1 217
 			}
-			massMult = 1.02
+			massMult = 1.0060
 
-			%ullage = True
-			%ignitions = 20
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 20
+			IGNITOR_RESOURCE
 			{
-				%name = ElectricCharge
-				%amount = 0.5
+				name = ElectricCharge
+				amount = 0.5
 			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -1115,14 +1146,14 @@
 				key = 0 465.5
 				key = 0.915 1
 			}
-			massMult = 1.659
+			massMult = 1.8084
 
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 15
+			IGNITOR_RESOURCE
 			{
-				%name = ElectricCharge
-				%amount = 0.5
+				name = ElectricCharge
+				amount = 0.5
 			}
 
 			//Delta III: 2 flights, 1 failure. (1 restart)
@@ -1159,7 +1190,7 @@
 			minThrust = 101.85
 			maxThrust = 101.85
 			heatProduction = 100
-			description = Cost reduced model with modern production techniques, used in single or double engine configurations on Atlas V.
+			description = Cost-reduced model with modern production techniques, used in single or double engine configurations on Atlas V.
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -1174,16 +1205,16 @@
 			atmosphereCurve
 			{
 				key = 0 449.7
-				key = 1 154
+				key = 1 148
 			}
-			massMult = 1.1437
+			massMult = 1.1138
 
-			%ullage = True
-			%ignitions = 20
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 20
+			IGNITOR_RESOURCE
 			{
-				%name = ElectricCharge
-				%amount = 0.5
+				name = ElectricCharge
+				amount = 0.5
 			}
 
 			//Atlas-5(401): 21 flights, 0 failures
@@ -1214,12 +1245,12 @@
 		}
 		CONFIG
 		{
-			name = RL10C-1-1
-			specLevel = prototype
-			minThrust = 105.9
-			maxThrust = 105.9
+			name = RL10C-1A
+			specLevel = operational
+			minThrust = 102.78
+			maxThrust = 102.78
 			heatProduction = 100
-			description = Planned upgrade of RL10C-1 for use on Vulcan-Centaur, OmegA, and later Atlas V launches
+			description = Cost-reduced model with modern production techniques, used in single or double engine configurations on Atlas V.
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -1234,16 +1265,64 @@
 			atmosphereCurve
 			{
 				key = 0 453.8
-				key = 1 123
+				key = 1 116
 			}
-			massMult = 1.1272
+			massMult = 1.1497
 
-			%ullage = True
-			%ignitions = 20
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 20
+			IGNITOR_RESOURCE
 			{
-				%name = ElectricCharge
-				%amount = 0.5
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			//same as C-1
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+				ratedBurnTime = 1130 //is modified RL10B-2
+				safeOverburn = true
+				ignitionReliabilityStart = 0.990206
+				ignitionReliabilityEnd = 0.998454
+				cycleReliabilityStart = 0.980612
+				cycleReliabilityEnd = 0.996939
+				ignitionDynPresFailMultiplier = 0.08
+				techTransfer = RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+			}
+		}
+		CONFIG
+		{
+			name = RL10C-1-1
+			specLevel = prototype
+			minThrust = 106.0
+			maxThrust = 106.0
+			heatProduction = 100
+			description = Upgrade of RL10C-1 for use on Vulcan-Centaur, OmegA, and later Atlas V launches
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7454
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2546 //5.5
+			}
+			atmosphereCurve
+			{
+				key = 0 453.8
+				key = 1 122
+			}
+			massMult = 1.1257
+
+			ullage = True
+			ignitions = 20
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
 			}
 
 			//no data, never flown
@@ -1258,15 +1337,64 @@
 				cycleReliabilityStart = 0.980612
 				cycleReliabilityEnd = 0.996939
 				ignitionDynPresFailMultiplier = 0.08
-				techTransfer = RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+				techTransfer = RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+			}
+		}
+		CONFIG
+		{
+			name = RL10C-2
+			specLevel = operational
+			minThrust = 110.1
+			maxThrust = 110.1
+			heatProduction = 100
+			description = RL10B-2 using RL10C-1 components and modified for use on ICPS.
+			PROPELLANT
+			{
+				name = LqdHydrogen
+				ratio = 0.7396
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.2604 //5.70
+			}
+			atmosphereCurve
+			{
+				key = 0 465.5
+				key = 0.915 1
+			}
+			massMult = 1.8263
+
+			ullage = True
+			ignitions = 15
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			//no data, never flown
+			//using C-1 data
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 9000		//Another major revision with plan for reuse in future, give ~2.5 hours (CECE rated time)
+				ratedBurnTime = 1130 //is modified RL10B-2
+				safeOverburn = true
+				ignitionReliabilityStart = 0.990206
+				ignitionReliabilityEnd = 0.998454
+				cycleReliabilityStart = 0.980612
+				cycleReliabilityEnd = 0.996939
+				ignitionDynPresFailMultiplier = 0.08
+				techTransfer = RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
 		}
 		CONFIG
 		{
 			name = RL10C-2-1	//Mentioned as identical to the B-2, probably a cost-reduced drop-in replacement for DCSS
 			specLevel = operational
-			minThrust = 111.2
-			maxThrust = 111.2
+			minThrust = 110.1
+			maxThrust = 110.1
 			heatProduction = 100
 			description = RL10B-2 using RL10C-1 components to reduce cost.
 			PROPELLANT
@@ -1285,7 +1413,7 @@
 				key = 0 465.5
 				key = 0.915 1
 			}
-			massMult = 1.659
+			massMult = 1.7964
 
 			%ullage = True
 			%ignitions = 15
@@ -1307,15 +1435,15 @@
 				cycleReliabilityStart = 0.980612
 				cycleReliabilityEnd = 0.996939
 				ignitionDynPresFailMultiplier = 0.08
-				techTransfer = RL10C-1-1,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
+				techTransfer = RL10C-2,RL10C-1-1,RL10C-1A,RL10C-1,RL10B-2,RL10A-4-2N,RL10A-4-1N,RL10A-4-1-2,RL10A-4N,RL10A-4,RL10A-3-3A,RL10A-3-3,RL10A-3-1,RL10A-1:50
 			}
 		}
 		CONFIG
 		{
 			name = RL10C-3
 			specLevel = prototype
-			minThrust = 108.5
-			maxThrust = 108.5
+			minThrust = 108.3
+			maxThrust = 108.3
 			heatProduction = 100
 			description = Man-rated for use on the EUS for Lunar missions.
 			PROPELLANT
@@ -1332,16 +1460,16 @@
 			atmosphereCurve
 			{
 				key = 0 460.1
-				key = 1 52
+				key = 1 45
 			}
-			massMult = 1.38
+			massMult = 1.3114
 
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 15
+			IGNITOR_RESOURCE
 			{
-				%name = ElectricCharge
-				%amount = 0.5
+				name = ElectricCharge
+				amount = 0.5
 			}
 
 			//no data, never flown
@@ -1363,10 +1491,10 @@
 		{
 			name = RL10C-X
 			specLevel = prototype
-			minThrust = 107.291
-			maxThrust = 107.291
+			minThrust = 107.3
+			maxThrust = 107.3
 			heatProduction = 100
-			description = Planned upgrade of RL10C-1-1 for use on Vulcan-Centaur and potentially the Exporation Upper Stage
+			description = Planned upgrade of RL10C-1-1 for use on Vulcan-Centaur and potentially the Exporation Upper Stage.
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -1381,16 +1509,16 @@
 			atmosphereCurve
 			{
 				key = 0 460.9
-				key = 1 52
+				key = 1 24
 			}
-			massMult = 1.377
+			massMult = 1.3593
 
-			%ullage = True
-			%ignitions = 15
-			%IGNITOR_RESOURCE
+			ullage = True
+			ignitions = 15
+			IGNITOR_RESOURCE
 			{
-				%name = ElectricCharge
-				%amount = 0.5
+				name = ElectricCharge
+				amount = 0.5
 			}
 
 			//no data, never flown


### PR DESCRIPTION
Add some new RL10 variants, including
- RL10C-1A: RL10C-1 with RL10C-1-1 nozzle
- RL10C-2: ICPS engine
- RL10E-1: Correct name for RL10C-X
- RL10E-3EL: 50 hour service life RL-10 for commercial passenger transport

Also correct performance of various RL10 variants based on chart in [[16]](https://doi.org/10.2514/6.2022-4270), and update TF data for the final flights of Delta-IV and recent flights of Atlas V.