### PR TITLE
Set airbag landing speed to more sensible value

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SXT/RO_SXT_Utility.cfg
@@ -1057,6 +1057,8 @@
 //  Realism Overhaul configuration.
 //  source: https://doi.org/10.1016/S0094-5765(01)00215-6
 //  Development and evaluation of the mars pathfinder inflatable airbag landing system
+//  Set impact speed rating to 70 m/s (~max impact speed of Ranger hard lander). Luna Ye-6 and Mars
+//  Pathfinder were only rated to 20-30 m/s though...
 //  ==================================================
 
 @PART[SXTAirbag]:FOR[RealismOverhaul]
@@ -1064,7 +1066,7 @@
     %RSSROConfig = True
     
 	@manufacturer = #roMfrGeneric
-    @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
+    @description = A more advanced alternative to the Mk-10 landing system. Rather stronger.
 
 	//Mars Pathfinder airbag system (bags, gas generators, and retraction systems) totalled 99 kg
 	//Mars Pathfinder had 4 sides, with 6 airbag lobes per side with a nominal diameter of 1.59 meters
@@ -1073,7 +1075,7 @@
 	@mass = 0.00325
 
     //restore to original SXT settings
-    %crashTolerance = 250
+    %crashTolerance = 70
     %breakingForce = 5000
     %breakingTorque = 5000
 	//Fiberglass
@@ -1086,12 +1088,12 @@
     %RSSROConfig = True
     
 	@manufacturer = #roMfrGeneric
-    @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.<#ef7b06> AUTHOR'S NOTE: Due to the limitations of KSP collision physics, the maximum safe speed of these airbags will be much lower than 250 m/s.</color>
+    @description = A set of inflatable balloons that can handle impacts of moderate speed on planetary surfaces. These airbags are well suited for landing small landers and probes on rough terrain when a skycrane or internal propulsion is lacking or imprecise. First used on Russian Luna landers like Luna 9, airbags served well as Mars landing systems during various missions.
 
 	@mass = 0.002
 
     //restore to original SXT settings
-    %crashTolerance = 250
+    %crashTolerance = 70
     %breakingForce = 5000
     %breakingTorque = 5000
 	//Fiberglass


### PR DESCRIPTION
Set airbag impact speed to a very generous 70 m/s, to match the Ranger hard lander.