### PR TITLE
Try to configure landing gear and air bags more sensibly

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayLarge.cfg
@@ -17,8 +17,9 @@
 		wheelRadius = 0.3
 		wheelMass = 0.2
 		suspensionTravel = 0.25
-		// Three of these should carry A340
-		maxLoadRating = 130
+		// Needs about 1.25x scale to match A340
+		// Three of these should carry A340 at 1.25x scale
+		maxLoadRating = 50
 		maxSpeed = 150
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayMed.cfg
@@ -17,8 +17,8 @@
 		wheelRadius = 0.2375
 		wheelMass = 0.15
 		suspensionTravel = 0.2
-		// Two such struts should be able to carry A321
-		maxLoadRating = 40
+		// Matches A321 at about 1.5x scale
+		maxLoadRating = 15 //about 50 tons at 1.5x scale, enough for A321 MTOW
 		maxSpeed = 135 // ~1.33x the 100m/s of small gear bay
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-baySmall.cfg
@@ -18,8 +18,8 @@
 		wheelMass = 0.1
 		suspensionTravel = 0.12
 		// Should correspond to ATR72 / Dash 8 weight
-		// was 15, modify to 17 to match 0.75^3 x med gear bay (40)
-		maxLoadRating = 17
+		// This is way too small for an ATR72. Scale based on Beech 1900/An-38
+		maxLoadRating = 8
 		maxSpeed = 100
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-bayXLarge.cfg
@@ -19,7 +19,8 @@
 		suspensionTravel = 0.527
 		// Assume, four of this gears should carry fully loaded A380
 		// or just two of them - B777
-		maxLoadRating = 180
+		// Needs about 1.4x scale to match B777
+		maxLoadRating = 70
 		maxSpeed = 150
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedMicro.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedMicro.cfg
@@ -15,7 +15,7 @@
 		wheelRadius = 0.198
 		wheelMass = 0.04
 		suspensionTravel = 0.05
-		maxLoadRating = 5
+		maxLoadRating = 0.8		//fairly generous, Cessna 172 max load is only 1.1 tons
 		maxSpeed = 50
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedSmall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KSPWheelStockPatches/Stock-gear-fixedSmall.cfg
@@ -14,8 +14,8 @@
 		wheelColliderOffset = 0.065
 		wheelRadius = 0.2
 		wheelMass = 0.04
-		suspensionTravel = 0.09
-		maxLoadRating = 5
+		suspensionTravel = 0.05
+		maxLoadRating = 1.25		//fairly generous, Cessna 172 max load is only 1.1 tons
 		maxSpeed = 50
 	}
 	MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -1064,7 +1064,7 @@
     %RSSROConfig = True
     
 	@manufacturer = #roMfrGeneric
-    @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.
+    @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
 
 	//Mars Pathfinder airbag system (bags, gas generators, and retraction systems) totalled 99 kg
 	//Mars Pathfinder had 4 sides, with 6 airbag lobes per side with a nominal diameter of 1.59 meters
@@ -1086,7 +1086,7 @@
     %RSSROConfig = True
     
 	@manufacturer = #roMfrGeneric
-    @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.
+    @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
 
 	@mass = 0.002
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -1055,6 +1055,8 @@
 //  Airbags
 
 //  Realism Overhaul configuration.
+//  source: https://doi.org/10.1016/S0094-5765(01)00215-6
+//  Development and evaluation of the mars pathfinder inflatable airbag landing system
 //  ==================================================
 
 @PART[SXTAirbag]:FOR[RealismOverhaul]
@@ -1063,6 +1065,12 @@
     
 	@manufacturer = #roMfrGeneric
     @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.
+
+	//Mars Pathfinder airbag system (bags, gas generators, and retraction systems) totalled 99 kg
+	//Mars Pathfinder had 4 sides, with 6 airbag lobes per side with a nominal diameter of 1.59 meters
+	//SXT bags are 1.25 meters at their largest dimension
+	//About 3.25 kg per airbag?
+	@mass = 0.00325
 
     //restore to original SXT settings
     %crashTolerance = 250
@@ -1079,6 +1087,8 @@
     
 	@manufacturer = #roMfrGeneric
     @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.
+
+	@mass = 0.002
 
     //restore to original SXT settings
     %crashTolerance = 250

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -164,7 +164,7 @@
 @PART[landingLeg1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.06
+	@mass = 0.0242	//scaled to Apollo LM leg
 	
 	//Aluminum
 	%skinTempTag = Aluminum
@@ -173,7 +173,7 @@
 @PART[landingLeg1-2]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
-	@mass = 0.125
+	@mass = 0.057	//same as an Apollo LM leg
 	
 	//Aluminum
 	%skinTempTag = Aluminum

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -127,36 +127,22 @@
 }
 
 //  ==================================================
-//  LY-10 Small Landing Gear.
-//  ==================================================
-
-@PART[SmallGearBay]:FOR[RealismOverhaul]
-{
-    %RSSROConfig = True
-    @maxTemp = 1000
-    @mass = 0.1
-    //Aluminum
-    %skinTempTag = Aluminum
-    %internalTempTag = Instruments
-
-    @MODULE[ModuleWheelBase] { @mass = 0.1 }
-    @MODULE[ModuleLight] { @resourceAmount = 0.025 }
-}
-
-//  ==================================================
 //  LY-01 Fixed Landing Gear.
+//  source for fixed gear: https://backcountrypilot.org/knowledge-base/latest/116-aircraft/modifications/167-cessna-172-heavy-duty-nosewheel
+//  These are suprisingly scaled almost perfectly. C172 wheels have an 18 inch OD, which perfectly matches ingame models
 //  ==================================================
 
 @PART[GearFixed]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     %CoMOffset = -0.65, -0.5, 0
-    @mass = 0.015
+    //Cessna 172 main wheel and fairing is only 7 kg each. Add another 10 kg for brakes and 10 kg for strut?
+    @mass = 0.027
     //Aluminum
     %skinTempTag = Aluminum
     %internalTempTag = Instruments
 
-    @MODULE[ModuleWheelBase] { @mass = 0.015 }
+    @MODULE[ModuleWheelBase] { @mass = 0.027 }
 }
 
 //  ==================================================
@@ -167,12 +153,29 @@
 {
     %RSSROConfig = True
     %CoMOffset = 0, -0.4, 0
-    @mass = 0.01
+    //Cessna 172 nosewheel, fork and fairing is only 7 kg. Add another 7 kg for Oleo strut and steering damper?
+    @mass = 0.014
     //Aluminum
     %skinTempTag = Aluminum
     %internalTempTag = Instruments
 
-    @MODULE[ModuleWheelBase] { @mass = 0.01 }
+    @MODULE[ModuleWheelBase] { @mass = 0.014 }
+}
+
+//  ==================================================
+//  LY-10 Small Landing Gear.
+//  ==================================================
+
+@PART[SmallGearBay]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @mass = 0.1
+    //Aluminum
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
+
+    @MODULE[ModuleWheelBase] { @mass = 0.1 }
+    @MODULE[ModuleLight] { @resourceAmount = 0.025 }
 }
 
 //  ==================================================
@@ -201,13 +204,13 @@
 {
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
-    @mass = 1.5
+    @mass = 1.0
     //Space Shuttle class I guess
     %skinTempTag = RCC
     %internalTempTag = Instruments
     %skinInsulationTag = True
 
-    @MODULE[ModuleWheelBase] { @mass = 1.5 }
+    @MODULE[ModuleWheelBase] { @mass = 1.0 }
     @MODULE[ModuleLight] { @resourceAmount = 0.2 }
 }
 
@@ -222,12 +225,12 @@
     // value despite extra wheels, as for B747 replica the gear like this will probably be upscaled
     // One fully assembled B747 wheel weighs 180 kg, so 1080 kg for wheels
     // only
-    @mass = 2.0
+    @mass = 1.53
     //Space Shuttle class I guess
     %skinTempTag = RCC
     %internalTempTag = Instruments
     %skinInsulationTag = True
 
-    @MODULE[ModuleWheelBase] { @mass = 2.0 }
+    @MODULE[ModuleWheelBase] { @mass = 1.53 }
     @MODULE[ModuleLight] { @resourceAmount = 0.3 }
 }


### PR DESCRIPTION
Try to configure landing legs, landing gear, and airbags better.

- Based on the Mars Pathfinder airbag system, the large airbag has been set to 3.25 kg and the small airbag to 2.00 kg
- Based on the Apollo LM landing legs, the LT-2 landing leg has been set to 52 kg, and the LT-1 landing leg to 24 kg
- The mass and maximum weight of the fixed landing gear has been set based on the Cessna 172
- The mass and maximum weight of the retractable landing gear models has been adjusted to better match real landing gear masses.