### PR TITLE
Remove multiple ignition capability from S1.5400

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD58_Config.cfg
@@ -17,7 +17,7 @@
 //	Prop Ratio: 2.48?
 //	Throttle: N/A
 //	Nozzle Ratio: 100?
-//	Ignitions: 5
+//	Ignitions: 1
 //	=================================================================================
 //	11D33
 //	Molnyia-M (Blok ML, Blok MVL)
@@ -32,7 +32,7 @@
 //	Prop Ratio: 2.48?
 //	Throttle: N/A
 //	Nozzle Ratio: 100?
-//	Ignitions: 5
+//	Ignitions: 1
 //	=================================================================================
 //	11D33M
 //	Molnyia-M (Block 2BLM, Block 2BL-SM)
@@ -47,7 +47,7 @@
 //	Prop Ratio: 2.48?
 //	Throttle: N/A
 //	Nozzle Ratio: 100?
-//	Ignitions: 5
+//	Ignitions: 1
 //	=================================================================================
 //	RD-58
 //	N-1, Proton (Blok D)
@@ -126,6 +126,8 @@
 //	=================================================================================
 
 //	Sources:
+//		http://space-propulsion.info/resources/articles/11D33.pdf
+//		http://space-propulsion.info/resources/books/S15400.zip
 //		http://www.energia.ru/english/energia/launchers/engines.html
 //		http://www.k204.ru/books/vrd/wiki2/PDF/Energia.pdf
 //		http://www.b14643.de/Spacerockets/Specials/Russian_Rocket_engines/engines.htm
@@ -189,7 +191,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 5
+			ignitions = 1
 
 			IGNITOR_RESOURCE
 			{
@@ -248,7 +250,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 5
+			ignitions = 1
 
 			IGNITOR_RESOURCE
 			{
@@ -309,7 +311,7 @@
 
 			ullage = True
 			pressureFed = False
-			ignitions = 5
+			ignitions = 1
 
 			IGNITOR_RESOURCE
 			{


### PR DESCRIPTION
It had a single set of pyrotechnic ignition charges (main combustion chamber, gas generator, pressurization/roll control system, turbopump starter).

In the 90's, a drop-in replacement chemical igniter was developed after production of the original solid-fueled charges had stopped; those still only provided the single ignition, though.