### PR TITLE
Update "Days Elapsed" to something a bit more clear

### DIFF
--- a/Source/ModuleROSolarPanel.cs
+++ b/Source/ModuleROSolarPanel.cs
@@ -15,7 +15,7 @@ namespace RealismOverhaul
             UI_ChooseOption(suppressEditorShipModified = true, options = new[] { "Choose One" })]
         public string selectedBody = string.Empty;
 
-        [KSPField(guiActiveEditor = true, guiName = "Days Elapsed", groupName = groupName),
+        [KSPField(guiActiveEditor = true, guiName = "Days Elapsed (Simulated)", groupName = groupName),
             UI_FloatRange(maxValue = 7300, minValue = 1, stepIncrement = 1, suppressEditorShipModified = true)]
         public float daysElapsed = 1f;
 


### PR DESCRIPTION
I've seen various [confusion](https://discord.com/channels/319857228905447436/845457276641738782/1436154306557640936) about the "Days Elapsed" slider, as people seem to think that it actually has an effect on how the solar panel behaves in flight.

There might be a better way to word this, not sure.