### PR TITLE
Fix small cargo bay scaling

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Spaceplanes.cfg
@@ -117,7 +117,6 @@
 }
 @PART[mk2CargoBayS]:FOR[RealismOverhaul]
 {
-	%rescaleFactor = 1.0
 	@mass /= 2.0
 }
 


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RealismOverhaul/issues/3115

The rescalefactor for the small cargo bay is already set in the config for `mk2CargoBayL|mk2CargoBayS`. It is then erroneously set to 1.