### PR TITLE
Add an High-Altitude Scientific Research Balloon from the Kerballoons mod

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -3,7 +3,6 @@
     %RSSROConfig = True
     %rescaleFactor = 1.0 
     %title = High-Altitude Scientific Research Balloon (Universal)
-    %manufacturer = Generic Aerospace Research
     %description = A scaled, zero-pressure atmospheric research balloon capable of carrying  payloads into upper stratospheres for weather observation, atmospheric sampling, and scientific telemetry.
     
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -1,0 +1,9 @@
+@PART[universalBalloonHP]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    %rescaleFactor = 1.0 
+    %title = High-Altitude Scientific Research Balloon (Universal)
+    %manufacturer = Generic Aerospace Research
+    %description = A scaled, zero-pressure atmospheric research balloon capable of carrying  payloads into upper stratospheres for weather observation, atmospheric sampling, and scientific telemetry.
+    
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -1,8 +1,18 @@
-@PART[universalBalloonHP]:FOR[RealismOverhaul]
+@PART[UniversalBalloon]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
 {
-    %RSSROConfig = True
-    %rescaleFactor = 1.0 
-    %title = High-Altitude Scientific Research Balloon (Universal)
-    %description = A scaled, zero-pressure atmospheric research balloon capable of carrying  payloads into upper stratospheres for weather observation, atmospheric sampling, and scientific telemetry.
+    %RSSROConfig = True    
+    %title = Heavy-Lift High-Altitude Research Balloon (Universal)
+    %manufacturer = Generic Aerospace Research
+    %description = An ultra-large, heavy-lift scientific balloon assembly capable of hoisting heavy payloads up to 50 metric tons into the upper atmosphere.
     
+    // Physical Parameters & Scaling
+    %rescaleFactor = 1.0
+    %mass = 0.05
+    %maxTemp = 800
+    %crashTolerance = 8
+    // Adjust KerBalloon module parameters for 150 t payload capacity
+    @MODULE[ModuleKerBalloon],*
+    {
+        %liftCapacity = 50.0 // Lift capacity 
+    }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -3,14 +3,11 @@
     %RSSROConfig = True    
     %title = Heavy-Lift High-Altitude Research Balloon (Universal)
     %manufacturer = Generic Aerospace Research
-    %description = An ultra-large, heavy-lift scientific balloon assembly capable of hoisting heavy payloads up to 50 metric tons into the upper atmosphere.
-    
-    // Physical Parameters & Scaling
+    %description = An ultra-large, heavy-lift scientific balloon assembly capable of hoisting heavy payloads up to 50 metric tons into the upper atmosphere.    
     %rescaleFactor = 1.0
     %mass = 0.05
     %maxTemp = 800
     %crashTolerance = 8
-    // Adjust KerBalloon module parameters for 150 t payload capacity
     @MODULE[ModuleKerBalloon],*
     {
         %liftCapacity = 80.0 // Lift capacity 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -1,4 +1,4 @@
-@PART[UniversalBalloon]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
+@PART[universalBalloonHP]:NEEDS[RealismOverhaul]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True    
     %title = Heavy-Lift High-Altitude Research Balloon (Universal)

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -13,6 +13,6 @@
     // Adjust KerBalloon module parameters for 150 t payload capacity
     @MODULE[ModuleKerBalloon],*
     {
-        %liftCapacity = 50.0 // Lift capacity 
+        %liftCapacity = 80.0 // Lift capacity 
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -10,6 +10,6 @@
     %crashTolerance = 8
     @MODULE[ModuleKerBalloon],*
     {
-        %liftCapacity = 80.0 // Lift capacity 
+        %liftCapacity = 150.0 // Lift capacity 
     }
 }

--- a/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/KerBalloons/RO_Kerballoon.cfg
@@ -2,12 +2,13 @@
 {
     %RSSROConfig = True    
     %title = Heavy-Lift High-Altitude Research Balloon (Universal)
-    %manufacturer = Generic Aerospace Research
+    %manufacturer = NASA/JPL
     %description = An ultra-large, heavy-lift scientific balloon assembly capable of hoisting heavy payloads up to 50 metric tons into the upper atmosphere.    
     %rescaleFactor = 1.0
     %mass = 0.05
     %maxTemp = 800
     %crashTolerance = 8
+    %category = Utility
     @MODULE[ModuleKerBalloon],*
     {
         %liftCapacity = 150.0 // Lift capacity 


### PR DESCRIPTION
this pr adds the universal balloon form the  kerballoons mod and so contains a :

High-Altitude Scientific Research Balloon (Universal)


<img width="955" height="536" alt="Capture d’écran 2026-07-21 175817" src="https://github.com/user-attachments/assets/041d2ec2-b09b-4db6-92e2-4d0a2dccafea" />

image from:https://youtu.be/0Oj4jqqJQOA?si=Nh_Pg8Eo0rrs1liJ 
