### PR TITLE
Update Raptor Config

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/RaptorVac_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RaptorVac_Config.cfg
@@ -39,7 +39,7 @@
 //
 //	Dry Mass: ??? kg
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 3000.8349 kN (306tf)
+//	Thrust (Vac): 2696.829 kN (275tf)
 //	ISP: 311.877 SL / 380 Vac
 //	Burn Time: ???
 //	Chamber Pressure: 33+ MPa
@@ -118,13 +118,13 @@
 			PROPELLANT // Ratio = 3.55 [1]
 			{
 				name = CooledLqdMethane
-				ratio = 0.43
+				ratio = 0.4248
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.57
+				ratio = 0.5752
 			}
 			atmosphereCurve
 			{
@@ -144,12 +144,12 @@
 			IGNITOR_RESOURCE // Torch-Lit System uses the same propellant has the engines [5]
 			{
 				name = CooledLqdMethane
-				amount = 0.4303 // ~ Guess
+				amount = 0.4248 // ~ Guess
 			}
 			IGNITOR_RESOURCE // Torch-Lit System uses the same propellant has the engines [5]
 			{
 				name = CooledLqdOxygen
-				amount = 0.5697 // ~ Guess
+				amount = 0.5752 // ~ Guess
 			}
 			//same as Raptor
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -183,13 +183,13 @@
 			PROPELLANT // Ratio = 3.55 [1]
 			{
 				name = CooledLqdMethane
-				ratio = 0.43
+				ratio = 0.4248
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.57
+				ratio = 0.5752
 			}
 			atmosphereCurve
 			{
@@ -209,12 +209,12 @@
 			IGNITOR_RESOURCE // Torch-Lit System uses the same propellant has the engines [5]
 			{
 				name = CooledLqdMethane
-				amount = 0.4303 // ~ Guess
+				amount = 0.4248 // ~ Guess
 			}
 			IGNITOR_RESOURCE // Torch-Lit System uses the same propellant has the engines [5]
 			{
 				name = CooledLqdOxygen
-				amount = 0.5697 // ~ Guess
+				amount = 0.5752 // ~ Guess
 			}
 			//Same as Raptor
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
@@ -240,8 +240,8 @@
 			name = Raptor-3V
 			specLevel = prototype
 			description = Third Generation Raptor-Engine with even greater simplification and even greater thrust, slightly heavier to include built in heatshielding.
-			maxThrust = 3000.8349
-			minThrust = 1200.33396 // 40% throttle [3]
+			maxThrust = 2696.829
+			minThrust = 1078.7315 // 40% throttle [3]
 			heatProduction = 100
 			ratedBurnTime = 3600
 			throttleResponseRate = 0.625
@@ -249,13 +249,13 @@
 			PROPELLANT // Ratio = 3.55 [1]
 			{
 				name = CooledLqdMethane
-				ratio = 0.4303
+				ratio = 0.4248
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.5697
+				ratio = 0.5752
 			}
 			atmosphereCurve
 			{
@@ -275,14 +275,23 @@
 			IGNITOR_RESOURCE
 			{
 				name = CooledLqdMethane
-				amount = 0.4303 // ~ Guess
+				amount = 0.4248 // ~ Guess
 			}
 			IGNITOR_RESOURCE
 			{
 				name = CooledLqdOxygen
-				amount = 0.5697 // ~ Guess
+				amount = 0.5752 // ~ Guess
 			}
-			//complete guess, never flown
+			SUBCONFIG
+			{
+				name = 306tf
+				description = Design goal for Raptor 3V at 306tf (3000.83kN)
+				specLevel = prototype
+				maxThrust = 2745.862
+				minThrust = 1098.3448 // 40% throttle [3]
+			}
+
+			//	Needs to be reworked when more Version 3 flights happen, current values are fine for Gameplay
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 360 // ~6 minutes for longest continuous burn

--- a/GameData/RealismOverhaul/Engine_Configs/Raptor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor_Config.cfg
@@ -180,6 +180,7 @@
 				ignitionReliabilityEnd = 0.988043
 				cycleReliabilityStart = 0.927083
 				cycleReliabilityEnd = 0.985417
+        		ignitionDynPresFailMultiplier = 9.0    //(96.5% @75Kpa)
 			}
 		}
 		CONFIG
@@ -255,6 +256,7 @@
 				ignitionReliabilityEnd = 0.992633
 				cycleReliabilityStart = 0.959070
 				cycleReliabilityEnd = 0.993537
+        		ignitionDynPresFailMultiplier = 9.0    //(96.5% @75Kpa)
 				techTransfer = Raptor-1,Raptor-1V:50
 			}
 		}
@@ -330,6 +332,7 @@
 				ignitionReliabilityEnd = 0.999
 				cycleReliabilityStart = 0.98
 				cycleReliabilityEnd = 0.999
+        		ignitionDynPresFailMultiplier = 9.0    //(96.5% @75Kpa)
 				techTransfer = Raptor-1,Raptor-2,Raptor-1V,Raptor-2V:50
 			}
 		}

--- a/GameData/RealismOverhaul/Engine_Configs/Raptor_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/Raptor_Config.cfg
@@ -39,7 +39,7 @@
 //
 //	Dry Mass: 1,525 kg (1,720kg Vehicle Side)
 //	Thrust (SL): ??? kN
-//	Thrust (Vac): 2745.862 kN (280tf)
+//	Thrust (Vac): 2451.663 kN (250tf)
 //	ISP: 334 SL / 350 Vac
 //	Burn Time: ???
 //	Chamber Pressure: 33+ MPa
@@ -119,13 +119,13 @@
 			PROPELLANT // Ratio = 3.55 [1]
 			{
 				name = CooledLqdMethane
-				ratio = 0.4303
+				ratio = 0.4248
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.5697
+				ratio = 0.5752
 			}
 			atmosphereCurve
 			{
@@ -145,12 +145,12 @@
 			IGNITOR_RESOURCE // Torch-Lit System uses the same propellant has the engines [5]
 			{
 				name = CooledLqdMethane
-				amount = 0.43 // ~ Guess
+				amount = 0.4248 // ~ Guess
 			}
 			IGNITOR_RESOURCE // Torch-Lit System uses the same propellant has the engines [5]
 			{
 				name = CooledLqdOxygen
-				amount = 0.57 // ~ Guess
+				amount = 0.5752 // ~ Guess
 			}
 
 			//Counting Raptor and RVac the same because RVac is basically identical with a nozzle extension
@@ -196,13 +196,13 @@
 			PROPELLANT // Ratio = 3.55 [1]
 			{
 				name = CooledLqdMethane
-				ratio = 0.4303
+				ratio = 0.4248
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.5697
+				ratio = 0.5752
 			}
 			atmosphereCurve
 			{
@@ -222,12 +222,12 @@
 			IGNITOR_RESOURCE
 			{
 				name = CooledLqdMethane
-				amount = 0.4303 // ~ Guess
+				amount = 0.4248 // ~ Guess
 			}
 			IGNITOR_RESOURCE
 			{
 				name = CooledLqdOxygen
-				amount = 0.5697 // ~ Guess
+				amount = 0.5752 // ~ Guess
 			}
 
 			//IFT-1 (B7): 1 flight, 6 failures (3 ignition, 3 cycle)
@@ -261,10 +261,10 @@
 		CONFIG
 		{
 			name = Raptor-3
-			specLevel = prototype
+			specLevel = operational
 			description = Third Generation Raptor-Engine with even greater simplification and even greater thrust, slightly heavier to include built in heatshielding.
-			maxThrust = 2745.862
-			minThrust = 1098.3448 // 40% throttle [3]
+			maxThrust = 2451.663
+			minThrust = 980.665 // 40% throttle [3]
 			heatProduction = 100
 			ratedBurnTime = 3600
 			throttleResponseRate = 0.625
@@ -272,13 +272,13 @@
 			PROPELLANT // Ratio = 3.55 [1]
 			{
 				name = CooledLqdMethane
-				ratio = 0.4303
+				ratio = 0.4248
 				DrawGauge = true
 			}
 			PROPELLANT
 			{
 				name = CooledLqdOxygen
-				ratio = 0.5697
+				ratio = 0.5752
 			}
 			atmosphereCurve
 			{
@@ -298,15 +298,23 @@
 			IGNITOR_RESOURCE
 			{
 				name = CooledLqdMethane
-				amount = 0.4303 // ~ Guess
+				amount = 0.4248 // ~ Guess
 			}
 			IGNITOR_RESOURCE
 			{
 				name = CooledLqdOxygen
-				amount = 0.5697 // ~ Guess
+				amount = 0.5752 // ~ Guess
+			}
+			SUBCONFIG
+			{
+				name = 280tf
+				description = Design goal for Raptor 3 at 280tf (2745.9kN)
+				specLevel = prototype
+				maxThrust = 2745.862
+				minThrust = 1098.3448 // 40% throttle [3]
 			}
 
-			//complete guess, never flown
+			//	Needs to be reworked when more Version 3 flights happen, current values are fine for Gameplay
 			TESTFLIGHT:NEEDS[TestLite|TestFlight]
 			{
 				ratedBurnTime = 360 // ~6 minutes for longest continuous burn


### PR DESCRIPTION
Change Raptor 3 thrust from 280tf to 250tf, and RVac thrust from 306tf to 275tf inline with real Raptor 3 performance.

Added a subconfig to allow for the original 280tf spec which is a stretch goal for the real engine.

Slight change to the mixture ratio to be inline with Starship Expansion Project and Flip&Burn.