### PR TITLE
Correct XLR99 config names

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/XLR99_Config.cfg
@@ -22,6 +22,7 @@
 //	XLR99-RM-3 (XLR99A)
 //	X-15A-2
 //	Recontoured nozzle plus 22.5:1 radiative extension. No other changes.
+//	Speculative designation, USAF never assigned this a real one?
 //
 //	Dry Mass: 432 kg	Guessing about 19 kg for nozzle extension (roughly the same as RL10A-4 extension)
 //	Thrust (SL): ??? kN
@@ -38,6 +39,7 @@
 //	XLR99-RM-5
 //	X-15A-3 Delta
 //	Heavily modified XLR99 for "hypersonic cruise" Mach 8 X-15.
+//	Speculative designation, USAF never assigned this a real one?
 //
 //	Dry Mass: 432 kg	Guessing about 19 kg for nozzle extension (roughly the same as RL10A-4 extension)
 //	Thrust (SL): ??? kN
@@ -99,11 +101,11 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		configuration = XLR99-RM-2
+		configuration = XLR99-RM-1
 		origMass = 0.413
 		CONFIG
 		{
-			name = XLR99-RM-2
+			name = XLR99-RM-1
 			specLevel = operational
 			minThrust = 102.9
 			maxThrust = 257.3
@@ -160,7 +162,6 @@
 			//X-15 could actually usually restart after an ignition failure. Since this is not a feature in TF, halve ignition failures.
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				name = XLR99-RM-2
 				ratedBurnTime = 3600		// "required overhaul after 1 hour of burn time".
 				ratedContinuousBurnTime = 180 // 180s rated burntime at full thrust
 				safeOverburn = true
@@ -183,7 +184,7 @@
 		}
 		CONFIG
 		{
-			name = XLR99-RM-2A
+			name = XLR99-RM-3
 			specLevel = prototype //engine was tested.
 			minThrust = 112.8
 			maxThrust = 281.9
@@ -243,7 +244,6 @@
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				name = XLR99-RM-2
 				ratedBurnTime = 3600		// "required overhaul after 1 hour of burn time".
 				ratedContinuousBurnTime = 180 // 180s rated burntime at full thrust
 				safeOverburn = true
@@ -262,12 +262,12 @@
 				cycleReliabilityStart = 0.971557
 				cycleReliabilityEnd = 0.994311
 				reliabilityDataRateMultiplier = 20
-				techTransfer = XLR99-RM-2:50
+				techTransfer = XLR99-RM-1:50
 			}
 		}
 		CONFIG
 		{
-			name = XLR99-RM-3
+			name = XLR99-RM-5
 			specLevel = concept //no engineering work was completed before the program was cancelled
 			minThrust = 35.6
 			maxThrust = 369.2
@@ -327,7 +327,6 @@
 
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
-				name = XLR99-RM-3
 				ratedBurnTime = 3600		// "required overhaul after 1 hour of burn time".
 				ratedContinuousBurnTime = 180 // 180s rated burntime at full thrust
 				safeOverburn = true
@@ -346,7 +345,7 @@
 				cycleReliabilityStart = 0.971557
 				cycleReliabilityEnd = 0.994311
 				reliabilityDataRateMultiplier = 20
-				techTransfer = XLR99-RM-2A,XLR99-RM-2:50
+				techTransfer = XLR99-RM-3,XLR99-RM-1:50
 			}
 		}
 	}


### PR DESCRIPTION
This is a USAF project, variant numbers should be odd. Upgrades never got far enough along to see new designations, so just arbitrarily assign next number in series.