### PR TITLE
Adds the Altair/LSAM lunar lander from Aquila Lunar Lander mod 

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
@@ -28,20 +28,7 @@ general statistics and specifications for the Altair Lunar Lander are also summa
             @rate = 1.2  // ~1.2 kW baseline avionics
         }
     }
-  !MODULE[ModuleDataTransmitter],* {}
 
-    MODULE
-    {
-        name = ModuleDataTransmitter
-        antennaType = DIRECT
-        packetInterval = 0.1
-        packetSize = 2
-        packetResourceCost = 0.05
-        requiredResource = ElectricCharge
-        antennaPower = 100000000000  // 100M km range (Lunar -> Earth DSN link)
-        optimumRange = 50000000000
-        antennaCombinable = True
-    }
     // ------------------------------------------------------------------------
     // Fuel & Life Support Tank Setup (RealFuels / ServiceModule)
     // ------------------------------------------------------------------------
@@ -122,8 +109,26 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     }
 }
 
-// Realism Overhaul Config for Aquila Lunar Lander - Altair Descent Stage
-// Mod author: rogerwang86
+@PART[Altair_AscentStage]:AFTER[RealismOverhaul]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+
+    // UHF Omni for proximity ops (Lunar Orbit / Surface EVA)
+    MODULE
+    {
+        name = ModuleRealAntenna
+        antennaDiameter = 0.3
+        RFBand = UHF
+    }
+
+    // High-Gain S-Band Dish for Direct-to-Earth link
+    MODULE
+    {
+        name = ModuleRealAntenna
+        antennaDiameter = 1.2
+        RFBand = S
+    }
+}
 
 @PART[Altair_DescentStage]:NEEDS[RealismOverhaul]
 {

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
@@ -1,0 +1,432 @@
+source:
+Altair schematics and specifications are based on NASA official Altair Lunar Lander design documents, which can be found in the following reference: 
+[NASA Altair Lunar Lander Design Reference](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjT9fycu-uVAxU8lIkEHUuhAv4QFnoECB0QAQ&url=https%3A%2F%2Fntrs.nasa.gov%2Fapi%2Fcitations%2F20090035549%2Fdownloads%2F20090035549.pdf%3Fattachment%3Dtrue&us
+
+general statistics and specifications for the Altair Lunar Lander are also summarized in the Wikipedia article: 
+[Altair (spacecraft)](https://en.wikipedia.org/wiki/Altair_(spacecraft)).
+
+
+
+@PART[Altair_AscentStage]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander Ascent Stage
+    @manufacturer = NASA / Contractor Team
+    @description = The crew cabin and ascent core of the Altair Lunar Lander. Houses 4 astronauts for lunar sorties, equipped with integrated avionics, RCS thrusters, and propellant storage. Designed to rely on the Descent Stage for long-duration life support supplies.
+
+    @mass = 3.2  // Tonnes dry mass
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+    @CrewCapacity = 4
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 1.2  // ~1.2 kW baseline avionics
+        }
+    }
+  !MODULE[ModuleDataTransmitter],* {}
+
+    MODULE
+    {
+        name = ModuleDataTransmitter
+        antennaType = DIRECT
+        packetInterval = 0.1
+        packetSize = 2
+        packetResourceCost = 0.05
+        requiredResource = ElectricCharge
+        antennaPower = 100000000000  // 100M km range (Lunar -> Earth DSN link)
+        optimumRange = 50000000000
+        antennaCombinable = True
+    }
+    // ------------------------------------------------------------------------
+    // Fuel & Life Support Tank Setup (RealFuels / ServiceModule)
+    // ------------------------------------------------------------------------
+    !RESOURCE[*],* {}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 6200  // Liters
+        type = ServiceModule
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 120000  // 120 kJ reserve
+            maxAmount = 120000
+        }
+
+        // Ascent Propellant (Aerozine50 / NTO)
+        TANK
+        {
+            name = Aerozine50
+            amount = 2650
+            maxAmount = 2650
+        }
+        TANK
+        {
+            name = NTO
+            amount = 2650
+            maxAmount = 2650
+        }
+        TANK
+        {
+            name = Helium
+            amount = 15000
+            maxAmount = 15000
+            utilization = 200
+        }
+
+        // Kerbalism Emergency / Short-Duration Buffer (~2.5 days for 4 crew)
+        TANK
+        {
+            name = Food
+            amount = 60
+            maxAmount = 60
+        }
+        TANK
+        {
+            name = Water
+            amount = 40
+            maxAmount = 40
+        }
+        TANK
+        {
+            name = Oxygen
+            amount = 12000
+            maxAmount = 12000
+        }
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 10000
+        }
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 100
+        }
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 100
+        }
+    }
+}
+
+// Realism Overhaul Config for Aquila Lunar Lander - Altair Descent Stage
+// Mod author: rogerwang86
+
+@PART[Altair_DescentStage]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander Descent Stage
+    @manufacturer = NASA / Contractor Team
+    @description = The heavy descent platform for the Altair lander. Houses cryogenic LH2/LOX propellants to perform Lunar Orbit Insertion (LOI) and Powered Descent, along with the primary 7-day life support consumables for 4 astronauts.
+
+    @mass = 4.8  // Tonnes dry mass (structure, legs, landing radar, tankage)
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+
+
+       // Cryo boiloff mitigation for multi-day lunar orbit/surface stay
+    MODULE
+    {
+        name = ModuleBOILOFF
+        boiloffGases = LqdHydrogen, LqdOxygen
+    }
+
+    // ------------------------------------------------------------------------
+    // Fuel & Life Support Tank Setup (RealFuels / ServiceModule)
+    // ------------------------------------------------------------------------
+    !RESOURCE[*],* {}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 68000  // Liters total volume
+        type = ServiceModule
+        basemass = -1
+
+        // --------------------------------------------------------------------
+        // Primary Propulsion: Hydrolox (LH2 / LOX)
+        // LOI (~900 m/s) + Landing (~1950 m/s) for ~45t total initial wet mass
+        // --------------------------------------------------------------------
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 45000
+            maxAmount = 45000
+        }
+        TANK
+        {
+            name = LqdOxygen
+            amount = 16200
+            maxAmount = 16200
+        }
+        TANK
+        {
+            name = Helium
+            amount = 80000
+            maxAmount = 80000
+            utilization = 200  // Cryo pressurant
+        }
+
+        // --------------------------------------------------------------------
+        // Power Generation & Primary Electrical Reserve
+        // --------------------------------------------------------------------
+        TANK
+        {
+            name = ElectricCharge
+            amount = 350000  // 350 kJ (~97 kWh for long surface stays)
+            maxAmount = 350000
+        }
+
+        // --------------------------------------------------------------------
+        // Primary Kerbalism Surface Life Support (4 Crew x 7 Days)
+        // --------------------------------------------------------------------
+        TANK
+        {
+            name = Food
+            amount = 168  // ~6 L / crew / day
+            maxAmount = 168
+        }
+        TANK
+        {
+            name = Water
+            amount = 112  // ~4 L / crew / day
+            maxAmount = 112
+        }
+        TANK
+        {
+            name = Oxygen
+            amount = 35000  // Compressed gaseous O2
+            maxAmount = 35000
+        }
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 30000
+        }
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 300
+        }
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 300
+        }
+    }
+}
+
+@PART[Altair_RCS]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    // ------------------------------------------------------------------------
+    // Rescaling & Mass Properties
+    // ------------------------------------------------------------------------
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander RCS Thruster Quad
+    @manufacturer = NASA / Contractor Team
+    @description = A heavy-duty reaction control system quad for the Altair Ascent/Descent stages. Uses hypergolic Aerozine50 and NTO to provide translation and attitude control during lunar descent, rendezvous, and docking maneuvers.
+
+    @mass = 0.028  // ~28 kg per thruster quad unit
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+
+    // ------------------------------------------------------------------------
+    // RCS Engine Parameters (Hypergolic Aerozine50/NTO)
+    // ------------------------------------------------------------------------
+    @MODULE[ModuleRCSFX],*
+    {
+        @name = ModuleRCSFX
+        @currentThrottle = True
+        @thrusterPower = 0.44  // 440 N (~100 lbf) per thruster
+        @resourceName = Aerozine50
+
+        !PROPELLANT[*],* {}
+
+        PROPELLANT
+        {
+            name = Aerozine50
+            ratio = 0.502
+            DrawGauge = True
+        }
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.498
+        }
+        PROPELLANT
+        {
+            name = ElectricCharge
+            ratio = 1.0
+            ignoreForIsp = True
+        }
+
+        @atmosphereCurve
+        {
+            @key,0 = 0 311  // High vacuum Isp for modern hypergolic RCS
+            @key,1 = 1 100
+        }
+    }
+}
+@PART[Altair_RCS]:AFTER[RealismOverhaul]:NEEDS[RealFuels]
+{
+    @MODULE[ModuleRCSFX],*
+    {
+        %fullThrust = True
+        %useZaxis = True
+    }
+}
+
+
+@PART[Altair_Airlock]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander Dedicated Airlock
+    @manufacturer = NASA / Contractor Team
+    @description = A dedicated EVA airlock for the Altair lander. Houses up to 2 astronauts for surface excursions while keeping lunar dust out of the primary ascent module and avoiding cabin depressurization cycles.
+
+    @mass = 0.85  // ~850 kg dry mass (structure, outer hatch, vacuum pumps, dust mitigation)
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+
+    // ------------------------------------------------------------------------
+    // Crew Capacity & Internal Power
+    // ------------------------------------------------------------------------
+    @CrewCapacity = 2
+
+    @MODULE[ModuleCommand]
+    {
+        @RESOURCE[ElectricCharge]
+        {
+            @rate = 0.2  // ~200 W operational power during EVA sequences
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Gas Buffers for Depressurization & Repressurization Cycles
+    // ------------------------------------------------------------------------
+    !RESOURCE[*],* {}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 600  // Liters internal buffer space
+        type = ServiceModule
+        basemass = -1
+
+        TANK
+        {
+            name = ElectricCharge
+            amount = 15000  // 15 kJ utility battery
+            maxAmount = 15000
+        }
+
+        // Compressed Nitrogen/Oxygen mixture for airlock repressurization
+        TANK
+        {
+            name = Oxygen
+            amount = 5000
+            maxAmount = 5000
+        }
+        TANK
+        {
+            name = Nitrogen
+            amount = 8000
+            maxAmount = 8000
+        }
+    }
+}
+
+
+@PART[Altair_Ladder]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander Surface Access Ladder
+    @manufacturer = NASA / Contractor Team
+    @description = A lightweight, extendable aluminum alloy ladder used by crew members to climb down from the Altair airlock or ascent cabin to the lunar surface.
+
+    @mass = 0.015  // ~15 kg structural mass
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+
+    %PhysicsSignificance = 1  // Massless physics part in KSP calculations
+}
+
+
+
+@PART[Altair_LandingLeg]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+
+    // ------------------------------------------------------------------------
+    // Rescaling & Mass Properties
+    // ------------------------------------------------------------------------
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander Primary Landing Leg
+    @manufacturer = NASA / Contractor Team
+    @description = A heavy-duty telescoping landing leg equipped with crushable aluminum honeycomb shock absorbers to cushion the impact of landing on rugged lunar terrain. Designed for 4-leg configurations.
+
+    @mass = 0.180  // ~180 kg per leg assembly (structure, hydraulics, crushable core, footpad)
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+
+    @crashTolerance = 12   // Withstands impacts up to ~12 m/s touchdown speed
+    @breakingForce = 250
+    @breakingTorque = 250
+
+    @MODULE[ModuleWheelBase]
+    {
+        @groundHeightOffset = 0
+    }
+
+    @MODULE[ModuleWheelSuspension]
+    {
+        @springRating = 1.8   // Tuned for ~45t total wet mass on Moon (1/6th g)
+        @damperRating = 1.2
+    }
+}
+
+@PART[Altair_Decoupler]:NEEDS[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 1.6
+
+    @title = Altair Lunar Lander Ascent/Descent Decoupler Ring
+    @manufacturer = NASA / Contractor Team
+    @description = A lightweight pyrotechnic decoupler ring connecting the Altair Ascent Stage to the Descent Stage platform. Uses high-reliability explosive bolts to separate the crew vehicle for lunar launch.
+
+    @mass = 0.085  // ~85 kg structural ring and pyrotechnic mechanisms
+    @maxTemp = 1073.15
+    @skinMaxTemp = 2000
+
+    @MODULE[ModuleDecouple]
+    {
+        @ejectionForce = 15  // Moderate impulse (~15 kN) to cleanly clear the descent stage structure
+        %staged = true
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
@@ -1,6 +1,6 @@
 
-// Mod Author: rogerwang86 | Scale Factor: 1.6x | Target Mass: ~9.78 t Dry
-// Crew Capacity: 4 Astronauts (Main Cabin) + 2 (EVA Airlock)
+// Mod Author: rogerwang86 | Target Mass: ~9.78 t Dry
+// Crew Capacity: 4 Astronauts (Main Cabin) + 1 (EVA Airlock)
 // Target Mission: Lunar Orbit Insertion (LOI), Surface Landing & 7-Day Stay
 // ============================================================================
 // SUMMARY OF PARTS & MASSES:
@@ -48,7 +48,7 @@ Altair schematics and specifications are based on NASA official Altair Lunar Lan
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 6200
+        volume = 28000
         type = ServiceModule
         basemass = -1
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
@@ -1,11 +1,11 @@
 
 // Mod Author: rogerwang86 | Target Mass: ~9.78 t Dry
-// Crew Capacity: 4 Astronauts (Main Cabin) + 1 (EVA Airlock)
-// Target Mission: Lunar Orbit Insertion (LOI), Surface Landing & 7-Day Stay
+// Crew Capacity: 4 Astronauts (Main Cabin) + 2 (EVA Airlock)
+// Target Mission: Lunar Orbit Insertion (LOI), Surface Landing (Crewed / 15t Cargo Variant) & 7-Day Stay
 // ============================================================================
 // SUMMARY OF PARTS & MASSES:
 //   - Ascent Stage   [Altair_AscentStage] : 3.200 t  (Aerozine50/NTO + RCS + 2.5d LS Buffer)
-//   - Descent Stage  [Altair_DescentStage]: 4.800 t  (Hydrolox + LOI/Landing + 7d Main LS)
+//   - Descent Stage  [Altair_DescentStage]: 4.800 t  (Hydrolox + LOI/Landing + 7d Main LS + 15t Cargo Volume)
 //   - Airlock        [Altair_Airlock]     : 0.850 t  (2 Crew EVA Hub + Repress Gas Buffer)
 //   - Decoupler Ring [Altair_Decoupler]   : 0.085 t  (15 kN Ejection Pyrotechnic Separation)
 //   - Landing Leg    [Altair_LandingLeg]  : 0.180 t  (x4 = 0.720 t Total, 12 m/s Tolerance)
@@ -13,12 +13,13 @@
 //   - Access Ladder  [Altair_Ladder]      : 0.015 t  (Massless Physics Child)
 // ----------------------------------------------------------------------------
 // TOTAL SYSTEM DRY MASS: ~9.782 tonnes
-// TOTAL PROPELLANT CAPACITY: 68,000 L (Descent Hydrolox) + 5,300 L (Ascent Hypergolic)
+// TOTAL TANK CAPACITY: 205,000 L (Descent Stage) + 28,000 L (Ascent Stage)
+// DEFAULT PROPELLANT LOAD: 80,240 L (Descent Hydrolox) + 5,300 L (Ascent Hypergolic)
 // ============================================================================
 source:
 Altair schematics and specifications are based on NASA official Altair Lunar Lander design documents, which can be found in the following reference: 
 [NASA Altair Lunar Lander Design Reference](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjT9fycu-uVAxU8lIkEHUuhAv4QFnoECB0QAQ&url=https%3A%2F%2Fntrs.nasa.gov%2Fapi%2Fcitations%2F20090035549%2Fdownloads%2F20090035549.pdf%3Fattachment%3Dtrue&us
- https://ntrs.nasa.gov/api/citations/20100035768/downloads/20100035768.pdf?attachment=true.general statistics and specifications for the Altair Lunar Lander are also summarized in the Wikipedia article: 
+https://ntrs.nasa.gov/api/citations/20100035768/downloads/20100035768.pdf?attachment=true.general statistics and specifications for the Altair Lunar Lander are also summarized in the Wikipedia article: 
 [Altair (spacecraft)](https://en.wikipedia.org/wiki/Altair_(spacecraft)).
 
 @PART[Altair_AscentStage]:NEEDS[RealismOverhaul]
@@ -142,7 +143,7 @@ Altair schematics and specifications are based on NASA official Altair Lunar Lan
 
     @title = Altair Lunar Lander Descent Stage
     @manufacturer = NASA / Contractor Team
-    @description = The heavy descent platform for the Altair lander. Houses cryogenic LH2/LOX propellants to perform Lunar Orbit Insertion (LOI) and Powered Descent, along with primary 7-day life support consumables for 4 astronauts.
+    @description = The heavy descent platform for the Altair lander. Houses cryogenic LH2/LOX propellants to perform Lunar Orbit Insertion (LOI) and Powered Descent for either the crewed Ascent Stage or up to a 15-tonne uncrewed cargo payload.
 
     @mass = 4.8
     @maxTemp = 1073.15
@@ -159,7 +160,7 @@ Altair schematics and specifications are based on NASA official Altair Lunar Lan
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 84000
+        volume = 205000
         type = ServiceModule
         basemass = -1
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/Aquila Lunar Lander/Aquila_RO_Altair.cfg
@@ -1,11 +1,25 @@
+
+// Mod Author: rogerwang86 | Scale Factor: 1.6x | Target Mass: ~9.78 t Dry
+// Crew Capacity: 4 Astronauts (Main Cabin) + 2 (EVA Airlock)
+// Target Mission: Lunar Orbit Insertion (LOI), Surface Landing & 7-Day Stay
+// ============================================================================
+// SUMMARY OF PARTS & MASSES:
+//   - Ascent Stage   [Altair_AscentStage] : 3.200 t  (Aerozine50/NTO + RCS + 2.5d LS Buffer)
+//   - Descent Stage  [Altair_DescentStage]: 4.800 t  (Hydrolox + LOI/Landing + 7d Main LS)
+//   - Airlock        [Altair_Airlock]     : 0.850 t  (2 Crew EVA Hub + Repress Gas Buffer)
+//   - Decoupler Ring [Altair_Decoupler]   : 0.085 t  (15 kN Ejection Pyrotechnic Separation)
+//   - Landing Leg    [Altair_LandingLeg]  : 0.180 t  (x4 = 0.720 t Total, 12 m/s Tolerance)
+//   - RCS Quad       [Altair_RCS]         : 0.028 t  (x4 = 0.112 t Total, 440 N Hypergolic)
+//   - Access Ladder  [Altair_Ladder]      : 0.015 t  (Massless Physics Child)
+// ----------------------------------------------------------------------------
+// TOTAL SYSTEM DRY MASS: ~9.782 tonnes
+// TOTAL PROPELLANT CAPACITY: 68,000 L (Descent Hydrolox) + 5,300 L (Ascent Hypergolic)
+// ============================================================================
 source:
 Altair schematics and specifications are based on NASA official Altair Lunar Lander design documents, which can be found in the following reference: 
 [NASA Altair Lunar Lander Design Reference](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjT9fycu-uVAxU8lIkEHUuhAv4QFnoECB0QAQ&url=https%3A%2F%2Fntrs.nasa.gov%2Fapi%2Fcitations%2F20090035549%2Fdownloads%2F20090035549.pdf%3Fattachment%3Dtrue&us
-
-general statistics and specifications for the Altair Lunar Lander are also summarized in the Wikipedia article: 
+ https://ntrs.nasa.gov/api/citations/20100035768/downloads/20100035768.pdf?attachment=true.general statistics and specifications for the Altair Lunar Lander are also summarized in the Wikipedia article: 
 [Altair (spacecraft)](https://en.wikipedia.org/wiki/Altair_(spacecraft)).
-
-
 
 @PART[Altair_AscentStage]:NEEDS[RealismOverhaul]
 {
@@ -16,7 +30,7 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     @manufacturer = NASA / Contractor Team
     @description = The crew cabin and ascent core of the Altair Lunar Lander. Houses 4 astronauts for lunar sorties, equipped with integrated avionics, RCS thrusters, and propellant storage. Designed to rely on the Descent Stage for long-duration life support supplies.
 
-    @mass = 3.2  // Tonnes dry mass
+    @mass = 3.2
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
     @CrewCapacity = 4
@@ -25,30 +39,25 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate = 1.2  // ~1.2 kW baseline avionics
+            @rate = 1.2
         }
     }
 
-    // ------------------------------------------------------------------------
-    // Fuel & Life Support Tank Setup (RealFuels / ServiceModule)
-    // ------------------------------------------------------------------------
     !RESOURCE[*],* {}
 
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 6200  // Liters
+        volume = 6200
         type = ServiceModule
         basemass = -1
 
         TANK
         {
             name = ElectricCharge
-            amount = 120000  // 120 kJ reserve
+            amount = 120000
             maxAmount = 120000
         }
-
-        // Ascent Propellant (Aerozine50 / NTO)
         TANK
         {
             name = Aerozine50
@@ -68,8 +77,6 @@ general statistics and specifications for the Altair Lunar Lander are also summa
             maxAmount = 15000
             utilization = 200
         }
-
-        // Kerbalism Emergency / Short-Duration Buffer (~2.5 days for 4 crew)
         TANK
         {
             name = Food
@@ -113,7 +120,6 @@ general statistics and specifications for the Altair Lunar Lander are also summa
 {
     !MODULE[ModuleDataTransmitter],* {}
 
-    // UHF Omni for proximity ops (Lunar Orbit / Surface EVA)
     MODULE
     {
         name = ModuleRealAntenna
@@ -121,7 +127,6 @@ general statistics and specifications for the Altair Lunar Lander are also summa
         RFBand = UHF
     }
 
-    // High-Gain S-Band Dish for Direct-to-Earth link
     MODULE
     {
         name = ModuleRealAntenna
@@ -137,85 +142,68 @@ general statistics and specifications for the Altair Lunar Lander are also summa
 
     @title = Altair Lunar Lander Descent Stage
     @manufacturer = NASA / Contractor Team
-    @description = The heavy descent platform for the Altair lander. Houses cryogenic LH2/LOX propellants to perform Lunar Orbit Insertion (LOI) and Powered Descent, along with the primary 7-day life support consumables for 4 astronauts.
+    @description = The heavy descent platform for the Altair lander. Houses cryogenic LH2/LOX propellants to perform Lunar Orbit Insertion (LOI) and Powered Descent, along with primary 7-day life support consumables for 4 astronauts.
 
-    @mass = 4.8  // Tonnes dry mass (structure, legs, landing radar, tankage)
+    @mass = 4.8
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
 
-
-       // Cryo boiloff mitigation for multi-day lunar orbit/surface stay
     MODULE
     {
         name = ModuleBOILOFF
         boiloffGases = LqdHydrogen, LqdOxygen
     }
 
-    // ------------------------------------------------------------------------
-    // Fuel & Life Support Tank Setup (RealFuels / ServiceModule)
-    // ------------------------------------------------------------------------
     !RESOURCE[*],* {}
 
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 68000  // Liters total volume
+        volume = 84000
         type = ServiceModule
         basemass = -1
 
-        // --------------------------------------------------------------------
-        // Primary Propulsion: Hydrolox (LH2 / LOX)
-        // LOI (~900 m/s) + Landing (~1950 m/s) for ~45t total initial wet mass
-        // --------------------------------------------------------------------
         TANK
         {
             name = LqdHydrogen
-            amount = 45000
-            maxAmount = 45000
+            amount = 59000
+            maxAmount = 59000
         }
         TANK
         {
             name = LqdOxygen
-            amount = 16200
-            maxAmount = 16200
+            amount = 21240
+            maxAmount = 21240
         }
         TANK
         {
             name = Helium
-            amount = 80000
-            maxAmount = 80000
-            utilization = 200  // Cryo pressurant
+            amount = 110000
+            maxAmount = 110000
+            utilization = 200
         }
-
-        // --------------------------------------------------------------------
-        // Power Generation & Primary Electrical Reserve
-        // --------------------------------------------------------------------
         TANK
         {
             name = ElectricCharge
-            amount = 350000  // 350 kJ (~97 kWh for long surface stays)
+            amount = 350000
             maxAmount = 350000
         }
-
-        // --------------------------------------------------------------------
-        // Primary Kerbalism Surface Life Support (4 Crew x 7 Days)
-        // --------------------------------------------------------------------
         TANK
         {
             name = Food
-            amount = 168  // ~6 L / crew / day
+            amount = 168
             maxAmount = 168
         }
         TANK
         {
             name = Water
-            amount = 112  // ~4 L / crew / day
+            amount = 112
             maxAmount = 112
         }
         TANK
         {
             name = Oxygen
-            amount = 35000  // Compressed gaseous O2
+            amount = 35000
             maxAmount = 35000
         }
         TANK
@@ -242,28 +230,21 @@ general statistics and specifications for the Altair Lunar Lander are also summa
 @PART[Altair_RCS]:NEEDS[RealismOverhaul]
 {
     %RSSROConfig = True
-
-    // ------------------------------------------------------------------------
-    // Rescaling & Mass Properties
-    // ------------------------------------------------------------------------
     @rescaleFactor = 1.6
 
     @title = Altair Lunar Lander RCS Thruster Quad
     @manufacturer = NASA / Contractor Team
     @description = A heavy-duty reaction control system quad for the Altair Ascent/Descent stages. Uses hypergolic Aerozine50 and NTO to provide translation and attitude control during lunar descent, rendezvous, and docking maneuvers.
 
-    @mass = 0.028  // ~28 kg per thruster quad unit
+    @mass = 0.028
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
 
-    // ------------------------------------------------------------------------
-    // RCS Engine Parameters (Hypergolic Aerozine50/NTO)
-    // ------------------------------------------------------------------------
     @MODULE[ModuleRCSFX],*
     {
         @name = ModuleRCSFX
         @currentThrottle = True
-        @thrusterPower = 0.44  // 440 N (~100 lbf) per thruster
+        @thrusterPower = 0.44
         @resourceName = Aerozine50
 
         !PROPELLANT[*],* {}
@@ -288,11 +269,12 @@ general statistics and specifications for the Altair Lunar Lander are also summa
 
         @atmosphereCurve
         {
-            @key,0 = 0 311  // High vacuum Isp for modern hypergolic RCS
+            @key,0 = 0 311
             @key,1 = 1 100
         }
     }
 }
+
 @PART[Altair_RCS]:AFTER[RealismOverhaul]:NEEDS[RealFuels]
 {
     @MODULE[ModuleRCSFX],*
@@ -301,7 +283,6 @@ general statistics and specifications for the Altair Lunar Lander are also summa
         %useZaxis = True
     }
 }
-
 
 @PART[Altair_Airlock]:NEEDS[RealismOverhaul]
 {
@@ -312,43 +293,35 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     @manufacturer = NASA / Contractor Team
     @description = A dedicated EVA airlock for the Altair lander. Houses up to 2 astronauts for surface excursions while keeping lunar dust out of the primary ascent module and avoiding cabin depressurization cycles.
 
-    @mass = 0.85  // ~850 kg dry mass (structure, outer hatch, vacuum pumps, dust mitigation)
+    @mass = 0.85
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
 
-    // ------------------------------------------------------------------------
-    // Crew Capacity & Internal Power
-    // ------------------------------------------------------------------------
     @CrewCapacity = 2
 
     @MODULE[ModuleCommand]
     {
         @RESOURCE[ElectricCharge]
         {
-            @rate = 0.2  // ~200 W operational power during EVA sequences
+            @rate = 0.2
         }
     }
 
-    // ------------------------------------------------------------------------
-    // Gas Buffers for Depressurization & Repressurization Cycles
-    // ------------------------------------------------------------------------
     !RESOURCE[*],* {}
 
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 600  // Liters internal buffer space
+        volume = 600
         type = ServiceModule
         basemass = -1
 
         TANK
         {
             name = ElectricCharge
-            amount = 15000  // 15 kJ utility battery
+            amount = 15000
             maxAmount = 15000
         }
-
-        // Compressed Nitrogen/Oxygen mixture for airlock repressurization
         TANK
         {
             name = Oxygen
@@ -364,7 +337,6 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     }
 }
 
-
 @PART[Altair_Ladder]:NEEDS[RealismOverhaul]
 {
     %RSSROConfig = True
@@ -374,33 +346,27 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     @manufacturer = NASA / Contractor Team
     @description = A lightweight, extendable aluminum alloy ladder used by crew members to climb down from the Altair airlock or ascent cabin to the lunar surface.
 
-    @mass = 0.015  // ~15 kg structural mass
+    @mass = 0.015
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
 
-    %PhysicsSignificance = 1  // Massless physics part in KSP calculations
+    %PhysicsSignificance = 1
 }
-
-
 
 @PART[Altair_LandingLeg]:NEEDS[RealismOverhaul]
 {
     %RSSROConfig = True
-
-    // ------------------------------------------------------------------------
-    // Rescaling & Mass Properties
-    // ------------------------------------------------------------------------
     @rescaleFactor = 1.6
 
     @title = Altair Lunar Lander Primary Landing Leg
     @manufacturer = NASA / Contractor Team
     @description = A heavy-duty telescoping landing leg equipped with crushable aluminum honeycomb shock absorbers to cushion the impact of landing on rugged lunar terrain. Designed for 4-leg configurations.
 
-    @mass = 0.180  // ~180 kg per leg assembly (structure, hydraulics, crushable core, footpad)
+    @mass = 0.180
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
 
-    @crashTolerance = 12   // Withstands impacts up to ~12 m/s touchdown speed
+    @crashTolerance = 12
     @breakingForce = 250
     @breakingTorque = 250
 
@@ -411,7 +377,7 @@ general statistics and specifications for the Altair Lunar Lander are also summa
 
     @MODULE[ModuleWheelSuspension]
     {
-        @springRating = 1.8   // Tuned for ~45t total wet mass on Moon (1/6th g)
+        @springRating = 1.8
         @damperRating = 1.2
     }
 }
@@ -425,13 +391,13 @@ general statistics and specifications for the Altair Lunar Lander are also summa
     @manufacturer = NASA / Contractor Team
     @description = A lightweight pyrotechnic decoupler ring connecting the Altair Ascent Stage to the Descent Stage platform. Uses high-reliability explosive bolts to separate the crew vehicle for lunar launch.
 
-    @mass = 0.085  // ~85 kg structural ring and pyrotechnic mechanisms
+    @mass = 0.085
     @maxTemp = 1073.15
     @skinMaxTemp = 2000
 
     @MODULE[ModuleDecouple]
     {
-        @ejectionForce = 15  // Moderate impulse (~15 kN) to cleanly clear the descent stage structure
+        @ejectionForce = 15
         %staged = true
     }
 }


### PR DESCRIPTION
this Pr brings the Altair lunar lander placed in 2018 where the first use of Altair as a landing system  was  planed 

<img width="480" height="416" alt="image" src="https://github.com/user-attachments/assets/1a4c2b76-187b-4e8d-a627-197a6bc9417d" />
