### PR TITLE
Nerf landing gear, make separate spaceplane gear

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalFoundries_2/KF-RO.cfg
@@ -515,6 +515,7 @@
 	%RSSROConfig = True
 	@mass = 0.19
 	@PhysicsSignificance = 0
+	//Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
 	%skinTempTag = Inconel
 	%internalTempTag = HotStructure
 
@@ -533,6 +534,7 @@
 	%RSSROConfig = True
 	@mass = 0.2
 	@PhysicsSignificance = 0
+	//Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
 	%skinTempTag = Inconel
 	%internalTempTag = HotStructure
 
@@ -551,9 +553,9 @@
 	%RSSROConfig = True
 	@mass = 0.46
 	@PhysicsSignificance = 0
-	%skinTempTag = RCC
+	//Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
+	%skinTempTag = Inconel
 	%internalTempTag = HotStructure
-	%skinInsulationTag = True
 
 	@MODULE[KSPWheelBase]
 	{
@@ -570,9 +572,9 @@
 	%RSSROConfig = True
 	@mass = 1.5
 	@PhysicsSignificance = 0
-	%skinTempTag = RCC
+	//Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
+	%skinTempTag = Inconel
 	%internalTempTag = HotStructure
-	%skinInsulationTag = True
 
 	@MODULE[KSPWheelBase]
 	{
@@ -582,4 +584,21 @@
 		%maxSpeed = 150
 		%maxLoadRating = 130
 	}
+}
+//Having re-entry rated parts unlock in the start node is apparently exploitable. Clone all the gear and make spaceplane-rated versions instead
+//run this in AFTER so we catch it after KSPWheel is done touching it
++PART[KF-ALG-Small|KF-ALG-SmallSide|KF-ALG-Medium|KF-ALG-Large]:AFTER[RealismOverhaul]
+{
+	@name ^= :$:-Spaceplane:	//Isn't regex fun?
+	@title ^= :$: (Spaceplane):	//I probably could figure out how to stick this into the title more smoothly but also I don't really care
+	@description ^= :$: This version has heat shielding for orbital use.:	//ditto
+	@mass *= 1.1	//yeah sure 10% heavier for heat shielding
+	//Get these too (patch both just in case KSPWheel isn't present)
+	@MODULE[ModuleWheelBase] { @mass *= 1.1 }
+	@MODULE[KSPWheelBase] { @wheelMass *= 1.1 }
+	
+	//Space Shuttle class I guess
+	%skinTempTag = RCC
+	%internalTempTag = HotStructure
+	%skinInsulationTag = True
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -171,8 +171,8 @@
     %RSSROConfig = True
     @mass = 0.1
     //Aluminum
-    %skinTempTag = Inconel
-    %internalTempTag = HotStructure
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 0.1 }
     @MODULE[ModuleLight] { @resourceAmount = 0.025 }
@@ -187,10 +187,8 @@
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
     @mass = 0.46
-    //Space Shuttle class I guess
-    %skinTempTag = RCC
-    %internalTempTag = HotStructure
-    %skinInsulationTag = True
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 0.46 }
     @MODULE[ModuleLight] { @resourceAmount = 0.1 }
@@ -205,10 +203,8 @@
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
     @mass = 1.0
-    //Space Shuttle class I guess
-    %skinTempTag = RCC
-    %internalTempTag = HotStructure
-    %skinInsulationTag = True
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 1.0 }
     @MODULE[ModuleLight] { @resourceAmount = 0.2 }
@@ -226,11 +222,30 @@
     // One fully assembled B747 wheel weighs 180 kg, so 1080 kg for wheels
     // only
     @mass = 1.53
-    //Space Shuttle class I guess
-    %skinTempTag = RCC
-    %internalTempTag = HotStructure
-    %skinInsulationTag = True
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 1.53 }
     @MODULE[ModuleLight] { @resourceAmount = 0.3 }
+}
+
+//  ==================================================
+//  Spaceplane landing gear
+//  ==================================================
+//Having re-entry rated parts unlock in the start node is apparently exploitable. Clone all the gear and make spaceplane-rated versions instead
+//run this in AFTER so we catch it after KSPWheel is done touching it
++PART[SmallGearBay|GearSmall|GearMedium|GearLarge]:AFTER[RealismOverhaul]
+{
+	@name ^= :$:Spaceplane:	//Isn't regex fun?
+	@title ^= :$: (Spaceplane):	//I probably could figure out how to stick this into the title more smoothly but also I don't really care
+	@description ^= :$: This version has heat shielding for orbital use.:	//ditto
+	@mass *= 1.1	//yeah sure 10% heavier for heat shielding
+	//Get these too (patch both just in case KSPWheel isn't present)
+	@MODULE[ModuleWheelBase] { @mass *= 1.1 }
+	@MODULE[KSPWheelBase] { @wheelMass *= 1.1 }
+	
+	//Space Shuttle class I guess
+	%skinTempTag = RCC
+    %internalTempTag = HotStructure
+	%skinInsulationTag = True
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -170,8 +170,8 @@
 {
     %RSSROConfig = True
     @mass = 0.1
-    //Aluminum
-    %skinTempTag = Aluminum
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
+    %skinTempTag = Titanium
     %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 0.1 }
@@ -187,7 +187,8 @@
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
     @mass = 0.46
-    %skinTempTag = Aluminum
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
+    %skinTempTag = Titanium
     %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 0.46 }
@@ -203,7 +204,8 @@
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
     @mass = 1.0
-    %skinTempTag = Aluminum
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
+    %skinTempTag = Titanium
     %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 1.0 }
@@ -222,7 +224,8 @@
     // One fully assembled B747 wheel weighs 180 kg, so 1080 kg for wheels
     // only
     @mass = 1.53
-    %skinTempTag = Aluminum
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
+    %skinTempTag = Titanium
     %internalTempTag = Instruments
 
     @MODULE[ModuleWheelBase] { @mass = 1.53 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Wheel.cfg
@@ -170,9 +170,9 @@
 {
     %RSSROConfig = True
     @mass = 0.1
-    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
-    %skinTempTag = Titanium
-    %internalTempTag = Instruments
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
+    %skinTempTag = Inconel
+    %internalTempTag = HotStructure
 
     @MODULE[ModuleWheelBase] { @mass = 0.1 }
     @MODULE[ModuleLight] { @resourceAmount = 0.025 }
@@ -187,9 +187,9 @@
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
     @mass = 0.46
-    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
-    %skinTempTag = Titanium
-    %internalTempTag = Instruments
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
+    %skinTempTag = Inconel
+    %internalTempTag = HotStructure
 
     @MODULE[ModuleWheelBase] { @mass = 0.46 }
     @MODULE[ModuleLight] { @resourceAmount = 0.1 }
@@ -204,9 +204,9 @@
     %RSSROConfig = True
     // Based on extrapolation of weight of B747 landing gear
     @mass = 1.0
-    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
-    %skinTempTag = Titanium
-    %internalTempTag = Instruments
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
+    %skinTempTag = Inconel
+    %internalTempTag = HotStructure
 
     @MODULE[ModuleWheelBase] { @mass = 1.0 }
     @MODULE[ModuleLight] { @resourceAmount = 0.2 }
@@ -224,9 +224,9 @@
     // One fully assembled B747 wheel weighs 180 kg, so 1080 kg for wheels
     // only
     @mass = 1.53
-    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Titanium for skin
-    %skinTempTag = Titanium
-    %internalTempTag = Instruments
+    //Aluminum probably, but I don't wanna make an X-15 rated version too so just say Inconel hot structure
+    %skinTempTag = Inconel
+    %internalTempTag = HotStructure
 
     @MODULE[ModuleWheelBase] { @mass = 1.53 }
     @MODULE[ModuleLight] { @resourceAmount = 0.3 }
@@ -239,16 +239,16 @@
 //run this in AFTER so we catch it after KSPWheel is done touching it
 +PART[SmallGearBay|GearSmall|GearMedium|GearLarge]:AFTER[RealismOverhaul]
 {
-	@name ^= :$:Spaceplane:	//Isn't regex fun?
-	@title ^= :$: (Spaceplane):	//I probably could figure out how to stick this into the title more smoothly but also I don't really care
-	@description ^= :$: This version has heat shielding for orbital use.:	//ditto
-	@mass *= 1.1	//yeah sure 10% heavier for heat shielding
-	//Get these too (patch both just in case KSPWheel isn't present)
-	@MODULE[ModuleWheelBase] { @mass *= 1.1 }
-	@MODULE[KSPWheelBase] { @wheelMass *= 1.1 }
-	
-	//Space Shuttle class I guess
-	%skinTempTag = RCC
+    @name ^= :$:Spaceplane: //Isn't regex fun?
+    @title ^= :$: (Spaceplane): //I probably could figure out how to stick this into the title more smoothly but also I don't really care
+    @description ^= :$: This version has heat shielding for orbital use.:   //ditto
+    @mass *= 1.1    //yeah sure 10% heavier for heat shielding
+    //Get these too (patch both just in case KSPWheel isn't present)
+    @MODULE[ModuleWheelBase] { @mass *= 1.1 }
+    @MODULE[KSPWheelBase] { @wheelMass *= 1.1 }
+    
+    //Space Shuttle class I guess
+    %skinTempTag = RCC
     %internalTempTag = HotStructure
-	%skinInsulationTag = True
+    %skinInsulationTag = True
 }


### PR DESCRIPTION
Since apparently some people can't behave when given re-entry related parts in the start node, nerf landing gear heat tolerance and create spaceplane versions instead.