### PR TITLE
Add PLANA Configs

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/DCY_Aerospike.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/DCY_Aerospike.cfg
@@ -1,0 +1,144 @@
+// Hypothetical stats for this engine
+// Force & Isp modeled to match performance goals, using the RS2200 figures as initial inspiration 
+// RS-25 reliability
+
+@PART[*]:HAS[#engineType[DCYAerospike]]:FOR[RealismOverhaulEngines]
+{
+    %title = DCY Aerospike Engine
+    %manufacturer = #roMfrMD
+    %description = A large and expensive altitude-compensating aerospike engine, later proposed for DCY.
+
+    @tags ^= :$: USA mcdonnell douglas dcy aerospike liquid pump sustainer lqdhydrogen lqdoxygen
+
+    %specLevel = speculative
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleAlternator],*{}
+    !RESOURCE,*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        origMass = 6.5
+        modded = false
+        configuration = DCY-Aerospike-Phase-I
+        
+        CONFIG 
+        {
+            name = DCY-Aerospike-Phase-I
+            description = Phase I Aerospike for the DC-Y
+            specLevel = speculative
+            minThrust = 110
+            maxThrust = 9544.2
+
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.7276
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2724
+            }
+            atmosphereCurve
+            {
+                key = 0 460 
+                key = 1 405
+            }
+            massMult = 1.0
+            
+            %ullage = True
+            %pressureFed = False
+            %ignitions = 25 
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight] // RS-25 
+            {
+                testedBurnTime = 4700
+                ratedBurnTime = 500
+                overburnPenalty = 1.5
+                safeOverburn = true
+
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
+
+                ignitionReliabilityStart = 0.954918
+                ignitionReliabilityEnd = 0.990984
+                cycleReliabilityStart = 0.971311
+                cycleReliabilityEnd = 0.994262
+                ignitionDynPresFailMultiplier = 7.0
+            }
+        }
+
+        CONFIG 
+        {
+            name = DCY-Aerospike-Phase-II
+            description = Phase II Aerospike for the DC-Y
+            specLevel = speculative
+            minThrust = 110
+            maxThrust = 10498.62
+
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.7276
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2724
+            }
+            atmosphereCurve
+            {
+                key = 0 460 
+                key = 1 425
+            }
+            massMult = 1.1
+            
+            %ullage = True
+            %pressureFed = False
+            %ignitions = 25 
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight] // RS-25
+            {
+                testedBurnTime = 4700
+                ratedBurnTime = 500
+                overburnPenalty = 1.5
+                safeOverburn = true
+
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
+
+                ignitionReliabilityStart = 0.975000
+                ignitionReliabilityEnd = 0.996053
+                cycleReliabilityStart = 0.975000
+                cycleReliabilityEnd = 0.999211
+                ignitionDynPresFailMultiplier = 7.0
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/DCY_Bimodal.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/DCY_Bimodal.cfg
@@ -1,0 +1,104 @@
+// Proposed engine for DC-Y, amalgamation of LR-129 and HM-6 tech
+// Eight would have been used
+
+@PART[*]:HAS[#engineType[DCYBimodal]]:FOR[RealismOverhaulEngines]
+{
+    @title = DC-Y Bimodal Engine
+    @manufacturer = #roMfrMD
+    @description = A highly advanced, throttleable hydrolox engine proposed for the full-scale Delta Clipper (DC-Y). To minimize development costs, it was designed as a hybrid: utilizing the Fiat Avio HM60 LOX turbopumps, Pratt & Whitney XLR-129 LH2 turbopumps, and an extendable nozzle derived from the RL-10 to allow for both sea-level and vacuum efficiency.
+
+    %specLevel = concept
+
+    @tags ^= :$: USA mcdonnell douglas dcy liquid pump sustainer lqdhydrogen lqdoxygen
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleAlternator],*{}
+    !RESOURCE,*{}
+
+    MODULE
+    {
+        name = ModuleBimodalEngineConfigs
+        type = ModuleEngines
+        configuration = DCY-Hybrid-Retracted
+        origMass = 2.2
+        modded = false
+        animationName = NozzleExtend
+
+        CONFIG
+        {
+            name = DCY-Hybrid-Retracted
+            description = Sea-Level phase with the nozzle retracted to prevent flow separation.
+            specLevel = concept
+            
+            // 10% deep throttling capability
+            minThrust = 80.7
+            maxThrust = 850
+
+            PROPELLANT 
+            {
+                name = LqdHydrogen
+                ratio = 0.7276
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2724
+            }
+            atmosphereCurve 
+            {
+                key = 0 430 
+                key = 1 330
+            }
+            
+            %ullage = True
+            %pressureFed = False
+            %ignitions = 25 
+            %IGNITOR_RESOURCE
+            {
+                %name = ElectricCharge
+                %amount = 0.5
+            }
+
+            SUBCONFIG
+            {
+                name = DCY-Hybrid-Extended
+                description = Vacuum phase with the nozzle fully extended for maximum expansion ratio.
+                
+                minThrust = 85.75
+                maxThrust = 875
+                
+                atmosphereCurve
+                {
+                    key = 0 460
+                    key = 1 150 // Flow separation if used early
+                }
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight] 
+            {
+                testedBurnTime = 1500
+                ratedBurnTime = 260
+                overburnPenalty = 1.5
+                safeOverburn = true
+
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
+
+                ignitionReliabilityStart = 0.9415
+                ignitionReliabilityEnd = 0.9995
+                cycleReliabilityStart = 0.9415
+                cycleReliabilityEnd = 0.9995
+                ignitionDynPresFailMultiplier = 7.0
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/DCY_SeaLevel.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/DCY_SeaLevel.cfg
@@ -1,0 +1,87 @@
+// Proposed fixed-nozzle sea-level engine for DC-Y, amalgamation of LR-129 and HM-6 tech
+
+@PART[*]:HAS[#engineType[DCYSeaLevel]]:FOR[RealismOverhaulEngines]
+{
+    @title = DC-Y Sea Level Engine
+    @manufacturer = #roMfrMD
+    @description = A highly advanced, throttleable hydrolox bell engine proposed for the full-scale Delta Clipper (DC-Y). To minimize development costs, it was designed as a hybrid: utilizing the Fiat Avio HM60 LOX turbopumps and Pratt & Whitney XLR-129 LH2 turbopumps. This is the fixed, sea-level optimized variant without the extendable nozzle hardware.
+
+    %specLevel = concept
+
+    @tags ^= :$: USA mcdonnell douglas dcy liquid pump sustainer lqdhydrogen lqdoxygen
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleAlternator],*{}
+    !RESOURCE,*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        configuration = DCY-SL
+        origMass = 2.0 // Lower mass due to no nozzle extension
+        modded = false
+
+        CONFIG
+        {
+            name = DCY-SL
+            description = Fixed-nozzle sea-level optimized hydrolox engine for the DC-Y.
+            specLevel = concept
+            
+            // 10% deep throttling capability
+            minThrust = 80.7
+            maxThrust = 880.0 // Slightly more due to being optimized for sea level use
+
+            PROPELLANT 
+            {
+                name = LqdHydrogen
+                ratio = 0.7276
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2724
+            }
+            atmosphereCurve 
+            {
+                key = 0 430 
+                key = 1 350 // Slightly better due to being optimized for sea level use
+            }
+            
+            %ullage = True
+            %pressureFed = False
+            %ignitions = 25 
+            %IGNITOR_RESOURCE
+            {
+                %name = ElectricCharge
+                %amount = 0.5
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight] 
+            {
+                testedBurnTime = 1500
+                ratedBurnTime = 260
+                overburnPenalty = 1.5
+                safeOverburn = true
+
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
+
+                ignitionReliabilityStart = 0.9415
+                ignitionReliabilityEnd = 0.9995
+                cycleReliabilityStart = 0.9415
+                cycleReliabilityEnd = 0.9995
+                ignitionDynPresFailMultiplier = 7.0
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/Engine_Configs/HopeXoms.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/HopeXoms.cfg
@@ -1,0 +1,133 @@
+@PART[*]:HAS[#engineType[HopeXoms]]:FOR[RealismOverhaulEngines]
+{
+    @title = HOPE-X OMS Engine
+    @manufacturer = JAXA
+    @description = HOPE-X Orbital Maneuvering Engine, used in a pair.
+
+    %specLevel = operational
+
+    @MODULE[ModuleEngines*]
+    {
+        %EngineType = LiquidFuel
+    }
+
+    !MODULE[ModuleAlternator],*{}
+    !MODULE[ModuleEngineConfigs],*{}
+    !RESOURCE,*{}
+
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleEngines
+        origMass = 0.12
+        modded = false
+        configuration = HopeX-OMS
+        
+        CONFIG 
+        {
+            name = HopeX-OMS
+            description = The standard OMS for HOPE-X.
+            specLevel = operational
+            minThrust = 10
+            maxThrust = 15
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4943
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = MON3
+                ratio = 0.5057
+                DrawGauge = False
+            }
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 12.9
+                ignoreForIsp = True
+            }
+            atmosphereCurve
+            {
+                key = 0 320
+                key = 1 120
+            }
+            massMult = 1.0
+            
+            %ullage = True
+            %pressureFed = True
+            %ignitions = 100
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight]
+            {
+                ratedContinuousBurnTime = 1250
+                ratedBurnTime = 54000
+                
+                ignitionReliabilityStart = 0.998820
+                ignitionReliabilityEnd = 0.999814
+                cycleReliabilityStart = 0.996468
+                cycleReliabilityEnd = 0.999442
+            }
+        }
+        CONFIG 
+        {
+            name = HopeX-OMS-extension
+            description = The OMS for HOPE-X equipped with a nozzle extension for higher vacuum efficiency.
+            specLevel = operational
+            minThrust = 10
+            maxThrust = 17
+
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.4943
+                DrawGauge = True
+            }
+            PROPELLANT
+            {
+                name = MON3
+                ratio = 0.5057
+                DrawGauge = False
+            }
+            PROPELLANT
+            {
+                name = Helium
+                ratio = 12.9
+                ignoreForIsp = True
+            }
+            atmosphereCurve
+            {
+                key = 0 350
+                key = 1 120
+            }
+            massMult = 1.05
+            
+            %ullage = True
+            %pressureFed = True
+            %ignitions = 100
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight]
+            {
+                ratedContinuousBurnTime = 1250
+                ratedBurnTime = 54000
+                
+                ignitionReliabilityStart = 0.998820
+                ignitionReliabilityEnd = 0.999814
+                cycleReliabilityStart = 0.996468
+                cycleReliabilityEnd = 0.999442
+            }
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY.cfg
@@ -1,4 +1,5 @@
 // https://archive.org/details/SSRTBrochure/SSRT%20Brochure%2004of12.jpeg
+
 @PART[PROXI-DCY-adapter]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True
@@ -286,9 +287,11 @@
     %RSSROConfig = True
     @rescaleFactor = 0.802
 
-    @title = DC-Y Main Body
+    @title = DC-Y & MD RLV Main Body
     %manufacturer = #roMfrMD
     @description = The primary structural airframe and propellant tankage for the Delta Clipper Experimental (DC-Y) vehicle. Covered in HRSI tiles for atmospheric reentry.
+    
+    @tags ^= :$: MD RLV
 
     @mass = 18.0
 

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY.cfg
@@ -1,0 +1,402 @@
+@PART[PROXI-DCY-adapter]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Adapter
+    %manufacturer = #roMfrMD
+    @description = Structural adapter for the Delta Clipper Experimental (DC-Y) vehicle.
+
+    @mass = 0.5
+
+    %skinTempTag = Aluminum
+    %internalTempTag = Aluminum
+}
+
+@PART[PROXI-DCY-avionicsV2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Avionics Bay
+    %manufacturer = #roMfrMD
+    @description = Primary avionics, guidance, and control systems for the DC-Y vehicle.
+
+    @mass = 1.0
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.5 // kW
+        }
+    }
+
+    !RESOURCE[ElectricCharge] {}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 250
+        basemass = -1
+        
+        TANK
+        {
+            name = ElectricCharge
+            amount = 10000
+            maxAmount = 10000
+        }
+    }
+}
+
+@PART[PROXI-DCY-crewBay]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Crew Cabin
+    %manufacturer = #roMfrMD
+    @description = Pressurized crew compartment for the DC-Y single-stage-to-orbit vehicle. Provides life support and living space for the flight crew.
+
+    @mass = 2.0
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+
+    !RESOURCE[ElectricCharge] {}
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.0
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 800
+        basemass = -1
+        
+        TANK
+        {
+            name = Oxygen
+            amount = 4000
+            maxAmount = 4000
+        }
+        TANK
+        {
+            name = Food
+            amount = 60
+            maxAmount = 60
+        }
+        TANK
+        {
+            name = Water
+            amount = 40
+            maxAmount = 40
+        }
+        TANK
+        {
+            name = ElectricCharge
+            amount = 10000
+            maxAmount = 10000
+        }
+    }
+}
+
+@PART[PROXI-DCY-Spike]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Aerospike Engine
+    %manufacturer = #roMfrMD
+    @description = A massive, highly efficient linear aerospike engine array designed for the Delta Clipper. Offers continuous altitude compensation from sea level to vacuum.
+
+    @mass = 6.5
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+
+    %engineType = DCYAerospike
+}
+
+@PART[PROXI-DCY-VAC]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Vacuum Engine
+    %manufacturer = #roMfrMD
+    @description = A vacuum-optimized hydrolox bell engine utilized by the DC-Y during upper atmospheric ascent and orbital maneuvers.
+
+    @mass = 2.5
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+
+    !MODULE[MultiModeEngine] {}
+    !MODULE[ModuleMultiStateEngine] {}
+
+    %engineType = DCYBimodal
+}
+
+@PART[PROXI-DCY-SL]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Sea Level Engine
+    %manufacturer = #roMfrMD
+    @description = A sea-level optimized hydrolox bell engine for the initial launch phase of the Delta Clipper. 
+
+    @mass = 2.0
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+    %engineType = DCYSeaLevel
+}
+
+@PART[PROXI-DCY-nose]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Nose Section
+    %manufacturer = #roMfrMD
+    @description = The aerodynamic nose section of the DC-Y. It contains primary RCS thrusters, auxiliary fuel tanks, and is fully tiled with High-Temperature Reusable Surface Insulation (HRSI) for atmospheric reentry.
+
+    @mass = 8.5
+
+    %skinTempTag = HRSI
+    %internalTempTag = HotStructure
+    %skinTempOverride = 2700
+    %paintEmissivityTag = 0.95
+
+    !RESOURCE[*],* {}
+
+    @MODULE[ModuleRCS*]
+    {
+        @name = ModuleRCSFX
+        @thrusterPower = 0.5 
+        @stagingEnabled = True
+        
+        !resourceName = DELETE
+        !PROPELLANT[*],* {}
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.4943
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.5057
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 12.9
+            ignoreForIsp = true
+        }
+        
+        !atmosphereCurve {}
+        atmosphereCurve
+        {
+            key = 0 340
+            key = 1 110
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 50000
+        basemass = -1
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 34846
+            maxAmount = 34846
+        }
+        TANK
+        {
+            name = LqdOxygen
+            amount = 12954
+            maxAmount = 12954
+        }
+        TANK
+        {
+            name = MMH
+            amount = 1000
+            maxAmount = 1000
+        }
+        TANK
+        {
+            name = MON3
+            amount = 1000
+            maxAmount = 1000
+        }
+        TANK
+        {
+            name = Helium
+            amount = 25000
+            maxAmount = 25000
+        }
+    }
+}
+
+@PART[PROXI-DCY-body]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Main Body
+    %manufacturer = #roMfrMD
+    @description = The primary structural airframe and propellant tankage for the Delta Clipper Experimental (DC-Y) vehicle. Covered in HRSI tiles for atmospheric reentry.
+
+    @mass = 18.0
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+
+    !RESOURCE[*],* {}
+
+    @MODULE[ModuleRCS*]
+    {
+        @name = ModuleRCSFX
+        @thrusterPower = 2.0 
+        @stagingEnabled = True
+        
+        !resourceName = DELETE
+        !PROPELLANT[*],* {}
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.4943
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.5057
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 12.9
+            ignoreForIsp = true
+        }
+        
+        !atmosphereCurve {}
+        atmosphereCurve
+        {
+            key = 0 340
+            key = 1 110
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 1200000
+        basemass = -1
+
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 873342
+            maxAmount = 873342
+        }
+        TANK
+        {
+            name = LqdOxygen
+            amount = 324658
+            maxAmount = 324658
+        }
+        TANK
+        {
+            name = MMH
+            amount = 500
+            maxAmount = 500
+        }
+        TANK
+        {
+            name = MON3
+            amount = 500
+            maxAmount = 500
+        }
+        TANK
+        {
+            name = Helium
+            amount = 12500
+            maxAmount = 12500
+        }
+    }
+}
+
+@PART[PROXI-DCY-leg]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = True
+    @rescaleFactor = 0.802
+
+    @title = DC-Y Landing Leg
+    %manufacturer = #roMfrMD
+    @description = A heavy-duty retractable landing leg designed to support the Delta Clipper Experimental (DC-Y) during vertical touchdown.
+
+    @mass = 1.0
+    
+    @crashTolerance = 100 
+
+    @maxTemp = 773
+    %skinMaxTemp = 2000
+    %heatConductivity = 0.01		//all conductivity
+    %skinInternalConductionMult = 0.005	//skin-to-int conductivity
+    %skinSkinConductionMult = 0.1
+    %emissiveConstant = 0.95		//matte black
+}
+
+@PART[PROXI-DCY-*]:LAST[RealismOverhaul]
+{
+    &tags = 
+    @tags ^= :$: USA mcdonnell douglas dcy ssto:
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY.cfg
@@ -1,3 +1,4 @@
+// https://archive.org/details/SSRTBrochure/SSRT%20Brochure%2004of12.jpeg
 @PART[PROXI-DCY-adapter]:FOR[RealismOverhaul]
 {
     %RSSROConfig = True

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY_RO_Shabby.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY_RO_Shabby.cfg
@@ -1,0 +1,24 @@
+@PART[ROE-DCYseaLevel-PROXIlaunchers]:FOR[PROXI_Launchers]:NEEDS[Resurfaced]
+{
+	SHABBY_MATERIAL_REPLACE
+	{
+	materialDef = DCY_Engine_Shab
+	targetMaterial = DCY_BellEngine
+	}
+}
+@PART[ROE-DCYbimodal-PROXIlaunchers]:FOR[PROXI_Launchers]:NEEDS[Resurfaced]
+{
+	SHABBY_MATERIAL_REPLACE
+	{
+	materialDef = DCY_Engine_Shab
+	targetMaterial = DCY_BellEngine
+	}
+}
+@PART[ROE-DCYspike-PROXIlaunchers]:FOR[PROXI_Launchers]:NEEDS[Resurfaced]
+{
+	SHABBY_MATERIAL_REPLACE
+	{
+	materialDef = DCY_Engine_Shab
+	targetMaterial = DCY_BellEngine
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY_RO_Waterfall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/DCY_RO_Waterfall.cfg
@@ -1,0 +1,271 @@
+// ============================================================================
+// DCY Aerospike Waterfall & Sound
+// ============================================================================
+@PART[PROXI-DCY-Spike]:NEEDS[Waterfall]:LAST[RealismOverhaul]
+{
+    // Hook the engine to the sound effect node
+    @MODULE[ModuleEngines*]
+    {
+        %runningEffectName = fx-DCYspike
+    }
+
+    !EFFECTS {}
+    EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_liq4
+                volume = 0.8
+                pitch = 1.0
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 0.8
+                pitch = 2.0
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 0.8
+                pitch = 2.0
+                loop = false
+            }
+        }
+        fx-DCYspike
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_altloop
+                volume = 0.0 0.0
+                volume = 1.0 0.8
+                pitch = 0.0 1.0
+                pitch = 1.0 1.0
+                loop = true
+            }
+        }
+    }
+
+    !MODULE[ModuleWaterfallFX],* {}
+    MODULE
+    {
+        name = ModuleWaterfallFX
+        moduleID = fxAerospikeRO
+        
+        // Controllers are mandatory for Waterfall to render
+        CONTROLLER
+        {
+            name = atmosphereDepth
+            linkedTo = atmosphere_density
+        }
+        CONTROLLER
+        {
+            name = throttle
+            linkedTo = throttle
+        }
+
+        TEMPLATE
+        {
+            templateName = waterfall-hydrolox-lower-1
+            overrideParentTransform = fxThrust
+            scale = 6,6,2
+            rotation = 0,0,0
+            position = 0,0,-0.02
+        }
+    }
+}
+
+// ============================================================================
+// DCY Sea Level Engine Waterfall & Sound
+// ============================================================================
+@PART[PROXI-DCY-SL]:NEEDS[Waterfall]:LAST[RealismOverhaul]
+{
+    // Hook the engine to the sound effect node
+    @MODULE[ModuleEngines*]
+    {
+        %runningEffectName = fx-DCYseaLevelEngine
+    }
+
+    !EFFECTS {}
+    EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_liq4
+                volume = 0.8
+                pitch = 1.0
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 0.8
+                pitch = 2.0
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 0.8
+                pitch = 2.0
+                loop = false
+            }
+        }
+        fx-DCYseaLevelEngine
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_altloop
+                volume = 0.0 0.0
+                volume = 1.0 0.8
+                pitch = 0.0 1.0
+                pitch = 1.0 1.0
+                loop = true
+            }
+        }
+    }
+
+    !MODULE[ModuleWaterfallFX],* {}
+    MODULE
+    {
+        name = ModuleWaterfallFX
+        moduleID = seaLevelEngineRO
+    
+        // Controllers are mandatory for Waterfall to render
+        CONTROLLER
+        {
+            name = atmosphereDepth
+            linkedTo = atmosphere_density
+        }
+        CONTROLLER
+        {
+            name = throttle
+            linkedTo = throttle
+        }
+
+        TEMPLATE
+        {
+            templateName = waterfall-hydrolox-lower-4
+            overrideParentTransform = thrustTransform
+            scale = 1.2,1.2,1.2
+            rotation = 0,0,0
+            position = 0,0,0
+        }
+    }
+}
+
+// ============================================================================
+// DCY Vacuum / Bimodal Engine Waterfall & Sound
+// ============================================================================
+@PART[PROXI-DCY-VAC]:NEEDS[Waterfall]:LAST[RealismOverhaul]
+{
+    // Hook the engine to the sound effect node
+    @MODULE[ModuleEngines*]
+    {
+        %runningEffectName = fx-DCYseaLevelEngine
+    }
+
+    !EFFECTS {}
+    EFFECTS
+    {
+        engage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_liq4
+                volume = 0.8
+                pitch = 1.0
+                loop = false
+            }
+        }
+        disengage
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_vent_soft
+                volume = 0.8
+                pitch = 2.0
+                loop = false
+            }
+        }
+        flameout
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_explosion_low
+                volume = 0.8
+                pitch = 2.0
+                loop = false
+            }
+        }
+        fx-DCYseaLevelEngine
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = Waterfall/Sounds/KW/sound_altloop
+                volume = 0.0 0.0
+                volume = 1.0 0.8
+                pitch = 0.0 1.0
+                pitch = 1.0 1.0
+                loop = true
+            }
+        }
+    }
+
+    !MODULE[ModuleWaterfallFX],* {}
+    MODULE
+    {
+        name = ModuleWaterfallFX
+        moduleID = vacLevelEngineRO
+    
+        CONTROLLER
+        {
+            name = atmosphereDepth
+            linkedTo = atmosphere_density
+        }
+        CONTROLLER
+        {
+            name = throttle
+            linkedTo = throttle
+        }
+
+        TEMPLATE
+        {
+            templateName = waterfall-hydrolox-lower-4
+            overrideParentTransform = fxTransformVAC
+            scale = 1.2,1.2,1.2
+            rotation = 0,0,0
+            position = 0,0,-0.2
+        }
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX.cfg
@@ -9,7 +9,7 @@
 
 // So, I am of the opinion that 10 tons dry/inert is the way to go. 
 
-@PART[PROXI-HopeX-*]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-*]:FOR[RealismOverhaul]
 {
     %maxTemp = 923.15
     %skinMaxTemp = 3000
@@ -33,7 +33,7 @@
     @tags ^= :$: NASDA HOPE-X JAXA spaceplane:
 }
 
-@PART[PROXI-HopeX-*Gear*]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-*Gear*]:FOR[RealismOverhaul]
 {
     %crashTolerance = 250 
     @MODULE[ModuleWheelDamage]
@@ -121,28 +121,28 @@
 }
 
 
-@PART[PROXI-HopeX-adapter]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-adapter]:FOR[RealismOverhaul]
 {
     @mass = 0.5
     @title = HOPE-X Adapter
     @description = Launch Vehicle Adapter for HOPE-X.
 }
 
-@PART[PROXI-HopeX-bay]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-bay]:FOR[RealismOverhaul]
 {
     @mass = 3.0
     @title = HOPE-X Cargo Bay
     @description = Unpressurized Cargo Bay for HOPE-X.
 }
 
-@PART[PROXI-HopeX-tube_v2]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-tube_v2]:FOR[RealismOverhaul]
 {
     @mass = 0.4
     @title = HOPE-X Crew Tube
     @description = Pressurized Crew Tube for HOPE-X.
 }
 
-@PART[PROXI-HopeX-dish]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-dish]:FOR[RealismOverhaul]
 {
     @mass = 0.06
     @title = HOPE-X Directional Antenna
@@ -152,77 +152,77 @@
     %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.55 }
 }
 
-@PART[PROXI-HopeX-flap]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-flap]:FOR[RealismOverhaul]
 {
     @mass = 0.25
     @title = HOPE-X Body Flap
     @description = Main Body Flap for HOPE-X.
 }
 
-@PART[PROXI-HopeX-ElevonL]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-ElevonL]:FOR[RealismOverhaul]
 {
     @mass = 0.2
     @title = HOPE-X Left Elevon
     @description = Left Elevon for HOPE-X.
 }
 
-@PART[PROXI-HopeX-ElevonR]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-ElevonR]:FOR[RealismOverhaul]
 {
     @mass = 0.2
     @title = HOPE-X Right Elevon
     @description = Right Elevon for HOPE-X.
 }
 
-@PART[PROXI-HopeX-rudder]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-rudder]:FOR[RealismOverhaul]
 {
     @mass = 0.2
     @title = HOPE-X Rudder
     @description = Rudder for HOPE-X.
 }
 
-@PART[PROXI-HopeX-rudderWing]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-rudderWing]:FOR[RealismOverhaul]
 {
     @mass = 0.25
     @title = HOPE-X Rudder Wing
     @description = Rudder on Wing for HOPE-X.
 }
 
-@PART[PROXI-HopeX-wingL]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-wingL]:FOR[RealismOverhaul]
 {
     @mass = 0.9
     @title = HOPE-X Left Wing
     @description = Left Wing on HOPE-X.
 }
 
-@PART[PROXI-HopeX-wingR]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-wingR]:FOR[RealismOverhaul]
 {
     @mass = 0.9
     @title = HOPE-X Right Wing
     @description = Right Wing on HOPE-X.
 }
 
-@PART[PROXI-HopeX-NoseGear]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-NoseGear]:FOR[RealismOverhaul]
 {
     @mass = 0.1
     @title = HOPE-X Nose Gear
     @description = Nose Gear for HOPE-X.
 }
 
-@PART[PROXI-HopeX-MainGearL]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-MainGearL]:FOR[RealismOverhaul]
 {
     @mass = 0.2
     @title = HOPE-X Left Main Gear
     @description = Left Main Gear for HOPE-X.
 }
 
-@PART[PROXI-HopeX-MainGearR]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-MainGearR]:FOR[RealismOverhaul]
 {
     @mass = 0.2
     @title = HOPE-X Right Main Gear
     @description = Right Main Gear for HOPE-X.
 }
 
-@PART[PROXI-HopeX-SM]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-SM]:FOR[RealismOverhaul]
 {
     @mass = 2.5
     @title = HOPE-X Service Module
@@ -239,7 +239,7 @@
     }
 }
 
-@PART[PROXI-HopeX-nose]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-nose]:FOR[RealismOverhaul]
 {
     @mass = 2.5
     @title = HOPE-X Nose
@@ -297,7 +297,7 @@
     }
 }
 
-@PART[PROXI-HopeX-rcs]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-rcs]:FOR[RealismOverhaul]
 {
     @mass = 0.1
     @title = HOPE-X Reaction Control Module
@@ -337,7 +337,7 @@
     }
 }
 
-@PART[PROXI-HopeX-cargo_v2]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-HopeX-cargo_v2]:FOR[RealismOverhaul]
 {
     @mass = 0.5
     @title = HOPE-X Cargo Container

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX.cfg
@@ -1,0 +1,343 @@
+// From what I can find, HOPE-X would have had 10 tons of dry mass, 2 tons of propellant for ~700 m/s of delta-v with 2 tons to LEO.
+// Or at least this is what I am gathering from wikipedia.
+// "Concept and TechnologyDevelopment for HOPE Spaceplane" at [1] https://arc.aiaa.org/doi/epdf/10.2514/6.1990-5223
+// seems to cover a previous version/design with a MTOW of 20 tons for the orbiter, broken down as:
+// - 20t at launch
+// - 16 t at "initial orbit injection"
+// - 15 t of "maximum landing weight"
+// - 10 t dry mass, 3 t of up payload and 5 ton of return payload
+
+// So, I am of the opinion that 10 tons dry/inert is the way to go. 
+
+@PART[PROXI-HopeX-*]:AFTER[zzzRealismOverhaul]
+{
+    %maxTemp = 923.15
+    %skinMaxTemp = 3000
+    %skinThermalMassModifier = 0.43613
+    %skinInternalConductionMult = 0.0000105
+    %skinMassPerArea = 0.815
+    %absorptiveConstant = 0.15	
+    %emissiveConstant = 0.85
+    %thermalMassModifier = 1.0
+
+    @manufacturer = NASDA
+    
+    %breakingForce = 50000
+    %breakingTorque = 50000
+
+    %RSSROConfig = True
+    
+    @rescaleFactor = 1
+
+    &tags = 
+    @tags ^= :$: NASDA HOPE-X JAXA spaceplane:
+}
+
+@PART[PROXI-HopeX-mainEngineV2]:FOR[RealismOverhaul]
+{
+    %RSSROConfig = true
+    
+    @title = HOPE-X OMS Engine
+    %manufacturer = NASDA
+    
+    @mass = 0.12
+    
+    %engineType = HopeXoms
+
+    !MODULE[ModuleEngineConfigs],*{}
+    !MODULE[ModuleAlternator],*{}
+    !RESOURCE,*{}
+
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        switcherDescription = Engine Mount
+        moduleID = HopeX_engineMount
+        affectDragCubes = true
+        affectFARVoxels = true
+
+        SUBTYPE
+        {
+            name = HopeXmount_on
+            title = On
+            defaultSubtypePriority = 1
+            transform = Mount
+        }
+        SUBTYPE
+        {
+            name = HopeXmount_off
+            title = Off
+            defaultSubtypePriority = 0
+        }
+    }
+
+    MODULE 
+    {
+        name = ModuleB9PartSwitch
+        switcherDescription = Nozzle (auto-switched)
+        moduleID = nozzle
+
+        SUBTYPE
+        {
+            name = No_extension
+            transform = fxNozzle
+        }
+        SUBTYPE
+        {
+            name = Extension
+            transform = NozzleExtension
+        }
+    }
+}
+
+@PART[PROXI-HopeX-mainEngine]:AFTER[RealismOverhaulEngines]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[HopeX-OMS]
+        {
+            %LinkB9PSModule[nozzle] {subtype = No_extension}
+        }
+        @CONFIG[HopeX-OMS-extension]
+        {
+            %LinkB9PSModule[nozzle] {subtype = Extension}
+        }
+    }
+}
+
+
+@PART[PROXI-HopeX-adapter]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.5
+    @title = HOPE-X Adapter
+    @description = Launch Vehicle Adapter for HOPE-X.
+}
+
+@PART[PROXI-HopeX-bay]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 3.0
+    @title = HOPE-X Cargo Bay
+    @description = Unpressurized Cargo Bay for HOPE-X.
+}
+
+@PART[PROXI-HopeX-tube_v2]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.4
+    @title = HOPE-X Crew Tube
+    @description = Pressurized Crew Tube for HOPE-X.
+}
+
+@PART[PROXI-HopeX-dish]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.06
+    @title = HOPE-X Directional Antenna
+    @description = Antenna for HOPE-X
+
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.55 }
+}
+
+@PART[PROXI-HopeX-flap]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.25
+    @title = HOPE-X Body Flap
+    @description = Main Body Flap for HOPE-X.
+}
+
+@PART[PROXI-HopeX-ElevonL]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.2
+    @title = HOPE-X Left Elevon
+    @description = Left Elevon for HOPE-X.
+}
+
+@PART[PROXI-HopeX-ElevonR]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.2
+    @title = HOPE-X Right Elevon
+    @description = Right Elevon for HOPE-X.
+}
+
+@PART[PROXI-HopeX-rudder]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.2
+    @title = HOPE-X Rudder
+    @description = Rudder for HOPE-X.
+}
+
+@PART[PROXI-HopeX-rudderWing]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.25
+    @title = HOPE-X Rudder Wing
+    @description = Rudder on Wing for HOPE-X.
+}
+
+@PART[PROXI-HopeX-wingL]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.9
+    @title = HOPE-X Left Wing
+    @description = Left Wing on HOPE-X.
+}
+
+@PART[PROXI-HopeX-wingR]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.9
+    @title = HOPE-X Right Wing
+    @description = Right Wing on HOPE-X.
+}
+
+@PART[PROXI-HopeX-NoseGear]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.1
+    @title = HOPE-X Nose Gear
+    @description = Nose Gear for HOPE-X.
+}
+
+@PART[PROXI-HopeX-MainGearL]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.2
+    @title = HOPE-X Left Main Gear
+    @description = Left Main Gear for HOPE-X.
+}
+
+@PART[PROXI-HopeX-MainGearR]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.2
+    @title = HOPE-X Right Main Gear
+    @description = Right Main Gear for HOPE-X.
+}
+
+@PART[PROXI-HopeX-SM]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 2.5
+    @title = HOPE-X Service Module
+    @description = Service Module for HOPE-X.
+    
+    !RESOURCE[*],* {}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        type = ServiceModule
+        volume = 2000.0
+        basemass = -1
+    }
+}
+
+@PART[PROXI-HopeX-nose]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 2.5
+    @title = HOPE-X Nose
+    @description = Nose for HOPE-X, also the flight computer. 
+    
+    !RESOURCE[*],* {}
+    !MODULE[ModuleReactionWheel*],*{}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 1.5
+        basemass = -1
+        type = ServiceModule
+        
+        TANK
+        {
+            name = ElectricCharge
+            amount = 5000.0
+            maxAmount = 5000.0
+        }
+    }
+
+    @MODULE[ModuleRCS*]
+    {
+        @name = ModuleRCSFX
+        @thrusterPower = 0.6
+
+        !resourceName = DELETE
+        !PROPELLANT[*],* {}
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.5078
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.4922
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 12.9
+            ignoreForIsp = True
+        }
+        
+        !atmosphereCurve {}
+        atmosphereCurve
+        {
+            key = 0 300
+            key = 1 100
+        }
+    }
+}
+
+@PART[PROXI-HopeX-rcs]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.1
+    @title = HOPE-X Reaction Control Module
+    @description = Reaction Control Module for HOPE-X.
+
+    @MODULE[ModuleRCS*]
+    {
+        @name = ModuleRCSFX
+        @thrusterPower = 0.5
+
+        !resourceName = DELETE
+        !PROPELLANT[*],* {}
+        
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.5078
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.4922
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 12.9
+            ignoreForIsp = True
+        }
+        
+        !atmosphereCurve {}
+        atmosphereCurve
+        {
+            key = 0 300
+            key = 1 100
+        }
+    }
+}
+
+@PART[PROXI-HopeX-cargo_v2]:AFTER[zzzRealismOverhaul]
+{
+    @mass = 0.5
+    @title = HOPE-X Cargo Container
+    @description = Cargo Container for HOPE-X.
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 10000
+        basemass = -1
+        type = ServiceModule
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX.cfg
@@ -33,6 +33,16 @@
     @tags ^= :$: NASDA HOPE-X JAXA spaceplane:
 }
 
+@PART[PROXI-HopeX-*Gear*]:AFTER[zzzRealismOverhaul]
+{
+    %crashTolerance = 250 
+    @MODULE[ModuleWheelDamage]
+    {
+        %stressTolerance = 90000
+        %impactTolerance = 30000
+    }
+}
+
 @PART[PROXI-HopeX-mainEngineV2]:FOR[RealismOverhaul]
 {
     %RSSROConfig = true
@@ -241,7 +251,7 @@
     MODULE
     {
         name = ModuleFuelTanks
-        volume = 1.5
+        volume = 5000
         basemass = -1
         type = ServiceModule
         

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX_RO_Waterfall.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/HopeX_RO_Waterfall.cfg
@@ -1,0 +1,11 @@
+@PART[PROXI-HopeX-mainEngine]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-white-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.8, 0.8, 0.6
+    }
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/MD_RLV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/MD_RLV.cfg
@@ -1,0 +1,125 @@
+@PART[PROXI-MDRLV-*]:AFTER[zzzRealismOverhaul]
+{
+	@rescaleFactor = 0.802
+
+	%maxTemp = 923.15
+	%skinMaxTemp = 3000
+	%skinThermalMassModifier = 0.43613
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.815
+	%absorptiveConstant = 0.15	
+	%emissiveConstant = 0.85
+	%thermalMassModifier = 1.0
+
+	@manufacturer = McDonnell Douglas
+	
+	%RSSROConfig = True
+}
+@PART[PROXI-MDRLV-nose]:AFTER[zzzRealismOverhaul]
+{
+	@mass = 22.93
+	@title = MD RLV Nose
+	@description = The nose section of the MD RLV, covered in tiles to protect it during reentry.
+	&tags =
+	@tags ^= :$: MD RLV:
+	
+	!RESOURCE[LiquidFuel]{}
+	!RESOURCE[Oxidizer]{}
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 100000
+		@maxAmount = 100000
+	}
+	MODULE
+	{
+		name = AdjustableCoMShifter
+		DescentModeCoM = 0, 15.0, 0
+	}
+	!RESOURCE[*],* {}
+
+	@MODULE[ModuleRCS*]
+	{
+		@name = ModuleRCSFX
+		@thrusterPower = 0.5 
+		@stagingEnabled = True
+
+		!resourceName = DELETE
+		!PROPELLANT[*],* {}	
+		PROPELLANT
+		{
+			name = MMH
+			ratio = 0.4943
+		}
+		PROPELLANT
+		{
+			name = MON3
+			ratio = 0.5057
+		}
+		PROPELLANT
+		{
+			name = Helium
+			ratio = 12.9
+			ignoreForIsp = true
+		}
+
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 340
+			key = 1 110
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule 
+		volume = 500000
+		basemass = -1
+
+		TANK
+		{
+			name = ElectricCharge
+			amount = 10000
+			maxAmount = 10000
+		}
+		TANK
+		{
+			name = LqdHydrogen
+			amount = 344147
+			maxAmount = 344147
+		}
+		TANK
+		{
+			name = LqdOxygen
+			amount = 128843
+			maxAmount = 128843
+		}
+		TANK
+		{
+			name = MMH
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = MON3
+			amount = 1000
+			maxAmount = 1000
+		}
+		TANK
+		{
+			name = Helium
+			amount = 25000
+			maxAmount = 25000
+		}
+	}
+}
+@PART[PROXI-MDRLV-wing]:AFTER[zzzRealismOverhaul]
+{
+	@mass = 0.67
+	@title = MDRLV Wing
+	@description = The wings and landing gear for MD RLV.
+	&tags =
+	@tags ^= :$: MD RLV:
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/MD_RLV.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/MD_RLV.cfg
@@ -1,4 +1,4 @@
-@PART[PROXI-MDRLV-*]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-MDRLV-*]:FOR[RealismOverhaul]
 {
 	@rescaleFactor = 0.802
 
@@ -15,7 +15,7 @@
 	
 	%RSSROConfig = True
 }
-@PART[PROXI-MDRLV-nose]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-MDRLV-nose]:FOR[RealismOverhaul]
 {
 	@mass = 22.93
 	@title = MD RLV Nose
@@ -115,7 +115,7 @@
 		}
 	}
 }
-@PART[PROXI-MDRLV-wing]:AFTER[zzzRealismOverhaul]
+@PART[PROXI-MDRLV-wing]:FOR[RealismOverhaul]
 {
 	@mass = 0.67
 	@title = MDRLV Wing

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/PLANA_FAR.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/PLANA_FAR.cfg
@@ -1,0 +1,169 @@
+@PART[PROXI-DCY-flap]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+    @MODULE[FARControllableSurface]
+    {
+        @MAC = 4.716
+        @b_2 = 3.455
+    }
+}
+
+@PART[PROXI-DCY-halfflap]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 4.791
+		@b_2 = 1.803
+	}
+}
+
+@PART[PROXI-HopeX-Elevon?]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 1.202 
+		@b_2 = 2.911
+	}
+}
+
+@PART[PROXI-HopeX-rudder]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 0.745 
+		@b_2 = 2.663
+	}
+}
+
+@PART[PROXI-HopeX-rudderWing]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@MAC = 1.243 
+		@b_2 = 2.776 
+	}
+}
+
+@PART[PROXI-HopeX-flap]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 1.952 
+		@b_2 = 2.578 
+	}
+}
+
+@PART[PROXI-HopeX-wing?]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@MAC = 5.104 
+		@b_2 = 3.405 
+	}
+}
+
+@PART[PROXI-HopeX-wingL]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@rootMidChordOffsetFromOrig = -1, 2, 0
+	}
+}
+
+@PART[PROXI-HopeX-wingR]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@rootMidChordOffsetFromOrig = 1, 2, 0
+	}
+}
+
+@PART[PROXI-MDX33-Flap]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@MAC = 1.5
+		@b_2 = 4.3
+	}
+}
+
+@PART[PROXI-MDX33-BodyFlap]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 1.66
+		@b_2 = 1.81
+	}
+}
+
+@PART[PROXI-MDRLV-wing]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@MAC = 3.488
+		@b_2 = 2.343
+	}
+}
+
+@PART[PROXI-XS1-*Wing]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARWingAerodynamicModel]
+	{
+		@MAC = 8.814
+		@b_2 = 6.5
+		@rootMidChordOffsetFromOrig = 0, 3, 0
+	}
+}
+
+@PART[PROXI-XS1-?I_Elevon]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 2.010
+		@b_2 = 2.963
+	}
+}
+
+@PART[PROXI-XS1-?O_Elevon]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 1.611
+		@b_2 = 2.554
+	}
+}
+
+@PART[PROXI-XS1-LeftRudder]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 4.036
+		@b_2 = 5.107
+	}
+}
+
+@PART[PROXI-XS1-RightRudder]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 4.036
+		@b_2 = 5.107
+	}
+}
+
+@PART[PROXI-XS1-Flap]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 2.585
+		@b_2 = 4.388
+	}
+}
+
+@PART[PROXI-RWX33-Rudder]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		@MAC = 3.664 
+		@b_2 = 5.446 
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/PLANA_FAR.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/PLANA_FAR.cfg
@@ -167,3 +167,31 @@
 		@b_2 = 5.446 
 	}
 }
+
+
+@PART[PROXI-SC-LF-?]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		%MAC = 3.235
+		%b_2 = 4.909
+	}
+}
+
+@PART[PROXI-SC-UF-?]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		%MAC = 2.346
+		%b_2 = 5.138
+	}
+}
+
+@PART[PROXI-SC-Wing?]:NEEDS[RealismOverhaul,FerramAerospaceResearch/Plugins]:AFTER[RealismOverhaul]
+{
+	@MODULE[FARControllableSurface]
+	{
+		%MAC = 8.923
+		%b_2 = 4.967
+	}
+}

--- a/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/Starclipper.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/PLANA/Starclipper.cfg
@@ -1,0 +1,175 @@
+@PART[PROXI-SC-*]:FOR[RealismOverhaul]
+{
+    %maxTemp = 923.15
+    %skinMaxTemp = 3000
+    %skinThermalMassModifier = 0.43613
+    %skinInternalConductionMult = 0.0000105
+    %skinMassPerArea = 0.815
+    %absorptiveConstant = 0.15	
+    %emissiveConstant = 0.85
+    %thermalMassModifier = 1.0
+
+    %RSSROConfig = True
+    @rescaleFactor = 1
+
+    @manufacturer = #roMfrLockhee
+
+
+    &tags = 
+    @tags ^= :$: PLANA Starclipper spaceplane:
+}
+
+
+@PART[PROXI-SC-body]:FOR[RealismOverhaul]
+{
+    @mass = 6.9 // 20 tons - 3 SSME - Aero = 6.9, haha nice
+    @title = Starclipper
+    @description = The main body of Lockheed's Starclipper proposal
+    
+    !RESOURCE[*],* {}
+    !MODULE[ModuleReactionWheel*],*{}
+
+    @MODULE[ModuleCommand]
+    {
+        @minimumCrew = 0
+        RESOURCE
+        {
+            name = ElectricCharge
+            rate = 1.0
+        }
+    }
+
+    %ROLSTankStorage = 30
+
+    @MODULE[ModuleRCS*]
+    {
+        @name = ModuleRCSFX
+        @thrusterPower = 1.5
+
+        !resourceName = DELETE
+        !PROPELLANT[*],* {}
+
+        PROPELLANT
+        {
+            name = MMH
+            ratio = 0.5078
+        }
+        PROPELLANT
+        {
+            name = MON3
+            ratio = 0.4922
+        }
+        PROPELLANT
+        {
+            name = Helium
+            ratio = 12.9
+            ignoreForIsp = True
+        }
+        
+        !atmosphereCurve {}
+        atmosphereCurve
+        {
+            key = 0 300
+            key = 1 100
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 100000
+        basemass = -1
+        type = ServiceModule
+        
+        TANK
+        {
+            name = ElectricCharge
+            amount = 10000.0
+            maxAmount = 10000.0
+        }
+        TANK
+        {
+            name = LqdOxygen
+            amount = 613.6
+            maxAmount = 613.6
+        }
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 1245.2
+            maxAmount = 1245.2
+        }
+    }
+}
+
+@PART[PROXI-SC-LF-L]:FOR[RealismOverhaul]
+{
+    @mass = 0.5
+    @title = Starclipper Left Lower Body Flap
+    @description = The Left Lower Body Flap for Lockheed's Starclipper proposal
+}
+
+@PART[PROXI-SC-LF-R]:FOR[RealismOverhaul]
+{
+    @mass = 0.5
+    @title = Starclipper Right Lower Body Flap
+    @description = The Right Lower Body Flap for Lockheed's Starclipper proposal
+}
+
+@PART[PROXI-SC-UF-L]:FOR[RealismOverhaul]
+{
+    @mass = 0.3
+    @title = Starclipper Left Upper Air Brake
+    @description = The Left Upper Air Brake for Lockheed's Starclipper proposal
+}
+
+@PART[PROXI-SC-UF-R]:FOR[RealismOverhaul]
+{
+    @mass = 0.3
+    @title = Starclipper Right Upper Air Brake
+    @description = The Right Upper Air Brake for Lockheed's Starclipper proposal
+}
+
+@PART[PROXI-SC-WingL]:FOR[RealismOverhaul]
+{
+    @mass = 1.5
+    @title = Starclipper Left Wing
+    @description = The Left Wing for Lockheed's Starclipper proposal
+}
+
+@PART[PROXI-SC-WingR]:FOR[RealismOverhaul]
+{
+    @mass = 1.5
+    @title = Starclipper Right Wing
+    @description = The Right Wing for Lockheed's Starclipper proposal
+}
+
+@PART[PROXI-SC-ET]:FOR[RealismOverhaul]
+{
+    @mass = 12.971 
+    @title = Starclipper External Tank
+    @description = The External Tank for Lockheed's Starclipper proposal
+    
+    !RESOURCE[*],* {}
+
+    MODULE
+    {
+        name = ModuleFuelTanks
+        volume = 4200000
+        basemass = -1
+        type = Cryogenic
+        
+        TANK
+        {
+            name = LqdOxygen
+            amount = 1140048
+            maxAmount = 1140048
+        }
+        TANK
+        {
+            name = LqdHydrogen
+            amount = 3059952
+            maxAmount = 3059952
+        }
+    }
+}


### PR DESCRIPTION
This PR adds configs for [PLANA](https://forum.kerbalspaceprogram.com/topic/229246-112x-proxis-launchers-and-aircraft-plana-conceptual-active-upcoming-vehicles-and-more-july-24-2026-v123/), which (at the time of writing), covers:
-  DC-Y
- HOPE-X
- MD X-33
- MD RLV
- XS-1
- RW X-33

At the moment, this PR configures:

- [x] DC-Y
- [x] HOPE-X
- [x] MD RLV
- [ ] MD X-33
- [ ] RW X-33
- [ ] XS-1
- [x] FAR for all of the above

[RP-1](https://github.com/KSP-RO/RP-1/pull/2914)