### PR TITLE
Remove restart penalties from IRFNA-III Agenas

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -205,10 +205,11 @@
 //	(5) AlternateWars Bell/Textron rocket engines - http://www.alternatewars.com/BBOW/Space_Engines/BellTextron_Engines.htm
 //	(6) NASA 19740024172 Reusable Agena Study Final Report (Technical Volume II) - http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19740024172.pdf
 //	(7)	AIAA DESIGN AND TEST RESULTS ON AGENA 2000 - https://www.pdf-archive.com/2017/05/31/design-and-test-results-on-agena-2000/design-and-test-results-on-agena-2000.pdf
-//	(8) https://arc.aiaa.org/doi/abs/10.2514/3.62175?journalCode=jsr
-//      [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 519 Table 7.11-2
+//	(8) Agena Primary and Integrated Secondary Propulsion Systems - https://arc.aiaa.org/doi/abs/10.2514/3.62175?journalCode=jsr
+//	(9) Agena restart simulation by turbopump testing - https://arc.aiaa.org/doi/abs/10.2514/6.1975-1274
+//	[A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 519 Table 7.11-2
 //	[B] X-15 Extending the Frontiers of Flight, Dennis R. Jenkins
-//  https://ntrs.nasa.gov/api/citations/20080008340/downloads/20080008340.pdf
+//	https://ntrs.nasa.gov/api/citations/20080008340/downloads/20080008340.pdf
 
 //	Used by:
 
@@ -473,7 +474,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-7
-			description = Model 8081, Agena B. Cannot restart between 15 minutes and 3 hours after shutdown.
+			description = Model 8081, Agena B.
 			specLevel = operational
 			maxThrust = 70.7
 			minThrust = 70.7
@@ -518,14 +519,6 @@
 				testedBurnTime = 480
 				ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 				safeOverburn = true
-				restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
-				{
-					key = 0 1 0 0
-					key = 900 1 0 0		//sharp drop after 15 minutes
-					key = 1800 0 0 0
-					key = 8874 0.5025576 0.0002037228 0.0002375458		//gentle slope back up as pumps cool down
-					key = 10800 1 0 0
-				}
 				ignitionReliabilityStart = 0.944823
 				ignitionReliabilityEnd = 0.991288
 				ignitionDynPresFailMultiplier = 0.1
@@ -539,7 +532,7 @@
 		CONFIG
 		{
 			name = XLR81-BA-11
-			description = Model 8096, Agena D. Cannot restart between 15 minutes and 3 hours after shutdown.
+			description = Model 8096, Agena D.
 			specLevel = operational
 			maxThrust = 71.17
 			minThrust = 71.17
@@ -612,14 +605,6 @@
 				testedBurnTime = 640
 				ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 				safeOverburn = true
-				restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
-				{
-					key = 0 1 0 0
-					key = 900 1 0 0		//sharp drop after 15 minutes
-					key = 1800 0 0 0
-					key = 8874 0.5025576 0.0002037228 0.0002375458		//gentle slope back up as pumps cool down
-					key = 10800 1 0 0
-				}
 				ignitionReliabilityStart = 0.985433
 				ignitionReliabilityEnd = 0.997700
 				ignitionDynPresFailMultiplier = 0.1
@@ -687,7 +672,7 @@
 				testedBurnTime = 640
 				ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 				safeOverburn = true
-				restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
+				restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in oxidizer pump (9)
 				{
 					key = 0 1 0 0
 					key = 900 1 0 0		//sharp drop after 15 minutes
@@ -758,7 +743,7 @@
 				testedBurnTime = 640
 				ratedBurnTime = 240		//Ran to 640 seconds during HDA tests with no damage
 				safeOverburn = true
-				restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in turbopumps
+				restartWindowPenalty		//cannot restart between 15 minutes and 3 hours due to heatsoak in oxidizer pump (9)
 				{
 					key = 0 1 0 0
 					key = 900 1 0 0		//sharp drop after 15 minutes


### PR DESCRIPTION
The oxidizer pump boilout problem was specifically due to the more volatile IRFNA-IV (HDA) oxidizer. The problem was fixed by slight modifications to the pump on later models.

Source: Agena restart simulation by turbopump testing - https://arc.aiaa.org/doi/abs/10.2514/6.1975-1274