### PR TITLE
Change radiatorHeadroom value to restore analytical propellant cooling functionality

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -940,7 +940,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.69
+    @radiatorHeadroom = 0.69 // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -983,7 +983,7 @@
     @manufacturer = Roscosmos
     @description = A small surface - mounted External Active Thermal Control System radiator panel.
 
-    @mass = 0.023
+    @mass = 0.0144
     %breakingForce = 250
     %breakingTorque = 250
 
@@ -992,7 +992,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.69
+    @radiatorHeadroom = 0.69 // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1044,7 +1044,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.69 // 0.2702 sets the limit to 17C, or 290K
+    @radiatorHeadroom = // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1092,7 +1092,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.69
+    @radiatorHeadroom = 0.69 // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1143,7 +1143,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.69 // just a test value
+    @radiatorHeadroom = 0.69 // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1193,7 +1193,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.69 // 0.2702 sets the limit to 17C, or 290K
+    @radiatorHeadroom = 0.69 // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -1044,7 +1044,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
+    @radiatorHeadroom = 0.69 // Multiplies the maximum internal temperature by this value to indicate the maximum temperature at which the radiator stops working. For 448K aluminium internals, this is 309K
 
     @MODULE[ModuleActiveRadiator]
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -940,7 +940,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.25
+    @radiatorHeadroom = 0.69
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -992,7 +992,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.25
+    @radiatorHeadroom = 0.69
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1044,7 +1044,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.28 // 0.2702 sets the limit to 17C, or 290K
+    @radiatorHeadroom = 0.69 // 0.2702 sets the limit to 17C, or 290K
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1092,7 +1092,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.28
+    @radiatorHeadroom = 0.69
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1143,7 +1143,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-    @radiatorHeadroom = 0.28 // just a test value
+    @radiatorHeadroom = 0.69 // just a test value
 
     @MODULE[ModuleActiveRadiator]
     {
@@ -1193,7 +1193,7 @@
     %internalTempTag = Aluminum
 
     %fuelCrossFeed = False
-	%radiatorHeadroom = 0.29 // 0.2702 sets the limit to 17C, or 290K
+    @radiatorHeadroom = 0.69 // 0.2702 sets the limit to 17C, or 290K
 
     @MODULE[ModuleActiveRadiator]
     {


### PR DESCRIPTION
Since PR #2876 radiators have not been working correctly. They provide zero cooling performance during analytical timewarp. The lowered temperature tolerances of the part somehow negatively affect its cooling capabilities.

Increasing the value of the radiatorHeadroom tag restores them to their old cooling performance. I don't actually know how this value is used to calculate radiator performance and the comments in the file are not particularly enlightening. Therefore, the 0.69 value for radiatorHeadroom was chosen to approximate the cooling performance of the radiators when they still had their old maxTemp = 1073.15 tags. 