### PR TITLE
Fix unrealistically long LR87 spool up time

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
@@ -160,7 +160,7 @@
 			heatProduction = 175
 			ignitions = 2
 			massMult = 1.25149
-			throttleResponseRate = 0.5 //Presumably similar to base LR87s, increased slightly due to being an upper stage engine
+			throttleResponseRate = 0.5 //~2.47s, presumably similar to J-2s which it was competing with
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -241,7 +241,7 @@
 			heatProduction = 175
 			massMult = 1.25149
 			ignitions = 3
-			throttleResponseRate = 0.5 //Presumably similar to base LR87s, increased due to being an upper stage engine 
+			throttleResponseRate = 0.5 //~2.47s, presumably similar to J-2s which it was competing with 
 			PROPELLANT
 			{
 				name = LqdHydrogen

--- a/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87LH2_Config.cfg
@@ -119,6 +119,7 @@
 			maxThrust = 667.0
 			heatProduction = 175
 			ignitions = 1
+			throttleResponseRate = 0.68 //Presumably similar to base LR87s, increased slightly because need for igniter
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -159,6 +160,7 @@
 			heatProduction = 175
 			ignitions = 2
 			massMult = 1.25149
+			throttleResponseRate = 0.5 //Presumably similar to base LR87s, increased slightly due to being an upper stage engine
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -199,6 +201,7 @@
 			heatProduction = 175
 			massMult = 1.11919
 			ignitions = 2
+			throttleResponseRate = 0.7 //Presumably similar to base LR87s, increased slightly due to need for igniter
 			PROPELLANT
 			{
 				name = LqdHydrogen
@@ -238,6 +241,7 @@
 			heatProduction = 175
 			massMult = 1.25149
 			ignitions = 3
+			throttleResponseRate = 0.5 //Presumably similar to base LR87s, increased due to being an upper stage engine 
 			PROPELLANT
 			{
 				name = LqdHydrogen

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
@@ -254,6 +254,7 @@
 			varyFlow = 0.0167	//1.67%, guess, based on 3% thrust variance and 1.8% Isp variance. [5]
 			residualsThresholdBase = 0.00989	//0.989% [5]
 			massMult = 1.11
+			throttleResponseRate = 0.7 //Requires an igniter so presumably takes slighly longer. In testing the first config doesn't seem to work properly 
 			PROPELLANT
 			{
 				name = RP-1
@@ -323,6 +324,7 @@
 			varyFlow = 0.0167	//1.67%, guess, based on 3% thrust variance and 1.8% Isp variance. [5]
 			residualsThresholdBase = 0.00989	//0.989% [5]
 			massMult = 1.00
+			throttleResponseRate = 0.7 //Requires an igniter so presumably takes slighly longer.
 			PROPELLANT
 			{
 				name = RP-1
@@ -391,6 +393,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 1.3 //~0.99s, rough guess based on available footage of tests and audio from launches
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -476,6 +479,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 0.7 // ~1.78s, requires an igniter so presumably takes slighly longer.
 			PROPELLANT
 			{
 				name = RP-1
@@ -556,6 +560,7 @@
 			varyMixture = 0.00038	//0.038% [5]
 			varyFlow = 0.010	//1.0%
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 1.3 //~0.99s, rough guess based on available footage of tests and audio from launches
 			PROPELLANT
 			{
 				name = CooledAerozine50
@@ -639,6 +644,7 @@
 			varyMixture = 0.00038	//0.038% [5]
 			varyFlow = 0.010	//1.0%
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 0.7 //Requires an igniter so presumably takes slighly longer.
 			PROPELLANT
 			{
 				name = CooledRP-1
@@ -719,6 +725,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 1.3 //Rough guess based on available footage of tests and audio from launches
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -803,6 +810,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 0.75 //Requires an igniter so presumably takes slighly longer, spoolup reduced slightly to simulate modifications for faster air start
 			PROPELLANT
 			{
 				name = RP-1
@@ -884,6 +892,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 1.3 //Assumed to be the same as prior versions
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -990,6 +999,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 0.78 //Requires an igniter so presumably takes slighly longer, spoolup reduced slightly to simulate modifications for faster air start
 			PROPELLANT
 			{
 				name = RP-1
@@ -1086,6 +1096,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 1.3 //Assumed to be the same as prior versions
 			PROPELLANT
 			{
 				name = Aerozine50
@@ -1173,6 +1184,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
+			throttleResponseRate = 0.8 //Requires an igniter so presumably takes slighly longer, spoolup reduced slightly to simulate modifications for faster air start
 			PROPELLANT
 			{
 				name = RP-1

--- a/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/LR87_Config.cfg
@@ -1184,7 +1184,7 @@
 			varyMixture = 0.00115	//0.115% [5]
 			varyFlow = 0.030	//3.0%, guess, based on 3% thrust variance and 1.0% Isp variance. [5]
 			residualsThresholdBase = 0.00444	//0.444% [5]
-			throttleResponseRate = 0.8 //Requires an igniter so presumably takes slighly longer, spoolup reduced slightly to simulate modifications for faster air start
+			throttleResponseRate = 0.883 //Requires an igniter so presumably takes slighly longer, spoolup reduced slightly to simulate modifications for faster air start
 			PROPELLANT
 			{
 				name = RP-1


### PR DESCRIPTION
Sets a throttle response rate so that the LR87s don't take unrealistically long to spool up. Based on available footage and audio spool up took around a second for the hypergolic variants, in game they take around ~3 seconds right now. Kero and LH2 variants are my best guess when accounting for the need for a separate ignition system.