### PR TITLE
Fix issues with Vexin/Valois/Vesta ignitions

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Vexin_Config.cfg
@@ -149,6 +149,12 @@
 
 			IGNITOR_RESOURCE
 			{
+				name = ElectricCharge
+				amount = 0.5
+			}
+
+			IGNITOR_RESOURCE
+			{
 				name = Furfuryl
 				amount = 1
 			}
@@ -222,6 +228,12 @@
 			gimbalRange = 6.0
 			useEngineResponseTime = True
 			engineAccelerationSpeed = 0.9
+
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 
 			IGNITOR_RESOURCE
 			{
@@ -375,7 +387,19 @@
 			gimbalRange = 6.0
 			useEngineResponseTime = True
 			engineAccelerationSpeed = 0.9
+			
+			IGNITOR_RESOURCE
+			{
+				name = ElectricCharge
+				amount = 0.5
+			}
 
+			IGNITOR_RESOURCE
+			{
+				name = Furfuryl
+				amount = 1
+			}
+			
 			PROPELLANT
 			{
 				name = UDMH
@@ -432,4 +456,11 @@
 			}
 		}
 	}
+	
+	RESOURCE
+	{
+		name = Furfuryl
+		amount = 1
+		maxAmount = 1
+	}	
 }


### PR DESCRIPTION
Fixes https://github.com/KSP-RO/ROEngines/issues/280
and https://github.com/Capkirk123/ROEngines-Extended/issues/9

All three engines were improperly configged and could only be groundlit despite having one ignition. I've fixed this, and also made the ignition resources align with those for Veronique and its children, but let me know if you'd like it implemented differently.