### PR TITLE
Fix RD-0210 description

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0210_Config.cfg
@@ -89,7 +89,7 @@
 {
 	%title = #roRD0210Title	//RD-0208/0210
 	%manufacturer = #roMfrOKB154
-	%description = #roRD0210Desc	//A staged combustion, hypergolic vacuum rocket engine. Used as a power plant on the second stage of the Proton launch vehicle family. Features a two-axis gimbal mechanism for attitude control.
+	%description = #roRD0210Desc	//A staged combustion, hypergolic vacuum rocket engine. Used as a power plant on the second stage of the Proton launch vehicle family. Features a one-axis gimbal mechanism for attitude control.
 
 	@tags ^= :$: USSR okb-154 kbkha kosberg rd-0208 rd-0209 rd-456 rd-0210 rd-0211 rd-468 liquid pump upper udmh nto
 


### PR DESCRIPTION
Reported by [Doc](https://discord.com/channels/319857228905447436/319857228905447436/1373318586390810775)

Comments indicate that the engine only has one axis of movement, which is correctly shown in-game, but the description was copied over from the RD-0203 without changing it.


![image](https://github.com/user-attachments/assets/ea3310b1-2fcd-4f41-bbd7-bf3934f5561b)