### PR TITLE
Reduce skin to internal conduction to prevent heatshields melting

### DIFF
--- a/GameData/RealismOverhaul/RO_Heatshields.cfg
+++ b/GameData/RealismOverhaul/RO_Heatshields.cfg
@@ -23,7 +23,7 @@
 	%heatShieldAblator = 30
 	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 5.0
-	%skinInternalConductionMult = 0.25
+	%skinInternalConductionMult = 0.1
 	%emissiveConstant = 0.4
 
 	%MODULE[ModuleAblator]
@@ -49,7 +49,7 @@
 	%heatShieldAblator = 35
 	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 5.0
-	%skinInternalConductionMult = 0.25
+	%skinInternalConductionMult = 0.1
 	%emissiveConstant = 0.4
 
 	%MODULE[ModuleAblator]
@@ -75,7 +75,7 @@
 	%heatShieldAblator = 25
 	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 4.0
-	%skinInternalConductionMult = 0.25
+	%skinInternalConductionMult = 0.1
 	%emissiveConstant = 0.8
 
 	%MODULE[ModuleAblator]
@@ -100,7 +100,7 @@
 	%heatShieldAblator = 25
 	%skinThermalMassModifier = 1.5
 	%skinMassPerArea = 5.0
-	%skinInternalConductionMult = 0.25
+	%skinInternalConductionMult = 0.1
 	%emissiveConstant = 0.8
 
 	%MODULE[ModuleAblator]


### PR DESCRIPTION
 The recent heatshield changes reduced the maximum tolerable internal temperature of heatshields. This has resulted in heatshields melting from high internal temperatures during normal usage.

Normal usage includes default size photo bucket mercury HS with sci core with film inside, which currently melts. The attached screenshot occurred a few seconds before the heatshield melted.
<img width="1003" height="582" alt="image" src="https://github.com/user-attachments/assets/7108d6e0-daf2-4d95-bd7a-49ead47c774a" />
This change reduced the peak internal temperate on repeat of this test to 480K, which seemed reasonable to me.