### PR TITLE
Revert RD-119 ISP to 352

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD109_Config.cfg
@@ -25,7 +25,7 @@
 //	Dry Mass: 168 kg
 //	Thrust (SL): 65.6 kN
 //	Thrust (Vac): 105.5 kN
-//	ISP: 220 SL / 362 Vac
+//	ISP: 220 SL / 352 Vac
 //	Burn Time: 260
 //	Chamber Pressure: 7.9 MPa
 //	Propellant: LOX / UDMH
@@ -42,6 +42,7 @@
 //	astronautix - RD-109:																	http://www.astronautix.com/r/rd-109.html
 //	Google Books - "Satan" and "Governor". The most formidable nuclear weapon in the world:	https://books.google.by/books?id=D-c5DQAAQBAJ&pg=PA53&lpg=PA53&dq=11%D0%B449+%D1%82%D1%80%D0%B5%D1%85%D1%80%D0%B5%D0%B6%D0%B8%D0%BC%D0%BD%D1%8B%D0%B9&source=bl&ots=GUOLiPbCo3&sig=ACfU3U2kM4lIDRQ_7y0XDznHmJ8oxRZFcg&hl=ru&sa=X&ved=2ahUKEwj1m-2qsInnAhXIMewKHcv4AfUQ6AEwAHoECAoQAQ#v=onepage&q=11%D0%B449%20%D1%82%D1%80%D0%B5%D1%85%D1%80%D0%B5%D0%B6%D0%B8%D0%BC%D0%BD%D1%8B%D0%B9&f=false
 //	N.K. MATVEEV, A.A. SEMENOV, RD-119 ENGINE DESIGN (Russian paper, 'Н.К. МАТВЕЕВ, А.А. СЕМЁНОВ, УСТРОЙСТВО ДВИГАТЕЛЯ РД-119'): http://library.voenmeh.ru/cnau/elr03216.pdf
+//  NP Energomash, Table of Engines:															https://web.archive.org/web/20141107202512/http://www.npoenergomash.ru/netcat_files/File/Table_of_Engines.docx
 
 //	Used by:
 


### PR DESCRIPTION
The fact that this early engine outperforms the staged-combustion UDMH/LOX engines despite its much lower chamber pressure and only marginally greater expansion ratio has been bothering me, and I went down a rabbit hole.

This was changed to 362s on the basis of https://web.archive.org/web/20230814113330/http://library.voenmeh.ru/cnau/elr03216.pdf, contradicting a consensus of 352s from all other sources (including some Russian ones, including an NPO Energomash document). However, that source is itself inconsistent: it gives three different values for ISP/exhaust velocity (all vacuum).
- Page 4, text: 3551m/s (362s)
- Page 8, summary of overall engine statistics: 3551m/s (362s)
- Page 10, text: 352s
- Page 14, summary of the combustion chamber: 3512m/s (358s)
 
We can also calculate ISP from the mass flow and thrust; 100.5kN from 30.82kg/s mass flow gives an even lower value of 332s. (Notably the combustion chamber table gives somewhat different mass flow rates, 170g/s less oxydizer and 1020g/s less fuel, and a different nominal mixture ratio; I suspect the discrepancy comes from the monopropellant gas generator. Still, using the lower combustion chamber mass flow rate still only brings ISP to 345. Using the higher thrust value of 106kN found in other sources gives 351s--but the exclusion of the gas generator mass flow makes that optimistic.) I think these inconsistencies, along with oddities such as the claimed expansion ratio of 1280, call into question the reliability of this source. While the author may have had access to superior primary sources, they seem to have uncritically mixed that information with some from less reliable sources. Since they give a bibliography but not footnotes, it is impossible to tell which of these values is most trustworthy without gaining access to the primary sources.