### PR TITLE
Fix NK-19 and NK-21 mixup

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/NK9V_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/NK9V_Config.cfg
@@ -191,7 +191,7 @@
 		CONFIG
 		{
 			name = NK-21
-			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
+			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
 			specLevel = operational
 			maxThrust = 402.1
 			minThrust = 241 // assume 60% throttle.
@@ -254,7 +254,7 @@
 		CONFIG
 		{
 			name = NK-19
-			description = NK-9V rerated for N1 Block G use. Gimbal, throttle.
+			description = NK-9V rerated for N1 Block V use. No gimbal, differential throttle.
 			specLevel = operational
 			maxThrust = 451.1
 			minThrust = 270.7


### PR DESCRIPTION
For some reason the descriptions were mixed up despite the stats and sources being properly attributed