### PR TITLE
Make dedicated wing tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -511,6 +511,34 @@ TANK_DEFINITION
 	}
 }
 
+TANK_DEFINITION
+{
+	name = Tank-Wet-Wing	//basically the same as aluminum fuselage, but with lower utilization since it's obviously difficult to utilize every internal space in a wing
+	title = Wet Wing
+	description = By sealing the stringers and spars, the wing structure itself can be directly used as a fuel tank. This can only be used with non-cryogenic and non-corrosive fluids, and cannot be highly pressurized.
+	highlyPressurized = False
+	basemass = 0.00003955 * volume
+	baseCost = 0.0022 * volume
+	addResourcesWing = true
+	addLead = true
+	maxUtilization = 75
+	defaultMass = 0.00004
+}
+
+TANK_DEFINITION
+{
+	name = Tank-Wet-Wing2	//Composite structure starts to be used in the 2000s. There should probably be more levels than this but I don't really care. Basically aluminum stringer tank
+	title = Composite Wet Wing
+	description = Use of composites as skin and structural members in a wing reduces weight, and frees up more internal volume for fuel.
+	highlyPressurized = False
+	basemass = 0.000027 * volume
+	baseCost = 0.0025 * volume
+	addResourcesWing = true
+	addLead = true
+	maxUtilization = 80
+	defaultMass = 0.000027
+}
+
 +TANK_DEFINITION[SM-I]:FIRST
 {
 	@name = Battery-I
@@ -837,6 +865,19 @@ PARTUPGRADE
 	basicInfo = You can now use Steel & Aluminum-Lithium Alloy balloon tanks
 	manufacturer = Generic
 	description = You can now use Steel & Aluminum-Lithium Alloy balloon tanks. These modern balloon tanks were first used by Centaur III. These are 5% lighter than refined balloon tanks while costing 7% more to tool and 25% more once tooled.
+}
+
+PARTUPGRADE
+{
+	name = RFTech-Tank-Wet-Wing2
+	partIcon = RO-RFTank-Separate
+	techRequired = materialsScienceInternational
+	entryCost = 0
+	cost = 0
+	title = Wet Wing Upgrade
+	basicInfo = You can now use composite wet wings
+	manufacturer = Generic
+	description = You can now use composite wet wings. Large-scale use of composite structures was first pioneered in the Boeing 787, 777X, and Airbus A350. These are 35% lighter than wet wing tanks while costing 10% more.
 }
 
 // These patches mangle stock RF tank types because stock RF tank types just have stuff manually added
@@ -1206,6 +1247,41 @@ PARTUPGRADE
 @TANK_DEFINITION:HAS[#addResourcesSM[true]]:FOR[zzzTagCleanup]
 {
 	-addResourcesSM = DEL
+}
+
+// Add wet wing resources
+// Basically just an unpressurized tank, but no cryogenic or particularly corrosive resources
+@TANK_DEFINITION:HAS[#addResourcesWing[true]]:FIRST
+{
+	%TANK[Aerozine50] {}	//hydrazines are non-corrosive (and have even been used as corrosion inhibitors) and stable at room temperature. Pure hydrazine is a little too touchy, but most derivatives are much more stable
+	%TANK[Aniline] {}	//kinda toxic, but otherwise a normal and stable hydrocarbon
+	%TANK[ANFA22] {}	//see above
+	%TANK[ANFA37] {}	//see above
+	%TANK[ASCENT] {}	//It's supposed to be safer than hydrazine
+	%TANK[AvGas] {}
+	%TANK[Ethanol75] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Ethanol90] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Ethanol] { %temperature = 361.8 }	//from NIST webbook
+	%TANK[Furfuryl] {}	//kinda toxic, but otherwise a normal and stable alcohol
+	%TANK[Hydyne] {}	//hydrazines are non-corrosive (and have even been used as corrosion inhibitors) and stable at room temperature. Pure hydrazine is a little too touchy, but most derivatives are much more stable
+	%TANK[Kerosene] {}
+	%TANK[Methanol] {}
+	%TANK[MMH] {}	//hydrazines are non-corrosive (and have even been used as corrosion inhibitors) and stable at room temperature. Pure hydrazine is a little too touchy, but most derivatives are much more stable
+	%TANK[MHF3] {}	//hydrazines are non-corrosive (and have even been used as corrosion inhibitors) and stable at room temperature. Pure hydrazine is a little too touchy, but most derivatives are much more stable
+	%TANK[RG-1] {}
+	%TANK[RP-1] {}
+	%TANK[Syntin] {}
+	%TANK[Tonka250] {}	//Lots of fun hydrocarbons, and quite toxic, but mostly non-corrosive and stable
+	%TANK[Tonka500] {}	//Lots of fun hydrocarbons, and quite toxic, but mostly non-corrosive and stable
+	%TANK[Turpentine] {}
+	%TANK[UDMH] {}	//hydrazines are non-corrosive (and have even been used as corrosion inhibitors) and stable at room temperature. Pure hydrazine is a little too touchy, but most derivatives are much more stable
+	%TANK[UH25] {}	//hydrazines are non-corrosive (and have even been used as corrosion inhibitors) and stable at room temperature. Pure hydrazine is a little too touchy, but most derivatives are much more stable
+	%TANK[Visol] {}	//Lots of fun hydrocarbons, and quite toxic, but mostly non-corrosive and stable
+	%TANK[Water] { %temperature = 388.2 }	//from NIST webbook
+}
+@TANK_DEFINITION:HAS[#addResourcesWing[true]]:FOR[zzzTagCleanup]
+{
+	-addResourcesWing = DEL
 }
 
 // Add lead and Beryllium

--- a/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/B9_ProceduralParts/B9_Wings.cfg
@@ -11,9 +11,13 @@
 		basemass = -1
 		utilizationTweakable = true
 		utilization = 0.5
-		type = Structural
-		typeAvailable = Fuselage
-		typeAvailable = Structural
+		type = Tank-Wet-Wing
+		typeAvailable = Tank-Wet-Wing
+		typeAvailable = Tank-Wet-Wing2
+		typeAvailable = SM-I
+		typeAvailable = SM-II
+		typeAvailable = SM-III
+		typeAvailable = SM-IV
 	}
 }
 @PART[B9_Aero_Wing_Procedural_TypeB]:FOR[RealismOverhaul]


### PR DESCRIPTION
Make dedicated wing tanks that can only hold non-corrosive, room temperature stable fluids. Basic wet wings have the same properties as aluminum fuselage, composite wet wings have the same properties as aluminum stringers. Wings can also use service module tanks if you really wanna put other stuff in them, since service modules are assumed to be a bunch of spheroid tanks inside an inert structure, it should simulate stuffing tanks into a wing well enough.

resolves https://github.com/KSP-RO/RealismOverhaul/issues/3112
resolves https://github.com/KSP-RO/RealismOverhaul/issues/2783