### PR TITLE
Nuclear propulsion and power generation/ISRU

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FarFutureTechnologies/FFT_RO.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FarFutureTechnologies/FFT_RO.cfg
@@ -1396,3 +1396,2110 @@ TANK_DEFINITION
 		}
 	}
 }
+// Realism Overhaul configuration for Far Future Technologies Beamed Core Antimatter Engine (Frisbee Drive)
+@PART[fft-antimatter-beam-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Scale up to realistic interstellar dimensions (approx 1.6x - 2x scale for RO)
+    %rescaleFactor = 1.6
+    
+    @mass = 450.0 // Mass adjusted for massive magnetic nozzles and cooling infrastructure
+    @maxTemp = 3600
+    @crashTolerance = 10
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 7500 // Extremely powerful torch/interstellar thrust (7,500 kN)
+        @heatProduction = 2500
+        
+        !PROPELLANT[*] {} // Clear fictional/stock propellants
+        
+        PROPELLANT
+        {
+            name = LiquidHydrogen
+            ratio = 1.0
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = Antimatter
+            ratio = 1e-5 // Microgram-to-gram consumption ratio relative to LH2 volume
+            DrawGauge = False
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 1000000 // 1,000,000 seconds Isp in vacuum for Beamed Core
+            @key,1 = 1 100     // Completely useless inside an atmosphere due to backpressure
+        }
+    }
+    
+    // Adjusting or replacing SystemHeat/FFT power requirements for RO compatibility
+    @MODULE[ModuleUpdateParameters]:NEEDS[FarFutureTechnologies]
+    {
+        // Maintains integration with FFTs native UI if preferred
+    }
+
+    // Configure RealFuels/EngineIgnitor profiles if needed
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = BeamedCoreAntimatter
+        modded = false
+        
+        CONFIG
+        {
+            name = BeamedCoreAntimatter
+            minThrust = 0
+            maxThrust = 7500
+            heatProduction = 2500
+            
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 1.0
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = Antimatter
+                ratio = 1e-5
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 1000000
+                key = 1 100
+            }
+        }
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies  Antimatter Factory
+@PART[fft-antimatter-factory-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x interstellar baseline infrastructure
+    %rescaleFactor = 1.6
+    
+    @mass = 180.0 // Heavy particle accelerator rings and containment magnetic coils
+    @maxTemp = 2500
+    @crashTolerance = 8
+    
+    %category = Utility
+    
+    // Clear out stock resource converters
+    !MODULE[ModuleResourceConverter],* {}
+    
+    // Mode 1: High-energy Pair Production via Liquid Hydrogen (Simulating massive power overhead)
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Antimatter Synthesis (LH2)
+        StartActionName = Start Antimatter Factory (LH2)
+        StopActionName = Stop Antimatter Factory (LH2)
+        ToggleActionName = Toggle Antimatter Factory (LH2)
+        FillAmount = 1.0
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+        
+        // Massive cooling required for particle accelerators (SystemHeat will hook into this)
+        TemperatureModifier
+        {
+            key = 0 250000
+            key = 750 100000
+            key = 1000 50000
+            key = 1250 25000
+            key = 1500 0
+        }
+        
+        // Realistic high energy-cost efficiency for pair-production
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 120000 // Requires 120 MW of continuous power
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = LiquidHydrogen
+            Rate = 12.5 // ~12.5 Liters per second processed
+        }
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Antimatter
+            Rate = 0.000125 // Micro-grams generated per second
+            DumpToggle = false
+        }
+    }
+
+    // Mode 2: Fission Pellet-catalyzed Antimatter Production (More mass-efficient input, lower power)
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Antimatter Synthesis (Fission Pellets)
+        StartActionName = Start Antimatter Factory (Pellets)
+        StopActionName = Stop Antimatter Factory (Pellets)
+        ToggleActionName = Toggle Antimatter Factory (Pellets)
+        FillAmount = 1.0
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+        
+        TemperatureModifier
+        {
+            key = 0 180000
+            key = 750 90000
+            key = 1000 45000
+            key = 1250 20000
+            key = 1500 0
+        }
+        
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 45000 // Requires 45 MW of continuous power
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = FissionPellets
+            Rate = 0.05
+        }
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Antimatter
+            Rate = 0.00025 // Faster return rate due to heavy core target collisions
+            DumpToggle = false
+        }
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies Antimatter-Initiated Microfission Engine (Hickam)
+@PART[fft-antimatter-microfission-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x interstellar/advanced torch infrastructure 
+    %rescaleFactor = 1.6
+    
+    @mass = 85.0 // Heavy magnetic confinement geometry and pellet injection rails
+    @maxTemp = 3400
+    @crashTolerance = 12
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 2200 // High-thrust torch configuration (2,200 kN)
+        @heatProduction = 1800
+        
+        !PROPELLANT[*] {} // Clear out stock/fictional propellant nodes
+        
+        PROPELLANT
+        {
+            name = FissionPellets
+            ratio = 0.4
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = LiquidHydrogen
+            ratio = 0.6
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = Antimatter
+            ratio = 1e-6 // Microgram catalyst usage per cycle
+            DrawGauge = False
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 28500 // 28,500s Isp vacuum performance (High-velocity fusion exhaust)
+            @key,1 = 1 450   // Highly degraded in-atmosphere due to plume disruption
+        }
+    }
+    
+    // Configure RealFuels Engine Configs Engine Interface
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = AntimatterMicrofission
+        modded = false
+        
+        CONFIG
+        {
+            name = AntimatterMicrofission
+            minThrust = 0
+            maxThrust = 2200
+            heatProduction = 1800
+            
+            PROPELLANT
+            {
+                name = FissionPellets
+                ratio = 0.4
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 0.6
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = Antimatter
+                ratio = 1e-6
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 28500
+                key = 1 450
+            }
+        }
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies Antimatter-Initiated Microfusion Engine (Oppenheimer)
+@PART[fft-antimatter-microfusion-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x interstellar/advanced torch infrastructure
+    %rescaleFactor = 1.6
+    
+    @mass = 62.0 // Lighter than microfission due to minimal heavy shielding requirements, but massive magnetic coils
+    @maxTemp = 3500
+    @crashTolerance = 10
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 1400 // Lower raw thrust than microfission (1,400 kN), but significantly higher exhaust velocity
+        @heatProduction = 1500
+        
+        !PROPELLANT[*] {} // Clear stock propellant nodes
+        
+        PROPELLANT
+        {
+            name = FusionPellets
+            ratio = 0.3
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = LiquidHydrogen
+            ratio = 0.7
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = Antimatter
+            ratio = 5e-7 // Ultra-lean antimatter catalyst ratio per pellet detonation
+            DrawGauge = False
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 65000 // 65,000s Vacuum Isp (Pure relativistic plasma exhaust)
+            @key,1 = 1 300   // Instantly snuffed out by atmospheric backpressure
+        }
+    }
+    
+    // Configure RealFuels ModuleEngineConfigs Interface
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = AntimatterMicrofusion
+        modded = false
+        
+        CONFIG
+        {
+            name = AntimatterMicrofusion
+            minThrust = 0
+            maxThrust = 1400
+            heatProduction = 1500
+            
+            PROPELLANT
+            {
+                name = FusionPellets
+                ratio = 0.3
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 0.7
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = Antimatter
+                ratio = 5e-7
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 65000
+                key = 1 300
+            }
+        }
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies Magnetic Mirror Fusion Engine
+@PART[fft-fusion-magnetic-mirror-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced fusion/interplanetary transfers
+    %rescaleFactor = 1.6
+    
+    @mass = 78.0 // Massive weight dedicated to linear superconducting magnetic coils and vacuum architecture
+    @maxTemp = 3200
+    @crashTolerance = 10
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 850 // Continuous, steady-state high thrust (850 kN)
+        @heatProduction = 1200
+        
+        !PROPELLANT[*] {} // Clear stock propellant setups
+        
+        PROPELLANT
+        {
+            name = LqdDeuterium
+            ratio = 0.4
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = LqdHe3
+            ratio = 0.4
+            DrawGauge = False
+        }
+        PROPELLANT
+        {
+            name = LiquidHydrogen // Used as a reaction mass top-up to increase raw thrust output
+            ratio = 0.2
+            DrawGauge = True
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 18500 // 18,500s Vacuum Isp (High-velocity linear plasma escape)
+            @key,1 = 1 150   // Instantly choked out by atmospheric ambient air pressure
+        }
+    }
+    
+    // Configure RealFuels ModuleEngineConfigs Interface
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = MagneticMirrorFusion
+        modded = false
+        
+        CONFIG
+        {
+            name = MagneticMirrorFusion
+            minThrust = 0
+            maxThrust = 850
+            heatProduction = 1200
+            
+            PROPELLANT
+            {
+                name = LqdDeuterium
+                ratio = 0.4
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdHe3
+                ratio = 0.4
+            }
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 0.2
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 18500
+                key = 1 150
+            }
+        }
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies Inertial Laser Fusion Engine (Ouroboros)
+@PART[fft-fusion-inertial-laser-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for large interplanetary torch vessels
+    %rescaleFactor = 1.6
+    
+    @mass = 95.0 // Massive weight from the capacitor banks, laser optics, and magnetic diversion geometry
+    @maxTemp = 3300
+    @crashTolerance = 9
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 3200 // Incredible high-thrust fusion torch capacity (3,200 kN)
+        @heatProduction = 2100
+        
+        !PROPELLANT[*] {} // Clear out stock fuel mixtures
+        
+        PROPELLANT
+        {
+            name = FusionPellets
+            ratio = 0.35
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = LiquidHydrogen
+            ratio = 0.65
+            DrawGauge = True
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 14500 // 14,500s Vacuum Isp (High energy laser-driven kinetic plume)
+            @key,1 = 1 250   // Heavily choked by atmospheric density pressures
+        }
+    }
+    
+    // Configure RealFuels Engine Configs Interface
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = InertialLaserFusion
+        modded = false
+        
+        CONFIG
+        {
+            name = InertialLaserFusion
+            minThrust = 0
+            maxThrust = 3200
+            heatProduction = 2100
+            
+            PROPELLANT
+            {
+                name = FusionPellets
+                ratio = 0.35
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 0.65
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 14500
+                key = 1 250
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies Axial Z-Pinch Fusion Engine
+@PART[fft-fusion-axial-zpinch-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for heavy interplanetary hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 110.0 // Very heavy due to massive capacitor banks, structural return bars, and switching gear
+    @maxTemp = 3100
+    @crashTolerance = 9
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 4500 // Exceptional pulsed torch thrust (4,500 kN)
+        @heatProduction = 2400
+        
+        !PROPELLANT[*] {} // Clear out stock fuel loops
+        
+        PROPELLANT
+        {
+            name = LqdDeuterium
+            ratio = 0.25
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = LqdTritium
+            ratio = 0.25
+            DrawGauge = False
+        }
+        PROPELLANT
+        {
+            name = LiquidHydrogen // Buffer / Reaction mass expander
+            ratio = 0.50
+            DrawGauge = True
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 11200 // 11,120s Vacuum Isp (High-density pulsed plasma push)
+            @key,1 = 1 200   // Highly unstable in dense atmospheric backpressures
+        }
+    }
+    
+    // Configure RealFuels ModuleEngineConfigs Interface
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = AxialZPinchFusion
+        modded = false
+        
+        CONFIG
+        {
+            name = AxialZPinchFusion
+            minThrust = 0
+            maxThrust = 4500
+            heatProduction = 2400
+            
+            PROPELLANT
+            {
+                name = LqdDeuterium
+                ratio = 0.25
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdTritium
+                ratio = 0.25
+            }
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 0.50
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 11200
+                key = 1 200
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies Magnetic Tokamak Fusion Engine
+@PART[fft-fusion-magnetic-tokamak-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for large interstellar/interplanetary capital vessels
+    %rescaleFactor = 1.6
+    
+    @mass = 135.0 // Extremely heavy due to massive toroidal D-shaped superconducting coils and cooling blankets
+    @maxTemp = 3300
+    @crashTolerance = 8
+    
+    %category = Engine
+    
+    @MODULE[ModuleEnginesFX]
+    {
+        @minThrust = 0
+        @maxThrust = 1850 // High continuous, steady-state thrust (1,850 kN)
+        @heatProduction = 1600
+        
+        !PROPELLANT[*] {} // Clear stock propellant nodes
+        
+        PROPELLANT
+        {
+            name = LqdDeuterium
+            ratio = 0.35
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = LqdHe3
+            ratio = 0.35
+            DrawGauge = False
+        }
+        PROPELLANT
+        {
+            name = LiquidHydrogen // Reaction mass modifier
+            ratio = 0.30
+            DrawGauge = True
+        }
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 32000 // 32,000s Vacuum Isp (Highly efficient toroidal magnetic plasma extraction)
+            @key,1 = 1 180   // Highly unstable and choked out inside atmospheric ambient pressures
+        }
+    }
+    
+    // Configure RealFuels ModuleEngineConfigs Interface
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = MagneticTokamakFusion
+        modded = false
+        
+        CONFIG
+        {
+            name = MagneticTokamakFusion
+            minThrust = 0
+            maxThrust = 1850
+            heatProduction = 1600
+            
+            PROPELLANT
+            {
+                name = LqdDeuterium
+                ratio = 0.35
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdHe3
+                ratio = 0.35
+            }
+            PROPELLANT
+            {
+                name = LiquidHydrogen
+                ratio = 0.30
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 32000
+                key = 1 180
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies Vulcan Nuclear Smelter (3.75m)
+@PART[fft-nuclear-smelter-375-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced planetary/deep space logistical infrastructure
+    %rescaleFactor = 1.6
+    
+    @mass = 48.0 // Heavily shielded isotopic processor, high-temp centrifugal arrays, and core plumbing
+    @maxTemp = 3100
+    @crashTolerance = 10
+    
+    %category = Utility
+    
+    // Strip out all stock Resource Converter configurations completely
+    !MODULE[ModuleResourceConverter],* {}
+    !MODULE[ModuleSystemHeatConverter],* {}
+
+    // Mode 1: Nuclear Salt Water Refinement (Blending EnrichedUranium with treated water/propellant)
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Nuclear Salt Water Formulation
+        StartActionName = Start NSW Blending
+        StopActionName = Stop NSW Blending
+        ToggleActionName = Toggle NSW Blending
+        FillAmount = 1.0
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+        
+        TemperatureModifier
+        {
+            key = 0 80000
+            key = 500 40000
+            key = 1000 10000
+            key = 1500 0
+        }
+        
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 15000 // Requires 15 MW continuous processing power
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = EnrichedUranium
+            Rate = 0.002 // Slow, steady addition of highly enriched fissile salts
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = LiquidHydrogen // Used as the base hydrogen propellant medium for the salt solutions
+            Rate = 25.0
+        }
+        OUTPUT_RESOURCE
+        {
+            ResourceName = NuclearSaltWater
+            Rate = 24.8 // Output proportional to mass inputs
+            DumpToggle = false
+        }
+        OUTPUT_RESOURCE
+        {
+            ResourceName = DepletedUranium
+            Rate = 0.0004
+            DumpToggle = true
+        }
+    }
+
+    // Mode 2: Fission Pellet Fabrication (Sintering raw regolith/uranium into precision reactor pellets)
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Fission Pellet Sintering
+        StartActionName = Start Pellet Fabrication
+        StopActionName = Stop Pellet Fabrication
+        ToggleActionName = Toggle Pellet Fabrication
+        FillAmount = 1.0
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+        
+        TemperatureModifier
+        {
+            key = 0 120000
+            key = 600 60000
+            key = 1200 15000
+            key = 1800 0
+        }
+        
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 35000 // High thermal sintering arc power (35 MW)
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = EnrichedUranium
+            Rate = 0.015
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = Regolith // Simulates target casing/matrix stabilization elements
+            Rate = 1.2
+        }
+        OUTPUT_RESOURCE
+        {
+            ResourceName = FissionPellets
+            Rate = 0.25
+            DumpToggle = false
+        }
+    }
+}
+// Realism Overhaul / Custom balance patch for FFT Regolith Scoop
+@PART[fft-regolith-scoop-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // --- Technical Specifications ---
+    @mass = 4.5  // Adjusted for realistic heavy structural frame and magnetic separation mechanics (Metric Tons)
+    @maxTemp = 1473 // Resilient to high thermal radiation environments (Kelvin)
+    @crashTolerance = 12
+
+    // --- Core Harvester Module Configuration ---
+    // This targets the main regolith processing module (e.g., Helium-3 / Regolith extraction)
+    @MODULE[ModuleResourceHarvester],*
+    {
+        @EnergyConsumption = 1200 // Ramped to 1.2 MW to simulate thermal desorption loops
+        
+        @EfficiencyAlarms
+        {
+            // Tailor processing efficiency based on environmental factors if applicable
+        }
+    }
+
+    // --- Resource Rates Overhaul ---
+    // Realism Overhaul uses different density and volume scaling metrics. 
+    // Adjust the conversion efficiency nodes if using Community Resource Pack (CRP) or Rational Resources.
+    @HARVESTED_RESOURCE[*]:HAS[#Name[Helium3]]
+    {
+        @BaseEfficiency = 0.005 // Scaled down to match actual parts-per-billion yields in lunar-analogue regolith
+    }
+
+    // --- System Heat Integration ---
+    // If you are managing thermal loops with Nerteas SystemHeat framework
+    @MODULE[ModuleSystemHeatProduction]:NEEDS[SystemHeat]
+    {
+        @heatProduction = 850 // MW or kW thermal output depending on your base SystemHeat scale
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies 3.75m "Hephaestus" Heavy Regolith Harvester
+@PART[fft-regolith-scoop-2]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for heavy 6-meter planetary deployment profiles
+    %rescaleFactor = 1.6
+    
+    @mass = 14.8 // Massive industrial cutting heads, magnetic sorting drums, and vibrating sieve decks
+    @maxTemp = 1500
+    @crashTolerance = 15 // Highly rugged structural framework built to withstand prolonged mechanical drilling vibrations
+    
+    // Massive power demand escalation to model realistic megawatt-scale thermal desorption loops
+    @MODULE[ModuleResourceHarvester],*
+    {
+        @EnergyConsumption = 3500 // Ramped up to 3.5 MW of continuous power draw when active
+    }
+    
+    // Scale Helium-3 yield downward to match real-world parts-per-billion lunar regolith limits
+    @HARVESTED_RESOURCE[*]:HAS[#Name[LqdHe3]]
+    {
+        @BaseEfficiency = 0.015 // Demands heavy, sustained strip-mining throughput for meaningful returns
+    }
+    
+    // System Heat management configuration
+    @MODULE[ModuleSystemHeatProduction]:NEEDS[SystemHeat]
+    {
+        @heatProduction = 2400 // Heavy thermal rejection required to run the sorting loops
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies 2.5m Magnetic Confinement Fusion Reactor
+@PART[fft-fusion-reactor-25-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary architectures (2.5m -> 4m)
+    %rescaleFactor = 1.6
+    
+    @mass = 28.5 // Heavy superconducting magnetic coils, cryo-jacket cooling lines, and plasma diversion shields
+    @maxTemp = 2400
+    @crashTolerance = 7
+    
+    %category = Electrical
+    
+    // Wipe clean any stock alternator or generation configurations
+    !MODULE[ModuleGenerator],* {}
+    !MODULE[ModuleResourceConverter],* {}
+    
+    // Configure the Tokamak Reactor loop via ModuleResourceConverter
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = D-3He Tokamak Fusion Core
+        StartActionName = Ignite Fusion Plasma
+        StopActionName = Quench Fusion Plasma
+        ToggleActionName = Toggle Fusion Core
+        FillAmount = 1.0
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+        
+        // High initial thermal load during startup operations
+        TemperatureModifier
+        {
+            key = 0 100000
+            key = 750 50000
+            key = 1000 10000
+            key = 1250 2500
+            key = 1500 0
+        }
+        
+        // Consumables per second at peak steady-state generation
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdDeuterium
+            Rate = 0.045 // Liters per second
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdHe3
+            Rate = 0.045 // Liters per second
+        }
+        
+        // Massive startup ignition overhead (Requires heavy battery banks or fission kicker loops to ignite the plasma)
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 12000.0 // Requires a 12 MW active containment and heating overhead during steady run
+        }
+        
+        // Net Electrical Yield (Gross generation is 72 MW; minus 12 MW internal overhead leaves 60 MW net output)
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 72000.0 // 72 MW Gross Output
+            DumpToggle = false
+        }
+    }
+    
+    // System Heat Integration for the intense thermal output of core magnetics
+    @MODULE[ModuleSystemHeatProduction]:NEEDS[SystemHeat]
+    {
+        @heatProduction = 18000 // Requires robust high-temperature radiator loops to reject thermal waste
+    }
+}
+
+// Realism Overhaul configuration for Far Future Technologies 3.75m Magnetic Confinement Fusion Reactor
+@PART[fft-fusion-reactor-375-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for intermediate capital hulls (3.75m -> 6m)
+    %rescaleFactor = 1.6
+    
+    @mass = 74.0 // Scale-up of superconducting magnets, structural support trusses, and massive lithium breeding/shielding blankets
+    @maxTemp = 2400
+    @crashTolerance = 7
+    
+    %category = Electrical
+    
+    // Wipe clean any stock alternator or generation configurations
+    !MODULE[ModuleGenerator],* {}
+    !MODULE[ModuleResourceConverter],* {}
+    
+    // Configure the Heavy Tokamak Reactor loop via ModuleResourceConverter
+    MODULE
+    {
+        name = ModuleResourceConverter
+        ConverterName = Heavy D-3He Tokamak Fusion Core
+        StartActionName = Ignite Fusion Plasma
+        StopActionName = Quench Fusion Plasma
+        ToggleActionName = Toggle Fusion Core
+        FillAmount = 1.0
+        AutoShutdown = true
+        GeneratesHeat = true
+        UseSpecialistBonus = false
+        
+        // High initial thermal load during startup operations
+        TemperatureModifier
+        {
+            key = 0 250000
+            key = 750 120000
+            key = 1000 25000
+            key = 1250 5000
+            key = 1500 0
+        }
+        
+        // Consumables per second at peak steady-state generation
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdDeuterium
+            Rate = 0.135 // Balanced burn-rate for scaled-up core volume
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdHe3
+            Rate = 0.135
+        }
+        
+        // Escalated internal magnetic confinement and heating overhead
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 36000.0 // Requires a 36 MW continuous input to sustain the magnetic bottle
+        }
+        
+        // Net Electrical Yield (Gross generation is 216 MW; minus 36 MW internal overhead leaves 180 MW net output)
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Rate = 216000.0 // 216 MW Gross Output
+            DumpToggle = false
+        }
+    }
+    
+    // System Heat Integration for the massive thermal output of capital-class magnetics
+    @MODULE[ModuleSystemHeatProduction]:NEEDS[SystemHeat]
+    {
+        @heatProduction = 54000 // Demands heavy high-temperature radiator arrays to dissipate thermal waste
+    }
+}
+--------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+Tanks
+
+
+--------------------------------------------------------------------------------------------------------------------------------------------------
+// Realism Overhaul configuration for Far Future Technologies 7.5m Antimatter Storage Ring
+@PART[fft-fueltank-antimatter-ring-75-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for interstellar-class capital hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 120.0 // Heavy structural mass due to massive superconducting magnets, vacuum pumps, and emergency backup capacitors
+    @maxTemp = 2000
+    @crashTolerance = 4 // Incredibly fragile; any structural breach results in catastrophic detonation
+    
+    %category = FuelTank
+    
+    // Wipe out stock fuel/resource definitions
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Set up standard RealFuels container or direct resource allocation for Antimatter
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 50000 // Measured in microgram-equivalent units for RO balance
+    }
+    
+    // Active power drain for magnetic confinement. If power fails, antimatter containment degrades.
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorage
+            title = Antimatter Containment Ring
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Magnetic Confinement Field
+                    StartActionName = Engage Confinement Field
+                    StopActionName = Disengage Confinement Field
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 75.0 // Continuous 75 kW power draw to maintain superconducting magnets
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 5m Antimatter Storage Tank Array
+@PART[fft-fueltank-antimatter-tank-5-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced interplanetary hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 42.0 // Heavy shielding matrix, structural bulkheads, and containment circuits
+    @maxTemp = 2200
+    @crashTolerance = 6 // Slightly more rugged than the open ring, but still highly volatile
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Direct resource assignment for RealFuels Antimatter units
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 18000 // Microgram-equivalent volumes balanced for medium capital craft
+    }
+    
+    // Active power drain for the cluster containment matrix
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorageArray
+            title = Antimatter Bottle Array
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Magnetic Containment Grid
+                    StartActionName = Energize Containment Grid
+                    StopActionName = De-energize Containment Grid
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 35.0 // Continuous 35 kW power draw to maintain localized bottle fields
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 5m Compact Antimatter Storage Tank (Short Variant)
+@PART[fft-fueltank-antimatter-tank-5-2]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced interplanetary/probe hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 22.0 // Lower dry mass than the 5-1 variant, but retains heavy magnetic shielding plates
+    @maxTemp = 2200
+    @crashTolerance = 6 // Rugged individual bottle layout provides identical relative impact tolerance
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Direct resource assignment for RealFuels Antimatter units (Proportional to size reduction)
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 9000 // Reduced microgram-equivalent capacity optimized for smaller profiles
+    }
+    
+    // Active power drain scaled down for fewer localized confinement traps
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorageCompact
+            title = Compact Antimatter Bottle Array
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Compact Magnetic Containment Grid
+                    StartActionName = Energize Containment Grid
+                    StopActionName = De-energize Containment Grid
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 18.5 // Continuous 18.5 kW power draw to maintain localized fields
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 5m Spherical Antimatter Storage Tank (Small Variant)
+@PART[fft-fueltank-antimatter-tank-5-3]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced interplanetary/probe hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 11.5 // Highly optimized spherical pressure hull reduces total dry mass while keeping heavy shielding plates
+    @maxTemp = 2200
+    @crashTolerance = 6 // Spherical structural geometry distributes physical stress uniformly
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Direct resource assignment for RealFuels Antimatter units (Scaled for spherical envelope)
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 4500 // Balanced microgram-equivalent capacity optimized for small tactical loads
+    }
+    
+    // Active power drain scaled down for a single localized core trap grid
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorageSpherical
+            title = Spherical Antimatter Bottle Unit
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Spherical Magnetic Containment Grid
+                    StartActionName = Energize Containment Grid
+                    StopActionName = De-energize Containment Grid
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 9.25 // Continuous 9.25 kW power draw to sustain the core trap array
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 5m Mini Antimatter Storage Capsule
+@PART[fft-fueltank-antimatter-tank-5-4]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced interplanetary/probe hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 5.8 // Lightest available footprint, optimized for localized micro-trap shielding
+    @maxTemp = 2200
+    @crashTolerance = 6 // Low profile minimizes cross-sectional exposure to impacts
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Direct resource assignment for RealFuels Antimatter units (Minimal capacity footprint)
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 2250 // Miniature microgram-equivalent capacity perfect for torch ignition charges
+    }
+    
+    // Active power drain scaled down to the absolute minimum required for baseline containment
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorageMini
+            title = Miniature Antimatter Capsule
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Miniature Magnetic Containment Grid
+                    StartActionName = Energize Containment Grid
+                    StopActionName = De-energize Containment Grid
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 4.625 // Continuous 4.625 kW power draw to maintain localized micro-fields
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 5m Compact Pellets Tank (Short Variant)
+@PART[fft-fueltank-targets-5-2]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for advanced interplanetary hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 14.5 // Solid structural frames, interior sorting channels, and automated feed tracks
+    @maxTemp = 2400
+    @crashTolerance = 12 // Rugged design protects internal solid target payloads from high-g impacts
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource definitions
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Implement B9PartSwitch for swapping between Fission and Fusion target payloads
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = targetSwitch
+        switcherDescription = Target Core Payload
+        baseVolume = 24000 // Scaled volumetric capacity baseline for RO proportions
+        
+        SUBTYPE
+        {
+            name = FusionPellets
+            title = Fusion Pellets Array
+            descriptionSummary = Advanced D-He3/DT pellet targets for thermonuclear microfusion drives.
+            
+            TANK_RESOURCE
+            {
+                name = FusionPellets
+                amount = 24000
+                maxAmount = 24000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = FissionPellets
+            title = Fission Pellets Array
+            descriptionSummary = Sub-critical fission target cores designed for catalyzed microfission torch systems.
+            
+            TANK_RESOURCE
+            {
+                name = FissionPellets
+                amount = 24000
+                maxAmount = 24000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = SplitTargets
+            title = Hybrid Target Matrix (50/50)
+            descriptionSummary = Split storage payload configuration for vessels hosting multiple engine architectures.
+            
+            TANK_RESOURCE
+            {
+                name = FusionPellets
+                amount = 12000
+                maxAmount = 12000
+            }
+            TANK_RESOURCE
+            {
+                name = FissionPellets
+                amount = 12000
+                maxAmount = 12000
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 2.5m Antimatter Storage Tank
+@PART[fft-fueltank-antimatter-tank-25-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary/heavy-probe hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 9.8 // Lightweight titanium-composite matrix with optimized internal magnetic shielding
+    @maxTemp = 2200
+    @crashTolerance = 5 // Slightly more delicate due to thinner structural buffer walls
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Direct resource assignment for RealFuels Antimatter units
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 3500 // Microgram-equivalent capacity optimized for medium cruise craft
+    }
+    
+    // Active power drain for the medium-class containment field
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorageMedium
+            title = Medium Antimatter Containment Unit
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Localized Magnetic Containment Grid
+                    StartActionName = Energize Containment Grid
+                    StopActionName = De-energize Containment Grid
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 7.5 // Continuous 7.5 kW power draw to sustain the internal bottle fields
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 2.5m Compact Antimatter Storage Tank (Short Variant)
+@PART[fft-fueltank-antimatter-tank-25-2]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary/heavy-probe hulls
+    %rescaleFactor = 1.6
+    
+    @mass = 5.2 // Minimal dry mass while maintaining core internal vacuum systems and magnetic shielding
+    @maxTemp = 2200
+    @crashTolerance = 5 // Standard delicate containment matrix limits
+    
+    %category = FuelTank
+    
+    // Purge stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Direct resource assignment for RealFuels Antimatter units (Proportional to volume reduction)
+    RESOURCE
+    {
+        name = Antimatter
+        amount = 0
+        maxAmount = 1750 // Halved microgram-equivalent capacity compared to the 25-1 model
+    }
+    
+    // Active power drain for the compact confinement loop
+    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelSwitch]]
+    {
+        !SUBTYPE,* {}
+        
+        SUBTYPE
+        {
+            name = AntimatterStorageMediumShort
+            title = Compact Medium Antimatter Containment Unit
+            tankType = Structural
+            
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleResourceConverter
+                }
+                DATA
+                {
+                    ConverterName = Compact Magnetic Containment Grid
+                    StartActionName = Energize Containment Grid
+                    StopActionName = De-energize Containment Grid
+                    
+                    INPUT_RESOURCE
+                    {
+                        ResourceName = ElectricCharge
+                        Rate = 3.75 // Continuous 3.75 kW power draw to maintain the magnetic field
+                    }
+                }
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 10m Fusion Propellant Tank
+@PART[fft-fueltank-fusion-10-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for colossal interstellar hulls (10m -> 16m)
+    %rescaleFactor = 1.6
+    
+    @mass = 68.0 // Massive multi-layered vacuum insulation blankets, micrometeorite shielding panels, and cryo-cooler frameworks
+    @maxTemp = 2000
+    @crashTolerance = 8
+    
+    %category = FuelTank
+    
+    // Completely wipe out stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Configure B9PartSwitch to select raw cryogenic fusion fuel cycles
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Fusion Propellant Cycle
+        baseVolume = 480000 // Massive structural volume for long-burn missions
+        
+        SUBTYPE
+        {
+            name = DeuteriumHe3
+            title = D-3He Cycle (Aneutronic)
+            descriptionSummary = Optimized 50/50 mix of Liquid Deuterium and Liquid Helium-3 for clean, high-efficiency steady-state magnetic confinement engines.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 240000
+                maxAmount = 240000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 240000
+                maxAmount = 240000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = DeuteriumTritium
+            title = D-T Cycle (High-Thrust)
+            descriptionSummary = Blended mixture of Liquid Deuterium and Liquid Tritium for high-energy pulsed plasma systems like Z-Pinch networks.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 240000
+                maxAmount = 240000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdTritium
+                amount = 240000
+                maxAmount = 240000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = PureDeuterium
+            title = Pure LqdDeuterium
+            descriptionSummary = Dedicated cargo storage configuration for raw Liquid Deuterium.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 480000
+                maxAmount = 480000
+            }
+        }
+
+        SUBTYPE
+        {
+            name = PureHe3
+            title = Pure LqdHe3
+            descriptionSummary = High-value specialized cargo configuration for Liquid Helium-3.
+            
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 480000
+                maxAmount = 480000
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 2.5m Fusion Propellant Tank
+@PART[fft-fueltank-fusion-25-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary/probe hulls (2.5m -> 4m)
+    %rescaleFactor = 1.6
+    
+    @mass = 1.95 // Scaled dry mass reflecting multi-layered micro-meteorite shields and integrated cryogenic coolers
+    @maxTemp = 2000
+    @crashTolerance = 8
+    
+    %category = FuelTank
+    
+    // Completely wipe out stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Configure B9PartSwitch to select raw cryogenic fusion fuel cycles
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Fusion Propellant Cycle
+        baseVolume = 12500 // Volumetric capacity optimized for 4m spherical RO dimensions
+        
+        SUBTYPE
+        {
+            name = DeuteriumHe3
+            title = D-3He Cycle (Aneutronic)
+            descriptionSummary = Optimized 50/50 mix of Liquid Deuterium and Liquid Helium-3 for clean, high-efficiency steady-state magnetic confinement engines.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 6250
+                maxAmount = 6250
+            }
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 6250
+                maxAmount = 6250
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = DeuteriumTritium
+            title = D-T Cycle (High-Thrust)
+            descriptionSummary = Blended mixture of Liquid Deuterium and Liquid Tritium for high-energy pulsed plasma systems like Z-Pinch networks.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 6250
+                maxAmount = 6250
+            }
+            TANK_RESOURCE
+            {
+                name = LqdTritium
+                amount = 6250
+                maxAmount = 6250
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = PureDeuterium
+            title = Pure LqdDeuterium
+            descriptionSummary = Dedicated cargo storage configuration for raw Liquid Deuterium.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 12500
+                maxAmount = 12500
+            }
+        }
+
+        SUBTYPE
+        {
+            name = PureHe3
+            title = Pure LqdHe3
+            descriptionSummary = High-value specialized cargo configuration for Liquid Helium-3.
+            
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 12500
+                maxAmount = 12500
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 2.5m Inline Fusion Propellant Tank
+@PART[fft-fueltank-fusion-25-2]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary/probe hulls (2.5m -> 4m)
+    %rescaleFactor = 1.6
+    
+    @mass = 3.6 // Slightly heavier dry mass than the spherical variant due to cylindrical wall surface area and internal bracing
+    @maxTemp = 2000
+    @crashTolerance = 8
+    
+    %category = FuelTank
+    
+    // Completely wipe out stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Configure B9PartSwitch to select raw cryogenic fusion fuel cycles
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Fusion Propellant Cycle
+        baseVolume = 26000 // Higher volumetric capacity due to elongated cylindrical geometry
+        
+        SUBTYPE
+        {
+            name = DeuteriumHe3
+            title = D-3He Cycle (Aneutronic)
+            descriptionSummary = Optimized 50/50 mix of Liquid Deuterium and Liquid Helium-3 for clean, high-efficiency steady-state magnetic confinement engines.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 13000
+                maxAmount = 13000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 13000
+                maxAmount = 13000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = DeuteriumTritium
+            title = D-T Cycle (High-Thrust)
+            descriptionSummary = Blended mixture of Liquid Deuterium and Liquid Tritium for high-energy pulsed plasma systems like Z-Pinch networks.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 13000
+                maxAmount = 13000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdTritium
+                amount = 13000
+                maxAmount = 13000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = PureDeuterium
+            title = Pure LqdDeuterium
+            descriptionSummary = Dedicated cargo storage configuration for raw Liquid Deuterium.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 26000
+                maxAmount = 26000
+            }
+        }
+
+        SUBTYPE
+        {
+            name = PureHe3
+            title = Pure LqdHe3
+            descriptionSummary = High-value specialized cargo configuration for Liquid Helium-3.
+            
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 26000
+                maxAmount = 26000
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 3.75m Fusion Propellant Tank
+@PART[fft-fueltank-fusion-375-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary/capital hulls (3.75m -> 6m)
+    %rescaleFactor = 1.6
+    
+    @mass = 7.20 // Balanced dry mass reflecting multi-layered vacuum insulation panels, heavy structural ribs, and integrated cryo-coolers
+    @maxTemp = 2000
+    @crashTolerance = 8
+    
+    %category = FuelTank
+    
+    // Completely wipe out stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Configure B9PartSwitch to select raw cryogenic fusion fuel cycles
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Fusion Propellant Cycle
+        baseVolume = 46000 // Optimized volumetric capacity for 6m spherical RO dimensions
+        
+        SUBTYPE
+        {
+            name = DeuteriumHe3
+            title = D-3He Cycle (Aneutronic)
+            descriptionSummary = Optimized 50/50 mix of Liquid Deuterium and Liquid Helium-3 for clean, high-efficiency steady-state magnetic confinement engines.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 23000
+                maxAmount = 23000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 23000
+                maxAmount = 23000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = DeuteriumTritium
+            title = D-T Cycle (High-Thrust)
+            descriptionSummary = Blended mixture of Liquid Deuterium and Liquid Tritium for high-energy pulsed plasma systems like Z-Pinch networks.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 23000
+                maxAmount = 23000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdTritium
+                amount = 23000
+                maxAmount = 23000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = PureDeuterium
+            title = Pure LqdDeuterium
+            descriptionSummary = Dedicated cargo storage configuration for raw Liquid Deuterium.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 46000
+                maxAmount = 46000
+            }
+        }
+
+        SUBTYPE
+        {
+            name = PureHe3
+            title = Pure LqdHe3
+            descriptionSummary = High-value specialized cargo configuration for Liquid Helium-3.
+            
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 46000
+                maxAmount = 46000
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 3.75m Cylindrical Fusion Propellant Tank
+@PART[fft-fueltank-fusion-375-2]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for standard interplanetary/capital hulls (3.75m -> 6m)
+    %rescaleFactor = 1.6
+    
+    @mass = 13.80 // Heavy internal anti-slosh baffling and longitudinal support trusses for high axial G-loading
+    @maxTemp = 2000
+    @crashTolerance = 10 // Reinforced stringers provide higher impact tolerance than pure spheres
+    
+    %category = FuelTank
+    
+    // Completely wipe out stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Configure B9PartSwitch to select raw cryogenic fusion fuel cycles
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Fusion Propellant Cycle
+        baseVolume = 88000 // Heavily expanded volumetric envelope compared to the 3.75m sphere
+        
+        SUBTYPE
+        {
+            name = DeuteriumHe3
+            title = D-3He Cycle (Aneutronic)
+            descriptionSummary = Optimized 50/50 mix of Liquid Deuterium and Liquid Helium-3 for clean, high-efficiency steady-state magnetic confinement engines.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 44000
+                maxAmount = 44000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 44000
+                maxAmount = 44000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = DeuteriumTritium
+            title = D-T Cycle (High-Thrust)
+            descriptionSummary = Blended mixture of Liquid Deuterium and Liquid Tritium for high-energy pulsed plasma systems like Z-Pinch networks.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 44000
+                maxAmount = 44000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdTritium
+                amount = 44000
+                maxAmount = 44000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = PureDeuterium
+            title = Pure LqdDeuterium
+            descriptionSummary = Dedicated cargo storage configuration for raw Liquid Deuterium.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 88000
+                maxAmount = 88000
+            }
+        }
+
+        SUBTYPE
+        {
+            name = PureHe3
+            title = Pure LqdHe3
+            descriptionSummary = High-value specialized cargo configuration for Liquid Helium-3.
+            
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 88000
+                maxAmount = 88000
+            }
+        }
+    }
+}
+// Realism Overhaul configuration for Far Future Technologies 5m Fusion Propellant Tank
+@PART[fft-fueltank-fusion-5-1]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Rescale to match 1.6x baseline for heavy capital hulls (5m -> 8m)
+    %rescaleFactor = 1.6
+    
+    @mass = 16.50 // Balanced dry mass reflecting heavy multi-layered insulation arrays, reinforcement stringers, and automated internal cryo-stills
+    @maxTemp = 2000
+    @crashTolerance = 8
+    
+    %category = FuelTank
+    
+    // Completely wipe out stock fuel and resource settings
+    !RESOURCE[*] {}
+    !MODULE[ModuleRealFuels],* {}
+    
+    // Configure B9PartSwitch to select raw cryogenic fusion fuel cycles
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Fusion Propellant Cycle
+        baseVolume = 110000 // Volumetric capacity optimized for 8m spherical RO dimensions
+        
+        SUBTYPE
+        {
+            name = DeuteriumHe3
+            title = D-3He Cycle (Aneutronic)
+            descriptionSummary = Optimized 50/50 mix of Liquid Deuterium and Liquid Helium-3 for clean, high-efficiency steady-state magnetic confinement engines.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 55000
+                maxAmount = 55000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 55000
+                maxAmount = 55000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = DeuteriumTritium
+            title = D-T Cycle (High-Thrust)
+            descriptionSummary = Blended mixture of Liquid Deuterium and Liquid Tritium for high-energy pulsed plasma systems like Z-Pinch networks.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 55000
+                maxAmount = 55000
+            }
+            TANK_RESOURCE
+            {
+                name = LqdTritium
+                amount = 55000
+                maxAmount = 55000
+            }
+        }
+        
+        SUBTYPE
+        {
+            name = PureDeuterium
+            title = Pure LqdDeuterium
+            descriptionSummary = Dedicated cargo storage configuration for raw Liquid Deuterium.
+            
+            TANK_RESOURCE
+            {
+                name = LqdDeuterium
+                amount = 110000
+                maxAmount = 110000
+            }
+        }
+
+        SUBTYPE
+        {
+            name = PureHe3
+            title = Pure LqdHe3
+            descriptionSummary = High-value specialized cargo configuration for Liquid Helium-3.
+            
+            TANK_RESOURCE
+            {
+                name = LqdHe3
+                amount = 110000
+                maxAmount = 110000
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerbalAtomics/KerbalAtomics.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerbalAtomics/KerbalAtomics.cfg
@@ -107,3 +107,207 @@
 	}
 	%rescaleFactor = 3.0
 }
+
+@PART[ntr-gc-25-2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    !MODULE[ModuleEngineConfigs] {}
+    
+    // Scale the part to realistic structural dimensions if necessary
+    // %rescaleFactor = 1.6 // Uncomment if scaling from 2.5m to ~4m standard
+    
+    @title = Open-Cycle Gas-Core Nuclear Thermal Rocket (2.5m)
+    @manufacturer = Generic RO Aerospace
+    @description = A high-thrust, ultra-high efficiency open-cycle gas-core nuclear thermal rocket engine. It uses gaseous uranium to heat liquid hydrogen propellant to extreme temperatures, achieving immense specific impulse at the cost of slight radioactive exhaust.
+    
+    @mass = 12.5
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 3600
+    
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 150
+        @maxThrust = 450
+        @heatProduction = 250
+        
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = lqdHydrogen
+            @ratio = 1.0
+        }
+        !PROPELLANT[Oxidizer] {}
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 2700
+            @key,1 = 1 1100
+        }
+    }
+    
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = GasCoreNTR-25
+        modded = false
+        origMass = 12.5
+        
+        CONFIG
+        {
+            name = GasCoreNTR-25
+            minThrust = 150
+            maxThrust = 450
+            heatProduction = 250
+            
+            PROPELLANT
+            {
+                name = lqdHydrogen
+                ratio = 1.0
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 2700
+                key = 1 1100
+            }
+        }
+    }
+}
+
+
+@PART[ntr-gc-25-3]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    !MODULE[ModuleEngineConfigs] {}
+    
+    @title = Advanced Gas-Core Nuclear Thermal Rocket (2.5m)
+    @manufacturer = Generic RO Aerospace
+    @description = A cutting-edge 2.5m gas-core nuclear rocket engine optimized for heavy interplanetary transfer stages. Offering a devastating combination of high thrust and phenomenal specific impulse, it represents the pinnacle of thermal nuclear propulsion.
+    @mass = 14.2
+    @crashTolerance = 12
+    %breakingForce = 250
+    %breakingTorque = 250
+    @maxTemp = 3800
+    
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 200
+        @maxThrust = 600
+        @heatProduction = 280
+        
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = lqdHydrogen
+            @ratio = 1.0
+        }
+        !PROPELLANT[Oxidizer] {}
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 2850
+            @key,1 = 1 1050
+        }
+    }
+    
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = GasCoreNTR-25-3
+        modded = false
+        origMass = 14.2
+        
+        CONFIG
+        {
+            name = GasCoreNTR-25-3
+            minThrust = 200
+            maxThrust = 600
+            heatProduction = 280
+            
+            PROPELLANT
+            {
+                name = lqdHydrogen
+                ratio = 1.0
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 2850
+                key = 1 1050
+            }
+        }
+    }
+}
+
+@PART[ntr-sc-375-1]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    !MODULE[ModuleEngineConfigs] {}
+    
+    @title = Scylla Heavy Solid-Core Nuclear Thermal Rocket (3.75m)
+    @manufacturer = Generic RO Aerospace
+    @description = A massive 3.75m solid-core nuclear thermal rocket designed for primary interplanetary propulsion. By passing liquid hydrogen through a high-temperature nuclear reactor core, it delivers incredible vacuum efficiency and sustained high thrust for deep space missions.
+    
+    @mass = 18.5
+    @crashTolerance = 12
+    %breakingForce = 350
+    %breakingTorque = 350
+    @maxTemp = 3200
+    
+    @MODULE[ModuleEngines*]
+    {
+        @minThrust = 250
+        @maxThrust = 750
+        @heatProduction = 300
+        
+        @PROPELLANT[LiquidFuel]
+        {
+            @name = lqdHydrogen
+            @ratio = 1.0
+        }
+        !PROPELLANT[Oxidizer] {}
+        
+        @atmosphereCurve
+        {
+            @key,0 = 0 925
+            @key,1 = 1 450
+        }
+    }
+    
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = Scylla-NTR-375
+        modded = false
+        origMass = 18.5
+        
+        CONFIG
+        {
+            name = Scylla-NTR-375
+            minThrust = 250
+            maxThrust = 750
+            heatProduction = 300
+            
+            PROPELLANT
+            {
+                name = lqdHydrogen
+                ratio = 1.0
+                DrawGauge = True
+            }
+            
+            atmosphereCurve
+            {
+                key = 0 925
+                key = 1 450
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Electrical_Nuclear.cfg
@@ -1,5 +1,5 @@
 // Nuclear Fuel/Recycler Parts
-@PART[nuclearfuel-25]:FOR[RealismOverhaul]
+@PART[nfe-nuclearfuel-25-1]:FOR[RealismOverhaul]
 {
 	@RESOURCE[EnrichedUranium]
 	{
@@ -7,7 +7,7 @@
 		@maxAmount = 1000
 	}
 }
-@PART[nuclearfuel-125]:FOR[RealismOverhaul]
+@PART[nfe-nuclearfuel-125-1]:FOR[RealismOverhaul]
 {
 	@RESOURCE[EnrichedUranium]
 	{
@@ -15,7 +15,7 @@
 		@maxAmount = 400
 	}
 }
-@PART[nuclearfuel-0625]:FOR[RealismOverhaul]
+@PART[nfe-nuclearfuel-0625-1]:FOR[RealismOverhaul]
 {
 	@RESOURCE[EnrichedUranium]
 	{
@@ -23,7 +23,7 @@
 		@maxAmount = 100
 	}
 }
-@PART[nuclear-recycler-25]:FOR[RealismOverhaul]
+@PART[nfe-nuclear-recycler-25-1]:FOR[RealismOverhaul]
 {
 	@RESOURCE[EnrichedUranium]
 	{
@@ -31,7 +31,7 @@
 		@maxAmount = 100
 	}
 }
-@PART[nuclearfuel-25|nuclearfuel-125|nuclearfuel-0625|nuclear-recycler-25]:FOR[RealismOverhaul]
+@PART[nfe-nuclearfuel-25-1|nfe-nuclearfuel-125-1|nfe-nuclearfuel-0625-1|nfe-nuclear-recycler-25-1]:FOR[RealismOverhaul]
 {
 	%RSSROConfig = True
 	@MODULE[TweakScale]
@@ -51,7 +51,7 @@
 		maxAmount = #$../RESOURCE[EnrichedUranium]/maxAmount$
 	}
 }
-@PART[nuclear-recycler-25]:FOR[RealismOverhaul]
+@PART[nfe-nuclear-recycler-25-1]:FOR[RealismOverhaul]
 {
 	!MODULE[TweakScale]	{}
 	@attachRules = 1,0,1,0,0

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyPhotonDrives/SillyPhotonDrives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyPhotonDrives/SillyPhotonDrives.cfg
@@ -1,0 +1,159 @@
+// Realism Overhaul config for Silly Photon Drives 0.625m Engine
+@PART[spd-Photon-625]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Title and description updates for realism context
+    @title = Directed Photon Thruster (0.625m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A highly advanced, theoretical propulsion system that utilizes ultra-high-intensity laser diodes to generate thrust directly from momentum transfer of photons. Requires massive electrical power from an onboard nuclear reactor or beamed power network. Incredible efficiency, near-zero thrust.
+    
+    // Scale and physical dimensions (0.625m fits standard small probe envelopes)
+    @mass = 0.15 // 150 kg for the laser emitter arrays and cooling geometry
+    @crashTolerance = 10
+    @maxTemp = 1473
+    %skinMaxTemp = 1473
+    
+    // Remove vanilla engine module and redefine with RO specs
+    !MODULE[ModuleEngines*],* {}
+    
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        exhaustDamage = False
+        ignitionThreshold = 0.1
+        minThrust = 0.00001 // 0.01 mN minimum throttling
+        maxThrust = 0.00001 // 10 mN maximum thrust (0.01 kN)
+        heatProduction = 150 // Generates severe thermal waste
+        
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            DrawGauge = True
+        }
+        
+        ATMOSPHERE_CURVE
+        {
+            key = 0 30591486 // Physical limit of photon propulsive efficiency (c / g0)
+            key = 1 0        // Photons completely scattered in atmosphere
+        }
+    }
+    
+    // Configure massive electrical consumption (1.5 MW = 1500 EC/s in RO)
+    @MODULE[ModuleEnginesRF]
+    {
+        @PROPELLANT[ElectricCharge]
+        {
+            // 1 EC/s in RO = 1 kW. 1500 kW = 1.5 MW.
+            %rate = 1500.0 
+        }
+    }
+}
+
+// Realism Overhaul config for Silly Photon Drives 1.25m Engine
+@PART[spd-Photon-125]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    @title = Directed Photon Thruster (1.25m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A heavy-duty, multi-megawatt theoretical propulsion system utilizing a dense array of high-intensity laser emitters. Designed for mid-sized deep-space exploration craft. It requires massive, dedicated power infrastructure—such as high-output fission or fusion reactors—to achieve usable acceleration.
+    
+    // Scale and physical dimensions (1.25m standard sizing)
+    @mass = 1.2 // 1.2 metric tons (1200 kg) for massive diode arrays, optics, and heavy-duty radiators
+    @crashTolerance = 10
+    @maxTemp = 1473
+    %skinMaxTemp = 1473
+    
+    // Remove vanilla engine module and redefine with RO specs
+    !MODULE[ModuleEngines*],* {}
+    
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        exhaustDamage = False
+        ignitionThreshold = 0.1
+        minThrust = 0.0001 // 0.1 mN minimum throttling
+        maxThrust = 0.0001 // 100 mN maximum thrust (0.0001 kN)
+        heatProduction = 800 // High thermal dissipation requirement
+        
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            DrawGauge = True
+        }
+        
+        ATMOSPHERE_CURVE
+        {
+            key = 0 30591486 // Infinite propulsive efficiency in vacuum (c / g0)
+            key = 1 0        // Photons completely scattered in atmosphere
+        }
+    }
+    
+    // Configure massive electrical consumption (15 MW = 15000 EC/s in RO)
+    @MODULE[ModuleEnginesRF]
+    {
+        @PROPELLANT[ElectricCharge]
+        {
+            // 1 EC/s in RO = 1 kW. 15,000 kW = 15 MW.
+            %rate = 15000.0 
+        }
+    }
+}
+
+// Realism Overhaul config for Silly Photon Drives 5.0m Engine
+@PART[spd-Photon-5]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    @title = Directed Photon Thruster (5.0m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = An industrial-scale, gigawatt-class photon propulsion array housed in a massive 5-meter chassis. Designed exclusively for interplanetary colony transports and interstellar motherships. The electrical requirements are astronomical, demanding multi-gigawatt power grids (such as high-output fusion reactors or dedicated orbital beamed-energy arrays) just to fire.
+    
+    // Scale and physical dimensions (5.0m mammoth engine core)
+    @mass = 48.0 // 48 metric tons for immense laser diode banks, superconducting power lines, and titanic radiators
+    @crashTolerance = 12
+    @maxTemp = 1673 // Enhanced thermal tolerance for massive power throughput
+    %skinMaxTemp = 1673
+    
+    // Remove vanilla engine module and redefine with RO specs
+    !MODULE[ModuleEngines*],* {}
+    
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        exhaustDamage = False
+        ignitionThreshold = 0.1
+        minThrust = 0.001 // 10 mN minimum throttling
+        maxThrust = 0.016 // 16 Newtons maximum thrust (0.016 kN)
+        heatProduction = 3500 // Generates extreme, catastrophic waste heat
+        
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            DrawGauge = True
+        }
+        
+        ATMOSPHERE_CURVE
+        {
+            key = 0 30591486 // Infinite propulsive efficiency in vacuum (c / g0)
+            key = 1 0        // Photons completely scattered in atmosphere
+        }
+    }
+    
+    // Configure massive electrical consumption (2.4 GW = 2,400,000 EC/s in RO)
+    @MODULE[ModuleEnginesRF]
+    {
+        @PROPELLANT[ElectricCharge]
+        {
+            // 1 EC/s in RO = 1 kW. 2,400,000 kW = 2.4 GW.
+            %rate = 2400000.0 
+        }
+    }
+}


### PR DESCRIPTION
more and more pr come out and probably will come out touching crewed interplanetary programs and i find that the current config of FFT (Far Future Technologies) are a bit lacking this pr main goal it to resolve that but by also setting the table for more pr touching interplanetary travel and habitation using ISRU

in this pr you will find config for:
Far Future Technologies - additional engine and 2 nuclear reactor and ISRU production part
Silly photon drive - Photon drive suite
kerbal atomics - 1 additional NTR and 2 Aerospikes engines
Near future electric - reactivation of nuclear fuel drum and repressor

note
some part had their behavior modified for integration 

