### PR TITLE
Add Moderately Plane Related Configs

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_100.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_100.cfg
@@ -1,0 +1,91 @@
+// F-100 Super Sabre Cockpit (with integrated nose intake)
+@PART[MPR_Cockpit_F100]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = F-100 Super Sabre Cockpit
+    @manufacturer = North American Aviation
+    @description = Single seat, early supersonic jet fighter cockpit with an integrated nose pitot intake. 
+    %rescaleFactor = 1.16
+
+    @mass = 0.6 // Higher than F-104 due to that weird nose
+    @crashTolerance = 8
+    @breakingForce = 2000
+    @breakingTorque = 2000
+    
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
+    
+    @MODULE[ModuleCommand]
+    {
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.0
+        }
+    }
+    !RESOURCE[ElectricCharge] {}
+    
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Fuselage
+        basemass = -1
+        volume = 120
+        TANK
+        {
+            name = ElectricCharge
+            amount = 10800
+            maxAmount = 10800
+        }
+        UNMANAGED_RESOURCE
+        {
+            name = Oxygen
+            amount = 50
+            maxAmount = 50
+        }
+        TANK
+        {
+            name = Water
+            amount = 2
+            maxAmount = 2
+        }
+        TANK
+        {
+            name = Food
+            amount = 1
+            maxAmount = 1
+        }
+    }
+    MODULE
+    {
+        name = ModuleSAS
+    }
+    MODULE
+    {
+        name = ModuleKrEjectPilot
+        MODULE
+        {
+            name = ModuleKrKerbalParachute
+            deployedDrag = 100
+            minAirPressureToOpen = 0.01
+            semiDeployedFraction = 0.0025
+            semiDeployedHeight = 1.25
+            deployTime = 0.33
+        }
+    }
+
+    // See RO_Squad_Intakes for the below
+    !RESOURCE[IntakeAtm] {}
+    !MODULE[ModuleResourceIntake] {}
+
+    MODULE
+    {
+        name = AJEInlet
+        Area = 0.75 // Sized appropriately for the J57 turbojet
+        
+        #@AJE_TPR_CURVE_DEFAULTS/PitotTube/TPRCurve {}
+
+        inletTitle = #$@AJE_TPR_CURVE_DEFAULTS/PitotTube/title$
+        inletDescription = #$@AJE_TPR_CURVE_DEFAULTS/PitotTube/description$
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_100.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_100.cfg
@@ -73,15 +73,32 @@
             deployTime = 0.33
         }
     }
+}
 
-    // See RO_Squad_Intakes for the below
-    !RESOURCE[IntakeAtm] {}
+// F-100 Super Sabre Nose Intake
+@PART[MPR_Aero_F100]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = F-100 Super Sabre Nose Intake
+    @manufacturer = North American Aviation
+    @description = Pitot-style nose intake specifically designed for the F-100 Super Sabre.
+    
+    %rescaleFactor = 1.16
+
+    @mass = 0.05
+    @crashTolerance = 10
+
+    %skinTempTag = Aluminum
+    %internalTempTag = Aluminum
+
     !MODULE[ModuleResourceIntake] {}
-
+    !RESOURCE[IntakeAtm] {}
+    
     MODULE
     {
         name = AJEInlet
-        Area = 0.75 // Sized appropriately for the J57 turbojet
+        Area = 0.75 
+        intakeTransformName = intakeTransform
         
         #@AJE_TPR_CURVE_DEFAULTS/PitotTube/TPRCurve {}
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_104.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_104.cfg
@@ -1,0 +1,159 @@
+// F-104 Starfighter Cockpit
+@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = F-104 Starfighter Cockpit
+    @manufacturer = Lockheed
+    @description = Single seat, supersonic jet fighter cockpit.
+    %rescaleFactor = 1.16
+
+    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
+    @crashTolerance = 8
+    @breakingForce = 2000
+    @breakingTorque = 2000
+    
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
+    
+    @MODULE[ModuleCommand]
+    {
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.0
+        }
+    }
+    !RESOURCE[ElectricCharge] {}
+    
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Fuselage
+        basemass = -1
+        volume = 120
+        TANK
+        {
+            name = ElectricCharge
+            amount = 10800
+            maxAmount = 10800
+        }
+        UNMANAGED_RESOURCE
+        {
+            name = Oxygen
+            amount = 50
+            maxAmount = 50
+        }
+        TANK
+        {
+            name = Water
+            amount = 2
+            maxAmount = 2
+        }
+        TANK
+        {
+            name = Food
+            amount = 1
+            maxAmount = 1
+        }
+    }
+    MODULE
+    {
+        name = ModuleSAS
+    }
+    MODULE
+    {
+        name = ModuleKrEjectPilot
+        MODULE
+        {
+            name = ModuleKrKerbalParachute
+            deployedDrag = 100
+            minAirPressureToOpen = 0.01
+            semiDeployedFraction = 0.0025
+            semiDeployedHeight = 1.25
+            deployTime = 0.33
+        }
+    }
+}
+
+// U-2 Dragon Lady Cockpit
++PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+{
+    @name = RO_Cockpit_U2
+    %RSSROConfig = True
+    @title = U-2 Dragon Lady Cockpit
+    @manufacturer = Lockheed
+    @description = Single seat, high-altitude reconnaissance aircraft cockpit. Features a lighter airframe and expanded life support for long-duration flights.
+    %rescaleFactor = 1.16
+
+    @mass = 0.35 // Stripped down F-104
+    @crashTolerance = 8
+    @breakingForce = 2000
+    @breakingTorque = 2000
+    
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
+    
+    @MODULE[ModuleCommand]
+    {
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.75
+        }
+    }
+    !RESOURCE[ElectricCharge] {}
+    
+    !MODULE[ModuleFuelTanks] {}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Fuselage
+        basemass = -1
+        volume = 150 
+        TANK
+        {
+            name = ElectricCharge
+            amount = 14400
+            maxAmount = 14400
+        }
+        UNMANAGED_RESOURCE
+        {
+            name = Oxygen
+            amount = 80
+            maxAmount = 80
+        }
+        TANK
+        {
+            name = Water
+            amount = 4
+            maxAmount = 4
+        }
+        TANK
+        {
+            name = Food
+            amount = 2
+            maxAmount = 2
+        }
+    }
+    
+    !MODULE[ModuleSAS] {}
+    MODULE
+    {
+        name = ModuleSAS
+    }
+    
+    !MODULE[ModuleKrEjectPilot] {}
+    MODULE
+    {
+        name = ModuleKrEjectPilot
+        MODULE
+        {
+            name = ModuleKrKerbalParachute
+            deployedDrag = 100
+            minAirPressureToOpen = 0.01
+            semiDeployedFraction = 0.0025
+            semiDeployedHeight = 1.25
+            deployTime = 0.33
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_14.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_14.cfg
@@ -1,14 +1,12 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[MPR_Cockpit_F14]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
-
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @title = F-14 Tomcat Cockpit
+    @manufacturer = Grumman
+    @description = Twin-seat, variable-sweep naval fighter cockpit.
+    
+    @mass = 1.2 // 2 NACES + canopy + avionics
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,40 +18,41 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.75
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {
         name = ModuleFuelTanks
         type = Fuselage
         basemass = -1
-        volume = 120
+        volume = 240
         TANK
         {
             name = ElectricCharge
-            amount = 10800
-            maxAmount = 10800
+            amount = 21600
+            maxAmount = 21600
         }
         UNMANAGED_RESOURCE
         {
             name = Oxygen
-            amount = 50
-            maxAmount = 50
+            amount = 100
+            maxAmount = 100
         }
         TANK
         {
             name = Water
-            amount = 2
-            maxAmount = 2
+            amount = 4
+            maxAmount = 4
         }
         TANK
         {
             name = Food
-            amount = 1
-            maxAmount = 1
+            amount = 2
+            maxAmount = 2
         }
     }
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_15.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_15.cfg
@@ -1,14 +1,13 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[SAE_Cockpit_F15]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = F-15C/E Eagle Cockpit
+    @manufacturer = McDonnell Douglas
+    @description = High-performance air superiority fighter cockpit.
+    %rescaleFactor = 1.43 
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 1 // ACES (160kg) + 90kg canopy + structural stuff, pretty difficult to estimate. 1 ton is a conservative estimate IMO
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,40 +19,41 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {
         name = ModuleFuelTanks
         type = Fuselage
         basemass = -1
-        volume = 120
+        volume = 150
         TANK
         {
             name = ElectricCharge
-            amount = 10800
-            maxAmount = 10800
+            amount = 14400
+            maxAmount = 14400
         }
         UNMANAGED_RESOURCE
         {
             name = Oxygen
-            amount = 50
-            maxAmount = 50
+            amount = 65
+            maxAmount = 65
         }
         TANK
         {
             name = Water
-            amount = 2
-            maxAmount = 2
+            amount = 3
+            maxAmount = 3
         }
         TANK
         {
             name = Food
-            amount = 1
-            maxAmount = 1
+            amount = 1.5
+            maxAmount = 1.5
         }
     }
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_16.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_16.cfg
@@ -1,14 +1,12 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[MPR_Cockpit_F16]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
-
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @title = F-16 Fighting Falcon Cockpit
+    @manufacturer = General Dynamics / Lockheed Martin
+    @description = Single-seat multirole fighter cockpit with integrated chin intake.
+    
+    @mass = 0.85
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +18,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.25
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {
@@ -72,5 +71,18 @@
             semiDeployedHeight = 1.25
             deployTime = 0.33
         }
+    }
+    
+    !RESOURCE[IntakeAir] {}
+    !RESOURCE[IntakeAtm] {}
+    !MODULE[ModuleResourceIntake] {}
+    
+    MODULE
+    {
+        name = AJEInlet
+        Area = 0.6 // Upper end of F-16 intake area
+        #@AJE_TPR_CURVE_DEFAULTS/PitotTube/TPRCurve {}
+        inletTitle = #$@AJE_TPR_CURVE_DEFAULTS/PitotTube/title$
+        inletDescription = #$@AJE_TPR_CURVE_DEFAULTS/PitotTube/description$
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_16.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_16.cfg
@@ -79,8 +79,11 @@
     MODULE
     {
         name = AJEInlet
-        Area = 0.6 // Upper end of F-16 intake area
+        Area = 0.6 
+        intakeTransformName = intakeTransform
+        
         #@AJE_TPR_CURVE_DEFAULTS/PitotTube/TPRCurve {}
+
         inletTitle = #$@AJE_TPR_CURVE_DEFAULTS/PitotTube/title$
         inletDescription = #$@AJE_TPR_CURVE_DEFAULTS/PitotTube/description$
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_16.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_16.cfg
@@ -73,7 +73,6 @@
         }
     }
     
-    !RESOURCE[IntakeAir] {}
     !RESOURCE[IntakeAtm] {}
     !MODULE[ModuleResourceIntake] {}
     

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_18.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_18.cfg
@@ -1,14 +1,12 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[SAE_Cockpit_FA18]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
-
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @title = F/A-18E/F Super Hornet Cockpit
+    @manufacturer = McDonnell Douglas / Boeing
+    @description = Carrier-capable multirole fighter cockpit.
+    
+    @mass = 1 // Could not determine a super accurate source for this. So 1 ton for conservative estimate
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +18,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_22.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_22.cfg
@@ -1,14 +1,14 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+// What a funky website: [1] https://web.eng.fiu.edu/allstar/f22raptor.html 
+@PART[SAE_Cockpit_F22T]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = F-22 Raptor Cockpit
+    @manufacturer = Lockheed Martin
+    @description = Single-seat, all-weather stealth tactical fighter cockpit.
+    %rescaleFactor = 1.43
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 0.95 // See [1] - forward is 770 kg, canopy is 160kg, with 200kg ontop for an ejection seat
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +20,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_4.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/F_4.cfg
@@ -1,0 +1,76 @@
+// F-4 Phantom II Cockpit
+@PART[MPR_Cockpit_F4]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @title = F-4 Phantom II Cockpit
+    @manufacturer = McDonnell Douglas
+    @description = Twin seat, supersonic cockpit.
+    %rescaleFactor = 1.2 
+
+    @mass = 1.0 // 2x 200kg ejection + AWG-10 (300kg) + LS + structure, rounded up 
+    @crashTolerance = 8
+    @breakingForce = 2000
+    @breakingTorque = 2000
+    
+    %skinTempTag = Aluminum
+    %internalTempTag = Instruments
+    
+    @MODULE[ModuleCommand]
+    {
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.25 // Larger avionics & radar
+        }
+    }
+    !RESOURCE[ElectricCharge] {}
+    
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = Fuselage
+        basemass = -1
+        volume = 120
+        TANK
+        {
+            name = ElectricCharge
+            amount = 21600
+            maxAmount = 21600
+        }
+        UNMANAGED_RESOURCE
+        {
+            name = Oxygen
+            amount = 100
+            maxAmount = 100
+        }
+        TANK
+        {
+            name = Water
+            amount = 4
+            maxAmount = 4
+        }
+        TANK
+        {
+            name = Food
+            amount = 2
+            maxAmount = 2
+        }
+    }
+    MODULE
+    {
+        name = ModuleSAS
+    }
+    MODULE
+    {
+        name = ModuleKrEjectPilot
+        MODULE
+        {
+            name = ModuleKrKerbalParachute
+            deployedDrag = 100
+            minAirPressureToOpen = 0.01
+            semiDeployedFraction = 0.0025
+            semiDeployedHeight = 1.25
+            deployTime = 0.33
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/J_20.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/J_20.cfg
@@ -1,14 +1,13 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[MPR_Cockpit_J20]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = J-20 Mighty Dragon Cockpit
+    @manufacturer = Chengdu Aircraft Industry Group
+    @description = Single-seat, all-weather stealth fighter cockpit.
+    %rescaleFactor = 1.43
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 0.85 // HTY-6G is somewhere between 150 to 200, canopy should be somewhere between 100 to 150. With avionics, structural parts, etc. this could be anywhere between 600 to 1 ton, depending on what you count. Hence, this is a nice middle ground.
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +19,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/Mig_29.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/Mig_29.cfg
@@ -1,14 +1,13 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[MPR_Cockpit_MiG29]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = MiG-29 Fulcrum Cockpit
+    @manufacturer = Mikoyan
+    @description = Single-seat, twin-engine air superiority fighter cockpit. 
+    %rescaleFactor = 1.43
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 0.9 // 250kg ejection seat + 100kg canopy - 900kg is based on other fighters of the size
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +19,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {} 
     
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/Su_34.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/Su_34.cfg
@@ -1,14 +1,13 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[MPR_Cockpit_Su34]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = Su-34 Fullback Cockpit
+    @manufacturer = Sukhoi
+    @description = Twin-seat side-by-side strike/bomber cockpit enclosed in a titanium armored tub.
+    %rescaleFactor = 1.43
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 1.6 // Titanium -> Heavy
+    @crashTolerance = 12
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,40 +19,41 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 2.0
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {
         name = ModuleFuelTanks
         type = Fuselage
         basemass = -1
-        volume = 120
+        volume = 240
         TANK
         {
             name = ElectricCharge
-            amount = 10800
-            maxAmount = 10800
+            amount = 21600
+            maxAmount = 21600
         }
         UNMANAGED_RESOURCE
         {
             name = Oxygen
-            amount = 50
-            maxAmount = 50
+            amount = 100
+            maxAmount = 100
         }
         TANK
         {
             name = Water
-            amount = 2
-            maxAmount = 2
+            amount = 4
+            maxAmount = 4
         }
         TANK
         {
             name = Food
-            amount = 1
-            maxAmount = 1
+            amount = 2
+            maxAmount = 2
         }
     }
     MODULE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/U_2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/U_2.cfg
@@ -1,5 +1,6 @@
-@PART[SAE_Cockpit_U2]:FOR[RealismOverhaul]
++PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
 {
+    @name = RO_Cockpit_U2
     %RSSROConfig = True
     @title = U-2 Dragon Lady Cockpit
     @manufacturer = Lockheed

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/U_2.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/U_2.cfg
@@ -1,13 +1,12 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[SAE_Cockpit_U2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
+    @title = U-2 Dragon Lady Cockpit
     @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
+    @description = Single seat, high-altitude reconnaissance aircraft cockpit. Features a lighter airframe and expanded life support for long-duration flights.
     %rescaleFactor = 1.16
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
+    @mass = 0.35 // Stripped down F-104
     @crashTolerance = 8
     @breakingForce = 2000
     @breakingTorque = 2000
@@ -20,46 +19,51 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 0.75
         }
     }
     !RESOURCE[ElectricCharge] {}
     
+    !MODULE[ModuleFuelTanks] {}
     MODULE
     {
         name = ModuleFuelTanks
         type = Fuselage
         basemass = -1
-        volume = 120
+        volume = 150 
         TANK
         {
             name = ElectricCharge
-            amount = 10800
-            maxAmount = 10800
+            amount = 14400
+            maxAmount = 14400
         }
         UNMANAGED_RESOURCE
         {
             name = Oxygen
-            amount = 50
-            maxAmount = 50
+            amount = 80
+            maxAmount = 80
         }
         TANK
         {
             name = Water
-            amount = 2
-            maxAmount = 2
+            amount = 4
+            maxAmount = 4
         }
         TANK
         {
             name = Food
-            amount = 1
-            maxAmount = 1
+            amount = 2
+            maxAmount = 2
         }
     }
+    
+    !MODULE[ModuleSAS] {}
     MODULE
     {
         name = ModuleSAS
     }
+    
+    !MODULE[ModuleKrEjectPilot] {}
     MODULE
     {
         name = ModuleKrEjectPilot

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/X_02.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/X_02.cfg
@@ -1,14 +1,13 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[SAE_Cockpit_X-02]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = X-02 Wyvern Cockpit
+    @manufacturer = Erusean Air and Space Administration
+    @description = Single-seat variable-sweep wing stealth fighter cockpit.
+    %rescaleFactor = 1.43
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 0.85 // This isn't even a real plane
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +19,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/X_02.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/X_02.cfg
@@ -1,9 +1,9 @@
 @PART[SAE_Cockpit_X-02]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = X-02 Wyvern Cockpit
-    @manufacturer = Erusean Air and Space Administration
-    @description = Single-seat variable-sweep wing stealth fighter cockpit.
+    @title = FCAS Cockpit
+    @manufacturer = Airbus
+    @description = Single-seat future stealth fighter cockpit.
     %rescaleFactor = 1.43
 
     @mass = 0.85 // This isn't even a real plane

--- a/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/YF_23.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/ModeratelyPlaneRelated/YF_23.cfg
@@ -1,14 +1,13 @@
-// F-104 Starfighter Cockpit
-@PART[MPR_Cockpit_F104]:FOR[RealismOverhaul]
+@PART[SAE_Cockpit_F23T]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = F-104 Starfighter Cockpit
-    @manufacturer = Lockheed
-    @description = Single seat, supersonic jet fighter cockpit.
-    %rescaleFactor = 1.16
+    @title = YF-23 Black Widow II Cockpit
+    @manufacturer = Northrop / McDonnell Douglas
+    @description = Single-seat stealth fighter prototype cockpit.
+    %rescaleFactor = 1.3
 
-    @mass = 0.5 // 95kg ejection seat + ASG-114 (120kg) + structure, so rounded up to 500 kg
-    @crashTolerance = 8
+    @mass = 1 // They never disclosed this, so I'll assume it's just a bit heavier than the F-22.
+    @crashTolerance = 10
     @breakingForce = 2000
     @breakingTorque = 2000
     
@@ -20,10 +19,11 @@
         RESOURCE
         {
             name = ElectricCharge
-            rate = 1.0
+            rate = 1.5
         }
     }
     !RESOURCE[ElectricCharge] {}
+    !MODULE[ModuleReactionWheel] {}
     
     MODULE
     {


### PR DESCRIPTION
This PR adds configs for the Moderately Plane Related cockpit parts. Initially, this is the
- F-100
- F-104
- U-2 (Using the model of the F-104 cockpit) 
- F-4 

If there is interest in them, I can add configs for the other more modern cockpit parts.