### PR TITLE
Update RO_SolarConfig.cfg to remove Kopernicus multistar blacklist flag

### DIFF
--- a/GameData/RealismOverhaul/RO_SolarConfig.cfg
+++ b/GameData/RealismOverhaul/RO_SolarConfig.cfg
@@ -161,10 +161,6 @@
 
 @PART:HAS[@MODULE[ModuleDeployableSolarPanel],!MODULE[ModuleROSolarPanel]]:FOR[RealismOverhaul]
 {
-	@MODULE[ModuleDeployableSolarPanel],*
-	{
-		%useKopernicusSolarPanels = false
-	}
 	@description ^=:$: Solar Panels degrade, affecting the power output over time.  Check this effect in the PAW.
 
 	MODULE


### PR DESCRIPTION
This simple three line change enables multistar support if (and only if) a user has a second star.  I realize that's exceedingly rare, but there seems no reason to blacklist it anymore when our config now protects you by simple virtue of being a single star solar system.