### PR TITLE
Make U-1700 speculative instead of altHist

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/U1250_Config.cfg
@@ -151,7 +151,7 @@
 		{
 			name = U-1700
 			description = Speculative upgrade for the U-1250
-			specLevel = altHist
+			specLevel = speculative
 			maxThrust = 19.411
 			minThrust = 19.411
 			massMult = 1.0


### PR DESCRIPTION
It literally says it is "speculative" twice in the description. The U-1700 is about as unreal as some other engines labeled `speculative`, such as the later variants of E-1 and HG-3.
I am all ears about why the U-1700 was set to `altHist` besides early game balance. 