### PR TITLE
Add Isp curves to common atmospheric throttleable engines

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/AR2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/AR2_Config.cfg
@@ -165,6 +165,21 @@
 			heatProduction = 100
 			pressureFed = True
 			ignitions = 100
+			useThrottleIspCurve = true
+			//I'm pretty sure throttle here is given in a vacuum, so no altitude correction needed
+			//75% Isp factor due to lower chamber pressure calculated by RPA. Borderline flow separation at 50%
+			throttleIspCurve
+			{
+				key = 0.00 0.001 0.0 2.0
+				key = 0.50 0.750 0.7 0.7
+				key = 1.00 1.000 0.2 0.0
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.05
+				key = 1.0 1.0
+			}
 			PROPELLANT
 			{
 				name = Kerosene
@@ -215,6 +230,21 @@
 			heatProduction = 100
 			pressureFed = False
 			ignitions = 100
+			useThrottleIspCurve = true
+			//I'm pretty sure throttle here is given in a vacuum, so no altitude correction needed
+			//76% Isp factor due to lower chamber pressure calculated by RPA. Borderline flow separation at 50%
+			throttleIspCurve
+			{
+				key = 0.00 0.001 0.0 2.0
+				key = 0.50 0.760 0.7 0.7
+				key = 1.00 1.000 0.2 0.0
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.05
+				key = 1.0 1.0
+			}
 			PROPELLANT
 			{
 				name = Kerosene

--- a/GameData/RealismOverhaul/Engine_Configs/BE-3_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-3_Config.cfg
@@ -7,7 +7,7 @@
 //	BE-3PM
 //	New Shepard
 //
-//	Dry Mass: 480 Kg
+//	Dry Mass: 480 kg
 //	Thrust (SL): 490 kN
 //	Thrust (Vac): 511.3? kN
 //	ISP: 345 SL / 360 Vac	estimated with RPA
@@ -15,7 +15,7 @@
 //	Chamber Pressure: 8.0? MPa	guess
 //	Propellant: LOX / LH2
 //	Prop Ratio: 6.0?
-//	Throttle: 490 kN to 89 kN
+//	Throttle: 490 kN to 89 kN (at sea level?)
 //	Nozzle Ratio: 5?	guess
 //	Ignitions: 50		A lot, reusable
 //	=================================================================================
@@ -66,7 +66,27 @@
 			name = BE3
 			specLevel = operational
 			maxThrust = 511.3	//490 kN SL
-			minThrust = 89
+			minThrust = 110.95	//89 kN SL
+			useThrottleIspCurve = true
+			//Stated performance is at sea level? Since throttling drops chamber pressure, throttling will decrease Isp which will in turn 
+			//decrease thrust even more
+			//490 kN * 0.217 throttle * Isp mult 0.837 * SL mult 1.000 = 89 kN
+			throttleIspCurve
+			{
+				key = 0.000 0.001 0.0 4.1
+				key = 0.200 0.820 1.5 1.5
+				key = 0.400 0.930 0.4 0.4
+				key = 0.600 0.969 0.2 0.2
+				key = 0.800 0.988 0.1 0.1
+				key = 1.000 1.000 0.1 0.0
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.05
+				key = 1.0 1.0
+			}
+
 			PROPELLANT
 			{
 				name = LqdHydrogen

--- a/GameData/RealismOverhaul/Engine_Configs/S155_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/S155_Config.cfg
@@ -60,6 +60,21 @@
 			maxThrust = 39
 			massMult = 1.0
 			heatProduction = 100
+			useThrottleIspCurve = true
+			//I'm pretty sure throttle here is given in a vacuum, so no altitude correction needed
+			//76% Isp factor due to lower chamber pressure calculated by RPA. Borderline flow separation at 50%
+			throttleIspCurve
+			{
+				key = 0.00 0.001 0.0 4.0
+				key = 0.50 0.939 0.1 0.1
+				key = 1.00 1.000 0.0 0.0
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.05
+				key = 1.0 1.0
+			}
 			PROPELLANT
 			{
 				name = Tonka250

--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -63,13 +63,42 @@
 		{
 			name = XLR25-CW-1
 			specLevel = operational
-			minThrust = 12.29
+			minThrust = 13.72
 			maxThrust = 73.75
 			massMult = 1.0
+			ullage = False
+			pressureFed = False
+			ignitions = 6
+			useThrottleIspCurve = true
 
-			%ullage = False
-			%pressureFed = False
-			%ignitions = 6
+			//Stated performance is at sea level. Since throttling drops chamber pressure, and this thing doesn't have much in the
+			//first place, throttling will decrease Isp which will in turn decrease thrust even more
+			//However, we have two chambers at 22.26 and 44.52 kN (SL?), which can be shut off to allow deep throttle without significantly 
+			//reducing chamber pressure (and thus Isp).
+			//We actually get a very lumpy throttle curve because of this, as we move from throttle sub-chamber->throttle main chamber->both
+			//sub-chamber min thrust (16.7% total thrust to 33.3% total thrust)
+			//22.26 kN * 0.557 throttle * Isp mult 0.898 * SL mult 1.000 = 11.13
+			//main chamber min thrust (assuming this is equal to the sub-chamber max thrust, 33.3% total thrust to 66.7% total thrust)
+			//44.52 kN * 0.557 throttle * Isp mult 0.898 * SL mult 1.000 = 22.27
+			//main chamber partial thrust + sub-chamber partial thrust (66.7% total thrust to 100% total thrust)
+			//assuming both chambers throttle equally so I don't have to do math
+			//66.72 * 0.708 throttle * Isp mult 0.947 * SL mult 1.000 = 44.53
+			throttleIspCurve
+			{
+				key = 0.00 0.898 0 0
+				key = 0.186 0.898 0.0 0.5	//min throttle sub-chamber
+				key = 0.333 1.000 1.0 0.0	//full throttle sub-chamber
+				key = 0.334 0.898 0.0 0.25	//min throttle main-chamber
+				key = 0.666 1.000 0.5 0.0	//full throttle main-chamber
+				key = 0.667 0.947 0.0 0.1	//partial throttle both
+				key = 1.000 1.000 0.2 0.0	//full throttle both
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.05
+				key = 1.0 1.0
+			}
 
 			PROPELLANT	//755.8 gallons LOX, 860.3 alcohol
 			{

--- a/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR25_Config.cfg
@@ -85,13 +85,13 @@
 			//66.72 * 0.708 throttle * Isp mult 0.947 * SL mult 1.000 = 44.53
 			throttleIspCurve
 			{
-				key = 0.00 0.898 0 0
-				key = 0.186 0.898 0.0 0.5	//min throttle sub-chamber
-				key = 0.333 1.000 1.0 0.0	//full throttle sub-chamber
-				key = 0.334 0.898 0.0 0.25	//min throttle main-chamber
-				key = 0.666 1.000 0.5 0.0	//full throttle main-chamber
-				key = 0.667 0.947 0.0 0.1	//partial throttle both
-				key = 1.000 1.000 0.2 0.0	//full throttle both
+				key = 0.000 0.001 0.0 10
+				key = 0.186 0.898 1.0 1.0	//min throttle sub-chamber
+				key = 0.333 1.000 0.5 0.0	//full throttle sub-chamber
+				key = 0.334 0.898 0.0 0.5	//min throttle main-chamber
+				key = 0.666 1.000 0.2 0.0	//full throttle main-chamber
+				key = 0.667 0.947 0.0 0.3	//partial throttle both
+				key = 1.000 1.000 0.1 0.0	//full throttle both
 			}
 			//We do some injector throttling, so small Isp penalty in vacuum
 			throttleIspCurveAtmStrength 

--- a/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
@@ -19,14 +19,14 @@
 //	Nozzle Ratio: 9.8
 //	Ignitions: 100	rated for 100 starts [C, p.210]
 //	=================================================================================
-//	XLR99-RM-1A
+//	XLR99-RM-3 (XLR99A)
 //	X-15A-2
 //	Recontoured nozzle plus 22.5:1 radiative extension. No other changes.
 //
 //	Dry Mass: 432 kg	Guessing about 19 kg for nozzle extension (roughly the same as RL10A-4 extension)
 //	Thrust (SL): ??? kN
 //	Thrust (Vac): 281.9 kN	63378 lbf [C, p.226]
-//	ISP: 205 SL / 298 Vac	205@SL (calculated with RPA), 298@vac [C, p.226]
+//	ISP: 198 SL / 298 Vac	198@SL (calculated with RPA), 298@vac [C, p.226]
 //	Burn Time: 180
 //	Chamber Pressure: 4.14 MPa
 //	Propellant: LOX / Ammonia
@@ -35,7 +35,7 @@
 //	Nozzle Ratio: 22.5
 //	Ignitions: 100
 //	=================================================================================
-//	XLR99-RM-3
+//	XLR99-RM-5
 //	X-15A-3 Delta
 //	Heavily modified XLR99 for "hypersonic cruise" Mach 8 X-15.
 //
@@ -109,6 +109,21 @@
 			maxThrust = 257.3
 			heatProduction = 100
 			varyFlow = 0.0263	//[C, p.415] +-1500 lbf(!) throttle error at 57000 lbf nominal thrust
+			useThrottleIspCurve = true
+			//I'm pretty sure throttle here is given in a vacuum, so no altitude correction needed
+			//77.2% Isp factor due to lower chamber pressure calculated by RPA. Borderline flow separation at 40%
+			throttleIspCurve
+			{
+				key = 0.00 0.001 0.0 4.0
+				key = 0.40 0.772 0.6 0.6
+				key = 1.00 1.000 0.2 0.0
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.05
+				key = 1.0 1.0
+			}
 			PROPELLANT
 			{
 				name = LqdAmmonia
@@ -175,6 +190,25 @@
 			heatProduction = 100
 			massMult = 1.046
 			varyFlow = 0.0263
+			useThrottleIspCurve = true
+			//25.1% Isp factor due to lower chamber pressure calculated by RPA. Complete flow separation of nozzle extension throttling at SL
+			throttleIspCurve
+			{
+				key = 0.00 0.001 0.00 0.00
+				key = 0.10 0.001 0.00 0.00	//catastrophic flow separation at sea level
+				key = 0.25 0.005 0.10 0.83	//recovers around 25% throttle
+				key = 0.40 0.251 2.05 2.05
+				key = 0.50 0.498 2.07 2.07
+				key = 0.60 0.664 1.36 1.36
+				key = 0.80 0.874 0.84 0.84
+				key = 1.00 1.000 0.63 0.63
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.01
+				key = 1.0 1.0
+			}
 			PROPELLANT
 			{
 				name = LqdAmmonia
@@ -196,7 +230,7 @@
 			atmosphereCurve
 			{
 				key = 0 298
-				key = 1 205
+				key = 1 198
 			}
 			ullage = False
 			pressureFed = False
@@ -240,6 +274,25 @@
 			heatProduction = 100
 			massMult = 1.046
 			varyFlow = 0.0263
+			useThrottleIspCurve = true
+			//25.1% Isp factor due to lower chamber pressure calculated by RPA. Complete flow separation of nozzle extension throttling at SL
+			throttleIspCurve
+			{
+				key = 0.00 0.001 0.00 0.00
+				key = 0.10 0.001 0.00 0.00	//catastrophic flow separation at sea level
+				key = 0.25 0.005 0.10 0.83	//recovers around 25% throttle
+				key = 0.40 0.251 2.05 2.05
+				key = 0.50 0.498 2.07 2.07
+				key = 0.60 0.664 1.36 1.36
+				key = 0.80 0.874 0.84 0.84
+				key = 1.00 1.000 0.63 0.63
+			}
+			//We do some injector throttling, so small Isp penalty in vacuum
+			throttleIspCurveAtmStrength 
+			{
+				key = 0.0 0.01
+				key = 1.0 1.0
+			}
 			PROPELLANT
 			{
 				name = LqdAmmonia


### PR DESCRIPTION
Add a throttle Isp curve to some of the more common atmospheric throttleable engines, including the XLR25, XLR99, AR-2, S-155, and BE-3PM.