### PR TITLE
More realistic MLP ROFIs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModularLaunchPads/MLP.cfg
@@ -63,6 +63,42 @@
 {
 	@rescaleFactor = 1.733333333
 }
+//more realistic ROFI behavior
+@PART[AM_MLP_GeneralROFI|AM_MLP_ShuttleLauncherTSM]:FOR[RealismOverhaul]
+{
+	!RESOURCE,* {}
+	//15-20 seconds effective run time, tapering off gradually after ~10 seconds
+	RESOURCE
+	{
+		name = SolidFuel
+		amount = 1
+		maxAmount = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		!PROPELLANT,* {}
+		PROPELLANT
+		{
+			name = SolidFuel
+			ratio = 1.0
+			DrawGauge = True
+		}
+		//It's a solid gas generator with a bunch of zirconium powder and no proper nozzle, pretty bad
+		@atmosphereCurve
+		{
+			@key,0 = 0 80
+			@key,1 = 1 80
+		}
+		curveResource = SolidFuel
+		thrustCurve
+		{
+			key = 1.00000 0.50000 -20.000  -20.000
+			key = 0.96000 1.00000 0.00000  0.00000
+			key = 0.25000 1.00000 0.00000  0.00000
+			key = 0.00000 0.05000 9.90000  9.90000
+		}
+	}
+}
 
 // Soyuz
 @PART[AM_MLP_SoyuzLaunchBase*]:FOR[RealismOverhaul]


### PR DESCRIPTION
Switch MLP ROFIs to use solid fuel, increase runtime to 15-20 seconds, and add a thrust curve for more realistic behavior.