### PR TITLE
Add early General Electric engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/A1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A1_Config.cfg
@@ -1,0 +1,148 @@
+//	==================================================
+//	Hermes A-1 Engine
+//
+//	Manufacturer: GE
+//
+//	=================================================================================
+//	A-1
+//	
+//
+//	Dry Mass: 140 kg	guess. Pretty high TWR for the time, very basic pressure-fed motor?
+//	Thrust (SL): 60.1 kN	13,500 lbf [A/1/10]
+//	Thrust (Vac): 71.2 kN	~16,000 lbf (see notes)
+//	ISP: 200 SL / 237 Vac	estimated with RPA
+//	Burn Time: 40			Looks like around 35-40 seconds to burnout from [11]
+//	Chamber Pressure: 2.28 MPa	same as XASR?
+//	Propellant: LOX / 75% Ethanol
+//	Prop Ratio: 1.12	//guess, same as A-3? [A]
+//	Throttle: N/A
+//	Nozzle Ratio: 5.6? based on shot of engine in [11]
+//	Ignitions: 1
+//	=================================================================================
+//
+//	SOURCES
+//	[1] https://web.archive.org/web/20200229064126/http://www.alternatewars.com/BBOW/Space_Engines/GE_Engines.htm
+//	[2] https://www.designation-systems.net/dusrm/app1/ssm-a-16.html
+//	[3] https://web.archive.org/web/20070707183816/https://www.nasm.si.edu/spacecraft/RM-HermesA-3B.htm
+//	[4] https://web.archive.org/web/20030207120603/http://www.ufx.org/gfb/hermes.html
+//	[5] http://www.astronautix.com/h/hermesmissile.html
+//	[6] http://www.astronautix.com/h/hermesa-1.html
+//	[7] https://en.wikipedia.org/wiki/Hermes_program#The_Surface_to_Air_and_Surface_to_Surface_Missiles
+//	[8] https://wsmrmuseum.com/2020/08/24/the-hermes-program/
+//	[9] https://weebau.com/rock_us/hermes-a1.php
+//	[10] http://heroicrelics.org/msfc/hermes/index.html
+//	[11] https://forum.nasaspaceflight.com/index.php?topic=43813.0
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton
+
+//	Used by:
+
+//	Notes:
+//	Two thrust levels quoted, 13,500 lbf by [A/1/10] and 16,000 lbf by [2/6]
+//	[11] quotes 19,000 lbf, likely a misreading of 16,000 lbf
+//	However, video of launch in [11] shows A-1 needs about 29 frames (1.21 seconds) to rise it's own height
+//	from the launch pad (300 inches), giving an acceleration of ~1.06 G and a liftoff TWR of 2.06
+//	Assuming quoted wet mass of 6675 lbs is accurate, this agrees with 13500 lbf thrust at sea level
+//	16000 lbf is probably vacuum thrust? Agrees with RPA-calculated numbers
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[A1]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roA1Title	//A-1
+	%manufacturer = #roMfrGE
+	%description = #roA1Desc
+
+	@tags ^= :$: us ge general electric a1 a-1 liquid pressure-fed booster ethanol liquid oxygen
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal]	//thrust vanes
+	{
+		%gimbalRange = 3
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = A-1
+		origMass = 0.140
+		literalZeroIgnitions = True
+
+		CONFIG
+		{
+			name = A-1
+			description = 
+			specLevel = operational
+			minThrust = 71.2
+			maxThrust = 71.2
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = True
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = Ethanol75
+				ratio = 0.5476
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4524
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 34.2
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 237
+				key = 1 200
+			}
+
+			//Hermes A-1: 5 flights, 1 failure (1 cycle)
+			//Flight #2 exploded after burnout [9] so probably not engine?
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 40
+				ignitionReliabilityStart = 0.875000
+				ignitionReliabilityEnd = 0.975000
+				cycleReliabilityStart = 0.750000
+				cycleReliabilityEnd = 0.941667
+				techTransfer = Wasserfall:50
+			}
+		}
+	}
+}
+
++PART[ROE-XLR10]
+{
+	@name = a1
+	@engineType = A1
+}

--- a/GameData/RealismOverhaul/Engine_Configs/A1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A1_Config.cfg
@@ -16,7 +16,7 @@
 //	Propellant: LOX / 75% Ethanol
 //	Prop Ratio: 1.12	//guess, same as A-3? [A]
 //	Throttle: N/A
-//	Nozzle Ratio: 5.6? based on shot of engine in [11]
+//	Nozzle Ratio: 5.5? based on shot of engine in [11]
 //	Ignitions: 1
 //	=================================================================================
 //
@@ -139,10 +139,4 @@
 			}
 		}
 	}
-}
-
-+PART[ROE-XLR10]
-{
-	@name = a1
-	@engineType = A1
 }

--- a/GameData/RealismOverhaul/Engine_Configs/A3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A3_Config.cfg
@@ -1,0 +1,216 @@
+//	==================================================
+//	Hermes A-3 Engine
+//
+//	Manufacturer: GE
+//
+//	=================================================================================
+//	A-3A
+//	RV-A-8
+//
+//	Dry Mass: 175 kg	guess, pump-fed. Similar to XLR-10
+//	Thrust (SL): 80.1 kN	18,000 lbf [A/1/10]
+//	Thrust (Vac): 94.9 kN
+//	ISP: 200 SL / 237 Vac	estimated with RPA
+//	Burn Time: 70			same as A-3B?
+//	Chamber Pressure: 2.28 MPa	same as A-1?
+//	Propellant: LOX / 75% Ethanol
+//	Prop Ratio: 1.12	[A]
+//	Throttle: N/A
+//	Nozzle Ratio: 5.6?	same as A-1?
+//	Ignitions: 1
+//	=================================================================================
+//	A-3B
+//	SSM-A-16
+//
+//	Dry Mass: 165 kg	guess. Simplified, and startup system moved from engine to launchpad. Closer to X-405
+//	Thrust (SL): 93.4 kN	21,000 lbf [A/1/10]
+//	Thrust (Vac): 110.9 kN
+//	ISP: 203 SL / 241 Vac	estimated with RPA
+//	Burn Time: 70			estimated from fuel load
+//	Chamber Pressure: 2.5 MPa	guess, uprated
+//	Propellant: LOX / 75% Ethanol
+//	Prop Ratio: 1.12	[A]
+//	Throttle: N/A
+//	Nozzle Ratio: 5.6?	same as A-1?
+//	Ignitions: 1
+//	=================================================================================
+//
+//	SOURCES
+//	[1] https://web.archive.org/web/20200229064126/http://www.alternatewars.com/BBOW/Space_Engines/GE_Engines.htm
+//	[2] https://www.designation-systems.net/dusrm/app1/ssm-a-16.html
+//	[3] https://web.archive.org/web/20070707183816/https://www.nasm.si.edu/spacecraft/RM-HermesA-3B.htm
+//	[4] https://web.archive.org/web/20030207120603/http://www.ufx.org/gfb/hermes.html
+//	[5] http://www.astronautix.com/h/hermesmissile.html
+//	[6] http://www.astronautix.com/h/hermesa-3a.html
+//	[7] https://en.wikipedia.org/wiki/Hermes_program#The_Surface_to_Air_and_Surface_to_Surface_Missiles
+//	[8] https://wsmrmuseum.com/2020/08/24/the-hermes-program/
+//	[9] https://weebau.com/rock_us/hermes-a1.php
+//	[10] http://heroicrelics.org/msfc/hermes/index.html
+//	[11] https://forum.nasaspaceflight.com/index.php?topic=43813.0
+//	[12] https://wsmrmuseum.com/2020/10/06/the-v-2-program-operation-backfire-to-the-hermes-project/7/
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton
+
+//	Used by:
+
+//	Notes:
+
+//	=================================================================================
+
+@PART[*]:HAS[#engineType[A3]]:FOR[RealismOverhaulEngines]
+{
+	%title = #roA3Title	//A-3
+	%manufacturer = #roMfrGE
+	%description = #roA3Desc
+
+	@tags ^= :$: us ge general electric a3 a-3 liquid pressure-fed booster ethanol liquid oxygen
+
+	%specLevel = operational
+
+	@MODULE[ModuleEngines*]
+	{
+		%EngineType = LiquidFuel
+	}
+
+	!MODULE[ModuleEngineConfigs],*{}
+	!MODULE[ModuleAlternator],*{}
+	!RESOURCE,*{}
+
+	@MODULE[ModuleGimbal]	//gimbal
+	{
+		%gimbalRange = 5	//guess
+		%useGimbalResponseSpeed = true
+		%gimbalResponseSpeed = 16
+	}
+
+	MODULE
+	{
+		name = ModuleEngineConfigs
+		type = ModuleEngines
+		configuration = A-3A
+		origMass = 0.175
+		literalZeroIgnitions = True
+
+		CONFIG
+		{
+			name = A-3A
+			description = Prototype engine, used on the Hermes A-3A (RV-A-8) test vehicle.
+			specLevel = operational
+			minThrust = 94.9
+			maxThrust = 94.9
+			heatProduction = 100
+			massMult = 1.0
+
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = Ethanol75
+				ratio = 0.5476
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4524
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.0108 // sqrt of fraction of X-405?
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 237
+				key = 1 200
+			}
+
+			//Hermes A-3A: 7 flights, 1 failure (1 cycle)
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 70
+				ignitionReliabilityStart = 0.881250
+				ignitionReliabilityEnd = 0.981250
+				cycleReliabilityStart = 0.750000
+				cycleReliabilityEnd = 0.956250
+				techTransfer = A-1:50
+			}
+		}
+		CONFIG
+		{
+			name = A-3B
+			description = Uprated engine for the Hermes A-3B (SSM-A-16) missile.
+			specLevel = operational
+			minThrust = 110.9
+			maxThrust = 110.9
+			heatProduction = 100
+			massMult = 0.9429
+
+			ullage = True
+			pressureFed = False
+			ignitions = 0
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			PROPELLANT
+			{
+				name = Ethanol75
+				ratio = 0.5476
+				DrawGauge = True
+			}
+
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.4524
+			}
+
+			PROPELLANT
+			{
+				name = HTP
+				ratio = 0.0113 // sqrt of fraction of X-405?
+				ignoreForIsp = True
+				DrawGauge = False
+			}
+
+			atmosphereCurve
+			{
+				key = 0 241
+				key = 1 203
+			}
+
+			//Hermes A-3B: 6 flights, 0 failure
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				ratedBurnTime = 70
+				ignitionReliabilityStart = 0.864286
+				ignitionReliabilityEnd = 0.978571
+				cycleReliabilityStart = 0.864286
+				cycleReliabilityEnd = 0.978571
+				techTransfer = A-3A,A-1:50
+			}
+		}
+	}
+}
+
++PART[ROE-XLR10]
+{
+	@name = a3
+	@engineType = A3
+}

--- a/GameData/RealismOverhaul/Engine_Configs/A3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/A3_Config.cfg
@@ -16,7 +16,7 @@
 //	Propellant: LOX / 75% Ethanol
 //	Prop Ratio: 1.12	[A]
 //	Throttle: N/A
-//	Nozzle Ratio: 5.6?	same as A-1?
+//	Nozzle Ratio: 5.5?	same as A-1/X-405?
 //	Ignitions: 1
 //	=================================================================================
 //	A-3B
@@ -31,7 +31,7 @@
 //	Propellant: LOX / 75% Ethanol
 //	Prop Ratio: 1.12	[A]
 //	Throttle: N/A
-//	Nozzle Ratio: 5.6?	same as A-1?
+//	Nozzle Ratio: 5.5?	same as A-1/X-405?
 //	Ignitions: 1
 //	=================================================================================
 //
@@ -207,10 +207,4 @@
 			}
 		}
 	}
-}
-
-+PART[ROE-XLR10]
-{
-	@name = a3
-	@engineType = A3
 }

--- a/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/X405_Config.cfg
@@ -199,7 +199,7 @@
 				ignitionReliabilityEnd = 0.968182
 				cycleReliabilityStart = 0.798485
 				cycleReliabilityEnd = 0.968182
-				techTransfer = XLR10-RM-2:50	//XLR10 appears to use same combustion chamber and nozzle
+				techTransfer = A-3B,A-3A,A-1:50	//Basically just an uprated A-3
 			}
 
 		}
@@ -270,7 +270,7 @@
 				ignitionReliabilityEnd = 0.965	//worse, since it now has to air-start
 				cycleReliabilityStart = 0.86
 				cycleReliabilityEnd = 0.975 // years more experience
-				techTransfer = X-405,XLR10-RM-2:50
+				techTransfer = X-405,A-3B,A-3A,A-1:50
 			}
 		}
 		CONFIG
@@ -340,7 +340,7 @@
 				ignitionReliabilityEnd = 0.98
 				cycleReliabilityStart = 0.90
 				cycleReliabilityEnd = 0.985
-				techTransfer = X-405H,X-405,XLR10-RM-2:50
+				techTransfer = X-405H,X-405,A-3B,A-3A,A-1:50
 			}
 		}
 		CONFIG
@@ -408,7 +408,7 @@
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
-				techTransfer = X-405H-2,X-405H,X-405,XLR10-RM-2:50
+				techTransfer = X-405H-2,X-405H,X-405,A-3B,A-3A,A-1:50
 			}
 		}
 		CONFIG
@@ -475,7 +475,7 @@
 				ignitionReliabilityEnd = 0.998649
 				cycleReliabilityStart = 0.980030
 				cycleReliabilityEnd = 0.996847
-				techTransfer = X-405H-3,X-405H-2,X-405H,X-405,XLR10-RM-2:50
+				techTransfer = X-405H-3,X-405H-2,X-405H,X-405,A-3B,A-3A,A-1:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -21,6 +21,12 @@ Localization
 		#ro25KS18000Title = Aerojet 2.5KS-18000
 		#ro25KS18000Desc = A small but powerful solid fueled booster used as the first stage for the Aerobee line of sounding rockets.
 		//A
+		//		A-1
+		#roA1Title = A-1
+		#roA1Desc = A basic pressure-fed booster engine developed by General Electric to power American-built Wasserfall missiles for the Hermes program (CTV-G-5). Although the design was deemed unsuitable for military use, several Hermes A-1 missiles were still flown to gain experience in the construction and operation of large rockets.
+		//		A-3
+		#roA3Title = A-3
+		#roA3Desc = A basic pump-fed booster engine developed as an improved version of the Hermes A-1 for the Hermes A-3 ballistic missile. Difficulties with development led the program being split into two parts, with the smaller A-3A testing the engine and guidance systems for the larger A-3B. Although it was evaluated for use by the US Army as the SSM-A-16, it was rejected due to poor performance and reliability.
 		//		A-4
 		#roA-4Title = A-4
 		#roA-4Desc = A Thiel alcolox engine used on the V-2 missile. Interim design, but went into production. Used 18 x 1.5 tonne thrust chambers that fed a common mixing chamber. Work began 1936, testing in 1939, and mass production from 1943-1945.


### PR DESCRIPTION
Add early General Electric engines from the Hermes project, A-1 and A-3.
Derived from Wasserfall, these engines were somewhat similar to the XLR10. They were upgraded many times as the demands of the Hermes program increased, and eventually became the X-405.