### PR TITLE
Improve Agena Engine configs, separate HDA Agena, 8096B

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Agena_XLR81_Config.cfg
@@ -359,6 +359,7 @@
 			heatProduction = 100
 			gimbalRange = 0		//No other X-15 engine had gimbal, so no gimbal
 			massMult = 0.8532
+			useThrottleIspCurve = true
 			//Stated performance is at 40kft. Since throttling drops chamber pressure, throttling will decrease Isp which will in turn decrease
 			//thrust even more. Since we are given altitude thrust: 8klbf (35.59 kN) target at 40kft
 			//64.50 * 0.596 throttle * Isp mult 0.926 = 35.60


### PR DESCRIPTION
General improvements to Agena configs with better sources, better throttling behavior for XLR81-BA-1, add HDA version of the model 8096 as it's own independent config, and add 8096B as an independent config from the 8096L.