### PR TITLE
Make better insulation

### DIFF
--- a/GameData/RealismOverhaul/RO_Materials.cfg
+++ b/GameData/RealismOverhaul/RO_Materials.cfg
@@ -303,7 +303,7 @@
 //	After, so we can be positively sure this runs after we set skin properties
 @PART:HAS[#skinInsulationTag[?rue]]:AFTER[RealismOverhaul_Materials]
 {
-	@skinInternalConductionMult *= 0.025	//skin is isolated from internal structure
+	@skinInternalConductionMult *= 0.010	//skin is isolated from internal structure
 }
 
 //	=================================================================================


### PR DESCRIPTION
In light of https://github.com/KSP-RO/RealismOverhaul/issues/2950 and related issues, make insulation between part skin and interior a little better. Smaller reentry-rated parts appear to still overheat because they have insufficient thermal mass to survive reentry, so try to reduce the amount of heat penetrating into them.