### PR TITLE
Add persistent rotation to conflicting on ckan

### DIFF
--- a/RealismOverhaul.netkan
+++ b/RealismOverhaul.netkan
@@ -117,6 +117,7 @@ conflicts:
   - name: DeadlyReentry
   - name: EngineLightRelit
   - name: RocketSoundEnhancement
+  - name: PersistentRotationUpgraded
 resources:
   homepage: >-
     http://forum.kerbalspaceprogram.com/index.php?/topic/155700-122-realism-overhaul-v1150-05262017/


### PR DESCRIPTION
RO provides persistent rotation, so installing the mod along with RO is bound to cause some problems