### PR TITLE
Add dependency on tweakscalerescaled-redist

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -11,9 +11,9 @@ license: CC-BY-SA
 release_status: stable
 depends:
   - name: ModuleManager
-  - name: AdvancedJetEngine
-    suppress_recommendations: true
   - name: TweakScaleRescaled-Redist
+    suppress_recommendations: true
+  - name: AdvancedJetEngine
     suppress_recommendations: true
   - name: FAR
     suppress_recommendations: true

--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -13,6 +13,8 @@ depends:
   - name: ModuleManager
   - name: AdvancedJetEngine
     suppress_recommendations: true
+  - name: TweakScaleRescaled-Redist
+    suppress_recommendations: true
   - name: FAR
     suppress_recommendations: true
   - name: KerbalJointReinforcementContinued


### PR DESCRIPTION
Since FAR depends on tweakscale-redist, users are prompted to choose between tweakscale-redist and tweakscaleRescaled-redist when installing.  Adding an explicit dependency here should remove that choice (which doesn't really matter) and prevent future problematic conflicts.