### PR TITLE
Fix missing TestFlight config for KTDU5A main engine

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/KTDU5A_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/KTDU5A_Config.cfg
@@ -106,6 +106,31 @@
 				key = 0 287
 				key = 1 117
 			}
+            
+			//Luna 4: 0 Burns completed. 1 failure (1 ignition failure)
+			//Luna 5: 1 Burn completed before computer failure
+			//Luna 6: 1 Burn completed. 1 failure (1 cycle failure, engine stuck on)
+			//Luna 7: 1 Burn completed before computer failure
+			//Luna 8: 2 Burns completed. 0 Failures
+			//Luna 9: 2 Burns completed. 0 Failures
+			//Luna 10: 2 Burns completed. 0 Failures
+			//Luna 11: 2 Burns completed. 0 Failures
+			//Luna 12: 2 Burns completed. 0 Failures
+			//Luna 13: 2 Burns completed. 0 Failures
+			//Luna 14: 2 Burns completed. 0 Failures
+			//11 ignitions, 1 failures
+			//17 cycles, 1 failures
+			//7 restarts, 0 failures
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 135	//early 60s engine, assume 150%?
+				ratedBurnTime = 90	//43 seconds stated, but this seems to have been per burn? (43 second course correction on verniers, 43 second braking manuever on main engine?)
+				ignitionReliabilityStart = 0.907895
+				ignitionReliabilityEnd = 0.981579
+				cycleReliabilityStart = 0.902778
+				cycleReliabilityEnd = 0.980556
+				
+			}
 		}
 	}
 
@@ -154,20 +179,6 @@
 				key = 1 117
 			}
 
-			//Luna 4: 0 Burns completed. 1 failure (1 ignition failure)
-			//Luna 5: 1 Burn completed before computer failure
-			//Luna 6: 1 Burn completed. 1 failure (1 cycle failure, engine stuck on)
-			//Luna 7: 1 Burn completed before computer failure
-			//Luna 8: 2 Burns completed. 0 Failures
-			//Luna 9: 2 Burns completed. 0 Failures
-			//Luna 10: 2 Burns completed. 0 Failures
-			//Luna 11: 2 Burns completed. 0 Failures
-			//Luna 12: 2 Burns completed. 0 Failures
-			//Luna 13: 2 Burns completed. 0 Failures
-			//Luna 14: 2 Burns completed. 0 Failures
-			//11 ignitions, 1 failures
-			//17 cycles, 1 failures
-			//7 restarts, 0 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 135	//early 60s engine, assume 150%?


### PR DESCRIPTION
Somehow the TestFlight config was only applied to KTDU-5A's verniers.
Copy-pasting the TF config from vernier over to the main engine, without changing any value.