### PR TITLE
Airbag Description Fix

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -1064,7 +1064,7 @@
     %RSSROConfig = True
     
 	@manufacturer = #roMfrGeneric
-    @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
+    @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
 
 	//Mars Pathfinder airbag system (bags, gas generators, and retraction systems) totalled 99 kg
 	//Mars Pathfinder had 4 sides, with 6 airbag lobes per side with a nominal diameter of 1.59 meters
@@ -1086,7 +1086,7 @@
     %RSSROConfig = True
     
 	@manufacturer = #roMfrGeneric
-    @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
+    @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
 
 	@mass = 0.002
 


### PR DESCRIPTION
Swaps the descriptions of the Mk-10 Inflatable Airbag and the Mk10-XL Inflatable Airbag, as they were opposite of intended based on description