### PR TITLE
Add Near Future Spacecraft 

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/NearFutureTechnologies/RO_NearFuture_Spacecraft.cfg
@@ -175,21 +175,29 @@
 		}
 	}
 }
-@PART[mk3-9pod]:FOR[RealismOverhaul]
+// --------------------------------------------------------
+// Mk 3-9 Command Pod
+// --------------------------------------------------------
+@PART[command-mk3-9]:FOR[RealismOverhaul]
 {
-	%RSSROConfig = True
-	!MODULE[TweakScale]
-	{
-	}
-	!mesh = DELETE
-	MODEL
-	{
-		model = NearFutureSpacecraft/Parts/Command/mk3-9pod/mk3-9pod
-		scale = 1.6, 1.6, 1.6
-	}
-	@scale = 1.6
-	@node_stack_bottom = 0.0, -0.336, 0.0, 0.0, -1.0, 0.0, 4
-	@node_stack_top = 0.0, 1.577, 0.0, 0.0, 1.0, 0.0, 1
+	%RSSROConfig = true
+	@rescaleFactor = 1.6
+	@title = Deep Space Command Module
+	@manufacturer = #roMfrLM
+	@descriptioon = An exploraation capsule designed for cislunar and interplanetary flight. It features advanced thermal protection for high-velocity atmospheric re-entries and carries substantial life support reserves for extended duration missions.
+
+	@mass = 4.20
+
+	%skinMaxTemp = 2600
+	%skinInternalConductionMult = 0.005
+	%skinTempTag = HRSI
+	%internalTempTag = Instruments
+
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel],* {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleDataTransmitter],* {}	
+
 	@MODULE[ModuleCommand]
 	{
 		@RESOURCE[ElectricCharge]
@@ -197,152 +205,117 @@
 			@rate = 0.5
 		}
 	}
-	!RESOURCE[ElectricCharge]
+
+	MODULE
 	{
+		name = ModuleRealAntenna
+		referenceGain = 1.0
 	}
-	!RESOURCE[MonoPropellant]
-	{
-	}
+
+
 	MODULE
 	{
 		name = ModuleFuelTanks
 		type = ServiceModule
-		volume = 3260
-		basemass = -1
-		TANK
-		{
-			name = ElectricCharge
-			amount = 43200
-			maxAmount = 43200
-		}
+		volume = 7500
+		basemass = -1	
 		TANK
 		{
 			name = Food
-			amount = 245.7
-			maxAmount = 245.7
+			amount = 120
+			maxAmount = 120
 		}
 		TANK
 		{
 			name = Water
-			amount = 162.4
-			maxAmount = 162.4
+			amount = 80
+			maxAmount = 80
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 5922
-			maxAmount = 5922
+			amount = 12000
+			maxAmount = 12000
 		}
 		TANK
 		{
-			name = LithiumHydroxide
-			amount = 31.5
-			maxAmount = 31.5
-		}
-		TANK
-		{
-			name = CarbonDioxide
-			amount = 0
-			maxAmount = 3069.2
+			name = Nitrogen
+			amount = 8000
+			maxAmount = 8000
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 22.344
+			maxAmount = 20
 		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 206.808
+			maxAmount = 40
 		}
 		TANK
 		{
-			name = LqdOxygen
-			amount = 43.9
-			maxAmount = 43.9
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
 		}
-	}
-	MODULE:NEEDS[TacLifeSupport]
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 40
+			maxAmount = 40
+		}
+		TANK
+		{
+			name = MMH
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = MON3
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = Helium
+			amount = 3000
+			maxAmount = 3000
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 25000
+			maxAmount = 25000
+		}
+	}	
+	@MODULE[ModuleRCSFX]
 	{
-		name = TacGenericConverter
-		converterName = CO2 Scrubber
-		StartActionName = Start CO2 Scrubber
-		StopActionName = Stop CO2 Scrubber
-		tag = Life Support
-		GeneratesHeat = False
-		UseSpecialistBonus = True
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ConverterSkill
-		EfficiencyBonus = 1
-		conversionRate = 2.0	// # of people - Figures based on per/person
-
-		INPUT_RESOURCE
+		@thrusterPower = 0.4
+		!resourceName = DELETE
+		PROPELLANT
 		{
-			ResourceName = CarbonDioxide
-			Ratio = 0.00589121
+			name = MMH
+			ratio = 0.4943
 		}
-
-		INPUT_RESOURCE
+		PROPELLANT
 		{
-			ResourceName = ElectricCharge
-			Ratio = 0.01
+			name = MON3
+			ratio = 0.5057
 		}
-
-		INPUT_RESOURCE
+		PROPELLANT
 		{
-			ResourceName = LithiumHydroxide
-			Ratio = 0.0000085683
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
 		}
-
-		OUTPUT_RESOURCE
+		@atmosphereCurve
 		{
-			ResourceName = WasteWater
-			Ratio = 0.0000046828
-			DumpExcess = True
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Waste
-			Ratio = 0.0000257297
-			DumpExcess = False
-		}
-	}
-	MODULE:NEEDS[TacLifeSupport]
-	{
-		name = TacGenericConverter
-		converterName = LOX-O2
-		StartActionName = Start LOX-O2
-		StopActionName = Stop LOX-O2
-		tag = Life Support
-		GeneratesHeat = False
-		UseSpecialistBonus = True
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		ExperienceEffect = ConverterSkill
-		EfficiencyBonus = 1
-		conversionRate = 2.0
-
-		INPUT_RESOURCE
-		{
-			ResourceName = LqdOxygen
-			Ratio = 0.0000084787
-		}
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.025
-		}
-
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Oxygen
-			Ratio = 0.006883126
-			DumpExcess = False
+			@key,0 = 0 285
+			@key,1 = 1 110
 		}
 	}
 }
@@ -667,4 +640,683 @@
 	%RSSROConfig = True
 	@mass = 0.1
 	@maxTemp = 1973.15
+}
+
+// --------------------------------------------------------
+// 3.75m Biconic Pod
+// --------------------------------------------------------
+@PART[command-375-biconic-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@rescaleFactor = 1.6
+	@title = Blue Origin Space Vehicle
+	@manufacturer = Blue Origin
+	@description = A biconic lifting-body spacecraft using its aerodynamic geometry to reduce re-entry G-loading and achieve significant cross-range capability. It is optimized for large-scale crew transport to orbit or deep space destinations.
+
+	@mass = 8.50
+
+	@maxTemp = 773
+	%skinMaxTemp = 2600
+	%skinInternalConductionMult = 0.005		//all conductivity
+	%skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	%skinSkinConductionMult = 0.1
+	%emissiveConstant = 0.95		//matte black
+
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel],* {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleDataTransmitter],* {}
+
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.5
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 1.0
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 12500
+		basemass = -1	
+		TANK
+		{
+			name = Food
+			amount = 250
+			maxAmount = 250
+		}
+		TANK
+		{
+			name = Water
+			amount = 160
+			maxAmount = 160
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 25000
+			maxAmount = 25000
+		}
+		TANK
+		{
+			name = Nitrogen
+			amount = 15000
+			maxAmount = 15000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 40
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 80
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 20000
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 80
+			maxAmount = 80
+		}
+		TANK
+		{
+			name = MMH
+			amount = 300
+			maxAmount = 300
+		}
+		TANK
+		{
+			name = MON3
+			amount = 300
+			maxAmount = 300
+		}
+		TANK
+		{
+			name = Helium
+			amount = 6000
+			maxAmount = 6000
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 45000
+			maxAmount = 45000
+		}
+	}	
+	@MODULE[ModuleRCSFX]
+	{
+		@thrusterPower = 0.6
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4943
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5057
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 285
+			@key,1 = 1 110
+		}
+	}
+}
+
+
+
+// --------------------------------------------------------
+// Command Pod
+// --------------------------------------------------------
+@PART[command-mk4-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@rescaleFactor = 1.6
+	@title = Martian Excursion Module
+	@manufacturer = #roMfrLM
+	@description = A high-volume command pod designed with crewed Mars missions in mind. it functions as a flight deck and habitation center for planetary descent, surface operations and ascent.
+
+	@mass = 7.50
+
+	%skinMaxTemp = 2600
+	%skinInternalConductionMult = 0.005
+	%skinTempTag = HRSI
+	%internalTempTag = Instruments
+	
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel],* {}
+	!MODULE[ModuleFuelTanks],* {}
+	!MODULE[ModuleDataTransmitter],* {}	
+	
+	
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.5
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 1.0
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 20000
+		basemass = -1	
+		TANK
+		{
+			name = Food
+			amount = 200
+			maxAmount = 200
+		}
+		TANK
+		{
+			name = Water
+			amount = 130
+			maxAmount = 130
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 20000
+			maxAmount = 20000
+		}
+		TANK
+		{
+			name = Nitrogen
+			amount = 12000
+			maxAmount = 12000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 35
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 65
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 15000
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 70
+			maxAmount = 70
+		}
+		TANK
+		{
+			name = MMH
+			amount = 200
+			maxAmount = 200
+		}
+		TANK
+		{
+			name = MON3
+			amount = 200
+			maxAmount = 200
+		}
+		TANK
+		{
+			name = Helium
+			amount = 4000
+			maxAmount = 4000
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 35000
+			maxAmount = 35000
+		}
+	}	
+	@MODULE[ModuleRCSFX]
+	{
+		@thrusterPower = 0.5
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4943
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5057
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 285
+			@key,1 = 1 110
+		}
+	}
+}
+
+// --------------------------------------------------------
+// Inline Command Pod
+// --------------------------------------------------------
+@PART[command-ppd-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@rescaleFactor = 1.6
+	@title = Inline Station Command
+	@manufacturer = #roMfrLM
+	@description = A pressurized orbital node lacking re-entry shielding designed as the primary command center and hub for space stations or interplanetary transfer vehicles.
+
+	@mass = 6.00
+	%skinMaxTemp = 2000	
+
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel],* {}
+	!MODULE[ModuleDataTransmitter],* {}	
+	@MODULE[ModuleCommand]
+
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.5
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 1.0
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 15000
+		basemass = -1	
+		TANK
+		{
+			name = Food
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = Water
+			amount = 100
+			maxAmount = 100
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 15000
+			maxAmount = 15000
+		}
+		TANK
+		{
+			name = Nitrogen
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 25
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 50
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 12000
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 50
+			maxAmount = 50
+		}
+		TANK
+		{
+			name = MMH
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = MON3
+			amount = 150
+			maxAmount = 150
+		}
+		TANK
+		{
+			name = Helium
+			amount = 3000
+			maxAmount = 3000
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 30000
+			maxAmount = 30000
+		}
+	}	
+	@MODULE[ModuleRCSFX]
+	{
+		@thrusterPower = 0.4
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4943
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5057
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 285
+			@key,1 = 1 110
+		}
+	}
+}
+
+// --------------------------------------------------------
+// 1.25m Advanced Pod
+// --------------------------------------------------------
+@PART[command-125-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@rescaleFactor = 1.6
+	@title = Advanced Lightweight Capsule
+	@manufacturer = #roMfrLM
+	@description = A 'modern Gemini', this two person capsule is designed with modern manufacturing techniques to provide the means for space agencies with less powerful rockets to also access space.
+
+	@mass = 1.0
+	%skinMaxTemp = 2500	
+
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel],* {}
+	!MODULE[ModuleDataTransmitter],* {}	
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.5
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 1.0
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3000
+		type = ServiceModule
+		basemass = -1
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 413
+			maxAmount = 413
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 317
+			maxAmount = 317
+		}
+		TANK
+		{
+			name = MMH
+			amount = 50
+			maxAmount = 50
+		}
+		TANK
+		{
+			name = MON3
+			amount = 50
+			maxAmount = 50
+		}
+		TANK
+		{
+			name = Helium
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Water
+			amount = 101
+			maxAmount = 101
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 315
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 10
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 55000
+			maxAmount = 55000
+		}
+	}	
+	@MODULE[ModuleRCSFX]
+	{
+		@thrusterPower = 0.15
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4943
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5057
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
+		@atmosphereCurve
+		{
+		@key,0 = 0 285
+		@key,1 = 1 110
+		}
+	}
+}
+
+// --------------------------------------------------------
+// 1.25m Orbital Pod 
+// --------------------------------------------------------
+@PART[command-125-orbit-1]:FOR[RealismOverhaul]
+{
+	%RSSROConfig = true
+	@rescaleFactor = 1.6
+	@title = Flexcraft
+	@manufacturer = #roMfrNASA
+	@description = A single-occupant, vacuum-restricted orbital pod designed for a shirtsleeve alternative to traditional extravehicular activity suits for external station maintenance and proximity operations.
+
+	@mass = 1.20
+	%skinMaxTemp = 2000	
+	!RESOURCE,* {}
+	!MODULE[ModuleReactionWheel],* {}
+	!MODULE[ModuleDataTransmitter],* {}	
+	MODULE
+	{
+	    name = ModuleRealAntenna
+	    referenceGain = 1.0
+	}	
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 300
+		basemass = -1	
+		TANK
+		{
+			name = Food
+			amount = 30
+			maxAmount = 30
+		}
+		TANK
+		{
+			name = Water
+			amount = 20
+			maxAmount = 20
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 3000
+			maxAmount = 3000
+		}
+		TANK
+		{
+			name = Nitrogen
+			amount = 2000
+			maxAmount = 2000
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 5
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 10
+		}
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 2500
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 10
+			maxAmount = 10
+		}
+		TANK
+		{
+			name = MMH
+			amount = 30
+			maxAmount = 30
+		}
+		TANK
+		{
+			name = MON3
+			amount = 30
+			maxAmount = 30
+		}
+		TANK
+		{
+			name = Helium
+			amount = 600
+			maxAmount = 600
+		}
+		TANK
+		{
+			name = ElectricCharge
+			amount = 8000
+			maxAmount = 8000
+		}
+	}	
+	@MODULE[ModuleRCSFX]
+	{
+		@thrusterPower = 0.15
+		!resourceName = DELETE
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4943
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5057
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 11.25
+			ignoreForIsp = True
+		}
+		@atmosphereCurve
+		{
+			@key,0 = 0 285
+			@key,1 = 1 110
+		}
+	}
 }


### PR DESCRIPTION
This PR adds configs for some of the NF Spacecraft capsules. As some are redundant either with other parts of the mod or with already existing parts, I've only done a few of them. These are:

- A MEM
- Blue Origin's Space Vehicle
- NASA's Flexcraft
- A modern "Gemini" [1]

[1] - Because Rad proposed using a Gemini in 2015 in their save, which is a crime.