### PR TITLE
Add VaporVent and Volumetric Vapor Cones

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VaporVent/RO_VaporVent.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VaporVent/RO_VaporVent.cfg
@@ -1,0 +1,6 @@
+@PART[vent|smallvent|tinyvent|VaporVent_Remake_Fx1|VaporVent_Remake_Fx2|VaporVent_Remake_Fx3]:FOR[RealismOverhaul]:NEEDS[VaporVent]
+{
+    %RSSROConfig = True
+    %mass = 0.0001
+    %maxTemp = 3000
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VolumetricVaporCones/RO_VolumetricVaporCones.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VolumetricVaporCones/RO_VolumetricVaporCones.cfg
@@ -1,0 +1,4 @@
+@PART[vaporCone]:FOR[RealismOverhaul]:NEEDS[VolumetricVaporCones]
+{
+    %RSSROConfig = True
+}


### PR DESCRIPTION
Both of these are aesthetics mods in a similar vein to conformal decals. VaporVent adds a vent of vapor that comes off of your rocket before launch. Volumetric Vapor Cones allows you to control where Vapor Cones form at the speed of sound.

Related: https://github.com/KSP-RO/RP-1/pull/2573