### PR TITLE
Titan (LR87 and LR91) engine config overhaul

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
@@ -1,5 +1,5 @@
 //	==================================================
-//	LR-87 LH2
+//	AJ23-65
 //
 //	Manufacturer: Aerojet
 //
@@ -64,6 +64,7 @@
 //	Sources:
 
 // http://www.astronautix.com/t/titanc.html
+// https://web.archive.org/web/20200229085200/https://www.alternatewars.com/BBOW/Space_Engines/AJ-23-65_Info.gif
 
 //	Used by:
 
@@ -79,7 +80,7 @@
 //	==================================================
 @PART[*]:HAS[#engineType[LR87LH2]]:FOR[RealismOverhaulEngines]
 {
-	%title = #roLR87LH2Title	//LR87-LH2
+	%title = #roLR87LH2Title	//AJ23-65
 	%manufacturer = #roMfrAerojet
 	%description = #roLR87LH2Desc	//Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. Aerojet also proposed this engine for Saturn upper stage duties, but NASA selected the J-2 over the LR87-LH2 and it was canceled in 1961.
 

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
@@ -1,97 +1,185 @@
 //	==================================================
-//	LR-87 Series Titan Engines
+//	LR-87 Series Engines
 //
 //	Manufacturer: Aerojet
 //
 //	=================================================================================
-//	LR87-AJ-3
-//	Titan A / Titan I
+//	LR87-AJ-1 (AJ23-128?)
+//	Titan A / Titan I (Before May 1960) [8]
 //
-//	Dry Mass: 839 kg
-//	Thrust (SL): 150,000 lbf = 667.233 kN
-//	Thrust (Vac): 172,193 lbf = 765.9523465 kN
-//	ISP: 249.5 SL / 286 Vac
-//	Burn Time: 137
-//	Chamber Pressure: 4.05 MPa
+//	Dry Mass: 932 kg		(1300 kg 25AR)	Titan 1 mass varied a lot depending on the production Lot and source [1/4]. Guess, 10% heavier?
+//	Thrust (SL): 667.233 kN			150klbf at sea level	[1/8/9]
+//	Thrust (Vac): 765.952 kN	(825.8 kN 25AR)
+//	ISP: 251.9 SL / 289.1 Vac		(205/311.7 25AR)	[9]
+//	Burn Time: 134		[1]
+//	Chamber Pressure: 4.05 MPa	[1/9]
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.02
-//	Engine Nozzle: 1.10 m diameter
-//	Nozzle Exit Area: 1462 in^2 = 0.943224 m^2
-//	Nozzle Ratio: 8
+//	Prop Ratio: 2.25	[1/9]
+//	Throttle: N/A
+//	Nozzle Ratio: 8		[1/9]
 //	Ignitions: 1
 //	=================================================================================
-//	LR87-AJ-5
+//	LR87-AJ-3 (AJ23-130)
+//	Titan A / Titan I (After May 1960) [8]
+//	Mostly identical to AJ-1, but with simplified pressurization system, reduced weight, etc.
+//
+//	Dry Mass: 839 kg	(1200 kg 25AR)	[5]
+//	Thrust (SL): 667.233 kN			150klbf at sea level	[1/8/9]
+//	Thrust (Vac): 765.952 kN	(825.8 kN 25AR)
+//	ISP: 251.9 SL / 289.1 Vac		(205/311.7 25AR)	[9]
+//	Burn Time: 134		[1]
+//	Chamber Pressure: 4.05 MPa	[1/9]
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.25	[1/9]
+//	Throttle: N/A
+//	Nozzle Ratio: 8		[1/9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-AJ-5 (AJ23-132)
 //	Titan B / Titan II
 //
-//	Dry Mass: 739 kg
-//	Thrust (SL): 215 klbf
-//	Thrust (Vac): 236.9 klbf = 1053.8 kN
-//	ISP: 258.8 SL / 285.2 Vac
+//	Dry Mass: 739 kg	(786 kg 15AR, 1105 kg 49AR)		[5]
+//	Thrust (SL): 215 klbf		[1/3/8/9]
+//	Thrust (Vac): 1053.9 kN		(1102.7 15AR, 1171.4 kN 49AR)
+//	ISP: 258.8 SL / 285.2 Vac	(248/298.4 15AR, 200/317 49AR)	[9]
+//	Burn Time: 149.26		[1]
+//	Chamber Pressure: 5.48 MPa	[9]
+//	Propellant: NTO / A50
+//	Prop Ratio: 1.93		[1/3/5/9]
+//	Throttle: N/A
+//	Nozzle Ratio: 8			[1/3/5/9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-AJ-5-Kero
+//	Speculative
+//
+//	Dry Mass: 755 kg	(803 15AR, 1129 49AR)
+//	Thrust (SL): ???
+//	Thrust (Vac): 913.5 kN	(952.3 15AR, 998.3 kN 49AR)
+//	ISP: 262.9 SL / 290.1 Vac	(252/303.5 15AR, 200/322.5 49AR)	simulated in RPA, with 1 percentage point drop in combustion efficiency
 //	Burn Time: 149.26
 //	Chamber Pressure: 5.48 MPa
-//	Propellant: NTO / A50
-//	Prop Ratio: 1.93
-//	Engine Nozzle: 1.10 m diameter
-//	Nozzle Exit Area: 1462 in^2 = 0.943224 m^2
+//	Propellant: LOx / RP1
+//	Prop Ratio: 2.25
+//	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	=================================================================================
-//	LR87-AJ-7
+//	LR87-AJ-7 (AJ23-134)
 //	Gemini-Titan II
 //
-//	Dry Mass: 713 Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 1097.2 kN
-//	ISP: 261 SL / 296 Vac
+//	Dry Mass: 739 kg	(786 kg 15AR, 1105 kg 49AR)		same as AJ-5? No major changes over AJ-5, mostly just better quality control
+//	Thrust (SL): 215 klbf		[1/3/8/9]
+//	Thrust (Vac): 1053.9 kN		(1102.7 15AR, 1171.4 kN 49AR)
+//	ISP: 258.8 SL / 285.2 Vac	(248/298.4 15AR, 200/317 49AR)	[9]
 //	Burn Time: 156
-//	Chamber Pressure: 5.56 MPa
+//	Chamber Pressure: 5.48 MPa	[9]
 //	Propellant: Subcooled NTO / Subcooled A50
-//	Prop Ratio: 1.93
+//	Prop Ratio: 1.93		[1/3/5/9]
+//	Throttle: N/A
+//	Nozzle Ratio: 8			[1/3/5/9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-AJ-7-Kero
+//	Speculative
+//
+//	Dry Mass: 755 kg	(803 15AR, 1129 49AR)		same as AJ-5?
+//	Thrust (SL): ???
+//	Thrust (Vac): 913.5 kN	(952.3 15AR, 998.3 kN 49AR)
+//	ISP: 262.9 SL / 290.1 Vac	(252/303.5 15AR, 200/322.5 49AR)	simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 156
+//	Chamber Pressure: 5.48 MPa
+//	Propellant: Subcooled LOx / Subcooled RP-1
+//	Prop Ratio: 2.25
 //	Throttle: N/A
 //	Nozzle Ratio: 8
 //	Ignitions: 1
 //	=================================================================================
-//	LR87-AJ-9
-//	Titan III
+//	LR87-AJ-9 (AJ23-136)
+//	Titan IIIA/B/C
 //
-//	Dry Mass: 713 Kg
-//	Thrust (SL): 1023.1 kN
-//	Thrust (Vac): 1172.1 kN
-//	ISP: 258 SL / 296 Vac
-//	Burn Time: ???
-//	Chamber Pressure: 5.67 MPa
+//	Dry Mass: 713 Kg	(758 15AR, 1066 49AR)
+//	Thrust (SL): 215 klbf		[1/3/8/9]
+//	Thrust (Vac): 1053.9 kN		(1102.7 15AR, 1171.4 kN 49AR)
+//	ISP: 258.8 SL / 285.2 Vac	(248/298.4 15AR, 200/317 49AR)	[9]
+//	Burn Time: 149		[4]
+//	Chamber Pressure: 5.48 MPa	[9]
 //	Propellant: NTO / A50
-//	Prop Ratio: 1.925
-//	Throttle: N/A
-//	Nozzle Ratio: 12
+//	Prop Ratio: 1.93		[9]
+//	Nozzle Ratio: 8			Ed Kyle claims AJ-9 Titan IIICs existed [4], [9] claims AJ-11 Titan IIICs with 15:1 nozzle. Titan IIIC seems to have been re-engined ~1970 with AJ-11, creating Titan-3(23)C, supported by pictures
 //	Ignitions: 1
 //	=================================================================================
-//	LR87-AJ-11
-//	
+//	LR87-AJ-9-Kero
+//	Speculative
 //
-//	Dry Mass: 758 Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 1170 kN
-//	ISP: 254 SL / 302 Vac
-//	Burn Time: 190
-//	Chamber Pressure: 5.70 MPa
-//	Propellant: NTO / A50
-//	Prop Ratio: 1.91
+//	Dry Mass: 729 kg	(771 15AR, 1089 49AR)
+//	Thrust (SL): ???
+//	Thrust (Vac): 913.5 kN	(952.3 15AR, 998.3 kN 49AR)
+//	ISP: 262.9 SL / 290.1 Vac	(252/303.5 15AR, 200/322.5 49AR)	simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 149.26
+//	Chamber Pressure: 5.48 MPa
+//	Propellant: LOx / RP-1
+//	Prop Ratio: 2.25
 //	Throttle: N/A
-//	Nozzle Ratio: 15
+//	Nozzle Ratio: 8
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-AJ-11 (AJ23-138 w/ 12:1 nozzle, AJ23-139 w/ 15:1 nozzle) [5]
+//	Titan 3D/3E/23B/24B/33B/34B/3(23)C/34D
+//
+//	Dry Mass: 758 kg		[5] (713 8AR, 733 12AR, 1066 49AR)
+//	Thrust (SL): 218.5 klbf	[9]
+//	Thrust (Vac): 1155.6 kN		(1105.5 8AR, 1139.1 12AR, 1227.9 49AR)
+//	ISP: 254 SL / 302 Vac	[9]	(263/288.9 8AR, 259/297.7 12AR, 205/320.9 49AR)
+//	Burn Time: 190
+//	Chamber Pressure: 5.58 MPa	[9]
+//	Propellant: NTO / A50		[9]
+//	Prop Ratio: 1.915			[9]
+//	Throttle: N/A
+//	Nozzle Ratio: 12/15			[9], 12:1 nozzle used on booster-less Titans? [11]
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-AJ-11-Kero
+//	Speculative
+//
+//	Dry Mass: 771 kg	(729 8AR, 747 12AR, 1089 49AR)
+//	Thrust (SL): ???
+//	Thrust (Vac): 1001.7 kN	(958.3 8AR, 987.0 12AR, 1064.4 kN 49AR)
+//	ISP: 257.3 SL / 306.9 Vac	(267/293.6 8AR, 262.7/302.4 12AR, 210/326.1 49AR)	simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 190
+//	Chamber Pressure: 5.58 MPa
+//	Propellant: LOx / RP-1
+//	Prop Ratio: 2.23
+//	Throttle: N/A
+//	Nozzle Ratio: 12/15
 //	Ignitions: 1
 //	=================================================================================
 //	LR87-AJ-11A
 //	Titan IV
 //
-//	Dry Mass: 758 Kg
-//	Thrust (SL): 1087.6 kN
-//	Thrust (Vac): 1225.3 kN
-//	ISP: 269.4 SL / 303.5 Vac
+//	Dry Mass: 758 kg		same as -11?
+//	Thrust (SL): ???
+//	Thrust (Vac): 1210.8 kN		272.2 klbf [4]	(1188.5 12AR, 1281.0 49AR)
+//	ISP: 254.3 SL / 303.5 Vac	[3]	(261/297.9 12AR, 207/321.1 49AR) no 8AR, it's underexpanded even at sea level. SL ISP calculated with RPA
 //	Burn Time: 190
-//	Chamber Pressure: 5.88 MPa
+//	Chamber Pressure: 5.89 MPa	[3]
 //	Propellant: NTO / A50
-//	Prop Ratio: 1.91
+//	Prop Ratio: 1.915		same as -11?
+//	Throttle: N/A
+//	Nozzle Ratio: 16		[3]
+//	Ignitions: 1
+//	=================================================================================
+//	LR87-AJ-11-Kero
+//	Speculative
+//
+//	Dry Mass: 771 kg	(747 12AR, 1089 49AR)
+//	Thrust (SL): ???
+//	Thrust (Vac): 1049.5 kN	(1029.8 12AR, 1110.4 kN 49AR)
+//	ISP: 257.7 SL / 308.4 Vac	(264.6/302.6 12AR, 212/326.3 49AR)	simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 190
+//	Chamber Pressure: 5.89 MPa
+//	Propellant: LOx / RP-1
+//	Prop Ratio: 2.23
 //	Throttle: N/A
 //	Nozzle Ratio: 16
 //	Ignitions: 1
@@ -99,6 +187,20 @@
 
 //	Sources:
 
+// [1] https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=16412.0;attach=276500;sess=0
+// [2] https://web.archive.org/web/20240801044404/http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
+// [3] https://web.archive.org/web/20220111200814/http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+// [4] https://forum.nasaspaceflight.com/index.php?topic=39251.0
+// [5] http://www.astronautix.com/l/lr87.html
+// [6] http://heroicrelics.org/info/titan-i/titan-i-stage-1-engines.html
+// [7] https://forum.nasaspaceflight.com/index.php?topic=52981.0
+// [8] https://doi.org/10.2514/6.1989-2389
+// [9] https://doi.org/10.2514/6.1986-1631
+// [10] https://apps.dtic.mil/sti/tr/pdf/AD0850432.pdf
+// [11] https://www.scribd.com/document/412910478/Titan-34B-34D-Users-Guide-1982-04
+// [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 382
+
+//OLD
 // [1] http://crgis.ndc.nasa.gov/crgis/images/c/cd/A_Historical_Look_at_US_Launch_Vehicles_1967-Present_%281988%29.pdf
 // [2] Astronautix
 // [3] https://ia802608.us.archive.org/29/items/gemini7nasamissi00godw/gemini7nasamissi00godw.pdf
@@ -143,17 +245,15 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = LR87-AJ-7
-		@configuration:NEEDS[RP-0] = LR87-AJ-3
+		configuration = LR87-AJ-1
 		modded = false
 		origMass = 0.839
 		literalZeroIgnitions = True
 		
 		CONFIG
 		{
-			// [5]
-			name = LR87-AJ-3
-			description = First stage engine for the Titan I ICBM
+			name = LR87-AJ-1
+			description = AJ23-128, First stage engine for Titan I ICBMs built before May 1960.
 			specLevel = operational
 			minThrust = 765.95
 			maxThrust = 765.95
@@ -162,21 +262,22 @@
 			varyMixture = 0.0028	//0.28% [5]
 			varyFlow = 0.0167	//1.67%, guess, based on 3% thrust variance and 1.8% Isp variance. [5]
 			residualsThresholdBase = 0.00989	//0.989% [5]
+			massMult = 1.11
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3859
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6141
 			}
 			atmosphereCurve
 			{
-				key = 0 286
-				key = 1 249.5
+				key = 0 289.1
+				key = 1 251.9
 			}
 			ullage = True
 			ignitions = 0
@@ -188,26 +289,27 @@
 			SUBCONFIG
 			{
 				name = 25AR
-				description = Speculative upper-stage version of the LR87-AJ-3 with the expansion ratio of the LR91-AJ-3
+				description = Speculative upper-stage version of the LR87-AJ-3 with the expansion ratio of the LR91-AJ-1
 				specLevel = speculative
-				minThrust = 830.23
-				maxThrust = 830.23
-				massMult = 1.43
-				costOffset = 20
+				minThrust = 825.8
+				maxThrust = 825.8
+				massMult = 1.5495
+				costOffset = 140
 				atmosphereCurve
 				{
-					key = 0 310
-					key = 1 232.5
+					key = 0 311.7
+					key = 1 205
 				}
 				ignitions = 1
 			}
 
 			//Titan R&D (various): 59 flights, 12 failures
 			//118 engines, 12 failures
+			//Using same data for AJ-1 and AJ-3, both remained in service and it's hard to find out which version a specific missile had
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 350
-				ratedBurnTime = 137
+				ratedBurnTime = 134
 				safeOverburn = true
 				ignitionReliabilityStart = 0.864286
 				ignitionReliabilityEnd = 0.978571
@@ -219,16 +321,80 @@
 		}
 		CONFIG
 		{
-			// [5], [6]. [7]
-			// Using a mix of the data -- the 281s vac in 5 seems obviously wrong
-			// compared to everything else. For now going with 257/289.
-			// Best guess is 5 uses very early -5s, and the other sources report
-			// late model -5s.
-			name = LR87-AJ-5
-			description = First stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
+			name = LR87-AJ-3
+			description = AJ23-130, First stage engine for Titan I ICBMs built after May 1960.
 			specLevel = operational
-			minThrust = 1053.8
-			maxThrust = 1053.8
+			minThrust = 765.95
+			maxThrust = 765.95
+			heatProduction = 100
+			varyIsp = 0.018		//1.8% [5]
+			varyMixture = 0.0028	//0.28% [5]
+			varyFlow = 0.0167	//1.67%, guess, based on 3% thrust variance and 1.8% Isp variance. [5]
+			residualsThresholdBase = 0.00989	//0.989% [5]
+			massMult = 1.00
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3859
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6141
+			}
+			atmosphereCurve
+			{
+				key = 0 289.1
+				key = 1 251.9
+			}
+			ullage = True
+			ignitions = 0
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+			SUBCONFIG
+			{
+				name = 25AR
+				description = Speculative upper-stage version of the LR87-AJ-3 with the expansion ratio of the LR91-AJ-1
+				specLevel = speculative
+				minThrust = 825.8
+				maxThrust = 825.8
+				massMult = 1.4303
+				costOffset = 137
+				atmosphereCurve
+				{
+					key = 0 311.7
+					key = 1 205
+				}
+				ignitions = 1
+			}
+
+			//Titan R&D (various): 59 flights, 12 failures
+			//118 engines, 12 failures
+			//Using same data for AJ-1 and AJ-3, both remained in service and it's hard to find out which version a specific missile had
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350
+				ratedBurnTime = 134
+				safeOverburn = true
+				ignitionReliabilityStart = 0.864286
+				ignitionReliabilityEnd = 0.978571
+				cycleReliabilityStart = 0.864286
+				cycleReliabilityEnd = 0.978571
+				
+				techTransfer = LR87-AJ-1:50&XLR43-NA-3:25&A-6:10&A-7:10		//Not a direct navaho derivative, but still related
+			}
+		}
+		CONFIG
+		{
+			name = LR87-AJ-5
+			description = AJ23-132, First stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
+			specLevel = operational
+			minThrust = 1053.9
+			maxThrust = 1053.9
 			heatProduction = 100
 			varyIsp = 0.010		//1.0% [5]
 			varyMixture = 0.00115	//0.115% [5]
@@ -257,7 +423,35 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.8808104887
+			massMult = 0.8808
+			SUBCONFIG
+			{
+				name = 15AR
+				description = Speculative upper-stage version of the LR87-AJ-5 with the same expansion ratio as the LR87-AJ-11.
+				minThrust = 1102.7
+				maxThrust = 1102.7
+				costOffset = 28
+				atmosphereCurve
+				{
+					key = 0 298.4
+					key = 1 248
+				}
+				massMult = 0.9364	//1.0631 * original nozzle
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the LR87-AJ-5 with the same expansion ratio as the LR91-AJ-5.
+				minThrust = 1171.4
+				maxThrust = 1171.4
+				costOffset = 182
+				atmosphereCurve
+				{
+					key = 0 317
+					key = 1 200
+				}
+				massMult = 1.3171	//1.4954 * original nozzle
+			}
 
 			//SM-68B: 81 flights, 7 failures
 			//Titan-2(23)G: 6 flights, 0 failures
@@ -274,7 +468,7 @@
 				cycleReliabilityStart = 0.948060
 				cycleReliabilityEnd = 0.991799
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-3:30
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-3,LR87-AJ-1:30
 			}
 		}
 		CONFIG
@@ -294,18 +488,18 @@
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3859
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6141
 			}
 			atmosphereCurve
 			{
-				key = 0 294.1
-				key = 1 266.5
+				key = 0 290.1
+				key = 1 262.9
 			}
 			ullage = True
 			ignitions = 1
@@ -314,20 +508,34 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.9
+			massMult = 0.8999
+			SUBCONFIG
+			{
+				name = 15AR
+				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-5 with the same expansion ratio as the LR87-AJ-11.
+				minThrust = 952.3
+				maxThrust = 952.3
+				costOffset = 31
+				atmosphereCurve
+				{
+					key = 0 303.5
+					key = 1 252
+				}
+				massMult = 0.9568	//1.0631 * original nozzle
+			}
 			SUBCONFIG
 			{
 				name = 49AR
 				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-5 with the same expansion ratio as the LR91-AJ-5.
 				minThrust = 998.3
 				maxThrust = 998.3
-				costOffset = 35
+				costOffset = 202
 				atmosphereCurve
 				{
-					key = 0 321.4
-					key = 1 165.0
+					key = 0 322.5
+					key = 1 200.0
 				}
-				massMult = 1.4
+				massMult = 1.3459	//1.4954 * original nozzle
 			}
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -340,17 +548,16 @@
 				cycleReliabilityStart = 0.948060
 				cycleReliabilityEnd = 0.991799
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 		CONFIG
 		{
-			// using Gemini mission reports here, with 7's vac Isp
 			name = LR87-AJ-7
 			specLevel = operational
 			description = First stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
-			minThrust = 1097.2
-			maxThrust = 1097.2
+			minThrust = 1053.9
+			maxThrust = 1053.9
 			heatProduction = 100
 			//engines tested, and only those that performed within 1 stddev were selected for GLV
 			//Divide variances by three?
@@ -371,8 +578,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 296
-				key = 1 261
+				key = 0 285.2
+				key = 1 258.8
 			}
 			ullage = True
 			ignitions = 1
@@ -381,21 +588,49 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.8498212157 // nautix 713kg per
+			massMult = 0.8808
+			SUBCONFIG
+			{
+				name = 15AR
+				description = Speculative upper-stage version of the LR87-AJ-5 with the same expansion ratio as the LR87-AJ-11.
+				minThrust = 1102.7
+				maxThrust = 1102.7
+				costOffset = 28
+				atmosphereCurve
+				{
+					key = 0 298.4
+					key = 1 248
+				}
+				massMult = 0.9364	//1.0631 * original nozzle
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the LR87-AJ-5 with the same expansion ratio as the LR91-AJ-5.
+				minThrust = 1171.4
+				maxThrust = 1171.4
+				costOffset = 232
+				atmosphereCurve
+				{
+					key = 0 317
+					key = 1 200
+				}
+				massMult = 1.3171	//1.4954 * original nozzle
+			}
 
 			//Titan-2-GLV: 12 flights, 0 failures
 			//24 engines, 0 failed
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 350 // [1] Page 11.C-9, 147s rounded up to 150
-				ratedBurnTime = 150
+				testedBurnTime = 350
+				ratedBurnTime = 156
 				safeOverburn = true
 				ignitionReliabilityStart = 0.962000
 				ignitionReliabilityEnd = 0.994000
 				cycleReliabilityStart = 0.962000
 				cycleReliabilityEnd = 0.994000
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-5,LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-5,LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 		CONFIG
@@ -404,8 +639,8 @@
 			description = Speculative config using equivalent technology to the LR87-AJ-7 but burning Kerosene and LOX for purely civilian applications.
 			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -9 then downscaled for -7. Isp calculated via RPA with -9's stats then fudged down slightly
-			minThrust = 947.5
-			maxThrust = 947.5
+			minThrust = 913.5
+			maxThrust = 913.5
 			heatProduction = 100
 			//engines tested, and only those that performed within 1 stddev were selected for GLV
 			//Divide variances by three?
@@ -416,18 +651,18 @@
 			PROPELLANT
 			{
 				name = CooledRP-1
-				ratio = 0.4117
+				ratio = 0.3991
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.5883
+				ratio = 0.6009
 			}
 			atmosphereCurve
 			{
-				key = 0 304.1
-				key = 1 264.7
+				key = 0 290.1
+				key = 1 262.9
 			}
 			ullage = True
 			ignitions = 1
@@ -436,45 +671,57 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.92 // Guess, FIXME. Bigger nozzle.
+			massMult = 0.8999	//same ratio as AJ-5 to AJ-7
+			SUBCONFIG
+			{
+				name = 15AR
+				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-5 with the same expansion ratio as the LR87-AJ-11.
+				minThrust = 952.3
+				maxThrust = 952.3
+				costOffset = 31
+				atmosphereCurve
+				{
+					key = 0 303.5
+					key = 1 252
+				}
+				massMult = 0.9568	//1.0631 * original nozzle
+			}
 			SUBCONFIG
 			{
 				name = 49AR
 				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-7 with the same expansion ratio as the LR91-AJ-7.
-				minThrust = 1012
-				maxThrust = 1012
-				costOffset = 35
+				minThrust = 998.3
+				maxThrust = 998.3
+				costOffset = 203
 				atmosphereCurve
 				{
-					key = 0 324.8
-					key = 1 166
+					key = 0 322.5
+					key = 1 200.0
 				}
-				massMult = 1.38
+				massMult = 1.3459	//1.4954 * original nozzle
 			}
 
 			//Dupe for LR87-AJ-7-Kero
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				testedBurnTime = 350 // [1] Page 11.C-9, 147s rounded up to 150
-				ratedBurnTime = 150
+				testedBurnTime = 350
+				ratedBurnTime = 156
 				safeOverburn = true
 				ignitionReliabilityStart = 0.962000
 				ignitionReliabilityEnd = 0.994000
 				cycleReliabilityStart = 0.962000
 				cycleReliabilityEnd = 0.994000
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-5-Kero,LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-5-Kero,LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 		CONFIG
 		{
-			// can't find good data on these.
-			// Let's claim 450klbf, 298/262 for the 12 AR nozzle.
 			name = LR87-AJ-9
-			description = First stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
+			description = AJ23-136, First stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
 			specLevel = operational
-			minThrust = 1172.1
-			maxThrust = 1172.1
+			minThrust = 1053.9
+			maxThrust = 1053.9
 			heatProduction = 100
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -484,18 +731,18 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4527
+				ratio = 0.4521
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5473
+				ratio = 0.5479
 			}
 			atmosphereCurve
 			{
-				key = 0 296
-				key = 1 258
+				key = 0 285.2
+				key = 1 258.8
 			}
 			ullage = True
 			ignitions = 1
@@ -504,7 +751,35 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.8498212157 // nautix 713kg per
+			massMult = 0.8498 // nautix 713kg per
+			SUBCONFIG
+			{
+				name = 15AR
+				description = Speculative upper-stage version of the LR87-AJ-5 with the same expansion ratio as the LR87-AJ-11.
+				minThrust = 1102.7
+				maxThrust = 1102.7
+				costOffset = 30
+				atmosphereCurve
+				{
+					key = 0 298.4
+					key = 1 248
+				}
+				massMult = 0.9034	//1.0631 * original nozzle
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the LR87-AJ-5 with the same expansion ratio as the LR91-AJ-5.
+				minThrust = 1171.4
+				maxThrust = 1171.4
+				costOffset = 226
+				atmosphereCurve
+				{
+					key = 0 317
+					key = 1 200
+				}
+				massMult = 1.2708	//1.4954 * original nozzle
+			}
 
 			//Titan-3A: 4 flights, 0 failures
 			//Titan-3B Agena-D: 22 flights, 1 failure
@@ -520,7 +795,7 @@
 				cycleReliabilityStart = 0.956996
 				cycleReliabilityEnd = 0.993210
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-7,LR87-AJ-5,LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-7,LR87-AJ-5,LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 		CONFIG
@@ -529,8 +804,8 @@
 			description = Speculative config using equivalent technology to the -AJ-9 but burning Kerosene and LOX for purely civilian applications.
 			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
-			minThrust = 1016
-			maxThrust = 1016
+			minThrust = 913.5
+			maxThrust = 913.5
 			heatProduction = 100
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -540,18 +815,18 @@
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3859
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6141
 			}
 			atmosphereCurve
 			{
-				key = 0 305.21
-				key = 1 265.64
+				key = 0 290.1
+				key = 1 262.9
 			}
 			ullage = True
 			ignitions = 1
@@ -560,35 +835,35 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.91 // Guess, FIXME. Bigger nozzle.
+			massMult = 0.8683
 			SUBCONFIG
 			{
 				name = 15AR
 				description = Speculative config using equivalent technology to the -AJ-9 but burning Kerosene and LOX for purely civilian applications. Uses nozzle extension for increased vacuum performance.
 				// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
-				minThrust = 1030
-				maxThrust = 1030
-				costOffset = 15
+				minThrust = 952.3
+				maxThrust = 952.3
+				costOffset = 30
 				atmosphereCurve
 				{
-					key = 0 309.43
-					key = 1 259.96
+					key = 0 303.5
+					key = 1 252
 				}
-				massMult = 0.95 // Guess, FIXME. Bigger nozzle.
+				massMult = 0.9190	//1.0631 * original nozzle
 			}
 			SUBCONFIG
 			{
 				name = 49AR
 				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-9 with the same expansion ratio as the LR91-AJ-9.
-				minThrust = 1083.5
-				maxThrust = 1083.5
-				costOffset = 40
+				minThrust = 998.3
+				maxThrust = 998.3
+				costOffset = 197
 				atmosphereCurve
 				{
-					key = 0 325.5
-					key = 1 167
+					key = 0 322.5
+					key = 1 200
 				}
-				massMult = 1.36
+				massMult = 1.2985		//1.4954 * original nozzle
 			}
 
 			//no data, never flew. Using AJ-9 data
@@ -602,16 +877,16 @@
 				cycleReliabilityStart = 0.956996
 				cycleReliabilityEnd = 0.993210
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-7-Kero,LR87-AJ-5-Kero,LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-7-Kero,LR87-AJ-5-Kero,LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 		CONFIG
 		{
 			name = LR87-AJ-11
-			description = First stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Modified to light in midair, since the UA120x boosters used by Titan III could lift Titan without assistance. Ignited just before booster burnout.
+			description = AJ23-139, First stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Modified to light in midair, since the UA120x boosters used by Titan III could lift Titan without assistance. Ignited just before booster burnout.
 			specLevel = operational
-			minThrust = 1170
-			maxThrust = 1170
+			minThrust = 1155.6
+			maxThrust = 1155.6
 			heatProduction = 100
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -621,13 +896,13 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4546
+				ratio = 0.4540
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5454
+				ratio = 0.5460
 			}
 			atmosphereCurve
 			{
@@ -641,7 +916,49 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.9034564958 // astronautix, but could be for 11A not 11?
+			massMult = 0.9035 // astronautix, but could be for 11A not 11?
+			SUBCONFIG
+			{
+				name = 8AR
+				description = Speculative version of the LR87-AJ-11 without nozzle extension.
+				minThrust = 1105.5
+				maxThrust = 1105.5
+				costOffset = -28
+				atmosphereCurve
+				{
+					key = 0 288.9
+					key = 1 263
+				}
+				massMult = 0.8498	//same as AJ-9 I guess
+			}
+			SUBCONFIG
+			{
+				name = 12AR
+				description = AJ23-138, LR87-AJ-11 with a shortened nozzle extension for sea-level operation on booster-less Titan 3 variants like Titan 34D.
+				minThrust = 1139.1
+				maxThrust = 1139.1
+				costOffset = -13
+				atmosphereCurve
+				{
+					key = 0 297.7
+					key = 1 259
+				}
+				massMult = 0.8737	//Guess, interpolate
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the LR87-AJ-11 with the same expansion ratio as the LR91-AJ-5.
+				minThrust = 1227.9
+				maxThrust = 1227.9
+				costOffset = 164
+				atmosphereCurve
+				{
+					key = 0 320.9
+					key = 1 205
+				}
+				massMult = 1.2706	//1.4954 * original nozzle
+			}
 
 			//Titan-3(23)B Agena-D: 9 flights, 0 failures
 			//Titan-3(33)B Agena-D: 3 flights, 0 failures
@@ -665,7 +982,104 @@
 				cycleReliabilityStart = 0.973259
 				cycleReliabilityEnd = 0.995778
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-9,LR87-AJ-5,LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-9,LR87-AJ-5,LR87-AJ-3,LR87-AJ-1:50
+			}
+		}
+		CONFIG
+		{
+			name = LR87-AJ-11-Kero
+			description = Speculative config using equivalent technology to the -AJ-11 but burning Kerosene and LOX for purely civilian applications.
+			specLevel = speculative
+			// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
+			minThrust = 1001.7
+			maxThrust = 1001.7
+			heatProduction = 100
+			//same as AJ-5?
+			varyIsp = 0.010		//1.0% [5]
+			varyMixture = 0.00115	//0.115% [5]
+			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
+			residualsThresholdBase = 0.00444	//0.444% [5]
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3880
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6120
+			}
+			atmosphereCurve
+			{
+				key = 0 306.9
+				key = 1 257.3
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+			massMult = 0.9190
+			SUBCONFIG
+			{
+				name = 8AR
+				description = Speculative config using equivalent technology to the -AJ-11 but burning Kerosene and LOX for purely civilian applications. No nozzle extension.
+				// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
+				minThrust = 958.3
+				maxThrust = 958.3
+				costOffset = -33
+				atmosphereCurve
+				{
+					key = 0 293.6
+					key = 1 267
+				}
+				massMult = 0.8689
+			}
+			SUBCONFIG
+			{
+				name = 12AR
+				description = Speculative config using equivalent technology to the -AJ-11 but burning Kerosene and LOX for purely civilian applications. Uses shortened nozzle extension of the AJ23-138 for sea level use.
+				// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
+				minThrust = 987
+				maxThrust = 987
+				costOffset = -17
+				atmosphereCurve
+				{
+					key = 0 302.4
+					key = 1 262.7
+				}
+				massMult = 0.8903
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-11 with the same expansion ratio as the LR91-AJ-11.
+				minThrust = 1064.4
+				maxThrust = 1064.4
+				costOffset = 178
+				atmosphereCurve
+				{
+					key = 0 326.1
+					key = 1 210
+				}
+				massMult = 1.2980		//1.4954 * original nozzle
+			}
+
+			//no data, never flew. Using AJ-11 data
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350 // [1] Page II.C-14 (Figure II.C-12) Rated to 200s but demonstrated to 300s. 164s used in Titan 34D and 190 in titan IV
+				ratedBurnTime = 190
+				safeOverburn = true
+				ignitionReliabilityStart = 0.973259
+				ignitionReliabilityEnd = 0.995778
+				cycleReliabilityStart = 0.973259
+				cycleReliabilityEnd = 0.995778
+				
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-9-Kero,LR87-AJ-5-Kero,LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 		CONFIG
@@ -673,8 +1087,8 @@
 			name = LR87-AJ-11A
 			description = First stage engine for Titan IVA and IVB. Equipped with a nozzle extension to improve vacuum performance, since it was not needed at sea level.
 			specLevel = operational
-			minThrust = 1225.3
-			maxThrust = 1225.3
+			minThrust = 1210.8
+			maxThrust = 1210.8
 			heatProduction = 100
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -684,18 +1098,18 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4546
+				ratio = 0.4540
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5454
+				ratio = 0.5460
 			}
 			atmosphereCurve
 			{
-				key = 0 303.9
-				key = 1 252.2
+				key = 0 303.5
+				key = 1 254.3
 			}
 			ullage = True
 			ignitions = 1
@@ -704,7 +1118,35 @@
 				name = ElectricCharge
 				amount = 2.0
 			}
-			massMult = 0.9034564958 // astronautix, but could be for 11A not 11?
+			massMult = 0.9035 // astronautix, but could be for 11A not 11?
+			SUBCONFIG
+			{
+				name = 12AR
+				description = Speculative LR87-AJ-11A with a shortened nozzle extension for sea-level operation.
+				minThrust = 1188.5
+				maxThrust = 1188.5
+				costOffset = -16
+				atmosphereCurve
+				{
+					key = 0 297.9
+					key = 1 261
+				}
+				massMult = 0.8768	//Guess, interpolate
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the LR87-AJ-11A with the same expansion ratio as the LR91-AJ-11A.
+				minThrust = 1281
+				maxThrust = 1281
+				costOffset = 188
+				atmosphereCurve
+				{
+					key = 0 321.1
+					key = 1 207
+				}
+				massMult = 1.2706	//1.4954 * original nozzle
+			}
 
 			//Commercial Titan 3: 4 flights, 0 failures
 			//Titan-4A: 10 flights, 0 failures
@@ -724,7 +1166,88 @@
 				cycleReliabilityStart = 0.974521
 				cycleReliabilityEnd = 0.995977
 				
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-11,LR87-AJ-9,LR87-AJ-5,LR87-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-11,LR87-AJ-9,LR87-AJ-5,LR87-AJ-3,LR87-AJ-1:50
+			}
+		}
+		CONFIG
+		{
+			name = LR87-AJ-11A-Kero
+			description = Speculative config using equivalent technology to the -AJ-11A but burning Kerosene and LOX for purely civilian applications.
+			specLevel = speculative
+			minThrust = 1049.5
+			maxThrust = 1049.5
+			heatProduction = 100
+			//same as AJ-5?
+			varyIsp = 0.010		//1.0% [5]
+			varyMixture = 0.00115	//0.115% [5]
+			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
+			residualsThresholdBase = 0.00444	//0.444% [5]
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3880
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6120
+			}
+			atmosphereCurve
+			{
+				key = 0 308.4
+				key = 1 257.7
+			}
+			ullage = True
+			ignitions = 1
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 2.0
+			}
+			massMult = 0.9190
+			SUBCONFIG
+			{
+				name = 12AR
+				description = Speculative config using equivalent technology to the -AJ-11A but burning Kerosene and LOX for purely civilian applications. Uses shortened nozzle extension of the AJ23-138 for sea level use.
+				// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
+				minThrust = 1029.8
+				maxThrust = 1029.8
+				costOffset = -22
+				atmosphereCurve
+				{
+					key = 0 302.6
+					key = 1 264.6
+				}
+				massMult = 0.8903
+			}
+			SUBCONFIG
+			{
+				name = 49AR
+				description = Speculative upper-stage version of the (speculative, kerosene-burning) LR87-AJ-11A with the same expansion ratio as the LR91-AJ-11A.
+				minThrust = 1110.4
+				maxThrust = 1110.4
+				costOffset = 177
+				atmosphereCurve
+				{
+					key = 0 326.3
+					key = 1 212
+				}
+				massMult = 1.2980		//1.4954 * original nozzle
+			}
+
+			//no data, never flew. Using AJ-11 data
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350
+				ratedBurnTime = 190
+				safeOverburn = true
+				ignitionReliabilityStart = 0.974521
+				ignitionReliabilityEnd = 0.995977
+				cycleReliabilityStart = 0.974521
+				cycleReliabilityEnd = 0.995977
+				
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR87-AJ-11-Kero,LR87-AJ-9-Kero,LR87-AJ-5-Kero,LR87-AJ-3,LR87-AJ-1:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
@@ -198,16 +198,7 @@
 // [9] https://doi.org/10.2514/6.1986-1631
 // [10] https://apps.dtic.mil/sti/tr/pdf/AD0850432.pdf
 // [11] https://www.scribd.com/document/412910478/Titan-34B-34D-Users-Guide-1982-04
-// [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 382
-
-//OLD
-// [1] http://crgis.ndc.nasa.gov/crgis/images/c/cd/A_Historical_Look_at_US_Launch_Vehicles_1967-Present_%281988%29.pdf
-// [2] Astronautix
-// [3] https://ia802608.us.archive.org/29/items/gemini7nasamissi00godw/gemini7nasamissi00godw.pdf
-// [4] http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
-// [5] NASA LV Handbook 1961 https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=16412.0;attach=276500;sess=0
-// [6] Alternate Wars Aerojet General Space Engines http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-// [7] Ed Kyle's Titan Booster Variants cards, see https://forum.nasaspaceflight.com/index.php?topic=39251.0
+// [12] https://ntrs.nasa.gov/api/citations/19750004937/downloads/19750004937.pdf
 // [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 382
 
 //	Used by:

--- a/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR91_Config.cfg
@@ -1,79 +1,156 @@
+//	==================================================
 //	LR-91 Series Titan Engines
 //
 //	Manufacturer: Aerojet
 //
 //	=================================================================================
-//	LR91-AJ-3
-//	Titan A / Titan I
+//	LR91-AJ-1 (AJ23-129?)
+//	Titan A / Titan I (Before May 1960) [8]
 //
-//	Dry Mass: 590 kg
+//	Dry Mass: 621 kg		Titan 1 mass varied a lot depending on the production Lot and source [1/4]. Guess, 5% heavier?
 //	Thrust (SL): ???
-//	Thrust (vac): 80,603 + 975 (turbine) lbf = 362.88 - Verniers = 360.5 kN
-//	ISP: ??? SL / 310 Vac
-//	Burn Time: 160
-//	Chamber Pressure: 5.65 Mpa
+//	Thrust (vac): 358.54 kN		80,000 lbf (chamber) + 603 lbf (vernier) [1]
+//	ISP: 210 SL / 312.5 Vac		[9]	SL Isp calculated with RPA
+//	Burn Time: 161				[4]
+//	Chamber Pressure: 4.72 Mpa	[1/9]
 //	Propellant: LOX / RP1
-//	Prop Ratio: 2.02 (from LR87 via Sutton)
+//	Prop Ratio: 2.25	[1/9]
 //	Throttle: N/A
-//	Nozzle Ratio: 25
+//	Nozzle Ratio: 25	[1/9]
 //	Ignitions: 1
 //	=================================================================================
-//	LR91-AJ-5
+//	LR91-AJ-3 (AJ23-131)
+//	Titan A / Titan I (After May 1960) [8]
+//	Mostly identical to AJ-1, but with ablative nozzle extension, reduced weight, improved gas generator, etc.
+//
+//	Dry Mass: 590 kg	[5]
+//	Thrust (SL): ???
+//	Thrust (vac): 358.54 kN		80,000 lbf (chamber) + 603 lbf (vernier) [1]
+//	ISP: 210 SL / 312.5 Vac		[9]	SL Isp calculated with RPA
+//	Burn Time: 161				[4]
+//	Chamber Pressure: 4.72 Mpa	[1/9]
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.25	[1/9]
+//	Throttle: N/A
+//	Nozzle Ratio: 25	[1/9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR91-AJ-5 (AJ23-133)
 //	Titan B / Titan II
 //
-//	Dry Mass: 500 kg
+//	Dry Mass: 500 kg	[5]
 //	Thrust (SL): ???
-//	Thrust (vac): 100,000 + 865 (turbine) lbf = 448.67 - Verniers = 446.3 kN
-//	ISP: ??? SL / 315 Vac
-//	Burn Time: 180
-//	Chamber Pressure: 5.7 MPa
+//	Thrust (vac): 448.7 kN 		100,000 lbf (chamber) + 865 lbf (turbine) [1]
+//	ISP: 195 SL / 309.2 Vac		[9] SL Isp calculated with RPA
+//	Burn Time: 182				[1]
+//	Chamber Pressure: 5.7 MPa	[9]
 //	Propellant: NTO / Aerozine50
-//	Prop Ratio: 1.80
+//	Prop Ratio: 1.880			[9]
+//	Throttle: N/A
+//	Nozzle Ratio: 49.2			[3/9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR91-AJ-5-Kero
+//	Speculative
+//
+//	Dry Mass: 550 kg
+//	Thrust (SL): ???
+//	Thrust (vac): 391.8 kN
+//	ISP: 195 SL / 313.3 Vac			simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 182
+//	Chamber Pressure: 5.7 MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.190
 //	Throttle: N/A
 //	Nozzle Ratio: 49.2
 //	Ignitions: 1
 //	=================================================================================
-//	LR91-AJ-7
+//	LR91-AJ-7 (AJ23-135)
 //	Titan II GLV
 //
-//	Dry Mass: 565 kg
+//	Dry Mass: 500? kg		basically identical to AJ-5, same mass?
 //	Thrust (SL): ???
-//	Thrust (vac): 100,000 + 865 (turbine) lbf = 448.67 - Verniers = 446.3 kN
-//	ISP: ??? SL / 315 Vac
+//	Thrust (vac): 448.7 kN 		100,000 lbf (chamber) + 865 lbf (turbine) [1]
+//	ISP: 195 SL / 309.2 Vac		[9] SL Isp calculated with RPA
+//	Burn Time: 190				[4]
+//	Chamber Pressure: 5.7 MPa	[9]
+//	Propellant: NTO / Aerozine50
+//	Prop Ratio: 1.880			[9]
+//	Throttle: N/A
+//	Nozzle Ratio: 49.2			[9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR91-AJ-7-Kero
+//	Speculative
+//
+//	Dry Mass: 550 kg
+//	Thrust (SL): ???
+//	Thrust (vac): 391.8 kN
+//	ISP: 195 SL / 313.3 Vac			simulated in RPA, with 1 percentage point drop in combustion efficiency
 //	Burn Time: 190
 //	Chamber Pressure: 5.7 MPa
-//	Propellant: NTO / Aerozine50	cooled propellants first stage only? Second stage was stretched
-//	Prop Ratio: 1.80
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.190
 //	Throttle: N/A
 //	Nozzle Ratio: 49.2
 //	Ignitions: 1
 //	=================================================================================
-//	LR91-AJ-9
-//	Titan 3A/B/C
+//	LR91-AJ-9 (AJ23-137)
+//	Titan IIIA/B/C
 //
-//	Dry Mass: 590 kg
+//	Dry Mass: 500? kg		basically identical to AJ-5, same mass?
 //	Thrust (SL): ???
-//	Thrust (vac): 456.1
-//	ISP: ??? SL / 316 Vac
+//	Thrust (vac): 448.7 kN 		100,000 lbf (chamber) + 865 lbf (turbine) [1]
+//	ISP: 195 SL / 309.2 Vac		[9] SL Isp calculated with RPA
+//	Burn Time: 210				[4]
+//	Chamber Pressure: 5.7 MPa	[9]
+//	Propellant: NTO / Aerozine50
+//	Prop Ratio: 1.880			[9]
+//	Throttle: N/A
+//	Nozzle Ratio: 49.2			[9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR91-AJ-9-Kero
+//	Speculative
+//
+//	Dry Mass: 550 kg
+//	Thrust (SL): ???
+//	Thrust (vac): 391.8 kN
+//	ISP: 195 SL / 313.3 Vac			simulated in RPA, with 1 percentage point drop in combustion efficiency
 //	Burn Time: 210
 //	Chamber Pressure: 5.7 MPa
-//	Propellant: NTO / Aerozine50
-//	Prop Ratio: 1.80
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.190
 //	Throttle: N/A
 //	Nozzle Ratio: 49.2
 //	Ignitions: 1
 //	=================================================================================
-//	LR91-AJ-11
-//	Titan 3D/E
+//	LR91-AJ-11 (AJ23-140)
+//	Titan 3D/3E/23B/24B/33B/34B/3(23)C/34D
 //
-//	Dry Mass: 589 kg
+//	Dry Mass: 589 kg	[5]
 //	Thrust (SL): ???
-//	Thrust (vac): 456.1
-//	ISP: ??? SL / 318 Vac
-//	Burn Time: 250
-//	Chamber Pressure: 5.7 MPa
+//	Thrust (vac): 448.7? kN 		same as AJ-5/7/9?
+//	ISP: 205 SL / 318 Vac			[9] SL Isp calculated with RPA
+//	Burn Time: 222					[4]
+//	Chamber Pressure: 5.7 MPa		[9]
 //	Propellant: NTO / Aerozine50
-//	Prop Ratio: 1.78
+//	Prop Ratio: 1.790				[3/9/12]
+//	Throttle: N/A
+//	Nozzle Ratio: 49.2				[3/9]
+//	Ignitions: 1
+//	=================================================================================
+//	LR91-AJ-11-Kero
+//	Speculative
+//
+//	Dry Mass: 648 kg
+//	Thrust (SL): ???
+//	Thrust (vac): 391.8 kN
+//	ISP: 205 SL / 319.9 Vac			simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 222
+//	Chamber Pressure: 5.7 MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.085
 //	Throttle: N/A
 //	Nozzle Ratio: 49.2
 //	Ignitions: 1
@@ -83,12 +160,27 @@
 //
 //	Dry Mass: 589 kg
 //	Thrust (SL): ???
-//	Thrust (vac): 474.6
-//	ISP: ??? SL / 325.5 Vac
-//	Burn Time: 250
-//	Chamber Pressure: 6.06 MPa
+//	Thrust (vac): 472.5		106.2klbf [4], about 5% from [9]
+//	ISP: 210 SL / 317.7 Vac			[4] SL Isp calculated with RPA
+//	Burn Time: 240					[4]
+//	Chamber Pressure: 6.06 MPa		[3]
 //	Propellant: NTO / Aerozine50
-//	Prop Ratio: 1.78
+//	Prop Ratio: 1.775				[3]
+//	Throttle: N/A
+//	Nozzle Ratio: 49.2				[3]
+//	Ignitions: 1
+//	=================================================================================
+//	LR91-AJ-11A-Kero
+//	Speculative
+//
+//	Dry Mass: 648 kg
+//	Thrust (SL): ???
+//	Thrust (vac): 412.6 kN
+//	ISP: 210 SL / 319.3 Vac			simulated in RPA, with 1 percentage point drop in combustion efficiency
+//	Burn Time: 240
+//	Chamber Pressure: 5.7 MPa
+//	Propellant: LOX / RP1
+//	Prop Ratio: 2.07
 //	Throttle: N/A
 //	Nozzle Ratio: 49.2
 //	Ignitions: 1
@@ -96,13 +188,18 @@
 
 //	Sources:
 
-// [1] http://crgis.ndc.nasa.gov/crgis/images/c/cd/A_Historical_Look_at_US_Launch_Vehicles_1967-Present_%281988%29.pdf
-// [2] https://ia802608.us.archive.org/29/items/gemini7nasamissi00godw/gemini7nasamissi00godw.pdf
-// [3] http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
-// [4] Astronautix
-// [5] NASA LV Handbook 1961 https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=16412.0;attach=276500;sess=0
-// [6] Alternate Wars Aerojet General Space Engines http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
-// [7] Ed Kyle's Titan Booster Variants cards, see https://forum.nasaspaceflight.com/index.php?topic=39251.0
+// [1] https://forum.nasaspaceflight.com/index.php?action=dlattach;topic=16412.0;attach=276500;sess=0
+// [2] https://web.archive.org/web/20240801044404/http://www.b14643.de/Spacerockets/Specials/U.S._Rocket_engines/engines.htm
+// [3] https://web.archive.org/web/20220111200814/http://www.alternatewars.com/BBOW/Space_Engines/Aerojet_Engines.htm
+// [4] https://forum.nasaspaceflight.com/index.php?topic=39251.0
+// [5] http://www.astronautix.com/l/lr91.html
+// [6] http://heroicrelics.org/info/titan-i/titan-i-stage-2-engine.html
+// [7] https://forum.nasaspaceflight.com/index.php?topic=52981.0
+// [8] https://doi.org/10.2514/6.1989-2389
+// [9] https://doi.org/10.2514/6.1986-1631
+// [10] https://apps.dtic.mil/sti/tr/pdf/AD0850432.pdf
+// [11] https://www.scribd.com/document/412910478/Titan-34B-34D-Users-Guide-1982-04
+// [12] https://ntrs.nasa.gov/api/citations/19750004937/downloads/19750004937.pdf
 // [A] History of Liquid Propellant Rocket Engines, George P. Sutton, Page 382
 
 //	Used by:
@@ -140,17 +237,15 @@
 	{
 		name = ModuleEngineConfigs
 		modded = false
-		configuration = LR91-AJ-7
-		@configuration:NEEDS[RP-0] = LR91-AJ-3
+		configuration = LR91-AJ-1
 		origMass = 0.5
 		CONFIG
 		{
-			// [5]
-			name = LR91-AJ-3
-			description = Second stage engine for the Titan I ICBM.
+			name = LR91-AJ-1
+			description = AJ23-129, second stage engine for Titan I ICBMs built before May 1960.
 			specLevel = operational
-			minThrust = 362.87
-			maxThrust = 362.87 // added the Verniers back to the thrust
+			minThrust = 358.54
+			maxThrust = 358.54
 			heatProduction = 100
 			varyIsp = 0.0097	//0.97% [5]
 			varyMixture = 0.0028	//0.28% [5]
@@ -159,18 +254,71 @@
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3859
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6141
 			}
 			atmosphereCurve
 			{
-				key = 0 310
-				key = 1 232.5
+				key = 0 312.5
+				key = 1 210
+			}
+			ullage = True
+			ignitions = 1
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.242
+
+			//Titan-1 R&D (various): 60 flights, 4 failures. (3 ignition, 1 cycle)
+			//60 ignitions, 3 failures
+			//57 cycles, 1 failures
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350
+				ratedBurnTime = 161
+				safeOverburn = true
+				ignitionReliabilityStart = 0.938525
+				ignitionReliabilityEnd = 0.987705
+				cycleReliabilityStart = 0.969828
+				cycleReliabilityEnd = 0.993966
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10		//Not a direct navaho derivative, but still related
+			}
+		}
+		CONFIG
+		{
+			name = LR91-AJ-3
+			description = AJ23-131, second stage engine for Titan I ICBMs built after May 1960.
+			specLevel = operational
+			minThrust = 358.54
+			maxThrust = 358.54
+			heatProduction = 100
+			varyIsp = 0.0097	//0.97% [5]
+			varyMixture = 0.0028	//0.28% [5]
+			varyFlow = 0.031	//3.1%, guess, based on 3% thrust variance and 0.97% Isp variance. [5]
+			residualsThresholdBase = 0.0074	//0.74% [5]
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.3859
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.6141
+			}
+			atmosphereCurve
+			{
+				key = 0 312.5
+				key = 1 210
 			}
 			ullage = True
 			ignitions = 1
@@ -194,17 +342,16 @@
 				ignitionReliabilityEnd = 0.987705
 				cycleReliabilityStart = 0.969828
 				cycleReliabilityEnd = 0.993966
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10		//Not a direct navaho derivative, but still related
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-1:50		//Not a direct navaho derivative, but still related
 			}
 		}
 		CONFIG
 		{
-			// [5]
 			name = LR91-AJ-5
-			description = Second stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
+			description = AJ23-133, second stage engine of Titan II. Modified to burn Aerozine50 and Nitrogen Tetroxide to allow storage for long periods of time.
 			specLevel = operational
-			minThrust = 448.2
-			maxThrust = 448.2 // added the Verniers back to the thrust
+			minThrust = 448.7
+			maxThrust = 448.7
 			heatProduction = 160
 			varyIsp = 0.010		//1.0% [5]
 			varyMixture = 0.00109	//0.109% [5]
@@ -213,18 +360,18 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4694
+				ratio = 0.4586
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5306
+				ratio = 0.5414
 			}
 			atmosphereCurve
 			{
-				key = 0 312
-				key = 1 200
+				key = 0 309.2
+				key = 1 195
 			}
 			ullage = True
 			ignitions = 1
@@ -245,14 +392,14 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 350 // Titan II SLV and Titan 23G.
-				ratedBurnTime = 180
+				ratedBurnTime = 182
 				safeOverburn = true
 				ignitionReliabilityStart = 0.989674
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-3:30
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-3,LR91-AJ-1:30
 			}
 		}
 		CONFIG
@@ -262,7 +409,7 @@
 			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -5. Isp calculated via RPA.
 			minThrust = 391.8
-			maxThrust = 391.8 // added the Verniers back to the thrust
+			maxThrust = 391.8
 			heatProduction = 100
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -272,18 +419,18 @@
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3923
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6077
 			}
 			atmosphereCurve
 			{
-				key = 0 321.4
-				key = 1 165.0
+				key = 0 313.3
+				key = 1 195
 			}
 			ullage = True
 			ignitions = 1
@@ -295,50 +442,48 @@
 			}
 			massMult = 1.1
 
-			// no data, never flew. Using -7 data
+			// no data, never flew. Using -5 data
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 350 // Titan II SLV and Titan 23G.
-				ratedBurnTime = 180
+				ratedBurnTime = 182
 				safeOverburn = true
 				ignitionReliabilityStart = 0.989674
 				ignitionReliabilityEnd = 0.998370
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-3,LR91-AJ-1:50
 			}
 		}
 		CONFIG
 		{
 			// Gemini 8 data
 			name = LR91-AJ-7
-			description = Second stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
+			description = AJ23-135, second stage engine of Titan II GLV. Modified for the Gemini program to reduce chances of failure and make the engine safer. 
 			specLevel = operational
-			minThrust = 456.1
-			maxThrust = 456.1 // added the Verniers back to the thrust
+			minThrust = 448.7
+			maxThrust = 448.7
 			heatProduction = 160
-			//engines tested, and only those that performed within 1 stddev were selected for GLV
-			//Divide variances by three?
-			varyIsp = 0.0033		//0.33%
-			varyMixture = 0.00036	//0.036%
-			varyFlow = 0.010	//1.0%
+			varyIsp = 0.010		//1.0% [5]
+			varyMixture = 0.00109	//0.109% [5]
+			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00428	//0.428% [5]
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4694
+				ratio = 0.4586
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5306
+				ratio = 0.5414
 			}
 			atmosphereCurve
 			{
-				key = 0 315
-				key = 1 200
+				key = 0 309.2
+				key = 1 195
 			}
 			ullage = True
 			ignitions = 1
@@ -348,7 +493,7 @@
 				name = ElectricCharge
 				amount = 0.8
 			}
-			massMult = 1.13
+			massMult = 1.0
 
 			//Titan-2-GLV: 12 flights, 0 failures
 			//12 ignitions, 0 failures
@@ -363,7 +508,7 @@
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5:50&LR91-AJ-3:30
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5:50&LR91-AJ-3,LR91-AJ-1:30
 			}
 		}
 		CONFIG
@@ -371,31 +516,30 @@
 			name = LR91-AJ-7-Kero
 			description = Speculative config using equivalent technology to the -AJ-7 but burning Kerosene and LOX for purely civilian applications.
 			specLevel = speculative
-			// Thrust scaled by density ratio * Isp ratio vs -7. Isp calculated via RPA.
-			minThrust = 402.9
-			maxThrust = 402.9 // added the Verniers back to the thrust
+			// Thrust scaled by density ratio * Isp ratio vs -5. Isp calculated via RPA.
+			minThrust = 391.8
+			maxThrust = 391.8
 			heatProduction = 100
-			//engines tested, and only those that performed within 1 stddev were selected for GLV
-			//Divide variances by three?
-			varyIsp = 0.0033		//0.33%
-			varyMixture = 0.00036	//0.036%
-			varyFlow = 0.010	//1.0%
+			//same as AJ-5?
+			varyIsp = 0.010		//1.0% [5]
+			varyMixture = 0.00109	//0.109% [5]
+			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00428	//0.428% [5]
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3923
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6077
 			}
 			atmosphereCurve
 			{
-				key = 0 324.8
-				key = 1 166
+				key = 0 313.3
+				key = 1 195
 			}
 			ullage = True
 			ignitions = 1
@@ -405,7 +549,7 @@
 				name = ElectricCharge
 				amount = 0.8
 			}
-			massMult = 1.18
+			massMult = 1.1
 
 			// no data, never flew. Using -7 data
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -418,18 +562,17 @@
 				cycleReliabilityStart = 0.948370
 				cycleReliabilityEnd = 0.991848
 
-    				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5-Kero,LR91-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-5-Kero,LR91-AJ-3,LR91-AJ-1:50
 			}
 		}
 		CONFIG
 		{
 			name = LR91-AJ-9
-			description = Second stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
+			description = AJ23-137, second stage engine for Titan IIIA, IIIB and IIIC. Longer burn time and slightly higher performance for the stretched fuel tank of Titan III.
 			specLevel = operational
-			minThrust = 456.1
-			maxThrust = 456.1 // added the Verniers back to the thrust
+			minThrust = 448.7
+			maxThrust = 448.7
 			heatProduction = 160
-			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
 			varyMixture = 0.00109	//0.109% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
@@ -437,18 +580,18 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4694
+				ratio = 0.4586
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5306
+				ratio = 0.5414
 			}
 			atmosphereCurve
 			{
-				key = 0 316
-				key = 1 200
+				key = 0 309.2
+				key = 1 195
 			}
 			ullage = True
 			ignitions = 1
@@ -458,7 +601,7 @@
 				name = ElectricCharge
 				amount = 0.8
 			}
-			massMult = 1.18 // FIXME no sourcing
+			massMult = 1.0
 
 			//Titan-3A: 4 flights, 0 failures
 			//Titan-3B Agena-D: 22 flights, 1 failure. (1 cycle)
@@ -475,7 +618,7 @@
 				cycleReliabilityStart = 0.944583
 				cycleReliabilityEnd = 0.991250
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3,LR91-AJ-1:30
 			}
 		}
 		CONFIG
@@ -484,8 +627,8 @@
 			description = Speculative config using equivalent technology to the -AJ-9 but burning Kerosene and LOX for purely civilian applications.
 			specLevel = speculative
 			// Thrust scaled by density ratio * Isp ratio vs -9. Isp calculated via RPA.
-			minThrust = 402.9
-			maxThrust = 402.9 // added the Verniers back to the thrust
+			minThrust = 391.8
+			maxThrust = 391.8
 			heatProduction = 100
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -495,18 +638,18 @@
 			PROPELLANT
 			{
 				name = RP-1
-				ratio = 0.4117
+				ratio = 0.3923
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = LqdOxygen
-				ratio = 0.5883
+				ratio = 0.6077
 			}
 			atmosphereCurve
 			{
-				key = 0 325.5
-				key = 1 167
+				key = 0 313.3
+				key = 1 195
 			}
 			ullage = True
 			ignitions = 1
@@ -516,7 +659,7 @@
 				name = ElectricCharge
 				amount = 0.8
 			}
-			massMult = 1.18
+			massMult = 1.1
 
 			//no data, never flew. Using AJ-9 data
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -529,16 +672,16 @@
 				cycleReliabilityStart = 0.944583
 				cycleReliabilityEnd = 0.991250
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-7-Kero,LR91-AJ-5-Kero,LR91-AJ-3:50
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-7-Kero,LR91-AJ-5-Kero,LR91-AJ-3,LR91-AJ-1:50
 			}
 		}
 		CONFIG
 		{
 			name = LR91-AJ-11
-			description = Second stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Slightly improved performance.
+			description = AJ23-140, second stage engine for Titan 24B, 34B, IIIBS, IIID, 34D, 34D7 and IIIE. Slightly improved performance.
 			specLevel = operational
-			minThrust = 456.1
-			maxThrust = 456.1 // added the Verniers back to the thrust
+			minThrust = 448.7
+			maxThrust = 448.7
 			heatProduction = 160
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -548,18 +691,18 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4722
+				ratio = 0.4708
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5278
+				ratio = 0.5292
 			}
 			atmosphereCurve
 			{
 				key = 0 318
-				key = 1 200
+				key = 1 205
 			}
 			ullage = True
 			ignitions = 1
@@ -587,23 +730,75 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 350 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
-				ratedBurnTime = 232
+				ratedBurnTime = 222
 				safeOverburn = true
 				ignitionReliabilityStart = 0.991441
 				ignitionReliabilityEnd = 0.998649
 				cycleReliabilityStart = 0.980030
 				cycleReliabilityEnd = 0.996847
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3,LR91-AJ-1:30
+			}
+		}
+		CONFIG
+		{
+			name = LR91-AJ-11-Kero
+			description = Speculative config using equivalent technology to the -AJ-11 but burning Kerosene and LOX for purely civilian applications.
+			minThrust = 391.8
+			maxThrust = 391.8
+			heatProduction = 160
+			//same as AJ-5?
+			varyIsp = 0.010		//1.0% [5]
+			varyMixture = 0.00109	//0.109% [5]
+			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
+			residualsThresholdBase = 0.00428	//0.428% [5]
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.4041
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.5959
+			}
+			atmosphereCurve
+			{
+				key = 0 319.9
+				key = 1 205
+			}
+			ullage = True
+			ignitions = 1
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.2958
+
+			//no data, never flew. Using AJ-11 data
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
+				ratedBurnTime = 222
+				safeOverburn = true
+				ignitionReliabilityStart = 0.991441
+				ignitionReliabilityEnd = 0.998649
+				cycleReliabilityStart = 0.980030
+				cycleReliabilityEnd = 0.996847
+
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-9-Kero,LR91-AJ-7-Kero,LR91-AJ-5-Kero,LR91-AJ-3,LR91-AJ-1:50
 			}
 		}
 		CONFIG
 		{
 			name = LR91-AJ-11A
-			description = Second stage engine for Titan IVA and IVB. Slightly improved performance
+			description = Second stage engine for Titan IVA and IVB. Slightly improved thrust.
 			specLevel = operational
-			minThrust = 474.6
-			maxThrust = 474.6 // added the Verniers back to the thrust
+			minThrust = 472.5
+			maxThrust = 472.5
 			heatProduction = 160
 			//same as AJ-5?
 			varyIsp = 0.010		//1.0% [5]
@@ -613,13 +808,13 @@
 			PROPELLANT
 			{
 				name = Aerozine50
-				ratio = 0.4722
+				ratio = 0.4729
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = NTO
-				ratio = 0.5278
+				ratio = 0.5271
 			}
 			ullage = True
 			ignitions = 1
@@ -632,8 +827,8 @@
 			
 			atmosphereCurve
 			{
-				key = 0 318
-				key = 1 200
+				key = 0 317.7
+				key = 1 210
 			}
 			ullage = True
 			ignitions = 1
@@ -656,14 +851,66 @@
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				testedBurnTime = 350
-				ratedBurnTime = 250
+				ratedBurnTime = 240
 				safeOverburn = true
 				ignitionReliabilityStart = 0.976829
 				ignitionReliabilityEnd = 0.996341
 				cycleReliabilityStart = 0.976829
 				cycleReliabilityEnd = 0.996341
 
-				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-11,LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3:30
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-11,LR91-AJ-9,LR91-AJ-7,LR91-AJ-5:50&LR91-AJ-3,LR91-AJ-1:30
+			}
+		}
+		CONFIG
+		{
+			name = LR91-AJ-11A-Kero
+			description = Speculative config using equivalent technology to the -AJ-11A but burning Kerosene and LOX for purely civilian applications.
+			minThrust = 412.6
+			maxThrust = 412.6
+			heatProduction = 160
+			//same as AJ-5?
+			varyIsp = 0.010		//1.0% [5]
+			varyMixture = 0.00109	//0.109% [5]
+			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
+			residualsThresholdBase = 0.00428	//0.428% [5]
+			PROPELLANT
+			{
+				name = RP-1
+				ratio = 0.4058
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = LqdOxygen
+				ratio = 0.5942
+			}
+			atmosphereCurve
+			{
+				key = 0 319.3
+				key = 1 210
+			}
+			ullage = True
+			ignitions = 1
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.8
+			}
+			massMult = 1.2958
+
+			//no data, never flew. Using AJ-11A data
+			TESTFLIGHT:NEEDS[TestLite|TestFlight]
+			{
+				testedBurnTime = 350 // [1] Page II.C-15 (Figure II.C-13) Rated to 225s but demonstrated to 250s.  219s used in Titan 34D and 232s in titan IV
+				ratedBurnTime = 240
+				safeOverburn = true
+				ignitionReliabilityStart = 0.976829
+				ignitionReliabilityEnd = 0.996341
+				cycleReliabilityStart = 0.976829
+				cycleReliabilityEnd = 0.996341
+
+				techTransfer = XLR43-NA-3:25&A-6:10&A-7:10&LR91-AJ-11-Kero,LR91-AJ-9-Kero,LR91-AJ-7-Kero,LR91-AJ-5-Kero,LR91-AJ-3,LR91-AJ-1:50
 			}
 		}
 	}

--- a/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
+++ b/GameData/RealismOverhaul/Localization/en-us-Engines.cfg
@@ -355,7 +355,7 @@ Localization
 		#roLR87Title = LR87
 		#roLR87Desc = Used in the first stage of the Titan rocket family, the LR87 is composed of two engines with separate turbomachinery integrated into one unit. The version used on Titan I burned kerosene and liquid oxygen, while Titan II through Titan IV burned storable propellants. A modified version burning liquid hydrogen was developed for the upper stages of Saturn V and Saturn IB, but the J-2 was selected instead.
 		//		LR87LH2
-		#roLR87LH2Title = LR87-LH2
+		#roLR87LH2Title = AJ23-65
 		#roLR87LH2Desc = Aerojet developed the LR87 engine (used for the Titan series) into a liquid hydrogen/oxygen engine for prospective USAF contracts in the 1958-1960 period, at the same time Aerojet was converting the LR87 to burn Aerozine and NTO. Aerojet also proposed this engine for Saturn upper stage duties, but NASA selected the J-2 over the LR87-LH2 and it was canceled in 1961.
 		//		LR89
 		#roLR89Title = LR43/LR89


### PR DESCRIPTION
Overhaul of Titan engine configs with better sources and more configs.

Almost all engine performance data has been updated, using more credible data sourced directly from Aerojet. Also add speculative kerosene and nozzle configs to all engine variants instead of just some, and the real 12:1 nozzle variant used on some Titan 3s.