### PR TITLE
Add MMH+MON1 and Aerozine50+MON1 RCS Configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RCS_Config.cfg
@@ -136,7 +136,33 @@
 			IspSL = 0.362
 			IspV = 0.952
 		}
+		CONFIG
+		{
+			name = MMH+MON1
+			specLevel = operational
+			thrusterPower = 0.445
+			PROPELLANT
+			{
+				name = MMH
+				ratio = 0.4971
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = MON1
+				ratio = 0.5029
+			}
 
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+
+			IspSL = 0.362
+			IspV = 0.952
+		}
 		CONFIG
 		{
 			name = MMH+MON3
@@ -235,6 +261,33 @@
 			{
 				name = NTO
 				ratio = 0.5051
+			}
+
+			PROPELLANT
+			{
+				name = Helium
+				ratio = 11.25
+				ignoreForIsp = True
+			}
+
+			IspSL = 0.366
+			IspV = 0.955
+		}
+		CONFIG
+		{
+			name = Aerozine50+MON1
+			specLevel = operational
+			thrusterPower = 0.455
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.4945
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = MON1
+				ratio = 0.5055
 			}
 
 			PROPELLANT


### PR DESCRIPTION
Frustratingly, the Apollo capsule and LEM have internal RCS configured to use MMH+MON1 and Aerozine50+MON1 respectively, however there is no option to have matching configs for the modular RCS blocks that players have access to. This addresses that oversight.

RP-1 PR: https://github.com/KSP-RO/RP-1/pull/2781