### PR TITLE
Resize Mk1 Crew Carrier to Mk1 size

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Command.cfg
@@ -52,8 +52,8 @@
     @description = Three-person inline crew hab section for Mk1 spaceplanes. Rated for LEO reentries.
     @CrewCapacity = 3
     @mass = 1.5
-    %rescaleFactor = 1.722222
-
+    %rescaleFactor = 1.64 
+							   
     //Space Shuttle class
     %skinTempTag = RCC
     %internalTempTag = Aluminum


### PR DESCRIPTION
Was very slightly too big to match with other Mk1 parts (2.25 m instead of 2.15 m), so I made it actually the right size for people wanting to build spaceplanes