### PR TITLE
More rocketplane engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AR2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AR2_Config.cfg
@@ -1,0 +1,262 @@
+//	==================================================
+//	AR-1/2
+//
+//	Manufacturer: Rocketdyne
+//
+//	=================================================================================
+//	XLR42-NA-2/AR-1
+//	FJ-4F
+//
+//	Dry Mass: 108.9 kg	[1]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 25.57 kN	5750 lbf@100kft [A, p.462], 5400 lbf@35kft [1]
+//	ISP: 180 SL / 246 Vac	Estimated with RPA, assuming same efficiency as XLR11. Also matches AR2-3
+//	Burn Time: 180	[1]
+//	Chamber Pressure: 3.0? MPa	estimated based on thrust gain at altitude
+//	Propellant: 90% HTP / JP4
+//	Prop Ratio: 6.5		same as AR2-3
+//	Throttle: N/A	[A, p.462]
+//	Nozzle Ratio: 12	same as AR2-3?
+//	Ignitions: 100?
+//	=================================================================================
+//	AR-2
+//	Prototype
+//
+//	Dry Mass: 103.9 kg	[1]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 29.36 kN	6600 lbf [A, p.462]
+//	ISP: 180 SL / 246 Vac	Estimated with RPA, assuming same efficiency as XLR11. Also matches AR2-3
+//	Burn Time: 180	[1]
+//	Chamber Pressure: 3.0? MPa	estimated based on thrust gain at altitude
+//	Propellant: 90% HTP / JP4
+//	Prop Ratio: 6.5		same as AR2-3
+//	Throttle: 50%	[A, p.462]
+//	Nozzle Ratio: 12	same as AR2-3?
+//	Ignitions: 100?
+//	=================================================================================
+//	LR121-NA-1/AR2-3
+//	FJ-4F, F-86, NF-104A
+//
+//	Dry Mass: 102.1 kg	[1]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 29.36 kN	6600 lbf [A, p.462]
+//	ISP: 195 SL / 246 Vac	[1],[A, p.463]
+//	Burn Time: 420 [1], 120 minutes between overhaul [A, p.463]
+//	Chamber Pressure: 3.86 MPa	[A, p.463]
+//	Propellant: 90% HTP / JP4
+//	Prop Ratio: 6.5		[A, p.463]
+//	Throttle: 50%	[A, p.463]
+//	Nozzle Ratio: 12	[A, p.463]
+//	Ignitions: 100?
+//	=================================================================================
+
+//	Sources:
+
+//	[1] https://web.archive.org/web/20200229064133/http://www.alternatewars.com/BBOW/Space_Engines/Rocketdyne_Engines.htm
+//	[2] https://en.wikipedia.org/wiki/Rocketdyne_AR2
+//	[3] http://www.astronautix.com/a/ar1.html
+//	[4] http://www.astronautix.com/a/ar2-3.html
+//	[5] https://ntrs.nasa.gov/api/citations/20000033615/downloads/20000033615.pdf
+//	[6] https://web.archive.org/web/20130216051328/http://sscfreedom.ssc.nasa.gov/etd/ETDPropulsionSS_H2O2AR23.asp
+//	[7] https://hydrogen-peroxide.us/uses-monoprop-steam-generation/NASA-Marshall-The-Peroxide-Pathway-early2000s.pdf
+//	[8] https://www.designation-systems.net/usmilav/engines.html#_MILSTD1812
+//	[9] https://www.hydrogen-peroxide.us/history-US-Reaction-Motors/AIAA-2001-3838_History_of_RMI_Super_Performance_90_Percent_H2O2-Kerosene_LR-40_RE-pitch.pdf
+//	[10] https://www.thisdayinaviation.com/tag/rocketdyne-lr121/
+//	[11] https://www.history.navy.mil/content/dam/nhhc/research/histories/naval-aviation/Naval%20Aviation%20News/1960/pdf/jan62.pdf
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton
+
+
+//	Used by:
+
+//	Notes:
+
+//	* AR-1, AR-2 and AR2-1 are pressure-fed, AR2-2 and AR2-3 are pumpfed [A, p.462]
+//	* Only AR-1 and AR2-3 ever flew, the rest were developmental models
+//	* LR42-NA-2 refers to AR-1 [11, p.14], even model number because it was a Navy project (FJ-4 was a navy aircraft)
+//	* LR46-NA-2 is mostly identical to the AR-1, but modified for use in the A3J/A-5 [11, p.14]
+//	* LR54-NA-2 is mostly identical to the AR-1, but modified for use in the F8U-1F [11, p.14]
+//	* LR121(-NA-1) refers to AR2-3 [8/10]? Odd model number because NF-104A was a USAF project
+//	==================================================
+@PART[*]:HAS[#engineType[AR2]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roAR2Title	//AR-1/2
+	%manufacturer = #roMfrRocketdyne
+	%description = #roAR2Desc
+
+	@tags ^= :$: USA north american rocketdyne ar-1 ar-2 ar2-3 xlr42 xlr46 xlr54 xlr121 liquid pressure-fed pump spaceplane kerosene htp
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = XLR42-NA-2
+		origMass = 0.1089
+		CONFIG
+		{
+			name = XLR42-NA-2
+			description = AR-1. Experimental pressure-fed super-performance booster for FJ-4F Fury.
+			specLevel = operational
+			minThrust = 25.57
+			maxThrust = 25.57
+			massMult = 1.0
+			heatProduction = 100
+			pressureFed = True
+			ignitions = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.2208
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.7792
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 45
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 246
+				key = 1 180
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600		//very simple and primitive, reused extensively. Give 1 hour
+				ratedContinuousBurnTime = 180	//3 minutes
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+			}
+		}
+		CONFIG
+		{
+			name = AR-2
+			description = Improved model, with throttle capability. Tested, but never flew.
+			specLevel = Prototype
+			minThrust = 14.68
+			maxThrust = 29.36
+			massMult = 0.9541
+			heatProduction = 100
+			pressureFed = True
+			ignitions = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.2208
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.7792
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 45
+				ignoreForIsp = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 246
+				key = 1 180
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600		//very simple and primitive, reused extensively. Give 1 hour
+				ratedContinuousBurnTime = 180	//3 minutes
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+				techTransfer = XLR42-NA-2:50
+			}
+		}
+		CONFIG
+		{
+			name = LR121-NA-1
+			description = AR2-3. Pump-fed model, able to share fuel tanks with jet engine. Used on the FJ-4F, F-86F(R), and NF-104A for astronaut training.
+			specLevel = Operational
+			minThrust = 14.68
+			maxThrust = 29.36
+			massMult = 0.9376
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.2208
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.7792
+			}
+
+			atmosphereCurve
+			{
+				key = 0 246
+				key = 1 195
+			}
+
+			//FJ-4F: 103 flights, ??? failures
+			//F-86F(R): 31 flights, ??? failures
+			//NF-104A: 302 flights, 2 failures? (2 inflight explosions)
+			//flew a lot, apparently never had a significant failure
+			//Assume twice as many ignition failures? (Aircraft could just return to airfield on failure to ignite)
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 7200		//120 minutes between overhaul
+				ratedContinuousBurnTime = 420	//7 minutes?
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.986232
+				ignitionReliabilityEnd = 0.997826
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.992029
+				cycleReliabilityEnd = 0.998741
+				techTransfer = AR-2,XLR42-NA-2:50
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Spectre_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Spectre_Config.cfg
@@ -1,0 +1,346 @@
+//	==================================================
+//	Spectre
+//
+//	Manufacturer: de Haviland
+//
+//	=================================================================================
+//	DSpe.1 Spectre
+//	SR.53
+//
+//	Dry Mass: 169.63 kg	same TWR as AR-1?
+//	Thrust (SL): 31.14 kN	7000 lbf takeoff thrust [5]
+//	Thrust (Vac): 39.83 kN
+//	ISP: 190 SL / 243 Vac	[1], vac estimated with RPA
+//	Burn Time: 420		7 minutes at full power [4]
+//	Chamber Pressure: 3.02 MPa	500 psi at rated thrust? [2] scale for 7000 lbf operation
+//	Propellant: 85% HTP / kerosene
+//	Prop Ratio: 9	[2]
+//	Throttle: Down to 2000 lbf [5]
+//	Nozzle Ratio: 10?
+//	Ignitions: 50	same as Sprite?
+//	=================================================================================
+//	DSpe.2 Spectre
+//	Constant thrust JATO, Vulcan, Victor
+//
+//	Dry Mass: 152.67 kg		10% lighter?
+//	Thrust (SL): 31.14 kN	7000 lbf takeoff thrust [5]
+//	Thrust (Vac): 39.83 kN
+//	ISP: 190 SL / 243 Vac	[1], vac estimated with RPA
+//	Burn Time: 40		same as Super Sprite?
+//	Chamber Pressure: 3.02 MPa	500 psi at rated thrust? [2] scale for 7000 lbf operation
+//	Propellant: 85% HTP / kerosene
+//	Prop Ratio: 9	[2]
+//	Throttle: N/A
+//	Nozzle Ratio: 10?
+//	Ignitions: 50	same as Sprite?
+//	=================================================================================
+//	DSpe.4 Spectre
+//	Constant thrust JATO, Vulcan, Victor
+//
+//	Dry Mass: 91.37 kg		10% lighter?
+//	Thrust (SL): 35.59 kN	8000 lbf takeoff thrust?
+//	Thrust (Vac): 43.58 kN
+//	ISP: 205 SL / 251 Vac	estimated from mass flow [2], vac calculated with RPA
+//	Burn Time: 40		same as Super Sprite?
+//	Chamber Pressure: 3.45 MPa	500 psi at rated thrust [2]
+//	Propellant: 85% HTP / kerosene
+//	Prop Ratio: 9	[2]
+//	Throttle: N/A
+//	Nozzle Ratio: 10?
+//	Ignitions: 50	same as Sprite?
+//	=================================================================================
+//	DSpe.5 Spectre
+//	SR.53
+//
+//	Dry Mass: 101.53 kg		Much lighter than Spectre 1 [5] Same TWR as XLR40?
+//	Thrust (SL): 35.59 kN	8000 lbf takeoff thrust?
+//	Thrust (Vac): 43.58 kN
+//	ISP: 205 SL / 251 Vac	estimated from mass flow [2], vac calculated with RPA
+//	Burn Time: 420		7 minutes at full power [4]
+//	Chamber Pressure: 3.45 MPa	500 psi at rated thrust [2]
+//	Propellant: 85% HTP / kerosene
+//	Prop Ratio: 9	[2]
+//	Throttle: Down to 2000 lbf [5]
+//	Nozzle Ratio: 10?
+//	Ignitions: 50	same as Sprite?
+//	=================================================================================
+//	DSpe.5A Spectre
+//	SR.177
+//
+//	Dry Mass: 101.53 kg
+//	Thrust (SL): 44.48 kN	10000 lbf takeoff thrust?
+//	Thrust (Vac): 52.38 kN
+//	ISP: 214 SL / 252 Vac	calculated with RPA
+//	Burn Time: 420		7 minutes at full power [4]
+//	Chamber Pressure: 4.30 MPa	Scale to 10klbf
+//	Propellant: 85% HTP / kerosene
+//	Prop Ratio: 9	[2]
+//	Throttle: Down to 2000 lbf [5]
+//	Nozzle Ratio: 10?
+//	Ignitions: 50	same as Sprite?
+//	=================================================================================
+
+//	Sources:
+
+//	[1] http://epizodsspace.airbase.ru/bibl/inostr-yazyki/A_Vertical_Empire.pdf
+//	[2] https://hydrogen-peroxide.us/history-UK/H2O2_Conf_1999-Past_Present_Uses_of_Rocket_Grade_Hydrogen_Peroxide.pdf
+//	[3] https://web.archive.org/web/20190511070349/http://www.spaceuk.org/htp/htp.htm
+//	[4] https://en.wikipedia.org/wiki/De_Havilland_Spectre
+//	[5] https://doi.org/10.1017/S0368393100070668
+//	[6] https://www.dehavillandmuseum.co.uk/aircraft/de-havilland-spectre-rocket/
+//	[7] https://airandspace.si.edu/collection-objects/jato-jet-assisted-take-unit-liquid-fueled-double-spectre/nasm_A19700330000
+//	[8] https://web.archive.org/web/20060215104117/http://www.cue-dih.co.uk/aerospace/aeropdfs/htp_for_prop.pdf
+//	[9] https://en.wikipedia.org/wiki/Saunders-Roe_SR.53
+//	[10] https://en.wikipedia.org/wiki/Saunders-Roe_SR.177
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton
+
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[Spectre]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roSpectreTitle	//Spectre
+	%manufacturer = #roMfrDH
+	%description = #roSpectreDesc
+
+	@tags ^= :$: UK britian de haviland dh spectre dspe liquid pump spaceplane kerosene htp
+
+	%specLevel = Operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = DSpe-1
+		origMass = 0.16963
+		CONFIG
+		{
+			name = DSpe-1
+			description = Spectre 1, booster engine for SR.53.
+			specLevel = Operational
+			minThrust = 11.38
+			maxThrust = 39.83
+			massMult = 1.0
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.8301
+			}
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.1699
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 243
+				key = 1 190
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600	//1 hour between overhauls?
+				ratedContinuousBurnTime = 420
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+			}
+		}
+		CONFIG
+		{
+			name = DSpe-2
+			description = Spectre 2, JATO engine for Vickers Valiant and Hadley-Page Victor.
+			specLevel = Operational
+			minThrust = 39.83
+			maxThrust = 39.83
+			massMult = 0.9
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.8301
+			}
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.1699
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 243
+				key = 1 190
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600	//1 hour between overhauls?
+				ratedContinuousBurnTime = 40
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+				techTransfer = DSpe-1:50
+			}
+		}
+		CONFIG
+		{
+			name = DSpe-4
+			description = Spectre 4, JATO engine for Vickers Valiant and Hadley-Page Victor.
+			specLevel = Operational
+			minThrust = 43.58
+			maxThrust = 43.58
+			massMult = 0.5386
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.8301
+			}
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.1699
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 251
+				key = 1 205
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600	//1 hour between overhauls?
+				ratedContinuousBurnTime = 40
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+				techTransfer = DSpe-2,DSpe-1:50
+			}
+		}
+		CONFIG
+		{
+			name = DSpe-5
+			description = Spectre 5, booster engine for SR.53.
+			specLevel = Operational
+			minThrust = 11.38
+			maxThrust = 43.58
+			massMult = 0.5985
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.8301
+			}
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.1699
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 251
+				key = 1 205
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600	//1 hour between overhauls?
+				ratedContinuousBurnTime = 420
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+				techTransfer = DSpe-4,DSpe-2,DSpe-1:50
+			}
+		}
+		CONFIG
+		{
+			name = DSpe-5A
+			description = Spectre 5A, booster engine for SR.177.
+			specLevel = Operational
+			minThrust = 11.38
+			maxThrust = 52.38
+			massMult = 0.5985
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.8301
+			}
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.1699
+				DrawGauge = True
+			}
+
+			atmosphereCurve
+			{
+				key = 0 252
+				key = 1 214
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 3600	//1 hour between overhauls?
+				ratedContinuousBurnTime = 420
+
+				//can't find flight data, but was apparently pretty reliable. Same as XLR11-RM-13
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.99
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.95
+				cycleReliabilityEnd = 0.998
+				techTransfer = DSpe-5,DSpe-4,DSpe-2,DSpe-1:50
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/Sprite_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Sprite_Config.cfg
@@ -1,0 +1,248 @@
+//	==================================================
+//	Sprite
+//
+//	Manufacturer: de Haviland
+//
+//	=================================================================================
+//	DSpr.1 Sprite
+//	Comet
+//
+//	Dry Mass: 70.76 kg		158.76 including fuel tanks? [2] subtract 88 kg
+//	Thrust (SL): 22.2 kN		5000 lbf takeoff thrust
+//	Thrust (Vac): 28.1 kN
+//	ISP: 95.6 SL / 121 Vac	estimated from total impulse (55,000 lbf) [4], vac estimated with RPA
+//	Burn Time: 16
+//	Chamber Pressure: 1.0? MPa	complete guess
+//	Propellant: 80% HTP + calcium permanganate catalyst solution
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 3?
+//	Ignitions: 50	rated for 50 flights [5]
+//	=================================================================================
+//	DSpr.2 Sprite
+//	Comet
+//
+//	Dry Mass: 70.76 kg		158.76 including fuel tanks? [2] subtract 88 kg
+//	Thrust (SL): 22.2 kN		5000 lbf takeoff thrust
+//	Thrust (Vac): 28.1 kN
+//	ISP: 95.6 SL / 121 Vac	estimated from total impulse (55,000 lbf) [4], vac estimated with RPA
+//	Burn Time: 16
+//	Chamber Pressure: 1.0? MPa	complete guess
+//	Propellant: 80% HTP
+//	Prop Ratio: N/A
+//	Throttle: N/A
+//	Nozzle Ratio: 3?
+//	Ignitions: 50	rated for 50 flights [5]
+//	=================================================================================
+//	DSpr.4 Super Sprite
+//	Valiant
+//
+//	Dry Mass: 153.23 kg		281.23 including fuel tanks? [2] subtract 128 kg
+//	Thrust (SL): 18.7 kN		4200 lbf takeoff thrust
+//	Thrust (Vac): 23.9 kN
+//	ISP: 142.9 SL / 183 Vac	estimated from total impulse (120,000 lbf) [6], vac estimated with RPA
+//	Burn Time: 40
+//	Chamber Pressure: 1.0? MPa	complete guess
+//	Propellant: 85% HTP / Kerosene
+//	Prop Ratio: 20	[2/6]
+//	Throttle: N/A
+//	Nozzle Ratio: 3?
+//	Ignitions: 50	rated for 50 flights [5]
+//	=================================================================================
+
+//	Sources:
+
+//	[1] http://epizodsspace.airbase.ru/bibl/inostr-yazyki/A_Vertical_Empire.pdf
+//	[2] https://hydrogen-peroxide.us/history-UK/H2O2_Conf_1999-Past_Present_Uses_of_Rocket_Grade_Hydrogen_Peroxide.pdf
+//	[3] https://web.archive.org/web/20190511070349/http://www.spaceuk.org/htp/htp.htm
+//	[4] https://en.wikipedia.org/wiki/De_Havilland_Sprite
+//	[5] https://airandspace.si.edu/collection-objects/rocket-engine-liquid-fuel-super-sprite-cut-away/nasm_A19700331000
+//	[6] https://web.archive.org/web/20160305030937/https://www.flightglobal.com/pdfarchive/view/1957/1957%20-%201249.html
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton
+
+
+//	Used by:
+
+//	Notes:
+//	* Dspr.1 uses continuous calcium permanganate solution injection to decompose HTP, later versions 
+//	use silver catalyst bed. Just use water.
+//	* These are probably both blow-down pressurized, their max thrust and burn time is not consistent with
+//	their reported total impulse. Their performance likely dropped as the tanks emptied.
+//	==================================================
+@PART[*]:HAS[#engineType[Sprite]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roSpriteTitle	//Sprite
+	%manufacturer = #roMfrDH
+	%description = #roSpriteDesc
+
+	@tags ^= :$: UK britian de haviland dh sprite dspr liquid pressurefed spaceplane kerosene htp
+
+	%specLevel = Operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = DSpr-1
+		origMass = 0.07076
+		CONFIG
+		{
+			name = DSpr-1
+			description = Sprite 1, JATO engine for the Vikers Valiant.
+			specLevel = Operational
+			minThrust = 28.1
+			maxThrust = 28.1
+			massMult = 1.0
+			heatProduction = 100
+			pressureFed = True
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.9157
+				DrawGauge = True
+			}
+			//just use water as calcium permanganate solution stand-in
+			//same ratio as super sprite, I'm pretty sure the kerosene tank is just the old permanganate tank
+			PROPELLANT
+			{
+				name = Water
+				ignoreForIsp = True
+				ratio = 0.0843
+			}
+			PROPELLANT
+			{
+				name = Nitrogen
+				ignoreForIsp = True
+				ratio = 15
+			}
+
+			atmosphereCurve
+			{
+				key = 0 121
+				key = 1 95.6
+			}
+
+			//Comet version was never used operationally, but V-bomber version was used extensively
+			//Extremely simple monopropellant engine
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 800
+				ratedContinuousBurnTime = 16
+
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.995
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.99
+				cycleReliabilityEnd = 0.998
+			}
+		}
+		CONFIG
+		{
+			name = DSpr-2
+			description = Sprite 2, JATO engine for the de Haviland Comet.
+			specLevel = Operational
+			minThrust = 28.1
+			maxThrust = 28.1
+			massMult = 1.0
+			heatProduction = 100
+			pressureFed = True
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 1.0
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Nitrogen
+				ignoreForIsp = True
+				ratio = 15
+			}
+
+			atmosphereCurve
+			{
+				key = 0 121
+				key = 1 95.6
+			}
+
+			//Comet version was never used operationally, but V-bomber version was used extensively
+			//Extremely simple monopropellant engine
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 800
+				ratedContinuousBurnTime = 16
+
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.995
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.99
+				cycleReliabilityEnd = 0.998
+				techTransfer = DSpr-1:50
+			}
+		}
+		CONFIG
+		{
+			name = DSpr-4
+			description = Super Sprite, with kerosene "afterburner" to increase performance for the Vickers Valiant.
+			specLevel = Operational
+			minThrust = 23.9
+			maxThrust = 23.9
+			massMult = 2.165
+			heatProduction = 100
+			pressureFed = True
+			ignitions = 50
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.9157
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.0843
+			}
+			PROPELLANT
+			{
+				name = Nitrogen
+				ignoreForIsp = True
+				ratio = 15
+			}
+
+			atmosphereCurve
+			{
+				key = 0 183
+				key = 1 142.9
+			}
+
+			//Comet version was never used operationally, but V-bomber version was used extensively
+			//Extremely simple monopropellant engine
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 2000
+				ratedContinuousBurnTime = 40
+
+				ignitionReliabilityStart = 0.95
+				ignitionReliabilityEnd = 0.995
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.99
+				cycleReliabilityEnd = 0.998
+				techTransfer = DSpr-2,DSpr-1:50
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/XLR40_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR40_Config.cfg
@@ -1,0 +1,114 @@
+//	==================================================
+//	XLR40
+//
+//	Manufacturer: RMI
+//
+//	=================================================================================
+//	XLR40-RM-2
+//	F8U-3F
+//
+//	Dry Mass: 97.52 kg	[2]
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 45.37 kN	10,200 lbf vacuum [2]
+//	ISP: 218 SL / 257 Vac	[2], SL estimated with RPA
+//	Burn Time: 
+//	Chamber Pressure: 3.65 MPa	[2]
+//	Propellant: 90% HTP / JP4
+//	Prop Ratio: 7.0		[2]
+//	Throttle: Down to 3,500 lbf
+//	Nozzle Ratio: 8.5
+//	Ignitions: 100?
+//	=================================================================================
+
+//	Sources:
+
+//	[1] https://www.designation-systems.net/usmilav/engines.html#_MILSTD1812
+//	[2] https://www.hydrogen-peroxide.us/history-US-Reaction-Motors/AIAA-2001-3838_History_of_RMI_Super_Performance_90_Percent_H2O2-Kerosene_LR-40_RE-pitch.pdf
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton
+
+
+//	Used by:
+
+//	Notes:
+
+//	==================================================
+@PART[*]:HAS[#engineType[XLR40]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roXLR40Title	//XLR40
+	%manufacturer = #roMfrRMI
+	%description = #roXLR40Desc
+
+	@tags ^= :$: USA reaction motors rmi xlr40 liquid pump spaceplane kerosene htp
+
+	%specLevel = Prototype
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	!MODULE[ModuleGimbal],*{}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		modded = false
+		configuration = XLR40-NA-2
+		origMass = 0.09752
+		CONFIG
+		{
+			name = XLR40-NA-2
+			description = 
+			specLevel = Prototype
+			minThrust = 15.57
+			maxThrust = 45.37
+			massMult = 1.0
+			heatProduction = 100
+			pressureFed = False
+			ignitions = 100
+			PROPELLANT
+			{
+				name = Kerosene
+				ratio = 0.2083
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.7917
+			}
+
+			atmosphereCurve
+			{
+				key = 0 257
+				key = 1 218
+			}
+
+			//Never flew
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 5400
+				ratedContinuousBurnTime = 300	//???
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.9
+				ignitionReliabilityEnd = 0.987
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.93
+				cycleReliabilityEnd = 0.998
+				techTransfer = XLR11-RM-3:20&XLR11-RM-13-8K,XLR11-RM-5:50
+			}
+		}
+	}
+}

--- a/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
@@ -26,7 +26,7 @@
 //	Dry Mass: 432 kg	Guessing about 19 kg for nozzle extension (roughly the same as RL10A-4 extension)
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 281.9 kN	63378 lbf [C, p.226]
-//	ISP: 200 SL / 298 Vac	200@SL (calculated with RPA), 298@cav [C, p.226]
+//	ISP: 205 SL / 298 Vac	205@SL (calculated with RPA), 298@vac [C, p.226]
 //	Burn Time: 180
 //	Chamber Pressure: 4.14 MPa
 //	Propellant: LOX / Ammonia
@@ -35,8 +35,22 @@
 //	Nozzle Ratio: 22.5
 //	Ignitions: 100
 //	=================================================================================
+//	XLR99-RM-3
+//	X-15A-3 Delta
+//	Heavily modified XLR99 for "hypersonic cruise" Mach 8 X-15.
 //
-//	==================================================
+//	Dry Mass: 432 kg	Guessing about 19 kg for nozzle extension (roughly the same as RL10A-4 extension)
+//	Thrust (SL): ??? kN
+//	Thrust (Vac): 369.2 kN	83000 lbf@100kft [C, p.575]
+//	ISP: 222 SL / 298 Vac	222@SL (calculated with RPA), 298@vac [C, p.226]
+//	Burn Time: 180
+//	Chamber Pressure: 5.42 MPa	performance improvements would come almost entirely from just increasing pump speed and pressure [C, p. 227]
+//	Propellant: LOX / Ammonia
+//	Prop Ratio: 1.25
+//	Throttle: 100% to 9.6%	throttle to 8000 lbf for hypersonic cruise [C, p.575]
+//	Nozzle Ratio: 22.5	same nozzle?
+//	Ignitions: 100
+//	=================================================================================
 
 //	Sources:
 
@@ -182,7 +196,7 @@
 			atmosphereCurve
 			{
 				key = 0 298
-				key = 1 200
+				key = 1 205
 			}
 			ullage = False
 			pressureFed = False
@@ -215,6 +229,71 @@
 				cycleReliabilityEnd = 0.994311
 				reliabilityDataRateMultiplier = 20
 				techTransfer = XLR99-RM-2:50
+			}
+		}
+		CONFIG
+		{
+			name = XLR99-RM-3
+			specLevel = concept //no engineering work was completed before the program was cancelled
+			minThrust = 35.6
+			maxThrust = 369.2
+			heatProduction = 100
+			massMult = 1.046
+			varyFlow = 0.0263
+			PROPELLANT
+			{
+				name = LqdAmmonia
+				ratio = 0.5652
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4348
+			}
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.01
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+			atmosphereCurve
+			{
+				key = 0 298
+				key = 1 222
+			}
+			ullage = False
+			pressureFed = False
+			ignitions = 100
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 1.00
+			}
+
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				name = XLR99-RM-3
+				ratedBurnTime = 3600		// "required overhaul after 1 hour of burn time".
+				ratedContinuousBurnTime = 180 // 180s rated burntime at full thrust
+				safeOverburn = true
+				overburnPenalty = 1		//No penalty
+
+				// assume roughly exponential relationship between chamber pressure and lifespan
+				thrustModifier
+				{
+					key = 0.00 0.05 0 0
+					key = 1.00 1.00 3 3
+				}
+
+				ignitionReliabilityStart = 0.977941
+				ignitionReliabilityEnd = 0.995588
+				ignitionDynPresFailMultiplier = 10.0
+				cycleReliabilityStart = 0.971557
+				cycleReliabilityEnd = 0.994311
+				reliabilityDataRateMultiplier = 20
+				techTransfer = XLR99-RM-2A,XLR99-RM-2:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -103,6 +103,9 @@ Localization
 		//		AR1
 		#roAR1Title = AR-1
 		#roAR1Desc = The AR-1 is a 2,200-kilonewton-class kerolox engine using oxidizer-rich staged combustion. Two of those were proposed to replace the Russian made RD-180 on the Atlas V rocket. Development of this engine was halted because Aerojet Rocketdyne was unwilling to pay for its completion.
+		//		AR2
+		#roAR2Title = AR-1/2
+		#roAR2Desc = A small liquid fueled booster rocket, intended to increase the performance of the FJ-4/F-86. Tested extensively, but the weight of the system offset any performance gains. Later upgraded to be pump-fed, allowing it to use fuel directly from the fuel tanks of the aircraft, and used to power the NF-104A astronaut training aircraft.
 		//		ASRB
 		#roASRBTitle = Advanced Booster
 		#roASRBDesc = A composite solid rocket motor designed as a drop-in replacement for the 5 Segment RSRM used on the Space Launch System (SLS). Its lower inert mass along with the higher surface thrust will enable the SLS to lift more than 130 metric tonnes into low Earth orbit.
@@ -763,6 +766,9 @@ Localization
 		//		SNTPPFE100
 		#roSNTPPFE100Title = SNTP-PFE100 Atomic Rocket Motor
 		#roSNTPPFE100Desc = The "SNTP-PFE" series is a 1000MW reactor. The reactor is a particle bed using metallic carbide coated uranium granules embedded in a graphite rod that hydrogen is passed through. This allows for power densities of up to 40MW/liter. Its core is capable of starting up five times.  An integral Tungsten Boron Lithium Hydride composite shield is included and the whole assembly is regeneratively cooled. A secondary circuit runs the shut down gasses through a small heat engine to minimize fuel loss and provide basic alternator power. This engine should be mounted three to six meters from the closest fuel tank.  Fuel should shield any crew and crew positions when running should be ten to fifteen meters from the engine. Additional shielding such as a water tank or high density fuel can somewhat reduce this amount. This rocket has impressive stats for its size (Nozzle Ae=100   Chamber Temp=3000   Ideal ISP=991  Reactor Power=1054MW(th)  TWR=13.94   Chamber Pressure=6800kPa   Ignitions =5   Tonnage including integral shadow shield:1.504tons ) The nozzle is a fixed ablatively cooled filament wound carbon-carbon design.
+		//		Spectre
+		#roSpectreTitle = Spectre
+		#roSpectreDesc = Derived from the Sprite, the Spectre was a rocket motor designed for the SR.53 interceptor, and to replace the Sprite for higher-performance JATO applications. It was tested extensively, both on the SR.53 prototypes and on the Vickers Valiant and Hadley-Page Victor, but improved jet engine performance and cancellation of the SR.53 and the SR.177 follow-on project resulted in the cancellation of the Spectre.
 		//		SPT-50
 		#roSPT50Title = SPT-50 Hall Effect Thruster
 		#roSPT50Desc = An early Soviet Hall Effect thruster, used on Soviet and Russian weather satellites.
@@ -778,6 +784,9 @@ Localization
 		//		SPT-140
 		#roSPT140Title = SPT-140 Hall Effect Thruster
 		#roSPT140Desc = The SPT-140 is an enlarged SPT-100 created to power large, modern communications satellites.
+		//		Sprite
+		#roSpriteTitle = Sprite
+		#roSpriteDesc = A small monopropellant rocket motor, intended for JATO use to improve the takeoff performance of various aircraft. Developed directly from german JATO boosters captured during WW2, the Sprite incorporated improvements such as silver gauze catalyst beds, but was still a low-performance motor. The Super Sprite added a kerosene "afterburner" that injected small amounts of kerosene into the combustion chamber to increase performance.
 		//		SR19
 		#roSR19Title = SR19
 		#roSR19Desc = The SR19 is an improved Minuteman second stage developed for the LGM-30F Minuteman II.
@@ -999,6 +1008,9 @@ Localization
 		//		XLR25
 		#roXLR25Title = XLR25
 		#roXLR25Desc = The XLR25 was designed for the X-2, to test higher speeds and altitudes than the X-1. It was the first continuously throttleable engine designed in the US. Although the engine was successful, the X-2 proved extremely unstable at high speeds and only a few flights were undertaken.
+		//		XLR40
+		#roXLR40Title = XLR40
+		#roXLR40Desc = A small rocket motor intended to be used on the XF8U-3 for increased performance. Cancelled after the prototype exploded during testing and the XF8U-3 was cancelled in favor of the F4H.
 		//		XLR41
 		#roXLR41Title = XLR41
 		#roXLR41Desc = Americanized version of the V-2 Model 39 (A-4). It was very similar to its predecessor, but was built using American SAE components rather than metric components, and featured several minor upgrades.

--- a/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Mfr.cfg
@@ -252,6 +252,7 @@ Localization
 		//D
 		#roMfrDaimlerBenz = Daimler-Benz	//(1926-1998) merged with Chrysler to for DaimlerChrysler
 		#roMfrDASA = Deutsche Aerospace (DASA)	//(1989-2000) merged with EADS
+		#roMfrDH = De Havilland	//(1920-1963) Absorbed by Hawker Siddeley
 		#roMfrDornier = Dornier Flugzeugwerke	//(1924-1996) bought by Daimler-Benz 1985, defence division merged with DASA. Bought by Fairchild Aircraft 1996
 		//E
 		#roMfrEADS = European Aeronautic Defence and Space (EADS)	//(2000-2006) holding company, reorganized into Airbus Group


### PR DESCRIPTION
Add configs for more rocketplane engines, including Sprite, Spectre, AR-1/2, and XLR40. Also add a new config to the XLR99.