### PR TITLE
Fix LK size

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RaiderNick/RO_RN_LK_LOK.cfg
@@ -3,9 +3,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 1.336 //1.436-0.1 for one crew mass
 	@manufacturer = MOM - Korolev
@@ -166,9 +166,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 1.44
 	@manufacturer = MOM - Korolev
@@ -304,9 +304,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 0.053
 	@manufacturer = SDO Yuzhnoye
@@ -406,9 +406,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 0.057
 	@manufacturer = SDO Yuzhnoye
@@ -1228,9 +1228,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 0.05
 	@manufacturer = SDO Yuzhnoye
@@ -1330,9 +1330,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 0.003
 	@manufacturer = SDO Yuzhnoye
@@ -1432,9 +1432,9 @@
 	%RSSROConfig = True
 	@MODEL
 	{
-		@scale = 1.0, 1.0, 1.0
+		@scale = 0.74, 0.74, 0.74
 	}
-	@scale = 1
+	@scale = 0.74
 	@rescaleFactor = 1
 	@mass = 0.057
 	@manufacturer = SDO Yuzhnoye


### PR DESCRIPTION
RN's LK is much bigger than it should, this PR fix this to match real life's stowed numbers (according to RussianSpaceWeb).

LK is now 2.26m wide stowed (legs excluded) and 4.5m wide deployed (legs included).

Might make interfacing with RN's N1 awkward though.