### PR TITLE
Make ORM-65 performance more realistic

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/ORM65_config.cfg
@@ -9,13 +9,13 @@
 //
 //	Dry Mass: 14.3 Kg
 //	Thrust (SL): 1.750 kN
-//	Thrust (Vac): 1.785 kN
-//	ISP: 210 SL / 215 Vac
+//	Thrust (Vac): 1.942 kN
+//	ISP: 210 SL / 233 Vac	//calculated with RPA, assuming same combustion efficiency as WAC-Corporal
 //	Burn Time: 80
 //	Chamber Pressure: 2.53 MPa
 //	Propellant: AK20 / Kerosene
 //	Prop Ratio: 4.0
-//	Throttle: 100% to 28%
+//	Throttle: 100% to 28.6% (0.5 kN)
 //	Nozzle Ratio: ???
 //	Ignitions: 1
 //	=================================================================================
@@ -24,28 +24,28 @@
 //
 //	Dry Mass: 12.3 Kg
 //	Thrust (SL): 1.431 kN
-//	Thrust (Vac): 1.460 kN
-//	ISP: 210 SL / 215 Vac
+//	Thrust (Vac): 1.588 kN
+//	ISP: 210 SL / 233 Vac	//calculated with RPA, assuming same combustion efficiency as WAC-Corporal
 //	Burn Time: 200
 //	Chamber Pressure: 2.53 MPa
 //	Propellant: AK20 / Kerosene
 //	Prop Ratio: 4.0
-//	Throttle: 100% to 34%
+//	Throttle: 100% to 34.2% (0.49 kN)
 //	Nozzle Ratio: ???
 //	Ignitions: 2
 //	=================================================================================
-//	RDA-1-150
+//	RDA-1-300
 //	planned upgrade for RP-318 rocket plane
 //
 //	Dry Mass: 12.3 Kg
-//	Thrust (SL): ??? kN
-//	Thrust (Vac): 2.942 kN
-//	ISP: 210 SL / 215 Vac
+//	Thrust (SL): 2.862? kN
+//	Thrust (Vac): 3.176 kN
+//	ISP: 210 SL / 233 Vac	//calculated with RPA, assuming same combustion efficiency as WAC-Corporal
 //	Burn Time: 200
 //	Chamber Pressure: 2.53 MPa
 //	Propellant: AK20 / Kerosene
 //	Prop Ratio: 4.0
-//	Throttle: 100% to 34%
+//	Throttle: 100% to 34.2?% (0.979? kN)
 //	Nozzle Ratio: ???
 //	Ignitions: 2
 //	=================================================================================
@@ -86,16 +86,35 @@
 		{
 			name = ORM-65
 			specLevel = operational
-			minThrust = 0.510
-			maxThrust = 1.785
+			minThrust = 0.693
+			maxThrust = 1.942
 			massMult = 1.0
 			heatProduction = 100
+			autoVariationScale = 2	//stated Isp variance of 210-215 is pretty wide. Handbuilt engines in a shed, poor quality control, lots of variance
+			useThrottleIspCurve = true
+
+			//Stated performance is almost certainly at sea level. Since throttling drops chamber pressure, and this thing doesn't have much in the
+			//first place, throttling will decrease Isp which will in turn decrease thrust even more
+			//As such, we don't actually need 28.5% throttle to reach 28.5% thrust
+			//1.942 kN * 0.357 throttle * Isp mult 0.800 * SL mult 0.901 = 0.500
+			throttleIspCurve
+			{
+				key = 0.00 0.80 0 0
+				key = 0.357 0.80 0 1
+				key = 1.0 1.0 1 0
+			}
+			//Throttles by shutting off injectors, no injector pressure drop, just less complete combustion from lower pressure
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.035
+				key = 1.0 1.0
+			}
 			
 			//only two throttle settings, low and high (and start, but that wasn't used during flight?)
 			throttleCurve
 			{
-				key = 0.000 0.286 0.00 0.00
-				key = 0.500 0.286 0.00 0.00
+				key = 0.000 0.357 0.00 0.00
+				key = 0.500 0.357 0.00 0.00
 				key = 0.501 1.000 0.00 0.00
 				key = 1.000 1.000 0.00 0.00
 			}
@@ -121,7 +140,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 215
+				key = 0 233
 				key = 1 210
 			}
 			
@@ -131,7 +150,7 @@
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				//reliability largley copied from aerobee, too few tests of ORM-65 to get accurate reliability info
+				//reliability largely copied from aerobee, too few tests of ORM-65 to get accurate reliability info
 				ratedBurnTime = 80
 
 				// very early engine, assume linear relationship between throttle and burn time
@@ -144,7 +163,7 @@
 				ignitionReliabilityStart = 0.9
 				ignitionReliabilityEnd = 0.96
 				ignitionDynPresFailMultiplier = 10.0
-				cycleReliabilityStart = 0.7
+				cycleReliabilityStart = 0.75
 				cycleReliabilityEnd = 0.9
 			}
 		}
@@ -153,16 +172,33 @@
 			name = RDA-1-150
 			description = Simplified ORM-65 for the RP-318 rocket planes
 			specLevel = operational
-			minThrust = 0.499
-			maxThrust = 1.460
+			minThrust = 0.649
+			maxThrust = 1.588
 			massMult = 0.86
+			autoVariationScale = 2		//stated Isp variance of 210-215 is pretty wide. Handbuilt engines in a shed, poor quality control, lots of variance
 			heatProduction = 100
+			//Stated performance is almost certainly at sea level. Since throttling drops chamber pressure, and this thing doesn't have much in the
+			//first place, throttling will decrease Isp which will in turn decrease thrust even more
+			//As such, we don't actually need 34.2% throttle to reach 34.2% thrust
+			//1.588 kN * 0.409 throttle * Isp mult 0.838 * SL mult 0.901 = 0.49
+			throttleIspCurve
+			{
+				key = 0.00 0.838 0 0
+				key = 0.409 0.838 0 1
+				key = 1.0 1.0 1 0
+			}
+			//Throttles by shutting off injectors, no injector pressure drop, just less complete combustion from lower pressure
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.035
+				key = 1.0 1.0
+			}
 			
 			//only two throttle settings, low and high (and start, but that wasn't used during flight?)
 			throttleCurve
 			{
-				key = 0.000 0.342 0.00 0.00
-				key = 0.500 0.342 0.00 0.00
+				key = 0.000 0.409 0.00 0.00
+				key = 0.500 0.409 0.00 0.00
 				key = 0.501 1.000 0.00 0.00
 				key = 1.000 1.000 0.00 0.00
 			}
@@ -188,7 +224,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 215
+				key = 0 233
 				key = 1 210
 			}
 			
@@ -217,7 +253,7 @@
 				ignitionReliabilityEnd = 0.98
 				ignitionDynPresFailMultiplier = 10.0
 				cycleReliabilityStart = 0.90
-				cycleReliabilityEnd = 0.95
+				cycleReliabilityEnd = 0.96
 				techTransfer = ORM-65:50
 			}
 		}
@@ -226,19 +262,37 @@
 			name = RDA-1-300
 			description = Uprated RDA-1-300, to allow the RP-318 to take off under its own power. Test site was overrun by the German army before it could be tested.
 			specLevel = prototype
-			minThrust = 0.499
-			maxThrust = 2.942
+			minThrust = 1.300
+			maxThrust = 3.176
 			massMult = 0.86
+			autoVariationScale = 2		//stated Isp variance of 210-215 is pretty wide. Handbuilt engines in a shed, poor quality control, lots of variance
 			heatProduction = 100
+			//Stated performance is almost certainly at sea level. Since throttling drops chamber pressure, and this thing doesn't have much in the
+			//first place, throttling will decrease Isp which will in turn decrease thrust even more
+			//As such, we don't actually need 34.2% throttle to reach 34.2% thrust
+			//3.176 kN * 0.409 throttle * Isp mult 0.838 * SL mult 0.901 = 0.979
+			throttleIspCurve
+			{
+				key = 0.00 0.838 0 0
+				key = 0.409 0.838 0 1
+				key = 1.0 1.0 1 0
+			}
+			//Throttles by shutting off injectors, no injector pressure drop, just less complete combustion from lower pressure
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.035
+				key = 1.0 1.0
+			}
 			
 			//only two throttle settings, low and high (and start, but that wasn't used during flight?)
 			throttleCurve
 			{
-				key = 0.000 0.170 0.00 0.00
-				key = 0.500 0.170 0.00 0.00
+				key = 0.000 0.409 0.00 0.00
+				key = 0.500 0.409 0.00 0.00
 				key = 0.501 1.000 0.00 0.00
 				key = 1.000 1.000 0.00 0.00
 			}
+			
 			
 			PROPELLANT
 			{
@@ -261,7 +315,7 @@
 
 			atmosphereCurve
 			{
-				key = 0 215
+				key = 0 233
 				key = 1 210
 			}
 			


### PR DESCRIPTION
Considering the given ORM-65 performance numbers almost certainly refer to sea level performance, compute vacuum performance with RPA (assuming similar efficiency to WAC-Corporal) and adjust ORM-65 stats to match. Also increase variance a little and tweak throttled performance.