### PR TITLE
Allow SoundingPayload in all HP tanks

### DIFF
--- a/GameData/RealismOverhaul/RO_RealFuels.cfg
+++ b/GameData/RealismOverhaul/RO_RealFuels.cfg
@@ -130,6 +130,7 @@ TANK_DEFINITION
 	addResources = true
 	addResourcesHP = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 90
 	defaultMass = 0.00009
 }
@@ -159,6 +160,7 @@ TANK_DEFINITION
 	addResources = true
 	addResourcesHP = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 96
 	defaultMass = 0.00005
 }
@@ -188,6 +190,7 @@ TANK_DEFINITION
 	addResources = true
 	addResourcesHP = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 96
 	defaultMass = 0.000042
 }
@@ -217,6 +220,7 @@ TANK_DEFINITION
 	addResources = true
 	addResourcesHP = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 96
 	defaultMass = 0.00008
 }
@@ -276,6 +280,7 @@ TANK_DEFINITION
 	addResources = true
 	addResourcesHP = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 94
 	defaultMass = 0.000047
 }
@@ -305,6 +310,7 @@ TANK_DEFINITION
 	addResources = true
 	addResourcesHP = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 96
 	defaultMass = 0.000039
 }
@@ -335,6 +341,7 @@ TANK_DEFINITION
 	//balloonTemps = true
 	addResources = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 96
 	defaultMass = 0.000028
 }
@@ -363,6 +370,7 @@ TANK_DEFINITION
 	baseCost = 0.01 * volume
 	addResources = true
 	addLead = true
+	addSoundingPayload = true
 	maxUtilization = 96
 	defaultMass = 0.00002
 }


### PR DESCRIPTION
Currently only the 4 earliest HP tank types (first 3 Conventional, first Isogrid) are configured to allow SoundingPayload. https://github.com/KSP-RO/RP-1/pull/2692 (Operational and Advanced Earth Observation) has a contract that uses SoundingPayload, intended to be taken with 1972 tech available. By that point most players will have better conventional and isogrid tanks.