### PR TITLE
Add Breaking Ground robotics parts

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Robotics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SquadExpansion/RO_SquadExpansion_Robotics.cfg
@@ -1,0 +1,160 @@
+@PART[hinge_01]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[hinge_01_s]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[hinge_03]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[hinge_03_s]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[hinge_04]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[piston_01]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[piston_02]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[piston_03]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[piston_04]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotor_01]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotor_01s]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotor_02]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotor_02s]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotor_03]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotor_03s]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotoServo_00]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotoServo_02]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotoServo_03]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[rotoServo_04]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}
+@PART[controller1000]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = True
+	
+	//Aluminum
+	%skinTempTag = Aluminum
+	%internalTempTag = Aluminum
+}


### PR DESCRIPTION
Breaking Ground doesn't have any RO configs yet, time to finally add some.

The default masses and power consumption actually seem fairly reasonable for the scale of the parts.
The part scales also fit with the cubic octagonal strut and modular girder without modification.
The power consumption is a few hundred watts to a couple of kW depending on the size of motor you select, which is also reasonable without modification.

Doesn't add any of the non-robotics Breaking Ground parts.

This probably resolves some issues asking for robotics parts in RO.