### PR TITLE
TQ-11 and TQ-12 Configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/TQ11_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TQ11_Config.cfg
@@ -1,0 +1,101 @@
+//	==================================================
+//	TQ-11
+//
+//	Manufacturer: LandSpace
+//
+//	=================================================================================
+//	TQ-11
+//	Zhuque-2 (ZQ-2)
+//
+//	Dry Mass: ??? Kg
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 80 kN
+//	ISP: 284.5 SL / 316.35 Vac
+//	Chamber Pressure: 10.1 MPa
+//	Propellant: LOX / CH4
+//	Prop Ratio: 2.92
+//	Ignitions: 4?
+//	=================================================================================
+//
+//	Sources:
+//
+//		https://www.landspace.com/engine/show.php?id=128
+//		https://www.thespacereview.com/article/3787/1
+//		https://en.wikipedia.org/wiki/TQ-11
+//		https://spacenews.com/space-pioneer-raises-14-million-to-develop-green-liquid-rocket-engines/
+//
+//	Used by:
+//
+//		KODS
+//
+//	==================================================
+
+@PART[*]:HAS[#engineType[TQ11]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = TQ-11
+	%manufacturer = #roMfrLS
+	%description = The TQ-11 is a Liquid Methane and Liquid Oxygen engine developed by LandSpace. Made up of 4 small nozzles, the engine serves as gimbal control for the Zhuque-2 2nd stage in conjunction with a TQ-12 Vacuum Engine. This engine is planned to be superceeded by the TQ-15A rocket engine on the Zhuque-2 Rocket. Powered by a Gas-Generator cycle, the TQ-11 powered the first Liquid Methane rocket to reach Earth Orbit.
+
+	@tags ^= :$: USA landspace tq11 zhuque liquid pump booster lqdmethane lqdoxygen
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 5 // Guess
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = TQ-11
+		origMass = 0.2 // Guess
+		CONFIG
+		{
+			name = TQ-11
+			specLevel = operational
+			minThrust = 80
+			maxThrust = 80
+			heatProduction = 100
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 4 // Guess
+
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 0.48196
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.51804
+			}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			atmosphereCurve
+			{
+				key = 0 337
+				key = 1 200 // Guess
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/TQ12_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/TQ12_Config.cfg
@@ -1,0 +1,230 @@
+//	==================================================
+//	TQ-12
+//
+//	Manufacturer: LandSpace
+//
+//	=================================================================================
+//	TQ-12
+//	Zhuque-2 (ZQ-2)
+//
+//	Dry Mass: 470 Kg // Guess
+//	Thrust (SL): 670 kN
+//	Thrust (Vac): 745 kN
+//	ISP: 284.5 SL / 316.35 Vac
+//	Chamber Pressure: 10.1 MPa
+//	Propellant: LOX / CH4
+//	Prop Ratio: 2.92
+//	Ignitions: 4?
+//	=================================================================================
+//	TQ-12A
+//	Zhuque-2 (ZQ-2)
+//
+//	Dry Mass: 370 Kg // Guess (w/ 100kg reducation)
+//	Thrust (SL): 730.3 kN
+//	Thrust (Vac): 812.05 kN
+//	ISP: 284.5 SL / 316.35 Vac
+//	Chamber Pressure: 10.1 MPa
+//	Propellant: LOX / CH4
+//	Prop Ratio: 2.92
+//	Ignitions: 4?
+//	=================================================================================
+//	TQ-12V
+//	Zhuque-3 (ZQ-3)
+//
+//	Dry Mass: 517 Kg // Guess
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 785 kN
+//	ISP: ??? SL / 337 Vac
+//	Chamber Pressure: 10.1 MPa
+//	Propellant: LOX / CH4
+//	Prop Ratio: 2.92
+//	Ignitions: 4?
+//	=================================================================================
+//
+//	Sources:
+//
+//		https://mp.weixin.qq.com/s/epm849_1t18X8WCQbuWRjA
+//		https://mp.weixin.qq.com/s?__biz=MzA5OTQ3OTA1NA==&mid=2653170924&idx=1&sn=def945de793bfa71aacf2c48bba3c73f&chksm=8b51378dbc26be9b15c22375488d3015bebc23467099e86667b739b02252bfadddb2056ba19b&token=575113164&lang=zh_CN&scene=21#wechat_redirect
+//		https://en.wikipedia.org/wiki/TQ-12
+//
+//	Used by:
+//
+//		KODS
+//
+//	==================================================
+
+@PART[*]:HAS[#engineType[TQ12]]:FOR[RealismOverhaulEngines]
+{
+	%category = Engine
+	%title = TQ-12
+	%manufacturer = #roMfrLS
+	%description = The TQ-12 is a Liquid Methane and Liquid Oxygen engine developed by LandSpace. Four of these engines are used on the Zhuque-2 (ZQ-2) Launch Vehicle, and 9 are used on the Zhuque-3 (ZQ-3) rocket's 1st Stage, a Vacuum variant also powers the 2nd stage of the Zhuque-3. Powered by a Gas-Generator cycle, the TQ-12 powered the first Liquid Methane rocket to reach Earth Orbit.
+
+	@tags ^= :$: USA landspace tq12 zhuque liquid pump booster lqdmethane lqdoxygen
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal],*
+	{
+		@gimbalRange = 5 // Guess
+		%useGimbalResponseSpeed = True
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = TQ-12
+		origMass = 0.47 // Best Guess
+		CONFIG
+		{
+			name = TQ-12
+			description = Base version of the engine used on the Zhuque-2 Launch Vehicle
+			specLevel = operational
+			minThrust = 338.636 // 45% throttle range
+			maxThrust = 745
+			heatProduction = 100
+			massMult = 1.0
+			ullage = True
+			pressureFed = False
+			ignitions = 4 // Guess
+
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 0.48196
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.51804
+			}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			atmosphereCurve
+			{
+				key = 0 316.35
+				key = 1 284.5
+			}
+		}
+		CONFIG
+		{
+			name = TQ-12A
+			description = Upgraded Engine with 9% higher thrust and 100kg decrease in dry mass
+			specLevel = prototype
+			minThrust = 365.42 // 45% throttle range
+			maxThrust = 812.05
+			heatProduction = 100
+			massMult = 0.787 // 100kg Decrease
+			ullage = True
+			pressureFed = False
+			ignitions = 4 // Guess
+
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 0.48196
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.51804
+			}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			atmosphereCurve
+			{
+				key = 0 316.35
+				key = 1 284.5
+			}
+		}
+		CONFIG
+		{
+			name = TQ-12-V
+			description = Vacuum Version for use on the Zhuque-3 Launch Vehicle
+			specLevel = operational
+			minThrust = 353.25 // 45% throttle range
+			maxThrust = 785
+			heatProduction = 100
+			massMult = 1.1
+			ullage = True
+			pressureFed = False
+			ignitions = 4 // Guess
+
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 0.48196
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.51804
+			}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			atmosphereCurve
+			{
+				key = 0 337
+				key = 1 200 // Guess
+			}
+		}
+		CONFIG
+		{
+			name = TQ-12A-V
+			description = Upgraded Engine with 9% higher thrust and 100kg decrease in dry mass
+			specLevel = operational
+			minThrust = 385.0425 // 45% throttle range
+			maxThrust = 855.65
+			heatProduction = 100
+			massMult = 0.887 // 100kg Decrease
+			ullage = True
+			pressureFed = False
+			ignitions = 4 // Guess
+
+			PROPELLANT
+			{
+				name = LqdMethane
+				ratio = 0.48196
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.51804
+			}
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+			atmosphereCurve
+			{
+				key = 0 337
+				key = 1 200 // Guess
+			}
+		}
+	}
+}


### PR DESCRIPTION
Note: TQ-11 is a vernier engine with 4 chambers used in conjunction with a TQ-12 upperstage engine. The engine are separate.