### PR TITLE
Fix gear overheating during regular use

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
@@ -515,8 +515,8 @@
 	%RSSROConfig = True
 	@mass = 0.19
 	@PhysicsSignificance = 0
-	%skinTempTag = Aluminum
-	%internalTempTag = Instruments
+	%skinTempTag = Inconel
+	%internalTempTag = HotStructure
 
 	@MODULE[KSPWheelBase]
 	{
@@ -533,8 +533,8 @@
 	%RSSROConfig = True
 	@mass = 0.2
 	@PhysicsSignificance = 0
-	%skinTempTag = Aluminum
-	%internalTempTag = Instruments
+	%skinTempTag = Inconel
+	%internalTempTag = HotStructure
 
 	@MODULE[KSPWheelBase]
 	{
@@ -552,7 +552,7 @@
 	@mass = 0.46
 	@PhysicsSignificance = 0
 	%skinTempTag = RCC
-	%internalTempTag = Instruments
+	%internalTempTag = HotStructure
 	%skinInsulationTag = True
 
 	@MODULE[KSPWheelBase]
@@ -571,7 +571,7 @@
 	@mass = 1.5
 	@PhysicsSignificance = 0
 	%skinTempTag = RCC
-	%internalTempTag = Instruments
+	%internalTempTag = HotStructure
 	%skinInsulationTag = True
 
 	@MODULE[KSPWheelBase]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -171,8 +171,8 @@
     %RSSROConfig = True
     @mass = 0.1
     //Aluminum
-    %skinTempTag = Aluminum
-    %internalTempTag = Instruments
+    %skinTempTag = Inconel
+    %internalTempTag = HotStructure
 
     @MODULE[ModuleWheelBase] { @mass = 0.1 }
     @MODULE[ModuleLight] { @resourceAmount = 0.025 }
@@ -189,7 +189,7 @@
     @mass = 0.46
     //Space Shuttle class I guess
     %skinTempTag = RCC
-    %internalTempTag = Instruments
+    %internalTempTag = HotStructure
     %skinInsulationTag = True
 
     @MODULE[ModuleWheelBase] { @mass = 0.46 }
@@ -207,7 +207,7 @@
     @mass = 1.0
     //Space Shuttle class I guess
     %skinTempTag = RCC
-    %internalTempTag = Instruments
+    %internalTempTag = HotStructure
     %skinInsulationTag = True
 
     @MODULE[ModuleWheelBase] { @mass = 1.0 }
@@ -228,7 +228,7 @@
     @mass = 1.53
     //Space Shuttle class I guess
     %skinTempTag = RCC
-    %internalTempTag = Instruments
+    %internalTempTag = HotStructure
     %skinInsulationTag = True
 
     @MODULE[ModuleWheelBase] { @mass = 1.53 }


### PR DESCRIPTION
Currently, all retractable landing gear directly exposed to heat levels experienced during things like hypersonic flight and faster are big fans of melting. 

This PR changes their skin and internal heat tolerance to be at minimum Inconel tier, preventing the gear from experiencing early death due to overheating when not fully shielded via clipping them inside parts. This clipping method is a workaround that only works for some gears. Now it should no longer be necessary.