### PR TITLE
Make Engine Lighting Relit and Rocket Sound Enhancement conflicting in ckan

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -113,6 +113,8 @@ conflicts:
   - name: StockWaterfallEffects
   - name: WaterfallRestock
   - name: DeadlyReentry
+  - name: EngineLightRelit
+  - name: RocketSoundEnhancement
 resources:
   homepage: >-
     http://forum.kerbalspaceprogram.com/index.php?/topic/155700-122-realism-overhaul-v1150-05262017/


### PR DESCRIPTION
Normally, a mod not having configs for RO would not end up with it being listed as conflicts in ckan with RO. However, for some reason, when either of these mods are installed with ro, they seem to cause a lot of [errors](https://discord.com/channels/319857228905447436/512556137380315139/1141777198047572139), [lag](https://discord.com/channels/319857228905447436/331813459417235457/1339201005459603550), and glitches. For this reason, it is fair to list them as conflicting.