### PR TITLE
Apply RO Material tags to Kerbal Foundries Parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
@@ -65,6 +65,8 @@
 	%RSSROConfig = True
 	@mass = 0.03
 	@crashTolerance = 18
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
 
 	@MODULE[KSPWheelBase]
 	{
@@ -96,6 +98,8 @@
 	%RSSROConfig = True
 	@mass = 0.02
 	@crashTolerance = 18
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
 
 	@MODULE[KSPWheelBase]
 	{
@@ -129,6 +133,8 @@
 	%RSSROConfig = True
 	@mass = 0.1
 	@crashTolerance = 18
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
 
 	@MODULE[KSPWheelBase]
 	{
@@ -162,6 +168,8 @@
 	%RSSROConfig = True
 	@mass = 0.75
 	@crashTolerance = 18
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
 
 	@MODULE[KSPWheelBase]
 	{
@@ -507,6 +515,8 @@
 	%RSSROConfig = True
 	@mass = 0.19
 	@PhysicsSignificance = 0
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
 
 	@MODULE[KSPWheelBase]
 	{
@@ -523,6 +533,8 @@
 	%RSSROConfig = True
 	@mass = 0.2
 	@PhysicsSignificance = 0
+	%skinTempTag = Aluminum
+	%internalTempTag = Instruments
 
 	@MODULE[KSPWheelBase]
 	{
@@ -539,6 +551,9 @@
 	%RSSROConfig = True
 	@mass = 0.46
 	@PhysicsSignificance = 0
+	%skinTempTag = RCC
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
 
 	@MODULE[KSPWheelBase]
 	{
@@ -555,6 +570,9 @@
 	%RSSROConfig = True
 	@mass = 1.5
 	@PhysicsSignificance = 0
+	%skinTempTag = RCC
+	%internalTempTag = Instruments
+	%skinInsulationTag = True
 
 	@MODULE[KSPWheelBase]
 	{


### PR DESCRIPTION
Apply Aluminium / Instruments tags to rover wheels and small landing gears, and RCC / Instruments tags to medium and large landing gears, matching the stock wheels.