### PR TITLE
Adds the Blue Moon (HLS/Mark 2)

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -1,0 +1,30 @@
+CONFIG
+        {
+            name = BE-7
+            specLevel = operational
+            minThrust = 8.9    // Highly deep-throttling capabilities down to 20%
+            maxThrust = 44.5   // 44.5 kN (approx. 10,000 lbf vacuum thrust)
+            heatProduction = 100
+
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.729
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.271
+            }
+
+            atmosphereCurve
+            {
+                key = 0 460    // High efficiency vacuum dual-expander cycle performance
+                key = 1 100
+            }
+
+            ullage = False
+            pressureFed = False
+            ignitions = 30     // Multiple restart capability optimized for descent/ascent cycles
+}

--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -10,12 +10,12 @@
 //  Dry Mass: 170 kg
 //  Thrust (Vac): 44.5 kN
 //  ISP: 200 SL / 453 Vac
-//  Burn Time: 2000 s per mission (10,000 s total lifetime across reuses)
+//  Burn Time: 2000 s per mission (15,000 s total lifetime across reuses)
 //  Chamber Pressure: 5.5 MPa
 //  Propellant: LOX / LH2
 //  Prop Ratio: 5.5
 //  Throttle: 20% to 100% (8.9 kN to 44.5 kN)
-//  Ignitions: 50 (configured for reusable multi-landing lunar architecture)
+//  Ignitions: Unlimited (configured for reusable multi-landing lunar architecture)
 //  =================================================================================
 
 //  Sources:
@@ -28,7 +28,7 @@
 //  * ROEngines
 //  ==================================================
 
-@PART[*]:HAS[#engineType[BE7]]:FOR[RealismOverhaulEngines]
+@PART[*]:HAS[#engineType[BE-7]]:FOR[RealismOverhaulEngines]
 {
     %category = Engine
     %title = #roBE7Title    // BE-7
@@ -72,7 +72,7 @@
             massMult = 1.0
             ullage = True
             pressureFed = False
-            ignitions = 50 
+            ignitions = 0 
 
             IGNITOR_RESOURCE
             {
@@ -100,10 +100,10 @@
                 key = 1 200
             }
 
-            TESTFLIGHT:NEEDS[TestLite|TestFlight]
+           TESTFLIGHT:NEEDS[TestLite|TestFlight]
             {
                 name = BE-7
-                testedBurnTime = 10000 // Extended lifetime rating for multiple surface sorties
+                testedBurnTime = 15000 
                 ratedBurnTime = 2000
                 safeOverburn = true
 
@@ -113,10 +113,10 @@
                     key = 1.00 1.00 3 3
                 }
 
-                ignitionReliabilityStart = 0.99
-                ignitionReliabilityEnd = 0.998
-                cycleReliabilityStart = 0.985
-                cycleReliabilityEnd = 0.998
+                ignitionReliabilityStart = 0.992
+                ignitionReliabilityEnd = 0.999
+                cycleReliabilityStart = 0.988
+                cycleReliabilityEnd = 0.999
             }
         }
     }

--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -38,7 +38,7 @@
 
     @MODULE[ModuleEngines*]
     {
-        %EngineType = LiquidFuel
+        %engineType = LiquidFuel
     }
 
     !MODULE[ModuleEngineConfigs],*{}

--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -23,9 +23,6 @@
 //   https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
 //   https://en.wikipedia.org/wiki/BE-7 
 //  NASA - Human Landing System (HLS) Option A / Sustaining Lander Data
-
-//  Used by:
-//  * ROEngines
 //  ==================================================
 
 @PART[*]:HAS[#engineType[BE-7]]:FOR[RealismOverhaulEngines]

--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -1,4 +1,4 @@
-//  ==================================================
+// ==================================================
 //  BE-7 global engine configuration.
 //
 //  Manufacturer: Blue Origin
@@ -13,24 +13,24 @@
 //  Burn Time: 2000 s per mission (15,000 s total lifetime across reuses)
 //  Chamber Pressure: 5.5 MPa
 //  Propellant: LOX / LH2
-//  Prop Ratio: 5.5
-//  Throttle: 20% to 100% (8.9 kN to 44.5 kN)
+//  Prop Ratio: 5.5 (O/F)
+//  Throttle: 10% to 100% (4.45 kN to 44.5 kN)
 //  Ignitions: Unlimited (configured for reusable multi-landing lunar architecture)
 //  =================================================================================
 
 //  Sources:
 //  Blue Origin - BE-7 Engine: https://www.blueorigin.com/news/be-7-engine-test/
-//   https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
-//   https://en.wikipedia.org/wiki/BE-7 
+//  https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
+//  https://en.wikipedia.org/wiki/BE-7 
 //  NASA - Human Landing System (HLS) Option A / Sustaining Lander Data
 //  ==================================================
 
 @PART[*]:HAS[#engineType[BE-7]]:FOR[RealismOverhaulEngines]
 {
     %category = Engine
-    %title = #roBE7Title    // BE-7
-    %manufacturer = #roMfrBO
-    %description = #roBE7Desc   // The BE-7 is a high-efficiency dual-expander cycle hydrolox engine developed by Blue Origin for deep space landers, specifically powering the Blue Moon lunar lander. Features deep throttling down to 20% thrust and multi-start capability across repeated reusable landing cycles.
+    %title =  BE-7
+    %manufacturer = Blue Origin
+    %description = The BE-7 is a high-efficiency dual-expander cycle hydrolox engine developed by Blue Origin for deep space landers, specifically powering the Blue Moon lunar lander. Features deep throttling down to 10% thrust and multi-start capability across repeated reusable landing cycles.
 
     @tags ^= :$: USA blue origin bo be-7 liquid pump lander lqdhydrogen lqdoxygen reusable
 
@@ -57,37 +57,37 @@
         name = ModuleEngineConfigs
         type = ModuleEngines
         configuration = BE-7
-        origMass = 0.17
+        origMass = 0.170
 
         CONFIG
         {
             name = BE-7
             specLevel = prototype
-            minThrust = 8.9
+            minThrust = 4.45
             maxThrust = 44.5
             heatProduction = 100
             massMult = 1.0
             ullage = True
             pressureFed = False
-            ignitions = 0 
+            ignitions = 0
 
             IGNITOR_RESOURCE
             {
                 name = ElectricCharge
-                amount = 0.25
+                amount = 0.5
             }
 
             PROPELLANT
             {
                 name = LqdHydrogen
-                ratio = 0.7454
+                ratio = 0.7380
                 DrawGauge = True
             }
 
             PROPELLANT
             {
                 name = LqdOxygen
-                ratio = 0.2546
+                ratio = 0.2620
                 DrawGauge = False
             }
 
@@ -97,23 +97,23 @@
                 key = 1 200
             }
 
-           TESTFLIGHT:NEEDS[TestLite|TestFlight]
+            TESTFLIGHT:NEEDS[TestLite|TestFlight]
             {
                 name = BE-7
-                testedBurnTime = 15000 
+                testedBurnTime = 15000
                 ratedBurnTime = 2000
                 safeOverburn = true
 
                 thrustModifier
                 {
-                    key = 0.00 0.05 0 0
-                    key = 1.00 1.00 3 3
+                    key = 0.10 0.10 1 1
+                    key = 1.00 1.00 1 1
                 }
 
-                ignitionReliabilityStart = 0.992
-                ignitionReliabilityEnd = 0.999
-                cycleReliabilityStart = 0.988
-                cycleReliabilityEnd = 0.999
+                ignitionReliabilityStart = 0.995
+                ignitionReliabilityEnd = 0.9995
+                cycleReliabilityStart = 0.992
+                cycleReliabilityEnd = 0.9995
             }
         }
     }

--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -1,30 +1,123 @@
-CONFIG
+//  ==================================================
+//  BE-7 global engine configuration.
+//
+//  Manufacturer: Blue Origin
+//
+//  =================================================================================
+//  BE-7
+//  Blue Moon Lander
+//
+//  Dry Mass: 170 kg
+//  Thrust (Vac): 44.5 kN
+//  ISP: 200 SL / 453 Vac
+//  Burn Time: 2000 s
+//  Chamber Pressure: 5.5 MPa
+//  Propellant: LOX / LH2
+//  Prop Ratio: 5.5
+//  Throttle: 20% to 100% (8.9 kN to 44.5 kN)
+//  Ignitions: 10
+//  =================================================================================
+
+//  Sources:
+//  Blue Origin - BE-7 Engine: https://www.blueorigin.com/news/be-7-engine-test/
+//   https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
+//   https://en.wikipedia.org/wiki/BE-7 
+//  NASA - Human Landing System (HLS) Option A / Sustaining Lander Data
+
+//  Used by:
+//  * ROEngines
+//  ==================================================
+
+@PART[*]:HAS[#engineType[BE7]]:FOR[RealismOverhaulEngines]
+{
+    %category = Engine
+    %title = #roBE7Title    // BE-7
+    %manufacturer = #roMfrBO
+    %description = #roBE7Desc   // The BE-7 is a high-efficiency dual-expander cycle hydrolox engine developed by Blue Origin for deep space landers, specifically powering the Blue Moon lunar lander. Features deep throttling down to 20% thrust to enable soft precision lunar landings.
+
+    @tags ^= :$: USA blue origin bo be-7 liquid pump lander lqdhydrogen lqdoxygen
+
+    %specLevel = prototype
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleAlternator],*{}
+    !RESOURCE,*{}
+
+    @MODULE[ModuleGimbal],*
+    {
+        @gimbalRange = 5.0
+        %useGimbalResponseSpeed = True
+        %gimbalResponseSpeed = 16
+    }
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = BE-7
+        origMass = 0.17
+
+        CONFIG
         {
             name = BE-7
-            specLevel = operational
-            minThrust = 8.9    // Highly deep-throttling capabilities down to 20%
-            maxThrust = 44.5   // 44.5 kN (approx. 10,000 lbf vacuum thrust)
+            specLevel = prototype
+            minThrust = 8.9
+            maxThrust = 44.5
             heatProduction = 100
+            massMult = 1.0
+            ullage = True
+            pressureFed = False
+            ignitions = 10
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.25
+            }
 
             PROPELLANT
             {
                 name = LqdHydrogen
-                ratio = 0.729
+                ratio = 0.7454
                 DrawGauge = True
             }
+
             PROPELLANT
             {
                 name = LqdOxygen
-                ratio = 0.271
+                ratio = 0.2546
+                DrawGauge = False
             }
 
             atmosphereCurve
             {
-                key = 0 460    // High efficiency vacuum dual-expander cycle performance
-                key = 1 100
+                key = 0 453
+                key = 1 200
             }
 
-            ullage = False
-            pressureFed = False
-            ignitions = 30     // Multiple restart capability optimized for descent/ascent cycles
+            TESTFLIGHT:NEEDS[TestLite|TestFlight]
+            {
+                name = BE-7
+                testedBurnTime = 4000
+                ratedBurnTime = 2000
+                safeOverburn = true
+
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
+
+                ignitionReliabilityStart = 0.98
+                ignitionReliabilityEnd = 0.995
+                cycleReliabilityStart = 0.98
+                cycleReliabilityEnd = 0.995
+            }
+        }
+    }
 }

--- a/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/BE-7_Config.cfg
@@ -2,20 +2,20 @@
 //  BE-7 global engine configuration.
 //
 //  Manufacturer: Blue Origin
-//
+//  
 //  =================================================================================
 //  BE-7
-//  Blue Moon Lander
+//  Blue Moon Lander (MK1 cargo & MK2 reusable human lander)
 //
 //  Dry Mass: 170 kg
 //  Thrust (Vac): 44.5 kN
 //  ISP: 200 SL / 453 Vac
-//  Burn Time: 2000 s
+//  Burn Time: 2000 s per mission (10,000 s total lifetime across reuses)
 //  Chamber Pressure: 5.5 MPa
 //  Propellant: LOX / LH2
 //  Prop Ratio: 5.5
 //  Throttle: 20% to 100% (8.9 kN to 44.5 kN)
-//  Ignitions: 10
+//  Ignitions: 50 (configured for reusable multi-landing lunar architecture)
 //  =================================================================================
 
 //  Sources:
@@ -33,9 +33,9 @@
     %category = Engine
     %title = #roBE7Title    // BE-7
     %manufacturer = #roMfrBO
-    %description = #roBE7Desc   // The BE-7 is a high-efficiency dual-expander cycle hydrolox engine developed by Blue Origin for deep space landers, specifically powering the Blue Moon lunar lander. Features deep throttling down to 20% thrust to enable soft precision lunar landings.
+    %description = #roBE7Desc   // The BE-7 is a high-efficiency dual-expander cycle hydrolox engine developed by Blue Origin for deep space landers, specifically powering the Blue Moon lunar lander. Features deep throttling down to 20% thrust and multi-start capability across repeated reusable landing cycles.
 
-    @tags ^= :$: USA blue origin bo be-7 liquid pump lander lqdhydrogen lqdoxygen
+    @tags ^= :$: USA blue origin bo be-7 liquid pump lander lqdhydrogen lqdoxygen reusable
 
     %specLevel = prototype
 
@@ -72,7 +72,7 @@
             massMult = 1.0
             ullage = True
             pressureFed = False
-            ignitions = 10
+            ignitions = 50 
 
             IGNITOR_RESOURCE
             {
@@ -103,7 +103,7 @@
             TESTFLIGHT:NEEDS[TestLite|TestFlight]
             {
                 name = BE-7
-                testedBurnTime = 4000
+                testedBurnTime = 10000 // Extended lifetime rating for multiple surface sorties
                 ratedBurnTime = 2000
                 safeOverburn = true
 
@@ -113,10 +113,10 @@
                     key = 1.00 1.00 3 3
                 }
 
-                ignitionReliabilityStart = 0.98
-                ignitionReliabilityEnd = 0.995
-                cycleReliabilityStart = 0.98
-                cycleReliabilityEnd = 0.995
+                ignitionReliabilityStart = 0.99
+                ignitionReliabilityEnd = 0.998
+                cycleReliabilityStart = 0.985
+                cycleReliabilityEnd = 0.998
             }
         }
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -136,6 +136,42 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
         amount = 500
         maxAmount = 500
     }
+
+MODULE
+    {
+        name = ModuleRCSFX
+        stagingEnabled = True
+        thrusterTransformName = rcsTransform
+        thrusterPower = 0.111 // ~111 N thrust
+        !resourceName = DELETE
+        resourceFlowMode = STAGE_PRIORITY_FLOW
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.48
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.52
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 15.0
+            ignoreForIsp = True
+        }
+
+        atmosphereCurve
+        {
+            key = 0 290
+            key = 1 100
+        }
+    }
+
+
 }
 
 @PART[IQBM_Hab]:FOR[RealismOverhaul]
@@ -248,6 +284,38 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
             name = Helium
             amount = 4000
             maxAmount = 4000
+        }
+    }
+    {
+        name = ModuleRCSFX
+        stagingEnabled = True
+        thrusterTransformName = rcsTransform 
+        !resourceName = DELETE
+        thrusterPower = 0.111 // ~111 N thrust per RCS thruster nozzle
+        resourceFlowMode = STAGE_PRIORITY_FLOW
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.48
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.52
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 15.0
+            ignoreForIsp = True
+        }
+
+        atmosphereCurve
+        {
+            key = 0 290 // Vacuum ISP for modern hypergolic attitude control thrusters
+            key = 1 100
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -63,12 +63,9 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     !MODULE[ModuleEngine*],* {}
     !MODULE[ModuleGimbal*],* {}
 
-    MODULE
-    {
-        name = ModuleEnginesRF
-        thrustVectorTransformName = thrustTransform
-        EngineType = LiquidFuel
-    }
+    
+    EngineType = BE-7
+    
 
     MODULE
     {
@@ -77,50 +74,6 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
         gimbalRange = 5.0
         useGimbalResponseSpeed = true
         gimbalResponseSpeed = 16
-    }
-
-    MODULE
-    {
-        name = ModuleEngineConfigs
-        type = ModuleEnginesRF
-        configuration = BE-7
-        origMass = 0.12
-
-        CONFIG
-        {
-            name = BE-7
-            specLevel = operational
-            minThrust = 8.9    // Highly deep-throttling capabilities down to 20%
-            maxThrust = 44.5   // 44.5 kN (approx. 10,000 lbf vacuum thrust)
-            heatProduction = 100
-
-            PROPELLANT
-            {
-                name = LqdHydrogen
-                ratio = 0.729
-                DrawGauge = True
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio = 0.271
-            }
-
-            atmosphereCurve
-            {
-                key = 0 460    // High efficiency vacuum dual-expander cycle performance
-                key = 1 100
-            }
-
-            ullage = False
-            pressureFed = False
-            ignitions = 30     // Multiple restart capability optimized for descent/ascent cycles
-
-            IGNORABLE_RESOURCES
-            {
-                name = ElectricCharge
-            }
-        }
     }
 }
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -1,3 +1,9 @@
+Source
+https://www.blueorigin.com/fr-FR/engines 
+https://en.wikipedia.org/wiki/BE-7 
+https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
+https://www.blueorigin.com/fr-FR/news/be7-engine-testing 
+
 // Realism Overhaul patch for IsaQuest Blue Moon Lander Fuel Tank (IQBM_Tank)
 @PART[IQBM_Tank]:FOR[RealismOverhaul]
 {
@@ -16,12 +22,11 @@
     !RESOURCE[*],* {}
     !MODULE[ModuleFuelTanks],* {}
 
-    // Implement RealFuels Tank Module
     MODULE
     {
         name = ModuleFuelTanks
         // Tank type 'Cryogenic' provides excellent insulation features for LH2/LOX combinations
-        volume = 42000 // Approximate realistic volume capacity in Liters; adjust based on target payload delta-V
+        volume = 42000 // Approximate realistic volume capacity in Liters
         type = Cryogenic
         utilization = 100
         typeAvailable = Cryogenic
@@ -104,13 +109,13 @@
 
             atmosphereCurve
             {
-                key = 0 453    // High efficiency vacuum dual-expander cycle performance
+                key = 0 460    // High efficiency vacuum dual-expander cycle performance
                 key = 1 100
             }
 
-            ullage = True
+            ullage = False
             pressureFed = False
-            ignitions = 15     // Multiple restart capability optimized for descent/ascent cycles
+            ignitions = 30     // Multiple restart capability optimized for descent/ascent cycles
 
             IGNORABLE_RESOURCES
             {
@@ -152,8 +157,8 @@
     %manufacturer = Blue Origin
     %description = Flight computer and GNC (Guidance, Navigation, and Control) bay for the Blue Moon lander. Contains redundant flight controllers, communication arrays, and power management systems.
 
-    !MODULE[ModuleCommand],* {}
-    !MODULE[ModuleSAS],* {}
+   !MODULE[ModuleDataTransmitter],* {}
+   !MODULE[ModuleReactionWheel],* {}
     !RESOURCE[ElectricCharge],* {}
 
     // Add command capability for remote/autonomous control
@@ -190,8 +195,10 @@
     %manufacturer = Blue Origin
     %description = Long-duration pressurized habitat and command module for the Blue Moon lander. Includes expanded life support, thermal control systems, and communication equipment capable of sustaining a crew of four for up to 30 days on the lunar surface.
 
-    !MODULE[ModuleCommand],* {}
-    !MODULE[ModuleSAS],* {}
+
+    !MODULE[ModuleDataTransmitter],* {}
+    !MODULE[ModuleReactionWheel],* {}
+    !MODULE[ModuleFuelTanks],* {}
     !RESOURCE[*],* {}
 
     MODULE
@@ -205,87 +212,89 @@
         }
     }
 
-    // --- KERBALISM LIFE SUPPORT RESOURCES (4 Crew, 30+ days margin) ---
-    
-    RESOURCE
+    MODULE
     {
-        name = ElectricCharge
-        amount = 5000
-        maxAmount = 5000
-    }
+        name = ModuleFuelTanks
+        volume = 300000 // Total allocated volumetric space in liters (highly driven by gaseous O2/N2)
+        type = ServiceModule
+        
+        TANK
+        {
+            name = ElectricCharge
+            amount = 5000
+            maxAmount = 5000
+        }
 
-    RESOURCE
-    {
-        name = Food
-        amount = 900
-        maxAmount = 900
-    }
+        // --- KERBALISM LIFE SUPPORT (Pre-filled Defaults for 4 Crew / 30 Days) ---
+        TANK
+        {
+            name = Food
+            amount = 900
+            maxAmount = 900
+        }
+        TANK
+        {
+            name = Water
+            amount = 500
+            maxAmount = 500
+        }
+        TANK
+        {
+            name = Oxygen
+            amount = 160000 // Gaseous oxygen storage
+            maxAmount = 160000
+        }
+        TANK
+        {
+            name = Nitrogen
+            amount = 130000 // Gaseous structural makeup gas
+            maxAmount = 130000
+        }
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 120
+            maxAmount = 120
+        }
 
-    RESOURCE
-    {
-        name = Water
-        amount = 500
-        maxAmount = 500
-    }
+        // --- LIFE SUPPORT WASTE STORAGE (Starts Empty) ---
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 25000
+        }
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 150
+        }
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 400
+        }
 
-    RESOURCE
-    {
-        name = Oxygen
-        amount = 160000 // Substantial increase for 30-day breathing and airlock cycles
-        maxAmount = 160000
-    }
-
-    RESOURCE
-    {
-        name = Nitrogen
-        amount = 130000 // Buffer for 30 days of hull atmospheric leakage
-        maxAmount = 130000
-    }
-
-    RESOURCE
-    {
-        name = LithiumHydroxide
-        amount = 120 // Solid scrubber material for a 30-day CO2 filtering cycle
-        maxAmount = 120
-    }
-    RESOURCE
-    {
-        name = CarbonDioxide
-        amount = 0
-        maxAmount = 25000
-    }
-
-    RESOURCE
-    {
-        name = Waste
-        amount = 0
-        maxAmount = 150
-    }
-
-    RESOURCE
-    {
-        name = WasteWater
-        amount = 0
-        maxAmount = 400
-    }
-    RESOURCE
-    {
-        name = MMH
-        amount = 120
-        maxAmount = 120
-    }
-
-    RESOURCE
-    {
-        name = MON3
-        amount = 130
-        maxAmount = 130
-    }
-
-    RESOURCE
-    {
-        name = Helium
-        amount = 4000
-        maxAmount = 4000
+        // --- RCS HYPERGOLS & PRESSURANT ---
+        TANK
+        {
+            name = MMH
+            amount = 120
+            maxAmount = 120
+        }
+        TANK
+        {
+            name = MON3
+            amount = 130
+            maxAmount = 130
+        }
+        TANK
+        {
+            name = Helium
+            amount = 4000
+            maxAmount = 4000
+        }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -18,7 +18,6 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     %manufacturer = Blue Origin
     %description = The main hydrolox cryogenic propellant tank for the Blue Moon Lunar Lander. Features integrated multi-layer insulation (MLI) to minimize liquid hydrogen boil-off during the transit to the Lunar surface.
 
-    // Remove stock resource modules completely
     !RESOURCE[*],* {}
     !MODULE[ModuleFuelTanks],* {}
 
@@ -128,8 +127,6 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 @PART[IQBM_Leg]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
-    // Match the scale factor used on your tank and engines (usually 1.0 or 1.5625)
     %rescaleFactor = 1.0
 
     // Realistic mass for an advanced aluminum-lithium/composite landing leg mechanism
@@ -182,7 +179,6 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     }
 }
 
-// Expanded with Kerbalism Life Support for a 30-Day Surface Stay (4 Crew)
 @PART[IQBM_Hab]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
@@ -225,7 +221,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
             maxAmount = 5000
         }
 
-        // --- KERBALISM LIFE SUPPORT (Pre-filled Defaults for 4 Crew / 30 Days) ---
+        // --- KERBALISM LIFE SUPPORT (for 4 Crew / 30 Days) ---
         TANK
         {
             name = Food
@@ -256,8 +252,6 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
             amount = 120
             maxAmount = 120
         }
-
-        // --- LIFE SUPPORT WASTE STORAGE (Starts Empty) ---
         TANK
         {
             name = CarbonDioxide

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -169,6 +169,12 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
             rate = 0.05 // Typical idle consumption for GNC computers
         }
     }
+    
+    MODULE
+	{
+		name = ModuleRealAntenna
+		referenceGain = 1.0
+	}
 
     // Internal battery for the flight computer
     RESOURCE

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -4,7 +4,7 @@ https://en.wikipedia.org/wiki/BE-7
 https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
 https://www.blueorigin.com/fr-FR/news/be7-engine-testing 
 
-// Realism Overhaul patch for IsaQuest Blue Moon Lander Fuel Tank (IQBM_Tank)
+
 @PART[IQBM_Tank]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -1,0 +1,291 @@
+// Realism Overhaul patch for IsaQuest Blue Moon Lander Fuel Tank (IQBM_Tank)
+@PART[IQBM_Tank]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    %rescaleFactor = 1.0
+
+    // Typical real-world empty mass estimation for an advanced composite cryogenic lander stage
+    @mass = 2.2 // Adjusted dry mass in metric tons
+
+    @maxTemp = 1200
+    @skinMaxTemp = 2000
+    %manufacturer = Blue Origin
+    %description = The main hydrolox cryogenic propellant tank for the Blue Moon Lunar Lander. Features integrated multi-layer insulation (MLI) to minimize liquid hydrogen boil-off during the transit to the Lunar surface.
+
+    // Remove stock resource modules completely
+    !RESOURCE[*],* {}
+    !MODULE[ModuleFuelTanks],* {}
+
+    // Implement RealFuels Tank Module
+    MODULE
+    {
+        name = ModuleFuelTanks
+        // Tank type 'Cryogenic' provides excellent insulation features for LH2/LOX combinations
+        volume = 42000 // Approximate realistic volume capacity in Liters; adjust based on target payload delta-V
+        type = Cryogenic
+        utilization = 100
+        typeAvailable = Cryogenic
+
+        // Pre-configure the tank with the standard hydrolox mixture ratio for the BE-7 engine (typically around 5.5:1 to 6:1 mass ratio)
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 30240 // 72% of total volume
+            maxAmount = 30240
+        }
+        TANK
+        {
+            name = LqdOxygen
+            amount = 11760 // 28% of total volume
+            maxAmount = 11760
+        }
+    }
+}
+
+@PART[IQ_BE-7]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %rescaleFactor = 1.0
+
+    // Real-world engine mass (estimated based on highly optimized additively manufactured design)
+    @mass = 0.12 // 120 kg
+
+    @maxTemp = 900
+    @skinMaxTemp = 1600
+    %manufacturer = Blue Origin
+    %description = The BE-7 is an advanced, high-performance, deep-throttling cryogenic engine running on liquid hydrogen and liquid oxygen. Optimized for deep-space and planetary lander applications like the Blue Moon HLS.
+
+    !MODULE[ModuleEngine*],* {}
+    !MODULE[ModuleGimbal*],* {}
+
+    MODULE
+    {
+        name = ModuleEnginesRF
+        thrustVectorTransformName = thrustTransform
+        EngineType = LiquidFuel
+    }
+
+    MODULE
+    {
+        name = ModuleGimbal
+        gimbalTransformName = gimbalTransform
+        gimbalRange = 5.0
+        useGimbalResponseSpeed = true
+        gimbalResponseSpeed = 16
+    }
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEnginesRF
+        configuration = BE-7
+        origMass = 0.12
+
+        CONFIG
+        {
+            name = BE-7
+            specLevel = operational
+            minThrust = 8.9    // Highly deep-throttling capabilities down to 20%
+            maxThrust = 44.5   // 44.5 kN (approx. 10,000 lbf vacuum thrust)
+            heatProduction = 100
+
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.729
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.271
+            }
+
+            atmosphereCurve
+            {
+                key = 0 453    // High efficiency vacuum dual-expander cycle performance
+                key = 1 100
+            }
+
+            ullage = True
+            pressureFed = False
+            ignitions = 15     // Multiple restart capability optimized for descent/ascent cycles
+
+            IGNORABLE_RESOURCES
+            {
+                name = ElectricCharge
+            }
+        }
+    }
+}
+
+@PART[IQBM_Leg]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    // Match the scale factor used on your tank and engines (usually 1.0 or 1.5625)
+    %rescaleFactor = 1.0
+
+    // Realistic mass for an advanced aluminum-lithium/composite landing leg mechanism
+    @mass = 0.085 // 85 kg per leg
+
+    @maxTemp = 900
+    @skinMaxTemp = 1200
+    %manufacturer = Blue Origin
+    %description = Heavy-duty, articulating landing gear specifically engineered for the Blue Moon architecture. Designed to absorb high impact energy on uneven lunar regolith while keeping the engine bell well clear of surface obstructions.
+    @crashTolerance = 19
+    
+    %breakingForce = 270
+    %breakingTorque = 270
+}
+@PART[IQBM_IU]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %rescaleFactor = 1.0
+
+    @mass = 0.06 // 60 kg
+
+    @maxTemp = 700
+    @skinMaxTemp = 1200
+    %manufacturer = Blue Origin
+    %description = Flight computer and GNC (Guidance, Navigation, and Control) bay for the Blue Moon lander. Contains redundant flight controllers, communication arrays, and power management systems.
+
+    !MODULE[ModuleCommand],* {}
+    !MODULE[ModuleSAS],* {}
+    !RESOURCE[ElectricCharge],* {}
+
+    // Add command capability for remote/autonomous control
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 0
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.05 // Typical idle consumption for GNC computers
+        }
+    }
+
+    // Internal battery for the flight computer
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 500
+        maxAmount = 500
+    }
+}
+
+// Expanded with Kerbalism Life Support for a 30-Day Surface Stay (4 Crew)
+@PART[IQBM_Hab]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    %rescaleFactor = 1.0
+    @mass = 3.2 
+
+    @maxTemp = 750
+    @skinMaxTemp = 1400
+    %manufacturer = Blue Origin
+    %description = Long-duration pressurized habitat and command module for the Blue Moon lander. Includes expanded life support, thermal control systems, and communication equipment capable of sustaining a crew of four for up to 30 days on the lunar surface.
+
+    !MODULE[ModuleCommand],* {}
+    !MODULE[ModuleSAS],* {}
+    !RESOURCE[*],* {}
+
+    MODULE
+    {
+        name = ModuleCommand
+        minimumCrew = 1
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.2 // Base avionics power drain
+        }
+    }
+
+    // --- KERBALISM LIFE SUPPORT RESOURCES (4 Crew, 30+ days margin) ---
+    
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 5000
+        maxAmount = 5000
+    }
+
+    RESOURCE
+    {
+        name = Food
+        amount = 900
+        maxAmount = 900
+    }
+
+    RESOURCE
+    {
+        name = Water
+        amount = 500
+        maxAmount = 500
+    }
+
+    RESOURCE
+    {
+        name = Oxygen
+        amount = 160000 // Substantial increase for 30-day breathing and airlock cycles
+        maxAmount = 160000
+    }
+
+    RESOURCE
+    {
+        name = Nitrogen
+        amount = 130000 // Buffer for 30 days of hull atmospheric leakage
+        maxAmount = 130000
+    }
+
+    RESOURCE
+    {
+        name = LithiumHydroxide
+        amount = 120 // Solid scrubber material for a 30-day CO2 filtering cycle
+        maxAmount = 120
+    }
+    RESOURCE
+    {
+        name = CarbonDioxide
+        amount = 0
+        maxAmount = 25000
+    }
+
+    RESOURCE
+    {
+        name = Waste
+        amount = 0
+        maxAmount = 150
+    }
+
+    RESOURCE
+    {
+        name = WasteWater
+        amount = 0
+        maxAmount = 400
+    }
+    RESOURCE
+    {
+        name = MMH
+        amount = 120
+        maxAmount = 120
+    }
+
+    RESOURCE
+    {
+        name = MON3
+        amount = 130
+        maxAmount = 130
+    }
+
+    RESOURCE
+    {
+        name = Helium
+        amount = 4000
+        maxAmount = 4000
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -8,7 +8,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 @PART[IQBM_Tank]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    %rescaleFactor = 1.0
+    %rescaleFactor = 1.6
 
     // Typical real-world empty mass estimation for an advanced composite cryogenic lander stage
     @mass = 2.2 // Adjusted dry mass in metric tons
@@ -50,7 +50,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 {
     %RSSROConfig = True
 
-    %rescaleFactor = 1.0
+    %rescaleFactor = 1.6
 
     // Real-world engine mass (estimated based on highly optimized additively manufactured design)
     @mass = 0.12 // 120 kg
@@ -80,7 +80,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 @PART[IQBM_Leg]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-    %rescaleFactor = 1.0
+    %rescaleFactor = 1.6
 
     // Realistic mass for an advanced aluminum-lithium/composite landing leg mechanism
     @mass = 0.085 // 85 kg per leg
@@ -98,7 +98,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 {
     %RSSROConfig = True
 
-    %rescaleFactor = 1.0
+    %rescaleFactor = 1.6
 
     @mass = 0.06 // 60 kg
 
@@ -142,7 +142,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 {
     %RSSROConfig = True
 
-    %rescaleFactor = 1.0
+    %rescaleFactor = 1.6
     @mass = 3.2 
     %CrewCapacity = 4
     @maxTemp = 750

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -191,7 +191,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 
     %rescaleFactor = 1.0
     @mass = 3.2 
-
+    %CrewCapacity = 4
     @maxTemp = 750
     @skinMaxTemp = 1400
     %manufacturer = Blue Origin

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -3,15 +3,19 @@
 //  - Manufacturer        : Blue Origin
 //  - Mission Profile     : 30-Day Human Lunar Lander / Cargo Delivery System
 //  - Scale Factor        : 1.6x (Real-scale geometry alignment)
-//  - Total Dry Mass      : ~16.000 metric tons (16,000 kg / ~17.6 short tons)
+//  - Total Dry Mass      : 16.000 metric tons (16,000 kg / ~35,200 lbs)
 //      * Habitat Module  : 6.000 t  (4-Crew / 30-Day Pressurized Cabin)
 //      * Tank Section    : 8.800 t  (MLI-shielded Hydrolox Main Tank)
 //      * Landing Gear    : 1.000 t  (4x 0.250 t Heavy Articulating Struts)
 //      * BE-7 Engine     : 0.120 t  (44.5 kN Dual-Expander Hydrolox Engine)
 //      * Av/IU & RCS Unit: 0.080 t  (GNC, TT&C, Active Cooling Loop)
 //
-//  - Main Propulsion     : 1x BE-7 Engine (LOX/LH2, Vacuum Isp 460s)
-//  - Main Tank Capacity  : 42,000 L Cryogenic (72% LH2 / 28% LOX by volume)
+//  - Total Wet Mass      : ~45.000 metric tons (45,000 kg / ~99,200 lbs)
+//  - Main Propulsion     : 1x BE-7 Engine (LOX/LH2, Vacuum Isp 453s)
+//  - Main Tank Capacity  : ~76,000 L Cryogenic (29,000 kg Propellant)
+//      * LqdHydrogen     : 50,700 L (~3,600 kg)
+//      * LqdOxygen       : 25,300 L (~25,400 kg)
+//  - Vacuum Delta-V      : ~4,590 m/s (Direct LLO-Surface-LLO trajectory)
 //  - RCS System          : Hypergolic (MMH / MON3 / He Pressurant, 290s Vac Isp)
 //  - Avionics & Comms    : Integrated Dual-Band (S-Band TT&C, X-Band High-Rate)
 //
@@ -31,7 +35,7 @@
     @maxTemp = 1200
     @skinMaxTemp = 2000
     %manufacturer = Blue Origin
-    %description = The main hydrolox cryogenic propellant tank for the Blue Moon Lunar Lander. Features integrated multi-layer insulation (MLI) to minimize liquid hydrogen boil-off during transit to the Lunar surface.
+    %description = Main cryogenic propellant tank for the Blue Moon Lunar Lander. Holds ~76,000 L (29,000 kg) of hydrolox propellant, yielding ~4,590 m/s of Delta-V with a 16 t dry frame for complete lunar descent, surface stay, and return insertion.
 
     !RESOURCE[*],* {}
     !MODULE[ModuleFuelTanks],* {}
@@ -39,7 +43,7 @@
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 42000
+        volume = 76000
         type = Cryogenic
         utilization = 100
         typeAvailable = Cryogenic
@@ -47,14 +51,14 @@
         TANK
         {
             name = LqdHydrogen
-            amount = 30240
-            maxAmount = 30240
+            amount = 50700
+            maxAmount = 50700
         }
         TANK
         {
             name = LqdOxygen
-            amount = 11760
-            maxAmount = 11760
+            amount = 25300
+            maxAmount = 25300
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -1,23 +1,23 @@
-// SUMMARY SPECIFICATIONS:
+
 // ----------------------------------------------------------------------------
-//  - Manufacturer        : Blue Origin
-//  - Mission Profile     : 30-Day Human Lunar Lander / Cargo Delivery System
-//  - Scale Factor        : 1.6x (Real-scale geometry alignment)
-//  - Total Dry Mass      : 16.000 metric tons (16,000 kg / ~35,200 lbs)
-//      * Habitat Module  : 6.000 t  (4-Crew / 30-Day Pressurized Cabin)
-//      * Tank Section    : 8.800 t  (MLI-shielded Hydrolox Main Tank)
-//      * Landing Gear    : 1.000 t  (4x 0.250 t Heavy Articulating Struts)
-//      * BE-7 Engine     : 0.120 t  (44.5 kN Dual-Expander Hydrolox Engine)
-//      * Av/IU & RCS Unit: 0.080 t  (GNC, TT&C, Active Cooling Loop)
+//  - Manufacturer         : Blue Origin
+//  - Mission Profile      : 30-Day Human Lunar Lander / Cargo Delivery System
+//  - Scale Factor         : 1.6x (Real-scale geometry alignment)
+//  - Total Dry Mass       : 16.000 metric tons (16,000 kg / ~35,200 lbs)
+//      * Habitat Module   : 6.000 t  (4-Crew / 30-Day Pressurized Cabin)
+//      * Tank Section     : 8.800 t  (MLI-shielded Hydrolox Main Tank)
+//      * Landing Gear     : 1.000 t  (4x 0.250 t Heavy Articulating Struts)
+//      * BE-7 Engine      : 0.120 t  (44.5 kN Dual-Expander Hydrolox Engine)
+//      * Av/IU & RCS Unit : 0.080 t  (GNC, TT&C, Active Cooling Loop)
 //
-//  - Total Wet Mass      : ~45.000 metric tons (45,000 kg / ~99,200 lbs)
-//  - Main Propulsion     : 1x BE-7 Engine (LOX/LH2, Vacuum Isp 453s)
-//  - Main Tank Capacity  : ~76,000 L Cryogenic (29,000 kg Propellant)
-//      * LqdHydrogen     : 50,700 L (~3,600 kg)
-//      * LqdOxygen       : 25,300 L (~25,400 kg)
-//  - Vacuum Delta-V      : ~4,590 m/s (Direct LLO-Surface-LLO trajectory)
-//  - RCS System          : Hypergolic (MMH / MON3 / He Pressurant, 290s Vac Isp)
-//  - Avionics & Comms    : Integrated Dual-Band (S-Band TT&C, X-Band High-Rate)
+//  - Total Wet Mass       : ~49.310 metric tons (49,310 kg / ~108,700 lbs)
+//  - Main Propulsion      : 1x BE-7 Engine (LOX/LH2, Vacuum Isp 453s)
+//  - Main Tank Capacity   : ~97,000 L Cryogenic (33,310 kg Propellant)
+//      * LqdHydrogen      : 72,300 L (~5,120 kg)
+//      * LqdOxygen        : 24,700 L (~28,190 kg)
+//  - Vacuum Delta-V       : ~5,000 m/s (Direct LLO-Surface-LLO trajectory + margins)
+//  - RCS System           : Hypergolic (MMH / MON3 / He Pressurant, 290s Vac Isp)
+//  - Avionics & Comms     : Integrated Dual-Band (S-Band TT&C, X-Band High-Rate)
 //
 // Source:
 // https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft)
@@ -35,7 +35,7 @@
     @maxTemp = 1200
     @skinMaxTemp = 2000
     %manufacturer = Blue Origin
-    %description = Main cryogenic propellant tank for the Blue Moon Lunar Lander. Holds ~76,000 L (29,000 kg) of hydrolox propellant, yielding ~4,590 m/s of Delta-V with a 16 t dry frame for complete lunar descent, surface stay, and return insertion.
+    %description = Main cryogenic propellant tank for the Blue Moon Lunar Lander.
 
     !RESOURCE[*],* {}
     !MODULE[ModuleFuelTanks],* {}
@@ -43,7 +43,7 @@
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 76000
+        volume = 97000
         type = Cryogenic
         utilization = 100
         typeAvailable = Cryogenic
@@ -51,14 +51,14 @@
         TANK
         {
             name = LqdHydrogen
-            amount = 50700
-            maxAmount = 50700
+            amount = 72300
+            maxAmount = 72300
         }
         TANK
         {
             name = LqdOxygen
-            amount = 25300
-            maxAmount = 25300
+            amount = 24700
+            maxAmount = 24700
         }
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -1,6 +1,4 @@
 Source
-https://www.blueorigin.com/fr-FR/engines 
-https://en.wikipedia.org/wiki/BE-7 
 https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
 https://www.blueorigin.com/fr-FR/news/be7-engine-testing 
 
@@ -10,7 +8,6 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     %RSSROConfig = True
     %rescaleFactor = 1.6
 
-    // Typical real-world empty mass estimation for an advanced composite cryogenic lander stage
     @mass = 2.2 // Adjusted dry mass in metric tons
 
     @maxTemp = 1200
@@ -24,13 +21,11 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     MODULE
     {
         name = ModuleFuelTanks
-        // Tank type 'Cryogenic' provides excellent insulation features for LH2/LOX combinations
         volume = 42000 // Approximate realistic volume capacity in Liters
         type = Cryogenic
         utilization = 100
         typeAvailable = Cryogenic
 
-        // Pre-configure the tank with the standard hydrolox mixture ratio for the BE-7 engine (typically around 5.5:1 to 6:1 mass ratio)
         TANK
         {
             name = LqdHydrogen
@@ -49,69 +44,46 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 @PART[IQ_BE-7]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
     %rescaleFactor = 1.6
-
-    // Real-world engine mass (estimated based on highly optimized additively manufactured design)
     @mass = 0.12 // 120 kg
-
     @maxTemp = 900
     @skinMaxTemp = 1600
-    %manufacturer = Blue Origin
-    %description = The BE-7 is an advanced, high-performance, deep-throttling cryogenic engine running on liquid hydrogen and liquid oxygen. Optimized for deep-space and planetary lander applications like the Blue Moon HLS.
-
-    !MODULE[ModuleEngine*],* {}
-    !MODULE[ModuleGimbal*],* {}
-
     
     EngineType = BE-7
-    
 
-    MODULE
-    {
-        name = ModuleGimbal
-        gimbalTransformName = gimbalTransform
-        gimbalRange = 5.0
-        useGimbalResponseSpeed = true
-        gimbalResponseSpeed = 16
-    }
 }
 
 @PART[IQBM_Leg]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6
-
-    // Realistic mass for an advanced aluminum-lithium/composite landing leg mechanism
     @mass = 0.085 // 85 kg per leg
-
     @maxTemp = 900
     @skinMaxTemp = 1200
     %manufacturer = Blue Origin
     %description = Heavy-duty, articulating landing gear specifically engineered for the Blue Moon architecture. Designed to absorb high impact energy on uneven lunar regolith while keeping the engine bell well clear of surface obstructions.
     @crashTolerance = 19
-    
     %breakingForce = 270
     %breakingTorque = 270
 }
 @PART[IQBM_IU]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
     %rescaleFactor = 1.6
 
-    @mass = 0.06 // 60 kg
+    @mass = 0.08
 
     @maxTemp = 700
     @skinMaxTemp = 1200
     %manufacturer = Blue Origin
-    %description = Flight computer and GNC (Guidance, Navigation, and Control) bay for the Blue Moon lander. Contains redundant flight controllers, communication arrays, and power management systems.
+    %description = Flight computer, GNC bay, and active thermal management unit for the Blue Moon lander. Features integrated RCS thrusters and an active radiator thermal loop designed to prevent LH2/LOX boil-off during multi-week surface stays.
 
-   !MODULE[ModuleDataTransmitter],* {}
-   !MODULE[ModuleReactionWheel],* {}
+    !MODULE[ModuleCommand],* {}
+    !MODULE[ModuleSAS],* {}
+    !MODULE[ModuleRCS*],* {}
+    !MODULE[ModuleActiveRadiator],* {}
     !RESOURCE[ElectricCharge],* {}
 
-    // Add command capability for remote/autonomous control
     MODULE
     {
         name = ModuleCommand
@@ -119,31 +91,31 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
         RESOURCE
         {
             name = ElectricCharge
-            rate = 0.05 // Typical idle consumption for GNC computers
+            rate = 0.05 
         }
     }
-    
-    MODULE
-	{
-		name = ModuleRealAntenna
-		referenceGain = 1.0
-	}
 
-    // Internal battery for the flight computer
-    RESOURCE
+    MODULE
     {
-        name = ElectricCharge
-        amount = 500
-        maxAmount = 500
+        name = ModuleActiveRadiator
+        maxEnergyTransfer = 25000 // Heat transfer rate in Watts
+        overcoolFactor = 0.25
+        isStartActive = true
+        headroom = 100
+        
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 0.25 // Power draw for thermal fluid pumps & radiator loop
+        }
     }
 
-MODULE
+    MODULE
     {
         name = ModuleRCSFX
         stagingEnabled = True
         thrusterTransformName = rcsTransform
-        thrusterPower = 0.111 // ~111 N thrust
-        !resourceName = DELETE
+        thrusterPower = 0.111
         resourceFlowMode = STAGE_PRIORITY_FLOW
 
         PROPELLANT
@@ -170,8 +142,6 @@ MODULE
             key = 1 100
         }
     }
-
-
 }
 
 @PART[IQBM_Hab]:FOR[RealismOverhaul]
@@ -206,17 +176,15 @@ MODULE
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 300000 // Total allocated volumetric space in liters (highly driven by gaseous O2/N2)
-        type = ServiceModule
+        volume = 300000 
         
         TANK
         {
             name = ElectricCharge
-            amount = 5000
-            maxAmount = 5000
+            amount = 150000
+            maxAmount = 150000
         }
 
-        // --- KERBALISM LIFE SUPPORT (for 4 Crew / 30 Days) ---
         TANK
         {
             name = Food

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -50,7 +50,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     @skinMaxTemp = 1600
     
     EngineType = BE-7
-
+ 
 }
 
 @PART[IQBM_Leg]:FOR[RealismOverhaul]

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -1,14 +1,31 @@
+// SUMMARY SPECIFICATIONS:
+// ----------------------------------------------------------------------------
+//  - Manufacturer        : Blue Origin
+//  - Mission Profile     : 30-Day Human Lunar Lander / Cargo Delivery System
+//  - Scale Factor        : 1.6x (Real-scale geometry alignment)
+//  - Total Dry Mass      : ~5.685 metric tons (Excluding payload & adaptors)
+//      * Tank Section    : 2.200 t  (MLI-shielded Cryogenic Hydrolox)
+//      * Habitat Module  : 3.200 t  (4-Crew / 30-Day Life Support)
+//      * BE-7 Engine     : 0.120 t  (44.5 kN Dual-Expander Hydrolox)
+//      * Landing Gear    : 0.340 t  (4x 0.085 t Articulating Struts)
+//      * Av/IU & RCS Unit: 0.080 t  (GNC, TT&C, Active Cooling Loop)
+//
+//  - Main Propulsion     : 1x BE-7 Engine (LOX/LH2, Vacuum Isp 460s)
+//  - Main Tank Capacity  : 42,000 L Cryogenic (72% LH2 / 28% LOX by volume)
+//  - RCS System          : Hypergolic (MMH / MON3 / He Pressurant, 290s Vac Isp)
+//  - Avionics & Comms    : Integrated Dual-Band (S-Band TT&C, X-Band High-Rate)
+
 Source
 https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
 https://www.blueorigin.com/fr-FR/news/be7-engine-testing 
-
-
+https://www.blueorigin.com/fr-FR/blue-moon
+// ============================================================================
 @PART[IQBM_Tank]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6
 
-    @mass = 2.2 // Adjusted dry mass in metric tons
+    @mass = 2.2 
 
     @maxTemp = 1200
     @skinMaxTemp = 2000
@@ -82,6 +99,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
     !MODULE[ModuleSAS],* {}
     !MODULE[ModuleRCS*],* {}
     !MODULE[ModuleActiveRadiator],* {}
+    !MODULE[ModuleDataTransmitter*],* {}
     !RESOURCE[ElectricCharge],* {}
 
     MODULE
@@ -94,11 +112,28 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
             rate = 0.05 
         }
     }
+   // Integrated Omni Antenna (S-Band - Low Gain / TT&C)
+    MODULE
+    {
+        name = ModuleRealAntenna
+        referenceGain = 3.0       // Low-gain omnidirectional coverage
+        RFBand = S                 // S-band default
+        TxPower = 30               // 30 dBm (~1 Watt)
+    }
+
+    // Integrated Directional Antenna (X-Band - High Rate Telemetry / Lunar Return)
+    MODULE
+    {
+        name = ModuleRealAntenna
+        antennaDiameter = 0.8      // 0.8m equivalent phased array / patch antenna
+        RFBand = X                 // X-band default
+        TxPower = 37               // 37 dBm (~5 Watts)
+    }
 
     MODULE
     {
         name = ModuleActiveRadiator
-        maxEnergyTransfer = 25000 // Heat transfer rate in Watts
+        maxEnergyTransfer = 25000 
         overcoolFactor = 0.25
         isStartActive = true
         headroom = 100
@@ -106,7 +141,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
         RESOURCE
         {
             name = ElectricCharge
-            rate = 0.25 // Power draw for thermal fluid pumps & radiator loop
+            rate = 0.25
         }
     }
 
@@ -169,7 +204,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
         RESOURCE
         {
             name = ElectricCharge
-            rate = 0.2 // Base avionics power drain
+            rate = 0.2 
         }
     }
 
@@ -200,13 +235,13 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
         TANK
         {
             name = Oxygen
-            amount = 160000 // Gaseous oxygen storage
+            amount = 160000 
             maxAmount = 160000
         }
         TANK
         {
             name = Nitrogen
-            amount = 130000 // Gaseous structural makeup gas
+            amount = 130000 
             maxAmount = 130000
         }
         TANK
@@ -282,7 +317,7 @@ https://www.blueorigin.com/fr-FR/news/be7-engine-testing
 
         atmosphereCurve
         {
-            key = 0 290 // Vacuum ISP for modern hypergolic attitude control thrusters
+            key = 0 290 
             key = 1 100
         }
     }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -3,34 +3,35 @@
 //  - Manufacturer        : Blue Origin
 //  - Mission Profile     : 30-Day Human Lunar Lander / Cargo Delivery System
 //  - Scale Factor        : 1.6x (Real-scale geometry alignment)
-//  - Total Dry Mass      : ~5.685 metric tons (Excluding payload & adaptors)
-//      * Tank Section    : 2.200 t  (MLI-shielded Cryogenic Hydrolox)
-//      * Habitat Module  : 3.200 t  (4-Crew / 30-Day Life Support)
-//      * BE-7 Engine     : 0.120 t  (44.5 kN Dual-Expander Hydrolox)
-//      * Landing Gear    : 0.340 t  (4x 0.085 t Articulating Struts)
+//  - Total Dry Mass      : ~16.000 metric tons (16,000 kg / ~17.6 short tons)
+//      * Habitat Module  : 6.000 t  (4-Crew / 30-Day Pressurized Cabin)
+//      * Tank Section    : 8.800 t  (MLI-shielded Hydrolox Main Tank)
+//      * Landing Gear    : 1.000 t  (4x 0.250 t Heavy Articulating Struts)
+//      * BE-7 Engine     : 0.120 t  (44.5 kN Dual-Expander Hydrolox Engine)
 //      * Av/IU & RCS Unit: 0.080 t  (GNC, TT&C, Active Cooling Loop)
 //
 //  - Main Propulsion     : 1x BE-7 Engine (LOX/LH2, Vacuum Isp 460s)
 //  - Main Tank Capacity  : 42,000 L Cryogenic (72% LH2 / 28% LOX by volume)
 //  - RCS System          : Hypergolic (MMH / MON3 / He Pressurant, 290s Vac Isp)
 //  - Avionics & Comms    : Integrated Dual-Band (S-Band TT&C, X-Band High-Rate)
-
-Source
-https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft) 
-https://www.blueorigin.com/fr-FR/news/be7-engine-testing 
-https://www.blueorigin.com/fr-FR/blue-moon
+//
+// Source:
+// https://en.wikipedia.org/wiki/Blue_Moon_(spacecraft)
+// https://www.blueorigin.com/fr-FR/news/be7-engine-testing
+// https://www.blueorigin.com/fr-FR/blue-moon
 // ============================================================================
+
 @PART[IQBM_Tank]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6
 
-    @mass = 2.2 
+    @mass = 8.8
 
     @maxTemp = 1200
     @skinMaxTemp = 2000
     %manufacturer = Blue Origin
-    %description = The main hydrolox cryogenic propellant tank for the Blue Moon Lunar Lander. Features integrated multi-layer insulation (MLI) to minimize liquid hydrogen boil-off during the transit to the Lunar surface.
+    %description = The main hydrolox cryogenic propellant tank for the Blue Moon Lunar Lander. Features integrated multi-layer insulation (MLI) to minimize liquid hydrogen boil-off during transit to the Lunar surface.
 
     !RESOURCE[*],* {}
     !MODULE[ModuleFuelTanks],* {}
@@ -38,7 +39,7 @@ https://www.blueorigin.com/fr-FR/blue-moon
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 42000 // Approximate realistic volume capacity in Liters
+        volume = 42000
         type = Cryogenic
         utilization = 100
         typeAvailable = Cryogenic
@@ -46,13 +47,13 @@ https://www.blueorigin.com/fr-FR/blue-moon
         TANK
         {
             name = LqdHydrogen
-            amount = 30240 // 72% of total volume
+            amount = 30240
             maxAmount = 30240
         }
         TANK
         {
             name = LqdOxygen
-            amount = 11760 // 28% of total volume
+            amount = 11760
             maxAmount = 11760
         }
     }
@@ -62,19 +63,18 @@ https://www.blueorigin.com/fr-FR/blue-moon
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6
-    @mass = 0.12 // 120 kg
+    @mass = 0.12
     @maxTemp = 900
     @skinMaxTemp = 1600
     
-    EngineType = BE-7
- 
+    %EngineType = BE-7
 }
 
 @PART[IQBM_Leg]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
     %rescaleFactor = 1.6
-    @mass = 0.085 // 85 kg per leg
+    @mass = 0.25
     @maxTemp = 900
     @skinMaxTemp = 1200
     %manufacturer = Blue Origin
@@ -83,6 +83,7 @@ https://www.blueorigin.com/fr-FR/blue-moon
     %breakingForce = 270
     %breakingTorque = 270
 }
+
 @PART[IQBM_IU]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
@@ -112,22 +113,21 @@ https://www.blueorigin.com/fr-FR/blue-moon
             rate = 0.05 
         }
     }
-   // Integrated Omni Antenna (S-Band - Low Gain / TT&C)
+
     MODULE
     {
         name = ModuleRealAntenna
-        referenceGain = 3.0       // Low-gain omnidirectional coverage
-        RFBand = S                 // S-band default
-        TxPower = 30               // 30 dBm (~1 Watt)
+        referenceGain = 3.0
+        RFBand = S
+        TxPower = 30
     }
 
-    // Integrated Directional Antenna (X-Band - High Rate Telemetry / Lunar Return)
     MODULE
     {
         name = ModuleRealAntenna
-        antennaDiameter = 0.8      // 0.8m equivalent phased array / patch antenna
-        RFBand = X                 // X-band default
-        TxPower = 37               // 37 dBm (~5 Watts)
+        antennaDiameter = 0.8
+        RFBand = X
+        TxPower = 37
     }
 
     MODULE
@@ -182,19 +182,18 @@ https://www.blueorigin.com/fr-FR/blue-moon
 @PART[IQBM_Hab]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
-
     %rescaleFactor = 1.6
-    @mass = 3.2 
+    @mass = 6.0 
     %CrewCapacity = 4
     @maxTemp = 750
     @skinMaxTemp = 1400
     %manufacturer = Blue Origin
     %description = Long-duration pressurized habitat and command module for the Blue Moon lander. Includes expanded life support, thermal control systems, and communication equipment capable of sustaining a crew of four for up to 30 days on the lunar surface.
 
-
-    !MODULE[ModuleDataTransmitter],* {}
+    !MODULE[ModuleDataTransmitter*],* {}
     !MODULE[ModuleReactionWheel],* {}
     !MODULE[ModuleFuelTanks],* {}
+    !MODULE[ModuleResourceConverter*],* {}
     !RESOURCE[*],* {}
 
     MODULE
@@ -210,8 +209,49 @@ https://www.blueorigin.com/fr-FR/blue-moon
 
     MODULE
     {
+        name = ModuleResourceConverter
+        ConverterName = Hydrolox Fuel Cell
+        StartActionName = Start Fuel Cell
+        StopActionName = Stop Fuel Cell
+        ToggleActionName = Toggle Fuel Cell
+        FillAmount = 0.95
+        AutoShutdown = false
+        GeneratesHeat = true
+        DefaultShutoffTemp = 0.8
+        UseSpecialistBonus = false
+
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdHydrogen
+            Ratio = 0.0002821 
+            FlowMode = STAGE_PRIORITY_FLOW
+        }
+        INPUT_RESOURCE
+        {
+            ResourceName = LqdOxygen
+            Ratio = 0.0001402 
+            FlowMode = STAGE_PRIORITY_FLOW
+        }
+
+        OUTPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 1.5 
+            DumpExcess = false
+        }
+        OUTPUT_RESOURCE
+        {
+            ResourceName = Water
+            Ratio = 0.0000001788 
+            DumpExcess = true 
+        }
+    }
+    
+    MODULE
+    {
         name = ModuleFuelTanks
         volume = 300000 
+        type = ServiceModule
         
         TANK
         {
@@ -219,7 +259,6 @@ https://www.blueorigin.com/fr-FR/blue-moon
             amount = 150000
             maxAmount = 150000
         }
-
         TANK
         {
             name = Food
@@ -268,8 +307,6 @@ https://www.blueorigin.com/fr-FR/blue-moon
             amount = 0
             maxAmount = 400
         }
-
-        // --- RCS HYPERGOLS & PRESSURANT ---
         TANK
         {
             name = MMH
@@ -289,12 +326,14 @@ https://www.blueorigin.com/fr-FR/blue-moon
             maxAmount = 4000
         }
     }
+
+    MODULE
     {
         name = ModuleRCSFX
         stagingEnabled = True
         thrusterTransformName = rcsTransform 
         !resourceName = DELETE
-        thrusterPower = 0.111 // ~111 N thrust per RCS thruster nozzle
+        thrusterPower = 0.111
         resourceFlowMode = STAGE_PRIORITY_FLOW
 
         PROPELLANT

--- a/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/IQ_BlueMoon/RO_IQ_BlueMoon.cfg
@@ -67,7 +67,7 @@
     @maxTemp = 900
     @skinMaxTemp = 1600
     
-    %EngineType = BE-7
+    %engineType = BE-7
 }
 
 @PART[IQBM_Leg]:FOR[RealismOverhaul]


### PR DESCRIPTION
this PR adds config for the Blue Moon (HLS/Mark 2) from the IsaQuest's Blue Moon Lander mod

<img width="960" height="1278" alt="image_2026-07-19_105309159" src="https://github.com/user-attachments/assets/109f6625-4402-4f03-a52d-e87d96af0416" />
