### PR TITLE
Add Kerbal Wind to "suggest" in netkan

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -101,6 +101,7 @@ suggests:
       - name: Restock
   - name: UniversalStorage
   - name: VenStockRevamp-NewParts
+  - name: KerbalWind
 provides:
   - RealPlumeConfigs
   - RealFuels-Engine-Configs


### PR DESCRIPTION
A lot of people use kerbal wind with RO, but surprisingly it isn't suggested by RO at all. As far as I know, it is entirely compatible with RO/FAR.