### PR TITLE
UDMH/LOX subconfigs for the Proton's second and third stage engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -156,6 +156,33 @@
 				key = 1 240
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0208. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 610.86
+				maxThrust = 610.86
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4490
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5510
+				}
+				atmosphereCurve
+				{
+					key = 0 355
+					key = 1 261
+				}
+			}
+
 			//Proton (8K82): 4 flights, 1 failure. (1 cycle)
 			//16 ignitions, 0 failures
 			//16 cycles, 1 failures
@@ -210,6 +237,33 @@
 			{
 				key = 0 327
 				key = 1 242
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0210. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 622.26
+				maxThrust = 622.26
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4476
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5524
+				}
+				atmosphereCurve
+				{
+					key = 0 356
+					key = 1 263
+				}
 			}
 
 			//Proton-K (8K82K): 28 flights, 1 failure. (1 cycle)
@@ -280,6 +334,33 @@
 			{
 				key = 0 327.3
 				key = 1 242
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0210 Mk-2. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 638.48
+				maxThrust = 638.48
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4476
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5524
+				}
+				atmosphereCurve
+				{
+					key = 0 356
+					key = 1 263
+				}
 			}
 
 			//630 ignitions, 0 failures

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -172,17 +172,17 @@
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.5418
+					ratio = 0.4537
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.4582
+					ratio = 0.5463
 				}
 				atmosphereCurve
 				{
-					key = 0 353.3
+					key = 0 353.34
 					key = 1 270
 				}
 			}
@@ -255,13 +255,13 @@
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.5418
+					ratio = 0.4524
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.4582
+					ratio = 0.5476
 				}
 				atmosphereCurve
 				{
@@ -346,20 +346,20 @@
 				name = UDMH/LOX
 				description = UDMH/LOX version of RD-0212-Mk2. Much higher performance, but requires cryogenic fuels.
 				specLevel = speculative
-				minThrust = 664
-				maxThrust = 664
+				minThrust = 664.1
+				maxThrust = 664.1
 				massMult = 1.0
 				costOffset = 0
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.5418
+					ratio = 0.4519
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.4582
+					ratio = 0.5481
 				}
 				atmosphereCurve
 				{
@@ -428,20 +428,20 @@
 				name = UDMH/LOX
 				description = UDMH/LOX version of RD-0212-Mk3. Much higher performance, but requires cryogenic fuels.
 				specLevel = speculative
-				minThrust = 678.06
-				maxThrust = 678.06
+				minThrust = 678.04
+				maxThrust = 678.04
 				massMult = 1.0
 				costOffset = 0
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.5418
+					ratio = 0.4518
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.4582
+					ratio = 0.5482
 				}
 				atmosphereCurve
 				{

--- a/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0212_Config.cfg
@@ -160,6 +160,33 @@
 				key = 1 239
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0205. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 643.3
+				maxThrust = 643.3
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.5418
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.4582
+				}
+				atmosphereCurve
+				{
+					key = 0 353.3
+					key = 1 270
+				}
+			}
+
 			//UR-200 (8K81) (R&D): 7 flights, 0 failures
 			//7 ignitions, 0 failures
 			//7 cycles, 0 failures
@@ -214,6 +241,33 @@
 			{
 				key = 0 325.3
 				key = 1 240
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0212. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 651
+				maxThrust = 651
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.5418
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.4582
+				}
+				atmosphereCurve
+				{
+					key = 0 354
+					key = 1 270
+				}
 			}
 
 			//Proton-K (8K82K): 27 flights, 0 failures
@@ -287,6 +341,33 @@
 				key = 1 240
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0212-Mk2. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 664
+				maxThrust = 664
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.5418
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.4582
+				}
+				atmosphereCurve
+				{
+					key = 0 354.03
+					key = 1 270
+				}
+			}
+
 			//142 ignitions, 0 failures
 			//142 cycles, 1 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -340,6 +421,33 @@
 			{
 				key = 0 325.3
 				key = 1 240
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0212-Mk3. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 678.06
+				maxThrust = 678.06
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.5418
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.4582
+				}
+				atmosphereCurve
+				{
+					key = 0 354.07
+					key = 1 270
+				}
 			}
 
 			//Proton-M Blok-DM-2 (8K82K 11S861): 6 flights, 0 failures

--- a/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
@@ -144,6 +144,33 @@
 				key = 1 241
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0206. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 612.4
+				maxThrust = 612.4
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4490
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5510
+				}
+				atmosphereCurve
+				{
+					key = 0 355
+					key = 1 261
+				}
+			}
+
 			//UR-200 (8K81) (R&D): 7 flights, 0 failures
 			//7 ignitions, 0 failures
 			//7 cycles, 0 failures
@@ -166,7 +193,7 @@
 		CONFIG
 		{
 			name = RD-0213
-			description = UR-500/Proton second stage main engine, used with RD-0214 verniers to form the RD-0212 engine module. AKA 8D48
+			description = UR-500/Proton third stage main engine, used with RD-0214 verniers to form the RD-0212 engine module. AKA 8D48
 			specLevel = operational
 			minThrust = 581.8
 			maxThrust = 581.8
@@ -190,6 +217,33 @@
 			{
 				key = 0 327
 				key = 1 242
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0213. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 619.1
+				maxThrust = 619.1
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4476
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5524
+				}
+				atmosphereCurve
+				{
+					key = 0 356
+					key = 1 263
+				}
 			}
 
 			//Proton-K (8K82K): 27 flights, 0 failures
@@ -256,6 +310,33 @@
 				key = 1 242
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0213 Mk-2. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 632.07
+				maxThrust = 632.07
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4476
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5524
+				}
+				atmosphereCurve
+				{
+					key = 0 356
+					key = 1 263
+				}
+			}
+
 			//142 ignitions, 0 failures
 			//142 cycles, 1 failures
 			//Since this is actually half an RD-0212, halve the failure rate
@@ -302,6 +383,33 @@
 			{
 				key = 0 327
 				key = 1 242
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0213 Mk-3. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 646.17
+				maxThrust = 646.17
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4476
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5524
+				}
+				atmosphereCurve
+				{
+					key = 0 356
+					key = 1 263
+				}
 			}
 
 			//Proton-M Blok-DM-2 (8K82K 11S861): 6 flights, 0 failures

--- a/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0213_Config.cfg
@@ -156,13 +156,13 @@
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.4490
+					ratio = 0.4491
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.5510
+					ratio = 0.5509
 				}
 				atmosphereCurve
 				{
@@ -231,13 +231,13 @@
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.4476
+					ratio = 0.4475
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.5524
+					ratio = 0.5525
 				}
 				atmosphereCurve
 				{
@@ -315,20 +315,20 @@
 				name = UDMH/LOX
 				description = UDMH/LOX version of RD-0213 Mk-2. Much higher performance, but requires cryogenic fuels.
 				specLevel = speculative
-				minThrust = 632.07
-				maxThrust = 632.07
+				minThrust = 632.1
+				maxThrust = 632.1
 				massMult = 1.0
 				costOffset = 0
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.4476
+					ratio = 0.4471
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.5524
+					ratio = 0.5529
 				}
 				atmosphereCurve
 				{
@@ -390,20 +390,20 @@
 				name = UDMH/LOX
 				description = UDMH/LOX version of RD-0213 Mk-3. Much higher performance, but requires cryogenic fuels.
 				specLevel = speculative
-				minThrust = 646.17
-				maxThrust = 646.17
+				minThrust = 646.14
+				maxThrust = 646.14
 				massMult = 1.0
 				costOffset = 0
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.4476
+					ratio = 0.4471
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.5524
+					ratio = 0.5529
 				}
 				atmosphereCurve
 				{

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -99,6 +99,33 @@
 				key = 1 152
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0207. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 30.9
+				maxThrust = 30.9
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.5647
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.4326
+				}
+				atmosphereCurve
+				{
+					key = 0 323.4
+					key = 1 161
+				}
+			}
+
 			//UR-200 (8K81) (R&D): 7 flights, 0 failures
 			//7 ignitions, 0 failures
 			//7 cycles, 0 failures
@@ -122,7 +149,7 @@
 		CONFIG
 		{
 			name = RD-0214
-			description = UR-500/Proton second stage verniers, used with RD-0213 main engine to form the RD-0212 engine module. AKA 8D811
+			description = UR-500/Proton third stage verniers, used with RD-0213 main engine to form the RD-0212 engine module. AKA 8D811
 			specLevel = operational
 			minThrust = 30.98
 			maxThrust = 30.98
@@ -145,6 +172,33 @@
 			{
 				key = 0 293
 				key = 1 189
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0214. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 31.91
+				maxThrust = 31.91
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.5647
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.4326
+				}
+				atmosphereCurve
+				{
+					key = 0 319
+					key = 1 195
+				}
 			}
 
 			//Proton-K (8K82K): 27 flights, 0 failures

--- a/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0214_Config.cfg
@@ -111,13 +111,13 @@
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.5647
+					ratio = 0.5354
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.4326
+					ratio = 0.4646
 				}
 				atmosphereCurve
 				{
@@ -186,13 +186,13 @@
 				PROPELLANT
 				{
 					name = UDMH
-					ratio = 0.5647
+					ratio = 0.5338
 					DrawGauge = True
 				}
 				PROPELLANT
 				{
 					name = LqdOxygen
-					ratio = 0.4326
+					ratio = 0.4662
 				}
 				atmosphereCurve
 				{


### PR DESCRIPTION
**Motivation:** I want to add these configs because it feels weird using upper stage engines with lower ISP than of the first stage's. I don't have any evidence that LOX configs ever existed. I don't mind hiding them behind the altHist speclevel.

**Calculations:** Specs of RD-0210/0213 are based on the existing RD-254 LOX subconfigs as they are all the same family's upper stage engines. LOX configs thrust increased by the same ratio as of the RD-254 configs, and the fuel ratios are the same. RD-0210/0213 have slightly lower expansion ratio, but, according to this [nozzle simulation tool](https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/nozzle/), it results in just about 1s of ISP decrease.
RD-0214 LOX specs are calculated based on the performance difference between NTO RD-0213 and RD-0214.
RD-0212 LOX specs calculated the same way as of the NTO configs - thrust is the sum of 2, ISP is the weighted average.