### PR TITLE
Adds UDMH/LOX speculative configs for the RD0203

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD0203_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD0203_Config.cfg
@@ -122,6 +122,33 @@
 				key = 1 278
 			}
 
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0203. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 598.03
+				maxThrust = 598.03
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4490
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5510
+				}
+				atmosphereCurve
+				{
+					key = 0 333
+					key = 1 297.5
+				}
+			}
+
 			//UR-200 (8K81) (R&D): 9 flights, 2 failures
 			//36 engines, 2 failures
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -175,6 +202,33 @@
 			{
 				key = 0 311
 				key = 1 278
+			}
+
+			SUBCONFIG
+			{
+				name = UDMH/LOX
+				description = UDMH/LOX version of RD-0203U. Much higher performance, but requires cryogenic fuels.
+				specLevel = speculative
+				minThrust = 609.05
+				maxThrust = 609.05
+				massMult = 1.0
+				costOffset = 0
+				PROPELLANT
+				{
+					name = UDMH
+					ratio = 0.4490
+					DrawGauge = True
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.5510
+				}
+				atmosphereCurve
+				{
+					key = 0 333
+					key = 1 297.5
+				}
 			}
 
 			//Using RD-0210 data


### PR DESCRIPTION
The RD0203 is kind of the odd one out in the UR 200/500 family of engines in not having a UDMH/LOX config. This is an especially noticeable omission, as the RD0203 has a speculative config based on upgrades to the RD0210, which does have its own speculative UDMH/LOX configs, but the RD0203 has no such config of its own.

I'll set up a PR for waterfall configs to ROEngines if this gets merged, unless that's something you want me to do as a precondition to merging this PR.