### PR TITLE
Rebalance TF du gains

### DIFF
--- a/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
+++ b/GameData/RealismOverhaul/TestFlight_Generic_Engines.cfg
@@ -95,7 +95,7 @@
 		&techTransfer =
 
 		// Default chance for triggering an additional failure on the same engine when an ignition failure occurs
-		&additionalIgnitionFailureChance = 0.2
+		&additionalIgnitionFailureChance = 0
 
 		//Create placeholder flat curve for restartWindowPenalty
 		&restartWindowPenalty
@@ -416,7 +416,7 @@
 	// then we normalize it based on the burn time.
 	@TESTFLIGHT:HAS[~explicitDataRate[?rue]]
 	{
-		@reliabilityDataRateMultiplier *= 640 // normalized to rate=4 at 160s burntime
+		@reliabilityDataRateMultiplier *= 390 // This amount of data for the full rated burntime. Note that TF will also award 250 for a successful ignition.
 		@reliabilityDataRateMultiplier /= #$ratedContinuousBurnTime$
 	}
 }
@@ -578,7 +578,7 @@
 		{
 			maxData = 10000
 			techTransferMax = 2000
-			perFlightMax = 1000
+			perFlightMax = 1250
 		}
 	}
 	@MODULE[FlightDataRecorder_Engine]
@@ -602,7 +602,7 @@
 				canBeRepairedByRemote = True
 			}
 			awardDuInPreLaunch = False
-			duFail = 1100
+			duFail = 750
 			weight = 32
 			failureType = software
 			failureTitle = Engine Shutdown
@@ -638,7 +638,7 @@
 			}
 			
 			restoreIgnitionCharge = False
-			duFail = 1050
+			duFail = 900
 			oneShot = True
 			awardDuInPreLaunch = True
 			failureType = mechanical
@@ -660,7 +660,7 @@
 				canBeRepairedByRemote = False
 				repairChance = 75
 			}
-			duFail = 700
+			duFail = 450
 			weight = 8
 			failureType = mechanical
 			failureTitle = Loss of Thrust
@@ -681,7 +681,7 @@
 				canBeRepairedByRemote = False
 				repairChance = 75
 			}
-			duFail = 800
+			duFail = 550
 			weight = 16
 			failureType = mechanical
 			failureTitle = Performance Loss
@@ -697,7 +697,7 @@
 		{
 			awardDuInPreLaunch = False
 			failureTitle = Explosion!
-			duFail = 1300
+			duFail = 500
 			weight = 2
 			failureType = mechanical
 			severity = major


### PR DESCRIPTION
* Up per-flight cap from 1000 to 1250. Nominally it takes 2 engines on a flight to reach this cap.
* Since first ignition now awards 250, make all other modes give roughly that much less.
* Nerf ignition failures a bit too... because why not.
* Explosion rewarding the most du appears kinda silly. There isn't much to analyze after the entire engine got blown to bits. Also those failures mostly only happen on severe overburns.
* The 20% chance of getting an additional same-engine failure on ignition just has to go.

CC: @ec429 since TL is feeding on TF configs