### PR TITLE
Give KSPWheel parts some rotational resistance

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/GeneralSettings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/GeneralSettings.cfg
@@ -1,0 +1,7 @@
+@PART[*]:HAS[@MODULE[KSPWheelBase]]:FOR[zzzRealismOverhaul]
+{
+	@MODULE[KSPWheelBase]
+	{
+		&rotationalResistance = 0.0001
+	}
+}


### PR DESCRIPTION
Something I've had in my install for a couple of years now and have mostly forgotten about.
Makes the wheels lose non-insignificant amounts of angular momentum over time. I believe I initially added this to combat plane landing gear breaking after takeoff. Added benefit is that rovers now actually slow down on level terrain. However it is possible that this slowdown effect is too large at high speeds so would be great if someone else gave the changes a try too.