### PR TITLE
Limit AdjustableCoMShifter offsets to within part bounds

### DIFF
--- a/Source/AdjustableCoMShifter.cs
+++ b/Source/AdjustableCoMShifter.cs
@@ -16,16 +16,22 @@ namespace RealismOverhaul
         [KSPField]
         public Vector3 DescentModeCoM = Vector3.zero;   // If configured, disable customization
 
-        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "CoM X-offset", guiFormat = "F0", guiUnits = "cm", groupName = groupName, groupDisplayName = groupDisplayName)]
-        [UI_FloatEdit(scene = UI_Scene.Editor, minValue = -100f, maxValue = 100f, incrementLarge = 10f, incrementSmall = 1f, incrementSlide = 0.01f, sigFigs = 2)]
+        /// <summary>
+        /// Maximum allowed offset as a percentage of the part's dimension.
+        /// </summary>
+        [KSPField]
+        public float maxDimensionOffsetPercent = 0.75f;
+
+        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "CoM X-offset", guiFormat = "F2", guiUnits = "m", groupName = groupName, groupDisplayName = groupDisplayName)]
+        [UI_FloatEdit(scene = UI_Scene.Editor, minValue = -1f, maxValue = 1f, incrementLarge = 0.1f, incrementSmall = 0.01f, incrementSlide = 0.001f, sigFigs = 3)]
         public float offsetX = 0;
 
-        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "CoM Y-offset", guiFormat = "F0", guiUnits = "cm", groupName = groupName)]
-        [UI_FloatEdit(scene = UI_Scene.Editor, minValue = -100f, maxValue = 100f, incrementLarge = 10f, incrementSmall = 1f, incrementSlide = 0.01f, sigFigs = 2)]
+        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "CoM Y-offset", guiFormat = "F2", guiUnits = "m", groupName = groupName)]
+        [UI_FloatEdit(scene = UI_Scene.Editor, minValue = -1f, maxValue = 1f, incrementLarge = 0.1f, incrementSmall = 0.01f, incrementSlide = 0.001f, sigFigs = 3)]
         public float offsetY = 0;
 
-        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "CoM Z-offset", guiFormat = "F0", guiUnits = "cm", groupName = groupName)]
-        [UI_FloatEdit(scene = UI_Scene.Editor, minValue = -100f, maxValue = 100f, incrementLarge = 10f, incrementSmall = 1f, incrementSlide = 0.01f, sigFigs = 2)]
+        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "CoM Z-offset", guiFormat = "F2", guiUnits = "m", groupName = groupName)]
+        [UI_FloatEdit(scene = UI_Scene.Editor, minValue = -1f, maxValue = 1f, incrementLarge = 0.1f, incrementSmall = 0.01f, incrementSlide = 0.001f, sigFigs = 3)]
         public float offsetZ = 0;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiFormat = "P0", guiName = "CoM Offset Limit", groupName = groupName, groupDisplayName = groupDisplayName)]
@@ -62,9 +68,14 @@ namespace RealismOverhaul
             DescentModeChanged(IsDescentMode);
         }
 
-        public void Update()
+        internal void Update()
         {
             Fields[nameof(comString)].guiActive = PhysicsGlobals.ThermalDataDisplay;
+        }
+
+        internal void OnDestroy()
+        {
+            GameEvents.onEditorShipModified.Remove(OnEditorShipModified);
         }
 
         protected void BindUI()
@@ -79,6 +90,9 @@ namespace RealismOverhaul
                 Fields[nameof(offsetX)].uiControlEditor.onFieldChanged += CoMOffsetChanged;
                 Fields[nameof(offsetY)].uiControlEditor.onFieldChanged += CoMOffsetChanged;
                 Fields[nameof(offsetZ)].uiControlEditor.onFieldChanged += CoMOffsetChanged;
+
+                UpdateSliderLimits();
+                GameEvents.onEditorShipModified.Add(OnEditorShipModified);
             }
 
             Actions[nameof(Toggle)].active = ConfiguredForDescentMode;
@@ -90,6 +104,32 @@ namespace RealismOverhaul
             Fields[nameof(offsetX)].guiActiveEditor = !ConfiguredForDescentMode;
             Fields[nameof(offsetY)].guiActiveEditor = !ConfiguredForDescentMode;
             Fields[nameof(offsetZ)].guiActiveEditor = !ConfiguredForDescentMode;
+        }
+
+        private void OnEditorShipModified(ShipConstruct sc)
+        {
+            UpdateSliderLimits();
+        }
+
+        protected void UpdateSliderLimits()
+        {
+            Vector3 extents = PartGeometryUtil.MergeBounds(part.GetRendererBounds(), part.partTransform).extents;
+            var xEdit = Fields[nameof(offsetX)].uiControlEditor as UI_FloatEdit;
+            var yEdit = Fields[nameof(offsetY)].uiControlEditor as UI_FloatEdit;
+            var zEdit = Fields[nameof(offsetZ)].uiControlEditor as UI_FloatEdit;
+            if (xEdit != null && yEdit != null && zEdit != null)
+            {
+                xEdit.minValue = -extents.x * maxDimensionOffsetPercent;
+                xEdit.maxValue = extents.x * maxDimensionOffsetPercent;
+                yEdit.minValue = -extents.y * maxDimensionOffsetPercent;
+                yEdit.maxValue = extents.y * maxDimensionOffsetPercent;
+                zEdit.minValue = -extents.z * maxDimensionOffsetPercent;
+                zEdit.maxValue = extents.z * maxDimensionOffsetPercent;
+
+                Mathf.Clamp(offsetX, xEdit.minValue, xEdit.maxValue);
+                Mathf.Clamp(offsetY, yEdit.minValue, yEdit.maxValue);
+                Mathf.Clamp(offsetZ, zEdit.minValue, zEdit.maxValue);
+            }
         }
 
         protected void OffsetPercentChanged(BaseField bf, object o) => UpdateCoM();
@@ -107,7 +147,7 @@ namespace RealismOverhaul
             if (ConfiguredForDescentMode)
                 part.CoMOffset += IsDescentMode ? DescentModeCoM * offsetPercent : Vector3.zero;
             else
-                part.CoMOffset += new Vector3(offsetX / 100, offsetY / 100, offsetZ / 100);
+                part.CoMOffset += new Vector3(offsetX, offsetY, offsetZ);
 
             comString = $"({part.CoMOffset.x:F2},{part.CoMOffset.y:F2},{part.CoMOffset.z:F2})";
         }

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("KSP-RO Group")]
 [assembly: AssemblyProduct("RealismOverhaul")]
-[assembly: AssemblyCopyright("Copyright ©  2014-2023")]
+[assembly: AssemblyCopyright("Copyright ©  2014-2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -38,8 +38,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("@MAJOR@.@MINOR@.@PATCH@.@BUILD@")]
 [assembly: KSPAssembly("RealismOverhaul", @MAJOR@, @MINOR@)]
 #else
-[assembly: AssemblyFileVersion("14.99.0.0")]
-[assembly: KSPAssembly("RealismOverhaul", 14, 99)]
+[assembly: AssemblyFileVersion("17.99.0.0")]
+[assembly: KSPAssembly("RealismOverhaul", 17, 99)]
 #endif
 
 [assembly: KSPAssemblyDependency("ROUtils", 1, 0, 1)]

--- a/Source/RealismOverhaul.csproj
+++ b/Source/RealismOverhaul.csproj
@@ -66,8 +66,9 @@
     <Compile Include="ModuleEngineText.cs" />
     <Compile Include="EjectionSeat\ModuleROEjectionSeat.cs" />
     <Compile Include="EjectionSeat\SeatConfig.cs" />
-    <Compile Include="UpgradePipeline.cs" />
     <Compile Include="StartupPopup.cs" />
+    <Compile Include="UpgradeScripts\v17_25_AdjustableCoMShifterUpgrade.cs" />
+    <Compile Include="UpgradeScripts\MECEngineConfigUpgrade.cs" />
     <Compile Include="VesselModuleRotationRO.cs" />
     <Compile Include="ModuleROSolarPanel.cs" />
     <Compile Include="ModuleEVADrag.cs" />

--- a/Source/UpgradeScripts/MECEngineConfigUpgrade.cs
+++ b/Source/UpgradeScripts/MECEngineConfigUpgrade.cs
@@ -1,9 +1,9 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using SaveUpgradePipeline;
 using UnityEngine;
 
-namespace RealismOverhaul
+namespace RealismOverhaul.UpgradeScripts
 {
     [UpgradeModule(LoadContext.SFS | LoadContext.Craft, sfsNodeUrl = "GAME/FLIGHTSTATE/VESSEL/PART", craftNodeUrl = "PART")]
     public class MECEngineConfigUpgrade : UpgradeScript

--- a/Source/UpgradeScripts/MECEngineConfigUpgrade.cs
+++ b/Source/UpgradeScripts/MECEngineConfigUpgrade.cs
@@ -177,13 +177,4 @@ namespace RealismOverhaul.UpgradeScripts
 
     [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/SPHPlans/KCTVessel/ShipNode/PART")]
     public class MECEngineConfigUpgrade_KCT6 : MECEngineConfigUpgrade_KCTBase { }
-
-    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/LaunchComplex/BuildList/KCTVessel/ShipNode/PART")]
-    public class MECEngineConfigUpgrade_KCT7 : MECEngineConfigUpgrade_KCTBase { }
-
-    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/LaunchComplex/Warehouse/KCTVessel/ShipNode/PART")]
-    public class MECEngineConfigUpgrade_KCT8 : MECEngineConfigUpgrade_KCTBase { }
-
-    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/LaunchComplex/Plans/KCTVessel/ShipNode/PART")]
-    public class MECEngineConfigUpgrade_KCT9 : MECEngineConfigUpgrade_KCTBase { }
 }

--- a/Source/UpgradeScripts/v17_25_AdjustableCoMShifterUpgrade.cs
+++ b/Source/UpgradeScripts/v17_25_AdjustableCoMShifterUpgrade.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using SaveUpgradePipeline;
+using UnityEngine;
+
+namespace RealismOverhaul.UpgradeScripts
+{
+    [UpgradeModule(LoadContext.SFS | LoadContext.Craft, sfsNodeUrl = "GAME/FLIGHTSTATE/VESSEL/PART", craftNodeUrl = "PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade : UpgradeScript
+    {
+        public override string Name => "RO AdjustableCoMShifter Unit Upgrade";
+        public override string Description => "Converts AdjustableCoMShifter offset fields from centimeters to meters";
+        public override Version EarliestCompatibleVersion => new Version(0, 0, 0);
+        public override Version TargetVersion => new Version(17, 25, 0);
+
+        public override TestResult OnTest(ConfigNode node, LoadContext loadContext, ref string nodeName)
+        {
+            nodeName = NodeUtil.GetPartNodeNameValue(node, loadContext);
+            if (node.GetNode("MODULE", "name", "AdjustableCoMShifter") is ConfigNode comNode && HasNonZeroOffset(comNode))
+                return TestResult.Upgradeable;
+            return TestResult.Pass;
+        }
+
+        public override void OnUpgrade(ConfigNode node, LoadContext loadContext, ConfigNode parentNode)
+        {
+            ConfigNode comNode = node.GetNode("MODULE", "name", "AdjustableCoMShifter");
+            if (comNode == null)
+                return;
+
+            ConvertOffset(comNode, "offsetX");
+            ConvertOffset(comNode, "offsetY");
+            ConvertOffset(comNode, "offsetZ");
+
+            Debug.Log($"[RealismOverhaul] UpgradePipeline context {loadContext} converted AdjustableCoMShifter offsets from cm to m on part {NodeUtil.GetPartNodeNameValue(node, loadContext)}.");
+        }
+
+        private static bool HasNonZeroOffset(ConfigNode comNode) =>
+            HasNonZeroValue(comNode, "offsetX") || HasNonZeroValue(comNode, "offsetY") || HasNonZeroValue(comNode, "offsetZ");
+
+        private static bool HasNonZeroValue(ConfigNode node, string key) =>
+            node.HasValue(key) && float.TryParse(node.GetValue(key), out float val) && val != 0f;
+
+        private static void ConvertOffset(ConfigNode node, string key)
+        {
+            if (node.HasValue(key) && float.TryParse(node.GetValue(key), out float val))
+                node.SetValue(key, val / 100f);
+        }
+    }
+
+    public class v17_25_AdjustableCoMShifterUpgrade_KCTBase : v17_25_AdjustableCoMShifterUpgrade
+    {
+        public override string Name { get => $"{base.Name} KCT-{nodeUrlSFS}"; }
+        public override TestResult OnTest(ConfigNode node, LoadContext loadContext, ref string nodeName) =>
+            loadContext == LoadContext.Craft ? TestResult.Pass : base.OnTest(node, loadContext, ref nodeName);
+    }
+
+    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/VABList/KCTVessel/ShipNode/PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade_KCT1 : v17_25_AdjustableCoMShifterUpgrade_KCTBase { }
+
+    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/SPHList/KCTVessel/ShipNode/PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade_KCT2 : v17_25_AdjustableCoMShifterUpgrade_KCTBase { }
+
+    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/VABWarehouse/KCTVessel/ShipNode/PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade_KCT3 : v17_25_AdjustableCoMShifterUpgrade_KCTBase { }
+
+    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/SPHWarehouse/KCTVessel/ShipNode/PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade_KCT4 : v17_25_AdjustableCoMShifterUpgrade_KCTBase { }
+
+    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/VABPlans/KCTVessel/ShipNode/PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade_KCT5 : v17_25_AdjustableCoMShifterUpgrade_KCTBase { }
+
+    [UpgradeModule(LoadContext.SFS, sfsNodeUrl = "GAME/SCENARIO/KSC/SPHPlans/KCTVessel/ShipNode/PART")]
+    public class v17_25_AdjustableCoMShifterUpgrade_KCT6 : v17_25_AdjustableCoMShifterUpgrade_KCTBase { }
+}


### PR DESCRIPTION
Upgrade pipeline is still scuffed and I refuse to sink more hours into this. So if anyone has a vessel in SCM queue or storage then you need to launch it; revert to VAB; launch again.

Resolves https://github.com/KSP-RO/RP-1/issues/2628