### PR TITLE
Add Kerbal Reusability Expansion Configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/FalconLegs.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/FalconLegs.cfg
@@ -5,6 +5,8 @@
 @PART[KRE-FalconLeg-S]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.464
+
     @title = Falcon Landing Leg (Small)
     @manufacturer = SpaceX
     @description = Small Falcon 9 Landing Leg
@@ -19,6 +21,8 @@
 @PART[KRE-FalconLeg-M]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.464
+
     @title = Falcon 9 Landing Leg
     @manufacturer = SpaceX
     @description = Standard Falcon 9 Landing Leg
@@ -33,6 +37,8 @@
 @PART[KRE-FalconLeg-L]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.464
+
     @title = Falcon Landing Leg (Large)
     @manufacturer = SpaceX
     @description = Large Falcon 9 Landing Leg

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/FalconLegs.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/FalconLegs.cfg
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------
+// Falcon Legs
+// -----------------------------------------------------------
+
+@PART[KRE-FalconLeg-S]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = Falcon Landing Leg (Small)
+    @manufacturer = SpaceX
+    @description = Small Falcon 9 Landing Leg
+    @mass = 0.15
+    @maxTemp = 1500
+    @skinMaxTemp = 2000
+    @crashTolerance = 20
+    @breakingForce = 250
+    @breakingTorque = 250
+}
+
+@PART[KRE-FalconLeg-M]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = Falcon 9 Landing Leg
+    @manufacturer = SpaceX
+    @description = Standard Falcon 9 Landing Leg
+    @mass = 0.60 // Block 5 leg set weighs ~2.4 tons, so scaled to each leg 
+    @maxTemp = 1500
+    @skinMaxTemp = 2400
+    @crashTolerance = 40
+    @breakingForce = 500
+    @breakingTorque = 500
+}
+
+@PART[KRE-FalconLeg-L]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = Falcon Landing Leg (Large)
+    @manufacturer = SpaceX
+    @description = Large Falcon 9 Landing Leg
+    @mass = 1.20
+    @maxTemp = 1500
+    @skinMaxTemp = 2400
+    @crashTolerance = 50
+    @breakingForce = 800
+    @breakingTorque = 800
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/GridFins.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/GridFins.cfg
@@ -1,0 +1,182 @@
+@PART[Grid?Fin?S]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = true
+    @rescaleFactor = 0.4392
+    @mass = 0.011
+    @title = Grid Fin (Small)
+    @description = A small aluminium grid fin.
+
+    %skinTempTag = Aluminum
+    %internalTempTag = Aluminum
+    %paintEmissivityTag = 0.9
+}
+
+@PART[Grid?Fin?M]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = true
+    @rescaleFactor = 0.8784
+    @mass = 0.044
+    @title = Grid Fin (Medium)
+    @description = A medium aluminium grid fin.
+
+    %skinTempTag = Aluminum
+    %internalTempTag = Aluminum
+    %paintEmissivityTag = 0.9
+}
+
+@PART[Grid?Fin?L]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = true
+    @rescaleFactor = 1.3176
+    @mass = 0.100
+    @title = Grid Fin (Large)
+    @description = A large aluminium grid fin.
+
+    %skinTempTag = Aluminum
+    %internalTempTag = Aluminum
+    %paintEmissivityTag = 0.9
+}
+
+@PART[Grid?Fin?S?Titanium]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = true
+    @rescaleFactor = 0.4392
+    @mass = 0.013
+    @title = Titanium Grid Fin (Small)
+    @description = A small titanium grid fin.
+
+    %skinTempTag = Titanium
+    %internalTempTag = Titanium
+}
+
+@PART[Grid?Fin?M?Titanium]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = true
+    @rescaleFactor = 0.8784
+    @mass = 0.053
+    @title = Titanium Grid Fin (Medium)
+    @description = A medium titanium grid fin.
+
+    %skinTempTag = Titanium
+    %internalTempTag = Titanium
+}
+
+@PART[Grid?Fin?L?Titanium]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = true
+    @rescaleFactor = 1.3176
+    @mass = 0.120
+    @title = Titanium Grid Fin (Large)
+    @description = A large titanium grid fin.
+
+    %skinTempTag = Titanium
+    %internalTempTag = Titanium
+}
+
+@PART[Grid?Fin?S]:NEEDS[FerramAerospaceResearch]
+{
+    !MODULE[ModuleControlSurface] {}
+
+    MODULE
+    {
+        name = FARControllableSurface
+        b_2 = 0.156
+        MAC = 0.435
+        nonSideAttach = 0
+        TaperRatio = 1.0
+        MidChordSweep = 0
+        maxdeflect = 35
+        controlSurfacePivot = 1, 0, 0
+        ctrlSurfFrac = 0.82
+    }
+}
+
+@PART[Grid?Fin?M]:NEEDS[FerramAerospaceResearch]
+{
+    !MODULE[ModuleControlSurface] {}
+
+    MODULE
+    {
+        name = FARControllableSurface
+        b_2 = 0.312
+        MAC = 0.869
+        nonSideAttach = 0
+        TaperRatio = 1.0
+        MidChordSweep = 0
+        maxdeflect = 35
+        controlSurfacePivot = 1, 0, 0
+        ctrlSurfFrac = 0.82
+    }
+}
+
+@PART[Grid?Fin?L]:NEEDS[FerramAerospaceResearch]
+{
+    !MODULE[ModuleControlSurface] {}
+
+    MODULE
+    {
+        name = FARControllableSurface
+        b_2 = 0.467
+        MAC = 1.304
+        nonSideAttach = 0
+        TaperRatio = 1.0
+        MidChordSweep = 0
+        maxdeflect = 35
+        controlSurfacePivot = 1, 0, 0
+        ctrlSurfFrac = 0.82
+    }
+}
+
+@PART[Grid?Fin?S?Titanium]:NEEDS[FerramAerospaceResearch]
+{
+    !MODULE[ModuleControlSurface] {}
+
+    MODULE
+    {
+        name = FARControllableSurface
+        b_2 = 0.156
+        MAC = 0.435
+        nonSideAttach = 0
+        TaperRatio = 1.0
+        MidChordSweep = 0
+        maxdeflect = 35
+        controlSurfacePivot = 1, 0, 0
+        ctrlSurfFrac = 0.82
+    }
+}
+
+@PART[Grid?Fin?M?Titanium]:NEEDS[FerramAerospaceResearch]
+{
+    !MODULE[ModuleControlSurface] {}
+
+    MODULE
+    {
+        name = FARControllableSurface
+        b_2 = 0.312
+        MAC = 0.869
+        nonSideAttach = 0
+        TaperRatio = 1.0
+        MidChordSweep = 0
+        maxdeflect = 35
+        controlSurfacePivot = 1, 0, 0
+        ctrlSurfFrac = 0.82
+    }
+}
+
+@PART[Grid?Fin?L?Titanium]:NEEDS[FerramAerospaceResearch]
+{
+    !MODULE[ModuleControlSurface] {}
+
+    MODULE
+    {
+        name = FARControllableSurface
+        b_2 = 0.467
+        MAC = 1.304
+        nonSideAttach = 0
+        TaperRatio = 1.0
+        MidChordSweep = 0
+        maxdeflect = 35
+        controlSurfacePivot = 1, 0, 0
+        ctrlSurfFrac = 0.82
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/NewGlennLegs.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/NewGlennLegs.cfg
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------
+// New Glenn Legs
+// -----------------------------------------------------------
+
+// These are far harder to source than Falcon's legs. If anyone has a better idea for the masses, I would greatly appreciate it.
+
+@PART[KRE-HexLegsMountM]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = New Glenn Landing Leg Mount (Medium)
+    @manufacturer = Blue Origin
+    @description = Medium New Glenn Landing Legs Mount
+    @mass = 0.30
+    @maxTemp = 1500
+    @skinMaxTemp = 2400
+    @crashTolerance = 50
+    @breakingForce = 600
+    @breakingTorque = 600
+}
+
+@PART[KRE-HexLegsM]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = New Glenn Landing Leg (Medium)
+    @manufacturer = Blue Origin
+    @description = Medium New Glenn Landing Leg
+    @mass = 1.50
+    @maxTemp = 1500
+    @skinMaxTemp = 2400
+    @crashTolerance = 60
+    @breakingForce = 1500
+    @breakingTorque = 1500
+}
+
+@PART[KRE-HexLegsMountL]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = New Glenn Landing Leg Mount (Large)
+    @manufacturer = Blue Origin
+    @description = Large New Glenn Landing Legs Mount
+    @mass = 0.80
+    @maxTemp = 1500
+    @skinMaxTemp = 2400
+    @crashTolerance = 50
+    @breakingForce = 1000
+    @breakingTorque = 1000
+}
+
+@PART[KRE-HexLegsL]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = New Glenn Landing Leg (Large)
+    @manufacturer = Blue Origin
+    @description = Large New Glenn Landing Leg
+    @mass = 3.50
+    @maxTemp = 1500
+    @skinMaxTemp = 2400
+    @crashTolerance = 80
+    @breakingForce = 3000
+    @breakingTorque = 3000
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/NewGlennLegs.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalReusabilityExpansion/NewGlennLegs.cfg
@@ -7,6 +7,8 @@
 @PART[KRE-HexLegsMountM]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.866
+
     @title = New Glenn Landing Leg Mount (Medium)
     @manufacturer = Blue Origin
     @description = Medium New Glenn Landing Legs Mount
@@ -21,6 +23,8 @@
 @PART[KRE-HexLegsM]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.866
+
     @title = New Glenn Landing Leg (Medium)
     @manufacturer = Blue Origin
     @description = Medium New Glenn Landing Leg
@@ -35,6 +39,8 @@
 @PART[KRE-HexLegsMountL]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.866
+
     @title = New Glenn Landing Leg Mount (Large)
     @manufacturer = Blue Origin
     @description = Large New Glenn Landing Legs Mount
@@ -49,6 +55,8 @@
 @PART[KRE-HexLegsL]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
+    @rescaleFactor *= 1.866
+
     @title = New Glenn Landing Leg (Large)
     @manufacturer = Blue Origin
     @description = Large New Glenn Landing Leg


### PR DESCRIPTION
This PR adds configs for Kerbal Reusability Expansion. Currently, only its F9 & New Glenn landing legs are configured. 