### PR TITLE
Add Silly photon drives config

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -1,0 +1,159 @@
+// Realism Overhaul config for Silly Photon Drives 0.625m Engine
+@PART[spd-Photon-625]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    // Title and description updates for realism context
+    @title = Directed Photon Thruster (0.625m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A highly advanced, theoretical propulsion system that utilizes ultra-high-intensity laser diodes to generate thrust directly from momentum transfer of photons. Requires massive electrical power from an onboard nuclear reactor or beamed power network. Incredible efficiency, near-zero thrust.
+    
+    // Scale and physical dimensions (0.625m fits standard small probe envelopes)
+    @mass = 0.15 // 150 kg for the laser emitter arrays and cooling geometry
+    @crashTolerance = 10
+    @maxTemp = 1473
+    %skinMaxTemp = 1473
+    
+    // Remove vanilla engine module and redefine with RO specs
+    !MODULE[ModuleEngines*],* {}
+    
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        exhaustDamage = False
+        ignitionThreshold = 0.1
+        minThrust = 0.00001 // 0.01 mN minimum throttling
+        maxThrust = 0.00001 // 10 mN maximum thrust (0.01 kN)
+        heatProduction = 150 // Generates severe thermal waste
+        
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            DrawGauge = True
+        }
+        
+        ATMOSPHERE_CURVE
+        {
+            key = 0 30591486 // Physical limit of photon propulsive efficiency (c / g0)
+            key = 1 0        // Photons completely scattered in atmosphere
+        }
+    }
+    
+    // Configure massive electrical consumption (1.5 MW = 1500 EC/s in RO)
+    @MODULE[ModuleEnginesRF]
+    {
+        @PROPELLANT[ElectricCharge]
+        {
+            // 1 EC/s in RO = 1 kW. 1500 kW = 1.5 MW.
+            %rate = 1500.0 
+        }
+    }
+}
+
+// Realism Overhaul config for Silly Photon Drives 1.25m Engine
+@PART[spd-Photon-125]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    @title = Directed Photon Thruster (1.25m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A heavy-duty, multi-megawatt theoretical propulsion system utilizing a dense array of high-intensity laser emitters. Designed for mid-sized deep-space exploration craft. It requires massive, dedicated power infrastructure—such as high-output fission or fusion reactors—to achieve usable acceleration.
+    
+    // Scale and physical dimensions (1.25m standard sizing)
+    @mass = 1.2 // 1.2 metric tons (1200 kg) for massive diode arrays, optics, and heavy-duty radiators
+    @crashTolerance = 10
+    @maxTemp = 1473
+    %skinMaxTemp = 1473
+    
+    // Remove vanilla engine module and redefine with RO specs
+    !MODULE[ModuleEngines*],* {}
+    
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        exhaustDamage = False
+        ignitionThreshold = 0.1
+        minThrust = 0.0001 // 0.1 mN minimum throttling
+        maxThrust = 0.0001 // 100 mN maximum thrust (0.0001 kN)
+        heatProduction = 800 // High thermal dissipation requirement
+        
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            DrawGauge = True
+        }
+        
+        ATMOSPHERE_CURVE
+        {
+            key = 0 30591486 // Infinite propulsive efficiency in vacuum (c / g0)
+            key = 1 0        // Photons completely scattered in atmosphere
+        }
+    }
+    
+    // Configure massive electrical consumption (15 MW = 15000 EC/s in RO)
+    @MODULE[ModuleEnginesRF]
+    {
+        @PROPELLANT[ElectricCharge]
+        {
+            // 1 EC/s in RO = 1 kW. 15,000 kW = 15 MW.
+            %rate = 15000.0 
+        }
+    }
+}
+
+// Realism Overhaul config for Silly Photon Drives 5.0m Engine
+@PART[spd-Photon-5]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    
+    @title = Directed Photon Thruster (5.0m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = An industrial-scale, gigawatt-class photon propulsion array housed in a massive 5-meter chassis. Designed exclusively for interplanetary colony transports and interstellar motherships. The electrical requirements are astronomical, demanding multi-gigawatt power grids (such as high-output fusion reactors or dedicated orbital beamed-energy arrays) just to fire.
+    
+    // Scale and physical dimensions (5.0m mammoth engine core)
+    @mass = 48.0 // 48 metric tons for immense laser diode banks, superconducting power lines, and titanic radiators
+    @crashTolerance = 12
+    @maxTemp = 1673 // Enhanced thermal tolerance for massive power throughput
+    %skinMaxTemp = 1673
+    
+    // Remove vanilla engine module and redefine with RO specs
+    !MODULE[ModuleEngines*],* {}
+    
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        exhaustDamage = False
+        ignitionThreshold = 0.1
+        minThrust = 0.001 // 10 mN minimum throttling
+        maxThrust = 0.016 // 16 Newtons maximum thrust (0.016 kN)
+        heatProduction = 3500 // Generates extreme, catastrophic waste heat
+        
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            DrawGauge = True
+        }
+        
+        ATMOSPHERE_CURVE
+        {
+            key = 0 30591486 // Infinite propulsive efficiency in vacuum (c / g0)
+            key = 1 0        // Photons completely scattered in atmosphere
+        }
+    }
+    
+    // Configure massive electrical consumption (2.4 GW = 2,400,000 EC/s in RO)
+    @MODULE[ModuleEnginesRF]
+    {
+        @PROPELLANT[ElectricCharge]
+        {
+            // 1 EC/s in RO = 1 kW. 2,400,000 kW = 2.4 GW.
+            %rate = 2400000.0 
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -4,10 +4,7 @@
     %RSSROConfig = True
     
     // Title and description updates for realism context
-    @title = Directed Photon Thruster (0.625m)
-    @manufacturer = Advanced Propulsion Concepts Group
-    @description = A highly advanced, theoretical propulsion system that utilizes ultra-high-intensity laser diodes to generate thrust directly from momentum transfer of photons. Requires massive electrical power from an onboard nuclear reactor or beamed power network. Incredible efficiency, near-zero thrust.
-    
+    @title = Directed Photon Thruster (0.625m)    
     // Scale and physical dimensions (0.625m fits standard small probe envelopes)
     @mass = 0.15 // 150 kg for the laser emitter arrays and cooling geometry
     @crashTolerance = 10
@@ -56,11 +53,7 @@
 @PART[spd-Photon-125]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    
     @title = Directed Photon Thruster (1.25m)
-    @manufacturer = Advanced Propulsion Concepts Group
-    @description = A heavy-duty, multi-megawatt theoretical propulsion system utilizing a dense array of high-intensity laser emitters. Designed for mid-sized deep-space exploration craft. It requires massive, dedicated power infrastructure—such as high-output fission or fusion reactors—to achieve usable acceleration.
-    
     // Scale and physical dimensions (1.25m standard sizing)
     @mass = 1.2 // 1.2 metric tons (1200 kg) for massive diode arrays, optics, and heavy-duty radiators
     @crashTolerance = 10
@@ -109,11 +102,7 @@
 @PART[spd-Photon-5]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    
     @title = Directed Photon Thruster (5.0m)
-    @manufacturer = Advanced Propulsion Concepts Group
-    @description = An industrial-scale, gigawatt-class photon propulsion array housed in a massive 5-meter chassis. Designed exclusively for interplanetary colony transports and interstellar motherships. The electrical requirements are astronomical, demanding multi-gigawatt power grids (such as high-output fusion reactors or dedicated orbital beamed-energy arrays) just to fire.
-    
     // Scale and physical dimensions (5.0m mammoth engine core)
     @mass = 48.0 // 48 metric tons for immense laser diode banks, superconducting power lines, and titanic radiators
     @crashTolerance = 12

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -1,265 +1,169 @@
-// Realism Overhaul Config for Silly Photon Drives
-// Properly formatted for RealFuels & RO engine structures
+based on: 
+https://en.wikipedia.org/wiki/Nuclear_photonic_rocket 
+https://en.wikipedia.org/wiki/Photon_rocket 
 
-// ===================================================================
-// PX-01 "Aura" / 0.625m Directed Photon Thruster
-// Mass: 0.15 t | Thrust: 12 mN | Power: 1.8 MW
-// ===================================================================
-@PART[spd_Photon_625]:FOR[RealismOverhaul]
+// NOTE: Photon drives are notoriously tricky—they demand immense power for minimal thrust output, rendering them inefficient compared to other propulsion systems. These configurations reflect that limitation. The "Omega" drive incorporates antimatter based on theoretical interstellar flight concepts. Its parameters have been scaled up to support viable interplanetary transit and continuous-burn interstellar trajectories.
+
+// ----------------------------------------------------------------------------
+// PART: PX-01 "Aura" Photonic Laser Thruster
+// Diameter: 0.625m | Mass: 0.15 t | Max Temp: 1973K / 2273K
+// Power Draw: 55.0 kW (55.0 EC/s)
+// Thrust Output: 0.00000007338 kN (73.38 uN)
+// Specific Impulse: 30,570,323 s
+// ----------------------------------------------------------------------------
+@PART[spd_Photon_625]:NEEDS[RealismOverhaul]
 {
     %RSSROConfig = True
-    %rescaleFactor = 1.0
-    
-    @title = PX-01 "Aura" Directed Photon Thruster (0.625m)
-    @manufacturer = Advanced Propulsion Concepts Group
-    @description = An ultra-compact 0.625m propulsion system utilizing high-intensity laser arrays to generate thrust directly from momentum transfer of photons. Requires substantial electrical power from onboard nuclear or beamed power networks.
-    
-    @mass = 0.15[cite: 2]
-    @crashTolerance = 10
-    @maxTemp = 1473
-    %skinMaxTemp = 1473
-    
-    !MODULE[ModuleEngines*],* {}
-    !MODULE[ModuleEngineConfigs],* {}
-    !MODULE[ModuleGenerator],* {}[cite: 2]
-    !RESOURCE[spd_radiation_pressure] {}[cite: 2]
-    
-    MODULE
+
+    @title = PX-01 "Aura" Photonic Laser Thruster
+    @manufacturer =  General Electrics 
+    @description = A compact 0.625m directional laser thruster emitting beamed coherent photons. Consumes 55 kW of electrical power to generate ~73.38 μN of thrust at absolute photon exhaust speed ($c$).
+
+    @mass = 0.15
+    @maxTemp = 1973
+    @skinMaxTemp = 2273
+
+    @MODULE[ModuleEnginesFX]
     {
-        name = ModuleEnginesRF
-        thrustVectorTransformName = thrustTransform[cite: 2]
-        exhaustDamage = False
-        ignitionThreshold = 0.1[cite: 2]
-        minThrust = 0[cite: 2]
-        maxThrust = 0.000012 // 12 mN
-        heatProduction = 0[cite: 2]
-        
-        PROPELLANT
+        @minThrust = 0
+        @maxThrust = 0.00000007338 // 73.38 uN in kN
+        @heatProduction = 0
+
+        @PROPELLANT[ElectricCharge]
         {
-            name = ElectricCharge
-            ratio = 1.0
-            DrawGauge = True[cite: 2]
+            @ratio = 55.0 // 55 kW power draw
         }
-        
-        ATMOSPHERE_CURVE
+        @PROPELLANT[spd_radiation_pressure]
         {
-            key = 0 30570323[cite: 2]
-            key = 1 0
+            @ratio = 0.004427305
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 30570323
         }
     }
-    
-    MODULE
+
+    %ENGINE_SETTINGS
     {
-        name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        techLevel = 7
-        origTechLevel = 7
-        engineType = E // Electric Propulsion
-        configuration = PX-01-Aura
-        modded = false
-        
-        CONFIG
-        {
-            name = PX-01-Aura
-            minThrust = 0[cite: 2]
-            maxThrust = 0.000012 // 12 mN
-            heatProduction = 0[cite: 2]
-            
-            PROPELLANT
-            {
-                name = ElectricCharge
-                ratio = 1.0
-                DrawGauge = True[cite: 2]
-            }
-            
-            // 1,800 EC/s = 1.8 MW power draw
-            %SUBNODE[PROPELLANT[ElectricCharge]]
-            {
-                %rate = 1800.0
-            }
-            
-            ATMOSPHERE_CURVE
-            {
-                key = 0 30570323[cite: 2]
-                key = 1 0
-            }
-        }
+        %EngineType = Electric
     }
 }
 
 
-// ===================================================================
-// PX-02 "Zenith" / 1.25m Directed Photon Thruster
-// Mass: 0.6 t | Thrust: 140 mN | Power: 21 MW
-// ===================================================================
-@PART[spd_Photon_125]:FOR[RealismOverhaul]
+// ----------------------------------------------------------------------------
+// PART: PX-02 "Zenith" Photonic Laser Thruster
+// Diameter: 1.25m | Mass: 0.60 t | Max Temp: 1973K / 2273K
+// Power Draw: 190.0 kW (190.0 EC/s)
+// Thrust Output: 0.00000031688 kN (316.88 uN)
+// Specific Impulse: 30,570,323 s
+// ----------------------------------------------------------------------------
+@PART[spd_Photon_125]:NEEDS[RealismOverhaul]
 {
     %RSSROConfig = True
-    %rescaleFactor = 1.0
-    
-    @title = PX-02 "Zenith" Directed Photon Thruster (1.25m)
-    @manufacturer = Advanced Propulsion Concepts Group
-    @description = A multi-megawatt propulsion unit utilizing a dense grid of solid-state photon emitters. Fits standard 1.25m craft stacks and features switchable mounting frames.
-    
-    @mass = 0.6[cite: 1]
-    @crashTolerance = 10
-    @maxTemp = 1473
-    %skinMaxTemp = 1473
-    
-    // Purge stock engines, generator, and custom dummy resources
-    !MODULE[ModuleEngines*],* {}
-    !MODULE[ModuleEngineConfigs],* {}
-    !MODULE[ModuleGenerator],* {}[cite: 1]
-    !RESOURCE[spd_radiation_pressure] {}[cite: 1]
-    
-    MODULE
+
+    @title = PX-02 "Zenith" Photonic Laser Thruster
+    @manufacturer = General Electrics 
+    @description = A medium 1.25m photonic propulsion unit. Operates at 50% optical efficiency, converting 190 kW of electrical power into 95 kW of thrust power (~316.88 μN of thrust).
+
+    @mass = 0.60
+    @maxTemp = 1973
+    @skinMaxTemp = 2273
+
+    @MODULE[ModuleEnginesFX]
     {
-        name = ModuleEnginesRF
-        thrustVectorTransformName = thrustTransform[cite: 1]
-        exhaustDamage = False
-        ignitionThreshold = 0.1[cite: 1]
-        minThrust = 0[cite: 1]
-        maxThrust = 0.00014 // 140 mN
-        heatProduction = 0[cite: 1]
-        
-        PROPELLANT
+        @minThrust = 0
+        @maxThrust = 0.00000031688 // 316.88 uN in kN
+        @heatProduction = 0
+
+        @PROPELLANT[ElectricCharge]
         {
-            name = ElectricCharge
-            ratio = 1.0
-            DrawGauge = True[cite: 1]
+            @ratio = 190.0 // 190 kW power draw
         }
-        
-        ATMOSPHERE_CURVE
+        @PROPELLANT[spd_radiation_pressure]
         {
-            key = 0 30570323[cite: 1]
-            key = 1 0
+            @ratio = 0.005565254
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 30570323
         }
     }
-    
-    MODULE
+
+    %ENGINE_SETTINGS
     {
-        name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        techLevel = 7
-        origTechLevel = 7
-        engineType = E // Electric Propulsion
-        configuration = PX-02-Zenith
-        modded = false
-        
-        CONFIG
-        {
-            name = PX-02-Zenith
-            minThrust = 0[cite: 1]
-            maxThrust = 0.00014 // 140 mN
-            heatProduction = 0[cite: 1]
-            
-            PROPELLANT
-            {
-                name = ElectricCharge
-                ratio = 1.0
-                DrawGauge = True[cite: 1]
-            }
-            
-            // 21,000 EC/s = 21 MW power draw
-            %SUBNODE[PROPELLANT[ElectricCharge]]
-            {
-                %rate = 21000.0
-            }
-            
-            ATMOSPHERE_CURVE
-            {
-                key = 0 30570323[cite: 1]
-                key = 1 0
-            }
-        }
+        %EngineType = Electric
     }
 }
 
 
-// ===================================================================
-// PX-10 "Omega" / 5.0m Interstellar Directed Photon Thruster
-// Mass: 13.0 t | Interstellar Thrust: 150 kN | Power: 22.5 TW
-// ===================================================================
-@PART[spd_Photon_5]:FOR[RealismOverhaul]
+// ----------------------------------------------------------------------------
+// PART: PX-10 "Omega" Photonic & Antimatter Drive
+// Diameter: 5.0m | Mass: 13.0 t | Max Temp: 2273K / 2573K
+// Mode 1 (PureEC): 4,950.0 kW (4.95 MW) | 10.898 kN Thrust | Isp: 30,570,323 s
+// Mode 2 (Antimatter): Antimatter/LqdHydrogen | 54.488 kN Thrust | Isp: 30,570,323 s
+// ----------------------------------------------------------------------------
+@PART[spd_Photon_5]:NEEDS[RealismOverhaul]
 {
     %RSSROConfig = True
-    %rescaleFactor = 1.0
-    
-    @title = PX-10 "Omega" Interstellar Photon Thruster (5.0m)
-    @manufacturer = Advanced Propulsion Concepts Group
-    @description = A petawatt-class interstellar propulsion core. Utilizing ultra-dense phased laser arrays and extreme relativistic energy conversion, this 5-meter drive delivers 150 kN of pure photon thrust for starship transit.
-    
+
+    @title = PX-10 "Omega" Photonic & Antimatter Drive
+    @manufacturer = General Electrics 
+    @description = A heavy 5m interstellar photon engine. In pure electrical mode, it draws 4.95 MW to produce ~10.9 mN of thrust. When configured with an antimatter-catalyzed reaction chamber, it outputs up to 16.33 MW of thrust power (~54.5 mN).
+
     @mass = 13.0
-    @crashTolerance = 12
-    @maxTemp = 3200
-    %skinMaxTemp = 3200
-    
-    // Purge stock multi-mode modules, engines, generator, and dummy resources
-    !MODULE[MultiModeEngine],* {}
-    !MODULE[ModuleEngines*],* {}
-    !MODULE[ModuleEngineConfigs],* {}
-    !MODULE[ModuleGenerator],* {}
-    !RESOURCE[spd_radiation_pressure] {}
-    
-    MODULE
+    @maxTemp = 2273
+    @skinMaxTemp = 2573
+
+    // Primary Electric Engine Mode
+    @MODULE[ModuleEnginesFX]:HAS[#engineID[PureEC]]
     {
-        name = ModuleEnginesRF
-        thrustVectorTransformName = thrustTransform
-        exhaustDamage = False
-        ignitionThreshold = 0.1
-        minThrust = 0
-        maxThrust = 150.0 // 150 kN
-        heatProduction = 0
-        
-        PROPELLANT
+        @minThrust = 0
+        @maxThrust = 10.898 
+        @heatProduction = 0
+
+        @PROPELLANT[ElectricCharge]
         {
-            name = ElectricCharge
-            ratio = 1.0
-            DrawGauge = True
+            @ratio = 4950.0 // 4,950 kW (4.95 MW) power draw
         }
-        
-        ATMOSPHERE_CURVE
+        @PROPELLANT[spd_radiation_pressure]
         {
-            key = 0 30570323
-            key = 1 0
+            @ratio = 0.007343801
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 30570323
         }
     }
-    
-    MODULE
+
+    // Secondary Antimatter Gamma-Ray Photon Mode
+    @MODULE[ModuleEnginesFX]:HAS[#engineID[Antimatter]]:NEEDS[CommunityResourcePack]
     {
-        name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        techLevel = 8
-        origTechLevel = 8
-        engineType = E // Electric Propulsion
-        configuration = PX-10-Omega
-        modded = false
-        
-        CONFIG
+        @minThrust = 0
+        @maxThrust = 54.488
+        @heatProduction = 0
+
+        @PROPELLANT[Antimatter]
         {
-            name = PX-10-Omega
-            minThrust = 0
-            maxThrust = 150.0 // 150 kN
-            heatProduction = 0
-            
-            PROPELLANT
-            {
-                name = ElectricCharge
-                ratio = 1.0
-                DrawGauge = True
-            }
-            
-            // 22.5 TW power draw
-            %SUBNODE[PROPELLANT[ElectricCharge]]
-            {
-                %rate = 22500000000.0
-            }
-            
-            ATMOSPHERE_CURVE
-            {
-                key = 0 30570323
-                key = 1 0
-            }
+            @ratio = 1.0
+            %resourceFlowMode = STAGE_PRIORITY_FLOW
         }
+        @PROPELLANT[LqdHydrogen]
+        {
+            @ratio = 1.0
+            %resourceFlowMode = STAGE_PRIORITY_FLOW
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 30570323 // Direct photon emission (c)
+        }
+    }
+
+    %ENGINE_SETTINGS
+    {
+        %EngineType = Electric
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -1,17 +1,19 @@
-// Realism Overhaul config for Silly Photon Drives 0.625m Engine
+General source:
+https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwin4rSzs_SVAxUcrYkEHY7_IU8QFnoECB0QAQ&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FPhoton_rocket&usg=AOvVaw0IUz5QMhfSW8fCxiZwo845&opi=89978449
+
+
+---------------------------------------------------------------------------------------------------
 @PART[spd-Photon-625]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    
-    // Title and description updates for realism context
-    @title = Directed Photon Thruster (0.625m)    
-    // Scale and physical dimensions (0.625m fits standard small probe envelopes)
-    @mass = 0.15 // 150 kg for the laser emitter arrays and cooling geometry
+    @title = Directed Photon Thruster (0.625m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A highly advanced propulsion system that utilizes ultra-high-intensity laser diodes to generate thrust directly from momentum transfer of photons. Requires massive electrical power from an onboard nuclear reactor or beamed power network. High efficiency, low thrust.
+    @mass = 0.15
     @crashTolerance = 10
     @maxTemp = 1473
     %skinMaxTemp = 1473
     
-    // Remove vanilla engine module and redefine with RO specs
     !MODULE[ModuleEngines*],* {}
     
     MODULE
@@ -20,9 +22,9 @@
         thrustVectorTransformName = thrustTransform
         exhaustDamage = False
         ignitionThreshold = 0.1
-        minThrust = 0.00001 // 0.01 mN minimum throttling
-        maxThrust = 0.00001 // 10 mN maximum thrust (0.01 kN)
-        heatProduction = 150 // Generates severe thermal waste
+        minThrust = 0.000012  
+        maxThrust = 0.000012  
+        heatProduction = 180
         
         PROPELLANT
         {
@@ -33,34 +35,31 @@
         
         ATMOSPHERE_CURVE
         {
-            key = 0 30591486 // Physical limit of photon propulsive efficiency (c / g0)
-            key = 1 0        // Photons completely scattered in atmosphere
+            key = 0 30591486
+            key = 1 0
         }
     }
     
-    // Configure massive electrical consumption (1.5 MW = 1500 EC/s in RO)
     @MODULE[ModuleEnginesRF]
     {
         @PROPELLANT[ElectricCharge]
         {
-            // 1 EC/s in RO = 1 kW. 1500 kW = 1.5 MW.
-            %rate = 1500.0 
+            %rate = 1800.0 // 1.8 MW (20% buff)
         }
     }
 }
 
-// Realism Overhaul config for Silly Photon Drives 1.25m Engine
 @PART[spd-Photon-125]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = Directed Photon Thruster (1.25m)
-    // Scale and physical dimensions (1.25m standard sizing)
-    @mass = 1.2 // 1.2 metric tons (1200 kg) for massive diode arrays, optics, and heavy-duty radiators
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A heavy-duty, multi-megawatt theoretical propulsion system utilizing a dense array of high-intensity laser emitters. Designed for mid-sized deep-space exploration craft. Requires dedicated power infrastructure to achieve usable acceleration.
+    @mass = 1.2
     @crashTolerance = 10
     @maxTemp = 1473
     %skinMaxTemp = 1473
     
-    // Remove vanilla engine module and redefine with RO specs
     !MODULE[ModuleEngines*],* {}
     
     MODULE
@@ -69,9 +68,9 @@
         thrustVectorTransformName = thrustTransform
         exhaustDamage = False
         ignitionThreshold = 0.1
-        minThrust = 0.0001 // 0.1 mN minimum throttling
-        maxThrust = 0.0001 // 100 mN maximum thrust (0.0001 kN)
-        heatProduction = 800 // High thermal dissipation requirement
+        minThrust = 0.00014  
+        maxThrust = 0.00014  
+        heatProduction = 1120
         
         PROPELLANT
         {
@@ -82,34 +81,30 @@
         
         ATMOSPHERE_CURVE
         {
-            key = 0 30591486 // Infinite propulsive efficiency in vacuum (c / g0)
-            key = 1 0        // Photons completely scattered in atmosphere
+            key = 0 30591486
+            key = 1 0
         }
     }
     
-    // Configure massive electrical consumption (15 MW = 15000 EC/s in RO)
     @MODULE[ModuleEnginesRF]
     {
         @PROPELLANT[ElectricCharge]
         {
-            // 1 EC/s in RO = 1 kW. 15,000 kW = 15 MW.
-            %rate = 15000.0 
+            %rate = 21000.0 // 21 MW (40% buff)
         }
     }
 }
 
-// Realism Overhaul config for Silly Photon Drives 5.0m Engine
 @PART[spd-Photon-5]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = Directed Photon Thruster (5.0m)
-    // Scale and physical dimensions (5.0m mammoth engine core)
-    @mass = 48.0 // 48 metric tons for immense laser diode banks, superconducting power lines, and titanic radiators
+    @title = Interstellar Directed Photon Thruster Array (5.0m)
+    @manufacturer = Advanced Propulsion Concepts Group
+    @description = A petawatt-class interstellar photon drive. Utilizing ultra-dense phased laser arrays and extreme relativistic energy conversion, this mammoth 5-meter engine produces meaningful kilonewton-scale thrust for interstellar transit. Demands gigawatt to terawatt-level power feeds from advanced antimatter or fusion power networks.
+    @mass = 25.0 // 25 metric tons (lightweight exotic materials & metamaterial mirrors)
     @crashTolerance = 12
-    @maxTemp = 1673 // Enhanced thermal tolerance for massive power throughput
-    %skinMaxTemp = 1673
-    
-    // Remove vanilla engine module and redefine with RO specs
+    @maxTemp = 3200 
+    %skinMaxTemp = 3200    
     !MODULE[ModuleEngines*],* {}
     
     MODULE
@@ -118,9 +113,9 @@
         thrustVectorTransformName = thrustTransform
         exhaustDamage = False
         ignitionThreshold = 0.1
-        minThrust = 0.001 // 10 mN minimum throttling
-        maxThrust = 0.016 // 16 Newtons maximum thrust (0.016 kN)
-        heatProduction = 3500 // Generates extreme, catastrophic waste heat
+        minThrust = 1.0     
+        maxThrust = 150.0   
+        heatProduction = 5000
         
         PROPELLANT
         {
@@ -131,18 +126,16 @@
         
         ATMOSPHERE_CURVE
         {
-            key = 0 30591486 // Infinite propulsive efficiency in vacuum (c / g0)
-            key = 1 0        // Photons completely scattered in atmosphere
+            key = 0 30591486 
+            key = 1 0        
         }
     }
-    
-    // Configure massive electrical consumption (2.4 GW = 2,400,000 EC/s in RO)
     @MODULE[ModuleEnginesRF]
     {
         @PROPELLANT[ElectricCharge]
         {
-            // 1 EC/s in RO = 1 kW. 2,400,000 kW = 2.4 GW.
-            %rate = 2400000.0 
+            // 22.5 TW = 22,500,000,000 EC/s in RO
+            %rate = 22500000000.0 
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -1,111 +1,205 @@
-General source:
-https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwin4rSzs_SVAxUcrYkEHY7_IU8QFnoECB0QAQ&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FPhoton_rocket&usg=AOvVaw0IUz5QMhfSW8fCxiZwo845&opi=89978449
+// Realism Overhaul Config for Silly Photon Drives
+// Properly formatted for RealFuels & RO engine structures
 
-
----------------------------------------------------------------------------------------------------
+// ===================================================================
+// PX-01 "Aura" / 0.625m Directed Photon Thruster
+// Mass: 0.15 t | Thrust: 12 mN | Power: 1.8 MW
+// ===================================================================
 @PART[spd_Photon_625]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = Directed Photon Thruster (0.625m)
+    %rescaleFactor = 1.0
+    
+    @title = PX-01 "Aura" Directed Photon Thruster (0.625m)
     @manufacturer = Advanced Propulsion Concepts Group
-    @description = A highly advanced propulsion system that utilizes ultra-high-intensity laser diodes to generate thrust directly from momentum transfer of photons. Requires massive electrical power from an onboard nuclear reactor or beamed power network. High efficiency, low thrust.
-    @mass = 0.15
+    @description = An ultra-compact 0.625m propulsion system utilizing high-intensity laser arrays to generate thrust directly from momentum transfer of photons. Requires substantial electrical power from onboard nuclear or beamed power networks.
+    
+    @mass = 0.15[cite: 2]
     @crashTolerance = 10
     @maxTemp = 1473
     %skinMaxTemp = 1473
     
     !MODULE[ModuleEngines*],* {}
+    !MODULE[ModuleEngineConfigs],* {}
+    !MODULE[ModuleGenerator],* {}[cite: 2]
+    !RESOURCE[spd_radiation_pressure] {}[cite: 2]
     
     MODULE
     {
         name = ModuleEnginesRF
-        thrustVectorTransformName = thrustTransform
+        thrustVectorTransformName = thrustTransform[cite: 2]
         exhaustDamage = False
-        ignitionThreshold = 0.1
-        minThrust = 0.000012  
-        maxThrust = 0.000012  
-        heatProduction = 180
+        ignitionThreshold = 0.1[cite: 2]
+        minThrust = 0[cite: 2]
+        maxThrust = 0.000012 // 12 mN
+        heatProduction = 0[cite: 2]
         
         PROPELLANT
         {
             name = ElectricCharge
             ratio = 1.0
-            DrawGauge = True
+            DrawGauge = True[cite: 2]
         }
         
         ATMOSPHERE_CURVE
         {
-            key = 0 30591486
+            key = 0 30570323[cite: 2]
             key = 1 0
         }
     }
     
-    @MODULE[ModuleEnginesRF]
+    MODULE
     {
-        @PROPELLANT[ElectricCharge]
+        name = ModuleEngineConfigs
+        type = ModuleEnginesRF
+        techLevel = 7
+        origTechLevel = 7
+        engineType = E // Electric Propulsion
+        configuration = PX-01-Aura
+        modded = false
+        
+        CONFIG
         {
-            %rate = 1800.0 // 1.8 MW (20% buff)
+            name = PX-01-Aura
+            minThrust = 0[cite: 2]
+            maxThrust = 0.000012 // 12 mN
+            heatProduction = 0[cite: 2]
+            
+            PROPELLANT
+            {
+                name = ElectricCharge
+                ratio = 1.0
+                DrawGauge = True[cite: 2]
+            }
+            
+            // 1,800 EC/s = 1.8 MW power draw
+            %SUBNODE[PROPELLANT[ElectricCharge]]
+            {
+                %rate = 1800.0
+            }
+            
+            ATMOSPHERE_CURVE
+            {
+                key = 0 30570323[cite: 2]
+                key = 1 0
+            }
         }
     }
 }
 
+
+// ===================================================================
+// PX-02 "Zenith" / 1.25m Directed Photon Thruster
+// Mass: 0.6 t | Thrust: 140 mN | Power: 21 MW
+// ===================================================================
 @PART[spd_Photon_125]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = Directed Photon Thruster (1.25m)
+    %rescaleFactor = 1.0
+    
+    @title = PX-02 "Zenith" Directed Photon Thruster (1.25m)
     @manufacturer = Advanced Propulsion Concepts Group
-    @description = A heavy-duty, multi-megawatt theoretical propulsion system utilizing a dense array of high-intensity laser emitters. Designed for mid-sized deep-space exploration craft. Requires dedicated power infrastructure to achieve usable acceleration.
-    @mass = 1.2
+    @description = A multi-megawatt propulsion unit utilizing a dense grid of solid-state photon emitters. Fits standard 1.25m craft stacks and features switchable mounting frames.
+    
+    @mass = 0.6[cite: 1]
     @crashTolerance = 10
     @maxTemp = 1473
     %skinMaxTemp = 1473
     
+    // Purge stock engines, generator, and custom dummy resources
     !MODULE[ModuleEngines*],* {}
+    !MODULE[ModuleEngineConfigs],* {}
+    !MODULE[ModuleGenerator],* {}[cite: 1]
+    !RESOURCE[spd_radiation_pressure] {}[cite: 1]
     
     MODULE
     {
         name = ModuleEnginesRF
-        thrustVectorTransformName = thrustTransform
+        thrustVectorTransformName = thrustTransform[cite: 1]
         exhaustDamage = False
-        ignitionThreshold = 0.1
-        minThrust = 0.00014  
-        maxThrust = 0.00014  
-        heatProduction = 1120
+        ignitionThreshold = 0.1[cite: 1]
+        minThrust = 0[cite: 1]
+        maxThrust = 0.00014 // 140 mN
+        heatProduction = 0[cite: 1]
         
         PROPELLANT
         {
             name = ElectricCharge
             ratio = 1.0
-            DrawGauge = True
+            DrawGauge = True[cite: 1]
         }
         
         ATMOSPHERE_CURVE
         {
-            key = 0 30591486
+            key = 0 30570323[cite: 1]
             key = 1 0
         }
     }
     
-    @MODULE[ModuleEnginesRF]
+    MODULE
     {
-        @PROPELLANT[ElectricCharge]
+        name = ModuleEngineConfigs
+        type = ModuleEnginesRF
+        techLevel = 7
+        origTechLevel = 7
+        engineType = E // Electric Propulsion
+        configuration = PX-02-Zenith
+        modded = false
+        
+        CONFIG
         {
-            %rate = 21000.0 // 21 MW (40% buff)
+            name = PX-02-Zenith
+            minThrust = 0[cite: 1]
+            maxThrust = 0.00014 // 140 mN
+            heatProduction = 0[cite: 1]
+            
+            PROPELLANT
+            {
+                name = ElectricCharge
+                ratio = 1.0
+                DrawGauge = True[cite: 1]
+            }
+            
+            // 21,000 EC/s = 21 MW power draw
+            %SUBNODE[PROPELLANT[ElectricCharge]]
+            {
+                %rate = 21000.0
+            }
+            
+            ATMOSPHERE_CURVE
+            {
+                key = 0 30570323[cite: 1]
+                key = 1 0
+            }
         }
     }
 }
 
+
+// ===================================================================
+// PX-10 "Omega" / 5.0m Interstellar Directed Photon Thruster
+// Mass: 13.0 t | Interstellar Thrust: 150 kN | Power: 22.5 TW
+// ===================================================================
 @PART[spd_Photon_5]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    @title = Interstellar Directed Photon Thruster Array (5.0m)
+    %rescaleFactor = 1.0
+    
+    @title = PX-10 "Omega" Interstellar Photon Thruster (5.0m)
     @manufacturer = Advanced Propulsion Concepts Group
-    @description = A petawatt-class interstellar photon drive. Utilizing ultra-dense phased laser arrays and extreme relativistic energy conversion, this mammoth 5-meter engine produces meaningful kilonewton-scale thrust for interstellar transit. Demands gigawatt to terawatt-level power feeds from advanced antimatter or fusion power networks.
-    @mass = 25.0 // 25 metric tons (lightweight exotic materials & metamaterial mirrors)
+    @description = A petawatt-class interstellar propulsion core. Utilizing ultra-dense phased laser arrays and extreme relativistic energy conversion, this 5-meter drive delivers 150 kN of pure photon thrust for starship transit.
+    
+    @mass = 13.0
     @crashTolerance = 12
-    @maxTemp = 3200 
-    %skinMaxTemp = 3200    
+    @maxTemp = 3200
+    %skinMaxTemp = 3200
+    
+    // Purge stock multi-mode modules, engines, generator, and dummy resources
+    !MODULE[MultiModeEngine],* {}
     !MODULE[ModuleEngines*],* {}
+    !MODULE[ModuleEngineConfigs],* {}
+    !MODULE[ModuleGenerator],* {}
+    !RESOURCE[spd_radiation_pressure] {}
     
     MODULE
     {
@@ -113,9 +207,9 @@ https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ve
         thrustVectorTransformName = thrustTransform
         exhaustDamage = False
         ignitionThreshold = 0.1
-        minThrust = 1.0     
-        maxThrust = 150.0   
-        heatProduction = 5000
+        minThrust = 0
+        maxThrust = 150.0 // 150 kN
+        heatProduction = 0
         
         PROPELLANT
         {
@@ -126,16 +220,46 @@ https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ve
         
         ATMOSPHERE_CURVE
         {
-            key = 0 30591486 
-            key = 1 0        
+            key = 0 30570323
+            key = 1 0
         }
     }
-    @MODULE[ModuleEnginesRF]
+    
+    MODULE
     {
-        @PROPELLANT[ElectricCharge]
+        name = ModuleEngineConfigs
+        type = ModuleEnginesRF
+        techLevel = 8
+        origTechLevel = 8
+        engineType = E // Electric Propulsion
+        configuration = PX-10-Omega
+        modded = false
+        
+        CONFIG
         {
-            // 22.5 TW = 22,500,000,000 EC/s in RO
-            %rate = 22500000000.0 
+            name = PX-10-Omega
+            minThrust = 0
+            maxThrust = 150.0 // 150 kN
+            heatProduction = 0
+            
+            PROPELLANT
+            {
+                name = ElectricCharge
+                ratio = 1.0
+                DrawGauge = True
+            }
+            
+            // 22.5 TW power draw
+            %SUBNODE[PROPELLANT[ElectricCharge]]
+            {
+                %rate = 22500000000.0
+            }
+            
+            ATMOSPHERE_CURVE
+            {
+                key = 0 30570323
+                key = 1 0
+            }
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -3,7 +3,7 @@ https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ve
 
 
 ---------------------------------------------------------------------------------------------------
-@PART[spd-Photon-625]:FOR[RealismOverhaul]
+@PART[spd_Photon_625]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = Directed Photon Thruster (0.625m)
@@ -49,7 +49,7 @@ https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ve
     }
 }
 
-@PART[spd-Photon-125]:FOR[RealismOverhaul]
+@PART[spd_Photon_125]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = Directed Photon Thruster (1.25m)
@@ -95,7 +95,7 @@ https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ve
     }
 }
 
-@PART[spd-Photon-5]:FOR[RealismOverhaul]
+@PART[spd_Photon_5]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     @title = Interstellar Directed Photon Thruster Array (5.0m)

--- a/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/SillyphotonDrives/Silly_photon_drives.cfg
@@ -1,15 +1,37 @@
 based on: 
 https://en.wikipedia.org/wiki/Nuclear_photonic_rocket 
 https://en.wikipedia.org/wiki/Photon_rocket 
-
-// NOTE: Photon drives are notoriously tricky—they demand immense power for minimal thrust output, rendering them inefficient compared to other propulsion systems. These configurations reflect that limitation. The "Omega" drive incorporates antimatter based on theoretical interstellar flight concepts. Its parameters have been scaled up to support viable interplanetary transit and continuous-burn interstellar trajectories.
+// ============================================================================
+// a 1/1  source config would modeled these as pure photon rockets (F = P/c),
+// which is physically correct but produces thrust in the tens-to-hundreds
+// of MICRONEWTONS even at multi-MW power — not usable for anything beyond
+// a thought experiment.
+//
+// THE BUFF (explicitly non-canon, for gameplay viability):
+// A hand-waved "coherent beam amplification" factor is applied per engine,
+// paired with a drop in Isp so the power/thrust/Isp relationship
+// (F = 2*eta*P_elec / v_e, v_e = Isp*g0) stays internally consistent
+// instead of just multiplying thrust for free:
+//   - Aura / Zenith: kept as high-Isp precision options (probes, small
+//     craft, station-keeping). ~110x / ~199x thrust buff, Isp down to
+//     900,000s / 400,000s. Power draw unchanged.
+//   - Omega: promoted to an actual interplanetary tug engine. ~1000x
+//     thrust buff, Isp down to 100,000s, and power draw raised from
+//     4.95 MW to 8.22 MW (narratively: a bigger antimatter-fed reactor
+//     feeding it) so the assumed 65% electrical-to-thrust efficiency
+//     stays physically sane rather than requiring free energy again.
+//
+//    Assumed efficiency (eta) in F = 2*eta*P/v_e: 0.65 across the family.
+//
+// 
+// ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
 // PART: PX-01 "Aura" Photonic Laser Thruster
 // Diameter: 0.625m | Mass: 0.15 t | Max Temp: 1973K / 2273K
-// Power Draw: 55.0 kW (55.0 EC/s)
-// Thrust Output: 0.00000007338 kN (73.38 uN)
-// Specific Impulse: 30,570,323 s
+// Power Draw: 55.0 kW (55.0 EC/s) — unchanged
+// Thrust Output: 0.008101 kN (8.101 mN) — ~110x buffed
+// Specific Impulse: 900,000 s
 // ----------------------------------------------------------------------------
 @PART[spd_Photon_625]:NEEDS[RealismOverhaul]
 {
@@ -17,7 +39,7 @@ https://en.wikipedia.org/wiki/Photon_rocket
 
     @title = PX-01 "Aura" Photonic Laser Thruster
     @manufacturer =  General Electrics 
-    @description = A compact 0.625m directional laser thruster emitting beamed coherent photons. Consumes 55 kW of electrical power to generate ~73.38 μN of thrust at absolute photon exhaust speed ($c$).
+    @description = A compact 0.625m directional laser thruster with coherent-beam amplification optics. Consumes 55 kW of electrical power to generate ~8.1 mN of thrust at an effective Isp of 900,000s. High-efficiency, low-thrust option for probes and small-craft station-keeping.
 
     @mass = 0.15
     @maxTemp = 1973
@@ -26,21 +48,21 @@ https://en.wikipedia.org/wiki/Photon_rocket
     @MODULE[ModuleEnginesFX]
     {
         @minThrust = 0
-        @maxThrust = 0.00000007338 // 73.38 uN in kN
+        @maxThrust = 0.008101 
         @heatProduction = 0
 
         @PROPELLANT[ElectricCharge]
         {
-            @ratio = 55.0 // 55 kW power draw
+            @ratio = 55.0 
         }
         @PROPELLANT[spd_radiation_pressure]
         {
-            @ratio = 0.004427305
+            @ratio = 0.48897 // scaled proportionally to thrust buff (~110x) — retune via playtesting
         }
 
         @atmosphereCurve
         {
-            @key,0 = 0 30570323
+            @key,0 = 0 900000
         }
     }
 
@@ -54,9 +76,9 @@ https://en.wikipedia.org/wiki/Photon_rocket
 // ----------------------------------------------------------------------------
 // PART: PX-02 "Zenith" Photonic Laser Thruster
 // Diameter: 1.25m | Mass: 0.60 t | Max Temp: 1973K / 2273K
-// Power Draw: 190.0 kW (190.0 EC/s)
-// Thrust Output: 0.00000031688 kN (316.88 uN)
-// Specific Impulse: 30,570,323 s
+// Power Draw: 190.0 kW (190.0 EC/s) — unchanged
+// Thrust Output: 0.06297 kN (62.97 mN) — ~199x buffed
+// Specific Impulse: 400,000 s
 // ----------------------------------------------------------------------------
 @PART[spd_Photon_125]:NEEDS[RealismOverhaul]
 {
@@ -64,7 +86,7 @@ https://en.wikipedia.org/wiki/Photon_rocket
 
     @title = PX-02 "Zenith" Photonic Laser Thruster
     @manufacturer = General Electrics 
-    @description = A medium 1.25m photonic propulsion unit. Operates at 50% optical efficiency, converting 190 kW of electrical power into 95 kW of thrust power (~316.88 μN of thrust).
+    @description = A medium 1.25m photonic propulsion unit with coherent-beam amplification. Converts 190 kW of electrical power into ~63 mN of thrust at an effective Isp of 400,000s. Suited to slow interplanetary cargo transfers.
 
     @mass = 0.60
     @maxTemp = 1973
@@ -73,21 +95,21 @@ https://en.wikipedia.org/wiki/Photon_rocket
     @MODULE[ModuleEnginesFX]
     {
         @minThrust = 0
-        @maxThrust = 0.00000031688 // 316.88 uN in kN
+        @maxThrust = 0.06297 // 62.97 mN in kN
         @heatProduction = 0
 
         @PROPELLANT[ElectricCharge]
         {
-            @ratio = 190.0 // 190 kW power draw
+            @ratio = 190.0 
         }
         @PROPELLANT[spd_radiation_pressure]
         {
-            @ratio = 0.005565254
+            @ratio = 1.10609 // scaled proportionally to thrust buff (~199x) — retune via playtesting
         }
 
         @atmosphereCurve
         {
-            @key,0 = 0 30570323
+            @key,0 = 0 400000
         }
     }
 
@@ -101,8 +123,8 @@ https://en.wikipedia.org/wiki/Photon_rocket
 // ----------------------------------------------------------------------------
 // PART: PX-10 "Omega" Photonic & Antimatter Drive
 // Diameter: 5.0m | Mass: 13.0 t | Max Temp: 2273K / 2573K
-// Mode 1 (PureEC): 4,950.0 kW (4.95 MW) | 10.898 kN Thrust | Isp: 30,570,323 s
-// Mode 2 (Antimatter): Antimatter/LqdHydrogen | 54.488 kN Thrust | Isp: 30,570,323 s
+// Mode 1 (PureEC): 8,220.0 kW (8.22 MW) | 10.898 kN... no — 0.010898 kN (10.898 N) Thrust | Isp: 100,000 s
+// Mode 2 (Antimatter): Antimatter/LqdHydrogen | 0.054488 kN (54.488 N) Thrust | Isp: 100,000 s
 // ----------------------------------------------------------------------------
 @PART[spd_Photon_5]:NEEDS[RealismOverhaul]
 {
@@ -110,39 +132,37 @@ https://en.wikipedia.org/wiki/Photon_rocket
 
     @title = PX-10 "Omega" Photonic & Antimatter Drive
     @manufacturer = General Electrics 
-    @description = A heavy 5m interstellar photon engine. In pure electrical mode, it draws 4.95 MW to produce ~10.9 mN of thrust. When configured with an antimatter-catalyzed reaction chamber, it outputs up to 16.33 MW of thrust power (~54.5 mN).
+    @description = A heavy 5m interstellar-derived tug engine, upgraded with coherent beam amplification and fed by a larger 8.22 MW reactor bus. In pure electrical mode it produces ~10.9 N of thrust at an effective Isp of 100,000s — enough for real interplanetary transfer burns. Fitted with an antimatter-catalyzed reaction chamber, it scales to ~54.5 N of thrust at the same Isp.
 
     @mass = 13.0
     @maxTemp = 2273
     @skinMaxTemp = 2573
 
-    // Primary Electric Engine Mode
     @MODULE[ModuleEnginesFX]:HAS[#engineID[PureEC]]
     {
         @minThrust = 0
-        @maxThrust = 10.898 
+        @maxThrust = 0.010898
         @heatProduction = 0
 
         @PROPELLANT[ElectricCharge]
         {
-            @ratio = 4950.0 // 4,950 kW (4.95 MW) power draw
+            @ratio = 8220.0 
         }
         @PROPELLANT[spd_radiation_pressure]
         {
-            @ratio = 0.007343801
+            @ratio = 7.343801 // scaled proportionally to thrust buff (1000x) — retune via playtesting
         }
 
         @atmosphereCurve
         {
-            @key,0 = 0 30570323
+            @key,0 = 0 100000
         }
     }
 
-    // Secondary Antimatter Gamma-Ray Photon Mode
     @MODULE[ModuleEnginesFX]:HAS[#engineID[Antimatter]]:NEEDS[CommunityResourcePack]
     {
         @minThrust = 0
-        @maxThrust = 54.488
+        @maxThrust = 0.054488 
         @heatProduction = 0
 
         @PROPELLANT[Antimatter]
@@ -158,7 +178,7 @@ https://en.wikipedia.org/wiki/Photon_rocket
 
         @atmosphereCurve
         {
-            @key,0 = 0 30570323 // Direct photon emission (c)
+            @key,0 = 0 100000 
         }
     }
 


### PR DESCRIPTION
this adds 3 new endgame engine (photon drives ) to the electric propulsion branch

in this pr :
3 photon drive of various size up 5 meters