### PR TITLE
Reduce minimum part RB mass even further to 0.1kg

### DIFF
--- a/GameData/RealismOverhaul/RO_Physics.cfg
+++ b/GameData/RealismOverhaul/RO_Physics.cfg
@@ -73,12 +73,12 @@
 	%perSeatReduction = 0.1
 	%perCommandSeatReduction = 0.205	// 100kg Kerbal, 29kg ACES parachute, 76kg AMU (jetpack)
 
-	@partRBMassMin = 0.001
+	@partRBMassMin = 0.0001
 }
 
 @PART[*]:FOR[zzzRealismOverhaul]
 {
-	&minimumRBMass = 0.001
+	&minimumRBMass = 0.0001
 }
 
 @PART:HAS[#CrewCapacity[>0]]:FOR[zzzRealismOverhaul]


### PR DESCRIPTION
Continuation of #2937.
Closes https://github.com/KSP-RO/ROSolar/issues/18.