### PR TITLE
Increase the heat tolerance of Internal RCS to match Conformal RCS

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Double.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Double.cfg
@@ -18,6 +18,9 @@
 	%useRcsConfig = RCSBlockTenth
 	%useRcsMass = True
 	%RcsNozzles = 2
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -46,6 +49,9 @@
 	%useRcsConfig = RCSBlockQuarter
 	%useRcsMass = True
 	%RcsNozzles = 2
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -74,6 +80,9 @@
 	%useRcsConfig = RCSBlockHalf
 	%useRcsMass = True
 	%RcsNozzles = 2
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -102,6 +111,9 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 	%RcsNozzles = 2
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -130,6 +142,9 @@
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
 	%RcsNozzles = 2
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Quad.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Quad.cfg
@@ -18,6 +18,9 @@
 	%useRcsConfig = RCSBlockTenth
 	%useRcsMass = True
 	%RcsNozzles = 4
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -46,6 +49,9 @@
 	%useRcsConfig = RCSBlockQuarter
 	%useRcsMass = True
 	%RcsNozzles = 4
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -74,6 +80,9 @@
 	%useRcsConfig = RCSBlockHalf
 	%useRcsMass = True
 	%RcsNozzles = 4
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -102,6 +111,9 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 	%RcsNozzles = 4
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -130,6 +142,9 @@
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
 	%RcsNozzles = 4
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Quint.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Quint.cfg
@@ -18,6 +18,9 @@
 	%useRcsConfig = RCSBlockTenth
 	%useRcsMass = True
 	%RcsNozzles = 5
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -46,6 +49,9 @@
 	%useRcsConfig = RCSBlockQuarter
 	%useRcsMass = True
 	%RcsNozzles = 5
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -74,6 +80,9 @@
 	%useRcsConfig = RCSBlockHalf
 	%useRcsMass = True
 	%RcsNozzles = 5
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -102,6 +111,9 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 	%RcsNozzles = 5
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -130,6 +142,9 @@
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
 	%RcsNozzles = 5
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Single.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Single.cfg
@@ -18,6 +18,9 @@
 	%useRcsConfig = RCSBlockTenth
 	%useRcsMass = True
 	%RcsNozzles = 1
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -46,6 +49,10 @@
 	%useRcsConfig = RCSBlockQuarter
 	%useRcsMass = True
 	%RcsNozzles = 1
+	
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -74,6 +81,9 @@
 	%useRcsConfig = RCSBlockHalf
 	%useRcsMass = True
 	%RcsNozzles = 1
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -102,6 +112,9 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 	%RcsNozzles = 1
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -130,6 +143,9 @@
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
 	%RcsNozzles = 1
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{

--- a/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Triple.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/InternalRCS/RCS_Triple.cfg
@@ -18,6 +18,9 @@
 	%useRcsConfig = RCSBlockTenth
 	%useRcsMass = True
 	%RcsNozzles = 3
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -46,6 +49,9 @@
 	%useRcsConfig = RCSBlockQuarter
 	%useRcsMass = True
 	%RcsNozzles = 3
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -74,6 +80,9 @@
 	%useRcsConfig = RCSBlockHalf
 	%useRcsMass = True
 	%RcsNozzles = 3
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -102,6 +111,9 @@
 	%useRcsConfig = RCSBlock
 	%useRcsMass = True
 	%RcsNozzles = 3
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{
@@ -130,6 +142,9 @@
 	%useRcsConfig = RCSBlockDouble
 	%useRcsMass = True
 	%RcsNozzles = 3
+	
+	%maxTemp = 1473.15
+	%skinMaxTemp = 2473.15
 
 	@MODULE[ModuleRCSFX]
 	{


### PR DESCRIPTION
Increases the heat tolerance for Internal RCS parts to match the Conformal Attitude Thrusterconfigured here - https://github.com/KSP-RO/RealismOverhaul/blob/031110c813138013667c4b840a28bab9c44a5fc0/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg#L1385

The existing tolerances are too low to use the thrusters for a re-entering spaceplane. Existing parts such as the Dynasoar cockpit have internal RCS built into the model, but it'd be nice to be able to customise them. There's the Conformal Attitude Thruster configured above, but it's big and ugly.

Possibly these limits are a bit too high? The shuttle nosecap only reached like 1600K during re-entry, but maybe there's some good reason the conformal RCS was configured that way, so I've gone with its values.