### PR TITLE
Fix meteo waterfall config

### DIFF
--- a/GameData/RealismOverhaul/Waterfall_Configs/Self/meteoSustainer.cfg
+++ b/GameData/RealismOverhaul/Waterfall_Configs/Self/meteoSustainer.cfg
@@ -7,7 +7,7 @@
         audio = pump-fed-light-1
         position = 0,0,0
         rotation = 0, 0, 0
-        scale = 0.22, 0.2475, 0.26
+        scale = 0.2475, 0.21, 0.26
         glow = _yellow
         glowStretch = 0.8
     }


### PR DESCRIPTION
The plume shape of U-1250/U-2000 seems to be broken.
Tweaking the X-Y scale seems to fix it.

Before:
![image](https://github.com/user-attachments/assets/78fca30d-e555-41b0-a65f-72f73cb1ddce)

After:
![image](https://github.com/user-attachments/assets/80610ad3-8431-432c-b11f-c85b61b07891)
