### PR TITLE
Rescale and adjust masses for ladders

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Utility.cfg
@@ -138,6 +138,8 @@
 @PART[ladder1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%rescaleFactor = 1.25
+	@mass = 0.002
 	
 	//Aluminum
 	%skinTempTag = Aluminum
@@ -146,6 +148,7 @@
 @PART[telescopicLadder]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%rescaleFactor = 1.2
 	@mass = 0.020
 	
 	//Aluminum
@@ -155,6 +158,7 @@
 @PART[telescopicLadderBay]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
+	%rescaleFactor = 1.2
 	@mass = 0.035
 	
 	//Aluminum

--- a/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Structural.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/VSR/VNP/RO_VNP_Structural.cfg
@@ -79,33 +79,34 @@
 @PART[MedLadder]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @mass = 0.012
+    @mass = 0.006
 }
 @PART[LongLadder]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @mass = 0.018
+    @mass = 0.01
 }
 @PART[MedLadderUtility]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = MK II Mobility Enhancer
-    @mass = 0.012
+    @mass = 0.007
 }
 @PART[SMLadderUtility]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = MK I Mobility Enhancer
-    @mass = 0.005
+    @mass = 0.003
 }
 @PART[LGLadderUtility]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = MK III Mobility Enhancer
-    @mass = 0.018
+    @mass = 0.012
 }
 @PART[MedLadder|LongLadder|MedLadderUtility|SMLadderUtility|LGLadderUtility]:FOR[RealismOverhaul]
 {
+    %rescaleFactor = 2
     @manufacturer = #roMfrGeneric
     @description = #The $title$, known in some circles as a "ladder", is a state-of-the-art vertical mobility device, allowing your intrepid crew to scamper around the exterior of your ship like highly caffeinated rodents.
     //Aluminum


### PR DESCRIPTION
Made the sizes of stock and Ven's ladders roughly correlate to each other. Without rescale they looked very off compared to pods that we have scaled up by 1.6x. Not a slightest clue why Ven needs 2x scale but stock only 1.2-1.25.

Also adjusted the masses of them. Two tiny little steps shouldn't be 5kg. 10kg gets you an alu stepladder with 6+ steps than can take 150kg on Earth gravity. In RO it makes sense to balance ladders for Moon, Mars etc gravity.

I didn't dare touch the masses of those fancy telescopic stock ladders. Not the slightest of clue what constructing something like that would take.